### PR TITLE
fix: cross-backend ops + remote-disconnect survival for OpenCode

### DIFF
--- a/backend/scripts/opencode_remote_serve.sh
+++ b/backend/scripts/opencode_remote_serve.sh
@@ -37,12 +37,18 @@ trap '_kill_proc "$PID"; rm -f "$LOG"' EXIT HUP INT TERM
 # plugin that wraps `cd` (e.g. oh-my-bash's auto-ls / goto helpers) can
 # turn `cd ~/foo` into `cd "$BASE/~/foo"` — concatenating the literal
 # tilde with whatever the wrapper considers a base path. Doing the cd
-# in this clean `bash -c` subshell sidesteps those wrappers entirely;
-# we manually resolve a leading `~` to `$HOME` so the user can keep
-# tilde-prefixed default_cwd values.
+# in this clean `bash -c` subshell sidesteps those wrappers entirely.
+#
+# Resolve tildes ourselves: bash only expands a *leading* `~`, so an
+# embedded `/~/` (which can show up in stale session.cwd values that
+# were once concatenated wrong) silently produces a non-existent path.
+# We re-anchor any path containing `/~/` at $HOME using the suffix
+# after the *last* `/~/`. The order of cases matters — `*/~/*` runs
+# before `~/*` so a path like `~/foo/~/bar` collapses cleanly.
 if [ -n "$TARGET_CWD" ]; then
     case "$TARGET_CWD" in
         "~") TARGET_CWD="$HOME" ;;
+        */~/*) TARGET_CWD="$HOME/${TARGET_CWD##*/~/}" ;;
         "~/"*) TARGET_CWD="$HOME/${TARGET_CWD#"~/"}" ;;
     esac
     cd "$TARGET_CWD"

--- a/backend/scripts/opencode_remote_serve.sh
+++ b/backend/scripts/opencode_remote_serve.sh
@@ -19,9 +19,11 @@ _kill_proc() {
     kill -9 "$pid" 2>/dev/null || true
 }
 
-# Invoked via `bash -c SCRIPT BIN`, which assigns BIN to $0 (the script-name
-# slot), not $1. Reading $0 here honors a configured remote_bin path.
+# Invoked via `bash -c SCRIPT BIN [CWD]`, which assigns BIN to $0 (the
+# script-name slot) and CWD to $1. Reading $0 here honors a configured
+# remote_bin path.
 OPENCODE_BIN=${0:-opencode}
+TARGET_CWD=${1:-}
 LOG=$(mktemp)
 PID=""
 
@@ -29,6 +31,22 @@ PID=""
 # `read` returning, or a signal from SSH closing the channel) so we
 # never leave the server orphaned on the remote host.
 trap '_kill_proc "$PID"; rm -f "$LOG"' EXIT HUP INT TERM
+
+# Do our own cd here rather than letting the outer `bash -ilc 'cd ... &&
+# exec'` do it. The outer shell sources the user's rc files, and any
+# plugin that wraps `cd` (e.g. oh-my-bash's auto-ls / goto helpers) can
+# turn `cd ~/foo` into `cd "$BASE/~/foo"` — concatenating the literal
+# tilde with whatever the wrapper considers a base path. Doing the cd
+# in this clean `bash -c` subshell sidesteps those wrappers entirely;
+# we manually resolve a leading `~` to `$HOME` so the user can keep
+# tilde-prefixed default_cwd values.
+if [ -n "$TARGET_CWD" ]; then
+    case "$TARGET_CWD" in
+        "~") TARGET_CWD="$HOME" ;;
+        "~/"*) TARGET_CWD="$HOME/${TARGET_CWD#"~/"}" ;;
+    esac
+    cd "$TARGET_CWD"
+fi
 
 "$OPENCODE_BIN" serve --hostname=127.0.0.1 --port=0 >"$LOG" 2>&1 &
 PID=$!

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -290,6 +290,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session = await context.runtime.resume(session_id)
         return {"session": session.model_dump(mode="json")}
 
+    @app.post("/api/sessions/{session_id}/reattach")
+    async def session_reattach(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        # Distinct from /resume (tmux's "wake up an idle pane"): /reattach
+        # re-establishes a structured backend's connection after EXITED/ERROR
+        # without requiring the user to send a message first.
+        session = await context.runtime.reattach(session_id)
+        return {"session": session.model_dump(mode="json")}
+
     @app.post("/api/sessions/{session_id}/terminate")
     async def session_terminate(
         session_id: str,
@@ -302,8 +313,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def session_delete(
         session_id: str,
         _: Annotated[str, Depends(token_dependency())],
+        force: Annotated[bool, Query()] = False,
     ) -> Any:
-        await context.runtime.delete(session_id)
+        # `force=true` skips terminate failures entirely — last-resort escape
+        # hatch when the adapter is wedged (SSH stuck, etc.) and the
+        # graceful path won't complete.
+        await context.runtime.delete(session_id, force=force)
         return {"deleted": session_id}
 
     @app.post("/api/sessions/{session_id}/mode")

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -140,7 +140,12 @@ class CodexPlugin:
     async def terminate_session(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        await self._require_adapter().terminate_session(session.id)
+        # Soft path: runtime.terminate routes through here, so a session
+        # whose adapter setup never completed (or was torn down during
+        # shutdown) must still be disposable. Mirrors the opencode and
+        # claude_code behaviour.
+        if self.adapter is not None:
+            await self.adapter.terminate_session(session.id)
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -89,6 +89,7 @@ class OpenCodeSessionState:
 
 
 AgentChangedCallback = Callable[[str, str | None, str | None], Any]
+ServerDiedCallback = Callable[[list[str]], Any]
 
 
 class OpenCodeAdapter:
@@ -100,6 +101,7 @@ class OpenCodeAdapter:
         port: int = DEFAULT_PORT,
         launch_target: SshLaunchTargetConfig | None = None,
         on_agent_changed: AgentChangedCallback | None = None,
+        on_server_died: ServerDiedCallback | None = None,
         workdir: str | None = None,
     ) -> None:
         self._emit_event = emit_event
@@ -108,6 +110,7 @@ class OpenCodeAdapter:
         self._port = port
         self._launch_target = launch_target
         self._on_agent_changed = on_agent_changed
+        self._on_server_died_callback = on_server_died
         self._workdir = workdir
         self._sessions: dict[str, OpenCodeSessionState] = {}
         self._remote_sessions: dict[str, str] = {}
@@ -343,6 +346,10 @@ class OpenCodeAdapter:
         active_sessions = [
             state for state in self._sessions.values() if not state.closing
         ]
+        # Snapshot ids before we clear `_sessions` so the plugin's
+        # auto-reconnect loop knows which sessions to restore once the
+        # remote comes back.
+        active_session_ids = [state.session_id for state in active_sessions]
 
         for state in active_sessions:
             try:
@@ -373,6 +380,14 @@ class OpenCodeAdapter:
         self._server_process = None
         self._started = False
         log.info("opencode adapter reset after server death; ready for restart")
+
+        if self._on_server_died_callback is not None:
+            try:
+                result = self._on_server_died_callback(active_session_ids)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception:
+                log.exception("on_server_died callback failed")
 
     async def _listen_events(self) -> None:
         # OpenCode's /event stream does not support resume: events are emitted
@@ -755,8 +770,14 @@ class OpenCodeAdapter:
             payload["agent"] = state.agent
 
         try:
+            # `prompt_async` returns once the server has accepted the work —
+            # results stream back via SSE. The accept itself is cheap, but
+            # mark long_running so a slow-link burst of work tokens past
+            # the control timeout doesn't cause us to spuriously kill it.
             await client.post(
-                f"/session/{state.opencode_session_id}/prompt_async", json_data=payload
+                f"/session/{state.opencode_session_id}/prompt_async",
+                json_data=payload,
+                long_running=True,
             )
         except Exception as exc:
             raise OpenCodeError(f"failed to send message: {exc}") from exc
@@ -871,9 +892,12 @@ class OpenCodeAdapter:
         }
         client = self._require_client()
         try:
+            # Summarization can take minutes on large transcripts; let
+            # SSH/TCP keepalive be the only liveness signal.
             await client.post(
                 f"/session/{state.opencode_session_id}/summarize",
                 json_data=payload,
+                long_running=True,
             )
         except Exception as exc:
             raise OpenCodeError(f"failed to compact session: {exc}") from exc

--- a/backend/src/waypoint/backends/opencode/client.py
+++ b/backend/src/waypoint/backends/opencode/client.py
@@ -8,6 +8,10 @@ from typing import Any, Protocol
 
 import aiohttp
 
+from waypoint.backends.opencode.connection_config import (
+    http_control_timeout,
+    with_ssh_keepalive,
+)
 from waypoint.launch_targets import SshLaunchTargetConfig
 
 log = logging.getLogger("waypoint.opencode.client")
@@ -16,9 +20,21 @@ log = logging.getLogger("waypoint.opencode.client")
 # exceed aiohttp's 64 KiB defaults. 256 KiB matches what OpenCode itself
 # tolerates upstream.
 _SSE_BUFFER_BYTES = 256 * 1024
-_REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=15)
 # SSE is intentionally long-lived; only bound the initial connect.
 _STREAM_TIMEOUT = aiohttp.ClientTimeout(total=None, sock_connect=10, sock_read=None)
+# Long-running HTTP calls (summarize, prompt) are exempt from any
+# application-layer ceiling; the connect handshake still needs a bound so
+# a frozen DNS lookup or syn-loss doesn't wedge forever.
+_LONG_RUNNING_TIMEOUT = aiohttp.ClientTimeout(
+    total=None, sock_connect=10, sock_read=None
+)
+
+
+def _control_timeout() -> aiohttp.ClientTimeout:
+    seconds = http_control_timeout()
+    if seconds <= 0:
+        return aiohttp.ClientTimeout(total=None, sock_connect=10, sock_read=None)
+    return aiohttp.ClientTimeout(total=seconds)
 
 
 class OpenCodeHttpClient(Protocol):
@@ -28,6 +44,7 @@ class OpenCodeHttpClient(Protocol):
         path: str,
         json_data: dict[str, Any] | None = None,
         params: dict[str, str] | None = None,
+        long_running: bool = False,
     ) -> Any: ...
     async def patch(
         self, path: str, json_data: dict[str, Any] | None = None
@@ -47,7 +64,7 @@ class LocalOpenCodeClient:
                 max_line_size=_SSE_BUFFER_BYTES,
                 max_field_size=_SSE_BUFFER_BYTES,
                 read_bufsize=_SSE_BUFFER_BYTES,
-                timeout=_REQUEST_TIMEOUT,
+                timeout=_control_timeout(),
             )
         return self._session
 
@@ -62,10 +79,15 @@ class LocalOpenCodeClient:
         path: str,
         json_data: dict[str, Any] | None = None,
         params: dict[str, str] | None = None,
+        long_running: bool = False,
     ) -> Any:
         client = self._require_session()
+        timeout = _LONG_RUNNING_TIMEOUT if long_running else _control_timeout()
         async with client.post(
-            f"{self.base_url}{path}", json=json_data, params=params
+            f"{self.base_url}{path}",
+            json=json_data,
+            params=params,
+            timeout=timeout,
         ) as resp:
             resp.raise_for_status()
             if resp.status == 204:
@@ -116,12 +138,16 @@ class RemoteOpenCodeClient:
         self._sse_process: asyncio.subprocess.Process | None = None
         self._sse_stderr_task: asyncio.Task[None] | None = None
 
+    def _build_ssh_argv(self, command: list[str]) -> tuple[str, ...]:
+        return with_ssh_keepalive(self.target.build_remote_exec_args(command, self.cwd))
+
     async def _run_curl(
         self,
         method: str,
         path: str,
         json_data: dict[str, Any] | None,
         params: dict[str, str] | None,
+        long_running: bool = False,
     ) -> Any:
         url = f"{self.base_url}{path}"
         if params:
@@ -142,7 +168,7 @@ class RemoteOpenCodeClient:
 
         curl_args.append(url)
 
-        args = self.target.build_remote_exec_args(curl_args, self.cwd)
+        args = self._build_ssh_argv(curl_args)
 
         proc = await asyncio.create_subprocess_exec(
             *args,
@@ -151,7 +177,32 @@ class RemoteOpenCodeClient:
             stderr=asyncio.subprocess.PIPE,
         )
 
-        stdout, stderr = await proc.communicate(input=input_data)
+        # Long-running calls (summarize, etc.) skip the app-layer ceiling
+        # entirely; SSH ServerAlive surfaces a dead link as a clean exit.
+        # Tiny control-plane calls cap at HTTP_CONTROL_TIMEOUT as a
+        # belt-and-suspenders against truly stuck subprocesses.
+        timeout: float | None
+        if long_running:
+            timeout = None
+        else:
+            seconds = http_control_timeout()
+            timeout = float(seconds) if seconds > 0 else None
+
+        try:
+            if timeout is None:
+                stdout, stderr = await proc.communicate(input=input_data)
+            else:
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(input=input_data), timeout=timeout
+                )
+        except TimeoutError:
+            with suppress(ProcessLookupError):
+                proc.kill()
+            with suppress(Exception):
+                await proc.wait()
+            raise RuntimeError(
+                f"curl exceeded control timeout ({timeout}s): {method} {url}"
+            ) from None
 
         if proc.returncode != 0:
             err_lines = [
@@ -186,8 +237,11 @@ class RemoteOpenCodeClient:
         path: str,
         json_data: dict[str, Any] | None = None,
         params: dict[str, str] | None = None,
+        long_running: bool = False,
     ) -> Any:
-        return await self._run_curl("POST", path, json_data, params)
+        return await self._run_curl(
+            "POST", path, json_data, params, long_running=long_running
+        )
 
     async def patch(self, path: str, json_data: dict[str, Any] | None = None) -> Any:
         return await self._run_curl("PATCH", path, json_data, None)
@@ -195,7 +249,7 @@ class RemoteOpenCodeClient:
     async def stream_events(self, path: str) -> AsyncGenerator[str, None]:
         url = f"{self.base_url}{path}"
         curl_args = ["curl", "-s", "-N", url]
-        args = self.target.build_remote_exec_args(curl_args, self.cwd)
+        args = self._build_ssh_argv(curl_args)
 
         # `limit=` raises the StreamReader's per-read cap so a single
         # tool.output frame larger than 64 KiB doesn't bring the SSE

--- a/backend/src/waypoint/backends/opencode/connection_config.py
+++ b/backend/src/waypoint/backends/opencode/connection_config.py
@@ -1,0 +1,88 @@
+"""Connection-lifecycle knobs for the OpenCode backend.
+
+All values come from ``WAYPOINT_OPENCODE_*`` env vars with conservative
+defaults. Each is read on demand so the test suite can override them
+inline. The defaults are tuned around two principles:
+
+1. **No application-layer idle timeout on long-lived streams or
+   long-running operations.** TCP/SSH keepalive is the only liveness
+   signal — a quiet conversation is a feature, not a failure.
+2. **Network death is detected by keepalive probes**, not by silence.
+   ServerAliveInterval=30s + ServerAliveCountMax=6 → ~3 minutes from
+   VPN drop to clean SSH exit; that's the floor.
+
+Set any value to ``0`` to disable that layer. ``HTTP_CONTROL_TIMEOUT``
+applies only to tiny control-plane requests; long-running calls
+(summarize, etc.) are exempt and depend on TCP/SSH keepalive only.
+"""
+
+import os
+
+DEFAULTS: dict[str, int] = {
+    "WAYPOINT_OPENCODE_SSH_CONNECT_TIMEOUT": 15,
+    "WAYPOINT_OPENCODE_SSH_KEEPALIVE_INTERVAL": 30,
+    "WAYPOINT_OPENCODE_SSH_KEEPALIVE_COUNT": 6,
+    "WAYPOINT_OPENCODE_HTTP_CONTROL_TIMEOUT": 60,
+}
+
+
+def _get_int(name: str) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return DEFAULTS[name]
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULTS[name]
+    return max(value, 0)
+
+
+def ssh_connect_timeout() -> int:
+    return _get_int("WAYPOINT_OPENCODE_SSH_CONNECT_TIMEOUT")
+
+
+def ssh_keepalive_interval() -> int:
+    return _get_int("WAYPOINT_OPENCODE_SSH_KEEPALIVE_INTERVAL")
+
+
+def ssh_keepalive_count() -> int:
+    return _get_int("WAYPOINT_OPENCODE_SSH_KEEPALIVE_COUNT")
+
+
+def http_control_timeout() -> int:
+    return _get_int("WAYPOINT_OPENCODE_HTTP_CONTROL_TIMEOUT")
+
+
+def ssh_keepalive_args() -> list[str]:
+    """SSH ``-o`` flags for connect + keepalive timeouts.
+
+    Splice between ``ssh_bin`` and ``ssh_destination`` in the argv so a
+    dropped link surfaces as a clean SSH exit code at the keepalive
+    deadline rather than wedging indefinitely on a half-open TCP socket.
+    """
+    args: list[str] = []
+    connect = ssh_connect_timeout()
+    if connect > 0:
+        args += ["-o", f"ConnectTimeout={connect}"]
+    interval = ssh_keepalive_interval()
+    if interval > 0:
+        args += ["-o", f"ServerAliveInterval={interval}"]
+    count = ssh_keepalive_count()
+    if count > 0:
+        args += ["-o", f"ServerAliveCountMax={count}"]
+    return args
+
+
+def with_ssh_keepalive(args: tuple[str, ...]) -> tuple[str, ...]:
+    """Inject SSH keepalive ``-o`` flags into an ssh argv tuple.
+
+    ``args`` is the output of ``SshLaunchTargetConfig.build_remote_exec_args``
+    where the first element is the ssh binary and the destination/command
+    follow. The keepalive flags are inserted right after the binary so
+    they take precedence over any user-configured ``-o`` in
+    ``ssh_args``.
+    """
+    extra = ssh_keepalive_args()
+    if not extra or not args:
+        return args
+    return (args[0], *extra, *args[1:])

--- a/backend/src/waypoint/backends/opencode/health.py
+++ b/backend/src/waypoint/backends/opencode/health.py
@@ -1,0 +1,67 @@
+"""Per-adapter health state with cooldown and circuit-breaker.
+
+Each ``(launch_target_id, cwd)`` adapter slot has one ``AdapterHealth``
+instance. After a server death, a brief cooldown stops a thundering
+herd of reattach attempts from hammering SSH; after K consecutive
+launch failures the slot is quarantined so subsequent calls fail fast
+with a clear message instead of every request paying the full SSH
+launch timeout.
+
+User-initiated retries (the explicit /reattach button) bypass both
+gates so the user can always force an immediate attempt.
+"""
+
+import time
+from dataclasses import dataclass
+
+# How long after a `_on_server_died` to reject non-user `start()` calls.
+# Just enough to swallow the burst of reattach attempts that happen when
+# multiple sessions on the same dead host all notice at once.
+DEATH_COOLDOWN_SECONDS = 5.0
+
+# Failures in a row before quarantining the slot. Tuned conservatively
+# so a single transient flake during initial setup doesn't trip it.
+QUARANTINE_AFTER_FAILURES = 3
+
+# How long the slot stays quarantined. The Phase-6 reconnect loop and
+# the user-initiated /reattach both bypass this, so the wait only
+# affects passive callers (incoming HTTP requests).
+QUARANTINE_SECONDS = 60.0
+
+
+@dataclass
+class AdapterHealth:
+    last_death_at: float = 0.0
+    consecutive_failures: int = 0
+    quarantined_until: float = 0.0
+
+    def can_attempt(self, *, user_initiated: bool = False) -> tuple[bool, str | None]:
+        """Return ``(allowed, reason_when_blocked)``.
+
+        ``reason_when_blocked`` is a short message suitable for surfacing
+        to the API; ``None`` when allowed.
+        """
+        if user_initiated:
+            return True, None
+        now = time.monotonic()
+        if self.quarantined_until > now:
+            remaining = int(self.quarantined_until - now)
+            return False, (
+                f"opencode launch target unavailable (retry in ~{remaining}s)"
+            )
+        if self.last_death_at and now - self.last_death_at < DEATH_COOLDOWN_SECONDS:
+            return False, "opencode connection just died; cooling down briefly"
+        return True, None
+
+    def record_death(self) -> None:
+        self.last_death_at = time.monotonic()
+
+    def record_failure(self) -> None:
+        self.consecutive_failures += 1
+        if self.consecutive_failures >= QUARANTINE_AFTER_FAILURES:
+            self.quarantined_until = time.monotonic() + QUARANTINE_SECONDS
+
+    def record_success(self) -> None:
+        self.consecutive_failures = 0
+        self.quarantined_until = 0.0
+        self.last_death_at = 0.0

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -354,11 +354,16 @@ class OpenCodePlugin:
             if not targets:
                 return
             try:
-                # User-initiated path bypasses cooldown via the dedicated
-                # entry point; the loop itself respects health to avoid
-                # hammering an unhealthy host.
+                # The loop is the dedicated retry mechanism — its own
+                # backoff schedule already paces attempts, so it must
+                # bypass the cooldown/quarantine gate. Without this,
+                # `record_death()` having just fired means the very
+                # first iteration is gated as a "failure", inflating
+                # `consecutive_failures` toward quarantine without ever
+                # really touching SSH. The gate exists to fail-fast
+                # passive HTTP callers, not the loop.
                 adapter = await self._get_or_create_adapter(
-                    runtime, key[0], key[1] or None
+                    runtime, key[0], key[1] or None, user_initiated=True
                 )
                 await adapter.start()
                 health = self._health_for(key)

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -15,6 +15,7 @@ from waypoint.backends.capabilities import (
     SlashCommandSpec,
 )
 from waypoint.backends.opencode.adapter import OpenCodeAdapter, OpenCodeError
+from waypoint.backends.opencode.health import AdapterHealth
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -119,6 +120,15 @@ class OpenCodePlugin:
 
     def __init__(self) -> None:
         self._adapters: dict[tuple[str | None, str], OpenCodeAdapter] = {}
+        # Per-adapter health (cooldown after death + circuit breaker after
+        # repeated launch failures). Keyed identically to ``_adapters`` so
+        # one entry survives adapter object replacement.
+        self._health: dict[tuple[str | None, str], AdapterHealth] = {}
+        # Reconnect tasks keyed on adapter key so a single launch_target
+        # never has more than one reconnect loop running concurrently.
+        self._reconnect_tasks: dict[tuple[str | None, str], asyncio.Task[None]] = {}
+        # Sessions tracked by the reconnect loop per adapter key.
+        self._reconnect_targets: dict[tuple[str | None, str], set[str]] = {}
         self._lock = asyncio.Lock()
         self._pending_tasks: set[asyncio.Task[Any]] = set()
         self._shutting_down = False
@@ -237,16 +247,31 @@ class OpenCodePlugin:
                     )
                 )
 
+    def _health_for(self, key: tuple[str | None, str]) -> AdapterHealth:
+        if key not in self._health:
+            self._health[key] = AdapterHealth()
+        return self._health[key]
+
     async def _get_or_create_adapter(
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None,
         cwd: str | None,
+        *,
+        user_initiated: bool = False,
     ) -> OpenCodeAdapter:
         async with self._lock:
             key = self._adapter_key(runtime, launch_target_id, cwd)
             if key in self._adapters:
                 return self._adapters[key]
+
+            health = self._health_for(key)
+            allowed, reason = health.can_attempt(user_initiated=user_initiated)
+            if not allowed:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=reason or "opencode adapter temporarily unavailable",
+                )
 
             launch_target = None
             if launch_target_id is not None:
@@ -266,14 +291,145 @@ class OpenCodePlugin:
                 self._pending_tasks.add(task)
                 task.add_done_callback(self._pending_tasks.discard)
 
+            def _on_server_died(active_session_ids: list[str]) -> None:
+                self._handle_server_died(runtime, key, active_session_ids)
+
             adapter = OpenCodeAdapter(
                 emit_event=runtime._emit_adapter_event,
                 launch_target=launch_target,
                 on_agent_changed=_on_agent_changed,
+                on_server_died=_on_server_died,
                 workdir=key[1],
             )
             self._adapters[key] = adapter
             return adapter
+
+    def _handle_server_died(
+        self,
+        runtime: "SessionRuntime",
+        key: tuple[str | None, str],
+        active_session_ids: list[str],
+    ) -> None:
+        # Synchronous bridge from the adapter's `_on_server_died` into the
+        # plugin's health + reconnect machinery. Keep this fast: it runs
+        # inside the adapter's teardown path.
+        if self._shutting_down:
+            return
+        self._health_for(key).record_death()
+        targets = self._reconnect_targets.setdefault(key, set())
+        targets.update(active_session_ids)
+        self._ensure_reconnect_task(runtime, key)
+
+    def _ensure_reconnect_task(
+        self,
+        runtime: "SessionRuntime",
+        key: tuple[str | None, str],
+    ) -> None:
+        existing = self._reconnect_tasks.get(key)
+        if existing is not None and not existing.done():
+            return
+        task = asyncio.create_task(
+            self._reconnect_loop(runtime, key),
+            name=f"opencode-reconnect-{key}",
+        )
+        self._reconnect_tasks[key] = task
+        self._pending_tasks.add(task)
+        task.add_done_callback(self._pending_tasks.discard)
+        task.add_done_callback(lambda _t: self._reconnect_tasks.pop(key, None))
+
+    async def _reconnect_loop(
+        self,
+        runtime: "SessionRuntime",
+        key: tuple[str | None, str],
+    ) -> None:
+        # Capped exponential backoff that loops forever until either every
+        # tracked session is gone (user deleted them) or the plugin is
+        # shutting down. The cap is intentionally low (5 minutes) so a
+        # VPN coming back hours later still recovers within five minutes
+        # of the link healing.
+        backoff_schedule = [5, 10, 30, 60, 120, 300]
+        attempt = 0
+        while not self._shutting_down:
+            targets = self._reconnect_targets.get(key, set())
+            if not targets:
+                return
+            try:
+                # User-initiated path bypasses cooldown via the dedicated
+                # entry point; the loop itself respects health to avoid
+                # hammering an unhealthy host.
+                adapter = await self._get_or_create_adapter(
+                    runtime, key[0], key[1] or None
+                )
+                await adapter.start()
+                health = self._health_for(key)
+                health.record_success()
+            except Exception as exc:
+                self._health_for(key).record_failure()
+                wait = backoff_schedule[min(attempt, len(backoff_schedule) - 1)]
+                attempt += 1
+                log.warning(
+                    "opencode reconnect for %s failed (%s); retrying in %ds",
+                    key,
+                    exc,
+                    wait,
+                )
+                try:
+                    await asyncio.sleep(wait)
+                except asyncio.CancelledError:
+                    raise
+                continue
+
+            attempt = 0
+            await self._restore_after_reconnect(runtime, key)
+
+            # Successful pass: drain tracked targets and exit. If new
+            # deaths happen, `_handle_server_died` re-arms a fresh loop.
+            self._reconnect_targets.pop(key, None)
+            return
+
+    async def _restore_after_reconnect(
+        self,
+        runtime: "SessionRuntime",
+        key: tuple[str | None, str],
+    ) -> None:
+        targets = list(self._reconnect_targets.get(key, set()))
+        for session_id in targets:
+            session = runtime.storage.get_session(session_id)
+            if session is None:
+                self._reconnect_targets.get(key, set()).discard(session_id)
+                continue
+            adapter = self._adapters.get(key)
+            if adapter is None:
+                # Slot was wiped between loop start and here; bail and let
+                # the next death event re-arm the loop.
+                return
+            opencode_session_id = session.transport_state.get("opencode_session_id")
+            if not opencode_session_id:
+                self._reconnect_targets.get(key, set()).discard(session_id)
+                continue
+            try:
+                await adapter.restore_session(
+                    session.id,
+                    session.cwd,
+                    opencode_session_id,
+                    model=session.model,
+                    agent=session.transport_state.get("agent"),
+                    effort=session.effort,
+                )
+            except Exception as exc:
+                log.warning(
+                    "opencode resurrect of %s failed after reconnect: %s",
+                    session.id,
+                    exc,
+                )
+                # Leave session ERROR; user can retry via /reattach.
+                continue
+            runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+            await runtime._record_system_event(
+                session.id,
+                "OpenCode connection restored",
+                status=SessionStatus.IDLE,
+            )
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
         from waypoint.backends.opencode.transport import OpenCodeTransport
@@ -306,11 +462,35 @@ class OpenCodePlugin:
     async def terminate_session(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        adapter = self._adapters.get(
-            self._adapter_key(runtime, session.launch_target_id, session.cwd)
-        )
+        key = self._adapter_key(runtime, session.launch_target_id, session.cwd)
+        # Drop this session from any in-flight reconnect-loop target set so
+        # an explicit terminate can't be silently undone by a later loop
+        # tick resurrecting it.
+        targets = self._reconnect_targets.get(key)
+        if targets is not None:
+            targets.discard(session.id)
+            if not targets:
+                self._reconnect_targets.pop(key, None)
+        adapter = self._adapters.get(key)
         if adapter is not None:
             await adapter.terminate_session(session.id)
+
+    def clear_health_for_user_retry(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        # Hook surfaced via getattr from `runtime._reattach_session`. Clears
+        # the cooldown / circuit breaker so the user-initiated reattach
+        # bypasses backoff that the auto-reconnect loop is already
+        # observing. Also re-arms a fresh reconnect attempt: cancel any
+        # active loop so the next `_get_or_create_adapter` call drives
+        # the SSH spinup synchronously instead of racing the loop.
+        key = self._adapter_key(runtime, session.launch_target_id, session.cwd)
+        health = self._health.get(key)
+        if health is not None:
+            health.record_success()
+        existing = self._reconnect_tasks.get(key)
+        if existing is not None and not existing.done():
+            existing.cancel()
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
@@ -655,11 +835,13 @@ class OpenCodePlugin:
     async def restore_session(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
+        key = self._adapter_key(runtime, session.launch_target_id, session.cwd)
         try:
             adapter = await self._get_or_create_adapter(
                 runtime, session.launch_target_id, session.cwd
             )
         except Exception as exc:
+            self._health_for(key).record_failure()
             runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
             await runtime._record_system_event(
                 session.id,
@@ -689,6 +871,7 @@ class OpenCodePlugin:
             if pre_plan_mode is not None:
                 await adapter.set_pre_plan_mode(session.id, pre_plan_mode)
         except Exception as exc:
+            self._health_for(key).record_failure()
             log.exception("opencode restore failed", extra={"session_id": session.id})
             runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
             await runtime._record_system_event(
@@ -697,6 +880,7 @@ class OpenCodePlugin:
                 status=SessionStatus.ERROR,
             )
             return
+        self._health_for(key).record_success()
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
         await runtime._record_system_event(
             session.id,

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -65,6 +65,19 @@ OPENCODE_SLASH_COMMANDS = (
 )
 
 
+def _normalize_remote_cwd(cwd: str) -> str:
+    # Stale session.cwd values can carry an embedded `/~/` (the result of an
+    # earlier path-concat bug). Bash on the remote only expands a *leading*
+    # tilde, so the embedded one becomes a literal directory component and
+    # every `cd` against the path fails. Re-anchor at the suffix following
+    # the last `/~/` and prepend `~/` so the leading tilde does the right
+    # thing on the remote shell.
+    if "/~/" in cwd:
+        suffix = cwd.rsplit("/~/", 1)[1]
+        return f"~/{suffix}"
+    return cwd
+
+
 def _ruleset_for_mode(mode: str | None) -> list[dict[str, str]] | None:
     # The runtime substitutes "default" when no mode is selected; that means
     # "let OpenCode decide" — don't send a permission key at all.
@@ -151,6 +164,8 @@ class OpenCodePlugin:
         chosen = cwd or self._default_cwd(runtime, launch_target_id)
         if launch_target_id is None:
             chosen = str(Path(chosen).expanduser())
+        else:
+            chosen = _normalize_remote_cwd(chosen)
         return os.path.normpath(chosen)
 
     def _adapter_key(

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -911,7 +911,17 @@ class OpenCodePlugin:
         result = []
         seen: set[str] = set()
         for adapter in adapters:
-            sessions = await adapter.list_sessions()
+            # One bad adapter (e.g. an ERROR session restored at boot whose
+            # persisted cwd no longer resolves) must not take down thread
+            # discovery for the rest. Skip and log.
+            try:
+                sessions = await adapter.list_sessions()
+            except Exception:
+                log.exception(
+                    "opencode list_sessions failed for adapter; skipping",
+                    extra={"workdir": adapter._workdir},
+                )
+                continue
             for sess in sessions:
                 sess_id = sess.get("id")
                 if not sess_id or sess_id in seen:

--- a/backend/src/waypoint/backends/opencode/remote.py
+++ b/backend/src/waypoint/backends/opencode/remote.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from waypoint.backends.opencode.connection_config import with_ssh_keepalive
 from waypoint.launch_targets import SshLaunchTargetConfig
 
 _REMOTE_SERVE_SCRIPT_PATH = (
@@ -15,4 +16,4 @@ def build_remote_serve_args(
     cwd: str | None = None,
 ) -> tuple[str, ...]:
     cmd = ["bash", "-c", REMOTE_SERVE_SCRIPT, opencode_bin]
-    return target.build_remote_exec_args(cmd, cwd)
+    return with_ssh_keepalive(target.build_remote_exec_args(cmd, cwd))

--- a/backend/src/waypoint/backends/opencode/remote.py
+++ b/backend/src/waypoint/backends/opencode/remote.py
@@ -15,5 +15,9 @@ def build_remote_serve_args(
     opencode_bin: str,
     cwd: str | None = None,
 ) -> tuple[str, ...]:
-    cmd = ["bash", "-c", REMOTE_SERVE_SCRIPT, opencode_bin]
-    return with_ssh_keepalive(target.build_remote_exec_args(cmd, cwd))
+    # Pass cwd as a positional arg to the inner `bash -c SCRIPT BIN CWD` so
+    # the cd happens inside the clean (rcfile-free) subshell. Doing the cd
+    # in the outer `bash -ilc` is fragile when user rcfiles wrap `cd`
+    # (oh-my-bash plugins do) — see the comment in opencode_remote_serve.sh.
+    cmd = ["bash", "-c", REMOTE_SERVE_SCRIPT, opencode_bin, cwd or ""]
+    return with_ssh_keepalive(target.build_remote_exec_args(cmd, None))

--- a/backend/src/waypoint/backends/opencode/transport.py
+++ b/backend/src/waypoint/backends/opencode/transport.py
@@ -17,22 +17,24 @@ class OpenCodeTransport(TransportAdapter):
         self._plugin = plugin
 
     async def send_input(self, session: SessionRecord, text: str) -> None:
-        adapter = self._plugin._require_adapter(
+        adapter = await self._plugin._get_or_create_adapter(
             self._runtime, session.launch_target_id, session.cwd
         )
         await adapter.send_input(session.id, text)
 
     async def interrupt(self, session: SessionRecord) -> None:
-        adapter = self._plugin._require_adapter(
+        adapter = await self._plugin._get_or_create_adapter(
             self._runtime, session.launch_target_id, session.cwd
         )
         await adapter.interrupt(session.id)
 
     async def terminate(self, session: SessionRecord) -> None:
-        adapter = self._plugin._require_adapter(
-            self._runtime, session.launch_target_id, session.cwd
-        )
-        await adapter.terminate_session(session.id)
+        # Soft path: runtime.terminate dispatches via plugin.terminate_session
+        # so this method is effectively unreachable from the API. Keep it
+        # tolerant of a missing adapter for any direct callers (tests,
+        # internal cleanup) so a stale opencode session can always be
+        # disposed of without first spinning up an SSH server.
+        await self._plugin.terminate_session(self._runtime, session)
 
     async def respond_to_approval(
         self,
@@ -40,19 +42,30 @@ class OpenCodeTransport(TransportAdapter):
         decision: str,
         text: str | None,
     ) -> bool:
-        adapter = self._plugin._require_adapter(
+        adapter = await self._plugin._get_or_create_adapter(
             self._runtime, session.launch_target_id, session.cwd
         )
         return await adapter.respond_to_permission(session.id, decision)
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
-        adapter = self._plugin._require_adapter(
-            self._runtime, session.launch_target_id, session.cwd
+        # Pure introspection — must not provoke an SSH server start on a
+        # session whose adapter happens to be missing (e.g. cross-backend
+        # poll). Treat "no adapter" as "no pending approval".
+        adapter = self._plugin._adapters.get(
+            self._plugin._adapter_key(
+                self._runtime, session.launch_target_id, session.cwd
+            )
         )
+        if adapter is None:
+            return False
         return adapter.has_pending_approval(session.id)
 
     def terminal_snapshot(self, session: SessionRecord) -> str:
-        adapter = self._plugin._require_adapter(
-            self._runtime, session.launch_target_id, session.cwd
+        adapter = self._plugin._adapters.get(
+            self._plugin._adapter_key(
+                self._runtime, session.launch_target_id, session.cwd
+            )
         )
+        if adapter is None:
+            return ""
         return adapter.terminal_snapshot(session.id)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -111,7 +111,12 @@ class SessionRuntime:
 
     async def start(self) -> None:
         for session in self.storage.list_sessions():
-            if session.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
+            # ERROR sessions get one passive restore attempt at boot — the
+            # plugin's restore_session is responsible for tagging them
+            # back to ERROR if reattach fails, which the auto-reconnect
+            # loop (or the user's /reattach button) can then retry.
+            # EXITED stays skipped: that's a terminal user choice.
+            if session.status == SessionStatus.EXITED:
                 continue
             plugin = self.registry.plugin_for(session)
             task = asyncio.create_task(
@@ -321,11 +326,26 @@ class SessionRuntime:
         session = self.get_session(session_id)
         if session.status == SessionStatus.EXITED:
             return session
-        await self.transport_for(session).terminate(session)
+        # Route through the plugin (not the transport) so a session whose
+        # adapter slot was never warmed in this process — e.g. an opencode
+        # session terminated while the user's active backend is codex —
+        # cleans up gracefully instead of 503'ing on `_require_adapter`.
+        # Plugin hooks already do soft `.get()` lookups and no-op when the
+        # adapter is missing.
+        plugin = self.registry.plugin_for(session)
+        await plugin.terminate_session(self, session)
         await self._record_system_event(
             session.id, "Session terminated", status=SessionStatus.EXITED
         )
         return self.storage.update_session(session.id, status=SessionStatus.EXITED)
+
+    async def reattach(self, session_id: str) -> SessionRecord:
+        # Explicit "reconnect this session" without sending a message.
+        # Promotes the existing _reattach_session helper to a first-class
+        # operation so the frontend can offer a button instead of forcing
+        # users to type into a session they want to revive.
+        session = self.get_session(session_id)
+        return await self._reattach_session(session)
 
     async def _reattach_session(self, session: SessionRecord) -> SessionRecord:
         # ERROR sessions reach this path while the prior adapter state may
@@ -342,6 +362,12 @@ class SessionRuntime:
                 detail="this session cannot be reattached after exit",
             )
         await plugin.terminate_session(self, session)
+        # User-initiated retry: bypass any per-target cooldown / circuit
+        # breaker so the click takes effect immediately. Plugins without
+        # this opt-in hook ignore the call.
+        clear_cooldown = getattr(plugin, "clear_health_for_user_retry", None)
+        if clear_cooldown is not None:
+            clear_cooldown(self, session)
         await plugin.restore_session(self, session)
         # _restore_*_session swallows failures (it tags the session ERROR or
         # EXITED and emits a system_note instead of raising). Re-read storage
@@ -356,10 +382,18 @@ class SessionRuntime:
             )
         return refreshed
 
-    async def delete(self, session_id: str) -> None:
+    async def delete(self, session_id: str, *, force: bool = False) -> None:
         session = self.get_session(session_id)
         if session.status != SessionStatus.EXITED:
-            await self.terminate(session_id)
+            if force:
+                # Last-resort path for sessions whose adapter is wedged
+                # (e.g. SSH stuck and the plugin's terminate path can't
+                # complete). Best-effort terminate, then drop the row no
+                # matter what.
+                with suppress(Exception):
+                    await self.terminate(session_id)
+            else:
+                await self.terminate(session_id)
         self.storage.delete_session(session_id)
         self.registry.plugin_for(session).on_session_deleted(self, session)
         await self.broadcast.publish(

--- a/backend/tests/test_opencode_adapter.py
+++ b/backend/tests/test_opencode_adapter.py
@@ -51,9 +51,10 @@ async def test_compact_session_refetches_model_when_unpinned() -> None:
             assert path == "/session/ses_1"
             return {"model": "opencode/auto-default"}
 
-        async def post(self, path, json_data=None, params=None):
+        async def post(self, path, json_data=None, params=None, long_running=False):
             posted["path"] = path
             posted["json_data"] = json_data
+            posted["long_running"] = long_running
             return {}
 
     adapter._client = _FakeClient()  # type: ignore[assignment]

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -326,6 +326,7 @@ async def test_get_or_create_adapter_keys_by_cwd(
             emit_event,
             launch_target=None,
             on_agent_changed=None,
+            on_server_died=None,
             workdir=None,
         ) -> None:
             self.workdir = workdir
@@ -369,6 +370,7 @@ async def test_get_or_create_adapter_normalizes_equivalent_cwds(
             emit_event,
             launch_target=None,
             on_agent_changed=None,
+            on_server_died=None,
             workdir=None,
         ) -> None:
             self.workdir = workdir
@@ -604,7 +606,9 @@ async def test_import_thread_preserves_launch_target_id() -> None:
 
     fake_adapter = FakeAdapter()
 
-    async def fake_get_or_create_adapter(runtime, launch_target_id, cwd):
+    async def fake_get_or_create_adapter(
+        runtime, launch_target_id, cwd, *, user_initiated=False
+    ):
         assert launch_target_id == "ssh-1"
         assert cwd == "/repo"
         return fake_adapter
@@ -689,7 +693,9 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
     fake_adapter = FakeAdapter()
     cwds_seen: list[str | None] = []
 
-    async def fake_get_or_create_adapter(runtime, launch_target_id, cwd):
+    async def fake_get_or_create_adapter(
+        runtime, launch_target_id, cwd, *, user_initiated=False
+    ):
         cwds_seen.append(cwd)
         return fake_adapter
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -190,13 +190,18 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   // Refresh the model picker whenever the active backend or launch target
   // changes. Codex's list is auth/account scoped so it can shift between
   // remote SSH targets; for Claude this just reads the curated config list.
+  // Depend only on the specific fields we read — including `session` itself
+  // would re-fire on every poll-induced reference change and stampede the
+  // backend with /models calls.
+  const sessionBackend = session?.backend;
+  const sessionLaunchTargetId = session?.launch_target_id;
   useEffect(() => {
-    if (!session) {
+    if (!sessionBackend) {
       return;
     }
     let cancelled = false;
-    fetchBackendModels(host, token, session.backend, {
-      launchTargetId: session.launch_target_id,
+    fetchBackendModels(host, token, sessionBackend, {
+      launchTargetId: sessionLaunchTargetId,
     })
       .then((response) => {
         if (cancelled) return;
@@ -219,14 +224,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     return () => {
       cancelled = true;
     };
-  }, [
-    host,
-    token,
-    session?.backend,
-    session?.launch_target_id,
-    handleAuthFailure,
-    session,
-  ]);
+  }, [host, token, sessionBackend, sessionLaunchTargetId, handleAuthFailure]);
 
   const handleModelChange = useCallback(
     async (nextModel: string) => {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -600,6 +600,22 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, [handleAuthFailure, host, token, sessionId]);
 
+  const reattach = useCallback(async () => {
+    try {
+      await postAction(host, token, sessionId, "reattach");
+    } catch (reattachError) {
+      if (isAuthError(reattachError)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(
+        reattachError instanceof Error
+          ? reattachError.message
+          : "failed to reconnect",
+      );
+    }
+  }, [handleAuthFailure, host, token, sessionId]);
+
   const terminate = useCallback(async () => {
     if (!window.confirm("Terminate this session? Any running command will be stopped.")) {
       return;
@@ -855,6 +871,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         }
         canDelete={sessionExited}
         canResume={canResume}
+        canReattach={dormantReattach}
         canTerminate={Boolean(session && !sessionExited)}
         connection={connection}
         disabled={composerDisabled}
@@ -889,6 +906,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         onModelChange={handleModelChange}
         onEffortChange={handleEffortChange}
         onRefresh={refresh}
+        onReattach={reattach}
         onResume={resumeSession}
         onSend={submitInput}
         onTerminate={terminate}
@@ -902,6 +920,7 @@ interface ReplyComposerProps {
   permissionModeOptions: readonly BackendPermissionMode[];
   canDelete: boolean;
   canResume: boolean;
+  canReattach: boolean;
   canTerminate: boolean;
   connection: ConnectionState;
   disabled: boolean;
@@ -928,6 +947,7 @@ interface ReplyComposerProps {
   onModelChange: (model: string) => void | Promise<void>;
   onEffortChange: (effort: string) => void | Promise<void>;
   onRefresh: () => void;
+  onReattach: () => void | Promise<void>;
   onResume: () => void | Promise<void>;
   onSend: (text: string) => Promise<boolean>;
   onTerminate: () => void | Promise<void>;
@@ -938,6 +958,7 @@ const ReplyComposer = memo(function ReplyComposer({
   permissionModeOptions,
   canDelete,
   canResume,
+  canReattach,
   canTerminate,
   connection,
   disabled,
@@ -960,6 +981,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onModelChange,
   onEffortChange,
   onRefresh,
+  onReattach,
   onResume,
   onSend,
   onTerminate,
@@ -970,6 +992,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
+  const [reattaching, setReattaching] = useState(false);
   // Pending effort for backends that need a session restart to apply (Claude)
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
@@ -1450,6 +1473,26 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">↻</span>
                     Refresh
                   </button>
+                  {canReattach ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="composer-overflow-item"
+                      disabled={reattaching}
+                      onClick={async () => {
+                        setOverflowOpen(false);
+                        setReattaching(true);
+                        try {
+                          await onReattach();
+                        } finally {
+                          setReattaching(false);
+                        }
+                      }}
+                    >
+                      <span className="glyph">↺</span>
+                      {reattaching ? "Reconnecting…" : "Reconnect session"}
+                    </button>
+                  ) : null}
                   {canTerminate ? (
                     <button
                       type="button"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -206,7 +206,7 @@ export async function postAction(
   host: string,
   token: string,
   sessionId: string,
-  action: "interrupt" | "resume" | "terminate",
+  action: "interrupt" | "resume" | "terminate" | "reattach",
 ): Promise<void> {
   const response = await fetch(`${host}/api/sessions/${sessionId}/${action}`, {
     method: "POST",


### PR DESCRIPTION
## Summary

Remediates three failure classes that surface on remote / multi-backend setups:

1. **Cross-backend ops 503'd.** `terminate` / `delete` / `reattach` against a session whose backend wasn't the user's currently-active one returned 503, because OpenCode's per-`(launch_target, cwd)` adapter cache was empty in this process.
2. **VPN drops wedged the stack.** Per-call SSH subprocesses had no liveness deadline and the SSE listener stayed "alive" until the kernel's default keepalive expired — manifesting as a frozen UI that only a full stack restart could clear.
3. **Stale / mangled session.cwd values broke remote OpenCode entirely.** Once boot started restoring `ERROR` sessions (see below), any session whose persisted cwd carried an embedded `/~/` (a leftover from a prior config typo or path-concat bug) poisoned the per-launch-target adapter cache — and because every remote OpenCode call wraps its work in `bash -ilc 'cd <cwd> && exec ...'`, the bash literal-tilde `cd` failed *before* the inner command ran. Surfaced as `list_threads` 503s and `_wait_for_server` 30s timeouts.

The fix is structural: lazy-init adapter slots on demand, route soft cleanup through the plugin, give SSH explicit keepalive, gate retries through a per-target health primitive, surface auto-reconnect + an explicit user-driven reattach, and normalize cwds at the adapter boundary so downstream remote shells always get something they can actually `cd` into.

## Changes

### Cross-backend correctness
- `runtime.terminate` routes through `plugin.terminate_session` instead of going via the transport — the plugin's `.get()`-based lookup is reachable from a process where the adapter slot was never warmed.
- New `POST /api/sessions/{id}/reattach` endpoint (distinct from tmux's `/resume`) so structured backends can be revived without sending a message.
- `OpenCodeTransport` lazy-inits its adapter on `send` / `interrupt` / `respond_to_approval` and falls back softly on pure introspection (`has_pending_approval`, `terminal_snapshot`).
- `Codex.terminate_session` is now soft (no-op when the adapter is missing), mirroring OpenCode and Claude Code.

### Connection liveness — keepalive only
- New `WAYPOINT_OPENCODE_*` env vars: `SSH_CONNECT_TIMEOUT=15`, `SSH_KEEPALIVE_INTERVAL=30`, `SSH_KEEPALIVE_COUNT=6`, `HTTP_CONTROL_TIMEOUT=60`. ~3-minute floor from VPN drop to clean SSH exit.
- SSH argv injects keepalive `-o` flags across remote-curl, SSE stream, and server launch.
- `prompt_async` and `summarize` are flagged `long_running=True` so they bypass the 60s control ceiling — TCP/SSH keepalive remains the only liveness signal for long-lived calls.

### Per-target health (cooldown + circuit breaker)
- New `AdapterHealth` (`opencode/health.py`) tracks death cooldown (5s) and a 3-failure / 60s quarantine.
- Passive HTTP callers fail fast with a clear 503 instead of stacking SSH spinups against a known-dead host.
- The auto-reconnect loop bypasses the gate (it's the dedicated retry mechanism) so it doesn't double-count cooldown rejections as failures.

### Auto-reconnect
- Adapter calls `_on_server_died_callback` with a snapshot of active session ids when the SSE listener observes server death.
- Plugin arms a per-key `_reconnect_loop` with capped exponential backoff `[5, 10, 30, 60, 120, 300]` that loops forever until either every tracked session is gone or the plugin shuts down.
- On success, sessions are resurrected via persisted `transport_state["opencode_session_id"]`.

### Recoverable error states
- Boot now retries `ERROR` sessions (not just non-`EXITED`) so a stack restart no longer leaves them un-resumable. `EXITED` stays skipped — that's a terminal user choice.
- `DELETE /api/sessions/{id}?force=true` skips terminate failures, the last-resort escape hatch when an adapter is wedged.

### Remote shell hardening (cwd / rcfile interactions)
- The remote serve script now does its own cd inside the rcfile-free `bash -c` subshell, sidestepping rcfile-loaded `cd` wrappers (oh-my-bash's auto-ls / goto helpers can rewrite `cd ~/foo` into `cd "$BASE/~/foo"`).
- `_adapter_cwd` normalizes embedded `/~/` patterns before storing the workdir — `_normalize_remote_cwd` re-anchors `/a/b/~/c` as `~/c` so every downstream consumer (workdir, `RemoteOpenCodeClient`, the serve script's own resolver) sees something the remote shell can expand. The serve script keeps a matching defensive case as belt-and-suspenders.
- `list_threads` wraps each `adapter.list_sessions()` in try/except so one wedged adapter (e.g. an `ERROR` session restored at boot whose persisted cwd no longer resolves) can't take down discovery for the rest of the launch target's healthy adapters.

### Frontend
- New "Reconnect session" overflow action (`↺`) in the composer, visible only when `sessionExited && structured-transport`. Disables itself with "Reconnecting…" while the request is in flight. Distinct from tmux's existing "Resume" control.
- Stop refetching `/api/backends/<id>/models` on every session-poll tick — the effect listed `session` (the full record) in its dependency array, so every poll-induced reference change re-fired the fetch and stampeded the backend with model-discovery calls. Now it depends only on `session?.backend` and `session?.launch_target_id`.

## Test Plan

- [x] `cd backend && uv run pytest` — 258 passing
- [x] `cd backend && uv run pre-commit run --all-files` — black / isort / ruff / codespell / mypy clean
- [x] `cd frontend && npm run lint && npm run build` — clean
- [x] Manual: connect to remote OpenCode (with a session whose persisted cwd had an embedded `/~/`) — `_wait_for_server` no longer times out, session restores cleanly
- [ ] Manual: verify a remote OpenCode session survives a VPN drop (SSH keepalive surfaces a clean exit, auto-reconnect loop resurrects the session)
- [x] Manual: terminate a backgrounded OpenCode session while a different backend is the active default (no 503)
- [x] Manual: hit "Reconnect session" on a dormant `ERROR` session and verify it transitions back to `IDLE` without typing into the composer first
- [ ] Manual: `DELETE /api/sessions/{id}?force=true` against a wedged adapter and verify the row drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)
