### PR TITLE
fix: polish file edit diff previews

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -199,6 +199,7 @@ class ClaudeSessionState:
     wait_task: asyncio.Task[None]
     pending: dict[str, ClaudePendingApproval] = field(default_factory=dict)
     emitted_diff_preview_tool_ids: set[str] = field(default_factory=set)
+    file_edit_preview_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
     last_message_text: dict[str, str] = field(default_factory=dict)
     terminal_fragments: list[str] = field(default_factory=list)
     stderr_tail: deque[str] = field(
@@ -669,6 +670,13 @@ class ClaudeCliAdapter:
             # the mode never gets consulted unless we do it here.
             tool_input = payload.get("tool_input")
             tool_input_dict = tool_input if isinstance(tool_input, dict) else None
+            diff_preview = payload.get("diff_preview")
+            if isinstance(diff_preview, dict):
+                state.file_edit_preview_metadata[tool_use_id] = {
+                    "tool_name": payload.get("tool_name"),
+                    "tool_input": payload.get("tool_input"),
+                    "diff_preview": diff_preview,
+                }
             # AskUserQuestion always surfaces to the user — auto-approving any
             # mode would let the binary's defer path auto-decline before the
             # answer arrives.
@@ -1306,6 +1314,11 @@ class ClaudeCliAdapter:
             }
             if tool_use_id:
                 state.terminal_fragments.append(text + "\n")
+                preview_metadata = state.file_edit_preview_metadata.pop(
+                    tool_use_id, None
+                )
+                if preview_metadata is not None:
+                    metadata.update(preview_metadata)
             await self._emit_event(state.session_id, kind, text, metadata, status)
 
     async def _handle_result(

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -198,6 +198,7 @@ class ClaudeSessionState:
     stderr_task: asyncio.Task[None]
     wait_task: asyncio.Task[None]
     pending: dict[str, ClaudePendingApproval] = field(default_factory=dict)
+    emitted_diff_preview_tool_ids: set[str] = field(default_factory=set)
     last_message_text: dict[str, str] = field(default_factory=dict)
     terminal_fragments: list[str] = field(default_factory=list)
     stderr_tail: deque[str] = field(
@@ -696,6 +697,7 @@ class ClaudeCliAdapter:
                             state.last_plan_content = _apply_plan_edit(
                                 state.last_plan_content, tool_name, tool_input_dict
                             )
+                await self._emit_tool_diff_preview(state, payload)
                 return auto
 
             # Inject the saved plan text into ExitPlanMode so the frontend can
@@ -729,6 +731,7 @@ class ClaudeCliAdapter:
                     tool_use_id=tool_use_id, payload=payload, future=future
                 )
                 state.pending[tool_use_id] = pending
+                await self._emit_tool_diff_preview(state, payload)
                 # AskUserQuestion's tool_call event already renders the
                 # question UI in the transcript via parseAskUserQuestion;
                 # emitting a separate APPROVAL_REQUEST card would show the
@@ -760,6 +763,35 @@ class ClaudeCliAdapter:
         # ClaudeCodePluginConfig.hook_timeout_seconds) is the only
         # network-liveness ceiling.
         return await pending.future
+
+    async def _emit_tool_diff_preview(
+        self, state: ClaudeSessionState, payload: dict[str, Any]
+    ) -> None:
+        tool_use_id = str(payload.get("tool_use_id") or "")
+        if not tool_use_id or tool_use_id in state.emitted_diff_preview_tool_ids:
+            return
+        diff_preview = payload.get("diff_preview")
+        if not isinstance(diff_preview, dict):
+            return
+        tool_name = str(payload.get("tool_name") or "tool")
+        if tool_name not in {"Edit", "Write", "MultiEdit"}:
+            return
+        state.emitted_diff_preview_tool_ids.add(tool_use_id)
+        await self._emit_event(
+            state.session_id,
+            EventKind.TOOL_RESULT,
+            f"{tool_name} diff preview",
+            {
+                "method": "PreToolUse.diff_preview",
+                "item_id": tool_use_id,
+                "tool_name": tool_name,
+                "tool_input": payload.get("tool_input"),
+                "tool_use_id": tool_use_id,
+                "diff_preview": diff_preview,
+                "status": SessionStatus.RUNNING,
+            },
+            SessionStatus.RUNNING,
+        )
 
     def has_pending_approval(self, session_id: str) -> bool:
         state = self._sessions.get(session_id)

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -560,6 +560,7 @@ class CodexAppServerAdapter:
                         kind == EventKind.TOOL_RESULT
                         and notification.method == "item/completed"
                         and item_id in state.streamed_tool_result_ids
+                        and diff_preview is None
                     ):
                         continue
                     await self._emit_event(

--- a/backend/src/waypoint/backends/diff_preview.py
+++ b/backend/src/waypoint/backends/diff_preview.py
@@ -152,8 +152,22 @@ def files_from_codex_file_changes(changes: Any) -> list[DiffPreviewFile]:
         diff = change.get("diff")
         if not path or not isinstance(diff, str):
             continue
-        kind = _normalize_change_type(change.get("kind"))
-        files.append(file_from_unified_diff(path, diff, kind))
+        kind_raw = change.get("kind")
+        kind = _normalize_change_type(kind_raw)
+        if kind == "add":
+            files.append(file_from_old_new(path, "", diff, "add"))
+        elif kind == "delete":
+            files.append(file_from_old_new(path, diff, "", "delete"))
+        else:
+            move_path = _move_path_from_change_kind(kind_raw)
+            files.append(
+                file_from_unified_diff(
+                    str(move_path or path),
+                    diff,
+                    "move" if move_path else kind,
+                    old_path=path if move_path else None,
+                )
+            )
     return files
 
 
@@ -280,6 +294,8 @@ def count_unified_diff(diff: str) -> tuple[int, int]:
 
 
 def _normalize_change_type(value: Any) -> ChangeType:
+    if isinstance(value, dict):
+        value = value.get("type")
     normalized = str(value or "").lower()
     if normalized in {"add", "added", "create", "created", "new"}:
         return "add"
@@ -290,6 +306,15 @@ def _normalize_change_type(value: Any) -> ChangeType:
     if normalized in {"move", "moved", "rename", "renamed"}:
         return "move"
     return "unknown"
+
+
+def _move_path_from_change_kind(value: Any) -> str | None:
+    if not isinstance(value, dict):
+        return None
+    if value.get("type") != "update":
+        return None
+    move_path = value.get("move_path")
+    return move_path if isinstance(move_path, str) and move_path else None
 
 
 def _split_unified_diff(diff: str) -> list[list[str]]:

--- a/backend/src/waypoint/backends/diff_preview.py
+++ b/backend/src/waypoint/backends/diff_preview.py
@@ -208,9 +208,13 @@ def files_from_opencode_diffs(diffs: Any) -> list[DiffPreviewFile]:
         )
         old_path = entry.get("old_path") or entry.get("oldPath")
         diff = entry.get("diff") or entry.get("patch")
+        before = entry.get("before")
+        after = entry.get("after")
         additions = entry.get("additions")
         deletions = entry.get("deletions")
-        change_type = _normalize_change_type(entry.get("type") or entry.get("kind"))
+        change_type = _normalize_change_type(
+            entry.get("type") or entry.get("kind") or entry.get("status")
+        )
         if isinstance(diff, str) and diff:
             files.append(
                 file_from_unified_diff(
@@ -220,6 +224,26 @@ def files_from_opencode_diffs(diffs: Any) -> list[DiffPreviewFile]:
                     old_path=str(old_path) if isinstance(old_path, str) else None,
                     additions=additions if isinstance(additions, int) else None,
                     deletions=deletions if isinstance(deletions, int) else None,
+                )
+            )
+        elif isinstance(before, str) and isinstance(after, str):
+            file = file_from_old_new(
+                path=path,
+                old=before,
+                new=after,
+                change_type=change_type,
+                old_path=str(old_path) if isinstance(old_path, str) else None,
+            )
+            files.append(
+                file.model_copy(
+                    update={
+                        "additions": (
+                            additions if isinstance(additions, int) else file.additions
+                        ),
+                        "deletions": (
+                            deletions if isinstance(deletions, int) else file.deletions
+                        ),
+                    }
                 )
             )
         elif isinstance(additions, int) or isinstance(deletions, int):

--- a/backend/src/waypoint/backends/diff_preview.py
+++ b/backend/src/waypoint/backends/diff_preview.py
@@ -160,11 +160,14 @@ def files_from_codex_file_changes(changes: Any) -> list[DiffPreviewFile]:
             files.append(file_from_old_new(path, diff, "", "delete"))
         else:
             move_path = _move_path_from_change_kind(kind_raw)
+            change_type = (
+                _change_type_from_diff_text(diff) if kind == "unknown" else kind
+            )
             files.append(
                 file_from_unified_diff(
                     str(move_path or path),
                     diff,
-                    "move" if move_path else kind,
+                    "move" if move_path else change_type,
                     old_path=path if move_path else None,
                 )
             )
@@ -229,6 +232,8 @@ def files_from_opencode_diffs(diffs: Any) -> list[DiffPreviewFile]:
         change_type = _normalize_change_type(
             entry.get("type") or entry.get("kind") or entry.get("status")
         )
+        if change_type == "unknown" and isinstance(diff, str):
+            change_type = _change_type_from_diff_text(diff)
         if isinstance(diff, str) and diff:
             files.append(
                 file_from_unified_diff(
@@ -375,6 +380,18 @@ def _change_type_from_chunk(lines: list[str]) -> ChangeType:
     if old_path and new_path and old_path != new_path:
         return "move"
     return "update"
+
+
+def _change_type_from_diff_text(diff: str) -> ChangeType:
+    chunks = _split_unified_diff(diff)
+    if not chunks:
+        return "unknown"
+    change_types = {_change_type_from_chunk(chunk) for chunk in chunks}
+    if len(change_types) == 1:
+        return next(iter(change_types))
+    if change_types:
+        return "update"
+    return "unknown"
 
 
 def _limit_file(file: DiffPreviewFile, max_bytes: int) -> DiffPreviewFile:

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -245,8 +245,10 @@ async def test_await_approval_preserves_hook_diff_preview() -> None:
     await resolver()
     await decision_task
 
-    assert emitted[0][1] == EventKind.APPROVAL_REQUEST
+    assert emitted[0][1] == EventKind.TOOL_RESULT
     assert emitted[0][3]["diff_preview"]["files"][0]["path"] == "/tmp/app.py"
+    assert emitted[1][1] == EventKind.APPROVAL_REQUEST
+    assert emitted[1][3]["diff_preview"]["files"][0]["path"] == "/tmp/app.py"
 
 
 def test_claude_hook_builds_edit_diff_preview(tmp_path: Path) -> None:

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -251,6 +251,62 @@ async def test_await_approval_preserves_hook_diff_preview() -> None:
     assert emitted[1][3]["diff_preview"]["files"][0]["path"] == "/tmp/app.py"
 
 
+@pytest.mark.asyncio
+async def test_user_tool_result_inherits_hook_diff_preview() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    state.permission_mode = "acceptEdits"
+    payload = {
+        "waypoint_session_id": "sess",
+        "tool_use_id": "toolu_1",
+        "tool_name": "Edit",
+        "tool_input": {"file_path": "/tmp/app.py"},
+        "diff_preview": {
+            "schema_version": 1,
+            "phase": "proposed",
+            "files": [
+                {
+                    "path": "/tmp/app.py",
+                    "change_type": "update",
+                    "diff": "--- /tmp/app.py\n+++ /tmp/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+                    "additions": 1,
+                    "deletions": 1,
+                    "truncated": False,
+                    "binary": False,
+                    "unavailable_reason": None,
+                }
+            ],
+            "total_additions": 1,
+            "total_deletions": 1,
+            "truncated": False,
+        },
+    }
+
+    decision = await adapter.await_approval(payload)
+    await adapter._dispatch(
+        state,
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "toolu_1",
+                        "content": "updated successfully",
+                    }
+                ]
+            },
+        },
+    )
+
+    assert decision["permissionDecision"] == "allow"
+    assert emitted[-1][1] == EventKind.TOOL_RESULT
+    assert emitted[-1][3]["tool_name"] == "Edit"
+    assert emitted[-1][3]["tool_input"] == {"file_path": "/tmp/app.py"}
+    assert emitted[-1][3]["diff_preview"]["files"][0]["path"] == "/tmp/app.py"
+
+
 def test_claude_hook_builds_edit_diff_preview(tmp_path: Path) -> None:
     hook = _load_claude_hook_module()
     target = tmp_path / "app.py"

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -488,6 +488,57 @@ async def test_streamed_tool_result_suppresses_duplicate_completed_event() -> No
     assert tool_results[0][2] == "line one\n"
 
 
+@pytest.mark.asyncio
+async def test_streamed_file_change_completed_preserves_diff_preview() -> None:
+    emitted: list[tuple[str, EventKind, str, dict[str, Any], SessionStatus]] = []
+    adapter, fake = make_adapter(emitted)
+    await adapter.start_session("sess", "/tmp/work")
+
+    fake.notifications.put_nowait(
+        FakeNotification(
+            "item/fileChange/outputDelta",
+            {
+                "itemId": "file-1",
+                "delta": "Success. Updated the following files:\nM app.py\n",
+            },
+        )
+    )
+    fake.notifications.put_nowait(
+        FakeNotification(
+            "item/completed",
+            {
+                "item": {
+                    "id": "file-1",
+                    "type": "fileChange",
+                    "status": "completed",
+                    "changes": [
+                        {
+                            "path": "app.py",
+                            "kind": "update",
+                            "diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+                        }
+                    ],
+                }
+            },
+        )
+    )
+    fake.notifications.put_nowait(
+        FakeNotification(
+            "turn/completed",
+            {"turn": {"id": "turn-1", "status": "completed"}},
+        )
+    )
+
+    await adapter.send_input("sess", "edit app.py")
+    state = adapter._sessions["sess"]
+    if state.stream_task is not None:
+        await state.stream_task
+
+    tool_results = [entry for entry in emitted if entry[1] == EventKind.TOOL_RESULT]
+    assert len(tool_results) == 2
+    assert tool_results[1][3]["diff_preview"]["files"][0]["path"] == "app.py"
+
+
 def test_map_notification_agent_message_delta() -> None:
     from waypoint.backends.codex.normalize import map_notification
 

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -573,7 +573,7 @@ def test_map_notification_file_change_patch_updated_has_preview() -> None:
         "changes": [
             {
                 "path": "app.py",
-                "kind": "update",
+                "kind": {"type": "update", "move_path": None},
                 "diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-old\n+new\n",
             }
         ],
@@ -588,8 +588,40 @@ def test_map_notification_file_change_patch_updated_has_preview() -> None:
     assert preview is not None
     assert preview.phase == "proposed"
     assert preview.files[0].path == "app.py"
+    assert preview.files[0].change_type == "update"
     assert preview.total_additions == 1
     assert preview.total_deletions == 1
+
+
+def test_codex_file_change_preview_handles_add_and_delete_content() -> None:
+    from waypoint.backends.codex.normalize import diff_preview_for_notification
+
+    preview = diff_preview_for_notification(
+        "item/fileChange/patchUpdated",
+        {
+            "itemId": "item_1",
+            "changes": [
+                {
+                    "path": "created.py",
+                    "kind": {"type": "add"},
+                    "diff": "print('created')\n",
+                },
+                {
+                    "path": "removed.py",
+                    "kind": {"type": "delete"},
+                    "diff": "print('removed')\n",
+                },
+            ],
+        },
+    )
+
+    assert preview is not None
+    assert preview.files[0].path == "created.py"
+    assert preview.files[0].change_type == "add"
+    assert preview.files[0].additions == 1
+    assert preview.files[1].path == "removed.py"
+    assert preview.files[1].change_type == "delete"
+    assert preview.files[1].deletions == 1
 
 
 def test_codex_apply_patch_approval_preview_handles_legacy_file_changes() -> None:

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -624,6 +624,26 @@ def test_codex_file_change_preview_handles_add_and_delete_content() -> None:
     assert preview.files[1].deletions == 1
 
 
+def test_codex_file_change_preview_infers_type_from_unified_diff() -> None:
+    from waypoint.backends.codex.normalize import diff_preview_for_notification
+
+    preview = diff_preview_for_notification(
+        "item/fileChange/patchUpdated",
+        {
+            "itemId": "item_1",
+            "changes": [
+                {
+                    "path": "app.py",
+                    "diff": "--- a/app.py\n+++ b/app.py\n@@ -1 +1 @@\n-old\n+new\n",
+                }
+            ],
+        },
+    )
+
+    assert preview is not None
+    assert preview.files[0].change_type == "update"
+
+
 def test_codex_apply_patch_approval_preview_handles_legacy_file_changes() -> None:
     from waypoint.backends.codex.normalize import diff_preview_for_approval
 

--- a/backend/tests/test_opencode_normalize.py
+++ b/backend/tests/test_opencode_normalize.py
@@ -91,6 +91,59 @@ def test_session_diff_maps_to_aggregate_diff_preview() -> None:
     assert metadata["diff_preview"]["files"][0]["change_type"] == "update"
 
 
+def test_session_diff_maps_opencode_snapshot_file_diff_status() -> None:
+    kind, text, metadata = map_event(
+        "session.diff",
+        {
+            "diff": [
+                {
+                    "file": "new_app.py",
+                    "status": "added",
+                    "additions": 1,
+                    "deletions": 0,
+                    "patch": "--- /dev/null\n+++ b/new_app.py\n@@ -0,0 +1 @@\n+print('hi')\n",
+                }
+            ]
+        },
+    )
+
+    assert kind == EventKind.SYSTEM_NOTE
+    assert text == "Changes: +1 -0"
+    file = metadata["diff_preview"]["files"][0]
+    assert file["path"] == "new_app.py"
+    assert file["change_type"] == "add"
+    assert metadata["diff_preview"]["total_additions"] == 1
+    assert metadata["diff_preview"]["total_deletions"] == 0
+
+
+def test_session_diff_generates_preview_from_opencode_before_after() -> None:
+    kind, text, metadata = map_event(
+        "session.diff",
+        {
+            "diff": [
+                {
+                    "file": "app.py",
+                    "status": "modified",
+                    "additions": 1,
+                    "deletions": 1,
+                    "before": "old\n",
+                    "after": "new\n",
+                }
+            ]
+        },
+    )
+
+    assert kind == EventKind.SYSTEM_NOTE
+    assert text == "Changes: +1 -1"
+    file = metadata["diff_preview"]["files"][0]
+    assert file["path"] == "app.py"
+    assert file["change_type"] == "update"
+    assert "--- app.py" in file["diff"]
+    assert "+++ app.py" in file["diff"]
+    assert "-old" in file["diff"]
+    assert "+new" in file["diff"]
+
+
 def test_question_asked_maps_to_ask_user_question_tool_call() -> None:
     kind, text, metadata = map_event(
         "question.asked",

--- a/frontend/src/components/DiffPreview.tsx
+++ b/frontend/src/components/DiffPreview.tsx
@@ -25,11 +25,12 @@ export function DiffPreview({ preview }: { preview: EventDiffPreview }) {
 }
 
 function DiffPreviewFileView({ file }: { file: EventDiffPreviewFile }) {
+  const changeType = displayChangeType(file);
   return (
     <section className="diff-preview-file">
       <div className="diff-file-header">
-        <span className={`diff-change-type ${file.changeType}`}>
-          {file.changeType}
+        <span className={`diff-change-type ${changeType.className}`}>
+          {changeType.label}
         </span>
         <span className="diff-file-path" title={file.path}>
           {file.oldPath && file.oldPath !== file.path ? `${file.oldPath} -> ${file.path}` : file.path}
@@ -54,6 +55,42 @@ function DiffPreviewFileView({ file }: { file: EventDiffPreviewFile }) {
       {file.truncated ? <p className="diff-unavailable">Diff truncated.</p> : null}
     </section>
   );
+}
+
+function displayChangeType(file: EventDiffPreviewFile): {
+  className: EventDiffPreviewFile["changeType"];
+  label: string;
+} {
+  if (file.changeType !== "unknown") {
+    return { className: file.changeType, label: file.changeType };
+  }
+  const inferred = inferChangeType(file.diff);
+  if (inferred !== "unknown") {
+    return { className: inferred, label: inferred };
+  }
+  return { className: "update", label: "edit" };
+}
+
+function inferChangeType(diff: string): EventDiffPreviewFile["changeType"] {
+  const lines = diff.split("\n");
+  const oldPath = lines.find((line) => line.startsWith("--- "))?.slice(4).trim();
+  const newPath = lines.find((line) => line.startsWith("+++ "))?.slice(4).trim();
+  if (oldPath === "/dev/null") return "add";
+  if (newPath === "/dev/null") return "delete";
+  if (oldPath && newPath && cleanDiffPath(oldPath) !== cleanDiffPath(newPath)) {
+    return "move";
+  }
+  if (lines.some((line) => line.startsWith("+") || line.startsWith("-"))) {
+    return "update";
+  }
+  return "unknown";
+}
+
+function cleanDiffPath(path: string): string {
+  const withoutTimestamp = path.split("\t", 1)[0];
+  return withoutTimestamp.startsWith("a/") || withoutTimestamp.startsWith("b/")
+    ? withoutTimestamp.slice(2)
+    : withoutTimestamp;
 }
 
 function classForDiffLine(line: string): string {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2053,7 +2053,9 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     if (event.kind === "tool_call") {
       item.pair.call = event;
     } else {
-      item.pair.result = event;
+      item.pair.result = item.pair.result
+        ? mergeToolResultEvent(item.pair.result, event)
+        : event;
     }
     item.pair.ts = event.ts;
     item.pair.sequence = Math.max(item.pair.sequence, event.sequence);
@@ -2115,6 +2117,16 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
   }
 
   return grouped;
+}
+
+function mergeToolResultEvent(existing: EventRecord, incoming: EventRecord): EventRecord {
+  return {
+    ...existing,
+    text: mergeEventText(existing, incoming),
+    metadata: { ...existing.metadata, ...incoming.metadata },
+    ts: incoming.ts,
+    sequence: Math.max(existing.sequence, incoming.sequence),
+  };
 }
 
 function filterOptimisticTranscriptEvents(
@@ -2665,7 +2677,36 @@ function ApprovalCardBody({
       </>
     );
   }
+  if (isApprovalFileEditTool(toolName)) {
+    const path = approvalFileEditPath(toolInput);
+    return (
+      <>
+        <p className="approval-prompt">
+          Approve {toolName}
+          {path ? ` on ${path}` : ""}
+        </p>
+        <p className="diff-unavailable">Diff preview was not included by the backend.</p>
+      </>
+    );
+  }
   return <pre>{eventText}</pre>;
+}
+
+function isApprovalFileEditTool(toolName: string | null): boolean {
+  return (
+    toolName === "Edit" ||
+    toolName === "MultiEdit" ||
+    toolName === "Write" ||
+    toolName === "NotebookEdit"
+  );
+}
+
+function approvalFileEditPath(toolInput: Record<string, unknown> | null): string | null {
+  if (!toolInput) {
+    return null;
+  }
+  const value = toolInput.file_path ?? toolInput.path ?? toolInput.notebook_path;
+  return typeof value === "string" && value ? value : null;
 }
 
 function sanitizeEvent(event: EventRecord): EventRecord {

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -2,7 +2,7 @@ import { memo, useCallback, useState } from "react";
 
 import { fidelityFor, transportLabel } from "@/lib/backends";
 import { EventRecord, SessionTransport } from "@/lib/types";
-import { normalizeToolName, parseEvent } from "@/lib/events";
+import { normalizeToolName, parseEvent, type EventDiffPreview } from "@/lib/events";
 import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 
@@ -340,6 +340,7 @@ function toolBadgeFor(toolName: string | null | undefined): ToolBadge {
       return { glyph: "▤", variant: "read", label: toolName };
     case "Edit":
     case "MultiEdit":
+    case "NotebookEdit":
       return { glyph: "✎", variant: "edit", label: toolName };
     case "Write":
       return { glyph: "✚", variant: "write", label: toolName };
@@ -374,6 +375,65 @@ export function readToolName(event: EventRecord): string | null {
   return null;
 }
 
+function isFileEditToolName(toolName: string | null | undefined): boolean {
+  return (
+    toolName === "Edit" ||
+    toolName === "MultiEdit" ||
+    toolName === "Write" ||
+    toolName === "NotebookEdit"
+  );
+}
+
+function fallbackDiffPreviewForFileEdit(
+  events: (EventRecord | null | undefined)[],
+  phase: EventDiffPreview["phase"],
+): EventDiffPreview | null {
+  for (const event of events) {
+    if (!event || !isFileEditToolName(readToolName(event))) {
+      continue;
+    }
+    const path = filePathForToolInput(toolInputForEvent(event));
+    if (!path) {
+      continue;
+    }
+    return {
+      schemaVersion: 1,
+      phase,
+      files: [
+        {
+          path,
+          oldPath: null,
+          changeType: "unknown",
+          diff: "",
+          additions: 0,
+          deletions: 0,
+          truncated: false,
+          binary: false,
+          unavailableReason: "Diff preview was not included by the backend.",
+        },
+      ],
+      totalAdditions: 0,
+      totalDeletions: 0,
+      truncated: false,
+    };
+  }
+  return null;
+}
+
+function toolInputForEvent(event: EventRecord): Record<string, unknown> | null {
+  const meta = event.metadata as Record<string, unknown> | undefined;
+  const payload = asRecord(meta?.payload);
+  return asRecord(payload?.input) ?? asRecord(meta?.tool_input);
+}
+
+function filePathForToolInput(input: Record<string, unknown> | null): string | null {
+  if (!input) {
+    return null;
+  }
+  const value = input.file_path ?? input.path ?? input.notebook_path;
+  return typeof value === "string" && value ? value : null;
+}
+
 export function ToolCallRunGroup({
   toolNames,
   initiallyOpen,
@@ -390,7 +450,7 @@ export function ToolCallRunGroup({
   let otherCount = 0;
   for (const name of toolNames) {
     if (name === "Bash") bashCount++;
-    else if (name === "Edit" || name === "MultiEdit" || name === "Write") editCount++;
+    else if (isFileEditToolName(name)) editCount++;
     else if (name === "Read" || name === "Grep" || name === "Glob") readCount++;
     else otherCount++;
   }
@@ -447,7 +507,12 @@ function ToolDisclosure({
   const tool = toolBadgeFor(readToolName(event));
   const preview = previewForToolEvent(event, tool.label);
   const kindLabel = event.kind === "tool_call" ? "call" : "result";
-  const diffPreview = parseEvent(event).diffPreview;
+  const diffPreview =
+    parseEvent(event).diffPreview ||
+    fallbackDiffPreviewForFileEdit(
+      [event],
+      event.kind === "tool_result" ? "applied" : "proposed",
+    );
   return (
     <details className={`panel transcript codex ${event.kind} tool-disclosure`}>
       <summary className="transcript-summary">
@@ -501,7 +566,8 @@ function ToolPairCard({
   const tool = toolBadgeFor(readToolName(call ?? result ?? ({} as EventRecord)));
   const diffPreview =
     (result ? parseEvent(result).diffPreview : null) ||
-    (call ? parseEvent(call).diffPreview : null);
+    (call ? parseEvent(call).diffPreview : null) ||
+    fallbackDiffPreviewForFileEdit([call, result], result ? "applied" : "proposed");
   const summary =
     (call ? previewForToolEvent(call, tool.label) : null) ||
     (result ? previewForToolEvent(result, tool.label) : null) ||
@@ -1039,26 +1105,18 @@ function previewForToolEvent(event: EventRecord, toolLabel: string): string {
   // event.text for Claude tool_call events is `"ToolName\n{json input}"`,
   // which is verbose and redundant with the tool-name chip we already render
   // in the role row.
-  const meta = event.metadata as Record<string, unknown> | undefined;
   const toolName = readToolName(event);
-  const payload = (meta?.payload ?? null) as Record<string, unknown> | null;
-  const input =
-    (payload && typeof payload.input === "object" && payload.input !== null
-      ? (payload.input as Record<string, unknown>)
-      : null) ??
-    (typeof meta?.tool_input === "object" && meta?.tool_input !== null
-      ? (meta.tool_input as Record<string, unknown>)
-      : null);
+  const input = toolInputForEvent(event);
 
   if (event.kind === "tool_call" && input) {
     if (toolName === "Bash" && typeof input.command === "string") {
       return truncate(collapseWhitespace(input.command), 240);
     }
-    if (
-      (toolName === "Edit" || toolName === "MultiEdit" || toolName === "Write") &&
-      (typeof input.file_path === "string" || typeof input.path === "string")
-    ) {
-      return String(input.file_path ?? input.path);
+    if (isFileEditToolName(toolName)) {
+      const path = filePathForToolInput(input);
+      if (path) {
+        return path;
+      }
     }
     if (toolName === "Read" && typeof input.file_path === "string") {
       const range =

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -403,7 +403,7 @@ function fallbackDiffPreviewForFileEdit(
         {
           path,
           oldPath: null,
-          changeType: "unknown",
+          changeType: "update",
           diff: "",
           additions: 0,
           deletions: 0,

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -153,6 +153,7 @@ const NORMALIZED_TOOL_NAMES: Record<string, string> = {
   edit: "Edit",
   multiedit: "MultiEdit",
   write: "Write",
+  notebookedit: "NotebookEdit",
   grep: "Grep",
   glob: "Glob",
   webfetch: "WebFetch",


### PR DESCRIPTION
## Summary

Follow-up to the file edit preview feature. Fixes the remaining cases where edit diffs were either hidden behind raw tool call/result text or rendered with unhelpful UNKNOWN change badges.

## Changes

- Preserve Codex file-change previews on visible completed events instead of suppressing them after streamed output.
- Carry Claude Code PreToolUse diff previews onto the final tool result, so reload/grouping does not replace the preview with raw Edit JSON and success text.
- Normalize OpenCode snapshot diff payloads, including status-based change types and before/after fallback patches.
- Handle Codex tagged change kinds and add/delete content payloads from the vendored app-server protocol.
- Merge repeated frontend tool results by item id so earlier diff metadata survives later result events.
- Infer edit badge labels from diff content and fall back to edit/update instead of displaying UNKNOWN.

## Test Plan

- [x] cd backend && uv run pytest tests/test_codex_app_server.py tests/test_claude_cli.py
- [x] cd backend && uv run pytest tests/test_opencode_normalize.py
- [x] cd backend && uv run ruff check src/waypoint/backends/diff_preview.py src/waypoint/backends/claude_code/adapter.py tests/test_codex_app_server.py tests/test_claude_cli.py
- [x] cd frontend && npm run lint
- [x] cd frontend && npm run build