### PR TITLE
feat: add Codex plan mode approval flow

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -32,6 +32,7 @@ from waypoint.schemas import (
     SessionInputRequest,
     SessionModelRequest,
     SessionPermissionModeRequest,
+    SessionPlanApprovalRequest,
     SessionTitleRequest,
     TerminalSnapshot,
 )
@@ -255,6 +256,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         session = await context.runtime.approve(session_id, request)
+        return {"session": session.model_dump(mode="json")}
+
+    @app.post("/api/sessions/{session_id}/approve-plan")
+    async def session_approve_plan(
+        session_id: str,
+        request: SessionPlanApprovalRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        session = await context.runtime.approve_plan(session_id, request)
         return {"session": session.model_dump(mode="json")}
 
     @app.post("/api/sessions/{session_id}/answer-question")

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -202,6 +202,16 @@ class BackendPlugin(Protocol):
         """Respond to a Claude AskUserQuestion tool call."""
         ...
 
+    async def approve_plan(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        plan_item_id: str,
+        text: str | None,
+    ) -> SessionRecord:
+        """Approve a backend-native plan item and resume execution."""
+        ...
+
     async def post_approval(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -41,6 +41,7 @@ class BackendCapabilities(_FrozenModel):
     supports_thread_discovery: bool = False
     supports_thread_import: bool = False
     supports_fork: bool = False
+    supports_plan_approval: bool = False
     supports_slash_compact: bool = False
     supports_approval_note: bool = False
     permission_modes: tuple[PermissionModeSpec, ...] = ()

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -518,6 +518,18 @@ class ClaudeCodePlugin:
         )
         return updated
 
+    async def approve_plan(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        plan_item_id: str,
+        text: str | None,
+    ) -> SessionRecord:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"plan approval is not supported for {self.id}",
+        )
+
     async def post_approval(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -205,6 +205,7 @@ class CodexAppServerAdapter:
             state, state.client.thread_start, thread_params
         )
         state.thread_id = started.thread.id
+        state.model = model or getattr(started, "model", None)
         return state.thread_id
 
     async def restore_session(
@@ -231,7 +232,8 @@ class CodexAppServerAdapter:
             model=model,
             effort=effort,
         )
-        await self._call_client(state, state.client.thread_resume, thread_id)
+        resumed = await self._call_client(state, state.client.thread_resume, thread_id)
+        state.model = model or getattr(resumed, "model", None)
 
     async def fork_session(
         self,
@@ -265,6 +267,7 @@ class CodexAppServerAdapter:
             state, state.client.thread_fork, thread_id, fork_params
         )
         state.thread_id = forked.thread.id
+        state.model = model or getattr(forked, "model", None)
         return state.thread_id
 
     async def _spawn_session(

--- a/backend/src/waypoint/backends/codex/permission_modes.py
+++ b/backend/src/waypoint/backends/codex/permission_modes.py
@@ -49,6 +49,7 @@ def codex_turn_params_for(
     mode: str | None,
     *,
     model: str | None = None,
+    effort: str | None = None,
     pre_plan_mode: str | None = None,
 ) -> dict[str, Any] | None:
     if mode is None:
@@ -64,13 +65,14 @@ def codex_turn_params_for(
     if preset is None:
         return None
     params = dict(preset)
-    if mode == CODEX_PLAN_MODE and model:
+    if model:
+        collaboration_mode = CODEX_PLAN_MODE if mode == CODEX_PLAN_MODE else "default"
         params["collaborationMode"] = {
-            "mode": "plan",
+            "mode": collaboration_mode,
             "settings": {
                 "model": model,
-                "reasoning_effort": "medium",
-                # Let app-server inject Codex's built-in Plan instructions.
+                "reasoning_effort": "medium" if mode == CODEX_PLAN_MODE else effort,
+                # Let app-server inject Codex's built-in mode instructions.
                 "developer_instructions": None,
             },
         }

--- a/backend/src/waypoint/backends/codex/permission_modes.py
+++ b/backend/src/waypoint/backends/codex/permission_modes.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from waypoint.backends.capabilities import PermissionModeSpec
 
+CODEX_PLAN_MODE = "plan"
+
 CODEX_PERMISSION_PRESETS: dict[str, dict[str, Any]] = {
     "default": {
         "approval_policy": "on-request",
@@ -29,15 +31,47 @@ CODEX_PERMISSION_PRESETS: dict[str, dict[str, Any]] = {
 
 CODEX_PERMISSION_MODE_SPECS: tuple[PermissionModeSpec, ...] = (
     PermissionModeSpec(id="default", label="Default"),
+    PermissionModeSpec(
+        id=CODEX_PLAN_MODE,
+        label="Plan",
+        description="Use Codex Plan collaboration mode with the previous permission preset",
+    ),
     PermissionModeSpec(id="auto_review", label="Auto review"),
     PermissionModeSpec(id="full_access", label="Full access"),
 )
 
+CODEX_PERMISSION_MODE_IDS: tuple[str, ...] = tuple(CODEX_PERMISSION_PRESETS) + (
+    CODEX_PLAN_MODE,
+)
 
-def codex_turn_params_for(mode: str | None) -> dict[str, Any] | None:
+
+def codex_turn_params_for(
+    mode: str | None,
+    *,
+    model: str | None = None,
+    pre_plan_mode: str | None = None,
+) -> dict[str, Any] | None:
     if mode is None:
         return None
-    preset = CODEX_PERMISSION_PRESETS.get(mode)
+    preset_mode = (
+        pre_plan_mode
+        if mode == CODEX_PLAN_MODE and pre_plan_mode in CODEX_PERMISSION_PRESETS
+        else mode
+    )
+    if mode == CODEX_PLAN_MODE and preset_mode == CODEX_PLAN_MODE:
+        preset_mode = "default"
+    preset = CODEX_PERMISSION_PRESETS.get(preset_mode)
     if preset is None:
         return None
-    return dict(preset)
+    params = dict(preset)
+    if mode == CODEX_PLAN_MODE and model:
+        params["collaborationMode"] = {
+            "mode": "plan",
+            "settings": {
+                "model": model,
+                "reasoning_effort": "medium",
+                # Let app-server inject Codex's built-in Plan instructions.
+                "developer_instructions": None,
+            },
+        }
+    return params

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -462,6 +462,11 @@ class CodexPlugin:
 
         now = datetime.now(UTC)
         raw_log.touch(exist_ok=True)
+        forked_transport_state: dict[str, Any] = {"thread_id": new_thread_id}
+        pre_plan_mode = session.transport_state.get("pre_plan_mode")
+        if pre_plan_mode is not None:
+            forked_transport_state["pre_plan_mode"] = pre_plan_mode
+
         new_session = SessionRecord(
             id=new_session_id,
             backend=self.id,
@@ -478,7 +483,7 @@ class CodexPlugin:
             last_event_at=now,
             raw_log_path=str(raw_log),
             structured_log_path=str(structured_log),
-            transport_state={"thread_id": new_thread_id},
+            transport_state=forked_transport_state,
             permission_mode=session.permission_mode,
             model=session.model,
             effort=session.effort,

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -31,8 +31,11 @@ from waypoint.backends.codex.adapter import (
     default_client_factory,
 )
 from waypoint.backends.codex.permission_modes import (
+    CODEX_PERMISSION_MODE_IDS,
     CODEX_PERMISSION_MODE_SPECS,
     CODEX_PERMISSION_PRESETS,
+    CODEX_PLAN_MODE,
+    codex_turn_params_for,
 )
 from waypoint.backends.codex.remote import build_remote_codex_client_factory
 from waypoint.backends.codex.schemas import (
@@ -108,6 +111,10 @@ class CodexPlugin:
         slash_commands=(
             SlashCommandSpec(name="status", description="Show session status"),
             SlashCommandSpec(name="compact", description="Compact the current thread"),
+            SlashCommandSpec(
+                name="plan",
+                description="Switch to Codex Plan mode or plan the provided prompt",
+            ),
         ),
         badges={"glyph": "X", "color": "#34d399"},
         cli_binary="codex",
@@ -167,23 +174,55 @@ class CodexPlugin:
     def validate_permission_mode(self, mode: str | None) -> str | None:
         if mode is None or mode == "":
             return None
-        if mode not in CODEX_PERMISSION_PRESETS:
+        if mode not in CODEX_PERMISSION_MODE_IDS:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
                     f"unsupported {self.id} permission mode: {mode}; "
-                    f"expected one of {', '.join(CODEX_PERMISSION_PRESETS)}"
+                    f"expected one of {', '.join(CODEX_PERMISSION_MODE_IDS)}"
                 ),
             )
         return mode
 
     @property
     def permission_mode_ids(self) -> tuple[str, ...]:
-        return tuple(CODEX_PERMISSION_PRESETS)
+        return CODEX_PERMISSION_MODE_IDS
+
+    def _session_model_for_turn(self, session: SessionRecord) -> str | None:
+        if session.model:
+            return session.model
+        if self.adapter is None:
+            return None
+        session_model = getattr(self.adapter, "session_model", None)
+        if not callable(session_model):
+            return None
+        return session_model(session.id)
+
+    def turn_params_for(self, session: SessionRecord) -> dict[str, Any] | None:
+        return codex_turn_params_for(
+            session.permission_mode,
+            model=self._session_model_for_turn(session),
+            pre_plan_mode=session.transport_state.get("pre_plan_mode"),
+        )
 
     async def apply_permission_mode(
         self, runtime: "SessionRuntime", session: SessionRecord, mode: str
     ) -> None:
+        if mode == CODEX_PLAN_MODE:
+            pre_plan_mode = (
+                session.permission_mode
+                if session.permission_mode != CODEX_PLAN_MODE
+                else session.transport_state.get("pre_plan_mode")
+            )
+            if pre_plan_mode not in CODEX_PERMISSION_PRESETS:
+                pre_plan_mode = "default"
+            state = {**session.transport_state, "pre_plan_mode": pre_plan_mode}
+            runtime.storage.update_session(session.id, transport_state=state)
+            return None
+        if session.transport_state.get("pre_plan_mode") is not None:
+            state = dict(session.transport_state)
+            state.pop("pre_plan_mode", None)
+            runtime.storage.update_session(session.id, transport_state=state)
         # Codex applies on next turn_start — no protocol round-trip here.
         return None
 
@@ -268,7 +307,11 @@ class CodexPlugin:
                 status=session.status,
             )
             try:
-                await self._require_adapter().send_input_items(session.id, items)
+                await self._require_adapter().send_input_items(
+                    session.id,
+                    items,
+                    turn_params=self.turn_params_for(updated),
+                )
             except Exception as exc:  # noqa: BLE001
                 runtime.storage.update_session(session.id, status=previous_status)
                 raise HTTPException(
@@ -278,7 +321,8 @@ class CodexPlugin:
             return updated
 
         command = request.text.strip()
-        command_name = command.split(None, 1)[0].lower()
+        command_parts = command.split(None, 1)
+        command_name = command_parts[0].lower() if command_parts else ""
         if command_name == "/status":
             await runtime._record_user_event(
                 session.id,
@@ -293,6 +337,41 @@ class CodexPlugin:
                 metadata={"builtin_command": "/status"},
             )
             return runtime.get_session(session.id)
+
+        if command_name == "/plan":
+            plan_prompt = command_parts[1].strip() if len(command_parts) > 1 else ""
+            updated = await runtime.set_permission_mode(session.id, CODEX_PLAN_MODE)
+            await runtime._record_user_event(
+                session.id,
+                request.text,
+                submit=request.submit,
+                status=session.status,
+            )
+            if not plan_prompt:
+                await runtime._record_system_event(
+                    session.id,
+                    "Switched Codex to plan mode",
+                    status=session.status,
+                    metadata={"builtin_command": "/plan"},
+                )
+                return updated
+
+            previous_status = updated.status
+            running = runtime.storage.update_session(
+                session.id, status=SessionStatus.RUNNING
+            )
+            try:
+                await self._require_adapter().send_input(
+                    session.id,
+                    plan_prompt,
+                    turn_params=self.turn_params_for(running),
+                )
+            except Exception as exc:  # noqa: BLE001
+                runtime.storage.update_session(session.id, status=previous_status)
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+                ) from exc
+            return running
 
         # Codex's app-server doesn't parse user text as control commands.
         # `/compact` takes effect through the thread/compact/start RPC; other

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -101,6 +101,7 @@ class CodexPlugin:
         supports_set_permission_mode_inline=True,
         supports_thread_discovery=True,
         supports_thread_import=True,
+        supports_fork=True,
         supports_slash_compact=True,
         supports_approval_note=False,
         supports_custom_cli_args=True,

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -198,10 +198,21 @@ class CodexPlugin:
             return None
         return session_model(session.id)
 
+    def _session_effort_for_turn(self, session: SessionRecord) -> str | None:
+        if session.effort:
+            return session.effort
+        if self.adapter is None:
+            return None
+        session_effort = getattr(self.adapter, "session_effort", None)
+        if not callable(session_effort):
+            return None
+        return session_effort(session.id)
+
     def turn_params_for(self, session: SessionRecord) -> dict[str, Any] | None:
         return codex_turn_params_for(
             session.permission_mode,
             model=self._session_model_for_turn(session),
+            effort=self._session_effort_for_turn(session),
             pre_plan_mode=session.transport_state.get("pre_plan_mode"),
         )
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -102,6 +102,7 @@ class CodexPlugin:
         supports_thread_discovery=True,
         supports_thread_import=True,
         supports_fork=True,
+        supports_plan_approval=True,
         supports_slash_compact=True,
         supports_approval_note=False,
         supports_custom_cli_args=True,
@@ -285,6 +286,60 @@ class CodexPlugin:
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
         return None
+
+    async def approve_plan(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        plan_item_id: str,
+        text: str | None,
+    ) -> SessionRecord:
+        if session.permission_mode != CODEX_PLAN_MODE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="codex session is not in plan mode",
+            )
+
+        plan = _plan_text_for_item(runtime, session.id, plan_item_id)
+        if not plan:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="codex plan item was not found",
+            )
+
+        target_mode = session.transport_state.get("pre_plan_mode")
+        if target_mode not in CODEX_PERMISSION_PRESETS:
+            target_mode = "default"
+
+        previous_status = session.status
+        runtime.storage.update_session(session.id, status=SessionStatus.RUNNING)
+        try:
+            await self._require_adapter().send_input(
+                session.id,
+                _format_plan_approval_prompt(plan, text),
+                turn_params=codex_turn_params_for(
+                    target_mode,
+                    model=self._session_model_for_turn(session),
+                    effort=self._session_effort_for_turn(session),
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            runtime.storage.update_session(session.id, status=previous_status)
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+
+        await runtime.set_permission_mode(session.id, target_mode)
+        running = runtime.storage.update_session(
+            session.id, status=SessionStatus.RUNNING
+        )
+        await runtime._record_system_event(
+            session.id,
+            f"Plan approved; exited plan mode ({target_mode})",
+            status=SessionStatus.RUNNING,
+            metadata={"plan_item_id": plan_item_id},
+        )
+        return running
 
     async def maybe_handle_input(
         self,
@@ -1083,6 +1138,39 @@ class CodexPlugin:
 
 def _deny_approval(_method: str, _params: dict[str, Any] | None) -> dict[str, Any]:
     return {"decision": "decline"}
+
+
+def _plan_text_for_item(
+    runtime: "SessionRuntime", session_id: str, plan_item_id: str
+) -> str:
+    for event in reversed(runtime.storage.list_events(session_id)):
+        if event.metadata.get("item_id") != plan_item_id:
+            continue
+        if event.metadata.get("item_type") != "plan":
+            continue
+        payload = event.metadata.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        item = payload.get("item")
+        if not isinstance(item, dict):
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text.strip():
+            return text.strip()
+    return ""
+
+
+def _format_plan_approval_prompt(plan: str, note: str | None = None) -> str:
+    lines = [
+        "User has approved your plan. You can now start coding. "
+        "Start with updating your todo list if applicable.",
+        "",
+        "## Approved Plan:",
+        plan,
+    ]
+    if note:
+        lines.extend(["", "User note:", note])
+    return "\n".join(lines)
 
 
 def _format_codex_status(session: SessionRecord) -> str:

--- a/backend/src/waypoint/backends/codex/transport.py
+++ b/backend/src/waypoint/backends/codex/transport.py
@@ -4,13 +4,6 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 
-# Re-exported from the backend plugin so legacy
-# `from waypoint.transports.codex import CODEX_PERMISSION_PRESETS`
-# imports keep working; the source of truth lives in
-# `backends/codex/permission_modes.py`.
-from waypoint.backends.codex.permission_modes import (
-    codex_turn_params_for,
-)
 from waypoint.schemas import SessionRecord
 from waypoint.transports.base import TransportAdapter
 
@@ -46,7 +39,7 @@ class CodexTransport(TransportAdapter):
             await self.adapter.send_input(
                 session.id,
                 text,
-                turn_params=codex_turn_params_for(session.permission_mode),
+                turn_params=self._plugin.turn_params_for(session),
             )
         except Exception as exc:
             raise HTTPException(

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -505,6 +505,9 @@ class OpenCodePlugin:
                     agent=session.transport_state.get("agent"),
                     effort=session.effort,
                 )
+                pre_plan_mode = session.transport_state.get("pre_plan_mode")
+                if pre_plan_mode is not None:
+                    await adapter.set_pre_plan_mode(session.id, pre_plan_mode)
             except Exception as exc:
                 log.warning(
                     "opencode resurrect of %s failed after reconnect: %s",
@@ -1268,6 +1271,8 @@ class OpenCodePlugin:
         }
         if agent:
             forked_transport_state["agent"] = agent
+        if pre_plan_mode is not None:
+            forked_transport_state["pre_plan_mode"] = pre_plan_mode
         new_session = SessionRecord(
             id=new_session_id,
             backend=self.id,
@@ -1518,6 +1523,9 @@ class OpenCodePlugin:
                 permission=mapped_permission,
             )
             session.transport_state = {"opencode_session_id": opencode_session_id}
+            if agent is not None:
+                session.transport_state["agent"] = agent
+                session.transport_state["pre_plan_mode"] = "default"
             runtime.storage.update_session(
                 session.id, transport_state=session.transport_state
             )

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1128,6 +1128,18 @@ class OpenCodePlugin:
         )
         return updated
 
+    async def approve_plan(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        plan_item_id: str,
+        text: str | None,
+    ) -> SessionRecord:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"plan approval is not supported for {self.id}",
+        )
+
     async def post_approval(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -178,6 +178,15 @@ class TmuxPlugin:
     ) -> SessionRecord:
         _unsupported("answer-question")
 
+    async def approve_plan(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        plan_item_id: str,
+        text: str | None,
+    ) -> SessionRecord:
+        _unsupported("plan approval")
+
     async def post_approval(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -31,6 +31,7 @@ from waypoint.schemas import (
     SessionCreateRequest,
     SessionEnvelope,
     SessionInputRequest,
+    SessionPlanApprovalRequest,
     SessionRecord,
     SessionSource,
     SessionStatus,
@@ -882,6 +883,20 @@ class SessionRuntime:
             return updated
         await transport.respond_to_approval(session, request.decision, request.text)
         return self.get_session(session_id)
+
+    async def approve_plan(
+        self, session_id: str, request: SessionPlanApprovalRequest
+    ) -> SessionRecord:
+        session = self.get_session(session_id)
+        plugin = self.registry.plugin_for(session)
+        if not plugin.capabilities.supports_plan_approval:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"plan approval is not supported for {session.backend}",
+            )
+        return await plugin.approve_plan(
+            self, session, request.plan_item_id, request.text
+        )
 
     def session_events(
         self, session_id: str, cursor: int | None = None

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -213,6 +213,11 @@ class SessionApprovalRequest(BaseModel):
     approval_id: str | None = None
 
 
+class SessionPlanApprovalRequest(BaseModel):
+    plan_item_id: str
+    text: str | None = None
+
+
 class SessionTitleRequest(BaseModel):
     title: Annotated[
         str,

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -102,6 +102,15 @@ class _StubPlugin:
     ) -> Any:
         raise NotImplementedError
 
+    async def approve_plan(
+        self,
+        runtime: Any,
+        session: Any,
+        plan_item_id: str,
+        text: str | None,
+    ) -> Any:
+        raise NotImplementedError
+
     async def post_approval(self, runtime: Any, session: Any) -> None:
         return None
 

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -17,6 +17,7 @@ class FakeThread:
 @dataclass
 class FakeStartResponse:
     thread: FakeThread
+    model: str | None = None
 
 
 @dataclass
@@ -37,6 +38,7 @@ class FakeAppServerClient:
         self.started = False
         self.initialized = False
         self.closed = False
+        self.start_model: str | None = None
 
     def start(self) -> None:
         self.started = True
@@ -49,7 +51,7 @@ class FakeAppServerClient:
 
     def thread_start(self, params: dict[str, Any]) -> FakeStartResponse:
         self.calls.append(("thread_start", (params,)))
-        return FakeStartResponse(FakeThread(id="thread-1"))
+        return FakeStartResponse(FakeThread(id="thread-1"), model=self.start_model)
 
     def thread_resume(self, thread_id: str) -> dict[str, Any]:
         self.calls.append(("thread_resume", (thread_id,)))
@@ -196,6 +198,17 @@ async def test_start_session_passes_model_to_thread_start() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_session_remembers_app_server_default_model() -> None:
+    emitted: list = []
+    adapter, fake = make_adapter(emitted)
+    fake.start_model = "gpt-5.3-codex"
+
+    await adapter.start_session("sess", "/tmp/work")
+
+    assert adapter.session_model("sess") == "gpt-5.3-codex"
+
+
+@pytest.mark.asyncio
 async def test_set_model_persists_and_re_emits_on_turn_start() -> None:
     """Codex model is a per-turn override that the SDK persists; waypoint must
     still re-emit it on every turn_start so a restart can't drop it."""
@@ -327,6 +340,24 @@ async def test_send_input_items_starts_structured_turn() -> None:
     await adapter.send_input_items("sess", items)
 
     assert ("turn_start", (state.thread_id, items)) in fake.calls
+    if state.stream_task is not None:
+        state.stream_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await state.stream_task
+
+
+@pytest.mark.asyncio
+async def test_send_input_items_accepts_per_turn_params() -> None:
+    emitted: list = []
+    adapter, fake = make_adapter(emitted)
+    await adapter.start_session("sess", "/tmp/work")
+    state = adapter._sessions["sess"]
+    items = [{"type": "text", "text": "plan this"}]
+    params = {"collaborationMode": {"mode": "plan"}}
+
+    await adapter.send_input_items("sess", items, turn_params=params)
+
+    assert ("turn_start", (state.thread_id, items, params)) in fake.calls
     if state.stream_task is not None:
         state.stream_task.cancel()
         with pytest.raises(asyncio.CancelledError):

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -9,12 +9,15 @@ from fastapi import HTTPException
 from waypoint.backends.opencode.plugin import (
     DEFAULT_OPENCODE_MODEL,
     OpenCodePlugin,
+    OpenCodePluginConfig,
     _ruleset_for_mode,
 )
 from waypoint.backends.opencode.transport import OpenCodeTransport
+from waypoint.git_meta import GitMeta
 from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
+    SessionCreateRequest,
     SessionInputRequest,
     SessionRecord,
     SessionSource,
@@ -41,8 +44,12 @@ def _session(**overrides: Any) -> SessionRecord:
         last_event_at=now,
         raw_log_path="",
         structured_log_path="",
-        transport_state={},
-        permission_mode=None,
+        transport_state=overrides.get("transport_state", {}),
+        permission_mode=overrides.get("permission_mode"),
+        model=overrides.get("model"),
+        effort=overrides.get("effort"),
+        args=overrides.get("args", []),
+        config_overrides=overrides.get("config_overrides", []),
     )
 
 
@@ -106,6 +113,7 @@ def test_validate_permission_mode_accepts_known_actions() -> None:
     assert plugin.validate_permission_mode("ask") == "ask"
     assert plugin.validate_permission_mode("allow") == "allow"
     assert plugin.validate_permission_mode("deny") == "deny"
+    assert plugin.validate_permission_mode("plan") == "plan"
 
 
 def test_validate_permission_mode_rejects_legacy_auto() -> None:
@@ -115,6 +123,78 @@ def test_validate_permission_mode_rejects_legacy_auto() -> None:
         HTTPException, match="unsupported opencode permission mode: auto"
     ):
         plugin.validate_permission_mode("auto")
+
+
+@pytest.mark.asyncio
+async def test_create_plan_session_persists_plan_agent_state(tmp_path) -> None:
+    plugin = OpenCodePlugin()
+
+    class FakeAdapter:
+        def __init__(self) -> None:
+            self.started: list[dict[str, Any]] = []
+
+        async def start_session(self, *args: object, **kwargs: object) -> str:
+            self.started.append({"args": args, "kwargs": kwargs})
+            return "ses_plan"
+
+    class FakeStorage:
+        def __init__(self) -> None:
+            self.sessions: dict[str, SessionRecord] = {}
+
+        def create_session(self, session: SessionRecord) -> None:
+            self.sessions[session.id] = session
+
+        def update_session(self, session_id: str, **kwargs: object) -> SessionRecord:
+            session = self.sessions[session_id]
+            for key, value in kwargs.items():
+                setattr(session, key, value)
+            return session
+
+    fake_adapter = FakeAdapter()
+
+    async def fake_get_or_create_adapter(
+        *args: object, **kwargs: object
+    ) -> FakeAdapter:
+        return fake_adapter
+
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
+
+    storage = FakeStorage()
+    runtime: Any = SimpleNamespace(
+        storage=storage,
+        settings=SimpleNamespace(plugin_config=lambda _id: OpenCodePluginConfig()),
+        _find_launch_target=lambda _id: None,
+        get_session=lambda session_id: storage.sessions[session_id],
+    )
+    request = SessionCreateRequest(
+        backend="opencode",
+        cwd="/repo",
+        args=[],
+        permission_mode="plan",
+    )
+
+    session = await plugin.create_session(
+        runtime,
+        request,
+        session_id="sess",
+        launch_target=None,
+        title="Plan",
+        raw_log=tmp_path / "raw.log",
+        structured_log=tmp_path / "events.jsonl",
+        git_meta=GitMeta(repo_name="repo", branch="main"),
+        permission_mode="plan",
+        resolved_model=None,
+        resolved_effort=None,
+    )
+
+    started_kwargs = fake_adapter.started[0]["kwargs"]
+    assert started_kwargs["agent"] == "plan"
+    assert started_kwargs["permission"] is None
+    assert session.transport_state == {
+        "opencode_session_id": "ses_plan",
+        "agent": "plan",
+        "pre_plan_mode": "default",
+    }
 
 
 @pytest.mark.asyncio
@@ -743,6 +823,163 @@ async def test_list_threads_sorts_by_updated_at_after_merging_adapters() -> None
     threads = await plugin.list_threads(runtime, launch_target_id="ssh-1")
 
     assert [thread.id for thread in threads] == ["ses_b", "ses_a"]
+
+
+@pytest.mark.asyncio
+async def test_reconnect_restore_rehydrates_pre_plan_mode(tmp_path) -> None:
+    plugin = OpenCodePlugin()
+    session = _session(
+        transport_state={
+            "opencode_session_id": "ses_plan",
+            "agent": "plan",
+            "pre_plan_mode": "ask",
+        },
+        permission_mode="plan",
+    )
+
+    class FakeAdapter:
+        def __init__(self) -> None:
+            self.restore_calls: list[dict[str, object]] = []
+            self.pre_plan_calls: list[tuple[str, str | None]] = []
+
+        async def restore_session(
+            self,
+            session_id: str,
+            cwd: str,
+            opencode_session_id: str,
+            model: str | None = None,
+            agent: str | None = None,
+            effort: str | None = None,
+        ) -> None:
+            self.restore_calls.append(
+                {
+                    "session_id": session_id,
+                    "cwd": cwd,
+                    "opencode_session_id": opencode_session_id,
+                    "model": model,
+                    "agent": agent,
+                    "effort": effort,
+                }
+            )
+
+        async def set_pre_plan_mode(self, session_id: str, mode: str | None) -> bool:
+            self.pre_plan_calls.append((session_id, mode))
+            return True
+
+    fake_adapter = FakeAdapter()
+    key = (None, "/repo", ())
+    plugin._adapters = cast(Any, {key: fake_adapter})
+    plugin._reconnect_targets[key] = {"sess"}
+
+    class FakeStorage:
+        def get_session(self, session_id: str) -> SessionRecord | None:
+            assert session_id == "sess"
+            return session
+
+        def update_session(self, session_id: str, **kwargs: object) -> SessionRecord:
+            assert session_id == "sess"
+            for key, value in kwargs.items():
+                setattr(session, key, value)
+            return session
+
+    async def record_system_event(*args: object, **kwargs: object) -> None:
+        return None
+
+    runtime: Any = SimpleNamespace(
+        storage=FakeStorage(),
+        _record_system_event=record_system_event,
+    )
+
+    await plugin._restore_after_reconnect(runtime, key)
+
+    assert fake_adapter.restore_calls[0]["agent"] == "plan"
+    assert fake_adapter.pre_plan_calls == [("sess", "ask")]
+    assert session.status == SessionStatus.IDLE
+
+
+@pytest.mark.asyncio
+async def test_fork_plan_session_persists_pre_plan_mode(tmp_path) -> None:
+    plugin = OpenCodePlugin()
+    session = _session(
+        transport_state={
+            "opencode_session_id": "ses_parent",
+            "agent": "plan",
+            "pre_plan_mode": "allow",
+        },
+        permission_mode="plan",
+    )
+
+    class FakeAdapter:
+        def __init__(self) -> None:
+            self.pre_plan_calls: list[tuple[str, str | None]] = []
+
+        async def fork_session(
+            self,
+            session_id: str,
+            cwd: str,
+            opencode_session_id: str,
+            model: str | None = None,
+            agent: str | None = None,
+            effort: str | None = None,
+        ) -> str:
+            assert (session_id, cwd, opencode_session_id, agent) == (
+                "forked",
+                "/repo",
+                "ses_parent",
+                "plan",
+            )
+            return "ses_forked"
+
+        async def set_pre_plan_mode(self, session_id: str, mode: str | None) -> bool:
+            self.pre_plan_calls.append((session_id, mode))
+            return True
+
+    fake_adapter = FakeAdapter()
+
+    async def fake_get_or_create_adapter(
+        *args: object, **kwargs: object
+    ) -> FakeAdapter:
+        return fake_adapter
+
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
+
+    class FakeStorage:
+        def __init__(self) -> None:
+            self.sessions: dict[str, SessionRecord] = {"sess": session}
+
+        def create_session(self, new_session: SessionRecord) -> None:
+            self.sessions[new_session.id] = new_session
+
+        def clone_events(self, source_id: str, target_id: str) -> None:
+            assert (source_id, target_id) == ("sess", "forked")
+
+    async def record_system_event(*args: object, **kwargs: object) -> None:
+        return None
+
+    storage = FakeStorage()
+    runtime: Any = SimpleNamespace(
+        storage=storage,
+        settings=SimpleNamespace(plugin_config=lambda _id: OpenCodePluginConfig()),
+        _find_launch_target=lambda _id: None,
+        _record_system_event=record_system_event,
+        get_session=lambda session_id: storage.sessions[session_id],
+    )
+
+    forked = await plugin.fork_session(
+        runtime,
+        session,
+        new_session_id="forked",
+        title="Forked",
+        raw_log=tmp_path / "raw.log",
+        structured_log=tmp_path / "events.jsonl",
+    )
+
+    assert fake_adapter.pre_plan_calls == [("forked", "allow")]
+    assert forked.transport_state == {
+        "opencode_session_id": "ses_forked",
+        "agent": "plan",
+        "pre_plan_mode": "allow",
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1086,8 +1086,11 @@ async def test_handle_input_builtin_compact_invokes_codex_thread_compact(
 async def test_handle_input_builtin_plan_switches_codex_plan_mode_only(
     tmp_path,
 ) -> None:
+    from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
+
     runtime, storage, settings = make_runtime(tmp_path)
     fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
     _codex_plugin(runtime).adapter = cast(Any, fake)
     session = make_session(settings, permission_mode="full_access")
     storage.create_session(session)
@@ -1104,6 +1107,22 @@ async def test_handle_input_builtin_plan_switches_codex_plan_mode_only(
     ]
     assert events[-1].metadata["builtin_command"] == "/plan"
     assert "plan mode" in events[-1].text
+
+    await runtime.handle_input("sess", SessionInputRequest(text="draft the plan"))
+
+    assert fake.inputs == [("sess", "draft the plan")]
+    [(_, params)] = fake.turn_params_calls
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["full_access"],
+        "collaborationMode": {
+            "mode": "plan",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": "medium",
+                "developer_instructions": None,
+            },
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -1678,7 +1697,9 @@ async def test_set_permission_mode_codex_persists_and_threads_to_next_turn(
     from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
 
     runtime, storage, settings = make_runtime(tmp_path)
-    fake = FakeStructuredAdapter()
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    fake.efforts["sess"] = "high"
     _codex_plugin(runtime).adapter = cast(Any, fake)
     session = make_session(settings)
     storage.create_session(session)
@@ -1693,7 +1714,17 @@ async def test_set_permission_mode_codex_persists_and_threads_to_next_turn(
     await runtime.handle_input("sess", SessionInputRequest(text="hello"))
     assert fake.inputs == [("sess", "hello")]
     [(_, params)] = fake.turn_params_calls
-    assert params == CODEX_PERMISSION_PRESETS["auto_review"]
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["auto_review"],
+        "collaborationMode": {
+            "mode": "default",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": "high",
+                "developer_instructions": None,
+            },
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -1734,8 +1765,12 @@ async def test_set_permission_mode_codex_plan_preserves_previous_preset(
 async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
     tmp_path,
 ) -> None:
+    from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
+
     runtime, storage, settings = make_runtime(tmp_path)
-    _codex_plugin(runtime).adapter = cast(Any, FakeCodexRuntimeAdapter())
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    _codex_plugin(runtime).adapter = cast(Any, fake)
     session = make_session(
         settings,
         permission_mode="plan",
@@ -1747,6 +1782,21 @@ async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
 
     assert updated.permission_mode == "default"
     assert "pre_plan_mode" not in runtime.get_session("sess").transport_state
+
+    await runtime.handle_input("sess", SessionInputRequest(text="am I still planning?"))
+
+    [(_, params)] = fake.turn_params_calls
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["default"],
+        "collaborationMode": {
+            "mode": "default",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": None,
+                "developer_instructions": None,
+            },
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1800,6 +1800,38 @@ async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
 
 
 @pytest.mark.asyncio
+async def test_runtime_fork_codex_session_uses_codex_plugin(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+
+    class CodexForkFake(FakeCodexRuntimeAdapter):
+        async def fork_session(
+            self,
+            session_id: str,
+            cwd: str,
+            thread_id: str,
+            client_factory_override: Any = None,
+            model: str | None = None,
+            effort: str | None = None,
+            custom_args: list[str] | None = None,
+            config_overrides: list[str] | None = None,
+        ) -> str:
+            assert session_id.startswith("codex-")
+            assert (cwd, thread_id) == ("/tmp/project", "thread-1")
+            return "thread-forked"
+
+    plugin = _codex_plugin(runtime)
+    plugin.adapter = cast(Any, CodexForkFake())
+    session = make_session(settings)
+    storage.create_session(session)
+
+    forked = await runtime.fork_session("sess")
+
+    assert forked.backend == "codex"
+    assert forked.title == "Session (fork #1)"
+    assert forked.transport_state == {"thread_id": "thread-forked"}
+
+
+@pytest.mark.asyncio
 async def test_fork_codex_plan_session_persists_pre_plan_mode(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
 

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -45,6 +45,7 @@ class FakeStructuredAdapter:
         self.inputs: list[tuple[str, str]] = []
         self.input_items: list[tuple[str, list[dict[str, Any]]]] = []
         self.turn_params_calls: list[tuple[str, dict[str, Any] | None]] = []
+        self.input_items_turn_params_calls: list[tuple[str, dict[str, Any] | None]] = []
         self.approval_calls: list[tuple[str, str]] = []
 
     async def send_input(
@@ -54,9 +55,13 @@ class FakeStructuredAdapter:
         self.turn_params_calls.append((session_id, turn_params))
 
     async def send_input_items(
-        self, session_id: str, items: list[dict[str, Any]]
+        self,
+        session_id: str,
+        items: list[dict[str, Any]],
+        turn_params: dict[str, Any] | None = None,
     ) -> None:
         self.input_items.append((session_id, items))
+        self.input_items_turn_params_calls.append((session_id, turn_params))
 
     def has_pending_approval(self, session_id: str) -> bool:
         return self.pending
@@ -516,6 +521,7 @@ async def test_list_command_completions_codex_omits_unsupported_legacy_commands(
     names = [item.name for item in completions]
     assert "status" in names
     assert "compact" in names
+    assert "plan" in names
     assert "help" not in names
     assert "permissions" not in names
 
@@ -1077,6 +1083,69 @@ async def test_handle_input_builtin_compact_invokes_codex_thread_compact(
 
 
 @pytest.mark.asyncio
+async def test_handle_input_builtin_plan_switches_codex_plan_mode_only(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(settings, permission_mode="full_access")
+    storage.create_session(session)
+
+    updated = await runtime.handle_input("sess", SessionInputRequest(text="/plan"))
+
+    assert updated.permission_mode == "plan"
+    assert runtime.get_session("sess").transport_state["pre_plan_mode"] == "full_access"
+    assert fake.inputs == []
+    events = storage.list_events("sess")
+    assert [event.kind for event in events] == [
+        EventKind.USER_INPUT,
+        EventKind.SYSTEM_NOTE,
+    ]
+    assert events[-1].metadata["builtin_command"] == "/plan"
+    assert "plan mode" in events[-1].text
+
+
+@pytest.mark.asyncio
+async def test_handle_input_builtin_plan_with_prompt_starts_plan_turn(
+    tmp_path,
+) -> None:
+    from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(settings, permission_mode="full_access")
+    storage.create_session(session)
+
+    updated = await runtime.handle_input(
+        "sess", SessionInputRequest(text="/plan design this")
+    )
+
+    assert updated.status == SessionStatus.RUNNING
+    assert fake.inputs == [("sess", "design this")]
+    assert runtime.get_session("sess").permission_mode == "plan"
+    assert runtime.get_session("sess").transport_state["pre_plan_mode"] == "full_access"
+    [(_, params)] = fake.turn_params_calls
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["full_access"],
+        "collaborationMode": {
+            "mode": "plan",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": "medium",
+                "developer_instructions": None,
+            },
+        },
+    }
+    events = storage.list_events("sess")
+    assert len(events) == 1
+    assert events[0].kind == EventKind.USER_INPUT
+    assert events[0].text == "/plan design this"
+
+
+@pytest.mark.asyncio
 async def test_handle_input_unknown_slash_command_forwards_to_structured_session(
     tmp_path,
 ) -> None:
@@ -1625,6 +1694,59 @@ async def test_set_permission_mode_codex_persists_and_threads_to_next_turn(
     assert fake.inputs == [("sess", "hello")]
     [(_, params)] = fake.turn_params_calls
     assert params == CODEX_PERMISSION_PRESETS["auto_review"]
+
+
+@pytest.mark.asyncio
+async def test_set_permission_mode_codex_plan_preserves_previous_preset(
+    tmp_path,
+) -> None:
+    from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(settings, permission_mode="auto_review")
+    storage.create_session(session)
+
+    updated = await runtime.set_permission_mode("sess", "plan")
+
+    assert updated.permission_mode == "plan"
+    assert runtime.get_session("sess").transport_state["pre_plan_mode"] == "auto_review"
+
+    await runtime.handle_input("sess", SessionInputRequest(text="hello"))
+
+    [(_, params)] = fake.turn_params_calls
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["auto_review"],
+        "collaborationMode": {
+            "mode": "plan",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": "medium",
+                "developer_instructions": None,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    _codex_plugin(runtime).adapter = cast(Any, FakeCodexRuntimeAdapter())
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "auto_review"},
+    )
+    storage.create_session(session)
+
+    updated = await runtime.set_permission_mode("sess", "default")
+
+    assert updated.permission_mode == "default"
+    assert "pre_plan_mode" not in runtime.get_session("sess").transport_state
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -18,6 +18,7 @@ from waypoint.schemas import (
     SessionApprovalRequest,
     SessionCreateRequest,
     SessionInputRequest,
+    SessionPlanApprovalRequest,
     SessionRecord,
     SessionSource,
     SessionStatus,
@@ -1877,6 +1878,198 @@ async def test_fork_codex_plan_session_persists_pre_plan_mode(tmp_path) -> None:
         "thread_id": "thread-forked",
         "pre_plan_mode": "full_access",
     }
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_restores_mode_and_sends_prompt(tmp_path) -> None:
+    from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "full_access"},
+    )
+    storage.create_session(session)
+    storage.append_event(
+        EventRecord(
+            session_id="sess",
+            ts=datetime.now(UTC),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Completed plan",
+            metadata={
+                "item_id": "plan-1",
+                "item_type": "plan",
+                "payload": {
+                    "item": {
+                        "id": "plan-1",
+                        "type": "plan",
+                        "text": "1. Update the UI\n2. Run tests",
+                    }
+                },
+            },
+            sequence=storage.next_sequence("sess"),
+        )
+    )
+
+    updated = await runtime.approve_plan(
+        "sess", SessionPlanApprovalRequest(plan_item_id="plan-1")
+    )
+
+    refreshed = storage.get_session("sess")
+    assert refreshed is not None
+    assert updated.permission_mode == "full_access"
+    assert refreshed.permission_mode == "full_access"
+    assert refreshed.status == SessionStatus.RUNNING
+    assert "pre_plan_mode" not in refreshed.transport_state
+    assert fake.inputs == [
+        (
+            "sess",
+            "User has approved your plan. You can now start coding. "
+            "Start with updating your todo list if applicable.\n\n"
+            "## Approved Plan:\n"
+            "1. Update the UI\n2. Run tests",
+        )
+    ]
+    [(_, params)] = fake.turn_params_calls
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["full_access"],
+        "collaborationMode": {
+            "mode": "default",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": None,
+                "developer_instructions": None,
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_rejects_when_not_in_plan_mode(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    _codex_plugin(runtime).adapter = cast(Any, FakeCodexRuntimeAdapter())
+    session = make_session(settings, permission_mode="default")
+    storage.create_session(session)
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.approve_plan(
+            "sess", SessionPlanApprovalRequest(plan_item_id="plan-1")
+        )
+
+    assert exc.value.status_code == 400
+    assert "not in plan mode" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_approve_plan_rejects_unsupported_backend(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    session = make_session(
+        settings,
+        id="claude-sess",
+        backend="claude_code",
+        transport="claude_cli",
+        permission_mode="plan",
+    )
+    storage.create_session(session)
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.approve_plan(
+            "claude-sess", SessionPlanApprovalRequest(plan_item_id="plan-1")
+        )
+
+    assert exc.value.status_code == 400
+    assert "not supported" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_rejects_unknown_plan_item(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    _codex_plugin(runtime).adapter = cast(Any, FakeCodexRuntimeAdapter())
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "auto_review"},
+    )
+    storage.create_session(session)
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.approve_plan(
+            "sess", SessionPlanApprovalRequest(plan_item_id="missing-plan")
+        )
+
+    assert exc.value.status_code == 400
+    assert "plan item was not found" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_send_failure_preserves_plan_state(
+    tmp_path,
+) -> None:
+    from fastapi import HTTPException
+
+    class FailingCodexAdapter(FakeCodexRuntimeAdapter):
+        async def send_input(
+            self,
+            session_id: str,
+            text: str,
+            turn_params: dict[str, Any] | None = None,
+        ) -> None:
+            raise RuntimeError("send failed")
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    _codex_plugin(runtime).adapter = cast(Any, FailingCodexAdapter())
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "full_access"},
+    )
+    storage.create_session(session)
+    storage.append_event(
+        EventRecord(
+            session_id="sess",
+            ts=datetime.now(UTC),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Completed plan",
+            metadata={
+                "item_id": "plan-1",
+                "item_type": "plan",
+                "payload": {
+                    "item": {
+                        "id": "plan-1",
+                        "type": "plan",
+                        "text": "Implement the change",
+                    }
+                },
+            },
+            sequence=storage.next_sequence("sess"),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.approve_plan(
+            "sess", SessionPlanApprovalRequest(plan_item_id="plan-1")
+        )
+
+    assert exc.value.status_code == 400
+    refreshed = storage.get_session("sess")
+    assert refreshed is not None
+    assert refreshed.permission_mode == "plan"
+    assert refreshed.status == SessionStatus.IDLE
+    assert refreshed.transport_state["pre_plan_mode"] == "full_access"
+    assert not any(
+        "Plan approved; exited plan mode" in event.text
+        for event in storage.list_events("sess")
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1750,6 +1750,54 @@ async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
 
 
 @pytest.mark.asyncio
+async def test_fork_codex_plan_session_persists_pre_plan_mode(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+
+    class CodexForkFake(FakeCodexRuntimeAdapter):
+        async def fork_session(
+            self,
+            session_id: str,
+            cwd: str,
+            thread_id: str,
+            client_factory_override: Any = None,
+            model: str | None = None,
+            effort: str | None = None,
+            custom_args: list[str] | None = None,
+            config_overrides: list[str] | None = None,
+        ) -> str:
+            assert (session_id, cwd, thread_id) == (
+                "forked",
+                "/tmp/project",
+                "thread-1",
+            )
+            return "thread-forked"
+
+    plugin = _codex_plugin(runtime)
+    plugin.adapter = cast(Any, CodexForkFake())
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "full_access"},
+    )
+    storage.create_session(session)
+
+    forked = await plugin.fork_session(
+        runtime,
+        session,
+        new_session_id="forked",
+        title="Forked",
+        raw_log=tmp_path / "raw.log",
+        structured_log=tmp_path / "events.jsonl",
+    )
+
+    assert forked.permission_mode == "plan"
+    assert forked.transport_state == {
+        "thread_id": "thread-forked",
+        "pre_plan_mode": "full_access",
+    }
+
+
+@pytest.mark.asyncio
 async def test_set_permission_mode_codex_rejects_unknown_mode(tmp_path) -> None:
     from fastapi import HTTPException
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2779,6 +2779,11 @@ html[data-theme="light"] .tool-call-run-children {
   gap: 12px;
 }
 
+.transcript.codex.plan-output {
+  justify-self: start;
+  width: min(94%, 820px);
+}
+
 .approval-prompt {
   font-weight: 600;
   margin: 0;
@@ -2809,6 +2814,10 @@ html[data-theme="light"] .approval-plan {
 
 html[data-theme="light"] .approval-shell {
   background: rgba(228, 222, 208, 0.7);
+}
+
+.approval-note-wrap {
+  margin: 0 12px;
 }
 
 .approval-pager {

--- a/frontend/src/components/ApprovalCard.tsx
+++ b/frontend/src/components/ApprovalCard.tsx
@@ -1,0 +1,368 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { DiffPreview } from "@/components/DiffPreview";
+import { MarkdownMessage } from "@/components/MarkdownMessage";
+import { CopyMessageButton } from "@/components/CopyMessageButton";
+import {
+  normalizeToolName,
+  parseEvent,
+  type EventDiffPreview,
+} from "@/lib/events";
+import type { EventRecord } from "@/lib/types";
+
+interface SharedApprovalAction {
+  id: string;
+  label: string;
+  className: "primary" | "secondary";
+  loadingLabel?: string;
+  onSelect: (note?: string) => void | Promise<void>;
+}
+
+interface SharedApprovalCardProps {
+  badge: string;
+  children: ReactNode;
+  actions?: SharedApprovalAction[];
+  className?: string;
+  copyLabel?: string;
+  copyText: string;
+  notePlaceholder?: string;
+  supportsNote?: boolean;
+  timeLabel?: string;
+}
+
+function SharedApprovalCard({
+  badge,
+  children,
+  actions = [],
+  className = "",
+  copyLabel = "Copy approval body",
+  copyText,
+  notePlaceholder = "Add a note…",
+  supportsNote = false,
+  timeLabel,
+}: SharedApprovalCardProps) {
+  const [noteOpen, setNoteOpen] = useState(false);
+  const [noteText, setNoteText] = useState("");
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  async function handleAction(action: SharedApprovalAction) {
+    if (pendingAction) {
+      return;
+    }
+    setPendingAction(action.id);
+    try {
+      await action.onSelect(noteText.trim() || undefined);
+    } finally {
+      if (mountedRef.current) {
+        setPendingAction(null);
+      }
+    }
+  }
+
+  const cardClassName = `panel approval${className ? ` ${className}` : ""}`;
+
+  return (
+    <section className={cardClassName}>
+      <div className="session-row">
+        <span className="badge fidelity structured">{badge}</span>
+        {timeLabel ? <span className="role-time">{timeLabel}</span> : null}
+        <CopyMessageButton text={copyText} label={copyLabel} />
+      </div>
+      {children}
+      {supportsNote && actions.length > 0 ? (
+        noteOpen ? (
+          <div className="approval-note-wrap ask-question-note">
+            <textarea
+              className="ask-question-note-input"
+              value={noteText}
+              onChange={(event) => setNoteText(event.target.value)}
+              placeholder={notePlaceholder}
+              rows={2}
+            />
+            <button
+              type="button"
+              className="link-button"
+              onClick={() => setNoteOpen(false)}
+            >
+              Hide note
+            </button>
+          </div>
+        ) : (
+          <div className="approval-note-wrap">
+            <button
+              type="button"
+              className="link-button ask-question-note-toggle"
+              onClick={() => setNoteOpen(true)}
+            >
+              + Add note
+            </button>
+          </div>
+        )
+      ) : null}
+      {actions.length > 0 ? (
+        <div className="action-row">
+          {actions.map((action) => (
+            <button
+              key={action.id}
+              className={action.className}
+              onClick={() => void handleAction(action)}
+              type="button"
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === action.id && action.loadingLabel
+                ? action.loadingLabel
+                : action.label}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export function ApprovalRequestCard({
+  event,
+  onDecide,
+  supportsNote = false,
+}: {
+  event: EventRecord;
+  onDecide: (decision: string, text?: string, approvalId?: string) => void | Promise<void>;
+  supportsNote?: boolean;
+}) {
+  const diffPreview = parseEvent(event).diffPreview;
+  const toolName = normalizeToolName(
+    typeof event.metadata.tool_name === "string" ? event.metadata.tool_name : null,
+  );
+  const toolInput =
+    event.metadata.tool_input && typeof event.metadata.tool_input === "object"
+      ? (event.metadata.tool_input as Record<string, unknown>)
+      : null;
+  const copyText = approvalCopyText(event.text, toolName, toolInput);
+  const approvalId =
+    typeof event.metadata?.approval_id === "string"
+      ? (event.metadata.approval_id as string)
+      : undefined;
+
+  return (
+    <SharedApprovalCard
+      badge="approval"
+      copyText={copyText}
+      notePlaceholder="Add a note to your approval or decline…"
+      supportsNote={supportsNote}
+      actions={[
+        {
+          id: "accept",
+          label: "Approve",
+          className: "primary",
+          onSelect: (note) => onDecide("accept", note, approvalId),
+        },
+        {
+          id: "acceptForSession",
+          label: "Approve for session",
+          className: "secondary",
+          onSelect: (note) => onDecide("acceptForSession", note, approvalId),
+        },
+        {
+          id: "decline",
+          label: "Decline",
+          className: "secondary",
+          onSelect: (note) => onDecide("decline", note, approvalId),
+        },
+        {
+          id: "cancel",
+          label: "Cancel",
+          className: "secondary",
+          onSelect: (note) => onDecide("cancel", note, approvalId),
+        },
+      ]}
+    >
+      <ApprovalCardBody
+        eventText={event.text}
+        toolName={toolName}
+        toolInput={toolInput}
+        diffPreview={diffPreview}
+      />
+    </SharedApprovalCard>
+  );
+}
+
+export function PlanApprovalCard({
+  agentLabel,
+  canApprove = false,
+  className,
+  onApprove,
+  plan,
+  prompt = "Approve plan and exit plan mode",
+  timeLabel,
+}: {
+  agentLabel: string;
+  canApprove?: boolean;
+  className?: string;
+  onApprove?: (note?: string) => void | Promise<void>;
+  plan: string;
+  prompt?: string;
+  timeLabel?: string;
+}) {
+  return (
+    <SharedApprovalCard
+      badge={`${agentLabel} plan`}
+      className={className}
+      copyLabel="Copy plan"
+      copyText={plan}
+      notePlaceholder="Add a note to your approval…"
+      supportsNote={canApprove}
+      timeLabel={timeLabel}
+      actions={
+        canApprove && onApprove
+          ? [
+              {
+                id: "approve",
+                label: "Approve",
+                loadingLabel: "Approving…",
+                className: "primary",
+                onSelect: onApprove,
+              },
+            ]
+          : []
+      }
+    >
+      <ApprovalPlanBody plan={plan} prompt={prompt} />
+    </SharedApprovalCard>
+  );
+}
+
+function approvalCopyText(
+  eventText: string,
+  toolName: string | null,
+  toolInput: Record<string, unknown> | null,
+): string {
+  if (toolName === "ExitPlanMode" && typeof toolInput?.plan === "string") {
+    return toolInput.plan as string;
+  }
+  if (
+    (toolName === "Task" || toolName === "Agent") &&
+    typeof toolInput?.prompt === "string"
+  ) {
+    return toolInput.prompt as string;
+  }
+  if (toolName === "Bash" && typeof toolInput?.command === "string") {
+    return toolInput.command as string;
+  }
+  return eventText;
+}
+
+function ApprovalCardBody({
+  eventText,
+  toolName,
+  toolInput,
+  diffPreview,
+}: {
+  eventText: string;
+  toolName: string | null;
+  toolInput: Record<string, unknown> | null;
+  diffPreview?: EventDiffPreview | null;
+}) {
+  if (diffPreview) {
+    return (
+      <>
+        <p className="approval-prompt">{eventText}</p>
+        <DiffPreview preview={diffPreview} />
+      </>
+    );
+  }
+  if (toolName === "ExitPlanMode" && typeof toolInput?.plan === "string") {
+    return <ApprovalPlanBody plan={toolInput.plan as string} />;
+  }
+  if (
+    (toolName === "Task" || toolName === "Agent") &&
+    toolInput &&
+    typeof toolInput.prompt === "string"
+  ) {
+    const description =
+      typeof toolInput.description === "string" ? (toolInput.description as string) : "";
+    const subagent =
+      typeof toolInput.subagent_type === "string"
+        ? (toolInput.subagent_type as string)
+        : "";
+    return (
+      <>
+        <p className="approval-prompt">
+          Approve subagent task
+          {description ? `: ${description}` : ""}
+          {subagent ? ` (via ${subagent})` : ""}
+        </p>
+        <div className="approval-plan">
+          <MarkdownMessage text={toolInput.prompt as string} />
+        </div>
+      </>
+    );
+  }
+  if (toolName === "Bash" && typeof toolInput?.command === "string") {
+    const desc =
+      typeof toolInput.description === "string"
+        ? (toolInput.description as string)
+        : "";
+    return (
+      <>
+        <p className="approval-prompt">
+          Approve Bash command{desc ? `: ${desc}` : ""}
+        </p>
+        <pre className="approval-shell">{toolInput.command as string}</pre>
+      </>
+    );
+  }
+  if (isApprovalFileEditTool(toolName)) {
+    const path = approvalFileEditPath(toolInput);
+    return (
+      <>
+        <p className="approval-prompt">
+          Approve {toolName}
+          {path ? ` on ${path}` : ""}
+        </p>
+        <p className="diff-unavailable">Diff preview was not included by the backend.</p>
+      </>
+    );
+  }
+  return <pre>{eventText}</pre>;
+}
+
+function ApprovalPlanBody({
+  plan,
+  prompt = "Approve plan and exit plan mode",
+}: {
+  plan: string;
+  prompt?: string;
+}) {
+  return (
+    <>
+      <p className="approval-prompt">{prompt}</p>
+      <div className="approval-plan">
+        <MarkdownMessage text={plan} />
+      </div>
+    </>
+  );
+}
+
+function isApprovalFileEditTool(toolName: string | null): boolean {
+  return (
+    toolName === "Edit" ||
+    toolName === "MultiEdit" ||
+    toolName === "Write" ||
+    toolName === "NotebookEdit"
+  );
+}
+
+function approvalFileEditPath(toolInput: Record<string, unknown> | null): string | null {
+  if (!toolInput) {
+    return null;
+  }
+  const value = toolInput.file_path ?? toolInput.path ?? toolInput.notebook_path;
+  return typeof value === "string" && value ? value : null;
+}

--- a/frontend/src/components/CopyMessageButton.tsx
+++ b/frontend/src/components/CopyMessageButton.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useState } from "react";
+
+function legacyCopy(text: string): boolean {
+  // execCommand("copy") has different security gating than the async API:
+  // it works on plain-HTTP origins and when document focus is ambiguous,
+  // as long as the call originates from a user gesture. It returns false
+  // (rather than throwing) when the host browser refuses.
+  const el = document.createElement("textarea");
+  el.value = text;
+  el.setAttribute("readonly", "");
+  el.style.position = "fixed";
+  el.style.opacity = "0";
+  document.body.appendChild(el);
+  el.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(el);
+  return ok;
+}
+
+export function CopyMessageButton({
+  text,
+  label = "Copy message",
+}: {
+  text: string;
+  label?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(async () => {
+    if (!text) return;
+    let ok = false;
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        ok = true;
+      } catch {
+        // writeText can reject at runtime when the document loses focus or
+        // the user denied clipboard-write permission. Fall back before giving
+        // up so the button still works in plain-HTTP development contexts.
+        ok = legacyCopy(text);
+      }
+    } else {
+      ok = legacyCopy(text);
+    }
+    if (!ok) return;
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1500);
+  }, [text]);
+  return (
+    <button
+      type="button"
+      className={`message-copy${copied ? " copied" : ""}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        void onCopy();
+      }}
+      aria-label={copied ? "Copied" : label}
+      title={copied ? "Copied" : label}
+    >
+      <span aria-hidden>{copied ? "✓" : "⎘"}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -14,6 +14,7 @@ import {
 
 import {
   answerAskQuestion,
+  approvePlan,
   approveSession,
   connectSessionSocket,
   createSession,
@@ -37,23 +38,26 @@ import {
   humaniseBackend,
   permissionModesFor,
   supportsApprovalNote,
+  supportsPlanApproval,
   supportsResume,
   supportsStructuredApproval,
   transportLabel,
   useBackendCatalog,
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
-import { normalizeToolName, parseEvent, type EventDiffPreview } from "@/lib/events";
-import { DiffPreview } from "@/components/DiffPreview";
-import { MarkdownMessage } from "@/components/MarkdownMessage";
 import {
-  AskAnswerEntry,
-  CopyMessageButton,
+  isPlanEvent,
+  itemIdForEvent,
+  planTextForEvent,
+} from "@/lib/events";
+import { ApprovalRequestCard, PlanApprovalCard } from "@/components/ApprovalCard";
+import {
   PendingUserInputCard,
   TranscriptCard,
-  ToolPair,
   ToolCallRunGroup,
   readToolName,
+  type AskAnswerEntry,
+  type ToolPair,
 } from "@/components/TranscriptCard";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
@@ -835,6 +839,23 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }
 
+  async function submitPlanApproval(planItemId: string, text?: string) {
+    try {
+      const updated = await approvePlan(host, token, sessionId, planItemId, text);
+      setSession(updated);
+    } catch (approvalError) {
+      if (isAuthError(approvalError)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(
+        approvalError instanceof Error
+          ? approvalError.message
+          : "failed to approve plan",
+      );
+    }
+  }
+
   const pendingApprovals =
     session && supportsStructuredApproval(session.transport)
       ? findPendingApprovals(events)
@@ -843,13 +864,28 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const safeApprovalPage = approvalCount > 0 ? Math.min(approvalPageIndex, approvalCount - 1) : 0;
   const pendingApproval = pendingApprovals[safeApprovalPage] ?? null;
   const agentBusy = session ? isAgentBusy(session, connection) : false;
-  const visibleEvents = filterMode === "all" ? renderedEvents : renderedEvents.filter(isImportantEvent);
-  const hiddenEventCount = renderedEvents.length - visibleEvents.length;
+  const displayEvents = collapseSupersededPlanEvents(renderedEvents);
+  const visibleEvents = filterMode === "all" ? displayEvents : displayEvents.filter(isImportantEvent);
+  const hiddenEventCount = displayEvents.length - visibleEvents.length;
   const transcriptEvents =
     optimisticMessages.length > 0
       ? filterOptimisticTranscriptEvents(visibleEvents, optimisticMessages)
       : visibleEvents;
-  const transcriptItems = buildTranscriptItems(transcriptEvents);
+  const pendingPlanApprovalEvent =
+    session?.permission_mode === "plan" &&
+    supportsPlanApproval(session.backend, catalog)
+      ? latestPlanEvent(transcriptEvents)
+      : null;
+  const pendingPlanApprovalItemId = pendingPlanApprovalEvent
+    ? itemIdForEvent(pendingPlanApprovalEvent)
+    : null;
+  const pendingPlanApprovalText = pendingPlanApprovalEvent
+    ? planTextForEvent(pendingPlanApprovalEvent)
+    : "";
+  const transcriptEventsForDisplay = pendingPlanApprovalEvent
+    ? transcriptEvents.filter((event) => event !== pendingPlanApprovalEvent)
+    : transcriptEvents;
+  const transcriptItems = buildTranscriptItems(transcriptEventsForDisplay);
   const hasToolRuns = transcriptItems.some((item) => item.kind === "tool_run");
   const usageSummary = extractUsageSummary(events);
   // Session has stopped its backend process (clean shutdown or crash).
@@ -1033,7 +1069,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                   />
                 );
               })
-            : session && optimisticMessages.length === 0
+            : session && optimisticMessages.length === 0 && !pendingPlanApprovalEvent
               ? (
                 <TranscriptEmpty
                   status={session.status}
@@ -1096,12 +1132,20 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
               </button>
             </div>
           ) : null}
-          <ApprovalCard
+          <ApprovalRequestCard
             event={pendingApproval}
             onDecide={submitApproval}
             supportsNote={session ? supportsApprovalNote(session.backend, catalog) : false}
           />
         </>
+      ) : null}
+      {!pendingApproval && pendingPlanApprovalItemId && pendingPlanApprovalText ? (
+        <PlanApprovalCard
+          agentLabel={session ? humaniseBackend(session.backend) : "Codex"}
+          canApprove
+          onApprove={(note) => submitPlanApproval(pendingPlanApprovalItemId, note)}
+          plan={pendingPlanApprovalText}
+        />
       ) : null}
       {view === "chat" && showScrollToBottom ? (
         <div className="scroll-latest-floater" aria-hidden={false}>
@@ -2150,11 +2194,7 @@ function mergeEvents(current: EventRecord[], incoming: EventRecord): EventRecord
 }
 
 function readItemId(event: EventRecord): string | null {
-  const meta = event.metadata;
-  if (typeof meta?.item_id === "string" && meta.item_id) {
-    return meta.item_id;
-  }
-  return null;
+  return itemIdForEvent(event);
 }
 
 function mergeEventText(existing: EventRecord, incoming: EventRecord): string {
@@ -2181,6 +2221,44 @@ function mergeEventText(existing: EventRecord, incoming: EventRecord): string {
   }
   const separator = existing.text.endsWith("\n") || incoming.text.startsWith("\n") ? "" : "\n";
   return `${existing.text}${separator}${incoming.text}`;
+}
+
+function collapseSupersededPlanEvents(events: EventRecord[]): EventRecord[] {
+  const latestPlanByItemId = new Map<string, EventRecord>();
+  for (const event of events) {
+    if (!isPlanEvent(event)) {
+      continue;
+    }
+    const itemId = readItemId(event);
+    if (itemId) {
+      latestPlanByItemId.set(itemId, event);
+    }
+  }
+  if (latestPlanByItemId.size === 0) {
+    return events;
+  }
+  return events.filter((event) => {
+    if (!isPlanEvent(event)) {
+      return true;
+    }
+    const itemId = readItemId(event);
+    return !itemId || latestPlanByItemId.get(itemId) === event;
+  });
+}
+
+function latestPlanEvent(events: EventRecord[]): EventRecord | null {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    const plan = planTextForEvent(event);
+    if (!plan) {
+      continue;
+    }
+    const itemId = readItemId(event);
+    if (itemId) {
+      return event;
+    }
+  }
+  return null;
 }
 
 type TranscriptItem =
@@ -2255,7 +2333,7 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
           ? "content"
           : "tool";
       default:
-        return "absorbed";
+        return isPlanEvent(event) ? "content" : "absorbed";
     }
   }
 
@@ -2383,6 +2461,9 @@ function isImportantEvent(event: EventRecord): boolean {
       return true;
     case "system_note":
     case "status_update":
+      if (isPlanEvent(event)) {
+        return true;
+      }
       if (typeof event.metadata?.builtin_command === "string") {
         return true;
       }
@@ -2392,12 +2473,6 @@ function isImportantEvent(event: EventRecord): boolean {
     default:
       return false;
   }
-}
-
-interface ApprovalCardProps {
-  event: EventRecord;
-  onDecide: (decision: string, text?: string, approvalId?: string) => void | Promise<void>;
-  supportsNote?: boolean;
 }
 
 interface UsageSummary {
@@ -2677,204 +2752,6 @@ function UsageCard({ summary }: { summary: UsageSummary }) {
       </div>
     </section>
   );
-}
-
-function ApprovalCard({ event, onDecide, supportsNote = false }: ApprovalCardProps) {
-  const diffPreview = parseEvent(event).diffPreview;
-  const toolName = normalizeToolName(
-    typeof event.metadata.tool_name === "string" ? event.metadata.tool_name : null
-  );
-  const toolInput =
-    event.metadata.tool_input && typeof event.metadata.tool_input === "object"
-      ? (event.metadata.tool_input as Record<string, unknown>)
-      : null;
-  const copyText = approvalCopyText(event.text, toolName, toolInput);
-
-  const [noteOpen, setNoteOpen] = useState(false);
-  const [noteText, setNoteText] = useState("");
-
-  const handleDecide = (decision: string) => {
-    const approvalId = typeof event.metadata?.approval_id === "string" ? event.metadata.approval_id as string : undefined;
-    void onDecide(decision, noteText.trim() || undefined, approvalId);
-  };
-
-  return (
-    <section className="panel approval">
-      <div className="session-row">
-        <span className="badge fidelity structured">approval</span>
-        <CopyMessageButton text={copyText} label="Copy approval body" />
-      </div>
-      <ApprovalCardBody
-        eventText={event.text}
-        toolName={toolName}
-        toolInput={toolInput}
-        diffPreview={diffPreview}
-      />
-      {supportsNote ? (
-        noteOpen ? (
-          <div className="ask-question-note" style={{ margin: "0 12px" }}>
-            <textarea
-              className="ask-question-note-input"
-              value={noteText}
-              onChange={(e) => setNoteText(e.target.value)}
-              placeholder="Add a note to your approval or decline…"
-              rows={2}
-            />
-            <button
-              type="button"
-              className="link-button"
-              onClick={() => setNoteOpen(false)}
-            >
-              Hide note
-            </button>
-          </div>
-        ) : (
-          <div style={{ margin: "0 12px" }}>
-            <button
-              type="button"
-              className="link-button ask-question-note-toggle"
-              onClick={() => setNoteOpen(true)}
-            >
-              + Add note
-            </button>
-          </div>
-        )
-      ) : null}
-      <div className="action-row">
-        <button className="primary" onClick={() => handleDecide("accept")} type="button">
-          Approve
-        </button>
-        <button className="secondary" onClick={() => handleDecide("acceptForSession")} type="button">
-          Approve for session
-        </button>
-        <button className="secondary" onClick={() => handleDecide("decline")} type="button">
-          Decline
-        </button>
-        <button className="secondary" onClick={() => handleDecide("cancel")} type="button">
-          Cancel
-        </button>
-      </div>
-    </section>
-  );
-}
-
-function approvalCopyText(
-  eventText: string,
-  toolName: string | null,
-  toolInput: Record<string, unknown> | null,
-): string {
-  if (toolName === "ExitPlanMode" && typeof toolInput?.plan === "string") {
-    return toolInput.plan as string;
-  }
-  if (
-    (toolName === "Task" || toolName === "Agent") &&
-    typeof toolInput?.prompt === "string"
-  ) {
-    return toolInput.prompt as string;
-  }
-  if (toolName === "Bash" && typeof toolInput?.command === "string") {
-    return toolInput.command as string;
-  }
-  return eventText;
-}
-
-function ApprovalCardBody({
-  eventText,
-  toolName,
-  toolInput,
-  diffPreview,
-}: {
-  eventText: string;
-  toolName: string | null;
-  toolInput: Record<string, unknown> | null;
-  diffPreview?: EventDiffPreview | null;
-}) {
-  if (diffPreview) {
-    return (
-      <>
-        <p className="approval-prompt">{eventText}</p>
-        <DiffPreview preview={diffPreview} />
-      </>
-    );
-  }
-  if (toolName === "ExitPlanMode" && typeof toolInput?.plan === "string") {
-    return (
-      <>
-        <p className="approval-prompt">Approve plan and exit plan mode</p>
-        <div className="approval-plan">
-          <MarkdownMessage text={toolInput.plan as string} />
-        </div>
-      </>
-    );
-  }
-  if (
-    (toolName === "Task" || toolName === "Agent") &&
-    toolInput &&
-    typeof toolInput.prompt === "string"
-  ) {
-    const description =
-      typeof toolInput.description === "string" ? (toolInput.description as string) : "";
-    const subagent =
-      typeof toolInput.subagent_type === "string"
-        ? (toolInput.subagent_type as string)
-        : "";
-    return (
-      <>
-        <p className="approval-prompt">
-          Approve subagent task
-          {description ? `: ${description}` : ""}
-          {subagent ? ` (via ${subagent})` : ""}
-        </p>
-        <div className="approval-plan">
-          <MarkdownMessage text={toolInput.prompt as string} />
-        </div>
-      </>
-    );
-  }
-  if (toolName === "Bash" && typeof toolInput?.command === "string") {
-    const desc =
-      typeof toolInput.description === "string"
-        ? (toolInput.description as string)
-        : "";
-    return (
-      <>
-        <p className="approval-prompt">
-          Approve Bash command{desc ? `: ${desc}` : ""}
-        </p>
-        <pre className="approval-shell">{toolInput.command as string}</pre>
-      </>
-    );
-  }
-  if (isApprovalFileEditTool(toolName)) {
-    const path = approvalFileEditPath(toolInput);
-    return (
-      <>
-        <p className="approval-prompt">
-          Approve {toolName}
-          {path ? ` on ${path}` : ""}
-        </p>
-        <p className="diff-unavailable">Diff preview was not included by the backend.</p>
-      </>
-    );
-  }
-  return <pre>{eventText}</pre>;
-}
-
-function isApprovalFileEditTool(toolName: string | null): boolean {
-  return (
-    toolName === "Edit" ||
-    toolName === "MultiEdit" ||
-    toolName === "Write" ||
-    toolName === "NotebookEdit"
-  );
-}
-
-function approvalFileEditPath(toolInput: Record<string, unknown> | null): string | null {
-  if (!toolInput) {
-    return null;
-  }
-  const value = toolInput.file_path ?? toolInput.path ?? toolInput.notebook_path;
-  return typeof value === "string" && value ? value : null;
 }
 
 function sanitizeEvent(event: EventRecord): EventRecord {

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -1,80 +1,17 @@
-import { memo, useCallback, useState } from "react";
+import { memo, useState } from "react";
 
 import { fidelityFor, transportLabel } from "@/lib/backends";
 import { EventRecord, SessionTransport } from "@/lib/types";
-import { normalizeToolName, parseEvent, type EventDiffPreview } from "@/lib/events";
+import {
+  normalizeToolName,
+  parseEvent,
+  planTextForEvent,
+  type EventDiffPreview,
+} from "@/lib/events";
+import { PlanApprovalCard } from "@/components/ApprovalCard";
+import { CopyMessageButton } from "@/components/CopyMessageButton";
 import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
-
-function legacyCopy(text: string): boolean {
-  // execCommand("copy") has different security gating than the async API:
-  // it works on plain-HTTP origins and when document focus is ambiguous,
-  // as long as the call originates from a user gesture. It returns false
-  // (rather than throwing) when the host browser refuses.
-  const el = document.createElement("textarea");
-  el.value = text;
-  el.setAttribute("readonly", "");
-  el.style.position = "fixed";
-  el.style.opacity = "0";
-  document.body.appendChild(el);
-  el.select();
-  let ok = false;
-  try {
-    ok = document.execCommand("copy");
-  } catch {
-    ok = false;
-  }
-  document.body.removeChild(el);
-  return ok;
-}
-
-export function CopyMessageButton({
-  text,
-  label = "Copy message",
-}: {
-  text: string;
-  label?: string;
-}) {
-  const [copied, setCopied] = useState(false);
-  const onCopy = useCallback(async () => {
-    if (!text) return;
-    let ok = false;
-    if (navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text);
-        ok = true;
-      } catch {
-        // writeText can reject at runtime — NotAllowedError when the
-        // document loses focus or the user denied clipboard-write
-        // permission. Fall back to the legacy path before giving up so
-        // we don't silently no-op in those contexts.
-        ok = legacyCopy(text);
-      }
-    } else {
-      ok = legacyCopy(text);
-    }
-    if (!ok) return;
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
-  }, [text]);
-  return (
-    <button
-      type="button"
-      className={`message-copy${copied ? " copied" : ""}`}
-      onClick={(event) => {
-        // Tool cards live inside a <details>, so the click would otherwise
-        // toggle the disclosure as well as copying.
-        event.stopPropagation();
-        event.preventDefault();
-        void onCopy();
-      }}
-      aria-label={copied ? "Copied" : label}
-      title={copied ? "Copied" : label}
-    >
-      <span aria-hidden>{copied ? "✓" : "⎘"}</span>
-    </button>
-  );
-}
 
 export interface ToolPair {
   call: EventRecord | null;
@@ -255,11 +192,24 @@ function CodexCard({
       // post-resolution "Approval response sent: …" system note.
       return null;
     case "system_note":
-    case "status_update":
+    case "status_update": {
+      const plan = planTextForEvent(event);
+      if (plan) {
+        return (
+          <PlanApprovalCard
+            agentLabel={agentLabel}
+            className="transcript codex plan-output"
+            plan={plan}
+            prompt="Plan"
+            timeLabel={formatTime(event.ts)}
+          />
+        );
+      }
       if (event.metadata?.builtin_command === "/status") {
         return <CommandStatusCard event={event} agentLabel={agentLabel} />;
       }
       return <SystemRule event={event} />;
+    }
     default:
       return <HeuristicCard event={event} />;
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -456,6 +456,26 @@ export async function approveSession(
   await ensureOk(response, "failed to send approval");
 }
 
+export async function approvePlan(
+  host: string,
+  token: string,
+  sessionId: string,
+  planItemId: string,
+  text?: string,
+): Promise<SessionRecord> {
+  const response = await fetch(`${host}/api/sessions/${sessionId}/approve-plan`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ plan_item_id: planItemId, text }),
+  });
+  await ensureOk(response, "failed to approve plan");
+  const body = await response.json();
+  return body.session as SessionRecord;
+}
+
 export interface AskAnswerPayload {
   question: string;
   answer: string | null;

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -60,6 +60,7 @@ const FALLBACK_STRUCTURED = new Set([
 ]);
 const FALLBACK_RESUMABLE = new Set(["tmux"]);
 const FALLBACK_APPROVAL_NOTE = new Set(["claude_code", "opencode"]);
+const FALLBACK_PLAN_APPROVAL = new Set(["codex"]);
 
 const FALLBACK_PERMISSION_MODES: Record<string, BackendPermissionMode[]> = {
   claude_code: [
@@ -148,6 +149,14 @@ export function supportsApprovalNote(
 ): boolean {
   const caps = catalog?.byId(backend)?.capabilities;
   return caps ? caps.supports_approval_note : FALLBACK_APPROVAL_NOTE.has(backend);
+}
+
+export function supportsPlanApproval(
+  backend: Backend,
+  catalog?: BackendCatalog,
+): boolean {
+  const caps = catalog?.byId(backend)?.capabilities;
+  return caps ? Boolean(caps.supports_plan_approval) : FALLBACK_PLAN_APPROVAL.has(backend);
 }
 
 export function permissionModesFor(

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -181,6 +181,31 @@ export function normalizeToolName(name: string | null | undefined): string | nul
   return normalized;
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+export function planTextForEvent(event: EventRecord): string {
+  if (event.metadata.item_type !== "plan") {
+    return "";
+  }
+  const payload = asRecord(event.metadata.payload);
+  const item = asRecord(payload?.item);
+  const text = item?.text;
+  return typeof text === "string" ? text.trim() : "";
+}
+
+export function isPlanEvent(event: EventRecord): boolean {
+  return planTextForEvent(event) !== "";
+}
+
+export function itemIdForEvent(event: EventRecord): string | null {
+  const value = event.metadata.item_id;
+  return typeof value === "string" && value ? value : null;
+}
+
 export function parseEvent(event: EventRecord): EventEnvelope {
   const metadata = event.metadata ?? {};
   const versionRaw = metadata.version;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -116,6 +116,7 @@ export interface BackendCapabilities {
   supports_set_permission_mode_inline: boolean;
   supports_thread_discovery: boolean;
   supports_thread_import: boolean;
+  supports_plan_approval: boolean;
   supports_slash_compact: boolean;
   supports_approval_note: boolean;
   supports_custom_cli_args: boolean;


### PR DESCRIPTION
## Summary

Adds Codex plan-mode support through the full Waypoint flow: preserving plan-mode state, rendering Codex plans in the transcript, approving the latest plan from the same frontend approval surface used by Claude Code, and resuming Codex with the approved-plan prompt.

This also enables Codex session forking and includes the approved `hello_world.txt` smoke-test fixture from the plan-approval handoff test.

## Changes

### Backend
- Added Codex plan-mode state handling, including pre-plan permission preservation across mode changes and forks.
- Added a backend-neutral plan-approval capability and `POST /api/sessions/{session_id}/approve-plan` endpoint.
- Implemented Codex plan approval by restoring the saved permission mode and sending an approved-plan prompt to the Codex backend.
- Added rollback coverage for failed approval sends and unsupported backend handling.

### Frontend
- Render Codex plan items as Markdown plan cards and deduplicate superseded lifecycle events by item id.
- Promote the latest pending Codex plan into the same approval area used by Claude Code approvals.
- Extracted shared approval-card and copy-button components so Claude approval requests and Codex plan approvals use the same UI shell.

## Test Plan

- [x] `cd backend && rtk uv run pytest tests/test_runtime.py -k "approve_codex_plan or approve_plan_rejects_unsupported_backend or set_permission_mode_codex_plan or leaving_plan"`
- [x] `cd backend && rtk uv run pytest tests/test_backend_registry.py`
- [x] `cd frontend && rtk npm run lint`
- [x] `cd frontend && rtk npm run build`
