### PR TITLE
feat: add session switcher modal with advanced search

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4284,7 +4284,8 @@ html[data-theme="light"] .help-tooltip {
 .session-switcher-modal {
   width: 100%;
   max-width: min(520px, calc(100vw - 32px));
-  max-height: calc(100vh - 64px);
+  max-height: calc(100% - 64px);
+  min-height: 0;
   background: rgba(14, 17, 24, 0.96);
   border: 1px solid var(--line-strong);
   border-radius: var(--radius);
@@ -4475,6 +4476,7 @@ html[data-theme="light"] .help-tooltip {
   
   .session-switcher-modal {
     max-width: 100%;
+    max-height: calc(100dvh - 24px);
     border-radius: var(--radius) var(--radius) 0 0;
     border-bottom: none;
     border-left: none;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2627,6 +2627,12 @@ details.tool-disclosure[open] .tool-glyph.todo {
   cursor: default;
 }
 
+.composer-overflow-separator {
+  height: 1px;
+  margin: 4px 0;
+  background: var(--line);
+}
+
 /* "Back to top" mirror of the latest-pill — same floating-pill language but
  * lighter and icon-only, since jumping to the top is a less-frequent need.
  * Sticks to the top edge of the section so the user can hop back without

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4482,16 +4482,23 @@ html[data-theme="light"] .help-tooltip {
     align-items: flex-end;
     padding: 0;
   }
-  
+
+  /* Definite height (not max-height) so the flex column has a fixed
+   * parent size for `flex: 1; min-height: 0` to size the list
+   * against — iOS Safari otherwise grows the modal to content height
+   * and the list never gains its own scroll. Subtract the bottom
+   * safe-area inset so the modal doesn't sit under the iOS home
+   * indicator (viewportFit: cover puts dvh under it). */
   .session-switcher-modal {
     max-width: 100%;
-    max-height: calc(100dvh - 24px);
+    height: calc(100dvh - 24px - env(safe-area-inset-bottom));
+    max-height: calc(100dvh - 24px - env(safe-area-inset-bottom));
     border-radius: var(--radius) var(--radius) 0 0;
     border-bottom: none;
     border-left: none;
     border-right: none;
   }
-  
+
   .session-switcher-footer {
     display: none;
   }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4355,8 +4355,12 @@ html[data-theme="light"] .help-tooltip {
   opacity: 0.6;
 }
 
+.session-switcher-row:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
 .session-switcher-row.selected {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 .session-switcher-rail {
@@ -4459,6 +4463,9 @@ html[data-theme="light"] .session-switcher-modal {
 html[data-theme="light"] .session-switcher-footer {
   background: rgba(240, 236, 226, 0.6);
 }
+html[data-theme="light"] .session-switcher-row:hover {
+  background: rgba(0, 0, 0, 0.02);
+}
 html[data-theme="light"] .session-switcher-row.selected {
-  background: rgba(0, 0, 0, 0.04);
+  background: rgba(0, 0, 0, 0.06);
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4270,7 +4270,10 @@ html[data-theme="light"] .help-tooltip {
 
 .session-switcher-backdrop {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100dvh;
   z-index: 100;
   display: flex;
   align-items: center;
@@ -4284,7 +4287,7 @@ html[data-theme="light"] .help-tooltip {
 .session-switcher-modal {
   width: 100%;
   max-width: min(520px, calc(100vw - 32px));
-  max-height: calc(100% - 64px);
+  max-height: calc(100dvh - 64px);
   min-height: 0;
   background: rgba(14, 17, 24, 0.96);
   border: 1px solid var(--line-strong);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4265,3 +4265,200 @@ html[data-theme="light"] .help-tooltip {
 .thread-panel-search {
   margin-top: 8px;
 }
+
+/* ─── Session Switcher ───────────────────────────────────────────────────── */
+
+.session-switcher-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  padding: 16px;
+}
+
+.session-switcher-modal {
+  width: 100%;
+  max-width: min(520px, calc(100vw - 32px));
+  max-height: calc(100vh - 64px);
+  background: rgba(14, 17, 24, 0.96);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.session-switcher-search {
+  padding: 14px 14px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.session-switcher-search input {
+  background: rgba(8, 11, 16, 0.5);
+}
+
+.session-switcher-list {
+  overflow-y: auto;
+  padding: 10px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.session-switcher-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.session-switcher-header {
+  padding: 0 16px 6px;
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  color: var(--muted);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.session-switcher-header span {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+}
+
+.session-switcher-row,
+.session-switcher-here {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 8px 16px;
+  text-align: left;
+  border: none;
+  background: transparent;
+  width: 100%;
+  transition: background-color 100ms ease;
+  cursor: pointer;
+}
+
+.session-switcher-here {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.session-switcher-row.selected {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.session-switcher-rail {
+  width: 3px;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--muted-soft);
+}
+.session-switcher-rail.running,
+.session-switcher-rail.waiting_input {
+  background: var(--accent-cool);
+}
+.session-switcher-rail.idle {
+  background: var(--success);
+}
+.session-switcher-rail.error,
+.session-switcher-rail.interrupted {
+  background: var(--warn);
+}
+.session-switcher-rail.exited {
+  background: var(--muted);
+  opacity: 0.5;
+}
+
+.session-switcher-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.session-switcher-title {
+  font-weight: 500;
+  color: var(--text-strong);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 0.92rem;
+}
+
+.session-switcher-breadcrumb {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.session-switcher-time {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+  white-space: nowrap;
+}
+
+.session-switcher-footer {
+  padding: 8px 16px;
+  border-top: 1px solid var(--line);
+  background: rgba(8, 11, 16, 0.4);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted-soft);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  text-align: center;
+}
+
+.session-switcher-empty {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 600px) {
+  .session-switcher-backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+  
+  .session-switcher-modal {
+    max-width: 100%;
+    border-radius: var(--radius) var(--radius) 0 0;
+    border-bottom: none;
+    border-left: none;
+    border-right: none;
+  }
+  
+  .session-switcher-footer {
+    display: none;
+  }
+}
+
+html[data-theme="light"] .session-switcher-modal {
+  background: rgba(252, 249, 242, 0.98);
+  box-shadow: 0 16px 48px rgba(60, 45, 20, 0.2);
+}
+html[data-theme="light"] .session-switcher-footer {
+  background: rgba(240, 236, 226, 0.6);
+}
+html[data-theme="light"] .session-switcher-row.selected {
+  background: rgba(0, 0, 0, 0.04);
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4224,7 +4224,7 @@ html[data-theme="light"] .search-bar input:focus {
   font-family: var(--font-mono);
   font-size: 0.75rem;
   color: var(--fg);
-  z-index: 50;
+  z-index: 200;
 }
 
 html[data-theme="light"] .help-tooltip {
@@ -4429,6 +4429,34 @@ html[data-theme="light"] .help-tooltip {
   text-align: center;
 }
 
+.session-switcher-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 8px 16px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+.session-switcher-pagination button {
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: rgba(28, 33, 44, 0.45);
+  color: var(--text);
+  cursor: pointer;
+  transition: all 120ms ease;
+}
+.session-switcher-pagination button:hover:not(:disabled) {
+  background: rgba(28, 33, 44, 0.85);
+  border-color: var(--line-strong);
+}
+.session-switcher-pagination button:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 .session-switcher-empty {
   padding: 24px 16px;
   text-align: center;
@@ -4462,6 +4490,12 @@ html[data-theme="light"] .session-switcher-modal {
 }
 html[data-theme="light"] .session-switcher-footer {
   background: rgba(240, 236, 226, 0.6);
+}
+html[data-theme="light"] .session-switcher-pagination button {
+  background: rgba(220, 210, 190, 0.45);
+}
+html[data-theme="light"] .session-switcher-pagination button:hover:not(:disabled) {
+  background: rgba(205, 194, 170, 0.85);
 }
 html[data-theme="light"] .session-switcher-row:hover {
   background: rgba(0, 0, 0, 0.02);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4306,6 +4306,8 @@ html[data-theme="light"] .help-tooltip {
 }
 
 .session-switcher-list {
+  flex: 1;
+  min-height: 0;
   overflow-y: auto;
   padding: 10px 0;
   display: flex;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 
+import { SwitcherProvider } from "@/components/SwitcherProvider";
 import { ThemeProvider } from "@/lib/theme";
 import "./globals.css";
 
@@ -44,7 +45,9 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         <script dangerouslySetInnerHTML={{ __html: antiFlashScript }} />
       </head>
       <body>
-        <ThemeProvider>{children}</ThemeProvider>
+        <ThemeProvider>
+          <SwitcherProvider>{children}</SwitcherProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -58,6 +58,20 @@ export function SearchInput({
     setTooltipOpen(true);
   }
 
+  function toggleTooltip(e?: React.MouseEvent | React.TouchEvent) {
+    if (e && e.type === "touchstart") {
+      // Prevent touchstart from also firing mouseenter/click right away
+      e.preventDefault();
+    }
+    cancelClose();
+    if (tooltipOpen) {
+      setTooltipOpen(false);
+    } else {
+      updatePosition();
+      setTooltipOpen(true);
+    }
+  }
+
   function scheduleClose() {
     cancelClose();
     closeTimerRef.current = window.setTimeout(() => {
@@ -162,6 +176,8 @@ export function SearchInput({
         tabIndex={0}
         onMouseEnter={openTooltip}
         onMouseLeave={scheduleClose}
+        onClick={toggleTooltip}
+        onTouchStart={toggleTooltip}
         onFocus={openTooltip}
         onBlur={scheduleClose}
       >

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -9,6 +9,7 @@ interface SearchInputProps {
   placeholder?: string;
   className?: string;
   showStatusExample?: boolean;
+  autoFocus?: boolean;
 }
 
 export function SearchInput({
@@ -17,6 +18,7 @@ export function SearchInput({
   placeholder,
   className = "",
   showStatusExample = true,
+  autoFocus = false,
 }: SearchInputProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [tooltipPos, setTooltipPos] = useState<{ top: number; right: number } | null>(null);
@@ -139,6 +141,7 @@ export function SearchInput({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           aria-label={placeholder || "Search"}
+          autoFocus={autoFocus}
         />
         {value !== "" ? (
           <button

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1707,7 +1707,7 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">⇄</span>
                     Switch session…
                   </button>
-                  <div className="composer-overflow-separator" style={{ height: 1, background: "var(--line)", margin: "4px 0" }} />
+                  <div className="composer-overflow-separator" />
                   {canTerminate ? (
                     <button
                       type="button"

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -415,6 +415,18 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     window.location.reload();
   }, []);
 
+  // Add global shortcut for the switcher
+  useEffect(() => {
+    function handleGlobalKeyDown(event: globalThis.KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
+        event.preventDefault();
+        setSwitcherOpen((open) => !open);
+      }
+    }
+    window.addEventListener("keydown", handleGlobalKeyDown);
+    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
+  }, []);
+
   useEffect(() => {
     let active = true;
     async function load() {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -49,6 +49,7 @@ import {
   TranscriptCard,
   ToolPair,
 } from "@/components/TranscriptCard";
+import { SessionSwitcher } from "@/components/SessionSwitcher";
 import {
   BackendModelOption,
   BackendPermissionMode,
@@ -124,6 +125,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [approvalPageIndex, setApprovalPageIndex] = useState(0);
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
+  const [switcherOpen, setSwitcherOpen] = useState(false);
   // Tracks the smallest raw sequence ever received from the server. Distinct
   // from `events[0].sequence` because `mergeEvents` advances a coalesced
   // item's sequence to the *last* delta — using that as a cursor would
@@ -979,6 +981,15 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           </button>
         </div>
       ) : null}
+      {switcherOpen ? (
+        <SessionSwitcher
+          host={host}
+          token={token}
+          currentSession={session}
+          onAuthFailure={handleAuthFailure}
+          onClose={() => setSwitcherOpen(false)}
+        />
+      ) : null}
       <ReplyComposer
         permissionModeOptions={
           session ? permissionModesFor(session.backend, catalog) : []
@@ -1023,6 +1034,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         onRefresh={refresh}
         onReattach={reattach}
         onResume={resumeSession}
+        onSwitchSession={() => setSwitcherOpen(true)}
         onSend={onSendWithOptimistic}
         onTerminate={terminate}
       />
@@ -1065,6 +1077,7 @@ interface ReplyComposerProps {
   onRefresh: () => void;
   onReattach: () => void | Promise<void>;
   onResume: () => void | Promise<void>;
+  onSwitchSession: () => void;
   onSend: (text: string) => Promise<boolean>;
   onTerminate: () => void | Promise<void>;
 }
@@ -1100,6 +1113,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onRefresh,
   onReattach,
   onResume,
+  onSwitchSession,
   onSend,
   onTerminate,
 }: ReplyComposerProps) {
@@ -1684,6 +1698,19 @@ const ReplyComposer = memo(function ReplyComposer({
                       {reattaching ? "Reconnecting…" : "Reconnect session"}
                     </button>
                   ) : null}
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="composer-overflow-item"
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      onSwitchSession();
+                    }}
+                  >
+                    <span className="glyph">⇄</span>
+                    Switch session…
+                  </button>
+                  <div className="composer-overflow-separator" style={{ height: 1, background: "var(--line)", margin: "4px 0" }} />
                   {canTerminate ? (
                     <button
                       type="button"

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -49,7 +49,7 @@ import {
   TranscriptCard,
   ToolPair,
 } from "@/components/TranscriptCard";
-import { SessionSwitcher } from "@/components/SessionSwitcher";
+import { useSwitcher } from "@/components/SwitcherProvider";
 import {
   BackendModelOption,
   BackendPermissionMode,
@@ -125,7 +125,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [approvalPageIndex, setApprovalPageIndex] = useState(0);
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
-  const [switcherOpen, setSwitcherOpen] = useState(false);
+  const { openSwitcher, setCurrentSession } = useSwitcher();
   // Tracks the smallest raw sequence ever received from the server. Distinct
   // from `events[0].sequence` because `mergeEvents` advances a coalesced
   // item's sequence to the *last* delta — using that as a cursor would
@@ -415,17 +415,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     window.location.reload();
   }, []);
 
-  // Add global shortcut for the switcher
+  // Publish the current session so the global switcher can mark it.
   useEffect(() => {
-    function handleGlobalKeyDown(event: globalThis.KeyboardEvent) {
-      if ((event.metaKey || event.ctrlKey) && event.key === "k") {
-        event.preventDefault();
-        setSwitcherOpen((open) => !open);
-      }
-    }
-    window.addEventListener("keydown", handleGlobalKeyDown);
-    return () => window.removeEventListener("keydown", handleGlobalKeyDown);
-  }, []);
+    setCurrentSession(session);
+    return () => setCurrentSession(null);
+  }, [session, setCurrentSession]);
 
   useEffect(() => {
     let active = true;
@@ -993,15 +987,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           </button>
         </div>
       ) : null}
-      {switcherOpen ? (
-        <SessionSwitcher
-          host={host}
-          token={token}
-          currentSession={session}
-          onAuthFailure={handleAuthFailure}
-          onClose={() => setSwitcherOpen(false)}
-        />
-      ) : null}
       <ReplyComposer
         permissionModeOptions={
           session ? permissionModesFor(session.backend, catalog) : []
@@ -1046,7 +1031,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         onRefresh={refresh}
         onReattach={reattach}
         onResume={resumeSession}
-        onSwitchSession={() => setSwitcherOpen(true)}
+        onSwitchSession={openSwitcher}
         onSend={onSendWithOptimistic}
         onTerminate={terminate}
       />

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -47,6 +47,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const router = useRouter();
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
   const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
 
@@ -111,14 +112,17 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     recent.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
     pinned.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
 
-    // Cap recent to 8 if no query, 20 if querying
-    const cappedRecent = query ? recent.slice(0, 20) : recent.slice(0, 8);
+    const PAGE_SIZE = 8;
+    const totalPages = Math.ceil(recent.length / PAGE_SIZE) || 1;
+    const cappedRecent = recent.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
     
     return {
       pinned,
-      recent: cappedRecent
+      recent: cappedRecent,
+      totalPages,
+      totalRecent: recent.length
     };
-  }, [sessions, query, currentSession?.id]);
+  }, [sessions, query, currentSession?.id, page]);
 
   const flatItems = useMemo(() => {
     return [...filteredSessions.pinned, ...filteredSessions.recent];
@@ -157,7 +161,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
       const target = flatItems[activeIndex];
       if (target) {
         onClose();
-        router.push(`/sessions/${target.id}`);
+        router.push(`/session/${target.id}`);
       }
     }
   }, [flatItems, activeIndex, onClose, router]);
@@ -200,7 +204,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
         className={`session-switcher-row ${isSelected ? 'selected' : ''}`}
         onClick={() => {
           onClose();
-          router.push(`/sessions/${s.id}`);
+          router.push(`/session/${s.id}`);
         }}
         onPointerMove={() => {
           if (activeIndex !== idx) setActiveIndex(idx);
@@ -226,6 +230,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
             value={query}
             onChange={(val) => {
               setQuery(val);
+              setPage(1);
               setActiveIndex(0);
             }}
             placeholder="Search sessions..."
@@ -257,9 +262,28 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
           {filteredSessions.recent.length > 0 ? (
             <div className="session-switcher-section">
               <div className="session-switcher-header">
-                Recent <span>{!query && sessions.length > 8 ? `8+` : filteredSessions.recent.length}</span>
+                Recent <span>{filteredSessions.totalRecent}</span>
               </div>
               {filteredSessions.recent.map((s, i) => renderRow(s, filteredSessions.pinned.length + i))}
+              {filteredSessions.totalPages > 1 ? (
+                <div className="session-switcher-pagination">
+                  <button 
+                    type="button" 
+                    onClick={() => setPage(p => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                  >
+                    Previous
+                  </button>
+                  <span>Page {page} of {filteredSessions.totalPages}</span>
+                  <button 
+                    type="button" 
+                    onClick={() => setPage(p => Math.min(filteredSessions.totalPages, p + 1))}
+                    disabled={page === filteredSessions.totalPages}
+                  >
+                    Next
+                  </button>
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -56,6 +56,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const [page, setPage] = useState(1);
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
+  const modalRef = useRef<HTMLDivElement>(null);
   const lastKeyTimeRef = useRef(0);
 
   useEffect(() => {
@@ -154,6 +155,29 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
       return;
     }
 
+    if (e.key === "Tab") {
+      const root = modalRef.current;
+      if (!root) return;
+      const focusable = root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && (active === first || !root.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !root.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
+      return;
+    }
+
     const navKeys = ["ArrowDown", "ArrowUp", "Home", "End"];
     if (navKeys.includes(e.key)) {
       lastKeyTimeRef.current = Date.now();
@@ -225,6 +249,17 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     };
   }, []);
 
+  // Restore focus to whatever was focused before the modal opened
+  // (typically the ⋯ trigger when opened from the overflow menu).
+  useEffect(() => {
+    const previous = document.activeElement as HTMLElement | null;
+    return () => {
+      if (previous && typeof previous.focus === "function") {
+        previous.focus();
+      }
+    };
+  }, []);
+
   const renderRow = (s: SessionRecord, idx: number) => {
     const isSelected = activeIndex === idx;
     const cwdSegments = formatCwdSegments(s.cwd);
@@ -260,7 +295,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     <div className="session-switcher-backdrop" onPointerDown={(e) => {
       if (e.target === e.currentTarget) onClose();
     }}>
-      <div className="session-switcher-modal" role="dialog" aria-modal="true" aria-label="Switch session">
+      <div className="session-switcher-modal" role="dialog" aria-modal="true" aria-label="Switch session" ref={modalRef}>
         <div className="session-switcher-search">
           <SearchInput 
             value={query}

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -333,7 +333,12 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
           {filteredSessions.recent.length > 0 ? (
             <div className="session-switcher-section">
               <div className="session-switcher-header">
-                Recent <span>{filteredSessions.totalRecent}</span>
+                Recent
+                <span>
+                  {(page - 1) * PAGE_SIZE + 1}–
+                  {Math.min(page * PAGE_SIZE, filteredSessions.totalRecent)} of{" "}
+                  {filteredSessions.totalRecent}
+                </span>
               </div>
               {filteredSessions.recent.map((s, i) => renderRow(s, filteredSessions.pinned.length + i))}
               {filteredSessions.totalPages > 1 ? (

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -111,8 +111,8 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     recent.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
     pinned.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
 
-    // Cap recent to 8 if no query
-    const cappedRecent = query ? recent : recent.slice(0, 8);
+    // Cap recent to 8 if no query, 20 if querying
+    const cappedRecent = query ? recent.slice(0, 20) : recent.slice(0, 8);
     
     return {
       pinned,
@@ -187,11 +187,11 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   }, []);
 
   const renderRow = (s: SessionRecord, idx: number) => {
-    const isSelected = flatItems.indexOf(s) === idx;
+    const isSelected = activeIndex === idx;
     const cwdSegments = formatCwdSegments(s.cwd);
-    const leaf = cwdSegments[cwdSegments.length - 1];
-    const branchInfo = typeof s.transport_state?.thread_id === "string" ? s.transport_state.thread_id : "";
-    const breadcrumb = [humaniseBackend(s.backend), leaf, branchInfo].filter(Boolean).join(" ▸ ");
+    const workspace = s.repo_name || cwdSegments[cwdSegments.length - 1];
+    const target = s.launch_target_id || "Local";
+    const breadcrumb = [humaniseBackend(s.backend), target, workspace].filter(Boolean).join(" ▸ ");
     
     return (
       <button 
@@ -202,7 +202,9 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
           onClose();
           router.push(`/sessions/${s.id}`);
         }}
-        onPointerEnter={() => setActiveIndex(idx)}
+        onPointerMove={() => {
+          if (activeIndex !== idx) setActiveIndex(idx);
+        }}
       >
         <div className={`session-switcher-rail ${s.status}`} />
         <div className="session-switcher-body">

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { connectSessionsSocket, fetchSessions } from "@/lib/api";
+import { matchesQuery, parseQuery } from "@/lib/search";
+import { SessionEnvelope, SessionRecord } from "@/lib/types";
+import { SearchInput } from "@/components/SearchInput";
+import { humaniseBackend } from "@/lib/backends";
+
+interface SessionSwitcherProps {
+  host: string;
+  token: string;
+  currentSession: SessionRecord | null;
+  onAuthFailure?: () => void;
+  onClose: () => void;
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+function formatCwdSegments(cwd: string): string[] {
+  if (!cwd) return [""];
+  const trimmed = cwd.replace(/\/+$/, "");
+  const segments = trimmed.split("/").filter(Boolean);
+  if (trimmed.startsWith("/")) {
+    return segments.length ? [`/${segments[0]}`, ...segments.slice(1)] : ["/"];
+  }
+  return segments.length ? segments : [trimmed];
+}
+
+export function SessionSwitcher({ host, token, currentSession, onAuthFailure, onClose }: SessionSwitcherProps) {
+  const router = useRouter();
+  const [sessions, setSessions] = useState<SessionRecord[]>([]);
+  const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let active = true;
+    let socket: WebSocket | null = null;
+
+    async function load() {
+      try {
+        const data = await fetchSessions(host, token);
+        if (active) {
+          setSessions(data);
+        }
+      } catch {
+        if (active && typeof onAuthFailure === "function") {
+          onAuthFailure();
+        }
+      }
+    }
+    load();
+
+    socket = connectSessionsSocket(
+      host,
+      token,
+      (message: SessionEnvelope) => {
+        if (message.type === "session_state") {
+          const updated = message.payload.session as SessionRecord;
+          setSessions((current) => {
+            const index = current.findIndex((s) => s.id === updated.id);
+            if (index !== -1) {
+              const next = [...current];
+              next[index] = updated;
+              return next;
+            }
+            return [updated, ...current];
+          });
+        }
+      },
+      () => {
+        if (active && typeof onAuthFailure === "function") {
+          onAuthFailure();
+        }
+      }
+    );
+
+    return () => {
+      active = false;
+      socket?.close();
+    };
+  }, [host, token, onAuthFailure]);
+
+  const filteredSessions = useMemo(() => {
+    let list = sessions.filter((s) => s.id !== currentSession?.id);
+    const parsed = parseQuery(query);
+    if (parsed) {
+      list = list.filter((s) => matchesQuery(s, parsed, ["title", "cwd", "backend", "repo_name", "status"]));
+    }
+
+    const pinned = list.filter((s) => s.pinned_at != null);
+    const recent = list.filter((s) => s.pinned_at == null);
+
+    recent.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+    pinned.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+
+    // Cap recent to 8 if no query
+    const cappedRecent = query ? recent : recent.slice(0, 8);
+    
+    return {
+      pinned,
+      recent: cappedRecent
+    };
+  }, [sessions, query, currentSession?.id]);
+
+  const flatItems = useMemo(() => {
+    return [...filteredSessions.pinned, ...filteredSessions.recent];
+  }, [filteredSessions]);
+
+  // Adjust active index if list shrinks
+  useEffect(() => {
+    if (activeIndex >= flatItems.length && flatItems.length > 0) {
+      setActiveIndex(flatItems.length - 1);
+    } else if (flatItems.length === 0) {
+      setActiveIndex(0);
+    }
+  }, [flatItems.length, activeIndex]);
+
+  const handleKeyDown = useCallback((e: globalThis.KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      onClose();
+      return;
+    }
+    
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setActiveIndex((i) => (i + 1) % flatItems.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setActiveIndex((i) => (i - 1 + flatItems.length) % flatItems.length);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveIndex(0);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveIndex(flatItems.length > 0 ? flatItems.length - 1 : 0);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const target = flatItems[activeIndex];
+      if (target) {
+        onClose();
+        router.push(`/sessions/${target.id}`);
+      }
+    }
+  }, [flatItems, activeIndex, onClose, router]);
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  }, [handleKeyDown]);
+
+  // Scroll active item into view
+  useEffect(() => {
+    if (listRef.current) {
+      const activeEl = listRef.current.querySelector('.selected');
+      if (activeEl) {
+        activeEl.scrollIntoView({ block: "nearest" });
+      }
+    }
+  }, [activeIndex]);
+
+  // Lock body scroll
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
+  const renderRow = (s: SessionRecord, idx: number) => {
+    const isSelected = flatItems.indexOf(s) === idx;
+    const cwdSegments = formatCwdSegments(s.cwd);
+    const leaf = cwdSegments[cwdSegments.length - 1];
+    const branchInfo = typeof s.transport_state?.thread_id === "string" ? s.transport_state.thread_id : "";
+    const breadcrumb = [humaniseBackend(s.backend), leaf, branchInfo].filter(Boolean).join(" ▸ ");
+    
+    return (
+      <button 
+        key={s.id}
+        type="button"
+        className={`session-switcher-row ${isSelected ? 'selected' : ''}`}
+        onClick={() => {
+          onClose();
+          router.push(`/sessions/${s.id}`);
+        }}
+        onPointerEnter={() => setActiveIndex(idx)}
+      >
+        <div className={`session-switcher-rail ${s.status}`} />
+        <div className="session-switcher-body">
+          <div className="session-switcher-title">{s.title || "Untitled Session"}</div>
+          <div className="session-switcher-breadcrumb">{breadcrumb}</div>
+        </div>
+        <div className="session-switcher-time">{formatRelativeTime(s.updated_at)}</div>
+      </button>
+    );
+  };
+
+  const content = (
+    <div className="session-switcher-backdrop" onPointerDown={(e) => {
+      if (e.target === e.currentTarget) onClose();
+    }}>
+      <div className="session-switcher-modal" role="dialog" aria-modal="true" aria-label="Switch session">
+        <div className="session-switcher-search">
+          <SearchInput 
+            value={query}
+            onChange={(val) => {
+              setQuery(val);
+              setActiveIndex(0);
+            }}
+            placeholder="Search sessions..."
+            autoFocus
+            showStatusExample={false}
+          />
+        </div>
+        
+        <div className="session-switcher-list" ref={listRef}>
+          {currentSession && !query ? (
+            <div className="session-switcher-here">
+              <div className={`session-switcher-rail ${currentSession.status}`} />
+              <div className="session-switcher-body">
+                <div className="session-switcher-title">{currentSession.title}</div>
+                <div className="session-switcher-breadcrumb">Current session</div>
+              </div>
+            </div>
+          ) : null}
+
+          {filteredSessions.pinned.length > 0 ? (
+            <div className="session-switcher-section">
+              <div className="session-switcher-header">
+                Pinned <span>{filteredSessions.pinned.length}</span>
+              </div>
+              {filteredSessions.pinned.map((s, i) => renderRow(s, i))}
+            </div>
+          ) : null}
+
+          {filteredSessions.recent.length > 0 ? (
+            <div className="session-switcher-section">
+              <div className="session-switcher-header">
+                Recent <span>{!query && sessions.length > 8 ? `8+` : filteredSessions.recent.length}</span>
+              </div>
+              {filteredSessions.recent.map((s, i) => renderRow(s, filteredSessions.pinned.length + i))}
+            </div>
+          ) : null}
+
+          {flatItems.length === 0 ? (
+            <div className="session-switcher-empty">
+              No matching sessions
+            </div>
+          ) : null}
+        </div>
+
+        <div className="session-switcher-footer">
+          ↑↓ navigate · ↵ open · esc close
+        </div>
+      </div>
+    </div>
+  );
+
+  return typeof document !== "undefined" ? createPortal(content, document.body) : null;
+}

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -18,6 +18,12 @@ interface SessionSwitcherProps {
   onClose: () => void;
 }
 
+const PAGE_SIZE = 8;
+// Window after a keypress during which mouse-hover updates to the
+// active row are ignored, so list scroll under a stationary cursor
+// doesn't snap the selection back.
+const MOUSE_AFTER_KEY_SUPPRESS_MS = 300;
+
 function formatRelativeTime(dateStr: string): string {
   const date = new Date(dateStr);
   const now = new Date();
@@ -50,6 +56,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const [page, setPage] = useState(1);
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
+  const lastKeyTimeRef = useRef(0);
 
   useEffect(() => {
     let active = true;
@@ -116,7 +123,6 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     recent.sort((a, b) => b.last_event_at.localeCompare(a.last_event_at));
     pinned.sort((a, b) => b.last_event_at.localeCompare(a.last_event_at));
 
-    const PAGE_SIZE = 8;
     const totalPages = Math.ceil(recent.length / PAGE_SIZE) || 1;
     const cappedRecent = recent.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
     
@@ -147,12 +153,37 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
       onClose();
       return;
     }
-    
+
+    const navKeys = ["ArrowDown", "ArrowUp", "Home", "End"];
+    if (navKeys.includes(e.key)) {
+      lastKeyTimeRef.current = Date.now();
+    }
+
+    const pinnedCount = filteredSessions.pinned.length;
+    const totalPages = filteredSessions.totalPages;
+
     if (e.key === "ArrowDown") {
       e.preventDefault();
+      if (flatItems.length === 0) return;
+      // At the last visible row with more pages remaining, advance the
+      // page and land on the first recent item of the new page.
+      if (activeIndex === flatItems.length - 1 && page < totalPages) {
+        setPage(page + 1);
+        setActiveIndex(pinnedCount);
+        return;
+      }
       setActiveIndex((i) => (i + 1) % flatItems.length);
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
+      if (flatItems.length === 0) return;
+      // At the first recent row with more pages preceding, step back a
+      // page and land on the last recent item of the previous page
+      // (which is always full since only the last page can be partial).
+      if (activeIndex === pinnedCount && page > 1) {
+        setPage(page - 1);
+        setActiveIndex(pinnedCount + PAGE_SIZE - 1);
+        return;
+      }
       setActiveIndex((i) => (i - 1 + flatItems.length) % flatItems.length);
     } else if (e.key === "Home") {
       e.preventDefault();
@@ -168,7 +199,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
         router.push(`/session/${target.id}`);
       }
     }
-  }, [flatItems, activeIndex, onClose, router]);
+  }, [flatItems, activeIndex, onClose, router, filteredSessions.pinned.length, filteredSessions.totalPages, page]);
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyDown, { capture: true });
@@ -210,7 +241,8 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
           onClose();
           router.push(`/session/${s.id}`);
         }}
-        onPointerMove={() => {
+        onMouseEnter={() => {
+          if (Date.now() - lastKeyTimeRef.current < MOUSE_AFTER_KEY_SUPPRESS_MS) return;
           if (activeIndex !== idx) setActiveIndex(idx);
         }}
       >

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -73,6 +73,10 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
       host,
       token,
       (message: SessionEnvelope) => {
+        if (message.type === "session_list_update") {
+          setSessions(message.payload.sessions as SessionRecord[]);
+          return;
+        }
         if (message.type === "session_state") {
           const updated = message.payload.session as SessionRecord;
           setSessions((current) => {
@@ -102,15 +106,15 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const filteredSessions = useMemo(() => {
     let list = sessions.filter((s) => s.id !== currentSession?.id);
     const parsed = parseQuery(query);
-    if (parsed) {
-      list = list.filter((s) => matchesQuery(s, parsed, ["title", "cwd", "backend", "repo_name", "status"]));
-    }
+    list = list.filter((s) =>
+      matchesQuery(s, parsed, ["title", "cwd", "repo_name", "branch", "backend", "search_status"]),
+    );
 
     const pinned = list.filter((s) => s.pinned_at != null);
     const recent = list.filter((s) => s.pinned_at == null);
 
-    recent.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
-    pinned.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
+    recent.sort((a, b) => b.last_event_at.localeCompare(a.last_event_at));
+    pinned.sort((a, b) => b.last_event_at.localeCompare(a.last_event_at));
 
     const PAGE_SIZE = 8;
     const totalPages = Math.ceil(recent.length / PAGE_SIZE) || 1;
@@ -215,7 +219,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
           <div className="session-switcher-title">{s.title || "Untitled Session"}</div>
           <div className="session-switcher-breadcrumb">{breadcrumb}</div>
         </div>
-        <div className="session-switcher-time">{formatRelativeTime(s.updated_at)}</div>
+        <div className="session-switcher-time">{formatRelativeTime(s.last_event_at)}</div>
       </button>
     );
   };

--- a/frontend/src/components/SwitcherProvider.tsx
+++ b/frontend/src/components/SwitcherProvider.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import { clearToken, readHost, readToken } from "@/lib/store";
+import { SessionRecord } from "@/lib/types";
+
+import { SessionSwitcher } from "./SessionSwitcher";
+
+interface SwitcherContextValue {
+  openSwitcher: () => void;
+  setCurrentSession: (session: SessionRecord | null) => void;
+}
+
+const SwitcherContext = createContext<SwitcherContextValue | null>(null);
+
+export function useSwitcher(): SwitcherContextValue {
+  const ctx = useContext(SwitcherContext);
+  if (!ctx) {
+    throw new Error("useSwitcher must be used within SwitcherProvider");
+  }
+  return ctx;
+}
+
+export function SwitcherProvider({ children }: { children: ReactNode }) {
+  const router = useRouter();
+  const [host, setHost] = useState("");
+  const [token, setToken] = useState("");
+  const [open, setOpen] = useState(false);
+  const [currentSession, setCurrentSession] = useState<SessionRecord | null>(null);
+
+  // Re-reading on every open keeps credentials fresh after login on
+  // another route — RootLayout mounts once for the whole app session.
+  const refreshCreds = useCallback(() => {
+    setHost(readHost());
+    setToken(readToken());
+  }, []);
+
+  const openSwitcher = useCallback(() => {
+    refreshCreds();
+    setOpen(true);
+  }, [refreshCreds]);
+
+  const closeSwitcher = useCallback(() => setOpen(false), []);
+
+  const handleAuthFailure = useCallback(() => {
+    clearToken();
+    setToken("");
+    setOpen(false);
+    router.replace("/");
+  }, [router]);
+
+  useEffect(() => {
+    function handleKey(event: globalThis.KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        refreshCreds();
+        setOpen((current) => !current);
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [refreshCreds]);
+
+  const value = useMemo(
+    () => ({ openSwitcher, setCurrentSession }),
+    [openSwitcher],
+  );
+
+  return (
+    <SwitcherContext.Provider value={value}>
+      {children}
+      {open && host && token ? (
+        <SessionSwitcher
+          host={host}
+          token={token}
+          currentSession={currentSession}
+          onAuthFailure={handleAuthFailure}
+          onClose={closeSwitcher}
+        />
+      ) : null}
+    </SwitcherContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a new globally accessible Session Switcher modal to navigate between sessions without returning to the home screen. Resolves #24.

## Changes

### Session Switcher
- **New Component:** `SessionSwitcher` renders a portaled modal accessed via `Cmd+K` / `Ctrl+K` (global shortcut, hoisted to root layout via `SwitcherProvider`) or the new `⇄ Switch session…` overflow menu item in `SessionDetail`.
- **Keyboard Navigation:** Full arrow key navigation (`Up`/`Down`, `Home`/`End`) with cross-page arrow wrapping, `Enter` to confirm, `Esc` to close, and a Tab focus trap inside the modal.
- **Advanced Search:** Reuses the advanced client-side search logic (booleans, regex, field matching) to filter both Pinned and Recent sessions dynamically, including `status:` virtual field.
- **Pagination:** The Recent section displays up to 8 sessions per page with a footer that adapts to active search filters.
- **Mobile Support:** On mobile, the modal is sized and positioned via `window.visualViewport` (tracking resize and scroll events) to a centered 90% × 70% panel. This avoids iOS Safari's `100dvh`/`viewportFit: cover` quirk where flex centering against the backdrop aligns to the layout viewport, which extends behind the bottom URL bar. Auto-focus on the search input is suppressed on mobile to prevent the keyboard from opening immediately.

### UI Improvements
- **Hover/Selected States:** Enhanced list selection styles that apply uniformly across mouse and keyboard interactions, with a 300 ms post-keystroke suppression window to prevent hover jitter when navigating by keyboard.
- **Breadcrumbs:** Session records are summarized as `Backend ▸ Launch Target ▸ Workspace` for immediate context inside the switcher list.
- **Tooltips:** Fixed stacking context issues preventing the `?` search syntax tooltip from rendering above the modal. Touch tap now toggles the tooltip via `onClick`; a `isTouchRef` flag suppresses the synthetic `mouseenter` that iOS fires after touch, with an `onMouseMove` reset so hover works again on hybrid (touch + trackpad) devices.

### Bug Fixes
- **BackendSwitcher peer-fetch flicker:** `onAuthFailure` was passed as an inline arrow from `page.tsx`, which re-renders on every WebSocket tick. This recreated the function reference on each render, causing `BackendSwitcher`'s fetch `useEffect` to tear down and restart in a loop, producing a loading-text flicker. Fixed by storing `onAuthFailure` in a ref inside `BackendSwitcher` and removing it from the effect's dependency array.

### Configuration
- **Transport badge:** Hidden by default on session cards. Set `NEXT_PUBLIC_SHOW_TRANSPORT_BADGE=true` to re-enable. See `frontend/.env.example`.

## Test Plan

- [x] `cd backend && uv run pytest`
- [x] `cd backend && uv run pre-commit run --all-files`
- [x] `cd frontend && npm run lint && npm run build`
- [x] Manual: Open a session and press `Cmd+K` (or `Ctrl+K`) to verify the modal opens globally (not just from the session detail page).
- [x] Manual: Use arrow keys to navigate the list; verify hover and selected styling update correctly, and that hover doesn't jitter right after a keypress.
- [x] Manual: Type a search query to verify pagination and filtering behave smoothly.
- [x] Manual: Test on iOS Safari and iOS Web App — verify the modal fits within the visible area at 90% × 70%, does not overflow, and does not auto-focus the keyboard on open.
- [x] Manual: Click the `?` icon to toggle the tooltip; verify tap-to-toggle works on mobile without a spurious hover opening.
- [x] Manual: Verify `BackendSwitcher` does not flicker the "Loading peers…" text while a session is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)