### PR TITLE
feat: add file edit diff previews

### DIFF
--- a/backend/scripts/claude_pretool_hook.py
+++ b/backend/scripts/claude_pretool_hook.py
@@ -9,11 +9,15 @@ Python the user happens to have on PATH.
 
 from __future__ import annotations
 
+import difflib
 import json
 import os
 import sys
 import urllib.error
 import urllib.request
+from pathlib import Path
+
+MAX_DIFF_BYTES = 200_000
 
 
 def emit(decision: str, reason: str) -> None:
@@ -28,6 +32,149 @@ def emit(decision: str, reason: str) -> None:
             }
         )
     )
+
+
+def build_diff_preview(payload: dict) -> dict | None:
+    tool_name = payload.get("tool_name")
+    tool_input = payload.get("tool_input")
+    if tool_name not in {"Edit", "Write", "MultiEdit"} or not isinstance(
+        tool_input, dict
+    ):
+        return None
+    path_text = tool_input.get("file_path") or tool_input.get("path")
+    if not isinstance(path_text, str) or not path_text:
+        return None
+    path = resolve_tool_path(path_text, payload.get("cwd"))
+    display_path = path_text
+    try:
+        old = path.read_text(encoding="utf-8") if path.exists() else ""
+    except Exception as exc:
+        return preview_payload(
+            [
+                {
+                    "path": display_path,
+                    "change_type": "unknown",
+                    "diff": "",
+                    "additions": 0,
+                    "deletions": 0,
+                    "truncated": False,
+                    "binary": False,
+                    "unavailable_reason": f"could not read file before edit: {exc}",
+                }
+            ]
+        )
+
+    try:
+        if tool_name == "Write":
+            content = tool_input.get("content")
+            if not isinstance(content, str):
+                return None
+            new = content
+            change_type = "add" if not path.exists() else "update"
+        elif tool_name == "Edit":
+            new = apply_edit(old, tool_input)
+            change_type = "update"
+        else:
+            new = old
+            for edit in tool_input.get("edits") or []:
+                if isinstance(edit, dict):
+                    new = apply_edit(new, edit)
+            change_type = "update"
+    except ValueError as exc:
+        return preview_payload(
+            [
+                {
+                    "path": display_path,
+                    "change_type": "unknown",
+                    "diff": "",
+                    "additions": 0,
+                    "deletions": 0,
+                    "truncated": False,
+                    "binary": False,
+                    "unavailable_reason": str(exc),
+                }
+            ]
+        )
+
+    diff = "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=display_path,
+            tofile=display_path,
+        )
+    )
+    additions, deletions = count_unified_diff(diff)
+    diff, truncated = limit_text(diff, MAX_DIFF_BYTES)
+    return preview_payload(
+        [
+            {
+                "path": display_path,
+                "change_type": change_type,
+                "diff": diff,
+                "additions": additions,
+                "deletions": deletions,
+                "truncated": truncated,
+                "binary": False,
+                "unavailable_reason": None,
+            }
+        ]
+    )
+
+
+def resolve_tool_path(path_text: str, cwd: object) -> Path:
+    path = Path(path_text).expanduser()
+    if path.is_absolute():
+        return path
+    if isinstance(cwd, str) and cwd:
+        return Path(cwd).expanduser() / path
+    return Path.cwd() / path
+
+
+def apply_edit(content: str, edit: dict) -> str:
+    old = edit.get("old_string")
+    new = edit.get("new_string")
+    if not isinstance(old, str) or not isinstance(new, str):
+        raise ValueError("edit payload did not include old_string/new_string")
+    if old == "":
+        raise ValueError("edit payload old_string was empty")
+    count = -1 if bool(edit.get("replace_all", False)) else 1
+    if old not in content:
+        raise ValueError("old_string was not found in the current file")
+    return content.replace(old, new, count)
+
+
+def preview_payload(files: list[dict]) -> dict:
+    total_additions = sum(file.get("additions", 0) for file in files)
+    total_deletions = sum(file.get("deletions", 0) for file in files)
+    return {
+        "schema_version": 1,
+        "phase": "proposed",
+        "files": files,
+        "total_additions": total_additions,
+        "total_deletions": total_deletions,
+        "truncated": any(bool(file.get("truncated")) for file in files),
+    }
+
+
+def count_unified_diff(diff: str) -> tuple[int, int]:
+    additions = 0
+    deletions = 0
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            additions += 1
+        elif line.startswith("-"):
+            deletions += 1
+    return additions, deletions
+
+
+def limit_text(text: str, max_bytes: int) -> tuple[str, bool]:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text, False
+    return encoded[:max_bytes].decode("utf-8", errors="ignore"), True
 
 
 def main() -> int:
@@ -50,18 +197,20 @@ def main() -> int:
     except ValueError:
         timeout = 300.0
 
-    body = json.dumps(
-        {
-            "waypoint_session_id": waypoint_session_id,
-            "claude_session_id": payload.get("session_id"),
-            "tool_name": payload.get("tool_name"),
-            "tool_input": payload.get("tool_input"),
-            "tool_use_id": payload.get("tool_use_id"),
-            "transcript_path": payload.get("transcript_path"),
-            "permission_mode": payload.get("permission_mode"),
-            "cwd": payload.get("cwd"),
-        }
-    ).encode("utf-8")
+    outbound = {
+        "waypoint_session_id": waypoint_session_id,
+        "claude_session_id": payload.get("session_id"),
+        "tool_name": payload.get("tool_name"),
+        "tool_input": payload.get("tool_input"),
+        "tool_use_id": payload.get("tool_use_id"),
+        "transcript_path": payload.get("transcript_path"),
+        "permission_mode": payload.get("permission_mode"),
+        "cwd": payload.get("cwd"),
+    }
+    diff_preview = build_diff_preview(payload)
+    if diff_preview is not None:
+        outbound["diff_preview"] = diff_preview
+    body = json.dumps(outbound).encode("utf-8")
     request = urllib.request.Request(
         backend_url.rstrip("/") + "/api/internal/hooks/claude/approval",
         data=body,

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -745,6 +745,11 @@ class ClaudeCliAdapter:
                             "approval_id": tool_use_id,
                             "method": "PreToolUse",
                             "status": SessionStatus.WAITING_INPUT,
+                            **(
+                                {"diff_preview": payload["diff_preview"]}
+                                if isinstance(payload.get("diff_preview"), dict)
+                                else {}
+                            ),
                         },
                         SessionStatus.WAITING_INPUT,
                     )

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -13,12 +13,15 @@ from codex_app_server.client import AppServerClient, AppServerConfig
 from codex_app_server.generated.v2_all import ModelListResponse
 
 from waypoint.backends.codex.normalize import (
+    diff_preview_for_approval,
+    diff_preview_for_notification,
     extract_item,
     extract_item_id,
     format_approval_text,
     map_notification,
     payload_to_dict,
 )
+from waypoint.backends.diff_preview import DiffPreviewPayload, preview_to_metadata
 from waypoint.schemas import EventKind, SessionStatus
 
 log = logging.getLogger("waypoint.codex")
@@ -147,6 +150,7 @@ class CodexSessionState:
     pending_approval: PendingApproval | None = None
     terminal_fragments: list[str] = field(default_factory=list)
     streamed_tool_result_ids: set[str] = field(default_factory=set)
+    file_diff_previews: dict[str, DiffPreviewPayload] = field(default_factory=dict)
     # Most recent model selection. Codex's protocol exposes model as a per-turn
     # override that persists, so we apply it on every turn_start to keep the
     # waypoint contract — "set once, apply going forward" — even across
@@ -282,6 +286,13 @@ class CodexAppServerAdapter:
             payload = params or {}
             pending = PendingApproval(method=method, params=payload)
             state.pending_approval = pending
+            item_id = payload.get("itemId")
+            cached_preview = (
+                state.file_diff_previews.get(item_id)
+                if isinstance(item_id, str)
+                else None
+            )
+            diff_preview = diff_preview_for_approval(method, payload, cached_preview)
             if self._loop is not None:
                 asyncio.run_coroutine_threadsafe(
                     self._emit_event(
@@ -292,6 +303,7 @@ class CodexAppServerAdapter:
                             "method": method,
                             "request": payload,
                             "status": SessionStatus.WAITING_INPUT,
+                            **preview_to_metadata(diff_preview),
                         },
                         SessionStatus.WAITING_INPUT,
                     ),
@@ -507,14 +519,20 @@ class CodexAppServerAdapter:
                 if kind is not None and text:
                     if notification.method == "item/commandExecution/outputDelta":
                         state.terminal_fragments.append(text)
+                    diff_preview = diff_preview_for_notification(
+                        notification.method, payload
+                    )
                     metadata: dict[str, Any] = {
                         "method": notification.method,
                         "payload": payload,
                         "status": status,
+                        **preview_to_metadata(diff_preview),
                     }
                     item_id = extract_item_id(payload)
                     if item_id is not None:
                         metadata["item_id"] = item_id
+                        if diff_preview is not None:
+                            state.file_diff_previews[item_id] = diff_preview
                     item = extract_item(payload) if "item" in payload else None
                     if isinstance(item, dict):
                         # Replace the wrapped {"root": {...}} form with the
@@ -555,6 +573,7 @@ class CodexAppServerAdapter:
                     state.active_turn_id = None
                     state.stream_task = None
                     state.streamed_tool_result_ids.clear()
+                    state.file_diff_previews.clear()
                     break
         except asyncio.CancelledError:
             raise
@@ -562,6 +581,7 @@ class CodexAppServerAdapter:
             state.active_turn_id = None
             state.stream_task = None
             state.streamed_tool_result_ids.clear()
+            state.file_diff_previews.clear()
             log.exception(
                 "codex stream failed",
                 extra={"session_id": state.session_id, "thread_id": state.thread_id},

--- a/backend/src/waypoint/backends/codex/normalize.py
+++ b/backend/src/waypoint/backends/codex/normalize.py
@@ -17,6 +17,13 @@ from typing import Any
 
 from codex_app_server.models import UnknownNotification
 
+from waypoint.backends.diff_preview import (
+    DiffPreviewPayload,
+    build_preview,
+    files_from_codex_file_changes,
+    files_from_codex_legacy_file_changes,
+    files_from_unified_diff,
+)
 from waypoint.schemas import EventKind, SessionStatus
 
 
@@ -42,6 +49,33 @@ def map_notification(
         return (
             EventKind.TOOL_RESULT,
             str(payload.get("delta", "")),
+            SessionStatus.RUNNING,
+        )
+    if method == "item/fileChange/patchUpdated":
+        changes = payload.get("changes", [])
+        paths = ", ".join(
+            str(change.get("path", ""))
+            for change in changes
+            if isinstance(change, dict) and change.get("path")
+        )
+        return (
+            EventKind.TOOL_RESULT,
+            f"File changes updated: {paths}".strip(),
+            SessionStatus.RUNNING,
+        )
+    if method == "turn/diff/updated":
+        diff = payload.get("diff")
+        additions = deletions = 0
+        if isinstance(diff, str):
+            preview = build_preview(
+                "aggregate", files_from_unified_diff(diff, "Turn changes")
+            )
+            if preview is not None:
+                additions = preview.total_additions
+                deletions = preview.total_deletions
+        return (
+            EventKind.SYSTEM_NOTE,
+            f"Turn changes: +{additions} -{deletions}",
             SessionStatus.RUNNING,
         )
     if method == "turn/started":
@@ -248,6 +282,46 @@ def extract_item(payload: dict[str, Any]) -> dict[str, Any]:
         if isinstance(root, dict):
             return root
     return item if isinstance(item, dict) else {}
+
+
+def diff_preview_for_notification(
+    method: str, payload: dict[str, Any]
+) -> DiffPreviewPayload | None:
+    if method in {"item/started", "item/updated", "item/completed"}:
+        item = extract_item(payload)
+        if item.get("type") != "fileChange":
+            return None
+        if method == "item/completed":
+            return build_preview(
+                "applied", files_from_codex_file_changes(item.get("changes"))
+            )
+        return build_preview(
+            "proposed", files_from_codex_file_changes(item.get("changes"))
+        )
+    if method == "item/fileChange/patchUpdated":
+        return build_preview(
+            "proposed", files_from_codex_file_changes(payload.get("changes"))
+        )
+    if method == "turn/diff/updated":
+        diff = payload.get("diff")
+        if not isinstance(diff, str):
+            return None
+        return build_preview("aggregate", files_from_unified_diff(diff, "Turn changes"))
+    return None
+
+
+def diff_preview_for_approval(
+    method: str,
+    params: dict[str, Any],
+    cached: DiffPreviewPayload | None = None,
+) -> DiffPreviewPayload | None:
+    if method == "item/fileChange/requestApproval":
+        return cached
+    if method == "applyPatchApproval":
+        return build_preview(
+            "proposed", files_from_codex_legacy_file_changes(params.get("fileChanges"))
+        )
+    return None
 
 
 def format_todo_list(item: dict[str, Any]) -> str:

--- a/backend/src/waypoint/backends/diff_preview.py
+++ b/backend/src/waypoint/backends/diff_preview.py
@@ -1,0 +1,338 @@
+import difflib
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+DiffPhase = Literal["proposed", "applied", "aggregate"]
+ChangeType = Literal["add", "delete", "update", "move", "unknown"]
+
+DEFAULT_MAX_FILE_BYTES = 200_000
+DEFAULT_MAX_TOTAL_BYTES = 1_000_000
+
+
+class DiffPreviewFile(BaseModel):
+    path: str
+    old_path: str | None = None
+    change_type: ChangeType = "unknown"
+    diff: str = ""
+    additions: int = 0
+    deletions: int = 0
+    truncated: bool = False
+    binary: bool = False
+    unavailable_reason: str | None = None
+
+
+class DiffPreviewPayload(BaseModel):
+    schema_version: Literal[1] = 1
+    phase: DiffPhase
+    files: list[DiffPreviewFile] = Field(default_factory=list)
+    total_additions: int = 0
+    total_deletions: int = 0
+    truncated: bool = False
+
+
+def build_preview(
+    phase: DiffPhase,
+    files: list[DiffPreviewFile],
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+) -> DiffPreviewPayload | None:
+    limited_files: list[DiffPreviewFile] = []
+    total_bytes = 0
+    truncated = False
+    for file in files:
+        limited = _limit_file(file, max_file_bytes)
+        encoded_len = len(limited.diff.encode("utf-8"))
+        if total_bytes + encoded_len > max_total_bytes:
+            remaining = max(max_total_bytes - total_bytes, 0)
+            limited = _limit_file(limited, remaining)
+            truncated = True
+        total_bytes += len(limited.diff.encode("utf-8"))
+        truncated = truncated or limited.truncated
+        limited_files.append(limited)
+        if total_bytes >= max_total_bytes:
+            break
+    if not limited_files:
+        return None
+    return DiffPreviewPayload(
+        phase=phase,
+        files=limited_files,
+        total_additions=sum(file.additions for file in limited_files),
+        total_deletions=sum(file.deletions for file in limited_files),
+        truncated=truncated,
+    )
+
+
+def file_from_unified_diff(
+    path: str,
+    diff: str,
+    change_type: ChangeType = "unknown",
+    old_path: str | None = None,
+    additions: int | None = None,
+    deletions: int | None = None,
+    binary: bool = False,
+    unavailable_reason: str | None = None,
+) -> DiffPreviewFile:
+    counted_additions, counted_deletions = count_unified_diff(diff)
+    return DiffPreviewFile(
+        path=path,
+        old_path=old_path,
+        change_type=change_type,
+        diff=diff,
+        additions=counted_additions if additions is None else additions,
+        deletions=counted_deletions if deletions is None else deletions,
+        binary=binary,
+        unavailable_reason=unavailable_reason,
+    )
+
+
+def file_from_old_new(
+    path: str,
+    old: str,
+    new: str,
+    change_type: ChangeType = "update",
+    old_path: str | None = None,
+) -> DiffPreviewFile:
+    fromfile = old_path or path
+    diff = "".join(
+        difflib.unified_diff(
+            old.splitlines(keepends=True),
+            new.splitlines(keepends=True),
+            fromfile=fromfile,
+            tofile=path,
+        )
+    )
+    if diff and not diff.endswith("\n"):
+        diff += "\n"
+    return file_from_unified_diff(path, diff, change_type, old_path=old_path)
+
+
+def unavailable_file(
+    path: str,
+    reason: str,
+    change_type: ChangeType = "unknown",
+    old_path: str | None = None,
+) -> DiffPreviewFile:
+    return DiffPreviewFile(
+        path=path,
+        old_path=old_path,
+        change_type=change_type,
+        unavailable_reason=reason,
+    )
+
+
+def files_from_unified_diff(
+    diff: str, fallback_path: str = "changes"
+) -> list[DiffPreviewFile]:
+    chunks = _split_unified_diff(diff)
+    if not chunks:
+        return [file_from_unified_diff(fallback_path, diff)] if diff else []
+    files: list[DiffPreviewFile] = []
+    for chunk in chunks:
+        path, old_path = _paths_from_diff_chunk(chunk, fallback_path)
+        files.append(
+            file_from_unified_diff(
+                path=path,
+                old_path=old_path if old_path != path else None,
+                change_type=_change_type_from_chunk(chunk),
+                diff="\n".join(chunk) + "\n",
+            )
+        )
+    return files
+
+
+def files_from_codex_file_changes(changes: Any) -> list[DiffPreviewFile]:
+    if not isinstance(changes, list):
+        return []
+    files: list[DiffPreviewFile] = []
+    for change in changes:
+        if not isinstance(change, dict):
+            continue
+        path = str(change.get("path") or "").strip()
+        diff = change.get("diff")
+        if not path or not isinstance(diff, str):
+            continue
+        kind = _normalize_change_type(change.get("kind"))
+        files.append(file_from_unified_diff(path, diff, kind))
+    return files
+
+
+def files_from_codex_legacy_file_changes(file_changes: Any) -> list[DiffPreviewFile]:
+    if not isinstance(file_changes, dict):
+        return []
+    files: list[DiffPreviewFile] = []
+    for raw_path, change in file_changes.items():
+        path = str(raw_path)
+        if not isinstance(change, dict):
+            continue
+        change_type = change.get("type")
+        if change_type == "update":
+            diff = change.get("unified_diff")
+            if isinstance(diff, str):
+                move_path = change.get("move_path")
+                path_out = (
+                    str(move_path) if isinstance(move_path, str) and move_path else path
+                )
+                files.append(
+                    file_from_unified_diff(
+                        path_out,
+                        diff,
+                        "move" if move_path else "update",
+                        old_path=path if move_path else None,
+                    )
+                )
+        elif change_type == "add":
+            content = change.get("content")
+            if isinstance(content, str):
+                files.append(file_from_old_new(path, "", content, "add"))
+        elif change_type == "delete":
+            content = change.get("content")
+            if isinstance(content, str):
+                files.append(file_from_old_new(path, content, "", "delete"))
+    return files
+
+
+def files_from_opencode_diffs(diffs: Any) -> list[DiffPreviewFile]:
+    if not isinstance(diffs, list):
+        return []
+    files: list[DiffPreviewFile] = []
+    for entry in diffs:
+        if not isinstance(entry, dict):
+            continue
+        path = str(
+            entry.get("path")
+            or entry.get("file")
+            or entry.get("name")
+            or entry.get("filename")
+            or "changes"
+        )
+        old_path = entry.get("old_path") or entry.get("oldPath")
+        diff = entry.get("diff") or entry.get("patch")
+        additions = entry.get("additions")
+        deletions = entry.get("deletions")
+        change_type = _normalize_change_type(entry.get("type") or entry.get("kind"))
+        if isinstance(diff, str) and diff:
+            files.append(
+                file_from_unified_diff(
+                    path=path,
+                    diff=diff,
+                    change_type=change_type,
+                    old_path=str(old_path) if isinstance(old_path, str) else None,
+                    additions=additions if isinstance(additions, int) else None,
+                    deletions=deletions if isinstance(deletions, int) else None,
+                )
+            )
+        elif isinstance(additions, int) or isinstance(deletions, int):
+            files.append(
+                DiffPreviewFile(
+                    path=path,
+                    old_path=str(old_path) if isinstance(old_path, str) else None,
+                    change_type=change_type,
+                    additions=additions if isinstance(additions, int) else 0,
+                    deletions=deletions if isinstance(deletions, int) else 0,
+                    unavailable_reason="diff content was not included by backend",
+                )
+            )
+    return files
+
+
+def preview_to_metadata(preview: DiffPreviewPayload | None) -> dict[str, Any]:
+    if preview is None:
+        return {}
+    return {"diff_preview": preview.model_dump(mode="json")}
+
+
+def count_unified_diff(diff: str) -> tuple[int, int]:
+    additions = 0
+    deletions = 0
+    for line in diff.splitlines():
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        if line.startswith("+"):
+            additions += 1
+        elif line.startswith("-"):
+            deletions += 1
+    return additions, deletions
+
+
+def _normalize_change_type(value: Any) -> ChangeType:
+    normalized = str(value or "").lower()
+    if normalized in {"add", "added", "create", "created", "new"}:
+        return "add"
+    if normalized in {"delete", "deleted", "remove", "removed"}:
+        return "delete"
+    if normalized in {"update", "updated", "modify", "modified", "change"}:
+        return "update"
+    if normalized in {"move", "moved", "rename", "renamed"}:
+        return "move"
+    return "unknown"
+
+
+def _split_unified_diff(diff: str) -> list[list[str]]:
+    chunks: list[list[str]] = []
+    current: list[str] = []
+    for line in diff.splitlines():
+        if line.startswith("diff --git ") and current:
+            chunks.append(current)
+            current = [line]
+        else:
+            current.append(line)
+    if current:
+        chunks.append(current)
+    return chunks
+
+
+def _paths_from_diff_chunk(
+    lines: list[str], fallback_path: str
+) -> tuple[str, str | None]:
+    old_path: str | None = None
+    new_path: str | None = None
+    for line in lines:
+        if line.startswith("--- "):
+            old_path = _clean_diff_path(line[4:].strip())
+        elif line.startswith("+++ "):
+            new_path = _clean_diff_path(line[4:].strip())
+    if new_path and new_path != "/dev/null":
+        return new_path, old_path if old_path != "/dev/null" else None
+    if old_path and old_path != "/dev/null":
+        return old_path, old_path
+    for line in lines:
+        if line.startswith("diff --git "):
+            parts = line.split()
+            if len(parts) >= 4:
+                return _clean_diff_path(parts[3]), _clean_diff_path(parts[2])
+    return fallback_path, None
+
+
+def _clean_diff_path(path: str) -> str:
+    path = path.split("\t", 1)[0]
+    if path.startswith("a/") or path.startswith("b/"):
+        return path[2:]
+    return path
+
+
+def _change_type_from_chunk(lines: list[str]) -> ChangeType:
+    old_path = None
+    new_path = None
+    for line in lines:
+        if line.startswith("--- "):
+            old_path = _clean_diff_path(line[4:].strip())
+        elif line.startswith("+++ "):
+            new_path = _clean_diff_path(line[4:].strip())
+    if old_path == "/dev/null":
+        return "add"
+    if new_path == "/dev/null":
+        return "delete"
+    if old_path and new_path and old_path != new_path:
+        return "move"
+    return "update"
+
+
+def _limit_file(file: DiffPreviewFile, max_bytes: int) -> DiffPreviewFile:
+    if max_bytes <= 0:
+        return file.model_copy(update={"diff": "", "truncated": True})
+    encoded = file.diff.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return file
+    limited = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return file.model_copy(update={"diff": limited, "truncated": True})

--- a/backend/src/waypoint/backends/events.py
+++ b/backend/src/waypoint/backends/events.py
@@ -2,6 +2,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from waypoint.backends.diff_preview import DiffPreviewPayload
 from waypoint.schemas import EventKind, SessionStatus
 
 
@@ -35,5 +36,6 @@ class EventEnvelope(BaseModel):
     status: SessionStatus | None = None
     item: ItemPayload | None = None
     approval: ApprovalPayload | None = None
+    diff_preview: DiffPreviewPayload | None = None
     metadata_version: Literal[1] = 1
     extra: dict[str, Any] = Field(default_factory=dict)

--- a/backend/src/waypoint/backends/events.py
+++ b/backend/src/waypoint/backends/events.py
@@ -2,7 +2,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
-from waypoint.backends.diff_preview import DiffPreviewPayload
 from waypoint.schemas import EventKind, SessionStatus
 
 
@@ -36,6 +35,5 @@ class EventEnvelope(BaseModel):
     status: SessionStatus | None = None
     item: ItemPayload | None = None
     approval: ApprovalPayload | None = None
-    diff_preview: DiffPreviewPayload | None = None
     metadata_version: Literal[1] = 1
     extra: dict[str, Any] = Field(default_factory=dict)

--- a/backend/src/waypoint/backends/opencode/normalize.py
+++ b/backend/src/waypoint/backends/opencode/normalize.py
@@ -1,6 +1,13 @@
 import json
 from typing import Any
 
+from waypoint.backends.diff_preview import (
+    DiffPhase,
+    build_preview,
+    files_from_opencode_diffs,
+    files_from_unified_diff,
+    preview_to_metadata,
+)
 from waypoint.schemas import EventKind, SessionStatus
 
 
@@ -172,6 +179,7 @@ def map_event(
         permission = properties
         tool_name = _permission_tool_name(permission)
         tool_input = _as_dict(permission.get("metadata")) or {}
+        preview = _diff_preview_from_opencode_properties(properties, "proposed")
         text = f"{tool_name}: {permission.get('permission', 'Permission request')}"
         patterns = permission.get("patterns", [])
         if isinstance(patterns, list) and patterns:
@@ -196,6 +204,7 @@ def map_event(
                 "tool_name": tool_name,
                 "tool_input": tool_input,
                 "status": SessionStatus.WAITING_INPUT,
+                **preview_to_metadata(preview),
             },
         )
 
@@ -268,6 +277,7 @@ def map_event(
 
     if event_type == "file.edited":
         file_path = properties.get("file", "")
+        preview = _diff_preview_from_opencode_properties(properties, "applied")
         return (
             EventKind.SYSTEM_NOTE,
             f"File edited: {file_path}",
@@ -275,6 +285,7 @@ def map_event(
                 "method": "file.edited",
                 "payload": properties,
                 "status": SessionStatus.RUNNING,
+                **preview_to_metadata(preview),
             },
         )
 
@@ -283,6 +294,7 @@ def map_event(
         if diffs:
             total_additions = sum(d.get("additions", 0) for d in diffs)
             total_deletions = sum(d.get("deletions", 0) for d in diffs)
+            preview = build_preview("aggregate", files_from_opencode_diffs(diffs))
             return (
                 EventKind.SYSTEM_NOTE,
                 f"Changes: +{total_additions} -{total_deletions}",
@@ -290,6 +302,7 @@ def map_event(
                     "method": "session.diff",
                     "payload": properties,
                     "status": SessionStatus.IDLE,
+                    **preview_to_metadata(preview),
                 },
             )
 
@@ -395,6 +408,27 @@ def _map_tool_event(
         )
 
     return (EventKind.SYSTEM_NOTE, "", {})
+
+
+def _diff_preview_from_opencode_properties(
+    properties: dict[str, Any], phase: DiffPhase
+):
+    files = files_from_opencode_diffs(properties.get("diff"))
+    if files:
+        return build_preview(phase, files)
+
+    metadata = _as_dict(properties.get("metadata")) or {}
+    for key in ("diff", "patch"):
+        value = metadata.get(key) or properties.get(key)
+        if isinstance(value, str) and value:
+            fallback = str(properties.get("file") or "changes")
+            return build_preview(phase, files_from_unified_diff(value, fallback))
+    for key in ("changes", "fileChanges", "files"):
+        value = metadata.get(key) or properties.get(key)
+        files = files_from_opencode_diffs(value)
+        if files:
+            return build_preview(phase, files)
+    return None
 
 
 def format_event_text(event_type: str, properties: dict[str, Any]) -> str:

--- a/backend/src/waypoint/backends/opencode/normalize.py
+++ b/backend/src/waypoint/backends/opencode/normalize.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from waypoint.backends.diff_preview import (
     DiffPhase,
+    DiffPreviewPayload,
     build_preview,
     files_from_opencode_diffs,
     files_from_unified_diff,
@@ -412,7 +413,7 @@ def _map_tool_event(
 
 def _diff_preview_from_opencode_properties(
     properties: dict[str, Any], phase: DiffPhase
-):
+) -> DiffPreviewPayload | None:
     files = files_from_opencode_diffs(properties.get("diff"))
     if files:
         return build_preview(phase, files)

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib.util
 import json
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,16 @@ from waypoint.backends.claude_code.adapter import (
 )
 from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
 from waypoint.schemas import EventKind, SessionStatus
+
+
+def _load_claude_hook_module() -> Any:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "claude_pretool_hook.py"
+    spec = importlib.util.spec_from_file_location("claude_pretool_hook_test", script)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 class FakeStream:
@@ -190,6 +201,75 @@ async def test_await_approval_resolves_via_respond() -> None:
     assert decision["permissionDecision"] == "allow"
     # Pending was emitted as APPROVAL_REQUEST
     assert emitted[0][1] == EventKind.APPROVAL_REQUEST
+
+
+@pytest.mark.asyncio
+async def test_await_approval_preserves_hook_diff_preview() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    _attach_state(adapter)
+    payload = {
+        "waypoint_session_id": "sess",
+        "tool_use_id": "toolu_1",
+        "tool_name": "Edit",
+        "tool_input": {"file_path": "/tmp/app.py"},
+        "diff_preview": {
+            "schema_version": 1,
+            "phase": "proposed",
+            "files": [
+                {
+                    "path": "/tmp/app.py",
+                    "change_type": "update",
+                    "diff": "--- /tmp/app.py\n+++ /tmp/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+                    "additions": 1,
+                    "deletions": 1,
+                    "truncated": False,
+                    "binary": False,
+                    "unavailable_reason": None,
+                }
+            ],
+            "total_additions": 1,
+            "total_deletions": 1,
+            "truncated": False,
+        },
+    }
+
+    async def resolver() -> None:
+        for _ in range(50):
+            if adapter.has_pending_approval("sess"):
+                break
+            await asyncio.sleep(0.01)
+        await adapter.respond_to_approval("sess", "decline")
+
+    decision_task = asyncio.create_task(adapter.await_approval(payload))
+    await resolver()
+    await decision_task
+
+    assert emitted[0][1] == EventKind.APPROVAL_REQUEST
+    assert emitted[0][3]["diff_preview"]["files"][0]["path"] == "/tmp/app.py"
+
+
+def test_claude_hook_builds_edit_diff_preview(tmp_path: Path) -> None:
+    hook = _load_claude_hook_module()
+    target = tmp_path / "app.py"
+    target.write_text("old\n", encoding="utf-8")
+
+    preview = hook.build_diff_preview(
+        {
+            "cwd": str(tmp_path),
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": "app.py",
+                "old_string": "old\n",
+                "new_string": "new\n",
+            },
+        }
+    )
+
+    assert preview["phase"] == "proposed"
+    assert preview["files"][0]["path"] == "app.py"
+    assert preview["files"][0]["additions"] == 1
+    assert preview["files"][0]["deletions"] == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -511,6 +511,58 @@ def test_map_notification_command_execution_started() -> None:
     assert "ls -la" in text
 
 
+def test_map_notification_file_change_patch_updated_has_preview() -> None:
+    from waypoint.backends.codex.normalize import (
+        diff_preview_for_notification,
+        map_notification,
+    )
+
+    payload = {
+        "itemId": "item_1",
+        "changes": [
+            {
+                "path": "app.py",
+                "kind": "update",
+                "diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+            }
+        ],
+    }
+
+    kind, text, status = map_notification("item/fileChange/patchUpdated", payload)
+    preview = diff_preview_for_notification("item/fileChange/patchUpdated", payload)
+
+    assert kind == EventKind.TOOL_RESULT
+    assert text == "File changes updated: app.py"
+    assert status == SessionStatus.RUNNING
+    assert preview is not None
+    assert preview.phase == "proposed"
+    assert preview.files[0].path == "app.py"
+    assert preview.total_additions == 1
+    assert preview.total_deletions == 1
+
+
+def test_codex_apply_patch_approval_preview_handles_legacy_file_changes() -> None:
+    from waypoint.backends.codex.normalize import diff_preview_for_approval
+
+    preview = diff_preview_for_approval(
+        "applyPatchApproval",
+        {
+            "fileChanges": {
+                "app.py": {
+                    "type": "update",
+                    "unified_diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+                    "move_path": None,
+                }
+            }
+        },
+    )
+
+    assert preview is not None
+    assert preview.phase == "proposed"
+    assert preview.files[0].path == "app.py"
+    assert preview.files[0].change_type == "update"
+
+
 def test_map_notification_todo_list_updated() -> None:
     from waypoint.backends.codex.normalize import map_notification
 

--- a/backend/tests/test_opencode_normalize.py
+++ b/backend/tests/test_opencode_normalize.py
@@ -48,6 +48,49 @@ def test_permission_asked_renders_all_patterns() -> None:
     assert text == "Bash: bash (npm test, npm build)"
 
 
+def test_permission_asked_carries_diff_preview_from_metadata_patch() -> None:
+    kind, _, metadata = map_event(
+        "permission.asked",
+        {
+            "id": "perm_3",
+            "permission": "edit",
+            "metadata": {
+                "tool": "Edit",
+                "diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+            },
+        },
+    )
+
+    assert kind == EventKind.APPROVAL_REQUEST
+    assert metadata["diff_preview"]["phase"] == "proposed"
+    assert metadata["diff_preview"]["files"][0]["path"] == "app.py"
+    assert metadata["diff_preview"]["total_additions"] == 1
+    assert metadata["diff_preview"]["total_deletions"] == 1
+
+
+def test_session_diff_maps_to_aggregate_diff_preview() -> None:
+    kind, text, metadata = map_event(
+        "session.diff",
+        {
+            "diff": [
+                {
+                    "path": "app.py",
+                    "kind": "modified",
+                    "additions": 2,
+                    "deletions": 1,
+                    "diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1,2 @@\n-old\n+new\n+line\n",
+                }
+            ]
+        },
+    )
+
+    assert kind == EventKind.SYSTEM_NOTE
+    assert text == "Changes: +2 -1"
+    assert metadata["diff_preview"]["phase"] == "aggregate"
+    assert metadata["diff_preview"]["files"][0]["path"] == "app.py"
+    assert metadata["diff_preview"]["files"][0]["change_type"] == "update"
+
+
 def test_question_asked_maps_to_ask_user_question_tool_call() -> None:
     kind, text, metadata = map_event(
         "question.asked",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2310,6 +2310,200 @@ html[data-theme="light"] .transcript.codex.tool_pair {
   color: var(--muted-soft);
 }
 
+.diff-preview {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.diff-preview-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.diff-preview-title {
+  min-width: 0;
+  color: var(--text-strong);
+  font-weight: 650;
+}
+
+.diff-preview-stat,
+.diff-preview-note,
+.diff-change-type {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 2px 7px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
+.diff-preview-stat.add {
+  color: var(--success);
+  background: rgba(108, 201, 154, 0.1);
+  border-color: rgba(108, 201, 154, 0.24);
+}
+
+html[data-theme="light"] .diff-preview-stat.add {
+  background: rgba(37, 122, 80, 0.09);
+  border-color: rgba(37, 122, 80, 0.2);
+}
+
+.diff-preview-stat.del {
+  color: var(--danger);
+  background: rgba(226, 108, 112, 0.1);
+  border-color: rgba(226, 108, 112, 0.24);
+}
+
+html[data-theme="light"] .diff-preview-stat.del {
+  background: rgba(184, 48, 56, 0.08);
+  border-color: rgba(184, 48, 56, 0.2);
+}
+
+.diff-preview-note {
+  color: var(--warn);
+  background: rgba(217, 154, 74, 0.1);
+  border-color: rgba(217, 154, 74, 0.24);
+}
+
+html[data-theme="light"] .diff-preview-note {
+  background: rgba(170, 102, 24, 0.08);
+  border-color: rgba(170, 102, 24, 0.2);
+}
+
+.diff-preview-files {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.diff-preview-file {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 11, 16, 0.38);
+}
+
+html[data-theme="light"] .diff-preview-file {
+  background: rgba(255, 252, 245, 0.66);
+}
+
+.diff-file-header {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.diff-change-type {
+  text-transform: uppercase;
+  color: var(--accent-cool);
+  background: rgba(143, 179, 214, 0.1);
+  border-color: rgba(143, 179, 214, 0.22);
+}
+
+html[data-theme="light"] .diff-change-type {
+  background: rgba(47, 111, 158, 0.08);
+  border-color: rgba(47, 111, 158, 0.18);
+}
+
+.diff-change-type.add {
+  color: var(--success);
+}
+
+.diff-change-type.delete {
+  color: var(--danger);
+}
+
+.diff-file-path {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+}
+
+.diff-file-stats {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.diff-code {
+  margin: 0;
+  max-height: 360px;
+  overflow: auto;
+  background: rgba(5, 7, 10, 0.52);
+  color: #cbd4e2;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+html[data-theme="light"] .diff-code {
+  background: rgba(246, 242, 232, 0.8);
+  color: var(--text);
+}
+
+.diff-line {
+  display: block;
+  min-width: max-content;
+  padding: 0 10px;
+  white-space: pre;
+}
+
+.diff-line.add {
+  background: rgba(108, 201, 154, 0.13);
+  color: #a8e6c5;
+}
+
+html[data-theme="light"] .diff-line.add {
+  background: rgba(37, 122, 80, 0.1);
+  color: #155c3a;
+}
+
+.diff-line.del {
+  background: rgba(226, 108, 112, 0.13);
+  color: #f1aaa8;
+}
+
+html[data-theme="light"] .diff-line.del {
+  background: rgba(184, 48, 56, 0.09);
+  color: #8f1d24;
+}
+
+.diff-line.hunk {
+  background: rgba(143, 179, 214, 0.12);
+  color: var(--accent-cool);
+}
+
+html[data-theme="light"] .diff-line.hunk {
+  background: rgba(47, 111, 158, 0.08);
+}
+
+.diff-line.meta {
+  color: var(--muted);
+}
+
+.diff-unavailable {
+  margin: 0;
+  padding: 10px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
 .badge.user {
   background: rgba(143, 179, 214, 0.14);
   color: var(--accent-cool);

--- a/frontend/src/components/DiffPreview.tsx
+++ b/frontend/src/components/DiffPreview.tsx
@@ -1,0 +1,67 @@
+import type { EventDiffPreview, EventDiffPreviewFile } from "@/lib/events";
+
+const PHASE_LABEL: Record<EventDiffPreview["phase"], string> = {
+  proposed: "Proposed changes",
+  applied: "Applied changes",
+  aggregate: "Turn changes",
+};
+
+export function DiffPreview({ preview }: { preview: EventDiffPreview }) {
+  return (
+    <div className="diff-preview">
+      <div className="diff-preview-header">
+        <span className="diff-preview-title">{PHASE_LABEL[preview.phase]}</span>
+        <span className="diff-preview-stat add">+{preview.totalAdditions}</span>
+        <span className="diff-preview-stat del">-{preview.totalDeletions}</span>
+        {preview.truncated ? <span className="diff-preview-note">truncated</span> : null}
+      </div>
+      <div className="diff-preview-files">
+        {preview.files.map((file, index) => (
+          <DiffPreviewFileView file={file} key={`${file.path}-${index}`} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function DiffPreviewFileView({ file }: { file: EventDiffPreviewFile }) {
+  return (
+    <section className="diff-preview-file">
+      <div className="diff-file-header">
+        <span className={`diff-change-type ${file.changeType}`}>
+          {file.changeType}
+        </span>
+        <span className="diff-file-path" title={file.path}>
+          {file.oldPath && file.oldPath !== file.path ? `${file.oldPath} -> ${file.path}` : file.path}
+        </span>
+        <span className="diff-file-stats">
+          +{file.additions} -{file.deletions}
+        </span>
+      </div>
+      {file.unavailableReason ? (
+        <p className="diff-unavailable">{file.unavailableReason}</p>
+      ) : file.diff ? (
+        <pre className="diff-code" aria-label={`Diff for ${file.path}`}>
+          {file.diff.split("\n").map((line, index) => (
+            <span className={`diff-line ${classForDiffLine(line)}`} key={index}>
+              {line || " "}
+            </span>
+          ))}
+        </pre>
+      ) : (
+        <p className="diff-unavailable">No diff content available.</p>
+      )}
+      {file.truncated ? <p className="diff-unavailable">Diff truncated.</p> : null}
+    </section>
+  );
+}
+
+function classForDiffLine(line: string): string {
+  if (line.startsWith("@@")) return "hunk";
+  if (line.startsWith("diff --git") || line.startsWith("---") || line.startsWith("+++")) {
+    return "meta";
+  }
+  if (line.startsWith("+")) return "add";
+  if (line.startsWith("-")) return "del";
+  return "context";
+}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -42,7 +42,8 @@ import {
   useBackendCatalog,
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
-import { normalizeToolName } from "@/lib/events";
+import { normalizeToolName, parseEvent, type EventDiffPreview } from "@/lib/events";
+import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 import {
   AskAnswerEntry,
@@ -2499,6 +2500,7 @@ function UsageCard({ summary }: { summary: UsageSummary }) {
 }
 
 function ApprovalCard({ event, onDecide, supportsNote = false }: ApprovalCardProps) {
+  const diffPreview = parseEvent(event).diffPreview;
   const toolName = normalizeToolName(
     typeof event.metadata.tool_name === "string" ? event.metadata.tool_name : null
   );
@@ -2526,6 +2528,7 @@ function ApprovalCard({ event, onDecide, supportsNote = false }: ApprovalCardPro
         eventText={event.text}
         toolName={toolName}
         toolInput={toolInput}
+        diffPreview={diffPreview}
       />
       {supportsNote ? (
         noteOpen ? (
@@ -2599,11 +2602,21 @@ function ApprovalCardBody({
   eventText,
   toolName,
   toolInput,
+  diffPreview,
 }: {
   eventText: string;
   toolName: string | null;
   toolInput: Record<string, unknown> | null;
+  diffPreview?: EventDiffPreview | null;
 }) {
+  if (diffPreview) {
+    return (
+      <>
+        <p className="approval-prompt">{eventText}</p>
+        <DiffPreview preview={diffPreview} />
+      </>
+    );
+  }
   if (toolName === "ExitPlanMode" && typeof toolInput?.plan === "string") {
     return (
       <>

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -2,7 +2,8 @@ import { memo, useCallback, useState } from "react";
 
 import { fidelityFor, transportLabel } from "@/lib/backends";
 import { EventRecord, SessionTransport } from "@/lib/types";
-import { normalizeToolName } from "@/lib/events";
+import { normalizeToolName, parseEvent } from "@/lib/events";
+import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 
 function legacyCopy(text: string): boolean {
@@ -262,6 +263,21 @@ function CodexCard({
 }
 
 function SystemRule({ event }: { event: EventRecord }) {
+  const diffPreview = parseEvent(event).diffPreview;
+  if (diffPreview) {
+    return (
+      <details className="panel transcript codex system diff-system-card">
+        <summary className="transcript-summary">
+          <div className="transcript-role">
+            <span className="badge neutral">changes</span>
+            <span className="role-time">{formatTime(event.ts)}</span>
+          </div>
+          <p className="transcript-preview">{event.text}</p>
+        </summary>
+        <DiffPreview preview={diffPreview} />
+      </details>
+    );
+  }
   return (
     <div className="system-rule" role="note">
       <span className="system-rule-body">
@@ -431,6 +447,7 @@ function ToolDisclosure({
   const tool = toolBadgeFor(readToolName(event));
   const preview = previewForToolEvent(event, tool.label);
   const kindLabel = event.kind === "tool_call" ? "call" : "result";
+  const diffPreview = parseEvent(event).diffPreview;
   return (
     <details className={`panel transcript codex ${event.kind} tool-disclosure`}>
       <summary className="transcript-summary">
@@ -444,7 +461,11 @@ function ToolDisclosure({
         </div>
         {preview ? <p className="transcript-preview">{preview}</p> : null}
       </summary>
-      <pre className={bodyClassName}>{event.text}</pre>
+      {diffPreview ? (
+        <DiffPreview preview={diffPreview} />
+      ) : (
+        <pre className={bodyClassName}>{event.text}</pre>
+      )}
     </details>
   );
 }
@@ -478,6 +499,9 @@ function ToolPairCard({
   }
   const status = result ? "complete" : "pending";
   const tool = toolBadgeFor(readToolName(call ?? result ?? ({} as EventRecord)));
+  const diffPreview =
+    (result ? parseEvent(result).diffPreview : null) ||
+    (call ? parseEvent(call).diffPreview : null);
   const summary =
     (call ? previewForToolEvent(call, tool.label) : null) ||
     (result ? previewForToolEvent(result, tool.label) : null) ||
@@ -496,21 +520,27 @@ function ToolPairCard({
         {summary ? <p className="transcript-preview">{summary}</p> : null}
       </summary>
       <div className="tool-pair-body">
-        {call ? (
-          <div className="tool-pair-section">
-            <p className="tool-pair-label">call</p>
-            <pre className="shell">{call.text}</pre>
-          </div>
-        ) : null}
-        {result ? (
-          <div className="tool-pair-section">
-            <p className="tool-pair-label">result</p>
-            <pre className="output">{result.text}</pre>
-          </div>
+        {diffPreview ? (
+          <DiffPreview preview={diffPreview} />
         ) : (
-          <div className="tool-pair-section">
-            <p className="tool-pair-label muted">awaiting result…</p>
-          </div>
+          <>
+            {call ? (
+              <div className="tool-pair-section">
+                <p className="tool-pair-label">call</p>
+                <pre className="shell">{call.text}</pre>
+              </div>
+            ) : null}
+            {result ? (
+              <div className="tool-pair-section">
+                <p className="tool-pair-label">result</p>
+                <pre className="output">{result.text}</pre>
+              </div>
+            ) : (
+              <div className="tool-pair-section">
+                <p className="tool-pair-label muted">awaiting result…</p>
+              </div>
+            )}
+          </>
         )}
       </div>
     </details>

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -31,6 +31,27 @@ export interface EventEnvelopeApproval {
   decisions?: string[];
 }
 
+export interface EventDiffPreviewFile {
+  path: string;
+  oldPath?: string | null;
+  changeType: "add" | "delete" | "update" | "move" | "unknown";
+  diff: string;
+  additions: number;
+  deletions: number;
+  truncated: boolean;
+  binary: boolean;
+  unavailableReason?: string | null;
+}
+
+export interface EventDiffPreview {
+  schemaVersion: 1;
+  phase: "proposed" | "applied" | "aggregate";
+  files: EventDiffPreviewFile[];
+  totalAdditions: number;
+  totalDeletions: number;
+  truncated: boolean;
+}
+
 export interface EventEnvelope {
   version: number | null;
   kind: EventRecord["kind"];
@@ -38,6 +59,7 @@ export interface EventEnvelope {
   status?: string | null;
   item?: EventEnvelopeItem;
   approval?: EventEnvelopeApproval;
+  diffPreview?: EventDiffPreview | null;
   // Untyped passthrough for fields not yet promoted to the schema.
   extra: Record<string, unknown>;
 }
@@ -67,6 +89,62 @@ function readStringArray(
     return value.filter((entry): entry is string => typeof entry === "string");
   }
   return undefined;
+}
+
+function readNumber(metadata: Record<string, unknown>, key: string): number {
+  const value = metadata[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function readBoolean(metadata: Record<string, unknown>, key: string): boolean {
+  return metadata[key] === true;
+}
+
+function readDiffPreview(metadata: Record<string, unknown>): EventDiffPreview | null {
+  const raw = readRecord(metadata, "diff_preview");
+  if (!raw) return null;
+  const filesRaw = raw.files;
+  if (!Array.isArray(filesRaw)) return null;
+  const files = filesRaw
+    .filter((entry): entry is Record<string, unknown> =>
+      Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+    )
+    .map((entry) => ({
+      path: readString(entry, "path") ?? "changes",
+      oldPath: readString(entry, "old_path"),
+      changeType: readChangeType(entry.change_type),
+      diff: readString(entry, "diff") ?? "",
+      additions: readNumber(entry, "additions"),
+      deletions: readNumber(entry, "deletions"),
+      truncated: readBoolean(entry, "truncated"),
+      binary: readBoolean(entry, "binary"),
+      unavailableReason: readString(entry, "unavailable_reason"),
+    }));
+  if (!files.length) return null;
+  return {
+    schemaVersion: 1,
+    phase: readDiffPhase(raw.phase),
+    files,
+    totalAdditions: readNumber(raw, "total_additions"),
+    totalDeletions: readNumber(raw, "total_deletions"),
+    truncated: readBoolean(raw, "truncated"),
+  };
+}
+
+function readDiffPhase(value: unknown): EventDiffPreview["phase"] {
+  return value === "applied" || value === "aggregate" || value === "proposed"
+    ? value
+    : "proposed";
+}
+
+function readChangeType(value: unknown): EventDiffPreviewFile["changeType"] {
+  return value === "add" ||
+    value === "delete" ||
+    value === "update" ||
+    value === "move" ||
+    value === "unknown"
+    ? value
+    : "unknown";
 }
 
 const NORMALIZED_TOOL_NAMES: Record<string, string> = {
@@ -134,6 +212,7 @@ export function parseEvent(event: EventRecord): EventEnvelope {
     status: readString(metadata, "status"),
     item,
     approval,
+    diffPreview: readDiffPreview(metadata),
     extra: { ...metadata },
   };
 }


### PR DESCRIPTION
## Summary

Adds a backend-neutral file edit diff preview pipeline so proposed and applied file changes render as color-coded diffs instead of opaque tool text like `Preparing file changes: ...`. The preview contract is produced by each coding-agent plugin and consumed by one shared frontend renderer, preserving the plugin boundary instead of teaching the UI backend-specific protocol shapes.

## Changes

### Backend Diff Preview Contract
- Added a shared `diff_preview` metadata payload model/helper for normalized file diffs, addition/deletion counts, truncation, and unavailable-diff markers.
- Kept the persisted contract on event metadata rather than extending the opt-in `EventEnvelope` placeholder before that refactor lands.
- Added focused normalizer tests for Codex, Claude Code, and OpenCode diff-preview paths.

### Backend Implementations
- **Codex:** Captures `fileChange` patch updates, item snapshots, turn diffs, and legacy `applyPatchApproval` payloads. Caches previews by `itemId` so file-change approval requests can show the pending patch.
- **Claude Code:** Generates proposed diffs inside the PreToolUse hook for `Edit`, `MultiEdit`, and `Write`, so local and SSH sessions read from the same filesystem Claude is about to modify.
- **OpenCode:** Normalizes permission/file/session diff payloads into the shared shape, including count-only entries when OpenCode does not include patch text.

### Frontend Rendering
- Added a typed frontend parser for `metadata.diff_preview`.
- Added a shared `DiffPreview` component with file headers, change counts, truncation/unavailable states, and line-level styling for additions, deletions, hunk headers, and metadata lines.
- Render previews in approval cards, tool disclosures/tool pairs, and aggregate system change cards.
- Added dark/light theme styling for the new diff UI.

### Review Fixes
- Removed the unused `EventEnvelope.diff_preview` field because adapters currently persist `diff_preview` directly in event metadata.
- Added the missing return annotation on OpenCode diff-preview normalization.

## Test Plan

- [x] `cd backend && uv run pytest` — 268 passing
- [x] `cd backend && uv run pytest tests/test_codex_app_server.py tests/test_opencode_normalize.py tests/test_claude_cli.py` — 84 passing
- [x] `cd backend && uv run ruff check src/waypoint/backends/diff_preview.py src/waypoint/backends/events.py src/waypoint/backends/codex/normalize.py src/waypoint/backends/codex/adapter.py src/waypoint/backends/opencode/normalize.py tests/test_codex_app_server.py tests/test_opencode_normalize.py tests/test_claude_cli.py ../backend/scripts/claude_pretool_hook.py`
- [x] `cd backend && uv run ruff check src/waypoint/backends/events.py src/waypoint/backends/opencode/normalize.py`
- [x] `cd backend && uv run pytest tests/test_opencode_normalize.py tests/test_storage.py` — 36 passing
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [ ] Manual: Run live edit approvals/results through Codex, Claude Code, and OpenCode to verify each backend shows the expected diff preview in the browser.