### PR TITLE
fix: improve plan viewing and approval timeouts

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -55,40 +55,7 @@ def _backend_descriptors(registry: BackendRegistry) -> list[dict[str, Any]]:
                 "transport_id": plugin.transport_id,
                 "label": plugin.label,
                 "badges": dict(caps.badges),
-                "capabilities": {
-                    "is_structured": caps.is_structured,
-                    "supports_resume": caps.supports_resume,
-                    "supports_terminate": caps.supports_terminate,
-                    "supports_set_model_inline": caps.supports_set_model_inline,
-                    "supports_set_effort_inline": caps.supports_set_effort_inline,
-                    "supports_set_effort_with_restart": (
-                        caps.supports_set_effort_with_restart
-                    ),
-                    "supports_set_permission_mode_inline": (
-                        caps.supports_set_permission_mode_inline
-                    ),
-                    "supports_thread_discovery": caps.supports_thread_discovery,
-                    "supports_thread_import": caps.supports_thread_import,
-                    "supports_slash_compact": caps.supports_slash_compact,
-                    "model_source": caps.model_source.value,
-                    "approval_decisions": list(caps.approval_decisions),
-                    "effort_levels": list(caps.effort_levels),
-                    "permission_modes": [
-                        {
-                            "id": spec.id,
-                            "label": spec.label,
-                            "description": spec.description,
-                            "requires_session_restart": spec.requires_session_restart,
-                        }
-                        for spec in caps.permission_modes
-                    ],
-                    "slash_commands": [
-                        {"name": cmd.name, "description": cmd.description}
-                        for cmd in caps.slash_commands
-                    ],
-                    "cli_binary": caps.cli_binary,
-                    "target_aliases": list(caps.target_aliases),
-                },
+                "capabilities": caps.model_dump(mode="json"),
             }
         )
     return payload

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -39,6 +39,7 @@ class BackendCapabilities:
     supports_thread_discovery: bool = False
     supports_thread_import: bool = False
     supports_slash_compact: bool = False
+    supports_approval_note: bool = False
     permission_modes: tuple[PermissionModeSpec, ...] = ()
     effort_levels: tuple[str, ...] = ()
     model_source: ModelSource = ModelSource.NONE

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -1,5 +1,6 @@
-from dataclasses import dataclass, field
 from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ModelSource(StrEnum):
@@ -8,22 +9,23 @@ class ModelSource(StrEnum):
     NONE = "none"
 
 
-@dataclass(frozen=True)
-class PermissionModeSpec:
+class _FrozenModel(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+
+class PermissionModeSpec(_FrozenModel):
     id: str
     label: str
     description: str | None = None
     requires_session_restart: bool = False
 
 
-@dataclass(frozen=True)
-class SlashCommandSpec:
+class SlashCommandSpec(_FrozenModel):
     name: str
     description: str | None = None
 
 
-@dataclass(frozen=True)
-class BackendCapabilities:
+class BackendCapabilities(_FrozenModel):
     is_structured: bool
     supports_resume: bool
     supports_terminate: bool = True
@@ -45,7 +47,7 @@ class BackendCapabilities:
     model_source: ModelSource = ModelSource.NONE
     slash_commands: tuple[SlashCommandSpec, ...] = ()
     approval_decisions: tuple[str, ...] = ("approve", "decline")
-    badges: dict[str, str] = field(default_factory=dict)
+    badges: dict[str, str] = Field(default_factory=dict, exclude=True)
     # CLI binary used when this backend is launched in attached-tmux
     # fallback mode. ``None`` means the plugin doesn't ship a CLI
     # entry-point and can't be paired with the tmux transport.
@@ -60,4 +62,4 @@ class BackendCapabilities:
     # opts out via ``is_available_for_managed_launch=False``. Exactly
     # one registered plugin should set this to ``True``; today only
     # the tmux fallback does.
-    is_fallback_for_managed_launch: bool = False
+    is_fallback_for_managed_launch: bool = Field(default=False, exclude=True)

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -715,7 +715,7 @@ class ClaudeCliAdapter:
                 waypoint_session_id,
                 EventKind.SYSTEM_NOTE,
                 "Approval timed out",
-                {"status": SessionStatus.RUNNING},
+                {"status": SessionStatus.RUNNING, "approval_id": tool_use_id},
                 SessionStatus.RUNNING,
             )
         return decision

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -71,7 +71,11 @@ def _auto_approve_for_mode(
             "permissionDecision": "allow",
             "permissionDecisionReason": "auto-approved by mode=acceptEdits",
         }
-    if mode == "plan" and tool_name == "Write" and tool_input is not None:
+    if (
+        mode == "plan"
+        and tool_name in ("Write", "Edit", "MultiEdit")
+        and tool_input is not None
+    ):
         path = str(tool_input.get("file_path") or "")
         if _is_plan_file_path(path):
             return {
@@ -88,6 +92,32 @@ def _auto_approve_for_mode(
 # does — surfacing an approval card for it duplicates the ExitPlanMode card
 # the user already sees. Detect the canonical location (with /private/var
 # realpath quirks on macOS) so we can pass it through silently.
+def _apply_plan_edit(content: str, tool_name: str, tool_input: dict[str, Any]) -> str:
+    """Return `content` with the Edit/MultiEdit patch applied in-memory.
+
+    Used to keep `last_plan_content` current without reading the file from
+    disk — which would fail for remote Claude Code sessions where the plan
+    lives on the SSH target, not the Waypoint host.
+    """
+    if tool_name == "Edit":
+        old = str(tool_input.get("old_string") or "")
+        new = str(tool_input.get("new_string") or "")
+        count = None if bool(tool_input.get("replace_all", False)) else 1
+        return (
+            content.replace(old, new)
+            if count is None
+            else content.replace(old, new, count)
+        )
+    if tool_name == "MultiEdit":
+        for edit in tool_input.get("edits") or []:
+            if not isinstance(edit, dict):
+                continue
+            old = str(edit.get("old_string") or "")
+            new = str(edit.get("new_string") or "")
+            content = content.replace(old, new, 1)
+    return content
+
+
 def _is_plan_file_path(path: str) -> bool:
     if not path:
         return False
@@ -141,6 +171,7 @@ GATED_TOOLS = (
 GATED_TOOLS_REGEX = "^(?:" + "|".join(GATED_TOOLS) + ")$"
 
 DEFAULT_TIMEOUT_SECONDS = 300.0
+HOOK_TIMEOUT_SECONDS = DEFAULT_TIMEOUT_SECONDS + 60
 
 STDERR_TAIL_LINES = 50
 
@@ -639,15 +670,20 @@ class ClaudeCliAdapter:
                 # to Claude in the same shape the binary's TUI uses.
                 if (
                     state.permission_mode == "plan"
-                    and tool_name == "Write"
+                    and tool_name in ("Write", "Edit", "MultiEdit")
                     and tool_input_dict is not None
                 ):
                     path = str(tool_input_dict.get("file_path") or "")
                     if _is_plan_file_path(path):
                         state.last_plan_path = path
-                        content = tool_input_dict.get("content")
-                        if isinstance(content, str):
-                            state.last_plan_content = content
+                        if tool_name == "Write":
+                            content = tool_input_dict.get("content")
+                            if isinstance(content, str):
+                                state.last_plan_content = content
+                        elif isinstance(state.last_plan_content, str):
+                            state.last_plan_content = _apply_plan_edit(
+                                state.last_plan_content, tool_name, tool_input_dict
+                            )
                 return auto
 
             # Inject the saved plan text into ExitPlanMode so the frontend can
@@ -694,7 +730,7 @@ class ClaudeCliAdapter:
                         {
                             "tool_name": payload.get("tool_name"),
                             "tool_input": payload.get("tool_input"),
-                            "tool_use_id": tool_use_id,
+                            "approval_id": tool_use_id,
                             "method": "PreToolUse",
                             "status": SessionStatus.WAITING_INPUT,
                         },
@@ -876,6 +912,7 @@ class ClaudeCliAdapter:
             "WAYPOINT_HOOK_URL": self._hook_url,
             "WAYPOINT_HOOK_SECRET": self._hook_secret,
             "WAYPOINT_SESSION_ID": session_id,
+            "WAYPOINT_HOOK_TIMEOUT": str(int(HOOK_TIMEOUT_SECONDS)),
         }
         return ClaudeLaunchSpec(
             args=args,

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -497,13 +497,23 @@ class ClaudeCliAdapter:
         )
 
     async def respond_to_approval(
-        self, session_id: str, decision: str, text: str | None = None
+        self,
+        session_id: str,
+        decision: str,
+        text: str | None = None,
+        approval_id: str | None = None,
     ) -> bool:
         state = self._sessions.get(session_id)
         if state is None or not state.pending:
             return False
-        # Resolve oldest pending first.
-        tool_use_id, pending = next(iter(state.pending.items()))
+
+        pending: ClaudePendingApproval | None
+        if approval_id and approval_id in state.pending:
+            pending = state.pending[approval_id]
+        else:
+            # Resolve oldest pending first if no ID is specified, or if ID isn't found.
+            approval_id, pending = next(iter(state.pending.items()))
+
         mapped = self._map_decision(decision)
         tool_name = pending.payload.get("tool_name")
         # ExitPlanMode is special: in `-p` mode the binary's tool echoes the
@@ -526,7 +536,7 @@ class ClaudeCliAdapter:
             }
         if not pending.future.done():
             pending.future.set_result(response)
-        state.pending.pop(tool_use_id, None)
+        state.pending.pop(approval_id, None)
         return True
 
     async def _exit_plan_mode_response(

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -64,12 +64,12 @@ def _auto_approve_for_mode(
     if mode in CLAUDE_AUTO_APPROVE_MODES:
         return {
             "permissionDecision": "allow",
-            "permissionDecisionReason": f"auto-approved by Waypoint mode={mode}",
+            "permissionDecisionReason": f"auto-approved by mode={mode}",
         }
     if mode == "acceptEdits" and tool_name in CLAUDE_ACCEPT_EDITS_TOOLS:
         return {
             "permissionDecision": "allow",
-            "permissionDecisionReason": "auto-approved by Waypoint mode=acceptEdits",
+            "permissionDecisionReason": "auto-approved by mode=acceptEdits",
         }
     if mode == "plan" and tool_name == "Write" and tool_input is not None:
         path = str(tool_input.get("file_path") or "")
@@ -77,7 +77,7 @@ def _auto_approve_for_mode(
             return {
                 "permissionDecision": "allow",
                 "permissionDecisionReason": (
-                    "Plan-file write auto-approved by Waypoint plan mode"
+                    "Plan-file write auto-approved by plan mode"
                 ),
             }
     return None
@@ -496,7 +496,9 @@ class ClaudeCliAdapter:
             for entry in state.pending.values()
         )
 
-    async def respond_to_approval(self, session_id: str, decision: str) -> bool:
+    async def respond_to_approval(
+        self, session_id: str, decision: str, text: str | None = None
+    ) -> bool:
         state = self._sessions.get(session_id)
         if state is None or not state.pending:
             return False
@@ -512,16 +514,15 @@ class ClaudeCliAdapter:
         # mirroring what the TUI does after the dialog returns.
         if tool_name == "ExitPlanMode":
             response = await self._exit_plan_mode_response(
-                state, mapped, pending.payload
+                state, mapped, pending.payload, text
             )
         else:
+            reason = "approved by user" if mapped == "allow" else "denied by user"
+            if text:
+                reason = f"{reason}\n\nUser note:\n{text}"
             response = {
                 "permissionDecision": mapped,
-                "permissionDecisionReason": (
-                    "approved by Waypoint user"
-                    if mapped == "allow"
-                    else "denied by Waypoint user"
-                ),
+                "permissionDecisionReason": reason,
             }
         if not pending.future.done():
             pending.future.set_result(response)
@@ -533,6 +534,7 @@ class ClaudeCliAdapter:
         state: ClaudeSessionState,
         mapped: str,
         payload: dict[str, Any],
+        note: str | None = None,
     ) -> dict[str, str]:
         # Phrasing mirrors the Claude binary's own ExitPlanMode tool_result so
         # the model sees the same approval/decline shape it was tuned for —
@@ -567,18 +569,26 @@ class ClaudeCliAdapter:
             if plan.strip():
                 lines.append("## Approved Plan:")
                 lines.append(plan)
+            if note:
+                lines.append("\nUser note:")
+                lines.append(note)
             state.last_plan_path = None
             state.last_plan_content = None
             return {
                 "permissionDecision": "deny",
                 "permissionDecisionReason": "\n".join(lines),
             }
+
+        reason = (
+            "User declined your plan. Revise the plan based on any "
+            "feedback or wait for further direction."
+        )
+        if note:
+            reason = f"{reason}\n\nUser note:\n{note}"
+
         return {
             "permissionDecision": "deny",
-            "permissionDecisionReason": (
-                "User declined your plan. Revise the plan based on any "
-                "feedback or wait for further direction."
-            ),
+            "permissionDecisionReason": reason,
         }
 
     async def await_approval(self, payload: dict[str, Any]) -> dict[str, str]:
@@ -684,7 +694,7 @@ class ClaudeCliAdapter:
         except TimeoutError:
             decision = {
                 "permissionDecision": "deny",
-                "permissionDecisionReason": "Waypoint approval timed out",
+                "permissionDecisionReason": "approval timed out",
             }
             state.pending.pop(tool_use_id, None)
 

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -508,10 +508,12 @@ class ClaudeCliAdapter:
             return False
 
         pending: ClaudePendingApproval | None
-        if approval_id and approval_id in state.pending:
+        if approval_id:
+            if approval_id not in state.pending:
+                return False
             pending = state.pending[approval_id]
         else:
-            # Resolve oldest pending first if no ID is specified, or if ID isn't found.
+            # Resolve oldest pending first if no ID is specified
             approval_id, pending = next(iter(state.pending.items()))
 
         mapped = self._map_decision(decision)

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -183,6 +183,7 @@ class ClaudeSessionState:
     # acceptEdits before opening a plan don't get bumped down to default.
     pre_plan_mode: str | None = None
     last_plan_path: str | None = None
+    last_plan_content: str | None = None
     closing: bool = False
     model: str | None = None
     # Reasoning effort. Claude's CLI accepts `--effort <level>` at launch
@@ -567,6 +568,7 @@ class ClaudeCliAdapter:
                 lines.append("## Approved Plan:")
                 lines.append(plan)
             state.last_plan_path = None
+            state.last_plan_content = None
             return {
                 "permissionDecision": "deny",
                 "permissionDecisionReason": "\n".join(lines),
@@ -621,6 +623,9 @@ class ClaudeCliAdapter:
                     path = str(tool_input_dict.get("file_path") or "")
                     if _is_plan_file_path(path):
                         state.last_plan_path = path
+                        content = tool_input_dict.get("content")
+                        if isinstance(content, str):
+                            state.last_plan_content = content
                 return auto
 
             # Inject the saved plan text into ExitPlanMode so the frontend can
@@ -629,14 +634,19 @@ class ClaudeCliAdapter:
                 if tool_input_dict is None:
                     tool_input_dict = {}
                     payload["tool_input"] = tool_input_dict
-                try:
-                    plan_text = Path(state.last_plan_path).read_text(encoding="utf-8")
-                    tool_input_dict["plan"] = plan_text
-                except Exception as exc:
-                    log.warning(
-                        "failed to read plan file for ExitPlanMode approval card",
-                        extra={"path": state.last_plan_path, "error": str(exc)},
-                    )
+                if state.last_plan_content is not None:
+                    tool_input_dict["plan"] = state.last_plan_content
+                else:
+                    try:
+                        plan_text = Path(state.last_plan_path).read_text(
+                            encoding="utf-8"
+                        )
+                        tool_input_dict["plan"] = plan_text
+                    except Exception as exc:
+                        log.warning(
+                            "failed to read plan file for ExitPlanMode approval card",
+                            extra={"path": state.last_plan_path, "error": str(exc)},
+                        )
 
             if tool_use_id in state.pending:
                 # Hook was retried for the same tool call. Reuse the existing future.

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -622,6 +622,22 @@ class ClaudeCliAdapter:
                     if _is_plan_file_path(path):
                         state.last_plan_path = path
                 return auto
+
+            # Inject the saved plan text into ExitPlanMode so the frontend can
+            # render it inside the approval card.
+            if tool_name == "ExitPlanMode" and state.last_plan_path:
+                if tool_input_dict is None:
+                    tool_input_dict = {}
+                    payload["tool_input"] = tool_input_dict
+                try:
+                    plan_text = Path(state.last_plan_path).read_text(encoding="utf-8")
+                    tool_input_dict["plan"] = plan_text
+                except Exception as exc:
+                    log.warning(
+                        "failed to read plan file for ExitPlanMode approval card",
+                        extra={"path": state.last_plan_path, "error": str(exc)},
+                    )
+
             if tool_use_id in state.pending:
                 # Hook was retried for the same tool call. Reuse the existing future.
                 pending = state.pending[tool_use_id]
@@ -652,16 +668,24 @@ class ClaudeCliAdapter:
                         },
                         SessionStatus.WAITING_INPUT,
                     )
+        timeout = 3600.0 if tool_name == "AskUserQuestion" else DEFAULT_TIMEOUT_SECONDS
         try:
-            decision = await asyncio.wait_for(
-                pending.future, timeout=DEFAULT_TIMEOUT_SECONDS
-            )
+            decision = await asyncio.wait_for(pending.future, timeout=timeout)
         except TimeoutError:
             decision = {
                 "permissionDecision": "deny",
                 "permissionDecisionReason": "Waypoint approval timed out",
             }
             state.pending.pop(tool_use_id, None)
+
+            # Emit a system note so the frontend knows to dequeue the approval card
+            await self._emit_event(
+                waypoint_session_id,
+                EventKind.SYSTEM_NOTE,
+                "Approval timed out",
+                {"status": SessionStatus.RUNNING},
+                SessionStatus.RUNNING,
+            )
         return decision
 
     def has_pending_approval(self, session_id: str) -> bool:

--- a/backend/src/waypoint/backends/claude_code/permission_modes.py
+++ b/backend/src/waypoint/backends/claude_code/permission_modes.py
@@ -18,12 +18,12 @@ CLAUDE_PERMISSION_MODES: tuple[str, ...] = (
 )
 
 CLAUDE_PERMISSION_MODE_SPECS: tuple[PermissionModeSpec, ...] = (
-    PermissionModeSpec("default", "Default"),
-    PermissionModeSpec("plan", "Plan"),
-    PermissionModeSpec("acceptEdits", "Accept edits"),
-    PermissionModeSpec("auto", "Auto"),
-    PermissionModeSpec("bypassPermissions", "Bypass"),
-    PermissionModeSpec("dontAsk", "Don't ask"),
+    PermissionModeSpec(id="default", label="Default"),
+    PermissionModeSpec(id="plan", label="Plan"),
+    PermissionModeSpec(id="acceptEdits", label="Accept edits"),
+    PermissionModeSpec(id="auto", label="Auto"),
+    PermissionModeSpec(id="bypassPermissions", label="Bypass"),
+    PermissionModeSpec(id="dontAsk", label="Don't ask"),
 )
 
 # Modes that bypass Waypoint's PreToolUse approval card entirely.

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -96,6 +96,7 @@ class ClaudeCodePlugin:
         supports_thread_discovery=True,
         supports_thread_import=True,
         supports_slash_compact=False,
+        supports_approval_note=True,
         permission_modes=CLAUDE_PERMISSION_MODE_SPECS,
         effort_levels=CLAUDE_EFFORT_LEVELS,
         model_source=ModelSource.STATIC,

--- a/backend/src/waypoint/backends/claude_code/transport.py
+++ b/backend/src/waypoint/backends/claude_code/transport.py
@@ -56,7 +56,7 @@ class ClaudeTransport(TransportAdapter):
         self, session: SessionRecord, decision: str, text: str | None
     ) -> bool:
         adapter = self._require_adapter()
-        return await adapter.respond_to_approval(session.id, decision)
+        return await adapter.respond_to_approval(session.id, decision, text)
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
         if self.adapter is None:

--- a/backend/src/waypoint/backends/claude_code/transport.py
+++ b/backend/src/waypoint/backends/claude_code/transport.py
@@ -53,10 +53,16 @@ class ClaudeTransport(TransportAdapter):
         await adapter.terminate_session(session.id)
 
     async def respond_to_approval(
-        self, session: SessionRecord, decision: str, text: str | None
+        self,
+        session: SessionRecord,
+        decision: str,
+        text: str | None,
+        approval_id: str | None = None,
     ) -> bool:
         adapter = self._require_adapter()
-        return await adapter.respond_to_approval(session.id, decision, text)
+        return await adapter.respond_to_approval(
+            session.id, decision, text, approval_id
+        )
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
         if self.adapter is None:

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -320,7 +320,9 @@ class CodexAppServerAdapter:
             with suppress(Exception):
                 await asyncio.to_thread(client.close)
 
-    async def respond_to_approval(self, session_id: str, decision: str) -> bool:
+    async def respond_to_approval(
+        self, session_id: str, decision: str, text: str | None = None
+    ) -> bool:
         state = self._require_session(session_id)
         pending = state.pending_approval
         if pending is None:

--- a/backend/src/waypoint/backends/codex/permission_modes.py
+++ b/backend/src/waypoint/backends/codex/permission_modes.py
@@ -28,9 +28,9 @@ CODEX_PERMISSION_PRESETS: dict[str, dict[str, Any]] = {
 }
 
 CODEX_PERMISSION_MODE_SPECS: tuple[PermissionModeSpec, ...] = (
-    PermissionModeSpec("default", "Default"),
-    PermissionModeSpec("auto_review", "Auto review"),
-    PermissionModeSpec("full_access", "Full access"),
+    PermissionModeSpec(id="default", label="Default"),
+    PermissionModeSpec(id="auto_review", label="Auto review"),
+    PermissionModeSpec(id="full_access", label="Full access"),
 )
 
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -97,7 +97,9 @@ class CodexPlugin:
         permission_modes=CODEX_PERMISSION_MODE_SPECS,
         effort_levels=(),  # discovered per-model from `model/list`
         model_source=ModelSource.LIVE_RPC,
-        slash_commands=(SlashCommandSpec("compact", "Compact the current thread"),),
+        slash_commands=(
+            SlashCommandSpec(name="compact", description="Compact the current thread"),
+        ),
         badges={"glyph": "X", "color": "#34d399"},
         cli_binary="codex",
         target_aliases=("codex",),

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -93,6 +93,7 @@ class CodexPlugin:
         supports_thread_discovery=True,
         supports_thread_import=True,
         supports_slash_compact=True,
+        supports_approval_note=False,
         permission_modes=CODEX_PERMISSION_MODE_SPECS,
         effort_levels=(),  # discovered per-model from `model/list`
         model_source=ModelSource.LIVE_RPC,

--- a/backend/src/waypoint/backends/codex/transport.py
+++ b/backend/src/waypoint/backends/codex/transport.py
@@ -60,8 +60,13 @@ class CodexTransport(TransportAdapter):
         await self.adapter.terminate_session(session.id)
 
     async def respond_to_approval(
-        self, session: SessionRecord, decision: str, text: str | None
+        self,
+        session: SessionRecord,
+        decision: str,
+        text: str | None,
+        approval_id: str | None = None,
     ) -> bool:
+        # Note: Codex does not support multiple concurrent approvals so approval_id is ignored
         return await self.adapter.respond_to_approval(session.id, decision, text)
 
     def has_pending_approval(self, session: SessionRecord) -> bool:

--- a/backend/src/waypoint/backends/codex/transport.py
+++ b/backend/src/waypoint/backends/codex/transport.py
@@ -62,7 +62,7 @@ class CodexTransport(TransportAdapter):
     async def respond_to_approval(
         self, session: SessionRecord, decision: str, text: str | None
     ) -> bool:
-        return await self.adapter.respond_to_approval(session.id, decision)
+        return await self.adapter.respond_to_approval(session.id, decision, text)
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
         return self.adapter.has_pending_approval(session.id)

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -800,7 +800,9 @@ class OpenCodeAdapter:
         except Exception:
             pass
 
-    async def respond_to_permission(self, session_id: str, decision: str) -> bool:
+    async def respond_to_permission(
+        self, session_id: str, decision: str, text: str | None = None
+    ) -> bool:
         state = self._sessions.get(session_id)
         if state is None:
             return False
@@ -810,10 +812,10 @@ class OpenCodeAdapter:
         permission_id = state.pending_permission_ids[0]
         client = self._require_client()
         try:
-            await client.post(
-                f"/session/{state.opencode_session_id}/permissions/{permission_id}",
-                json_data={"reply": reply},
-            )
+            payload: dict[str, Any] = {"reply": reply}
+            if text is not None:
+                payload["message"] = text
+            await client.post(f"/permission/{permission_id}/reply", json_data=payload)
         except Exception:
             return False
         state.pending_permission_ids.pop(0)

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -801,7 +801,11 @@ class OpenCodeAdapter:
             pass
 
     async def respond_to_permission(
-        self, session_id: str, decision: str, text: str | None = None
+        self,
+        session_id: str,
+        decision: str,
+        text: str | None = None,
+        approval_id: str | None = None,
     ) -> bool:
         state = self._sessions.get(session_id)
         if state is None:
@@ -809,7 +813,12 @@ class OpenCodeAdapter:
         if not state.pending_permission_ids:
             return False
         reply = self._map_decision_to_reply(decision)
-        permission_id = state.pending_permission_ids[0]
+
+        if approval_id and approval_id in state.pending_permission_ids:
+            permission_id = approval_id
+        else:
+            permission_id = state.pending_permission_ids[0]
+
         client = self._require_client()
         try:
             payload: dict[str, Any] = {"reply": reply}

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -814,7 +814,9 @@ class OpenCodeAdapter:
             return False
         reply = self._map_decision_to_reply(decision)
 
-        if approval_id and approval_id in state.pending_permission_ids:
+        if approval_id:
+            if approval_id not in state.pending_permission_ids:
+                return False
             permission_id = approval_id
         else:
             permission_id = state.pending_permission_ids[0]
@@ -827,7 +829,7 @@ class OpenCodeAdapter:
             await client.post(f"/permission/{permission_id}/reply", json_data=payload)
         except Exception:
             return False
-        state.pending_permission_ids.pop(0)
+        state.pending_permission_ids.remove(permission_id)
         return True
 
     def _map_decision_to_reply(self, decision: str) -> str:

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -791,6 +791,15 @@ class OpenCodePlugin:
         command = rest[0] if rest else ""
 
         if command == "compact":
+            await runtime._record_user_event(
+                session.id, text, submit=getattr(request, "submit", True)
+            )
+            await runtime._record_system_event(
+                session.id,
+                "Compacting session...",
+                status=SessionStatus.RUNNING,
+                metadata={"builtin_command": "/compact"},
+            )
             try:
                 await adapter.compact_session(session.id)
             except OpenCodeError as exc:
@@ -798,11 +807,6 @@ class OpenCodePlugin:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=str(exc),
                 ) from exc
-            await runtime._record_system_event(
-                session.id,
-                "Compacting session...",
-                status=SessionStatus.RUNNING,
-            )
             return runtime.get_session(session.id)
 
         return None

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -122,6 +122,7 @@ class OpenCodePlugin:
         supports_thread_discovery=True,
         supports_thread_import=True,
         supports_slash_compact=True,
+        supports_approval_note=True,
         permission_modes=OPENCODE_PERMISSION_MODES,
         effort_levels=(),
         model_source=ModelSource.LIVE_RPC,

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -64,6 +64,20 @@ OPENCODE_SLASH_COMMANDS = (
     SlashCommandSpec(name="new", description="Start a new session"),
 )
 
+OPENCODE_REASONING_EFFORTS = (
+    "none",
+    "minimal",
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "extra high",
+    "max",
+)
+OPENCODE_REASONING_EFFORT_LEVELS = dict(
+    (level.lower(), i) for i, level in enumerate(OPENCODE_REASONING_EFFORTS)
+)
+
 
 def _normalize_remote_cwd(cwd: str) -> str:
     # Stale session.cwd values can carry an embedded `/~/` (the result of an
@@ -695,10 +709,22 @@ class OpenCodePlugin:
     def _flatten_provider_models(
         self,
         providers: dict[str, Any],
-        *,
         include_hidden: bool,
     ) -> list[dict[str, Any]]:
-        # `/provider` returns every provider in the models.dev manifest, but
+        def _sort_efforts(efforts: list[str]) -> None:
+            def _key(e: str) -> tuple[int, Any]:
+                levels = OPENCODE_REASONING_EFFORT_LEVELS
+                e_lower = e.lower()
+                if e_lower in levels:
+                    return (levels[e_lower], e)
+                base_unknown_level = len(levels)
+                try:
+                    return (base_unknown_level, float(e))
+                except ValueError:
+                    return (base_unknown_level + 1, e_lower)
+
+            efforts.sort(key=_key)
+
         # OpenCode only resolves models from providers it has actually
         # *connected* (env API key, stored auth, or auto-loaded). Listing
         # the rest leads the user into picking a model that the runtime
@@ -736,6 +762,7 @@ class OpenCodePlugin:
                 variants = model.get("variants")
                 if isinstance(variants, dict):
                     supported_efforts = list(variants.keys())
+                    _sort_efforts(supported_efforts)
 
                 flattened.append(
                     {

--- a/backend/src/waypoint/backends/opencode/transport.py
+++ b/backend/src/waypoint/backends/opencode/transport.py
@@ -41,11 +41,14 @@ class OpenCodeTransport(TransportAdapter):
         session: SessionRecord,
         decision: str,
         text: str | None,
+        approval_id: str | None = None,
     ) -> bool:
         adapter = await self._plugin._get_or_create_adapter(
             self._runtime, session.launch_target_id, session.cwd
         )
-        return await adapter.respond_to_permission(session.id, decision, text)
+        return await adapter.respond_to_permission(
+            session.id, decision, text, approval_id
+        )
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
         # Pure introspection — must not provoke an SSH server start on a

--- a/backend/src/waypoint/backends/opencode/transport.py
+++ b/backend/src/waypoint/backends/opencode/transport.py
@@ -45,7 +45,7 @@ class OpenCodeTransport(TransportAdapter):
         adapter = await self._plugin._get_or_create_adapter(
             self._runtime, session.launch_target_id, session.cwd
         )
-        return await adapter.respond_to_permission(session.id, decision)
+        return await adapter.respond_to_permission(session.id, decision, text)
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
         # Pure introspection — must not provoke an SSH server start on a

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -64,7 +64,11 @@ class TmuxTransport(TransportAdapter):
                 await monitor
 
     async def respond_to_approval(
-        self, session: SessionRecord, decision: str, text: str | None
+        self,
+        session: SessionRecord,
+        decision: str,
+        text: str | None,
+        approval_id: str | None = None,
     ) -> bool:
         normalized = decision.strip().lower()
         mapped = "y" if normalized in {"approve", "yes", "y"} else "n"

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -571,6 +571,11 @@ class SessionRuntime:
                 session.id,
                 f"Approval response sent: {request.decision}",
                 status=SessionStatus.RUNNING,
+                metadata=(
+                    {"approval_id": request.approval_id}
+                    if request.approval_id
+                    else None
+                ),
             )
             plugin = self.registry.plugin_for(session)
             await plugin.post_approval(self, session)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -561,16 +561,18 @@ class SessionRuntime:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="no pending approval request",
                 )
-            # Same ordering as handle_input: flip status to RUNNING before
-            # _record_system_event broadcasts the session_state snapshot, so
-            # the spinner doesn't lag until Claude's next emitted chunk.
-            updated = self.storage.update_session(
-                session.id, status=SessionStatus.RUNNING
+            # Stay WAITING_INPUT if more approvals remain so the pager stays
+            # visible; flip to RUNNING only once the queue fully drains.
+            next_status = (
+                SessionStatus.WAITING_INPUT
+                if transport.has_pending_approval(session)
+                else SessionStatus.RUNNING
             )
+            updated = self.storage.update_session(session.id, status=next_status)
             await self._record_system_event(
                 session.id,
                 f"Approval response sent: {request.decision}",
-                status=SessionStatus.RUNNING,
+                status=next_status,
                 metadata=(
                     {"approval_id": request.approval_id}
                     if request.approval_id

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -554,7 +554,7 @@ class SessionRuntime:
         transport = self.transport_for(session)
         if transport.is_structured:
             handled = await transport.respond_to_approval(
-                session, request.decision, request.text
+                session, request.decision, request.text, request.approval_id
             )
             if not handled:
                 raise HTTPException(

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -162,6 +162,7 @@ class SessionInputRequest(BaseModel):
 class SessionApprovalRequest(BaseModel):
     decision: str
     text: str | None = None
+    approval_id: str | None = None
 
 
 class SessionPermissionModeRequest(BaseModel):

--- a/backend/src/waypoint/transports/base.py
+++ b/backend/src/waypoint/transports/base.py
@@ -29,7 +29,11 @@ class TransportAdapter(ABC):
 
     @abstractmethod
     async def respond_to_approval(
-        self, session: SessionRecord, decision: str, text: str | None
+        self,
+        session: SessionRecord,
+        decision: str,
+        text: str | None,
+        approval_id: str | None = None,
     ) -> bool: ...
 
     @abstractmethod

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -351,7 +351,7 @@ async def test_await_approval_auto_allows_in_auto_mode() -> None:
 
     assert decision == {
         "permissionDecision": "allow",
-        "permissionDecisionReason": "auto-approved by Waypoint mode=auto",
+        "permissionDecisionReason": "auto-approved by mode=auto",
     }
     # Auto-approved hooks should never surface an approval card.
     assert not any(item[1] == EventKind.APPROVAL_REQUEST for item in emitted)

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -245,7 +245,9 @@ class _FakeAdapter:
         self.calls.append(("terminate_session", session_id, ()))
         return True
 
-    async def respond_to_permission(self, session_id: str, decision: str) -> bool:
+    async def respond_to_permission(
+        self, session_id: str, decision: str, text: str | None = None
+    ) -> bool:
         self.calls.append(("respond_to_permission", session_id, (decision,)))
         return True
 

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -246,7 +246,11 @@ class _FakeAdapter:
         return True
 
     async def respond_to_permission(
-        self, session_id: str, decision: str, text: str | None = None
+        self,
+        session_id: str,
+        decision: str,
+        text: str | None = None,
+        approval_id: str | None = None,
     ) -> bool:
         self.calls.append(("respond_to_permission", session_id, (decision,)))
         return True

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -53,7 +53,11 @@ class FakeStructuredAdapter:
         return self.pending
 
     async def respond_to_approval(
-        self, session_id: str, decision: str, text: str | None = None
+        self,
+        session_id: str,
+        decision: str,
+        text: str | None = None,
+        approval_id: str | None = None,
     ) -> bool:
         self.approval_calls.append((session_id, decision))
         return True

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1202,6 +1202,77 @@ async def test_approve_syncs_storage_when_adapter_flips_mode(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_approve_keeps_waiting_input_until_queue_drains(tmp_path) -> None:
+    """Multi-approval queue contract: while another approval is still
+    pending the session must stay WAITING_INPUT (so the pager UI keeps
+    rendering) and the system_note must carry the responded approval_id
+    so the frontend can dequeue precisely that card. Status flips to
+    RUNNING only once the queue fully drains.
+    """
+    runtime, storage, settings = make_runtime(tmp_path)
+
+    class QueueFake(FakeClaudeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.pending_ids: list[str] = ["approval-a", "approval-b"]
+            self.responded: list[tuple[str, str | None, str | None]] = []
+
+        def has_pending_approval(self, session_id: str) -> bool:
+            return bool(self.pending_ids)
+
+        async def respond_to_approval(
+            self,
+            session_id: str,
+            decision: str,
+            text: str | None = None,
+            approval_id: str | None = None,
+        ) -> bool:
+            self.responded.append((decision, text, approval_id))
+            target = approval_id or self.pending_ids[0]
+            if target not in self.pending_ids:
+                return False
+            self.pending_ids.remove(target)
+            return True
+
+    fake = QueueFake()
+    _claude_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        id="claude-sess",
+        backend="claude_code",
+        transport="claude_cli",
+        status=SessionStatus.WAITING_INPUT,
+    )
+    storage.create_session(session)
+
+    first = await runtime.approve(
+        "claude-sess",
+        SessionApprovalRequest(decision="accept", approval_id="approval-a"),
+    )
+    assert first.status == SessionStatus.WAITING_INPUT
+
+    second = await runtime.approve(
+        "claude-sess",
+        SessionApprovalRequest(decision="accept", approval_id="approval-b"),
+    )
+    assert second.status == SessionStatus.RUNNING
+
+    notes = [
+        e
+        for e in storage.list_events("claude-sess")
+        if e.kind == EventKind.SYSTEM_NOTE and "Approval response sent" in e.text
+    ]
+    assert [n.metadata.get("approval_id") for n in notes] == [
+        "approval-a",
+        "approval-b",
+    ]
+    assert fake.responded == [
+        ("accept", None, "approval-a"),
+        ("accept", None, "approval-b"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_set_permission_mode_claude_rejects_unknown_mode(tmp_path) -> None:
     from fastapi import HTTPException
 

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -52,7 +52,9 @@ class FakeStructuredAdapter:
     def has_pending_approval(self, session_id: str) -> bool:
         return self.pending
 
-    async def respond_to_approval(self, session_id: str, decision: str) -> bool:
+    async def respond_to_approval(
+        self, session_id: str, decision: str, text: str | None = None
+    ) -> bool:
         self.approval_calls.append((session_id, decision))
         return True
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1249,6 +1249,8 @@ pre {
 }
 
 .transcript {
+  display: flex;
+  flex-direction: column;
   gap: 8px;
   position: relative;
   min-width: 0;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1505,6 +1505,49 @@ details.tool-disclosure[open] .tool-glyph.todo {
   box-shadow: var(--shadow-soft), inset -2px 0 0 rgba(143, 179, 214, 0.32);
 }
 
+.transcript.codex.user_input.pending-optimistic {
+  opacity: 0.5;
+}
+
+.transcript.codex.user_input.pending-optimistic.persisted {
+  opacity: 1;
+}
+
+.transcript.codex.user_input.pending-optimistic.persisted::after {
+  content: "";
+  position: absolute;
+  top: 10px;
+  right: 0;
+  width: 4px;
+  height: calc(100% - 20px);
+  border-radius: 999px 0 0 999px;
+  background: linear-gradient(
+    180deg,
+    rgba(143, 179, 214, 0.15),
+    rgba(143, 179, 214, 0.72),
+    rgba(143, 179, 214, 0.15)
+  );
+  box-shadow: 0 0 0 1px rgba(143, 179, 214, 0.14), 0 0 18px rgba(143, 179, 214, 0.28);
+  animation: transcript-persisted-edge 5s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes transcript-persisted-edge {
+  0%,
+  100% {
+    opacity: 0.28;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .transcript.codex.user_input.pending-optimistic.persisted::after {
+    animation: none;
+  }
+}
+
 .transcript.codex.user_input.ask-answer-summary {
   width: 100%;
   max-width: min(92%, 760px);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1952,6 +1952,49 @@ details.tool-disclosure[open] .tool-glyph.todo {
   overflow-x: auto;
 }
 
+.approval-pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.approval-pager-label {
+  font-size: 0.76rem;
+  font-family: var(--font-mono);
+  color: var(--muted);
+  letter-spacing: 0.06em;
+  min-width: 3.2em;
+  text-align: center;
+}
+
+.approval-pager-btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.approval-pager-btn:hover:not(:disabled) {
+  border-color: var(--line-strong);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.approval-pager-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+
 .transcript pre {
   line-height: 1.55;
   overflow-wrap: anywhere;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -792,9 +792,58 @@ pre {
   text-transform: uppercase;
   font-family: var(--font-mono);
   padding: 6px 12px;
-  border: 1px dashed var(--line-strong);
+  border: 1px dashed;
   border-radius: var(--radius-pill);
   overflow-wrap: anywhere;
+}
+
+.connection-banner.connecting {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
+  background: color-mix(in srgb, var(--warn) 8%, transparent);
+}
+
+.connection-banner.reconnecting {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
+  background: color-mix(in srgb, var(--danger) 8%, transparent);
+}
+
+.error-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 10px 12px 10px 14px;
+  border: 1px solid color-mix(in srgb, var(--danger) 55%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in srgb, var(--danger) 12%, var(--bg-card));
+  color: var(--danger);
+  font-size: 0.9rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.error-banner > span {
+  flex: 1;
+  min-width: 0;
+}
+
+.error-banner-dismiss {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.2rem;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0.8;
+}
+
+.error-banner-dismiss:hover {
+  opacity: 1;
 }
 
 /* ────────────────────────────────────────────────────────────────────────

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -785,30 +785,6 @@ pre {
   opacity: 1;
 }
 
-.connection-banner {
-  text-align: center;
-  font-size: 0.82rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  font-family: var(--font-mono);
-  padding: 6px 12px;
-  border: 1px dashed;
-  border-radius: var(--radius-pill);
-  overflow-wrap: anywhere;
-}
-
-.connection-banner.connecting {
-  color: var(--warn);
-  border-color: color-mix(in srgb, var(--warn) 45%, transparent);
-  background: color-mix(in srgb, var(--warn) 8%, transparent);
-}
-
-.connection-banner.reconnecting {
-  color: var(--danger);
-  border-color: color-mix(in srgb, var(--danger) 45%, transparent);
-  background: color-mix(in srgb, var(--danger) 8%, transparent);
-}
-
 .error-banner {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -639,6 +639,17 @@ export default function HomePage() {
           {host ? <span className="muted">{host}</span> : null}
         </div>
       </header>
+      {token && connection !== "open" && connection !== "idle" ? (
+        <p className={`connection-banner ${connection}`} role="status">
+          {connection === "connecting" ? "Connecting…" : "Reconnecting…"}
+        </p>
+      ) : null}
+      {error ? (
+        <div className="error-banner" role="alert">
+          <span>{error}</span>
+          <button className="error-banner-dismiss" onClick={() => setError("")} aria-label="Dismiss">×</button>
+        </div>
+      ) : null}
       {!token ? <LoginForm defaultHost={host} onSubmit={handleLogin} /> : null}
       {token ? (
         <BackendSwitcher
@@ -686,12 +697,6 @@ export default function HomePage() {
           onClearHistory={handleClearScheduleHistory}
           onAuthFailure={() => resetAuthState("Session expired. Log in again.")}
         />
-      ) : null}
-      {error ? <p className="error">{error}</p> : null}
-      {token && connection !== "open" && connection !== "idle" ? (
-        <p className="connection-banner muted">
-          {connection === "connecting" ? "Connecting…" : "Reconnecting…"}
-        </p>
       ) : null}
       {token ? (
         <SessionList

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -639,11 +639,6 @@ export default function HomePage() {
           {host ? <span className="muted">{host}</span> : null}
         </div>
       </header>
-      {token && connection !== "open" && connection !== "idle" ? (
-        <p className={`connection-banner ${connection}`} role="status">
-          {connection === "connecting" ? "Connecting…" : "Reconnecting…"}
-        </p>
-      ) : null}
       {error ? (
         <div className="error-banner" role="alert">
           <span>{error}</span>

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -79,22 +79,28 @@ export function LaunchPanel({
     setBackend(defaultBackend);
   }, [defaultBackend]);
 
-  // Reset effort whenever the backend changes — supported levels can shift
+  // Reset effort and model whenever the backend changes — supported levels can shift
   // and an "xhigh" carried over from one backend would be invalid on the
-  // next.
+  // next. Also, models are entirely different per backend.
   useEffect(() => {
     setEffort("");
+    setModel("");
     setModelInfo(null);
   }, [backend, launchTargetId]);
 
   const effortOptions = useMemo(() => {
     if (!modelInfo) return [];
-    if (model) {
-      const opt = modelInfo.models.find((entry) => entry.id === model);
-      return opt?.supported_efforts ?? [];
+    
+    const resolvedModelId = model || modelInfo.default_model_id;
+    if (resolvedModelId) {
+      const opt = modelInfo.models.find((entry) => entry.id === resolvedModelId);
+      if (opt) {
+        return opt.supported_efforts ?? [];
+      }
     }
-    // No explicit model picked — show the union of every supported level so
-    // the picker still works against the backend's default model.
+    
+    // No explicit model picked and no default_model_id found — show the union
+    // of every supported level so the picker still works against the backend's default model.
     const union = new Set<string>();
     for (const entry of modelInfo.models) {
       for (const level of entry.supported_efforts ?? []) {

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -75,8 +75,18 @@ export function LaunchPanel({
   const [tmuxTarget, setTmuxTarget] = useState("");
   const [formBusy, setFormBusy] = useState(false);
 
+  const handleBackendChange = useCallback((nextBackend: Backend) => {
+    setBackend(nextBackend);
+    setModel("");
+    setEffort("");
+    setModelInfo(null);
+  }, []);
+
   useEffect(() => {
     setBackend(defaultBackend);
+    setModel("");
+    setEffort("");
+    setModelInfo(null);
   }, [defaultBackend]);
 
   // Reset effort and model whenever the backend changes — supported levels can shift
@@ -162,7 +172,7 @@ export function LaunchPanel({
         </div>
         <label className="field">
           <span>Backend</span>
-          <select value={backend} onChange={(event) => setBackend(event.target.value as Backend)}>
+          <select value={backend} onChange={(event) => handleBackendChange(event.target.value as Backend)}>
             {supportedBackends.map((id) => (
               <option key={id} value={id}>
                 {catalog.byId(id)?.label ?? humaniseBackend(id)}
@@ -181,6 +191,7 @@ export function LaunchPanel({
           <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Optional" />
         </label>
         <ModelPicker
+          key={`${backend}:${launchTargetId ?? "local"}`}
           host={host}
           token={token}
           backend={backend}
@@ -213,7 +224,7 @@ export function LaunchPanel({
         </label>
         <label className="field">
           <span>Backend hint</span>
-          <select value={backend} onChange={(event) => setBackend(event.target.value as Backend)}>
+          <select value={backend} onChange={(event) => handleBackendChange(event.target.value as Backend)}>
             {supportedBackends.map((id) => (
               <option key={id} value={id}>
                 {catalog.byId(id)?.label ?? humaniseBackend(id)}

--- a/frontend/src/components/SchedulePanel.tsx
+++ b/frontend/src/components/SchedulePanel.tsx
@@ -84,15 +84,21 @@ export function SchedulePanel({
   }, [permissionOptions, permissionMode]);
   useEffect(() => {
     setEffort("");
+    setModel("");
     setModelInfo(null);
   }, [backend, launchTargetId]);
 
   const effortOptions = useMemo(() => {
     if (!modelInfo) return [];
-    if (model) {
-      const opt = modelInfo.models.find((entry) => entry.id === model);
-      return opt?.supported_efforts ?? [];
+    
+    const resolvedModelId = model || modelInfo.default_model_id;
+    if (resolvedModelId) {
+      const opt = modelInfo.models.find((entry) => entry.id === resolvedModelId);
+      if (opt) {
+        return opt.supported_efforts ?? [];
+      }
     }
+    
     const union = new Set<string>();
     for (const entry of modelInfo.models) {
       for (const level of entry.supported_efforts ?? []) {

--- a/frontend/src/components/SchedulePanel.tsx
+++ b/frontend/src/components/SchedulePanel.tsx
@@ -244,6 +244,7 @@ export function SchedulePanel({
             </label>
           ) : null}
           <ModelPicker
+            key={`${backend}:${launchTargetId ?? "local"}`}
             host={host}
             token={token}
             backend={backend}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -114,6 +114,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [defaultEffort, setDefaultEffort] = useState<string | null>(null);
   const [modelBusy, setModelBusy] = useState(false);
   const [effortBusy, setEffortBusy] = useState(false);
+  const [approvalPageIndex, setApprovalPageIndex] = useState(0);
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   // Tracks the smallest raw sequence ever received from the server. Distinct
@@ -658,10 +659,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }
 
-  const pendingApproval =
-    session && supportsStructuredApproval(session.transport) && session.status === "waiting_input"
-      ? findPendingApproval(events)
-      : null;
+  const pendingApprovals =
+    session && supportsStructuredApproval(session.transport)
+      ? findPendingApprovals(events)
+      : [];
+  const approvalCount = pendingApprovals.length;
+  const safeApprovalPage = approvalCount > 0 ? Math.min(approvalPageIndex, approvalCount - 1) : 0;
+  const pendingApproval = pendingApprovals[safeApprovalPage] ?? null;
   const agentBusy = session ? isAgentBusy(session, connection) : false;
   const visibleEvents = filterMode === "all" ? renderedEvents : renderedEvents.filter(isImportantEvent);
   const hiddenEventCount = renderedEvents.length - visibleEvents.length;
@@ -836,11 +840,38 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         </section>
       )}
       {pendingApproval ? (
-        <ApprovalCard
-          event={pendingApproval}
-          onDecide={submitApproval}
-          supportsNote={session ? supportsApprovalNote(session.backend, catalog) : false}
-        />
+        <>
+          {approvalCount > 1 ? (
+            <div className="approval-pager">
+              <button
+                type="button"
+                className="approval-pager-btn"
+                onClick={() => setApprovalPageIndex((i) => Math.max(0, i - 1))}
+                disabled={safeApprovalPage === 0}
+                aria-label="Previous approval"
+              >
+                ‹
+              </button>
+              <span className="approval-pager-label">
+                {safeApprovalPage + 1} / {approvalCount}
+              </span>
+              <button
+                type="button"
+                className="approval-pager-btn"
+                onClick={() => setApprovalPageIndex((i) => Math.min(approvalCount - 1, i + 1))}
+                disabled={safeApprovalPage === approvalCount - 1}
+                aria-label="Next approval"
+              >
+                ›
+              </button>
+            </div>
+          ) : null}
+          <ApprovalCard
+            event={pendingApproval}
+            onDecide={submitApproval}
+            supportsNote={session ? supportsApprovalNote(session.backend, catalog) : false}
+          />
+        </>
       ) : null}
       {view === "chat" && showScrollToBottom ? (
         <div className="scroll-latest-floater" aria-hidden={false}>
@@ -1760,14 +1791,10 @@ function isAgentBusy(
   return connection === "open" && session.status === "running";
 }
 
-function findPendingApproval(events: EventRecord[]): EventRecord | null {
+function findPendingApprovals(events: EventRecord[]): EventRecord[] {
   // Track approvals as a queue: every approval_request enqueues, every
-  // "Approval response sent" system note dequeues the oldest. The Claude
-  // adapter resolves pending futures in the same order (`next(iter(state.pending))`),
-  // so the UI must show the same head-of-queue entry. The previous
-  // walk-from-newest-and-bail-on-system-note logic hid the card whenever
-  // Claude fired multiple gated tools in parallel — the user accepted the
-  // first one and the rest stayed silently pending.
+  // "Approval response sent" / "Approval timed out" system note dequeues
+  // its matching entry (by approval_id, falling back to oldest-first).
   const queue: EventRecord[] = [];
   for (const event of events) {
     if (event.kind === "approval_request") {
@@ -1785,7 +1812,7 @@ function findPendingApproval(events: EventRecord[]): EventRecord | null {
       }
     }
   }
-  return queue[0] ?? null;
+  return queue;
 }
 
 function isImportantEvent(event: EventRecord): boolean {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -645,9 +645,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, [handleAuthFailure, host, router, token, sessionId]);
 
-  async function submitApproval(decision: string) {
+  async function submitApproval(decision: string, text?: string) {
     try {
-      await approveSession(host, token, sessionId, decision);
+      await approveSession(host, token, sessionId, decision, text);
     } catch (approvalError) {
       if (isAuthError(approvalError)) {
         handleAuthFailure();
@@ -1789,7 +1789,7 @@ function isImportantEvent(event: EventRecord): boolean {
 
 interface ApprovalCardProps {
   event: EventRecord;
-  onDecide: (decision: string) => void | Promise<void>;
+  onDecide: (decision: string, text?: string) => void | Promise<void>;
 }
 
 interface UsageSummary {
@@ -2025,6 +2025,14 @@ function ApprovalCard({ event, onDecide }: ApprovalCardProps) {
       ? (event.metadata.tool_input as Record<string, unknown>)
       : null;
   const copyText = approvalCopyText(event.text, toolName, toolInput);
+
+  const [noteOpen, setNoteOpen] = useState(false);
+  const [noteText, setNoteText] = useState("");
+
+  const handleDecide = (decision: string) => {
+    void onDecide(decision, noteText.trim() || undefined);
+  };
+
   return (
     <section className="panel approval">
       <div className="session-row">
@@ -2036,17 +2044,45 @@ function ApprovalCard({ event, onDecide }: ApprovalCardProps) {
         toolName={toolName}
         toolInput={toolInput}
       />
+      {noteOpen ? (
+        <div className="ask-question-note" style={{ margin: "0 12px" }}>
+          <textarea
+            className="ask-question-note-input"
+            value={noteText}
+            onChange={(e) => setNoteText(e.target.value)}
+            placeholder="Add a note to your approval or decline…"
+            rows={2}
+          />
+          <button
+            type="button"
+            className="link-button"
+            onClick={() => setNoteOpen(false)}
+          >
+            Hide note
+          </button>
+        </div>
+      ) : (
+        <div style={{ margin: "0 12px" }}>
+          <button
+            type="button"
+            className="link-button ask-question-note-toggle"
+            onClick={() => setNoteOpen(true)}
+          >
+            + Add note
+          </button>
+        </div>
+      )}
       <div className="action-row">
-        <button className="primary" onClick={() => void onDecide("accept")} type="button">
+        <button className="primary" onClick={() => handleDecide("accept")} type="button">
           Approve
         </button>
-        <button className="secondary" onClick={() => void onDecide("acceptForSession")} type="button">
+        <button className="secondary" onClick={() => handleDecide("acceptForSession")} type="button">
           Approve for session
         </button>
-        <button className="secondary" onClick={() => void onDecide("decline")} type="button">
+        <button className="secondary" onClick={() => handleDecide("decline")} type="button">
           Decline
         </button>
-        <button className="secondary" onClick={() => void onDecide("cancel")} type="button">
+        <button className="secondary" onClick={() => handleDecide("cancel")} type="button">
           Cancel
         </button>
       </div>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -44,6 +44,7 @@ import { MarkdownMessage } from "@/components/MarkdownMessage";
 import {
   AskAnswerEntry,
   CopyMessageButton,
+  PendingUserInputCard,
   TranscriptCard,
   ToolPair,
 } from "@/components/TranscriptCard";
@@ -124,6 +125,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   // re-fetch every earlier delta of the same logical message. We compute
   // this from the raw payload before coalescing.
   const [oldestRawSequence, setOldestRawSequence] = useState<number | null>(null);
+  const [optimisticMessages, setOptimisticMessages] = useState<
+    { tempId: string; text: string; ts: string; confirmed: boolean }[]
+  >([]);
   const sectionRef = useRef<HTMLElement | null>(null);
   const nearBottomRef = useRef(true);
   const pendingEventsRef = useRef<EventRecord[]>([]);
@@ -298,6 +302,25 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       return;
     }
     pendingEventsRef.current = [];
+    const confirmedUserTexts = pending
+      .filter((e) => e.kind === "user_input")
+      .map((e) => e.text);
+    if (confirmedUserTexts.length > 0) {
+      setOptimisticMessages((prev) => {
+        let next = prev;
+        for (const text of confirmedUserTexts) {
+          const idx = next.findIndex((m) => !m.confirmed && m.text === text);
+          if (idx !== -1) {
+            next = [
+              ...next.slice(0, idx),
+              { ...next[idx], confirmed: true },
+              ...next.slice(idx + 1),
+            ];
+          }
+        }
+        return next;
+      });
+    }
     startTransition(() => {
       setEvents((current) =>
         pending.reduce<EventRecord[]>((acc, event) => mergeEvents(acc, event), current),
@@ -558,6 +581,20 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, [handleAuthFailure, host, token, sessionId]);
 
+  const onSendWithOptimistic = useCallback(
+    async (text: string) => {
+      const tempId = Math.random().toString(36).slice(2);
+      const ts = new Date().toISOString();
+      setOptimisticMessages((prev) => [...prev, { tempId, text, ts, confirmed: false }]);
+      try {
+        return await submitInput(text);
+      } finally {
+        setOptimisticMessages((prev) => prev.filter((m) => m.tempId !== tempId));
+      }
+    },
+    [submitInput],
+  );
+
   const submitAskAnswer = useCallback(
     async (
       answer: string,
@@ -672,7 +709,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const agentBusy = session ? isAgentBusy(session, connection) : false;
   const visibleEvents = filterMode === "all" ? renderedEvents : renderedEvents.filter(isImportantEvent);
   const hiddenEventCount = renderedEvents.length - visibleEvents.length;
-  const transcriptItems = buildTranscriptItems(visibleEvents);
+  const transcriptEvents =
+    optimisticMessages.length > 0
+      ? filterOptimisticTranscriptEvents(visibleEvents, optimisticMessages)
+      : visibleEvents;
+  const transcriptItems = buildTranscriptItems(transcriptEvents);
   const usageSummary = extractUsageSummary(events);
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
@@ -816,7 +857,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                   />
                 ),
               )
-            : session
+            : session && optimisticMessages.length === 0
               ? (
                 <TranscriptEmpty
                   status={session.status}
@@ -826,6 +867,16 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                 />
               )
               : null}
+          {session
+            ? optimisticMessages.map((msg) => (
+              <PendingUserInputCard
+                  key={msg.tempId}
+                  text={msg.text}
+                  ts={msg.ts}
+                  confirmed={msg.confirmed}
+                />
+              ))
+            : null}
         </section>
       ) : (
         <section className="panel terminal stack">
@@ -946,7 +997,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         onRefresh={refresh}
         onReattach={reattach}
         onResume={resumeSession}
-        onSend={submitInput}
+        onSend={onSendWithOptimistic}
         onTerminate={terminate}
       />
     </section>
@@ -1150,15 +1201,17 @@ const ReplyComposer = memo(function ReplyComposer({
   }
 
   async function handleSend() {
-    if (!draft.trim()) {
+    const text = draft.trim();
+    if (!text) {
       return;
     }
     setSending(true);
+    setDraft("");
+    setSuggestionsDismissed(false);
     try {
-      const sent = await onSend(draft);
-      if (sent) {
-        setDraft("");
-        setSuggestionsDismissed(false);
+      const sent = await onSend(text);
+      if (!sent) {
+        setDraft(text);
       }
     } finally {
       setSending(false);
@@ -1771,6 +1824,33 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     item.pair.sequence = Math.max(item.pair.sequence, event.sequence);
   }
   return result;
+}
+
+function filterOptimisticTranscriptEvents(
+  events: EventRecord[],
+  optimisticMessages: { text: string }[],
+): EventRecord[] {
+  const pendingCounts = new Map<string, number>();
+  for (const message of optimisticMessages) {
+    pendingCounts.set(message.text, (pendingCounts.get(message.text) ?? 0) + 1);
+  }
+  if (pendingCounts.size === 0) {
+    return events;
+  }
+  const filtered: EventRecord[] = [];
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (event.kind === "user_input") {
+      const pendingCount = pendingCounts.get(event.text) ?? 0;
+      if (pendingCount > 0) {
+        pendingCounts.set(event.text, pendingCount - 1);
+        continue;
+      }
+    }
+    filtered.push(event);
+  }
+  filtered.reverse();
+  return filtered;
 }
 
 function isToolResultDelta(event: EventRecord): boolean {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -646,9 +646,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, [handleAuthFailure, host, router, token, sessionId]);
 
-  async function submitApproval(decision: string, text?: string) {
+  async function submitApproval(decision: string, text?: string, approvalId?: string) {
     try {
-      await approveSession(host, token, sessionId, decision, text);
+      await approveSession(host, token, sessionId, decision, text, approvalId);
     } catch (approvalError) {
       if (isAuthError(approvalError)) {
         handleAuthFailure();
@@ -1794,7 +1794,7 @@ function isImportantEvent(event: EventRecord): boolean {
 
 interface ApprovalCardProps {
   event: EventRecord;
-  onDecide: (decision: string, text?: string) => void | Promise<void>;
+  onDecide: (decision: string, text?: string, approvalId?: string) => void | Promise<void>;
   supportsNote?: boolean;
 }
 
@@ -2036,7 +2036,8 @@ function ApprovalCard({ event, onDecide, supportsNote = false }: ApprovalCardPro
   const [noteText, setNoteText] = useState("");
 
   const handleDecide = (decision: string) => {
-    void onDecide(decision, noteText.trim() || undefined);
+    const approvalId = typeof event.metadata?.approval_id === "string" ? event.metadata.approval_id as string : undefined;
+    void onDecide(decision, noteText.trim() || undefined, approvalId);
   };
 
   return (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1765,7 +1765,13 @@ function findPendingApproval(events: EventRecord[]): EventRecord | null {
       event.kind === "system_note" &&
       /(Approval response sent|Approval timed out)/i.test(event.text)
     ) {
-      queue.shift();
+      const approvalId = event.metadata?.approval_id;
+      if (typeof approvalId === "string") {
+        const index = queue.findIndex((e) => e.metadata?.approval_id === approvalId);
+        if (index !== -1) queue.splice(index, 1);
+      } else {
+        queue.shift();
+      }
     }
   }
   return queue[0] ?? null;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1758,7 +1758,7 @@ function findPendingApproval(events: EventRecord[]): EventRecord | null {
       queue.push(event);
     } else if (
       event.kind === "system_note" &&
-      /Approval response sent/i.test(event.text)
+      /(Approval response sent|Approval timed out)/i.test(event.text)
     ) {
       queue.shift();
     }
@@ -1779,7 +1779,7 @@ function isImportantEvent(event: EventRecord): boolean {
       if (typeof event.metadata?.builtin_command === "string") {
         return true;
       }
-      return /(approval response|attached|started|terminated|interrupt|resume|failed|error|exited|compact)/i.test(event.text);
+      return /(approval response|approval timed out|attached|started|terminated|interrupt|resume|failed|error|exited|compact)/i.test(event.text);
     case "raw_terminal_chunk":
       return false;
     default:

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -32,6 +32,7 @@ import {
   fidelityFor,
   humaniseBackend,
   permissionModesFor,
+  supportsApprovalNote,
   supportsResume,
   supportsStructuredApproval,
   transportLabel,
@@ -835,7 +836,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         </section>
       )}
       {pendingApproval ? (
-        <ApprovalCard event={pendingApproval} onDecide={submitApproval} />
+        <ApprovalCard
+          event={pendingApproval}
+          onDecide={submitApproval}
+          supportsNote={session ? supportsApprovalNote(session.backend, catalog) : false}
+        />
       ) : null}
       {view === "chat" && showScrollToBottom ? (
         <div className="scroll-latest-floater" aria-hidden={false}>
@@ -1790,6 +1795,7 @@ function isImportantEvent(event: EventRecord): boolean {
 interface ApprovalCardProps {
   event: EventRecord;
   onDecide: (decision: string, text?: string) => void | Promise<void>;
+  supportsNote?: boolean;
 }
 
 interface UsageSummary {
@@ -2016,7 +2022,7 @@ function UsageCard({ summary }: { summary: UsageSummary }) {
   );
 }
 
-function ApprovalCard({ event, onDecide }: ApprovalCardProps) {
+function ApprovalCard({ event, onDecide, supportsNote = false }: ApprovalCardProps) {
   const toolName = normalizeToolName(
     typeof event.metadata.tool_name === "string" ? event.metadata.tool_name : null
   );
@@ -2044,34 +2050,36 @@ function ApprovalCard({ event, onDecide }: ApprovalCardProps) {
         toolName={toolName}
         toolInput={toolInput}
       />
-      {noteOpen ? (
-        <div className="ask-question-note" style={{ margin: "0 12px" }}>
-          <textarea
-            className="ask-question-note-input"
-            value={noteText}
-            onChange={(e) => setNoteText(e.target.value)}
-            placeholder="Add a note to your approval or decline…"
-            rows={2}
-          />
-          <button
-            type="button"
-            className="link-button"
-            onClick={() => setNoteOpen(false)}
-          >
-            Hide note
-          </button>
-        </div>
-      ) : (
-        <div style={{ margin: "0 12px" }}>
-          <button
-            type="button"
-            className="link-button ask-question-note-toggle"
-            onClick={() => setNoteOpen(true)}
-          >
-            + Add note
-          </button>
-        </div>
-      )}
+      {supportsNote ? (
+        noteOpen ? (
+          <div className="ask-question-note" style={{ margin: "0 12px" }}>
+            <textarea
+              className="ask-question-note-input"
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+              placeholder="Add a note to your approval or decline…"
+              rows={2}
+            />
+            <button
+              type="button"
+              className="link-button"
+              onClick={() => setNoteOpen(false)}
+            >
+              Hide note
+            </button>
+          </div>
+        ) : (
+          <div style={{ margin: "0 12px" }}>
+            <button
+              type="button"
+              className="link-button ask-question-note-toggle"
+              onClick={() => setNoteOpen(true)}
+            >
+              + Add note
+            </button>
+          </div>
+        )
+      ) : null}
       <div className="action-row">
         <button className="primary" onClick={() => handleDecide("accept")} type="button">
           Approve

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1132,6 +1132,17 @@ const ReplyComposer = memo(function ReplyComposer({
     if (event.nativeEvent.isComposing) {
       return;
     }
+    if (event.key === "Tab" && event.shiftKey) {
+      event.preventDefault();
+      if (permissionModeOptions.length > 0 && !modeBusy) {
+        const currentIndex = permissionModeOptions.findIndex(
+          (opt) => opt.id === (permissionMode ?? "")
+        );
+        const nextIndex = (currentIndex + 1) % permissionModeOptions.length;
+        void onModeChange(permissionModeOptions[nextIndex].id);
+      }
+      return;
+    }
     if (suggestionsOpen) {
       if (
         event.key === "Tab" ||

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -110,6 +110,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [showScrollToTop, setShowScrollToTop] = useState(false);
   const [modeBusy, setModeBusy] = useState(false);
   const [modelOptions, setModelOptions] = useState<BackendModelOption[]>([]);
+  const [defaultModelId, setDefaultModelId] = useState<string | null>(null);
   const [defaultModelLabel, setDefaultModelLabel] = useState<string | null>(null);
   const [defaultEffort, setDefaultEffort] = useState<string | null>(null);
   const [modelBusy, setModelBusy] = useState(false);
@@ -208,6 +209,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       .then((response) => {
         if (cancelled) return;
         setModelOptions(response.models);
+        setDefaultModelId(response.default_model_id ?? null);
         setDefaultModelLabel(response.default_model_label ?? null);
         setDefaultEffort(response.default_effort ?? null);
       })
@@ -220,6 +222,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         // Discovery failure is non-fatal: the picker just falls back to
         // showing whatever model the session already has.
         setModelOptions([]);
+        setDefaultModelId(null);
         setDefaultModelLabel(null);
         setDefaultEffort(null);
       });
@@ -915,6 +918,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         modeBusy={modeBusy}
         modelBusy={modelBusy}
         modelOptions={modelOptions}
+        defaultModelId={defaultModelId}
         defaultModelLabel={defaultModelLabel}
         defaultEffort={defaultEffort}
         currentModel={session?.model ?? null}
@@ -963,6 +967,7 @@ interface ReplyComposerProps {
   modeBusy: boolean;
   modelBusy: boolean;
   modelOptions: BackendModelOption[];
+  defaultModelId: string | null;
   defaultModelLabel: string | null;
   defaultEffort: string | null;
   currentModel: string | null;
@@ -1001,6 +1006,7 @@ const ReplyComposer = memo(function ReplyComposer({
   modeBusy,
   modelBusy,
   modelOptions,
+  defaultModelId,
   defaultModelLabel,
   defaultEffort,
   currentModel,
@@ -1232,9 +1238,10 @@ const ReplyComposer = memo(function ReplyComposer({
       : modelOptions;
   // Effort levels gated by the currently-selected model. With no explicit
   // model pick (rare for a live session, but possible), fall back to the
-  // union of every model's supported levels.
-  const matchingModelEntry = currentModel
-    ? modelOptions.find((opt) => opt.id === currentModel)
+  // default model's supported levels.
+  const resolvedModelId = currentModel || defaultModelId;
+  const matchingModelEntry = resolvedModelId
+    ? modelOptions.find((opt) => opt.id === resolvedModelId)
     : undefined;
   const effortOptions: string[] = matchingModelEntry
     ? matchingModelEntry.supported_efforts ?? []

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -793,7 +793,7 @@ function AskUserQuestionCard({
                         [index]: e.target.value,
                       }))
                     }
-                    placeholder="Add a note for this question (optional)…"
+                    placeholder="Type your own answer or add a note here…"
                     rows={2}
                     disabled={submitting}
                   />
@@ -813,7 +813,7 @@ function AskUserQuestionCard({
                   onClick={() => toggleNote(index)}
                   disabled={submitting}
                 >
-                  + Add note
+                  + Other / Custom response
                 </button>
               )
             ) : null}

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -101,6 +101,28 @@ export interface AskAnswerEntry {
   notes?: string;
 }
 
+export function PendingUserInputCard({
+  text,
+  ts,
+  confirmed = false,
+}: {
+  text: string;
+  ts: string;
+  confirmed?: boolean;
+}) {
+  return (
+    <article
+      className={`panel transcript codex user_input${confirmed ? " pending-optimistic persisted" : " pending-optimistic"}`}
+    >
+      <div className="transcript-role">
+        <span className="badge user">you</span>
+        <span className="role-time">{formatTime(ts)}</span>
+      </div>
+      <MarkdownMessage text={text} />
+    </article>
+  );
+}
+
 interface TranscriptCardProps {
   event: EventRecord;
   transport: SessionTransport;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -372,6 +372,7 @@ export async function approveSession(
   sessionId: string,
   decision: string,
   text?: string,
+  approvalId?: string,
 ): Promise<void> {
   const response = await fetch(`${host}/api/sessions/${sessionId}/approve`, {
     method: "POST",
@@ -379,7 +380,7 @@ export async function approveSession(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ decision, text }),
+    body: JSON.stringify({ decision, text, approval_id: approvalId }),
   });
   await ensureOk(response, "failed to send approval");
 }

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -58,6 +58,7 @@ const FALLBACK_STRUCTURED = new Set([
   "opencode_http",
 ]);
 const FALLBACK_RESUMABLE = new Set(["tmux"]);
+const FALLBACK_APPROVAL_NOTE = new Set(["claude_code", "opencode"]);
 
 const FALLBACK_PERMISSION_MODES: Record<string, BackendPermissionMode[]> = {
   claude_code: [
@@ -138,6 +139,14 @@ export function supportsStructuredApproval(
 ): boolean {
   const caps = catalog?.byTransport(transport)?.capabilities;
   return caps ? caps.is_structured : FALLBACK_STRUCTURED.has(transport);
+}
+
+export function supportsApprovalNote(
+  backend: Backend,
+  catalog?: BackendCatalog,
+): boolean {
+  const caps = catalog?.byId(backend)?.capabilities;
+  return caps ? caps.supports_approval_note : FALLBACK_APPROVAL_NOTE.has(backend);
 }
 
 export function permissionModesFor(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -83,6 +83,7 @@ export interface BackendCapabilities {
   supports_thread_discovery: boolean;
   supports_thread_import: boolean;
   supports_slash_compact: boolean;
+  supports_approval_note: boolean;
   model_source: "static" | "live_rpc" | "none";
   approval_decisions: string[];
   effort_levels: string[];


### PR DESCRIPTION
## Summary

Fixes bugs mentioned in [#30](https://github.com/kaiitunnz/waypoint/issues/30) (chat window bugs) and [#29](https://github.com/kaiitunnz/waypoint/issues/29) (timed-out approvals blocking subsequent tool calls). Also adds Shift+Tab hotkey for mode switching ([#27](https://github.com/kaiitunnz/waypoint/issues/27)).

**Two main fixes:**

1.  **Plan viewing**: Inject the saved plan text into `ExitPlanMode` events so the frontend can render the full plan inside the approval card instead of just a link to the file.

2.  **Approval timeouts**: Use a longer timeout (1 hour) for `AskUserQuestion` vs the default 10 minutes, and emit a system note on timeout so the frontend properly dequeues the stuck approval card.

## Changes

### Backend

| File | Description |
|------|-------------|
| `claude_code/adapter.py` | Read plan file and inject `plan` into `tool_input` for `ExitPlanMode`; use 3600s timeout for questions, emit system note on timeout |
| `claude_code/permission_modes.py` | Permission mode updates |
| `claude_code/transport.py` | Transport adjustments |
| `codex/adapter.py`, `codex/permission_modes.py`, `codex/transport.py` | Codex backend updates |
| `opencode/adapter.py`, `opencode/plugin.py`, `opencode/transport.py` | OpenCode backend updates |
| `runtime.py` | Runtime improvements for approval handling; keep status WAITING_INPUT until the approval queue drains, propagate approval_id into system_note metadata |
| `schemas.py` | Schema updates |
| `transports/base.py` | Base transport changes |
| `tests/` | Test updates, incl. multi-approval queue contract test for `runtime.approve` |

### Frontend

| File | Description |
|------|-------------|
| `globals.css` | Make `.transcript` a flex column for proper layout |
| `SessionDetail.tsx` | Match "Approval timed out" when dequeuing approvals, mark as important event |
| `TranscriptCard.tsx` | Improve UX text for custom responses (+ Other / Custom response) |
| `page.tsx` | Homepage UI improvements |
| `LaunchPanel.tsx` | Launch panel updates |
| `SchedulePanel.tsx` | Schedule panel updates |
| `lib/backends.ts` | Backend capability helpers |
| `lib/types.ts` | Type updates |

## Additional Fixes in This PR

- **Approval pagination**: Add pagination for sessions with multiple pending approvals
- **Homepage UI**: Remove connection banner, improve homepage layout
- **Claude Code plan mode**: Fix bugs in CC plan mode
- **Backend capabilities**: Refactor to use `BaseModel` for `BackendCapabilities`
- **Model reset**: Reset models and efforts when changing coding agents
- **Reasoning efforts**: Sort OpenCode's reasoning efforts
- **Session compacting**: Fix session compacting stuck in OpenCode
- **Permission modes**: Allow Shift+Tab to cycle through permission modes
- **Approval ID handling**: Fix unknown approval ID handling, resolve by approval request ID

## Related Issues

### From #4 (Open Bugs)
- **#30** (Bugs in the chat window) — **FIXED** — main focus of this PR
- **#29** (Timed-out approvals stay queued, head-of-line blocks) — **FIXED** — increased AskUserQuestion timeout to 1 hour, added system note on timeout for frontend to properly dequeuer

### From #5 (Feature Requests)
- **#27** (Hotkey for mode switching) — **ADDED** — Shift+Tab to cycle through permission modes
- **#31** (Polish the chat window) — **PARTIALLY ADDRESSED** — homepage UI improvements

## Test Plan

- [x] `cd backend && uv run pytest` — 259 passing
- [x] `cd backend && uv run mypy src tests` — clean
- [x] `cd backend && uv run ruff check src tests` — clean
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npm run lint` — clean
- [x] `cd frontend && npm run build` — clean