### PR TITLE
fix: allow MagicDNS frontend origins

### DIFF
--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -15,10 +15,14 @@ BACKEND_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CONFIG_PATH = BACKEND_ROOT / "waypoint.yaml"
 
 DEFAULT_CORS_ORIGINS: tuple[str, ...] = ()
+DNS_LABEL_PATTERN = r"[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+TAILSCALE_DNS_NAME_PATTERN = rf"(?:{DNS_LABEL_PATTERN}\.)+(?:ts\.net|tailscale\.net)"
+
 DEFAULT_CORS_ORIGIN_REGEX = (
     r"^https?://(localhost|127\.0\.0\.1|"
     r"100\.\d{1,3}\.\d{1,3}\.\d{1,3}|"
-    r"\[fd7a:115c:a1e0(:[0-9a-fA-F]{0,4}){0,7}\])(:\d+)?$"
+    r"\[fd7a:115c:a1e0(:[0-9a-fA-F]{0,4}){0,7}\]|"
+    rf"{DNS_LABEL_PATTERN}|{TAILSCALE_DNS_NAME_PATTERN})(:\d+)?$"
 )
 
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,38 @@ def test_load_settings_silently_uses_default_when_file_missing(
     settings = load_settings()
     assert settings.config_path is None
     assert settings.host == "127.0.0.1"
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://100.64.0.1:3000",
+        "http://mymachine:3000",
+        "http://my-machine-1:3000",
+        "http://mymachine.tailnet.ts.net:3000",
+        "http://mymachine.github.beta.tailscale.net:3000",
+        "https://mymachine:3000",
+    ],
+)
+def test_default_cors_regex_allows_local_and_tailscale_origins(origin: str) -> None:
+    assert settings_module.DEFAULT_CORS_ORIGIN_REGEX is not None
+    assert re.fullmatch(settings_module.DEFAULT_CORS_ORIGIN_REGEX, origin)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "http://example.com:3000",
+        "http://not_tailscale:3000",
+        "http://bad-.tailnet.ts.net:3000",
+        "ftp://mymachine:3000",
+    ],
+)
+def test_default_cors_regex_rejects_public_or_invalid_origins(origin: str) -> None:
+    assert settings_module.DEFAULT_CORS_ORIGIN_REGEX is not None
+    assert not re.fullmatch(settings_module.DEFAULT_CORS_ORIGIN_REGEX, origin)
 
 
 def test_load_settings_loads_default_when_file_exists(

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -5,7 +5,7 @@ default_backend: codex
 default_cwd: ~/
 data_dir: ~/.waypoint/data
 cors_origins: []
-# cors_allow_origin_regex: ^https?://(localhost|127\.0\.0\.1|100\.\d{1,3}\.\d{1,3}\.\d{1,3})(:\d+)?$
+# cors_allow_origin_regex: defaults to localhost, Tailscale IPs, and MagicDNS names.
 # chat_page_messages: 20  # latest N *logical* chat messages per page.
                           # Codex streams a single agent reply as
                           # hundreds of same-item_id deltas; the


### PR DESCRIPTION
## Summary

Fixes #44.

Allows the frontend to log in when it is opened through a Tailscale MagicDNS hostname such as `http://mymachine:3000`. The frontend already infers `http://<page-host>:8787`; the backend CORS default was rejecting that MagicDNS origin even though direct Tailscale IP origins were allowed.

## Changes

- Added DNS-safe single-label hostnames to the default backend CORS origin regex for short MagicDNS names.
- Added full Tailscale DNS name support for `*.ts.net` and legacy `*.tailscale.net` origins.
- Added regression coverage for localhost, Tailscale IP, MagicDNS, full Tailscale DNS names, and invalid/public origins.
- Updated the example config comment to describe the default CORS coverage.

## Test Plan

- [x] `cd backend && rtk uv run pytest tests/test_config.py`
- [x] `cd backend && rtk uv run ruff check src/waypoint/settings.py tests/test_config.py`
- [x] `cd backend && rtk uv run black --check src/waypoint/settings.py tests/test_config.py`