### PR TITLE
fix: clear stale Claude approval cards on mode change

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -813,6 +813,12 @@ class ClaudeCliAdapter:
         state = self._sessions.get(session_id)
         return bool(state and state.pending)
 
+    def pending_approval_ids(self, session_id: str) -> tuple[str, ...]:
+        state = self._sessions.get(session_id)
+        if state is None:
+            return ()
+        return tuple(state.pending.keys())
+
     def session_permission_mode(self, session_id: str) -> str | None:
         """Read the binary's currently-active permission mode for a session.
 

--- a/backend/src/waypoint/backends/claude_code/permission_modes.py
+++ b/backend/src/waypoint/backends/claude_code/permission_modes.py
@@ -31,3 +31,11 @@ CLAUDE_AUTO_APPROVE_MODES = frozenset({"auto", "bypassPermissions", "dontAsk"})
 
 # Tools acceptEdits auto-approves; everything else still surfaces the card.
 CLAUDE_ACCEPT_EDITS_TOOLS = frozenset({"Edit", "Write", "MultiEdit", "NotebookEdit"})
+
+CLAUDE_PERMISSION_MODE_LABELS = {
+    spec.id: spec.label for spec in CLAUDE_PERMISSION_MODE_SPECS
+}
+
+
+def claude_permission_mode_label(mode: str) -> str:
+    return CLAUDE_PERMISSION_MODE_LABELS.get(mode, mode)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -31,6 +31,7 @@ from waypoint.backends.claude_code.models import (
 from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_PERMISSION_MODE_SPECS,
     CLAUDE_PERMISSION_MODES,
+    claude_permission_mode_label,
 )
 from waypoint.backends.claude_code.remote import build_remote_claude_launch_factory
 from waypoint.backends.claude_code.runtime_hook import (
@@ -304,12 +305,37 @@ class ClaudeCodePlugin:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="claude adapter is not configured on this backend",
             )
+        before_pending = self.adapter.pending_approval_ids(session.id)
         try:
             await self.adapter.set_permission_mode(session.id, mode)
         except Exception as exc:  # noqa: BLE001 — surface adapter errors as 400
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
+        after_pending = set(self.adapter.pending_approval_ids(session.id))
+        cleared_pending = [
+            approval_id
+            for approval_id in before_pending
+            if approval_id not in after_pending
+        ]
+        if not cleared_pending:
+            return
+        next_status = (
+            SessionStatus.WAITING_INPUT if after_pending else SessionStatus.RUNNING
+        )
+        runtime.storage.update_session(session.id, status=next_status)
+        mode_label = claude_permission_mode_label(mode)
+        for approval_id in cleared_pending:
+            await runtime._record_system_event(
+                session.id,
+                f"Pending approval cleared by permission mode change to {mode_label}",
+                status=next_status,
+                metadata={
+                    "method": "approval.invalidated",
+                    "approval_id": approval_id,
+                    "permission_mode": mode,
+                },
+            )
 
     async def apply_model(
         self,

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 
 import pytest
 
+from waypoint.backends.claude_code.permission_modes import CLAUDE_AUTO_APPROVE_MODES
 from waypoint.backends.claude_code.schemas import ClaudeThreadImportRequest
 from waypoint.backends.claude_code.threads import ClaudeThreadInfo
 from waypoint.backends.codex.permission_modes import (
@@ -98,6 +99,7 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         self.models: dict[str, str | None] = {}
         self.efforts: dict[str, str | None] = {}
         self.slash_commands: dict[str, tuple[str, ...]] = {}
+        self.pending_ids: list[str] = []
 
     async def terminate_session(self, session_id: str) -> bool:
         self.terminate_calls.append(session_id)
@@ -161,6 +163,8 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
     async def set_permission_mode(self, session_id: str, mode: str) -> None:
         self.permission_mode_calls.append((session_id, mode))
         self.modes[session_id] = mode
+        if mode in CLAUDE_AUTO_APPROVE_MODES:
+            self.pending_ids.clear()
 
     async def set_model(self, session_id: str, model: str | None) -> None:
         self.model_calls.append((session_id, model))
@@ -181,6 +185,9 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
 
     def session_slash_commands(self, session_id: str) -> tuple[str, ...]:
         return self.slash_commands.get(session_id, ())
+
+    def pending_approval_ids(self, session_id: str) -> tuple[str, ...]:
+        return tuple(self.pending_ids)
 
 
 class FakeCodexRuntimeAdapter(FakeStructuredAdapter):
@@ -2326,6 +2333,39 @@ async def test_set_permission_mode_claude_calls_adapter(tmp_path) -> None:
 
     assert fake.permission_mode_calls == [("claude-sess", "plan")]
     assert updated.permission_mode == "plan"
+
+
+@pytest.mark.asyncio
+async def test_set_permission_mode_claude_emits_invalidation_note(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeClaudeAdapter()
+    fake.pending_ids = ["approval-1"]
+    _claude_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        id="claude-sess",
+        backend="claude_code",
+        transport="claude_cli",
+        status=SessionStatus.WAITING_INPUT,
+    )
+    storage.create_session(session)
+
+    updated = await runtime.set_permission_mode("claude-sess", "auto")
+
+    refreshed = storage.get_session("claude-sess")
+    assert refreshed is not None
+    assert updated.permission_mode == "auto"
+    assert refreshed.status == SessionStatus.RUNNING
+
+    notes = [
+        event
+        for event in storage.list_events("claude-sess")
+        if event.kind == EventKind.SYSTEM_NOTE
+        and event.metadata.get("method") == "approval.invalidated"
+    ]
+    assert len(notes) == 1
+    assert notes[0].metadata.get("approval_id") == "approval-1"
+    assert "permission mode change to Auto" in notes[0].text
 
 
 @pytest.mark.asyncio

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2460,10 +2460,7 @@ function findPendingApprovals(events: EventRecord[]): EventRecord[] {
   for (const event of events) {
     if (event.kind === "approval_request") {
       queue.push(event);
-    } else if (
-      event.kind === "system_note" &&
-      /(Approval response sent|Approval timed out)/i.test(event.text)
-    ) {
+    } else if (event.kind === "system_note" && isApprovalResolutionEvent(event)) {
       const approvalId = event.metadata?.approval_id;
       if (typeof approvalId === "string") {
         const index = queue.findIndex((e) => e.metadata?.approval_id === approvalId);
@@ -2476,6 +2473,13 @@ function findPendingApprovals(events: EventRecord[]): EventRecord[] {
   return queue;
 }
 
+function isApprovalResolutionEvent(event: EventRecord): boolean {
+  if (event.metadata?.method === "approval.invalidated") {
+    return true;
+  }
+  return /(Approval response sent|Approval timed out)/i.test(event.text);
+}
+
 function isImportantEvent(event: EventRecord): boolean {
   switch (event.kind) {
     case "user_input":
@@ -2486,6 +2490,9 @@ function isImportantEvent(event: EventRecord): boolean {
       return true;
     case "system_note":
     case "status_update":
+      if (event.metadata?.method === "approval.invalidated") {
+        return true;
+      }
       if (isPlanEvent(event)) {
         return true;
       }


### PR DESCRIPTION
## Summary

Claude approval requests could remain visible after switching the session permission mode to an auto-approve mode because the frontend only knew how to clear cards when it saw an explicit approval response. This PR adds a backend-owned approval invalidation event for Claude and teaches the frontend queue to consume it.

## Changes

### Backend
- Added live pending approval introspection to the Claude adapter.
- When a Claude permission-mode change clears pending approvals, emit a `system_note` with `metadata.method = "approval.invalidated"` and `approval_id`.
- Keep session state aligned with the cleared queue and add regression coverage.

### Frontend
- Treat `approval.invalidated` as a normal approval resolution event.
- Mark the invalidation note as important so it appears in the transcript feed.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_runtime.py -k "set_permission_mode_claude or approve_keeps_waiting_input_until_queue_drains"`
- [x] `cd frontend && npm run lint`