### PR TITLE
fix: unbound user response for Claude Code tool approvals

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -170,8 +170,6 @@ GATED_TOOLS = (
 )
 GATED_TOOLS_REGEX = "^(?:" + "|".join(GATED_TOOLS) + ")$"
 
-DEFAULT_TIMEOUT_SECONDS = 300.0
-HOOK_TIMEOUT_SECONDS = DEFAULT_TIMEOUT_SECONDS + 60
 
 STDERR_TAIL_LINES = 50
 
@@ -243,6 +241,7 @@ class ClaudeCliAdapter:
         hook_settings_path: Path,
         hook_secret: str,
         hook_url: str,
+        default_hook_timeout_seconds: int,
         binary: str | None = None,
         launch_factory: LaunchFactory | None = None,
     ) -> None:
@@ -250,6 +249,7 @@ class ClaudeCliAdapter:
         self._hook_settings_path = hook_settings_path
         self._hook_secret = hook_secret
         self._hook_url = hook_url
+        self._default_hook_timeout_seconds = default_hook_timeout_seconds
         self._binary = binary
         self._launch_factory = launch_factory
         self._sessions: dict[str, ClaudeSessionState] = {}
@@ -748,25 +748,13 @@ class ClaudeCliAdapter:
                         },
                         SessionStatus.WAITING_INPUT,
                     )
-        timeout = 3600.0 if tool_name == "AskUserQuestion" else DEFAULT_TIMEOUT_SECONDS
-        try:
-            decision = await asyncio.wait_for(pending.future, timeout=timeout)
-        except TimeoutError:
-            decision = {
-                "permissionDecision": "deny",
-                "permissionDecisionReason": "approval timed out",
-            }
-            state.pending.pop(tool_use_id, None)
-
-            # Emit a system note so the frontend knows to dequeue the approval card
-            await self._emit_event(
-                waypoint_session_id,
-                EventKind.SYSTEM_NOTE,
-                "Approval timed out",
-                {"status": SessionStatus.RUNNING, "approval_id": tool_use_id},
-                SessionStatus.RUNNING,
-            )
-        return decision
+        # No deadline on user response. The future is resolved by
+        # respond_to_approval / respond_to_ask_question, or cancelled
+        # via terminate_session if the session ends. The hook script's
+        # own urlopen timeout (WAYPOINT_HOOK_TIMEOUT, sourced from
+        # ClaudeCodePluginConfig.hook_timeout_seconds) is the only
+        # network-liveness ceiling.
+        return await pending.future
 
     def has_pending_approval(self, session_id: str) -> bool:
         state = self._sessions.get(session_id)
@@ -958,7 +946,7 @@ class ClaudeCliAdapter:
             "WAYPOINT_HOOK_URL": self._hook_url,
             "WAYPOINT_HOOK_SECRET": self._hook_secret,
             "WAYPOINT_SESSION_ID": session_id,
-            "WAYPOINT_HOOK_TIMEOUT": str(int(HOOK_TIMEOUT_SECONDS)),
+            "WAYPOINT_HOOK_TIMEOUT": str(self._default_hook_timeout_seconds),
         }
         return ClaudeLaunchSpec(
             args=args,

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -77,6 +77,22 @@ class ClaudeCodePluginConfig(PluginConfig):
     models: list[BackendModelOption] = Field(
         default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
     )
+    # Network-failure ceiling (seconds) for the PreToolUse hook's HTTP
+    # request — *not* a deadline on user response time, which is
+    # unbounded. Sized as the upper bound for "the SSH reverse tunnel
+    # is wedged, give up and let Claude defer to its policy". Per-target
+    # overrides live on ``ClaudeCodeLaunchTargetConfig``.
+    hook_timeout_seconds: int = Field(default=3600, ge=1)
+
+
+class ClaudeCodeLaunchTargetConfig(PluginLaunchTargetConfig):
+    """Per-target overrides for Claude Code on an SSH launch target.
+
+    ``hook_timeout_seconds=None`` (the default) falls through to the
+    plugin-global ``ClaudeCodePluginConfig.hook_timeout_seconds``.
+    """
+
+    hook_timeout_seconds: int | None = Field(default=None, ge=1)
 
 
 class ClaudeCodePlugin:
@@ -85,7 +101,7 @@ class ClaudeCodePlugin:
     label = "Claude Code"
     import_request_schema: type[BaseModel] | None = ClaudeThreadImportRequest
     config_schema: type[PluginConfig] = ClaudeCodePluginConfig
-    launch_target_schema: type[PluginLaunchTargetConfig] = PluginLaunchTargetConfig
+    launch_target_schema: type[PluginLaunchTargetConfig] = ClaudeCodeLaunchTargetConfig
     capabilities = BackendCapabilities(
         is_structured=True,
         supports_resume=False,
@@ -142,6 +158,7 @@ class ClaudeCodePlugin:
             hook_settings_path=hook.settings_path,
             hook_secret=hook.secret,
             hook_url=hook_url,
+            default_hook_timeout_seconds=self._config(runtime).hook_timeout_seconds,
         )
         self.thread_enumerator = RemoteClaudeThreadEnumerator(
             hook.thread_enumerator_path
@@ -246,6 +263,24 @@ class ClaudeCodePlugin:
                     return target_config.cli_args + custom_args
             return list(custom_args)
         return self._config(runtime).cli_args + custom_args
+
+    def _resolve_hook_timeout(
+        self,
+        runtime: "SessionRuntime",
+        launch_target_id: str | None,
+    ) -> int:
+        plugin_default = self._config(runtime).hook_timeout_seconds
+        if not launch_target_id:
+            return plugin_default
+        launch_target = runtime._find_launch_target(launch_target_id)
+        if launch_target is None:
+            return plugin_default
+        target_config = launch_target.plugin_config(self.id)
+        if isinstance(target_config, ClaudeCodeLaunchTargetConfig):
+            override = target_config.hook_timeout_seconds
+            if override is not None:
+                return override
+        return plugin_default
 
     def static_model_options(self, runtime: "SessionRuntime") -> list[Any]:
         # Plugin config carries the (configurable) Claude model catalogue.
@@ -644,6 +679,7 @@ class ClaudeCodePlugin:
             hook_script_path=self.hook.hook_script_path,
             hook_secret=self.hook.secret,
             local_backend_port=runtime.settings.port,
+            hook_timeout_seconds=self._resolve_hook_timeout(runtime, launch_target_id),
         )
 
     def generate_session_id(self) -> str:

--- a/backend/src/waypoint/backends/claude_code/remote.py
+++ b/backend/src/waypoint/backends/claude_code/remote.py
@@ -27,6 +27,25 @@ CLAUDE_DEFAULT_BIN = "claude"
 # absolute path of the hook script after `$HOME` is resolved.
 HOOK_PATH_PLACEHOLDER = "__WAYPOINT_HOOK_PATH__"
 
+# SSH-layer liveness probes for the reverse tunnel that carries the
+# PreToolUse hook's HTTP request. ``ServerAliveInterval=30`` +
+# ``ServerAliveCountMax=6`` means a wedged tunnel collapses into a
+# clean ssh exit within ~3 minutes; the runtime then drives normal
+# session teardown and resolves any pending approvals as
+# ``"session terminated"``. Without this floor a half-open TCP socket
+# inside the tunnel could leave Claude parked for hours waiting on a
+# hook reply that will never arrive. Inserted immediately after the
+# ssh binary so user-supplied ``ssh_args`` cannot accidentally relax
+# them (ssh first-value-wins).
+SSH_KEEPALIVE_ARGS: tuple[str, ...] = (
+    "-o",
+    "ConnectTimeout=15",
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=6",
+)
+
 
 def build_remote_claude_launch_factory(
     target: SshLaunchTargetConfig,
@@ -117,6 +136,7 @@ def build_remote_claude_launch_factory(
         )
         args = [
             _resolve_local_binary(target.ssh_bin),
+            *SSH_KEEPALIVE_ARGS,
             *target.ssh_args,
             "-o",
             "ExitOnForwardFailure=yes",

--- a/backend/src/waypoint/backends/claude_code/remote.py
+++ b/backend/src/waypoint/backends/claude_code/remote.py
@@ -34,6 +34,7 @@ def build_remote_claude_launch_factory(
     hook_script_path: Path,
     hook_secret: str,
     local_backend_port: int,
+    hook_timeout_seconds: int,
 ) -> LaunchFactory:
     hook_script = hook_script_path.read_text(encoding="utf-8")
 
@@ -112,6 +113,7 @@ def build_remote_claude_launch_factory(
             hook_secret=hook_secret,
             hook_url=f"http://127.0.0.1:{reverse_port}",
             session_id=session_id,
+            hook_timeout_seconds=hook_timeout_seconds,
         )
         args = [
             _resolve_local_binary(target.ssh_bin),
@@ -162,6 +164,7 @@ def _build_remote_claude_command(
     hook_secret: str,
     hook_url: str,
     session_id: str,
+    hook_timeout_seconds: int,
 ) -> str:
     launch_line = [
         f"cd {quote_remote_path(cwd)}",
@@ -174,6 +177,7 @@ def _build_remote_claude_command(
         "WAYPOINT_HOOK_URL": hook_url,
         "WAYPOINT_HOOK_SECRET": hook_secret,
         "WAYPOINT_SESSION_ID": session_id,
+        "WAYPOINT_HOOK_TIMEOUT": str(hook_timeout_seconds),
     }
     for key, value in sorted(combined_env.items()):
         launch_line.append(shlex.quote(f"{key}={value}"))

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -6,11 +6,11 @@ from typing import Any
 import pytest
 
 from waypoint.backends.claude_code.adapter import (
-    DEFAULT_TIMEOUT_SECONDS,
     ClaudeCliAdapter,
     ClaudeSessionState,
     claude_cli_mode_for,
 )
+from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
 from waypoint.schemas import EventKind, SessionStatus
 
 
@@ -74,6 +74,7 @@ def _make_adapter(
         hook_settings_path=Path("/tmp/waypoint-test-settings.json"),
         hook_secret="test-secret",
         hook_url="http://127.0.0.1:8787",
+        default_hook_timeout_seconds=3600,
     )
 
 
@@ -232,8 +233,9 @@ def test_map_decision_table() -> None:
     assert adapter._map_decision("anything-else") == "deny"
 
 
-def test_default_timeout_is_finite() -> None:
-    assert 0 < DEFAULT_TIMEOUT_SECONDS < 24 * 3600
+def test_hook_timeout_default_is_finite() -> None:
+    config = ClaudeCodePluginConfig()
+    assert 0 < config.hook_timeout_seconds < 24 * 3600
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_claude_remote.py
+++ b/backend/tests/test_claude_remote.py
@@ -31,6 +31,7 @@ def test_remote_claude_launch_factory_builds_reverse_tunnel_and_hook_bootstrap(
         hook_script_path=hook_script,
         hook_secret="secret-123",
         local_backend_port=8787,
+        hook_timeout_seconds=3600,
     )
     launch = factory(
         "claude-sess",
@@ -70,6 +71,7 @@ def test_remote_claude_launch_factory_builds_reverse_tunnel_and_hook_bootstrap(
     assert "WAYPOINT_HOOK_URL=http://127.0.0.1:21234" in remote_command
     assert "WAYPOINT_HOOK_SECRET=secret-123" in remote_command
     assert "WAYPOINT_SESSION_ID=claude-sess" in remote_command
+    assert "WAYPOINT_HOOK_TIMEOUT=3600" in remote_command
     assert "OPENAI_API_KEY=sk-test" in remote_command
     assert "/opt/claude/bin/claude -p" in remote_command
     assert "--resume claude-uuid" in remote_command
@@ -101,6 +103,7 @@ def test_remote_claude_launch_factory_appends_model_flag(
         hook_script_path=hook_script,
         hook_secret="secret-123",
         local_backend_port=8787,
+        hook_timeout_seconds=3600,
     )
     launch = factory(
         "claude-sess",

--- a/backend/tests/test_claude_remote.py
+++ b/backend/tests/test_claude_remote.py
@@ -47,15 +47,24 @@ def test_remote_claude_launch_factory_builds_reverse_tunnel_and_hook_bootstrap(
 
     assert launch.cwd is None
     assert launch.env is None
-    assert launch.args[:6] == [
+    # SSH-layer liveness probes (~3 min detection floor) sit immediately
+    # after the binary, before user ssh_args, so first-value-wins keeps
+    # them authoritative against any user override.
+    assert launch.args[:12] == [
         "/usr/bin/ssh",
+        "-o",
+        "ConnectTimeout=15",
+        "-o",
+        "ServerAliveInterval=30",
+        "-o",
+        "ServerAliveCountMax=6",
         "-o",
         "ExitOnForwardFailure=yes",
         "-R",
         "21234:127.0.0.1:8787",
         "dev@example.com",
     ]
-    remote_command = launch.args[6]
+    remote_command = launch.args[12]
     assert 'WAYPOINT_DIR="$HOME/.waypoint/claude/claude-sess"' in remote_command
     assert 'mkdir -p "$WAYPOINT_DIR"' in remote_command
     assert "claude_pretool_hook.py" in remote_command
@@ -116,7 +125,7 @@ def test_remote_claude_launch_factory_appends_model_flag(
         [],
         None,
     )
-    assert "--model opus" in launch.args[6]
+    assert "--model opus" in launch.args[12]
 
 
 def test_build_remote_thread_enumeration_args_wraps_in_bash_and_passes_env(


### PR DESCRIPTION
## Summary

Fixes a UX failure where a user typing feedback into a Claude Code approval card could see the request auto-denied with `"approval timed out"` mid-keystroke. The 5-minute deadline served two unrelated purposes — "user is still composing a note" and "the SSH reverse tunnel for the PreToolUse hook is wedged" — and the network case forced the user-facing knob to stay tight.

This PR decouples the two axes (commit 1) and shores up the network case independently with SSH keepalive (commit 2).

## Changes

### Commit 1: `fix(claude_code): unbound user response time for tool approvals`

**Behavior:**
- The backend's `await pending.future` is now unbounded. Pending approvals are released when the user submits a decision, or by `terminate_session` resolving them as `"session terminated"` on shutdown. No deadline on user response time.
- The hook script's `urlopen` keeps a finite ceiling sized purely as a network-failure floor — if the SSH reverse tunnel wedges, the hook eventually gives up and Claude defers to its policy.

**Configuration surface:**
- `ClaudeCodePluginConfig.hook_timeout_seconds: int = Field(default=3600, ge=1)` — plugin-global hook ceiling.
- New `ClaudeCodeLaunchTargetConfig` extends `PluginLaunchTargetConfig` with `hook_timeout_seconds: int | None`. `None` falls through to the plugin-global default; per-target blocks in `waypoint.yaml` can override.
- Drops `WAYPOINT_CLAUDE_HOOK_TIMEOUT` env var, the `DEFAULT_TIMEOUT_SECONDS` / `HOOK_TIMEOUT_SECONDS` module constants, the `AskUserQuestion` 1h special case (now redundant), and the `"approval timed out"` deny + system-note path.

**Latent bug fix:** the remote launch built its env in `_build_remote_claude_command` without ever setting `WAYPOINT_HOOK_TIMEOUT`, so remote sessions silently fell back to the hook script's 300s default regardless of any backend config. Local and remote now both source the same configured value.

| File | Description |
|------|-------------|
| `claude_code/adapter.py` | Drop `wait_for` wrapper, drop env-var reading, take `default_hook_timeout_seconds` via constructor |
| `claude_code/plugin.py` | Add `hook_timeout_seconds` to `ClaudeCodePluginConfig`; new `ClaudeCodeLaunchTargetConfig` registered as `launch_target_schema`; `_resolve_hook_timeout` resolves per-target → plugin-global |
| `claude_code/remote.py` | Thread `hook_timeout_seconds` through `build_remote_claude_launch_factory` and `_build_remote_claude_command`; emit `WAYPOINT_HOOK_TIMEOUT` in remote env |
| `tests/test_claude_cli.py`, `tests/test_claude_remote.py` | Update for new constructor / factory signatures; assert the remote-env regression |

### Commit 2: `fix(claude_code): add SSH keepalive to remote launch tunnel`

The ssh process that hosts the reverse tunnel for the PreToolUse hook had no application-layer liveness probes, so a wedged tunnel only surfaced when the kernel's default keepalive expired — ~2h. Inject `ServerAliveInterval=30` + `ServerAliveCountMax=6` (and `ConnectTimeout=15` for the initial handshake) into the ssh argv so a dead tunnel collapses into a clean ssh exit within ~3 minutes. The runtime then drives normal session teardown and resolves any pending approvals as `"session terminated"`, mirroring the floor OpenCode already uses for its remote shells.

The flags are spliced immediately after the ssh binary so first-value-wins keeps them authoritative against any user-supplied `-o` in `target.ssh_args`.

| File | Description |
|------|-------------|
| `claude_code/remote.py` | New `SSH_KEEPALIVE_ARGS` constant, spliced into the ssh argv before user `ssh_args` |
| `tests/test_claude_remote.py` | Update argv-prefix assertion to anchor the new shape |

## Test Plan

- [x] `cd backend && uv run pytest` — 262 passing
- [x] `cd backend && uv run pre-commit run --all-files` — black / isort / ruff / codespell / mypy clean
- [ ] Manual: type a multi-minute feedback note into a Claude Code approval card, submit, verify the agent receives the decision (used to auto-deny at 5 min)
- [ ] Manual: drop the network on a remote Claude Code session and verify the session ends cleanly within ~3 minutes via SSH keepalive (vs hanging for ~2h)
- [ ] Manual: set `plugin_configs.claude_code.hook_timeout_seconds: 600` in `waypoint.yaml` and verify the value reaches the remote hook (`WAYPOINT_HOOK_TIMEOUT=600` in the remote env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)