### PR TITLE
feat: group tool calls and absorb transcript noise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Coding-agent backends live in `backend/src/waypoint/backends/<id>/` (currently `
 `./scripts/waypoint.sh` (run from the repo root) is the canonical way to manage the running stack. Use it whenever the user asks to deploy, bring up, tear down, restart, or check on the app:
 - Deploy / bring up: `./scripts/waypoint.sh start`.
 - Teardown: `./scripts/waypoint.sh stop`.
-- Apply code changes: `./scripts/waypoint.sh restart` — neither half runs with hot reload, so a manual restart is always required after backend or frontend edits, including type-check or lint changes that look invisible.
+- Apply code changes: `./scripts/waypoint.sh restart [backend|frontend]` — DO NOT RUN `./scripts/waypoint.sh restart` OR `./scripts/waypoint.sh restart backend` WITHOUT EXPLICIT VERBAL PERMISSION FROM THE USER. `./scripts/waypoint.sh restart frontend` can be run safely when the frontend code is updated.
 - Check state during testing: `./scripts/waypoint.sh status` for health, `./scripts/waypoint.sh logs [backend|frontend]` for output. Restart before re-testing if you have changed code since the last `start`.
 Override ports or paths inline with `WAYPOINT_STACK_BACKEND_PORT`, `WAYPOINT_STACK_FRONTEND_PORT`, `WAYPOINT_STACK_CONFIG`, or `WAYPOINT_STACK_BACKEND_DATA_DIR` rather than editing the script.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,2 @@
+# Show the transport badge on session cards (default: hidden).
+# NEXT_PUBLIC_SHOW_TRANSPORT_BADGE=1

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2104,6 +2104,18 @@ details.tool-disclosure[open] .tool-glyph.todo {
   max-width: 100%;
 }
 
+/* system-rule inside a run group: suppress the decorative left/right gradient
+ * lines — they look odd at this width. Keep just the text. */
+.tool-call-run-children .system-rule {
+  grid-template-columns: auto;
+  padding: 1px 0;
+}
+
+.tool-call-run-children .system-rule::before,
+.tool-call-run-children .system-rule::after {
+  display: none;
+}
+
 .badge.tool {
   background: rgba(217, 154, 74, 0.12);
   color: var(--warn);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1948,6 +1948,42 @@ details.tool-disclosure[open] .tool-glyph.todo {
   color: var(--muted);
 }
 
+/* Tool runs group contiguous tool invocations — collapsed to keep transcript
+ * scannable, presenting a summary pill like "Ran 5 commands • Edited 2 files" */
+.transcript.tool-call-run {
+  background: rgba(151, 162, 179, 0.05);
+  border-color: rgba(151, 162, 179, 0.15);
+  box-shadow: none;
+  border-radius: var(--radius-md);
+  margin-top: 6px;
+  margin-bottom: 6px;
+}
+
+.transcript.tool-call-run > .transcript-summary {
+  padding-right: 30px;
+}
+
+.transcript.tool-call-run > .transcript-summary .transcript-role .badge.reasoning {
+  background: transparent;
+  border-color: transparent;
+  padding-left: 0;
+}
+
+.transcript.tool-call-run > .transcript-summary .transcript-preview {
+  color: var(--muted);
+  font-size: 0.85em;
+  letter-spacing: 0.02em;
+}
+
+.tool-call-run-children {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px dashed rgba(151, 162, 179, 0.15);
+}
+
 .badge.tool {
   background: rgba(217, 154, 74, 0.12);
   color: var(--warn);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1027,37 +1027,6 @@ pre {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
-  position: sticky;
-  top: 0;
-  z-index: 4;
-  /* Blurred backdrop so transcript cards scrolling behind are masked. */
-  background: linear-gradient(180deg, rgba(10, 13, 18, 0.96), rgba(10, 13, 18, 0.88));
-  backdrop-filter: blur(14px) saturate(1.1);
-  margin-left: calc(-20px - env(safe-area-inset-left));
-  margin-right: calc(-20px - env(safe-area-inset-right));
-  padding: 10px calc(20px + env(safe-area-inset-right)) 10px calc(20px + env(safe-area-inset-left));
-  border-bottom: 1px solid rgba(120, 138, 168, 0.1);
-}
-
-.session-toolbar-right {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-@media (max-width: 520px) {
-  .session-toolbar {
-    row-gap: 8px;
-  }
-
-  .session-toolbar-right {
-    flex: 1 0 100%;
-    justify-content: space-between;
-  }
-
-  .tool-run-toggle-label {
-    display: none;
-  }
 }
 
 .tool-run-toggle {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1039,6 +1039,27 @@ pre {
   border-bottom: 1px solid rgba(120, 138, 168, 0.1);
 }
 
+.session-toolbar-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+@media (max-width: 520px) {
+  .session-toolbar {
+    row-gap: 8px;
+  }
+
+  .session-toolbar-right {
+    flex: 1 0 100%;
+    justify-content: space-between;
+  }
+
+  .tool-run-toggle-label {
+    display: none;
+  }
+}
+
 .tool-run-toggle {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1948,40 +1948,160 @@ details.tool-disclosure[open] .tool-glyph.todo {
   color: var(--muted);
 }
 
-/* Tool runs group contiguous tool invocations — collapsed to keep transcript
- * scannable, presenting a summary pill like "Ran 5 commands • Edited 2 files" */
-.transcript.tool-call-run {
-  background: rgba(151, 162, 179, 0.05);
-  border-color: rgba(151, 162, 179, 0.15);
-  box-shadow: none;
-  border-radius: var(--radius-md);
-  margin-top: 6px;
-  margin-bottom: 6px;
+/* ─── Tool-run groups ──────────────────────────────────────────────────────
+ * Contiguous tool invocations are collapsed into a compact "process log" row.
+ * Deliberately NOT inheriting from panel/transcript/agent_output — this is a
+ * distinct element type that reads as infrastructure, not conversation.
+ * ──────────────────────────────────────────────────────────────────────────── */
+
+.tool-call-run {
+  position: relative;
+  background: rgba(8, 11, 16, 0.35);
+  border: 1px solid rgba(120, 138, 168, 0.1);
+  border-radius: var(--radius-sm);
+  margin: 3px 0;
+  overflow: hidden;
+  transition: border-color 160ms ease, background-color 160ms ease;
 }
 
-.transcript.tool-call-run > .transcript-summary {
-  padding-right: 30px;
+/* Left accent bar: a tri-colour gradient signalling "mixed tool work". */
+.tool-call-run::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(
+    to bottom,
+    rgba(94, 210, 156, 0.55),
+    rgba(200, 169, 106, 0.45),
+    rgba(143, 179, 214, 0.45)
+  );
 }
 
-.transcript.tool-call-run > .transcript-summary .transcript-role .badge.reasoning {
-  background: transparent;
-  border-color: transparent;
-  padding-left: 0;
+.tool-call-run[open] {
+  border-color: rgba(120, 138, 168, 0.17);
+  background: rgba(10, 13, 20, 0.5);
 }
 
-.transcript.tool-call-run > .transcript-summary .transcript-preview {
+.tool-call-run-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 36px 6px 14px;
+  cursor: pointer;
+  list-style: none;
+  position: relative;
+  user-select: none;
+  min-width: 0;
+}
+
+.tool-call-run-summary::-webkit-details-marker {
+  display: none;
+}
+
+.tool-call-run-summary::after {
+  content: "▸";
+  position: absolute;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%) rotate(0deg);
+  color: var(--muted-soft);
+  font-size: 0.6rem;
+  line-height: 1;
+  transition: transform 160ms ease, color 160ms ease;
+}
+
+.tool-call-run[open] > .tool-call-run-summary::after {
+  transform: translateY(-50%) rotate(90deg);
+  color: var(--accent-cool);
+}
+
+.tool-run-chips {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.tool-run-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px 2px 7px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono);
+  font-size: 0.71rem;
+  letter-spacing: 0.03em;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.tool-run-chip.bash {
+  background: rgba(94, 210, 156, 0.08);
+  border-color: rgba(94, 210, 156, 0.18);
+  color: var(--success);
+}
+
+.tool-run-chip.edit {
+  background: rgba(200, 169, 106, 0.08);
+  border-color: rgba(200, 169, 106, 0.18);
+  color: var(--accent);
+}
+
+.tool-run-chip.read {
+  background: rgba(143, 179, 214, 0.08);
+  border-color: rgba(143, 179, 214, 0.18);
+  color: var(--accent-cool);
+}
+
+.tool-run-chip.other {
+  background: rgba(151, 162, 179, 0.06);
+  border-color: rgba(151, 162, 179, 0.14);
   color: var(--muted);
-  font-size: 0.85em;
-  letter-spacing: 0.02em;
+}
+
+.tool-run-glyph {
+  font-weight: 600;
+}
+
+.tool-run-label {
+  letter-spacing: 0.05em;
+  opacity: 0.85;
+}
+
+.tool-run-count {
+  opacity: 0.6;
+}
+
+.tool-run-total {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+  flex-shrink: 0;
+  padding-right: 2px;
 }
 
 .tool-call-run-children {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  margin-top: 12px;
-  padding-top: 12px;
-  border-top: 1px dashed rgba(151, 162, 179, 0.15);
+  gap: 6px;
+  padding: 8px 8px 10px 12px;
+  border-top: 1px solid rgba(120, 138, 168, 0.08);
+}
+
+/* Tool cards inside a run group: strip the default side margin so they sit
+ * flush with the group container's own padding. */
+.tool-call-run-children .transcript.codex.tool_call,
+.tool-call-run-children .transcript.codex.tool_result,
+.tool-call-run-children .transcript.codex.tool_pair {
+  margin: 0;
+  max-width: 100%;
 }
 
 .badge.tool {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1027,6 +1027,43 @@ pre {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  /* Blurred backdrop so transcript cards scrolling behind are masked. */
+  background: linear-gradient(180deg, rgba(10, 13, 18, 0.96), rgba(10, 13, 18, 0.88));
+  backdrop-filter: blur(14px) saturate(1.1);
+  margin-left: calc(-20px - env(safe-area-inset-left));
+  margin-right: calc(-20px - env(safe-area-inset-right));
+  padding: 10px calc(20px + env(safe-area-inset-right)) 10px calc(20px + env(safe-area-inset-left));
+  border-bottom: 1px solid rgba(120, 138, 168, 0.1);
+}
+
+.tool-run-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: border-color 140ms ease, color 140ms ease, background-color 140ms ease;
+}
+
+.tool-run-toggle:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.tool-run-toggle-glyph {
+  font-size: 0.85rem;
+  line-height: 1;
 }
 
 .segmented {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4673,27 +4673,9 @@ html[data-theme="light"] .help-tooltip {
 }
 
 @media (max-width: 600px) {
-  .session-switcher-backdrop {
-    align-items: flex-end;
-    padding: 0;
-  }
-
-  /* Definite height (not max-height) so the flex column has a fixed
-   * parent size for `flex: 1; min-height: 0` to size the list
-   * against — iOS Safari otherwise grows the modal to content height
-   * and the list never gains its own scroll. Subtract the bottom
-   * safe-area inset so the modal doesn't sit under the iOS home
-   * indicator (viewportFit: cover puts dvh under it). */
-  .session-switcher-modal {
-    max-width: 100%;
-    height: calc(100dvh - 24px - env(safe-area-inset-bottom));
-    max-height: calc(100dvh - 24px - env(safe-area-inset-bottom));
-    border-radius: var(--radius) var(--radius) 0 0;
-    border-bottom: none;
-    border-left: none;
-    border-right: none;
-  }
-
+  /* Modal is sized and positioned inline from visualViewport (see
+   * SessionSwitcher.tsx) — 90% × 70% centered. The footer keyboard
+   * hint isn't useful on touch. */
   .session-switcher-footer {
     display: none;
   }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -472,6 +472,10 @@ export default function HomePage() {
     setError(message);
   }
 
+  function handleAuthFailure() {
+    resetAuthState("Session expired. Log in again.");
+  }
+
   async function handleCreateSchedule(payload: ScheduleCreateRequest) {
     try {
       const created = await createScheduleRequest(host, token, {
@@ -691,7 +695,7 @@ export default function HomePage() {
           launchTargets={launchTargets}
           targetId={activeLaunchTargetId}
           onSwitch={handleSwitchBackend}
-          onAuthFailure={() => resetAuthState("Session expired. Log in again.")}
+          onAuthFailure={handleAuthFailure}
         />
       ) : null}
       {token ? (
@@ -710,7 +714,7 @@ export default function HomePage() {
           onAttach={handleAttach}
           onCreate={handleCreate}
           onImportThread={handleImportThread}
-          onAuthFailure={() => resetAuthState("Session expired. Log in again.")}
+          onAuthFailure={handleAuthFailure}
         />
       ) : null}
       {token ? (
@@ -728,7 +732,7 @@ export default function HomePage() {
           onCreate={handleCreateSchedule}
           onCancel={handleCancelSchedule}
           onClearHistory={handleClearScheduleHistory}
-          onAuthFailure={() => resetAuthState("Session expired. Log in again.")}
+          onAuthFailure={handleAuthFailure}
         />
       ) : null}
       {token ? (

--- a/frontend/src/components/BackendSwitcher.tsx
+++ b/frontend/src/components/BackendSwitcher.tsx
@@ -33,6 +33,8 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
   const [customHost, setCustomHost] = useState(host);
   const [probe, setProbe] = useState<ProbeStatus>("idle");
   const probeAbortRef = useRef<AbortController | null>(null);
+  const onAuthFailureRef = useRef(onAuthFailure);
+  useEffect(() => { onAuthFailureRef.current = onAuthFailure; });
 
   const pageHost = typeof window === "undefined" ? "localhost" : window.location.hostname || "localhost";
 
@@ -67,14 +69,14 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
       .then((fetched) => setSnapshot(fetched))
       .catch((error) => {
         if (isAuthError(error)) {
-          onAuthFailure?.();
+          onAuthFailureRef.current?.();
           return;
         }
         setSnapshot({ available: false, error: "discovery failed", peers: [] });
       })
       .finally(() => setSnapshotLoading(false));
     return () => controller.abort();
-  }, [open, host, token, onAuthFailure]);
+  }, [open, host, token]);
 
   useEffect(() => {
     if (!open) {

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -24,6 +24,7 @@ export function SearchInput({
   const [tooltipPos, setTooltipPos] = useState<{ top: number; right: number } | null>(null);
   const iconRef = useRef<HTMLDivElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
+  const isTouchRef = useRef(false);
 
   function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
     if (event.key === "Escape") {
@@ -53,16 +54,13 @@ export function SearchInput({
   }
 
   function openTooltip() {
+    if (isTouchRef.current) return;
     cancelClose();
     updatePosition();
     setTooltipOpen(true);
   }
 
-  function toggleTooltip(e?: React.MouseEvent | React.TouchEvent) {
-    if (e && e.type === "touchstart") {
-      // Prevent touchstart from also firing mouseenter/click right away
-      e.preventDefault();
-    }
+  function toggleTooltip() {
     cancelClose();
     if (tooltipOpen) {
       setTooltipOpen(false);
@@ -174,10 +172,11 @@ export function SearchInput({
         ref={iconRef}
         aria-label="Search syntax help"
         tabIndex={0}
+        onTouchStart={() => { isTouchRef.current = true; }}
+        onMouseMove={() => { isTouchRef.current = false; }}
         onMouseEnter={openTooltip}
         onMouseLeave={scheduleClose}
         onClick={toggleTooltip}
-        onTouchStart={toggleTooltip}
         onFocus={openTooltip}
         onBlur={scheduleClose}
       >

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -828,7 +828,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           </button>
         </div>
         {view === "chat" ? (
-          <>
+          <div className="session-toolbar-right">
             <div className="segmented segmented-quiet" role="radiogroup" aria-label="Event filter">
               <button
                 type="button"
@@ -864,7 +864,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                 <span className="tool-run-toggle-label">{toolRunsExpanded ? "collapse" : "expand"}</span>
               </button>
             ) : null}
-          </>
+          </div>
         ) : null}
       </div>
       {view === "chat" ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -828,42 +828,25 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           </button>
         </div>
         {view === "chat" ? (
-          <div className="session-toolbar-right">
-            <div className="segmented segmented-quiet" role="radiogroup" aria-label="Event filter">
-              <button
-                type="button"
-                role="radio"
-                aria-checked={filterMode === "important"}
-                className={`segmented-item ${filterMode === "important" ? "active" : ""}`}
-                onClick={() => { setFilterMode("important"); setToolRunsExpanded(false); }}
-              >
-                Important
-              </button>
-              <button
-                type="button"
-                role="radio"
-                aria-checked={filterMode === "all"}
-                className={`segmented-item ${filterMode === "all" ? "active" : ""}`}
-                onClick={() => { setFilterMode("all"); setToolRunsExpanded(true); }}
-              >
-                All events
-              </button>
-            </div>
-            {hasToolRuns ? (
-              <button
-                type="button"
-                className="tool-run-toggle"
-                onClick={() => {
-                  const next = !toolRunsExpanded;
-                  document.querySelectorAll<HTMLDetailsElement>("details.tool-call-run").forEach((el) => { el.open = next; });
-                  setToolRunsExpanded(next);
-                }}
-                title={toolRunsExpanded ? "Collapse all tool runs" : "Expand all tool runs"}
-              >
-                <span className="tool-run-toggle-glyph">{toolRunsExpanded ? "⊟" : "⊞"}</span>
-                <span className="tool-run-toggle-label">{toolRunsExpanded ? "collapse" : "expand"}</span>
-              </button>
-            ) : null}
+          <div className="segmented segmented-quiet" role="radiogroup" aria-label="Event filter">
+            <button
+              type="button"
+              role="radio"
+              aria-checked={filterMode === "important"}
+              className={`segmented-item ${filterMode === "important" ? "active" : ""}`}
+              onClick={() => { setFilterMode("important"); setToolRunsExpanded(false); }}
+            >
+              Important
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={filterMode === "all"}
+              className={`segmented-item ${filterMode === "all" ? "active" : ""}`}
+              onClick={() => { setFilterMode("all"); setToolRunsExpanded(true); }}
+            >
+              All events
+            </button>
           </div>
         ) : null}
       </div>
@@ -906,7 +889,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                     <ToolCallRunGroup
                       key={`run-${index}`}
                       toolNames={toolNames}
-                      filterMode={filterMode}
+                      initiallyOpen={toolRunsExpanded || filterMode === "all"}
                     >
                       {item.items.map((child) =>
                         child.kind === "pair" ? (
@@ -1078,6 +1061,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                 ?.capabilities.supports_set_effort_with_restart,
           )
         }
+        hasToolRuns={hasToolRuns}
+        toolRunsExpanded={toolRunsExpanded}
+        onToggleToolRuns={() => {
+          const next = !toolRunsExpanded;
+          document.querySelectorAll<HTMLDetailsElement>("details.tool-call-run").forEach((el) => { el.open = next; });
+          setToolRunsExpanded(next);
+        }}
         onDelete={removeFromList}
         onInterrupt={interruptSession}
         onModeChange={handlePermissionModeChange}
@@ -1097,6 +1087,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
 interface ReplyComposerProps {
   agentBusy: boolean;
   permissionModeOptions: readonly BackendPermissionMode[];
+  hasToolRuns: boolean;
+  toolRunsExpanded: boolean;
+  onToggleToolRuns: () => void;
   canDelete: boolean;
   canResume: boolean;
   canReattach: boolean;
@@ -1157,6 +1150,9 @@ const ReplyComposer = memo(function ReplyComposer({
   permissionMode,
   transport,
   effortRequiresConfirm,
+  hasToolRuns,
+  toolRunsExpanded,
+  onToggleToolRuns,
   onDelete,
   onInterrupt,
   onModeChange,
@@ -1762,6 +1758,17 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">⇄</span>
                     Switch session…
                   </button>
+                  {hasToolRuns ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="composer-overflow-item"
+                      onClick={() => { onToggleToolRuns(); setOverflowOpen(false); }}
+                    >
+                      <span className="glyph">{toolRunsExpanded ? "⊟" : "⊞"}</span>
+                      {toolRunsExpanded ? "Collapse tool runs" : "Expand tool runs"}
+                    </button>
+                  ) : null}
                   <div className="composer-overflow-separator" />
                   {canTerminate ? (
                     <button

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1971,38 +1971,54 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     item.pair.sequence = Math.max(item.pair.sequence, event.sequence);
   }
 
+  // Classify each item so the grouping loop is easy to reason about.
+  // "content"  → user messages, agent text, approvals, todos, ask-questions:
+  //              always breaks (and terminates) the current tool run.
+  // "tool"     → ordinary tool call/result pairs/singles: join the run.
+  // "absorbed" → system_note / status_update lifecycle noise: silently join
+  //              the active run (rendered as quiet separators when expanded),
+  //              or fall through as standalone if no run is active yet.
+  function classifyItem(item: Extract<TranscriptItem, { kind: "single" | "pair" }>): "content" | "tool" | "absorbed" {
+    if (item.kind === "pair") {
+      const { call, result } = item.pair;
+      const isSpecial = (e: EventRecord | null) =>
+        e !== null && (isTodoListEvent(e) || readToolName(e) === "AskUserQuestion");
+      return isSpecial(call) || isSpecial(result) ? "content" : "tool";
+    }
+    const { event } = item;
+    switch (event.kind) {
+      case "user_input":
+      case "agent_output":
+      case "approval_request":
+        return "content";
+      case "tool_call":
+      case "tool_result":
+        return isTodoListEvent(event) || readToolName(event) === "AskUserQuestion"
+          ? "content"
+          : "tool";
+      default:
+        return "absorbed";
+    }
+  }
+
   const grouped: TranscriptItem[] = [];
   let currentRun: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] = [];
 
   for (const item of result) {
-    const isToolEvent = (event: EventRecord) =>
-      event.kind === "tool_call" || event.kind === "tool_result";
-    
-    let isTool = false;
-    let isTodo = false;
-
-    if (item.kind === "pair") {
-      isTool = true;
-      if ((item.pair.call && isTodoListEvent(item.pair.call)) ||
-          (item.pair.result && isTodoListEvent(item.pair.result))) {
-        isTodo = true;
-      }
-    } else if (item.kind === "single") {
-      if (isToolEvent(item.event)) {
-        isTool = true;
-        if (isTodoListEvent(item.event)) {
-          isTodo = true;
-        }
-      }
-    }
-
-    if (isTool && !isTodo) {
+    const cls = classifyItem(item);
+    if (cls === "tool") {
       currentRun.push(item);
+    } else if (cls === "absorbed") {
+      if (currentRun.length > 0) {
+        currentRun.push(item);
+      } else {
+        grouped.push(item);
+      }
     } else {
       if (currentRun.length >= 1) {
         grouped.push({ kind: "tool_run", items: currentRun });
+        currentRun = [];
       }
-      currentRun = [];
       grouped.push(item);
     }
   }

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -113,6 +113,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [snapshotLoading, setSnapshotLoading] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
   const [filterMode, setFilterMode] = useState<FilterMode>("important");
+  const [toolRunsExpanded, setToolRunsExpanded] = useState(false);
   const [error, setError] = useState("");
   const [connection, setConnection] = useState<ConnectionState>("connecting");
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
@@ -745,6 +746,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       ? filterOptimisticTranscriptEvents(visibleEvents, optimisticMessages)
       : visibleEvents;
   const transcriptItems = buildTranscriptItems(transcriptEvents);
+  const hasToolRuns = transcriptItems.some((item) => item.kind === "tool_run");
   const usageSummary = extractUsageSummary(events);
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
@@ -826,26 +828,43 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           </button>
         </div>
         {view === "chat" ? (
-          <div className="segmented segmented-quiet" role="radiogroup" aria-label="Event filter">
-            <button
-              type="button"
-              role="radio"
-              aria-checked={filterMode === "important"}
-              className={`segmented-item ${filterMode === "important" ? "active" : ""}`}
-              onClick={() => setFilterMode("important")}
-            >
-              Important
-            </button>
-            <button
-              type="button"
-              role="radio"
-              aria-checked={filterMode === "all"}
-              className={`segmented-item ${filterMode === "all" ? "active" : ""}`}
-              onClick={() => setFilterMode("all")}
-            >
-              All events
-            </button>
-          </div>
+          <>
+            <div className="segmented segmented-quiet" role="radiogroup" aria-label="Event filter">
+              <button
+                type="button"
+                role="radio"
+                aria-checked={filterMode === "important"}
+                className={`segmented-item ${filterMode === "important" ? "active" : ""}`}
+                onClick={() => { setFilterMode("important"); setToolRunsExpanded(false); }}
+              >
+                Important
+              </button>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={filterMode === "all"}
+                className={`segmented-item ${filterMode === "all" ? "active" : ""}`}
+                onClick={() => { setFilterMode("all"); setToolRunsExpanded(true); }}
+              >
+                All events
+              </button>
+            </div>
+            {hasToolRuns ? (
+              <button
+                type="button"
+                className="tool-run-toggle"
+                onClick={() => {
+                  const next = !toolRunsExpanded;
+                  document.querySelectorAll<HTMLDetailsElement>("details.tool-call-run").forEach((el) => { el.open = next; });
+                  setToolRunsExpanded(next);
+                }}
+                title={toolRunsExpanded ? "Collapse all tool runs" : "Expand all tool runs"}
+              >
+                <span className="tool-run-toggle-glyph">{toolRunsExpanded ? "⊟" : "⊞"}</span>
+                <span className="tool-run-toggle-label">{toolRunsExpanded ? "collapse" : "expand"}</span>
+              </button>
+            ) : null}
+          </>
         ) : null}
       </div>
       {view === "chat" ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -48,6 +48,8 @@ import {
   PendingUserInputCard,
   TranscriptCard,
   ToolPair,
+  ToolCallRunGroup,
+  readToolName,
 } from "@/components/TranscriptCard";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
@@ -873,8 +875,42 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
             </p>
           ) : null}
           {session && transcriptItems.length > 0
-            ? transcriptItems.map((item) =>
-                item.kind === "pair" ? (
+            ? transcriptItems.map((item, index) => {
+                if (item.kind === "tool_run") {
+                  const toolNames = item.items
+                    .map((child) => {
+                      const event = child.kind === "pair" ? child.pair.call ?? child.pair.result : child.event;
+                      return event ? readToolName(event) : null;
+                    })
+                    .filter((name): name is string => name !== null);
+                  return (
+                    <ToolCallRunGroup
+                      key={`run-${index}`}
+                      toolNames={toolNames}
+                      filterMode={filterMode}
+                    >
+                      {item.items.map((child) =>
+                        child.kind === "pair" ? (
+                          <TranscriptCard
+                            event={child.pair.call ?? child.pair.result ?? child.event}
+                            pair={child.pair}
+                            transport={session.transport}
+                            onAnswerAskQuestion={submitAskAnswer}
+                            key={`pair-${child.pair.itemId}`}
+                          />
+                        ) : (
+                          <TranscriptCard
+                            event={child.event}
+                            transport={session.transport}
+                            onAnswerAskQuestion={submitAskAnswer}
+                            key={`${child.event.sequence}-${child.event.id ?? "local"}`}
+                          />
+                        ),
+                      )}
+                    </ToolCallRunGroup>
+                  );
+                }
+                return item.kind === "pair" ? (
                   <TranscriptCard
                     event={item.pair.call ?? item.pair.result ?? item.event}
                     pair={item.pair}
@@ -889,8 +925,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                     onAnswerAskQuestion={submitAskAnswer}
                     key={`${item.event.sequence}-${item.event.id ?? "local"}`}
                   />
-                ),
-              )
+                );
+              })
             : session && optimisticMessages.length === 0
               ? (
                 <TranscriptEmpty
@@ -1893,10 +1929,11 @@ function mergeEventText(existing: EventRecord, incoming: EventRecord): string {
 
 type TranscriptItem =
   | { kind: "single"; event: EventRecord }
-  | { kind: "pair"; event: EventRecord; pair: ToolPair };
+  | { kind: "pair"; event: EventRecord; pair: ToolPair }
+  | { kind: "tool_run"; items: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] };
 
 function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
-  const result: TranscriptItem[] = [];
+  const result: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] = [];
   const pairIndex = new Map<string, number>();
   for (const event of events) {
     if (event.kind !== "tool_call" && event.kind !== "tool_result") {
@@ -1933,7 +1970,33 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     item.pair.ts = event.ts;
     item.pair.sequence = Math.max(item.pair.sequence, event.sequence);
   }
-  return result;
+
+  const grouped: TranscriptItem[] = [];
+  let currentRun: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] = [];
+
+  for (const item of result) {
+    const isTool =
+      item.kind === "pair" ||
+      (item.kind === "single" && (item.event.kind === "tool_call" || item.event.kind === "tool_result"));
+    if (isTool) {
+      currentRun.push(item);
+    } else {
+      if (currentRun.length >= 2) {
+        grouped.push({ kind: "tool_run", items: currentRun });
+      } else {
+        grouped.push(...currentRun);
+      }
+      currentRun = [];
+      grouped.push(item);
+    }
+  }
+  if (currentRun.length >= 2) {
+    grouped.push({ kind: "tool_run", items: currentRun });
+  } else {
+    grouped.push(...currentRun);
+  }
+
+  return grouped;
 }
 
 function filterOptimisticTranscriptEvents(

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1766,7 +1766,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       onClick={() => { onToggleToolRuns(); setOverflowOpen(false); }}
                     >
                       <span className="glyph">{toolRunsExpanded ? "⊟" : "⊞"}</span>
-                      {toolRunsExpanded ? "Collapse tool runs" : "Expand tool runs"}
+                      {toolRunsExpanded ? "Collapse tools" : "Expand tools"}
                     </button>
                   ) : null}
                   <div className="composer-overflow-separator" />

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2049,7 +2049,7 @@ function isToolResultDelta(event: EventRecord): boolean {
 }
 
 function isTodoListEvent(event: EventRecord): boolean {
-  return event.metadata?.item_type === "todo_list";
+  return event.metadata?.item_type === "todo_list" || readToolName(event) === "TodoWrite";
 }
 
 function isAgentBusy(

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1975,25 +1975,39 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
   let currentRun: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] = [];
 
   for (const item of result) {
-    const isTool =
-      item.kind === "pair" ||
-      (item.kind === "single" && (item.event.kind === "tool_call" || item.event.kind === "tool_result"));
-    if (isTool) {
+    const isToolEvent = (event: EventRecord) =>
+      event.kind === "tool_call" || event.kind === "tool_result";
+    
+    let isTool = false;
+    let isTodo = false;
+
+    if (item.kind === "pair") {
+      isTool = true;
+      if ((item.pair.call && isTodoListEvent(item.pair.call)) ||
+          (item.pair.result && isTodoListEvent(item.pair.result))) {
+        isTodo = true;
+      }
+    } else if (item.kind === "single") {
+      if (isToolEvent(item.event)) {
+        isTool = true;
+        if (isTodoListEvent(item.event)) {
+          isTodo = true;
+        }
+      }
+    }
+
+    if (isTool && !isTodo) {
       currentRun.push(item);
     } else {
-      if (currentRun.length >= 2) {
+      if (currentRun.length >= 1) {
         grouped.push({ kind: "tool_run", items: currentRun });
-      } else {
-        grouped.push(...currentRun);
       }
       currentRun = [];
       grouped.push(item);
     }
   }
-  if (currentRun.length >= 2) {
+  if (currentRun.length >= 1) {
     grouped.push({ kind: "tool_run", items: currentRun });
-  } else {
-    grouped.push(...currentRun);
   }
 
   return grouped;

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -184,9 +184,11 @@ export function SessionList({
           <span className={`badge ${session.backend}`}>
             {humaniseBackend(session.backend)}
           </span>
-          <span className={`badge transport ${session.transport}`}>
-            {transportLabel(session.transport)}
-          </span>
+          {process.env.NEXT_PUBLIC_SHOW_TRANSPORT_BADGE === "1" ? (
+            <span className={`badge transport ${session.transport}`}>
+              {transportLabel(session.transport)}
+            </span>
+          ) : null}
           {session.launch_target_id ? (
             <span className="badge neutral">{session.launch_target_id}</span>
           ) : null}

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -67,8 +67,13 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   // Tracks the visible viewport on mobile via visualViewport — iOS
   // Safari's 100dvh doesn't shrink for the on-screen keyboard or
   // always exclude the bottom URL bar with viewportFit: cover, so we
-  // size and position the sheet from JS instead.
-  const [mobileVV, setMobileVV] = useState<{ height: number; offsetTop: number } | null>(null);
+  // size and position the modal from JS instead.
+  const [mobileVV, setMobileVV] = useState<{
+    height: number;
+    width: number;
+    offsetTop: number;
+    offsetLeft: number;
+  } | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -260,16 +265,27 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     };
   }, []);
 
-  // Track visualViewport on mobile so the bottom-sheet always matches
-  // the actual visible area (URL bar collapse, keyboard show/hide).
+  // Track visualViewport on mobile so the modal always matches the
+  // actual visible area (URL bar collapse, keyboard show/hide).
   useEffect(() => {
     if (!isMobile) return;
     const vv = window.visualViewport;
     if (!vv) {
-      setMobileVV({ height: window.innerHeight, offsetTop: 0 });
+      setMobileVV({
+        height: window.innerHeight,
+        width: window.innerWidth,
+        offsetTop: 0,
+        offsetLeft: 0,
+      });
       return;
     }
-    const update = () => setMobileVV({ height: vv.height, offsetTop: vv.offsetTop });
+    const update = () =>
+      setMobileVV({
+        height: vv.height,
+        width: vv.width,
+        offsetTop: vv.offsetTop,
+        offsetLeft: vv.offsetLeft,
+      });
     update();
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
@@ -334,18 +350,18 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
         style={
           isMobile && mobileVV !== null
             ? {
-                // Pin to the visualViewport directly — flex `align-items:
-                // flex-end` against the backdrop would put us behind the
-                // bottom URL bar on iOS Safari (viewportFit: cover puts
-                // the layout viewport under it).
+                // Pin to the visualViewport directly — flex centering
+                // against the backdrop aligns to the layout viewport,
+                // which extends behind the bottom URL bar on iOS
+                // Safari (viewportFit: cover puts dvh under it).
+                // 90% wide × 70% tall, centered in the visible area.
                 position: "fixed",
-                left: 0,
-                right: 0,
-                top: `${mobileVV.offsetTop + 24}px`,
-                height: `calc(${mobileVV.height}px - 24px - env(safe-area-inset-bottom))`,
-                maxHeight: `calc(${mobileVV.height}px - 24px - env(safe-area-inset-bottom))`,
-                width: "100%",
-                maxWidth: "100%",
+                width: `${mobileVV.width * 0.9}px`,
+                height: `${mobileVV.height * 0.7}px`,
+                maxWidth: `${mobileVV.width * 0.9}px`,
+                maxHeight: `${mobileVV.height * 0.7}px`,
+                top: `${mobileVV.offsetTop + mobileVV.height * 0.15}px`,
+                left: `${mobileVV.offsetLeft + mobileVV.width * 0.05}px`,
               }
             : undefined
         }

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -51,6 +51,7 @@ function formatCwdSegments(cwd: string): string[] {
 
 export function SessionSwitcher({ host, token, currentSession, onAuthFailure, onClose }: SessionSwitcherProps) {
   const router = useRouter();
+  const toggleHint = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform) ? "⌘K" : "Ctrl+K";
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
   const [query, setQuery] = useState("");
   const [page, setPage] = useState(1);
@@ -371,7 +372,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
         </div>
 
         <div className="session-switcher-footer">
-          ↑↓ navigate · ↵ open · esc close
+          ↑↓ navigate · ↵ open · {toggleHint} toggle · esc close
         </div>
       </div>
     </div>

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -59,6 +59,16 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const listRef = useRef<HTMLDivElement>(null);
   const modalRef = useRef<HTMLDivElement>(null);
   const lastKeyTimeRef = useRef(0);
+  // Resolved synchronously on first render so SearchInput's autoFocus
+  // prop is correct on mount (avoids the keyboard popping up on iOS).
+  const [isMobile] = useState(() =>
+    typeof window !== "undefined" && window.matchMedia("(max-width: 600px)").matches,
+  );
+  // Tracks the visible viewport on mobile via visualViewport — iOS
+  // Safari's 100dvh doesn't shrink for the on-screen keyboard or
+  // always exclude the bottom URL bar with viewportFit: cover, so we
+  // size the sheet from JS instead.
+  const [mobileViewportHeight, setMobileViewportHeight] = useState<number | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -250,6 +260,26 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     };
   }, []);
 
+  // Track visualViewport.height on mobile so the bottom-sheet always
+  // matches the actual visible area (URL bar showing/hiding, keyboard
+  // up/down).
+  useEffect(() => {
+    if (!isMobile) return;
+    const vv = window.visualViewport;
+    if (!vv) {
+      setMobileViewportHeight(window.innerHeight);
+      return;
+    }
+    const update = () => setMobileViewportHeight(vv.height);
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, [isMobile]);
+
   // Restore focus to whatever was focused before the modal opened
   // (typically the ⋯ trigger when opened from the overflow menu).
   useEffect(() => {
@@ -296,7 +326,21 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     <div className="session-switcher-backdrop" onPointerDown={(e) => {
       if (e.target === e.currentTarget) onClose();
     }}>
-      <div className="session-switcher-modal" role="dialog" aria-modal="true" aria-label="Switch session" ref={modalRef}>
+      <div
+        className="session-switcher-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Switch session"
+        ref={modalRef}
+        style={
+          isMobile && mobileViewportHeight !== null
+            ? {
+                height: `${mobileViewportHeight - 24}px`,
+                maxHeight: `${mobileViewportHeight - 24}px`,
+              }
+            : undefined
+        }
+      >
         <div className="session-switcher-search">
           <SearchInput 
             value={query}
@@ -306,7 +350,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
               setActiveIndex(0);
             }}
             placeholder="Search sessions..."
-            autoFocus
+            autoFocus={!isMobile}
             showStatusExample={false}
           />
         </div>

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -67,8 +67,8 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   // Tracks the visible viewport on mobile via visualViewport — iOS
   // Safari's 100dvh doesn't shrink for the on-screen keyboard or
   // always exclude the bottom URL bar with viewportFit: cover, so we
-  // size the sheet from JS instead.
-  const [mobileViewportHeight, setMobileViewportHeight] = useState<number | null>(null);
+  // size and position the sheet from JS instead.
+  const [mobileVV, setMobileVV] = useState<{ height: number; offsetTop: number } | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -260,17 +260,16 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     };
   }, []);
 
-  // Track visualViewport.height on mobile so the bottom-sheet always
-  // matches the actual visible area (URL bar showing/hiding, keyboard
-  // up/down).
+  // Track visualViewport on mobile so the bottom-sheet always matches
+  // the actual visible area (URL bar collapse, keyboard show/hide).
   useEffect(() => {
     if (!isMobile) return;
     const vv = window.visualViewport;
     if (!vv) {
-      setMobileViewportHeight(window.innerHeight);
+      setMobileVV({ height: window.innerHeight, offsetTop: 0 });
       return;
     }
-    const update = () => setMobileViewportHeight(vv.height);
+    const update = () => setMobileVV({ height: vv.height, offsetTop: vv.offsetTop });
     update();
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
@@ -333,10 +332,20 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
         aria-label="Switch session"
         ref={modalRef}
         style={
-          isMobile && mobileViewportHeight !== null
+          isMobile && mobileVV !== null
             ? {
-                height: `${mobileViewportHeight - 24}px`,
-                maxHeight: `${mobileViewportHeight - 24}px`,
+                // Pin to the visualViewport directly — flex `align-items:
+                // flex-end` against the backdrop would put us behind the
+                // bottom URL bar on iOS Safari (viewportFit: cover puts
+                // the layout viewport under it).
+                position: "fixed",
+                left: 0,
+                right: 0,
+                top: `${mobileVV.offsetTop + 24}px`,
+                height: `calc(${mobileVV.height}px - 24px - env(safe-area-inset-bottom))`,
+                maxHeight: `calc(${mobileVV.height}px - 24px - env(safe-area-inset-bottom))`,
+                width: "100%",
+                maxWidth: "100%",
               }
             : undefined
         }

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -360,11 +360,11 @@ export function readToolName(event: EventRecord): string | null {
 
 export function ToolCallRunGroup({
   toolNames,
-  filterMode,
+  initiallyOpen,
   children,
 }: {
   toolNames: string[];
-  filterMode: string;
+  initiallyOpen: boolean;
   children: React.ReactNode;
 }) {
   const count = toolNames.length;
@@ -380,7 +380,7 @@ export function ToolCallRunGroup({
   }
 
   return (
-    <details className="tool-call-run" open={filterMode === "all"}>
+    <details className="tool-call-run" open={initiallyOpen}>
       <summary className="tool-call-run-summary">
         <div className="tool-run-chips">
           {bashCount > 0 && (

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -349,13 +349,57 @@ function toolBadgeFor(toolName: string | null | undefined): ToolBadge {
   }
 }
 
-function readToolName(event: EventRecord): string | null {
+export function readToolName(event: EventRecord): string | null {
   const meta = event.metadata as Record<string, unknown> | undefined;
   if (!meta) return null;
   if (typeof meta.tool_name === "string" && meta.tool_name) {
     return normalizeToolName(meta.tool_name);
   }
   return null;
+}
+
+export function ToolCallRunGroup({
+  toolNames,
+  filterMode,
+  children,
+}: {
+  toolNames: string[];
+  filterMode: string;
+  children: React.ReactNode;
+}) {
+  const count = toolNames.length;
+  let bashCount = 0;
+  let editCount = 0;
+  let readCount = 0;
+  let otherCount = 0;
+  for (const name of toolNames) {
+    if (name === "Bash") bashCount++;
+    else if (name === "Edit" || name === "MultiEdit" || name === "Write") editCount++;
+    else if (name === "Read" || name === "Grep" || name === "Glob") readCount++;
+    else otherCount++;
+  }
+
+  const parts = [];
+  if (bashCount > 0) parts.push(`Ran ${bashCount} command${bashCount > 1 ? "s" : ""}`);
+  if (editCount > 0) parts.push(`Edited ${editCount} file${editCount > 1 ? "s" : ""}`);
+  if (readCount > 0) parts.push(`Read ${readCount} file${readCount > 1 ? "s" : ""}`);
+  if (otherCount > 0) parts.push(`Used ${otherCount} other tool${otherCount > 1 ? "s" : ""}`);
+
+  const summary = parts.length > 0 ? parts.join(" • ") : `Used ${count} tools`;
+
+  return (
+    <details className="panel transcript codex agent_output tool-call-run" open={filterMode === "all"}>
+      <summary className="transcript-summary">
+        <div className="transcript-role">
+          <span className="badge agent reasoning">Tool Run</span>
+        </div>
+        <p className="transcript-preview">{summary}</p>
+      </summary>
+      <div className="tool-call-run-children">
+        {children}
+      </div>
+    </details>
+  );
 }
 
 function ToolDisclosure({

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -379,21 +379,40 @@ export function ToolCallRunGroup({
     else otherCount++;
   }
 
-  const parts = [];
-  if (bashCount > 0) parts.push(`Ran ${bashCount} command${bashCount > 1 ? "s" : ""}`);
-  if (editCount > 0) parts.push(`Edited ${editCount} file${editCount > 1 ? "s" : ""}`);
-  if (readCount > 0) parts.push(`Read ${readCount} file${readCount > 1 ? "s" : ""}`);
-  if (otherCount > 0) parts.push(`Used ${otherCount} other tool${otherCount > 1 ? "s" : ""}`);
-
-  const summary = parts.length > 0 ? parts.join(" • ") : `Used ${count} tools`;
-
   return (
-    <details className="panel transcript codex agent_output tool-call-run" open={filterMode === "all"}>
-      <summary className="transcript-summary">
-        <div className="transcript-role">
-          <span className="badge agent reasoning">Tool Run</span>
+    <details className="tool-call-run" open={filterMode === "all"}>
+      <summary className="tool-call-run-summary">
+        <div className="tool-run-chips">
+          {bashCount > 0 && (
+            <span className="tool-run-chip bash">
+              <span className="tool-run-glyph">›_</span>
+              <span className="tool-run-label">bash</span>
+              <span className="tool-run-count">×{bashCount}</span>
+            </span>
+          )}
+          {editCount > 0 && (
+            <span className="tool-run-chip edit">
+              <span className="tool-run-glyph">✎</span>
+              <span className="tool-run-label">edit</span>
+              <span className="tool-run-count">×{editCount}</span>
+            </span>
+          )}
+          {readCount > 0 && (
+            <span className="tool-run-chip read">
+              <span className="tool-run-glyph">▤</span>
+              <span className="tool-run-label">read</span>
+              <span className="tool-run-count">×{readCount}</span>
+            </span>
+          )}
+          {otherCount > 0 && (
+            <span className="tool-run-chip other">
+              <span className="tool-run-glyph">✦</span>
+              <span className="tool-run-label">other</span>
+              <span className="tool-run-count">×{otherCount}</span>
+            </span>
+          )}
         </div>
-        <p className="transcript-preview">{summary}</p>
+        <span className="tool-run-total">{count} call{count !== 1 ? "s" : ""}</span>
       </summary>
       <div className="tool-call-run-children">
         {children}


### PR DESCRIPTION
## Summary

This PR cleans up the session transcript UI by grouping tool calls into compact, expandable "Tool Run" blocks. It also absorbs minor session lifecycle events (like start/exit/attach messages) into these groups, drastically reducing visual noise while keeping the raw log accessible. Additionally, it introduces robust mobile fixes for the Session Switcher and eliminates a component fetching loop on the home page.

Addresses part 1 of #31.

## Changes

### Tool Call Grouping
- **Tool Runs:** Contiguous tool calls and their results are now grouped into a single, expandable `<details>` block ("Tool Run"). This matches the Claude Desktop pattern and prevents long sequences of recursive grep/read commands from burying the chat.
- **Categorization Chips:** The "Tool Run" summary generates dynamic counts for the tools used (e.g., `Ran 3 commands • Edited 2 files • Read 5 files • Used 1 other tool`), giving an immediate overview of the agent's actions without needing to expand the block.
- **Single Calls:** Even single tool invocations are wrapped in the "Tool Run" block in "important" mode. This enforces absolute UI consistency — all tool outputs are presented as compact pills unless explicitly expanded.
- **TODO Exclusion:** Tasks utilizing the `TodoWrite` tool (or carrying the `todo_list` metadata item type) are strictly exempted from grouping. They remain visible at the top level alongside user inputs and approval prompts, reflecting their importance as high-level task tracking mechanisms.
- **Expand/Collapse All & Menu:** Added a sticky expand/collapse toggle for all tool runs into the `⋯` overflow menu, alongside a compact toggle in the session toolbar. The chosen expansion state is now sticky for newly incoming events.

### Transcript Noise Reduction
- **Absorbing Lifecycle Events:** Minor system notes and status updates (such as "Session started", "Attached to session", "Session exited", or "Compact context") are now categorized as tool-like events during the reduction pass. If they occur adjacently to a tool run, they are silently absorbed into the expanded details block rather than taking up vertical space in the main chat view.

### Session Switcher Mobile Fixes
- **Visual Viewport Sizing:** The mobile SessionSwitcher is now anchored and sized using `window.visualViewport` instead of `100dvh`. This fixes significant overflow issues on iOS Safari where the bottom URL bar obscured content and the virtual keyboard shrank the visible area uncontrollably.
- **No Auto-Focus:** Disabled autofocus on mobile devices to prevent the keyboard from popping open immediately and cramping the layout upon opening the modal.

### Bug Fixes & Chores
- **BackendSwitcher Flicker:** Prevented an infinite peer-refetching loop that caused "Loading peers…" to flash repeatedly. The `onAuthFailure` callback was stored in a ref to decouple it from `useEffect` dependency arrays that fired upon every WebSocket tick.
- **Tooltip Interactions:** Made the search syntax `?` tooltip tap-to-toggle on touch devices, fixing hover state stickiness.
- **Documentation:** Added clear agent instructions to `AGENTS.md` about stack restart semantics.

### Configuration
- **Transport Badge:** The backend transport badge on session cards is now hidden by default for a cleaner look. It can be re-enabled by setting `NEXT_PUBLIC_SHOW_TRANSPORT_BADGE=true` in `frontend/.env`.

## Test Plan

- [x] `cd backend && uv run pytest`
- [x] `cd backend && uv run pre-commit run --all-files`
- [x] `cd frontend && npm run lint && npm run build`
- [x] Manual: Start a session and instruct the agent to run a shell command, read a file, and edit a file. Verify all commands collapse into a single "Tool Run" block in the "important" filter mode.
- [x] Manual: Expand the block and ensure all individual tool disclosures render correctly.
- [x] Manual: Verify the summary chips correctly count the number of bash, edit, read, and "other" tools.
- [x] Manual: Ask the agent to use its Todo list. Verify the TODO widget appears at the top level and is not swallowed by the grouping logic.
- [x] Manual: Open the `⋯` menu and toggle Expand/Collapse tools. Verify all tool blocks react immediately.
- [x] Manual: On an iOS device or simulator, open the Session Switcher (`Cmd+K`). Verify it sizes itself perfectly within the visual viewport above the URL bar, and the keyboard does not pop up automatically.
- [x] Manual: Monitor the active sessions list; confirm that "Loading peers…" no longer flickers on every background update.