### PR TITLE
fix: align Codex plan approval actions

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -207,9 +207,10 @@ class BackendPlugin(Protocol):
         runtime: "SessionRuntime",
         session: SessionRecord,
         plan_item_id: str,
+        decision: str,
         text: str | None,
     ) -> SessionRecord:
-        """Approve a backend-native plan item and resume execution."""
+        """Apply a plan-approval decision (accept / decline / cancel)."""
         ...
 
     async def post_approval(

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -523,6 +523,7 @@ class ClaudeCodePlugin:
         runtime: "SessionRuntime",
         session: SessionRecord,
         plan_item_id: str,
+        decision: str,
         text: str | None,
     ) -> SessionRecord:
         raise HTTPException(

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -20,6 +20,7 @@ from waypoint.backends.codex.normalize import (
     format_approval_text,
     map_notification,
     payload_to_dict,
+    plan_metadata_for_item,
 )
 from waypoint.backends.diff_preview import DiffPreviewPayload, preview_to_metadata
 from waypoint.schemas import EventKind, SessionStatus
@@ -601,6 +602,9 @@ class CodexAppServerAdapter:
                         tool_name = _extract_tool_name(item_type, item)
                         if tool_name:
                             metadata["tool_name"] = tool_name
+                        plan_envelope = plan_metadata_for_item(item)
+                        if plan_envelope is not None:
+                            metadata["plan"] = plan_envelope
                     if (
                         kind == EventKind.TOOL_RESULT
                         and notification.method

--- a/backend/src/waypoint/backends/codex/normalize.py
+++ b/backend/src/waypoint/backends/codex/normalize.py
@@ -284,6 +284,31 @@ def extract_item(payload: dict[str, Any]) -> dict[str, Any]:
     return item if isinstance(item, dict) else {}
 
 
+_PLAN_DECISIONS: tuple[str, ...] = ("accept", "acceptForSession", "decline", "cancel")
+
+
+def plan_metadata_for_item(item: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a normalised plan envelope for a Codex ``plan`` item.
+
+    Frontends consume this directly so they don't have to re-derive the
+    plan id / text from the raw codex item shape, and so the same view
+    model can express Claude's ExitPlanMode flow in a future change.
+    """
+
+    if item.get("type") != "plan":
+        return None
+    plan_id = item.get("id")
+    text = item.get("text", "")
+    if not isinstance(text, str):
+        text = ""
+    return {
+        "id": plan_id if isinstance(plan_id, str) and plan_id else None,
+        "text": text,
+        "source": "codex",
+        "decisions": list(_PLAN_DECISIONS),
+    }
+
+
 def diff_preview_for_notification(
     method: str, payload: dict[str, Any]
 ) -> DiffPreviewPayload | None:

--- a/backend/src/waypoint/backends/codex/permission_modes.py
+++ b/backend/src/waypoint/backends/codex/permission_modes.py
@@ -5,11 +5,90 @@ Codex's TUI builds for the equivalent /permissions picker entry. See
 ``tmp/docs/BACKEND_CONTROL_PROTOCOLS.md`` for the source-of-truth wiring.
 """
 
+from functools import cache
+from pathlib import Path
 from typing import Any
 
 from waypoint.backends.capabilities import PermissionModeSpec
 
 CODEX_PLAN_MODE = "plan"
+
+# Source-of-truth Codex collaboration-mode templates ship in the vendored
+# codex submodule. The TUI bundles `plan.md`/`default.md` into its
+# `builtin_collaboration_mode_presets` and ships them as the per-mode
+# ``developer_instructions``. Sending ``null`` from an app-server client
+# instead suppresses Codex's `build_collaboration_mode_update_item`
+# emit (see ``codex-rs/core/src/context_manager/updates.rs``), so the
+# previous mode's instructions linger in the prompt — i.e. switching
+# out of plan mode visibly fails because the model never receives the
+# default-mode developer message that supersedes it. We render the
+# same templates here so a Waypoint mode switch carries the same
+# instruction body the TUI would.
+_CODEX_MODE_TEMPLATES_DIR = (
+    Path(__file__).resolve().parents[5]
+    / "3rdparty"
+    / "codex"
+    / "codex-rs"
+    / "collaboration-mode-templates"
+    / "templates"
+)
+# Mirrors `format_mode_names(&TUI_VISIBLE_COLLABORATION_MODES)` in
+# `models-manager/src/collaboration_mode_presets.rs`. The TUI lists Plan
+# and Default; Waypoint renders the same set so the model's view of
+# "known modes" matches Codex's own prompts.
+_KNOWN_MODE_NAMES = "Plan and Default"
+_DEFAULT_MODE_REQUEST_USER_INPUT_AVAILABILITY = (
+    "The `request_user_input` tool is unavailable in Default mode. "
+    "If you call it while in Default mode, it will return an error."
+)
+_DEFAULT_MODE_ASKING_QUESTIONS_GUIDANCE = (
+    "In Default mode, strongly prefer making reasonable assumptions and "
+    "executing the user's request rather than stopping to ask questions. "
+    "If you absolutely must ask a question because the answer cannot be "
+    "discovered from local context and a reasonable assumption would be "
+    "risky, ask the user directly with a concise plain-text question. "
+    "Never write a multiple choice question as a textual assistant message."
+)
+
+
+@cache
+def _load_mode_template(name: str) -> str | None:
+    path = _CODEX_MODE_TEMPLATES_DIR / name
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError:
+        # Submodule is optional at install time; fall back to ``None``
+        # so we still send something rather than crash on every turn.
+        return None
+
+
+@cache
+def codex_mode_developer_instructions(mode: str) -> str | None:
+    """Return the developer-instructions body Codex's TUI sends for ``mode``.
+
+    Returns ``None`` only when the bundled templates are missing; callers
+    should treat ``None`` as "no instruction switch available" and fall
+    back to a non-empty placeholder so the App Server still emits a
+    collaboration-mode update item.
+    """
+
+    if mode == CODEX_PLAN_MODE:
+        return _load_mode_template("plan.md")
+    template = _load_mode_template("default.md")
+    if template is None:
+        return None
+    return (
+        template.replace("{{KNOWN_MODE_NAMES}}", _KNOWN_MODE_NAMES)
+        .replace(
+            "{{REQUEST_USER_INPUT_AVAILABILITY}}",
+            _DEFAULT_MODE_REQUEST_USER_INPUT_AVAILABILITY,
+        )
+        .replace(
+            "{{ASKING_QUESTIONS_GUIDANCE}}",
+            _DEFAULT_MODE_ASKING_QUESTIONS_GUIDANCE,
+        )
+    )
+
 
 CODEX_PERMISSION_PRESETS: dict[str, dict[str, Any]] = {
     "default": {
@@ -67,13 +146,18 @@ def codex_turn_params_for(
     params = dict(preset)
     if model:
         collaboration_mode = CODEX_PLAN_MODE if mode == CODEX_PLAN_MODE else "default"
+        # Always send the rendered mode template. ``None`` here would let
+        # Codex's prior collaboration_mode instructions linger because the
+        # App Server only emits a switch when the next turn carries
+        # non-empty developer instructions.
         params["collaborationMode"] = {
             "mode": collaboration_mode,
             "settings": {
                 "model": model,
                 "reasoning_effort": "medium" if mode == CODEX_PLAN_MODE else effort,
-                # Let app-server inject Codex's built-in mode instructions.
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions(
+                    collaboration_mode
+                ),
             },
         }
     return params

--- a/backend/src/waypoint/backends/codex/permission_modes.py
+++ b/backend/src/waypoint/backends/codex/permission_modes.py
@@ -49,6 +49,19 @@ _DEFAULT_MODE_ASKING_QUESTIONS_GUIDANCE = (
     "risky, ask the user directly with a concise plain-text question. "
     "Never write a multiple choice question as a textual assistant message."
 )
+_PLAN_MODE_FALLBACK = (
+    "# Plan Mode (Conversational)\n\n"
+    "You are in Plan Mode. Do not edit files or run mutating commands. "
+    "Explore the repository, ask clarifying questions when needed, and "
+    "return a decision-complete plan in a <proposed_plan> block."
+)
+_DEFAULT_MODE_FALLBACK = (
+    "# Collaboration Mode: Default\n\n"
+    "You are now in Default mode. Any previous instructions for other modes "
+    "(e.g. Plan mode) are no longer active.\n\n"
+    f"{_DEFAULT_MODE_REQUEST_USER_INPUT_AVAILABILITY}\n\n"
+    f"{_DEFAULT_MODE_ASKING_QUESTIONS_GUIDANCE}"
+)
 
 
 @cache
@@ -63,20 +76,20 @@ def _load_mode_template(name: str) -> str | None:
 
 
 @cache
-def codex_mode_developer_instructions(mode: str) -> str | None:
+def codex_mode_developer_instructions(mode: str) -> str:
     """Return the developer-instructions body Codex's TUI sends for ``mode``.
 
-    Returns ``None`` only when the bundled templates are missing; callers
-    should treat ``None`` as "no instruction switch available" and fall
-    back to a non-empty placeholder so the App Server still emits a
-    collaboration-mode update item.
+    Always returns a non-empty body. Codex's App Server only emits a
+    collaboration-mode update item when the next turn carries developer
+    instructions, so missing vendored templates must fall back to explicit
+    instructions rather than ``None``.
     """
 
     if mode == CODEX_PLAN_MODE:
-        return _load_mode_template("plan.md")
+        return _load_mode_template("plan.md") or _PLAN_MODE_FALLBACK
     template = _load_mode_template("default.md")
     if template is None:
-        return None
+        return _DEFAULT_MODE_FALLBACK
     return (
         template.replace("{{KNOWN_MODE_NAMES}}", _KNOWN_MODE_NAMES)
         .replace(

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -49,6 +49,7 @@ from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
+    EventRecord,
     SessionCreateRequest,
     SessionInputRequest,
     SessionRecord,
@@ -306,11 +307,11 @@ class CodexPlugin:
                 detail=f"unsupported plan decision: {decision}",
             )
 
-        plan = _plan_text_for_item(runtime, session.id, plan_item_id)
+        plan = _current_plan_text_for_item(runtime, session.id, plan_item_id)
         if not plan:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="codex plan item was not found",
+                detail="codex plan item was not found or is no longer current",
             )
 
         accept = decision in {"accept", "acceptForSession"}
@@ -1168,28 +1169,64 @@ def _deny_approval(_method: str, _params: dict[str, Any] | None) -> dict[str, An
     return {"decision": "decline"}
 
 
-def _plan_text_for_item(
+def _current_plan_text_for_item(
     runtime: "SessionRuntime", session_id: str, plan_item_id: str
 ) -> str:
+    decided_plan_ids: set[str] = set()
     for event in reversed(runtime.storage.list_events(session_id)):
-        if event.metadata.get("item_id") != plan_item_id:
-            continue
         if event.metadata.get("item_type") != "plan":
+            decision_plan_id = event.metadata.get("plan_item_id")
+            if (
+                isinstance(decision_plan_id, str)
+                and event.metadata.get("plan_decision") in _PLAN_DECISIONS
+            ):
+                decided_plan_ids.add(decision_plan_id)
             continue
-        plan = event.metadata.get("plan")
-        if isinstance(plan, dict):
-            text = plan.get("text")
-            if isinstance(text, str) and text.strip():
-                return text.strip()
-        payload = event.metadata.get("payload")
-        if not isinstance(payload, dict):
-            continue
+        current_plan_id = _plan_id_for_event(event)
+        if not current_plan_id or current_plan_id in decided_plan_ids:
+            return ""
+        if current_plan_id != plan_item_id:
+            return ""
+        text = _plan_text_for_event(event)
+        if text:
+            return text
+    return ""
+
+
+def _plan_id_for_event(event: EventRecord) -> str | None:
+    plan = event.metadata.get("plan")
+    if isinstance(plan, dict):
+        plan_id = plan.get("id")
+        if isinstance(plan_id, str) and plan_id:
+            return plan_id
+    item_id = event.metadata.get("item_id")
+    if isinstance(item_id, str) and item_id:
+        return item_id
+    payload = event.metadata.get("payload")
+    if isinstance(payload, dict):
         item = payload.get("item")
-        if not isinstance(item, dict):
-            continue
-        text = item.get("text")
+        if isinstance(item, dict):
+            item_id = item.get("id")
+            if isinstance(item_id, str) and item_id:
+                return item_id
+    return None
+
+
+def _plan_text_for_event(event: EventRecord) -> str:
+    plan = event.metadata.get("plan")
+    if isinstance(plan, dict):
+        text = plan.get("text")
         if isinstance(text, str) and text.strip():
             return text.strip()
+    payload = event.metadata.get("payload")
+    if not isinstance(payload, dict):
+        return ""
+    item = payload.get("item")
+    if not isinstance(item, dict):
+        return ""
+    text = item.get("text")
+    if isinstance(text, str) and text.strip():
+        return text.strip()
     return ""
 
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -292,12 +292,18 @@ class CodexPlugin:
         runtime: "SessionRuntime",
         session: SessionRecord,
         plan_item_id: str,
+        decision: str,
         text: str | None,
     ) -> SessionRecord:
         if session.permission_mode != CODEX_PLAN_MODE:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="codex session is not in plan mode",
+            )
+        if decision not in _PLAN_DECISIONS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"unsupported plan decision: {decision}",
             )
 
         plan = _plan_text_for_item(runtime, session.id, plan_item_id)
@@ -307,20 +313,29 @@ class CodexPlugin:
                 detail="codex plan item was not found",
             )
 
-        target_mode = session.transport_state.get("pre_plan_mode")
-        if target_mode not in CODEX_PERMISSION_PRESETS:
-            target_mode = "default"
+        accept = decision in {"accept", "acceptForSession"}
+        # accept: exit plan mode, send approval prompt under restored mode.
+        # decline / cancel: stay in plan mode, send rejection prompt under plan mode.
+        if accept:
+            target_mode = session.transport_state.get("pre_plan_mode")
+            if target_mode not in CODEX_PERMISSION_PRESETS:
+                target_mode = "default"
+            prompt = _format_plan_approval_prompt(plan, text)
+        else:
+            target_mode = CODEX_PLAN_MODE
+            prompt = _format_plan_rejection_prompt(decision, text)
 
         previous_status = session.status
         runtime.storage.update_session(session.id, status=SessionStatus.RUNNING)
         try:
             await self._require_adapter().send_input(
                 session.id,
-                _format_plan_approval_prompt(plan, text),
+                prompt,
                 turn_params=codex_turn_params_for(
                     target_mode,
                     model=self._session_model_for_turn(session),
                     effort=self._session_effort_for_turn(session),
+                    pre_plan_mode=session.transport_state.get("pre_plan_mode"),
                 ),
             )
         except Exception as exc:  # noqa: BLE001
@@ -329,15 +344,28 @@ class CodexPlugin:
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
 
-        await runtime.set_permission_mode(session.id, target_mode)
+        if accept:
+            await runtime.set_permission_mode(session.id, target_mode)
+            running = runtime.storage.update_session(
+                session.id, status=SessionStatus.RUNNING
+            )
+            await runtime._record_system_event(
+                session.id,
+                f"Plan approved; exited plan mode ({target_mode})",
+                status=SessionStatus.RUNNING,
+                metadata={"plan_item_id": plan_item_id, "plan_decision": decision},
+            )
+            return running
+
         running = runtime.storage.update_session(
             session.id, status=SessionStatus.RUNNING
         )
+        rejection_label = "declined" if decision == "decline" else "cancelled"
         await runtime._record_system_event(
             session.id,
-            f"Plan approved; exited plan mode ({target_mode})",
+            f"Plan {rejection_label}; staying in plan mode",
             status=SessionStatus.RUNNING,
-            metadata={"plan_item_id": plan_item_id},
+            metadata={"plan_item_id": plan_item_id, "plan_decision": decision},
         )
         return running
 
@@ -1148,6 +1176,11 @@ def _plan_text_for_item(
             continue
         if event.metadata.get("item_type") != "plan":
             continue
+        plan = event.metadata.get("plan")
+        if isinstance(plan, dict):
+            text = plan.get("text")
+            if isinstance(text, str) and text.strip():
+                return text.strip()
         payload = event.metadata.get("payload")
         if not isinstance(payload, dict):
             continue
@@ -1160,6 +1193,9 @@ def _plan_text_for_item(
     return ""
 
 
+_PLAN_DECISIONS = frozenset({"accept", "acceptForSession", "decline", "cancel"})
+
+
 def _format_plan_approval_prompt(plan: str, note: str | None = None) -> str:
     lines = [
         "User has approved your plan. You can now start coding. "
@@ -1168,6 +1204,20 @@ def _format_plan_approval_prompt(plan: str, note: str | None = None) -> str:
         "## Approved Plan:",
         plan,
     ]
+    if note:
+        lines.extend(["", "User note:", note])
+    return "\n".join(lines)
+
+
+def _format_plan_rejection_prompt(decision: str, note: str | None) -> str:
+    if decision == "cancel":
+        intro = "User has cancelled the plan; stay in plan mode and wait for further instructions."
+    else:
+        intro = (
+            "User has declined the plan; stay in plan mode and revise the plan "
+            "based on the note below before proposing a new plan."
+        )
+    lines = [intro]
     if note:
         lines.extend(["", "User note:", note])
     return "\n".join(lines)

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1133,6 +1133,7 @@ class OpenCodePlugin:
         runtime: "SessionRuntime",
         session: SessionRecord,
         plan_item_id: str,
+        decision: str,
         text: str | None,
     ) -> SessionRecord:
         raise HTTPException(

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -183,6 +183,7 @@ class TmuxPlugin:
         runtime: "SessionRuntime",
         session: SessionRecord,
         plan_item_id: str,
+        decision: str,
         text: str | None,
     ) -> SessionRecord:
         _unsupported("plan approval")

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -895,7 +895,7 @@ class SessionRuntime:
                 detail=f"plan approval is not supported for {session.backend}",
             )
         return await plugin.approve_plan(
-            self, session, request.plan_item_id, request.text
+            self, session, request.plan_item_id, request.decision, request.text
         )
 
     def session_events(

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -215,6 +215,7 @@ class SessionApprovalRequest(BaseModel):
 
 class SessionPlanApprovalRequest(BaseModel):
     plan_item_id: str
+    decision: Literal["accept", "acceptForSession", "decline", "cancel"] = "accept"
     text: str | None = None
 
 

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -107,6 +107,7 @@ class _StubPlugin:
         runtime: Any,
         session: Any,
         plan_item_id: str,
+        decision: str,
         text: str | None,
     ) -> Any:
         raise NotImplementedError

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -7,6 +7,9 @@ import pytest
 
 from waypoint.backends.claude_code.schemas import ClaudeThreadImportRequest
 from waypoint.backends.claude_code.threads import ClaudeThreadInfo
+from waypoint.backends.codex.permission_modes import (
+    codex_mode_developer_instructions,
+)
 from waypoint.backends.codex.schemas import CodexThreadImportRequest
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.runtime import SessionRuntime
@@ -1120,7 +1123,7 @@ async def test_handle_input_builtin_plan_switches_codex_plan_mode_only(
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": "medium",
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("plan"),
             },
         },
     }
@@ -1155,7 +1158,7 @@ async def test_handle_input_builtin_plan_with_prompt_starts_plan_turn(
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": "medium",
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("plan"),
             },
         },
     }
@@ -1722,7 +1725,7 @@ async def test_set_permission_mode_codex_persists_and_threads_to_next_turn(
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": "high",
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("default"),
             },
         },
     }
@@ -1756,7 +1759,7 @@ async def test_set_permission_mode_codex_plan_preserves_previous_preset(
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": "medium",
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("plan"),
             },
         },
     }
@@ -1794,10 +1797,17 @@ async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": None,
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("default"),
             },
         },
     }
+    # Sanity: a non-empty body is required for Codex's app-server to
+    # emit a collaboration-mode update item; otherwise the previous
+    # plan-mode developer instructions linger and the model behaves
+    # as if it never left plan mode.
+    body = params["collaborationMode"]["settings"]["developer_instructions"]
+    assert isinstance(body, str) and "Default" in body
+    assert "Plan Mode (Conversational)" not in body
 
 
 @pytest.mark.asyncio
@@ -1964,7 +1974,7 @@ async def test_approve_codex_plan_restores_mode_and_sends_prompt(tmp_path) -> No
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": None,
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("default"),
             },
         },
     }
@@ -2036,7 +2046,7 @@ async def test_approve_codex_plan_decline_keeps_plan_mode(tmp_path) -> None:
             "settings": {
                 "model": "gpt-5.3-codex",
                 "reasoning_effort": "medium",
-                "developer_instructions": None,
+                "developer_instructions": codex_mode_developer_instructions("plan"),
             },
         },
     }

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1810,6 +1810,23 @@ async def test_set_permission_mode_codex_leaving_plan_clears_previous_preset(
     assert "Plan Mode (Conversational)" not in body
 
 
+def test_codex_mode_developer_instructions_falls_back_when_templates_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from waypoint.backends.codex import permission_modes
+
+    permission_modes.codex_mode_developer_instructions.cache_clear()
+    monkeypatch.setattr(permission_modes, "_load_mode_template", lambda name: None)
+    try:
+        default_body = permission_modes.codex_mode_developer_instructions("default")
+        plan_body = permission_modes.codex_mode_developer_instructions("plan")
+    finally:
+        permission_modes.codex_mode_developer_instructions.cache_clear()
+
+    assert "Default mode" in default_body
+    assert "Plan Mode" in plan_body
+
+
 @pytest.mark.asyncio
 async def test_runtime_fork_codex_session_uses_codex_plugin(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
@@ -2152,6 +2169,69 @@ async def test_approve_codex_plan_rejects_unknown_plan_item(tmp_path) -> None:
 
     assert exc.value.status_code == 400
     assert "plan item was not found" in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_rejects_stale_plan_item(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "auto_review"},
+    )
+    storage.create_session(session)
+    _seed_plan_event(storage, plan_id="plan-1", text="Old plan")
+    _seed_plan_event(storage, plan_id="plan-2", text="New plan")
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.approve_plan(
+            "sess",
+            SessionPlanApprovalRequest(plan_item_id="plan-1", decision="accept"),
+        )
+
+    assert exc.value.status_code == 400
+    assert "no longer current" in str(exc.value.detail)
+    assert fake.inputs == []
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_rejects_already_decided_plan_item(tmp_path) -> None:
+    from fastapi import HTTPException
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "auto_review"},
+    )
+    storage.create_session(session)
+    _seed_plan_event(storage, plan_id="plan-1", text="Plan to revise")
+    storage.append_event(
+        EventRecord(
+            session_id="sess",
+            ts=datetime.now(UTC),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Plan declined; staying in plan mode",
+            metadata={"plan_item_id": "plan-1", "plan_decision": "decline"},
+            sequence=storage.next_sequence("sess"),
+        )
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.approve_plan(
+            "sess",
+            SessionPlanApprovalRequest(plan_item_id="plan-1", decision="accept"),
+        )
+
+    assert exc.value.status_code == 400
+    assert "no longer current" in str(exc.value.detail)
+    assert fake.inputs == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1880,6 +1880,46 @@ async def test_fork_codex_plan_session_persists_pre_plan_mode(tmp_path) -> None:
     }
 
 
+def _seed_plan_event(
+    storage: Storage,
+    *,
+    session_id: str = "sess",
+    plan_id: str = "plan-1",
+    text: str = "1. Update the UI\n2. Run tests",
+) -> None:
+    storage.append_event(
+        EventRecord(
+            session_id=session_id,
+            ts=datetime.now(UTC),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Completed plan",
+            metadata={
+                "item_id": plan_id,
+                "item_type": "plan",
+                "plan": {
+                    "id": plan_id,
+                    "text": text,
+                    "source": "codex",
+                    "decisions": [
+                        "accept",
+                        "acceptForSession",
+                        "decline",
+                        "cancel",
+                    ],
+                },
+                "payload": {
+                    "item": {
+                        "id": plan_id,
+                        "type": "plan",
+                        "text": text,
+                    }
+                },
+            },
+            sequence=storage.next_sequence(session_id),
+        )
+    )
+
+
 @pytest.mark.asyncio
 async def test_approve_codex_plan_restores_mode_and_sends_prompt(tmp_path) -> None:
     from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
@@ -1894,29 +1934,11 @@ async def test_approve_codex_plan_restores_mode_and_sends_prompt(tmp_path) -> No
         transport_state={"thread_id": "thread-1", "pre_plan_mode": "full_access"},
     )
     storage.create_session(session)
-    storage.append_event(
-        EventRecord(
-            session_id="sess",
-            ts=datetime.now(UTC),
-            kind=EventKind.SYSTEM_NOTE,
-            text="Completed plan",
-            metadata={
-                "item_id": "plan-1",
-                "item_type": "plan",
-                "payload": {
-                    "item": {
-                        "id": "plan-1",
-                        "type": "plan",
-                        "text": "1. Update the UI\n2. Run tests",
-                    }
-                },
-            },
-            sequence=storage.next_sequence("sess"),
-        )
-    )
+    _seed_plan_event(storage)
 
     updated = await runtime.approve_plan(
-        "sess", SessionPlanApprovalRequest(plan_item_id="plan-1")
+        "sess",
+        SessionPlanApprovalRequest(plan_item_id="plan-1", decision="accept"),
     )
 
     refreshed = storage.get_session("sess")
@@ -1946,6 +1968,117 @@ async def test_approve_codex_plan_restores_mode_and_sends_prompt(tmp_path) -> No
             },
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_accept_for_session_matches_accept(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "auto_review"},
+    )
+    storage.create_session(session)
+    _seed_plan_event(storage)
+
+    updated = await runtime.approve_plan(
+        "sess",
+        SessionPlanApprovalRequest(plan_item_id="plan-1", decision="acceptForSession"),
+    )
+
+    refreshed = storage.get_session("sess")
+    assert refreshed is not None
+    assert updated.permission_mode == "auto_review"
+    assert refreshed.permission_mode == "auto_review"
+    assert "pre_plan_mode" not in refreshed.transport_state
+    assert fake.inputs[0][1].startswith("User has approved your plan.")
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_decline_keeps_plan_mode(tmp_path) -> None:
+    from waypoint.backends.codex.permission_modes import CODEX_PERMISSION_PRESETS
+
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "full_access"},
+    )
+    storage.create_session(session)
+    _seed_plan_event(storage)
+
+    updated = await runtime.approve_plan(
+        "sess",
+        SessionPlanApprovalRequest(
+            plan_item_id="plan-1", decision="decline", text="prefer option B"
+        ),
+    )
+
+    refreshed = storage.get_session("sess")
+    assert refreshed is not None
+    assert updated.permission_mode == "plan"
+    assert refreshed.permission_mode == "plan"
+    assert refreshed.transport_state["pre_plan_mode"] == "full_access"
+    assert refreshed.status == SessionStatus.RUNNING
+    [(_, prompt)] = fake.inputs
+    assert prompt.startswith("User has declined the plan;")
+    assert "prefer option B" in prompt
+    [(_, params)] = fake.turn_params_calls
+    assert params == {
+        **CODEX_PERMISSION_PRESETS["full_access"],
+        "collaborationMode": {
+            "mode": "plan",
+            "settings": {
+                "model": "gpt-5.3-codex",
+                "reasoning_effort": "medium",
+                "developer_instructions": None,
+            },
+        },
+    }
+    assert any(
+        "Plan declined; staying in plan mode" in event.text
+        for event in storage.list_events("sess")
+    )
+
+
+@pytest.mark.asyncio
+async def test_approve_codex_plan_cancel_keeps_plan_mode(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    fake.models["sess"] = "gpt-5.3-codex"
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        permission_mode="plan",
+        transport_state={"thread_id": "thread-1", "pre_plan_mode": "default"},
+    )
+    storage.create_session(session)
+    _seed_plan_event(storage)
+
+    updated = await runtime.approve_plan(
+        "sess",
+        SessionPlanApprovalRequest(plan_item_id="plan-1", decision="cancel"),
+    )
+
+    refreshed = storage.get_session("sess")
+    assert refreshed is not None
+    assert updated.permission_mode == "plan"
+    assert refreshed.permission_mode == "plan"
+    assert refreshed.transport_state["pre_plan_mode"] == "default"
+    [(_, prompt)] = fake.inputs
+    assert prompt.startswith("User has cancelled the plan;")
+    [(_, params)] = fake.turn_params_calls
+    assert params is not None
+    assert params["collaborationMode"]["mode"] == "plan"
+    assert any(
+        "Plan cancelled; staying in plan mode" in event.text
+        for event in storage.list_events("sess")
+    )
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/ApprovalCard.tsx
+++ b/frontend/src/components/ApprovalCard.tsx
@@ -7,6 +7,7 @@ import {
   normalizeToolName,
   parseEvent,
   type EventDiffPreview,
+  type PlanDecision,
 } from "@/lib/events";
 import type { EventRecord } from "@/lib/types";
 
@@ -193,11 +194,44 @@ export function ApprovalRequestCard({
   );
 }
 
+const PLAN_ACTION_DEFINITIONS: ReadonlyArray<{
+  id: PlanDecision;
+  label: string;
+  loadingLabel: string;
+  className: "primary" | "secondary";
+}> = [
+  {
+    id: "accept",
+    label: "Approve",
+    loadingLabel: "Approving…",
+    className: "primary",
+  },
+  {
+    id: "acceptForSession",
+    label: "Approve for session",
+    loadingLabel: "Approving…",
+    className: "secondary",
+  },
+  {
+    id: "decline",
+    label: "Decline",
+    loadingLabel: "Declining…",
+    className: "secondary",
+  },
+  {
+    id: "cancel",
+    label: "Cancel",
+    loadingLabel: "Cancelling…",
+    className: "secondary",
+  },
+];
+
 export function PlanApprovalCard({
   agentLabel,
   canApprove = false,
   className,
-  onApprove,
+  decisions,
+  onDecide,
   plan,
   prompt = "Approve plan and exit plan mode",
   timeLabel,
@@ -205,33 +239,39 @@ export function PlanApprovalCard({
   agentLabel: string;
   canApprove?: boolean;
   className?: string;
-  onApprove?: (note?: string) => void | Promise<void>;
+  decisions?: ReadonlyArray<PlanDecision>;
+  onDecide?: (decision: PlanDecision, note?: string) => void | Promise<void>;
   plan: string;
   prompt?: string;
   timeLabel?: string;
 }) {
+  const allowed = new Set<PlanDecision>(
+    decisions && decisions.length > 0
+      ? decisions
+      : PLAN_ACTION_DEFINITIONS.map((entry) => entry.id),
+  );
+  const actions =
+    canApprove && onDecide
+      ? PLAN_ACTION_DEFINITIONS.filter((entry) => allowed.has(entry.id)).map(
+          (entry) => ({
+            id: entry.id,
+            label: entry.label,
+            loadingLabel: entry.loadingLabel,
+            className: entry.className,
+            onSelect: (note?: string) => onDecide(entry.id, note),
+          }),
+        )
+      : [];
   return (
     <SharedApprovalCard
       badge={`${agentLabel} plan`}
       className={className}
       copyLabel="Copy plan"
       copyText={plan}
-      notePlaceholder="Add a note to your approval…"
+      notePlaceholder="Add a note to your decision…"
       supportsNote={canApprove}
       timeLabel={timeLabel}
-      actions={
-        canApprove && onApprove
-          ? [
-              {
-                id: "approve",
-                label: "Approve",
-                loadingLabel: "Approving…",
-                className: "primary",
-                onSelect: onApprove,
-              },
-            ]
-          : []
-      }
+      actions={actions}
     >
       <ApprovalPlanBody plan={plan} prompt={prompt} />
     </SharedApprovalCard>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -49,7 +49,6 @@ import {
   isPlanEvent,
   itemIdForEvent,
   planForEvent,
-  planTextForEvent,
   type PlanDecision,
   type PlanViewModel,
 } from "@/lib/events";
@@ -888,7 +887,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const pendingPlanApprovalEvent =
     session?.permission_mode === "plan" &&
     supportsPlanApproval(session.backend, catalog)
-      ? latestPlanEvent(transcriptEvents)
+      ? latestActionablePlanEvent(displayEvents)
       : null;
   const pendingPlanApprovalView: PlanViewModel | null = pendingPlanApprovalEvent
     ? planForEvent(pendingPlanApprovalEvent)
@@ -2260,19 +2259,31 @@ function collapseSupersededPlanEvents(events: EventRecord[]): EventRecord[] {
   });
 }
 
-function latestPlanEvent(events: EventRecord[]): EventRecord | null {
+function latestActionablePlanEvent(events: EventRecord[]): EventRecord | null {
+  const decidedPlanIds = new Set<string>();
   for (let index = events.length - 1; index >= 0; index -= 1) {
     const event = events[index];
-    const plan = planTextForEvent(event);
-    if (!plan) {
+    const decisionPlanId = planDecisionItemId(event);
+    if (decisionPlanId) {
+      decidedPlanIds.add(decisionPlanId);
       continue;
     }
-    const itemId = readItemId(event);
-    if (itemId) {
-      return event;
+    const plan = planForEvent(event);
+    if (!plan || event.kind === "approval_request") {
+      continue;
     }
+    return decidedPlanIds.has(plan.id) ? null : event;
   }
   return null;
+}
+
+function planDecisionItemId(event: EventRecord): string | null {
+  const planItemId = event.metadata.plan_item_id;
+  if (typeof planItemId !== "string" || !planItemId) {
+    return null;
+  }
+  const decision = event.metadata.plan_decision;
+  return typeof decision === "string" ? planItemId : null;
 }
 
 type TranscriptItem =

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -48,7 +48,10 @@ import { clearToken } from "@/lib/store";
 import {
   isPlanEvent,
   itemIdForEvent,
+  planForEvent,
   planTextForEvent,
+  type PlanDecision,
+  type PlanViewModel,
 } from "@/lib/events";
 import { ApprovalRequestCard, PlanApprovalCard } from "@/components/ApprovalCard";
 import {
@@ -839,9 +842,20 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }
 
-  async function submitPlanApproval(planItemId: string, text?: string) {
+  async function submitPlanApproval(
+    planItemId: string,
+    decision: PlanDecision,
+    text?: string,
+  ) {
     try {
-      const updated = await approvePlan(host, token, sessionId, planItemId, text);
+      const updated = await approvePlan(
+        host,
+        token,
+        sessionId,
+        planItemId,
+        decision,
+        text,
+      );
       setSession(updated);
     } catch (approvalError) {
       if (isAuthError(approvalError)) {
@@ -876,12 +890,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     supportsPlanApproval(session.backend, catalog)
       ? latestPlanEvent(transcriptEvents)
       : null;
-  const pendingPlanApprovalItemId = pendingPlanApprovalEvent
-    ? itemIdForEvent(pendingPlanApprovalEvent)
+  const pendingPlanApprovalView: PlanViewModel | null = pendingPlanApprovalEvent
+    ? planForEvent(pendingPlanApprovalEvent)
     : null;
-  const pendingPlanApprovalText = pendingPlanApprovalEvent
-    ? planTextForEvent(pendingPlanApprovalEvent)
-    : "";
   const transcriptEventsForDisplay = pendingPlanApprovalEvent
     ? transcriptEvents.filter((event) => event !== pendingPlanApprovalEvent)
     : transcriptEvents;
@@ -1139,12 +1150,15 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           />
         </>
       ) : null}
-      {!pendingApproval && pendingPlanApprovalItemId && pendingPlanApprovalText ? (
+      {!pendingApproval && pendingPlanApprovalView ? (
         <PlanApprovalCard
           agentLabel={session ? humaniseBackend(session.backend) : "Codex"}
           canApprove
-          onApprove={(note) => submitPlanApproval(pendingPlanApprovalItemId, note)}
-          plan={pendingPlanApprovalText}
+          decisions={pendingPlanApprovalView.decisions}
+          onDecide={(decision, note) =>
+            submitPlanApproval(pendingPlanApprovalView.id, decision, note)
+          }
+          plan={pendingPlanApprovalView.text}
         />
       ) : null}
       {view === "chat" && showScrollToBottom ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -461,6 +461,7 @@ export async function approvePlan(
   token: string,
   sessionId: string,
   planItemId: string,
+  decision: "accept" | "acceptForSession" | "decline" | "cancel",
   text?: string,
 ): Promise<SessionRecord> {
   const response = await fetch(`${host}/api/sessions/${sessionId}/approve-plan`, {
@@ -469,7 +470,7 @@ export async function approvePlan(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ plan_item_id: planItemId, text }),
+    body: JSON.stringify({ plan_item_id: planItemId, decision, text }),
   });
   await ensureOk(response, "failed to approve plan");
   const body = await response.json();

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -187,14 +187,107 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-export function planTextForEvent(event: EventRecord): string {
-  if (event.metadata.item_type !== "plan") {
-    return "";
+export type PlanDecision = "accept" | "acceptForSession" | "decline" | "cancel";
+
+export const PLAN_DECISIONS: ReadonlyArray<PlanDecision> = [
+  "accept",
+  "acceptForSession",
+  "decline",
+  "cancel",
+];
+
+export interface PlanViewModel {
+  id: string;
+  text: string;
+  source: "codex" | "claude_code";
+  decisions: ReadonlyArray<PlanDecision>;
+}
+
+function readDecisions(value: unknown): ReadonlyArray<PlanDecision> {
+  if (!Array.isArray(value)) {
+    return PLAN_DECISIONS;
   }
-  const payload = asRecord(event.metadata.payload);
-  const item = asRecord(payload?.item);
-  const text = item?.text;
-  return typeof text === "string" ? text.trim() : "";
+  const allowed = new Set<PlanDecision>(PLAN_DECISIONS);
+  const seen: PlanDecision[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string" && allowed.has(entry as PlanDecision)) {
+      seen.push(entry as PlanDecision);
+    }
+  }
+  return seen.length > 0 ? seen : PLAN_DECISIONS;
+}
+
+/**
+ * Resolve a Codex plan event or Claude ExitPlanMode approval request to a
+ * shared plan approval view model. Returns ``null`` when the event does
+ * not represent a plan.
+ */
+export function planForEvent(event: EventRecord): PlanViewModel | null {
+  const metadata = event.metadata ?? {};
+  const planEnvelope = asRecord(metadata.plan);
+  if (planEnvelope) {
+    const text = typeof planEnvelope.text === "string" ? planEnvelope.text.trim() : "";
+    const id =
+      typeof planEnvelope.id === "string" && planEnvelope.id
+        ? planEnvelope.id
+        : (typeof metadata.item_id === "string" && metadata.item_id
+            ? metadata.item_id
+            : null);
+    if (text && id) {
+      const sourceRaw = planEnvelope.source;
+      const source: PlanViewModel["source"] =
+        sourceRaw === "claude_code" ? "claude_code" : "codex";
+      return {
+        id,
+        text,
+        source,
+        decisions: readDecisions(planEnvelope.decisions),
+      };
+    }
+  }
+
+  if (metadata.item_type === "plan") {
+    const payload = asRecord(metadata.payload);
+    const item = asRecord(payload?.item);
+    const text = typeof item?.text === "string" ? item.text.trim() : "";
+    const id =
+      typeof metadata.item_id === "string" && metadata.item_id
+        ? metadata.item_id
+        : (typeof item?.id === "string" && item.id ? (item.id as string) : null);
+    if (text && id) {
+      return { id, text, source: "codex", decisions: PLAN_DECISIONS };
+    }
+  }
+
+  if (event.kind === "approval_request") {
+    const toolName = typeof metadata.tool_name === "string" ? metadata.tool_name : null;
+    if (toolName === "ExitPlanMode") {
+      const toolInput = asRecord(metadata.tool_input);
+      const text = typeof toolInput?.plan === "string" ? toolInput.plan.trim() : "";
+      const approvalId =
+        typeof metadata.approval_id === "string" && metadata.approval_id
+          ? metadata.approval_id
+          : null;
+      if (text && approvalId) {
+        return {
+          id: approvalId,
+          text,
+          source: "claude_code",
+          decisions: PLAN_DECISIONS,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+export function planTextForEvent(event: EventRecord): string {
+  const plan = planForEvent(event);
+  // Approval-request plans (Claude's ExitPlanMode) live in the
+  // approval pipeline; transcript helpers that consume this only
+  // care about backend-emitted plan items.
+  return plan && event.kind !== "approval_request" ? plan.text : "";
 }
 
 export function isPlanEvent(event: EventRecord): boolean {


### PR DESCRIPTION
## Summary

Fixes Codex plan-mode approval parity with Claude Code. Codex plans now expose the same approval actions in the frontend, route the selected decision through the backend, and keep Codex collaboration-mode instructions synchronized when entering or leaving plan mode.

The branch also hardens stale-plan handling so only the latest undecided Codex plan can be acted on, and declined/cancelled plans stop rendering as actionable cards until Codex emits a newer plan.

## Changes

### Backend
- Added `decision` handling to Codex plan approval requests for `accept`, `acceptForSession`, `decline`, and `cancel`.
- Kept `accept` / `acceptForSession` on the existing approve-and-exit path, restoring the saved pre-plan permission mode.
- Added decline/cancel handling that keeps the session in plan mode and sends Codex a rejection prompt with any user note.
- Added normalized Codex plan metadata and backend validation so stale or already-decided plan ids are rejected.
- Render Codex collaboration-mode developer instructions per turn, with non-empty fallback instructions when vendored templates are unavailable.

### Frontend
- Added a shared plan view model that normalizes Codex plan events and Claude ExitPlanMode approval data.
- Updated Codex plan approval cards to render Approve, Approve for session, Decline, and Cancel.
- Suppressed decided Codex plan cards so the same declined/cancelled plan cannot be repeatedly acted on.

## Test Plan

- [x] `cd backend && rtk uv run pytest tests/test_runtime.py -k "approve_codex_plan or codex_mode_developer_instructions or plan_mode or codex_plan"`
- [x] `cd backend && rtk uv run pytest tests/test_backend_registry.py`
- [x] `cd frontend && rtk npm run build`
