### PR TITLE
feat: support session forking

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -258,6 +258,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session = await context.runtime.resume(session_id)
         return {"session": session.model_dump(mode="json")}
 
+    @app.post("/api/sessions/{session_id}/fork")
+    async def session_fork(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        session = await context.runtime.fork_session(session_id)
+        return {"session": session.model_dump(mode="json")}
+
     @app.post("/api/sessions/{session_id}/reattach")
     async def session_reattach(
         session_id: str,

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 from pydantic import BaseModel
@@ -157,8 +158,8 @@ class BackendPlugin(Protocol):
         session: SessionRecord,
         new_session_id: str,
         title: str,
-        raw_log: Any,
-        structured_log: Any,
+        raw_log: Path,
+        structured_log: Path,
     ) -> SessionRecord:
         """Fork an existing session into a new branch."""
         ...

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -151,6 +151,18 @@ class BackendPlugin(Protocol):
         """Spawn a new session for this backend."""
         ...
 
+    async def fork_session(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> SessionRecord:
+        """Fork an existing session into a new branch."""
+        ...
+
     async def maybe_handle_input(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -40,6 +40,7 @@ class BackendCapabilities(_FrozenModel):
     supports_set_permission_mode_inline: bool = False
     supports_thread_discovery: bool = False
     supports_thread_import: bool = False
+    supports_fork: bool = False
     supports_slash_compact: bool = False
     supports_approval_note: bool = False
     permission_modes: tuple[PermissionModeSpec, ...] = ()

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -141,7 +141,7 @@ EmitEvent = Callable[
     Coroutine[Any, Any, None],
 ]
 LaunchFactory = Callable[
-    [str, str, str, bool, str, str | None, str | None, list[str]],
+    [str, str, str, bool, str, str | None, str | None, list[str], str | None],
     "ClaudeLaunchSpec",
 ]
 
@@ -265,6 +265,7 @@ class ClaudeCliAdapter:
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        fork_from_claude_session_id: str | None = None,
     ) -> str:
         state = await self._spawn(
             session_id,
@@ -276,6 +277,7 @@ class ClaudeCliAdapter:
             model=model,
             effort=effort,
             custom_args=custom_args or [],
+            fork_from_claude_session_id=fork_from_claude_session_id,
         )
         return state.claude_session_id
 
@@ -842,6 +844,7 @@ class ClaudeCliAdapter:
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        fork_from_claude_session_id: str | None = None,
     ) -> ClaudeSessionState:
         resolved_mode = (
             permission_mode if permission_mode in CLAUDE_PERMISSION_MODES else "default"
@@ -859,6 +862,7 @@ class ClaudeCliAdapter:
                 model,
                 effort,
                 effective_custom_args,
+                fork_from_claude_session_id,
             )
         else:
             spec = launch_factory(
@@ -870,6 +874,7 @@ class ClaudeCliAdapter:
                 model,
                 effort,
                 effective_custom_args,
+                fork_from_claude_session_id,
             )
         process = await asyncio.create_subprocess_exec(
             *spec.args,
@@ -910,6 +915,7 @@ class ClaudeCliAdapter:
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        fork_from_claude_session_id: str | None = None,
     ) -> ClaudeLaunchSpec:
         binary = self._binary or shutil.which("claude")
         if binary is None:
@@ -931,7 +937,17 @@ class ClaudeCliAdapter:
             args.extend(["--model", model])
         if effort:
             args.extend(["--effort", effort])
-        if resume:
+        if fork_from_claude_session_id:
+            args.extend(
+                [
+                    "--resume",
+                    fork_from_claude_session_id,
+                    "--fork-session",
+                    "--session-id",
+                    claude_session_id,
+                ]
+            )
+        elif resume:
             args.extend(["--resume", claude_session_id])
         else:
             args.extend(["--session-id", claude_session_id])

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -519,6 +519,7 @@ class ClaudeCodePlugin:
             config_overrides=session.config_overrides,
         )
         runtime.storage.create_session(new_session)
+        runtime.storage.clone_events(session.id, new_session_id)
         await runtime._record_system_event(
             new_session_id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -443,8 +443,8 @@ class ClaudeCodePlugin:
         session: SessionRecord,
         new_session_id: str,
         title: str,
-        raw_log: Any,
-        structured_log: Any,
+        raw_log: Path,
+        structured_log: Path,
     ) -> SessionRecord:
         if self.adapter is None:
             raise HTTPException(

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -95,6 +95,7 @@ class ClaudeCodePlugin:
         supports_set_permission_mode_inline=True,
         supports_thread_discovery=True,
         supports_thread_import=True,
+        supports_fork=True,
         supports_slash_compact=False,
         supports_approval_note=True,
         supports_custom_cli_args=True,
@@ -435,6 +436,96 @@ class ClaudeCodePlugin:
                 },
             )
         )
+
+    async def fork_session(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> SessionRecord:
+        if self.adapter is None:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="claude adapter is not initialized",
+            )
+        thread_id = session.transport_state.get("thread_id")
+        if not thread_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="claude session has no thread id to fork from",
+            )
+        if (
+            session.launch_target_id
+            and runtime._find_launch_target(session.launch_target_id) is None
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"claude session launch target {session.launch_target_id} is no longer configured",
+            )
+
+        new_claude_session_id = self.generate_session_id()
+        try:
+            await self.adapter.start_session(
+                new_session_id,
+                session.cwd,
+                new_claude_session_id,
+                self.launch_factory(runtime, session.launch_target_id),
+                permission_mode=session.permission_mode,
+                model=session.model,
+                effort=session.effort,
+                custom_args=self._effective_args(
+                    runtime, session.launch_target_id, session.args
+                ),
+                fork_from_claude_session_id=thread_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.exception(
+                "claude fork failed",
+                extra={
+                    "session_id": session.id,
+                    "claude_session_id": thread_id,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+
+        now = datetime.now(UTC)
+        raw_log.touch(exist_ok=True)
+        new_session = SessionRecord(
+            id=new_session_id,
+            backend=self.id,
+            source=SessionSource.MANAGED,
+            transport=self.transport_id,
+            title=title,
+            cwd=session.cwd,
+            launch_target_id=session.launch_target_id,
+            repo_name=session.repo_name,
+            branch=session.branch,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"thread_id": new_claude_session_id},
+            permission_mode=session.permission_mode,
+            model=session.model,
+            effort=session.effort,
+            args=session.args,
+            config_overrides=session.config_overrides,
+        )
+        runtime.storage.create_session(new_session)
+        await runtime._record_system_event(
+            new_session_id,
+            self.format_restore_message(runtime, session.cwd, session.launch_target_id)
+            + f" (forked from {session.title or session.id})",
+            status=SessionStatus.IDLE,
+        )
+        return runtime.get_session(new_session_id)
 
     async def restore_session(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/claude_code/remote.py
+++ b/backend/src/waypoint/backends/claude_code/remote.py
@@ -46,6 +46,7 @@ def build_remote_claude_launch_factory(
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        fork_from_claude_session_id: str | None = None,
     ) -> ClaudeLaunchSpec:
         cwd = cwd or target.default_cwd
         reverse_port = _random_reverse_tunnel_port()
@@ -86,7 +87,17 @@ def build_remote_claude_launch_factory(
             claude_args.extend(["--model", model])
         if effort:
             claude_args.extend(["--effort", effort])
-        if resume:
+        if fork_from_claude_session_id:
+            claude_args.extend(
+                [
+                    "--resume",
+                    fork_from_claude_session_id,
+                    "--fork-session",
+                    "--session-id",
+                    claude_session_id,
+                ]
+            )
+        elif resume:
             claude_args.extend(["--resume", claude_session_id])
         else:
             claude_args.extend(["--session-id", claude_session_id])

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -229,6 +229,40 @@ class CodexAppServerAdapter:
         )
         await self._call_client(state, state.client.thread_resume, thread_id)
 
+    async def fork_session(
+        self,
+        session_id: str,
+        cwd: str,
+        thread_id: str,
+        client_factory_override: ClientFactory | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        custom_args: list[str] | None = None,
+        config_overrides: list[str] | None = None,
+    ) -> str:
+        effective_factory = _apply_codex_args(
+            client_factory_override,
+            tuple(custom_args or []),
+            tuple(config_overrides or []),
+        )
+        state = await self._spawn_session(
+            session_id,
+            cwd,
+            client_factory_override=effective_factory,
+            model=model,
+            effort=effort,
+        )
+        fork_params: dict[str, Any] = {}
+        if model:
+            fork_params["model"] = model
+        if effort:
+            fork_params["config"] = {"model_reasoning_effort": effort}
+        forked = await self._call_client(
+            state, state.client.thread_fork, thread_id, fork_params
+        )
+        state.thread_id = forked.thread.id
+        return state.thread_id
+
     async def _spawn_session(
         self,
         session_id: str,

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -353,6 +353,7 @@ class CodexPlugin:
             config_overrides=session.config_overrides,
         )
         runtime.storage.create_session(new_session)
+        runtime.storage.clone_events(session.id, new_session_id)
         await runtime._record_system_event(
             new_session_id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id)

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -266,6 +266,101 @@ class CodexPlugin:
         )
         return runtime.storage.update_session(session.id, status=SessionStatus.RUNNING)
 
+    async def fork_session(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> SessionRecord:
+        thread_id = session.transport_state.get("thread_id")
+        if not thread_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="codex session has no thread id to fork from",
+            )
+
+        if (
+            session.launch_target_id
+            and runtime._find_launch_target(session.launch_target_id) is None
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"codex session launch target {session.launch_target_id} is no longer configured",
+            )
+
+        effective_cli_args = self._effective_args(
+            runtime, session.launch_target_id, session.args
+        )
+        effective_config_overrides = self._effective_config_overrides(
+            runtime, session.launch_target_id, session.config_overrides
+        )
+
+        try:
+            new_thread_id = await self._require_adapter().fork_session(
+                new_session_id,
+                session.cwd,
+                thread_id,
+                self.client_factory(
+                    runtime,
+                    session.launch_target_id,
+                    custom_args=effective_cli_args,
+                    custom_config_overrides=effective_config_overrides,
+                ),
+                model=session.model,
+                effort=session.effort,
+                custom_args=effective_cli_args,
+                config_overrides=effective_config_overrides,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.exception(
+                "codex fork failed",
+                extra={
+                    "session_id": session.id,
+                    "thread_id": thread_id,
+                    "cwd": session.cwd,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+
+        now = datetime.now(UTC)
+        raw_log.touch(exist_ok=True)
+        new_session = SessionRecord(
+            id=new_session_id,
+            backend=self.id,
+            source=SessionSource.MANAGED,
+            transport=self.transport_id,
+            title=title,
+            cwd=session.cwd,
+            launch_target_id=session.launch_target_id,
+            repo_name=session.repo_name,
+            branch=session.branch,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"thread_id": new_thread_id},
+            permission_mode=session.permission_mode,
+            model=session.model,
+            effort=session.effort,
+            args=session.args,
+            config_overrides=session.config_overrides,
+        )
+        runtime.storage.create_session(new_session)
+        await runtime._record_system_event(
+            new_session_id,
+            self.format_restore_message(runtime, session.cwd, session.launch_target_id)
+            + f" (forked from {session.title or session.id})",
+            status=SessionStatus.IDLE,
+        )
+        return runtime.get_session(new_session_id)
+
     async def restore_session(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -272,8 +272,8 @@ class CodexPlugin:
         session: SessionRecord,
         new_session_id: str,
         title: str,
-        raw_log: Any,
-        structured_log: Any,
+        raw_log: Path,
+        structured_log: Path,
     ) -> SessionRecord:
         thread_id = session.transport_state.get("thread_id")
         if not thread_id:

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -723,6 +723,52 @@ class OpenCodeAdapter:
             raise OpenCodeError(f"invalid session ID returned: {session_id}")
         return session_id
 
+    async def fork_session(
+        self,
+        session_id: str,
+        cwd: str,
+        opencode_session_id: str,
+        model: str | None = None,
+        agent: str | None = None,
+        effort: str | None = None,
+    ) -> str:
+        if not self._started:
+            await self.start()
+
+        client = self._require_client()
+        try:
+            data = await client.post(
+                f"/session/{opencode_session_id}/fork", json_data={}
+            )
+        except Exception as exc:
+            log.error("failed to fork session: %s", exc)
+            raise OpenCodeError(f"failed to fork session: {exc}") from exc
+
+        new_real_session_id = data.get("id", "")
+        if not new_real_session_id or not new_real_session_id.startswith("ses"):
+            log.error("invalid session ID returned on fork: %s", data)
+            raise OpenCodeError(
+                f"invalid session ID returned on fork: {new_real_session_id}"
+            )
+
+        state = OpenCodeSessionState(
+            session_id=session_id,
+            cwd=cwd,
+            opencode_session_id=new_real_session_id,
+            model=model,
+            agent=agent,
+            effort=effort,
+        )
+        self._register_session(state)
+        await self._emit_event(
+            session_id,
+            EventKind.SYSTEM_NOTE,
+            f"OpenCode session forked ({new_real_session_id})",
+            {"status": SessionStatus.IDLE},
+            SessionStatus.IDLE,
+        )
+        return new_real_session_id
+
     async def restore_session(
         self,
         session_id: str,

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -718,7 +718,7 @@ class OpenCodeAdapter:
             raise OpenCodeError(f"failed to create session: {exc}") from exc
 
         session_id = data.get("id", "")
-        if not session_id or not session_id.startswith("ses"):
+        if not session_id:
             log.error("invalid session ID returned: %s", data)
             raise OpenCodeError(f"invalid session ID returned: {session_id}")
         return session_id
@@ -745,7 +745,7 @@ class OpenCodeAdapter:
             raise OpenCodeError(f"failed to fork session: {exc}") from exc
 
         new_real_session_id = data.get("id", "")
-        if not new_real_session_id or not new_real_session_id.startswith("ses"):
+        if not new_real_session_id:
             log.error("invalid session ID returned on fork: %s", data)
             raise OpenCodeError(
                 f"invalid session ID returned on fork: {new_real_session_id}"

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -760,13 +760,6 @@ class OpenCodeAdapter:
             effort=effort,
         )
         self._register_session(state)
-        await self._emit_event(
-            session_id,
-            EventKind.SYSTEM_NOTE,
-            f"OpenCode session forked ({new_real_session_id})",
-            {"status": SessionStatus.IDLE},
-            SessionStatus.IDLE,
-        )
         return new_real_session_id
 
     async def restore_session(

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1067,27 +1067,24 @@ class OpenCodePlugin:
         session: SessionRecord,
         new_session_id: str,
         title: str,
-        raw_log: Any,
-        structured_log: Any,
+        raw_log: Path,
+        structured_log: Path,
     ) -> SessionRecord:
+        effective_args = tuple(
+            self._effective_args(runtime, session.launch_target_id, session.args)
+        )
         key = self._adapter_key(
             runtime,
             session.launch_target_id,
             session.cwd,
-            tuple(
-                self._effective_args(runtime, session.launch_target_id, session.args)
-            ),
+            effective_args,
         )
         try:
             adapter = await self._get_or_create_adapter(
                 runtime,
                 session.launch_target_id,
                 session.cwd,
-                custom_args=tuple(
-                    self._effective_args(
-                        runtime, session.launch_target_id, session.args
-                    )
-                ),
+                custom_args=effective_args,
             )
         except Exception as exc:
             self._health_for(key).record_failure()
@@ -1103,13 +1100,14 @@ class OpenCodePlugin:
                 detail="OpenCode session has no opencode_session_id to fork from",
             )
 
+        agent = session.transport_state.get("agent")
         try:
             new_opencode_session_id = await adapter.fork_session(
                 new_session_id,
                 session.cwd,
                 opencode_session_id,
                 model=session.model,
-                agent=session.transport_state.get("agent"),
+                agent=agent,
                 effort=session.effort,
             )
             pre_plan_mode = session.transport_state.get("pre_plan_mode")
@@ -1126,6 +1124,11 @@ class OpenCodePlugin:
         self._health_for(key).record_success()
         now = datetime.now(UTC)
         raw_log.touch(exist_ok=True)
+        forked_transport_state: dict[str, Any] = {
+            "opencode_session_id": new_opencode_session_id,
+        }
+        if agent:
+            forked_transport_state["agent"] = agent
         new_session = SessionRecord(
             id=new_session_id,
             backend=self.id,
@@ -1142,7 +1145,7 @@ class OpenCodePlugin:
             last_event_at=now,
             raw_log_path=str(raw_log),
             structured_log_path=str(structured_log),
-            transport_state={"opencode_session_id": new_opencode_session_id},
+            transport_state=forked_transport_state,
             permission_mode=session.permission_mode,
             model=session.model,
             effort=session.effort,

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1153,6 +1153,7 @@ class OpenCodePlugin:
             config_overrides=session.config_overrides,
         )
         runtime.storage.create_session(new_session)
+        runtime.storage.clone_events(session.id, new_session_id)
         await runtime._record_system_event(
             new_session_id,
             f"OpenCode session forked from {session.title or session.id}",

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -135,6 +135,7 @@ class OpenCodePlugin:
         supports_set_permission_mode_inline=True,
         supports_thread_discovery=True,
         supports_thread_import=True,
+        supports_fork=True,
         supports_slash_compact=True,
         supports_approval_note=True,
         supports_custom_cli_args=True,
@@ -1059,6 +1060,102 @@ class OpenCodePlugin:
             "OpenCode session restored from previous backend process",
             status=SessionStatus.IDLE,
         )
+
+    async def fork_session(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> SessionRecord:
+        key = self._adapter_key(
+            runtime,
+            session.launch_target_id,
+            session.cwd,
+            tuple(
+                self._effective_args(runtime, session.launch_target_id, session.args)
+            ),
+        )
+        try:
+            adapter = await self._get_or_create_adapter(
+                runtime,
+                session.launch_target_id,
+                session.cwd,
+                custom_args=tuple(
+                    self._effective_args(
+                        runtime, session.launch_target_id, session.args
+                    )
+                ),
+            )
+        except Exception as exc:
+            self._health_for(key).record_failure()
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"OpenCode adapter unavailable; cannot fork: {exc}",
+            ) from exc
+
+        opencode_session_id = session.transport_state.get("opencode_session_id")
+        if not opencode_session_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="OpenCode session has no opencode_session_id to fork from",
+            )
+
+        try:
+            new_opencode_session_id = await adapter.fork_session(
+                new_session_id,
+                session.cwd,
+                opencode_session_id,
+                model=session.model,
+                agent=session.transport_state.get("agent"),
+                effort=session.effort,
+            )
+            pre_plan_mode = session.transport_state.get("pre_plan_mode")
+            if pre_plan_mode is not None:
+                await adapter.set_pre_plan_mode(new_session_id, pre_plan_mode)
+        except Exception as exc:
+            self._health_for(key).record_failure()
+            log.exception("opencode fork failed", extra={"session_id": session.id})
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"OpenCode session fork failed: {exc}",
+            ) from exc
+
+        self._health_for(key).record_success()
+        now = datetime.now(UTC)
+        raw_log.touch(exist_ok=True)
+        new_session = SessionRecord(
+            id=new_session_id,
+            backend=self.id,
+            source=SessionSource.MANAGED,
+            transport=self.transport_id,
+            title=title,
+            cwd=session.cwd,
+            launch_target_id=session.launch_target_id,
+            repo_name=session.repo_name,
+            branch=session.branch,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"opencode_session_id": new_opencode_session_id},
+            permission_mode=session.permission_mode,
+            model=session.model,
+            effort=session.effort,
+            args=session.args,
+            config_overrides=session.config_overrides,
+        )
+        runtime.storage.create_session(new_session)
+        await runtime._record_system_event(
+            new_session_id,
+            f"OpenCode session forked from {session.title or session.id}",
+            status=SessionStatus.IDLE,
+        )
+        return runtime.get_session(new_session_id)
 
     async def list_threads(
         self,

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -185,20 +185,26 @@ class TmuxPlugin:
     async def import_thread(
         self, runtime: "SessionRuntime", request: Any
     ) -> SessionRecord:
-        _unsupported("thread import")
+        raise NotImplementedError
 
-    def format_start_message(
+    async def fork_session(
         self,
-        backend_label: str,
-        launch_target: SshLaunchTargetConfig | None,
-        cwd: str | None,
-    ) -> str:
-        if launch_target is None:
-            return f"Managed session started for {backend_label}"
-        return (
-            f"Managed session started for {backend_label} via SSH target {launch_target.name} "
-            f"on {launch_target.ssh_destination} ({cwd or launch_target.default_cwd})"
-        )
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> SessionRecord:
+        raise NotImplementedError
+
+    def format_start_message(self, backend: str, launch_target: Any, cwd: str) -> str:
+        if launch_target is not None:
+            return (
+                f"{backend} session started via SSH target {launch_target.name} "
+                f"on {launch_target.ssh_destination} ({cwd or launch_target.default_cwd})"
+            )
+        return f"{backend} session started"
 
     async def create_session(
         self,

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -193,8 +193,8 @@ class TmuxPlugin:
         session: SessionRecord,
         new_session_id: str,
         title: str,
-        raw_log: Any,
-        structured_log: Any,
+        raw_log: Path,
+        structured_log: Path,
     ) -> SessionRecord:
         raise NotImplementedError
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -3,6 +3,7 @@ import json
 import logging
 import re
 import secrets
+import shutil
 from collections import defaultdict
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -239,6 +240,15 @@ class SessionRuntime:
         session_dir = self._session_dir(new_session_id)
         raw_log = session_dir / "raw.log"
         structured_log = session_dir / "events.jsonl"
+
+        # Seed the forked session's log files from the parent so the transcript
+        # is pre-populated at the fork point rather than starting blank.
+        for src, dst in [
+            (Path(session.raw_log_path), raw_log),
+            (Path(session.structured_log_path), structured_log),
+        ]:
+            if src.exists():
+                shutil.copy2(src, dst)
 
         # Add branch/fork suffix to the original title if it doesn't already have one
         base_title = session.title or session.id

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -241,8 +241,7 @@ class SessionRuntime:
         raw_log = session_dir / "raw.log"
         structured_log = session_dir / "events.jsonl"
 
-        # Seed the forked session's log files from the parent so the transcript
-        # is pre-populated at the fork point rather than starting blank.
+        # Seed the forked session's log files from the parent.
         for src, dst in [
             (Path(session.raw_log_path), raw_log),
             (Path(session.structured_log_path), structured_log),

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -226,6 +226,48 @@ class SessionRuntime:
             resolved_effort=resolved_effort,
         )
 
+    async def fork_session(self, session_id: str) -> SessionRecord:
+        session = self.get_session(session_id)
+        plugin = self.registry.plugin_for(session)
+        if not plugin.capabilities.supports_fork:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Backend {session.backend} does not support forking",
+            )
+
+        new_session_id = self._generate_session_id(session.backend)
+        session_dir = self._session_dir(new_session_id)
+        raw_log = session_dir / "raw.log"
+        structured_log = session_dir / "events.jsonl"
+
+        # Add branch/fork suffix to the original title if it doesn't already have one
+        base_title = session.title or session.id
+        match = re.match(r"^(.+) \(fork #(\d+)\)$", base_title)
+        if match:
+            new_title = f"{match.group(1)} (fork #{int(match.group(2)) + 1})"
+        else:
+            new_title = f"{base_title} (fork #1)"
+
+        new_session = await plugin.fork_session(
+            self,
+            session,
+            new_session_id,
+            new_title,
+            raw_log,
+            structured_log,
+        )
+        await self.broadcast.publish(
+            SessionEnvelope(
+                type="session_list_update",
+                payload={
+                    "sessions": [
+                        item.model_dump(mode="json") for item in self.list_sessions()
+                    ]
+                },
+            )
+        )
+        return new_session
+
     async def attach_tmux(self, request: SessionAttachRequest) -> SessionRecord:
         try:
             target = await self.tmux.describe_target(request.tmux_target)

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -304,6 +304,27 @@ class Storage:
         return event.model_copy(update={"id": int(last_id)})
 
     @_synchronized
+    def clone_events(self, source_session_id: str, target_session_id: str) -> int:
+        """Bulk-copy all events from source to target, reassigning session_id.
+
+        Returns the number of rows inserted.
+        """
+        self.connection.execute(
+            """
+            INSERT INTO events (session_id, ts, kind, text, metadata, sequence)
+            SELECT ?, ts, kind, text, metadata, sequence
+            FROM events
+            WHERE session_id = ?
+            ORDER BY sequence ASC, id ASC
+            """,
+            (target_session_id, source_session_id),
+        )
+        self.connection.commit()
+        return self.connection.execute(
+            "SELECT COUNT(*) FROM events WHERE session_id = ?", (target_session_id,)
+        ).fetchone()[0]
+
+    @_synchronized
     def list_events(
         self,
         session_id: str,

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -113,6 +113,17 @@ class _StubPlugin:
     async def import_thread(self, runtime: Any, request: Any) -> Any:
         raise NotImplementedError
 
+    async def fork_session(
+        self,
+        runtime: Any,
+        session: Any,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> Any:
+        raise NotImplementedError
+
     async def create_session(self, runtime: Any, request: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 

--- a/backend/tests/test_claude_remote.py
+++ b/backend/tests/test_claude_remote.py
@@ -41,6 +41,7 @@ def test_remote_claude_launch_factory_builds_reverse_tunnel_and_hook_bootstrap(
         None,
         None,
         [],
+        None,
     )
 
     assert launch.cwd is None
@@ -110,6 +111,7 @@ def test_remote_claude_launch_factory_appends_model_flag(
         "opus",
         None,
         [],
+        None,
     )
     assert "--model opus" in launch.args[6]
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -530,6 +530,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   }, [view, refreshSnapshot]);
 
   useEffect(() => {
+    if (!session) return;
+    const prev = document.title;
+    document.title = `${humaniseBackend(session.backend)} · ${session.title}`;
+    return () => { document.title = prev; };
+  }, [session]);
+
+  useEffect(() => {
     if (view !== "chat") {
       setShowScrollToBottom(false);
       setShowScrollToTop(false);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -16,11 +16,13 @@ import {
   answerAskQuestion,
   approveSession,
   connectSessionSocket,
+  createSession,
   deleteSession as deleteSessionRequest,
   fetchBackendModels,
   fetchEvents,
   fetchSession,
   fetchTerminalSnapshot,
+  forkSession,
   isAuthError,
   postAction,
   sendInput,
@@ -66,6 +68,8 @@ const SLASH_COMMANDS: ReadonlyArray<{ command: string; description: string }> = 
   { command: "/status", description: "Forward to the agent's status" },
   { command: "/permissions", description: "Forward to the agent's permissions" },
   { command: "/compact", description: "Compact context to reclaim tokens" },
+  { command: "/new", description: "Start a new session with the same settings" },
+  { command: "/fork", description: "Fork this session into a new branch" },
 ];
 
 const EFFORT_LABEL: Record<string, string> = {
@@ -584,6 +588,56 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     if (!text.trim()) {
       return false;
     }
+    
+    if (text.startsWith("/new")) {
+      if (!session) return false;
+      const trailing = text.slice(4).trim();
+      try {
+        const created = await createSession(host, token, {
+          backend: session.backend,
+          cwd: session.cwd,
+          launch_target_id: session.launch_target_id,
+          model: session.model,
+          effort: session.effort,
+          permission_mode: session.permission_mode,
+          args: session.args,
+          config_overrides: session.config_overrides,
+        });
+        if (trailing) {
+          await sendInput(host, token, created.id, trailing);
+        }
+        router.push(`/session/${created.id}`);
+        return true;
+      } catch (e) {
+        if (isAuthError(e)) {
+          handleAuthFailure();
+          return false;
+        }
+        setError(e instanceof Error ? e.message : "failed to create session");
+        return false;
+      }
+    }
+
+    if (text.startsWith("/fork")) {
+      if (!session) return false;
+      const trailing = text.slice(5).trim();
+      try {
+        const forked = await forkSession(host, token, sessionId);
+        if (trailing) {
+          await sendInput(host, token, forked.id, trailing);
+        }
+        router.push(`/session/${forked.id}`);
+        return true;
+      } catch (e) {
+        if (isAuthError(e)) {
+          handleAuthFailure();
+          return false;
+        }
+        setError(e instanceof Error ? e.message : "failed to fork session");
+        return false;
+      }
+    }
+
     try {
       await sendInput(host, token, sessionId, text);
       return true;
@@ -595,7 +649,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       setError(sendError instanceof Error ? sendError.message : "failed to send input");
       return false;
     }
-  }, [handleAuthFailure, host, token, sessionId]);
+  }, [handleAuthFailure, host, token, sessionId, session, router]);
 
   const onSendWithOptimistic = useCallback(
     async (text: string) => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -162,6 +162,23 @@ export async function createSession(
   return body.session as SessionRecord;
 }
 
+export async function forkSession(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionRecord> {
+  const response = await fetch(`${host}/api/sessions/${sessionId}/fork`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  await ensureOk(response, "failed to fork session");
+  const body = await response.json();
+  return body.session as SessionRecord;
+}
+
 export async function attachTmux(
   host: string,
   token: string,

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -37,6 +37,7 @@ export interface BackendCatalog {
 const FALLBACK_LABELS: Record<string, string> = {
   claude_code: "Claude Code",
   codex: "Codex",
+  opencode: "OpenCode",
   tmux: "Tmux",
 };
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -48,6 +48,8 @@ export interface SessionRecord {
   permission_mode?: string | null;
   model?: string | null;
   effort?: string | null;
+  args: string[];
+  config_overrides: string[];
 }
 
 export interface EventRecord {


### PR DESCRIPTION
## Summary
This PR introduces native `/new` and `/fork` functionality to the Waypoint stack for all supported backends (Codex, OpenCode, and Claude Code). It allows users to branch off existing conversations or start fresh sessions retaining the same configurations, directly from the chat composer.

Addresses #25.

## Changes

### Backend Layer
- **New API Route:** Added `POST /api/sessions/{session_id}/fork` to the FastAPI backend.
- **Runtime Orchestrator:** Implemented `fork_session` in `SessionRuntime`. This method checks if the plugin is capable of forking, generates new Waypoint session variables (`raw.log` / `events.jsonl`), increments the session title via regex matching `(fork #N)`, calls the plugin layer, registers the new session in the local SQLite DB, and pushes the WebSocket broadcast update.
- **Capabilities:** Added `supports_fork: bool = False` to the `BackendCapabilities` descriptor and added the `fork_session` abstract method to the `PluginDescriptor` interface.

### Backend Implementations
- **Codex:** Added `supports_fork=True`. Called the async SDK function `client.thread_fork(thread_id, fork_params)` using the `CodexAppServerAdapter`.
- **OpenCode:** Added `supports_fork=True`. Added `fork_session` to the `OpenCodeAdapter` utilizing OpenCode's native `/session/{session_id}/fork` POST API.
- **Claude Code:** Added `supports_fork=True`. Since Claude uses SQLite natively and does not support true in-memory network forking, the CLI supports resuming a thread as a new session. `LaunchFactory` in the remote target launcher, `_build_local_launch_spec`, and `start_session` in `ClaudeCliAdapter` were all updated to support a new `fork_from_claude_session_id` parameter. When set, this executes `claude --resume <old-id> --fork-session --session-id <new-id>`.
- **Tmux:** Kept `supports_fork=False` as raw PTYs do not support branching.

### Review Fixes
- **OpenCode Fork State:** Preserved the agent configuration in the forked OpenCode session's `transport_state` so `restore_session` correctly re-enters plan mode after a server restart.
- **Type Signatures:** Tightened `fork_session` plugin signatures across all backends to enforce `raw_log` and `structured_log` as `Path` objects instead of `Any`.
- **Validation:** Removed fragile `startswith("ses")` checks for session IDs in the OpenCode adapter, relying on generic non-empty validation instead.

### Frontend Layer
- **Composer Interception:** Intercepted input in `SessionDetail.tsx` before it routes to the agent:
  - `/new`: Re-calls `createSession` utilizing the existing session's variables (`backend`, `effort`, `permission_mode`, `model`, `cwd`, etc.), pushes the user to the newly created session window using `router.push()`, and optionally fires off a trailing input message.
  - `/fork`: Pings the new `POST /api/sessions/{session_id}/fork` route, pushes the user to the new branch window natively, and sends any trailing message input to the forked thread.
- **Autocomplete:** Updated `SLASH_COMMANDS` globally across the UI so users will now see `/new` and `/fork` autocomplete hints.
- **Types:** Updated `SessionRecord` types to include missing `args` and `config_overrides` parameters, which are required to clone session constraints accurately when executing a `/new` command.
- **API Helpers:** Updated `frontend/src/lib/api.ts` to export the new async helper `forkSession()`.
- **Window Title:** Dynamically sets the browser tab/window title to reflect the active `BackendName · SessionName`.
- **Backend Labeling:** Added `opencode` to the `humaniseBackend` fallback labels, preventing it from displaying as a raw ID string in the UI.

## Test Plan
- [x] `cd backend && uv run pre-commit run --all-files`
- [x] `cd backend && uv run pytest`
- [x] `cd frontend && npm run lint && npm run build`