### PR TITLE
docs: refresh README compatibility notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Waypoint speaks to Claude Code, Codex, and OpenCode through wire formats that ch
 
 | Agent       | Tested versions   | Wire entry point                                                     | Notes                                                                                       |
 | ----------- | ----------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Claude Code | `2.1.136`         | `claude -p --input-format=stream-json --output-format=stream-json`   | Relies on `--include-hook-events`, the `system/status`/`compact_boundary` events, and `--session-id`/`--resume`. |
-| Codex CLI   | `0.129.0`         | `codex app-server --listen stdio://`                                 | Driven via the vendored Python SDK in `3rdparty/codex/sdk/python` (`thread_*` / `turn_*` RPCs). |
+| Claude Code | `2.1.123`-`2.1.136` | `claude -p --input-format=stream-json --output-format=stream-json`   | Relies on `--include-hook-events`, the `system/status`/`compact_boundary` events, and `--session-id`/`--resume`. |
+| Codex CLI   | `0.125.0`-`0.129.0` | `codex app-server --listen stdio://`                                 | Driven via the vendored Python SDK in `3rdparty/codex/sdk/python` (`thread_*` / `turn_*` RPCs). |
 | Codex SDK   | `0.116.0a1`       | `3rdparty/codex/` submodule pin                                      | Bumped together with Codex CLI; track via `git submodule update --remote 3rdparty/codex`.   |
 | OpenCode   | `1.14.30`        | `opencode serve` with REST + SSE API                             | HTTP-based; discovers models from `/provider`. |
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Waypoint
 
-Waypoint is a personal remote-control companion for Claude Code and Codex sessions running on your Mac. It provides a private, phone-first interface over Tailscale with:
+Waypoint is a personal remote-control companion for Claude Code, Codex, and OpenCode sessions running on your Mac. It provides a private, phone-first interface over Tailscale with:
 
 - a unified session list
 - chat-style transcript rendering
@@ -10,15 +10,13 @@ Waypoint is a personal remote-control companion for Claude Code and Codex sessio
 
 ## Issue Tracking
 
-GitHub Issues are the source of truth for active bugs and feature requests.
+GitHub Issues are the source of truth for active bugs and feature requests. Create leaf issues directly; tracking issues are no longer used.
 
 Use this convention when opening issues:
 
 - one leaf issue per actionable bug or feature request
-- lowercase title prefixes: `bug: ...`, `feature request: ...`, `tracking issue: ...`
+- lowercase title prefixes: `bug: ...` and `feature request: ...`
 - label bug reports with `bug` and feature requests with `enhancement`
-- one thin tracking issue per area when you want a checklist view that links the leaf issues
-- pinned tracking issues: [`tracking issue: open bugs`](https://github.com/kaiitunnz/waypoint/issues/4) and [`tracking issue: open feature requests`](https://github.com/kaiitunnz/waypoint/issues/5)
 
 ## Layout
 
@@ -29,12 +27,12 @@ Use this convention when opening issues:
 
 ## Supported agent versions
 
-Waypoint speaks to Claude Code and Codex through wire formats that change between releases (stream-json envelopes, codex app-server RPCs, hook-event shapes). Bumps outside the tested range are likely to work but are not guaranteed.
+Waypoint speaks to Claude Code, Codex, and OpenCode through wire formats that change between releases (stream-json envelopes, codex app-server RPCs, hook-event shapes, REST/SSE event streams). Bumps outside the tested range are likely to work but are not guaranteed.
 
 | Agent       | Tested versions   | Wire entry point                                                     | Notes                                                                                       |
 | ----------- | ----------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Claude Code | `2.1.123`         | `claude -p --input-format=stream-json --output-format=stream-json`   | Relies on `--include-hook-events`, the `system/status`/`compact_boundary` events, and `--session-id`/`--resume`. |
-| Codex CLI   | `0.125.0`         | `codex app-server --listen stdio://`                                 | Driven via the vendored Python SDK in `3rdparty/codex/sdk/python` (`thread_*` / `turn_*` RPCs). |
+| Claude Code | `2.1.136`         | `claude -p --input-format=stream-json --output-format=stream-json`   | Relies on `--include-hook-events`, the `system/status`/`compact_boundary` events, and `--session-id`/`--resume`. |
+| Codex CLI   | `0.129.0`         | `codex app-server --listen stdio://`                                 | Driven via the vendored Python SDK in `3rdparty/codex/sdk/python` (`thread_*` / `turn_*` RPCs). |
 | Codex SDK   | `0.116.0a1`       | `3rdparty/codex/` submodule pin                                      | Bumped together with Codex CLI; track via `git submodule update --remote 3rdparty/codex`.   |
 | OpenCode   | `1.14.30`        | `opencode serve` with REST + SSE API                             | HTTP-based; discovers models from `/provider`. |
 
@@ -44,6 +42,7 @@ To extend this matrix:
 2. Re-run the integration paths that touch the wire format:
    - Claude: `backend/src/waypoint/backends/claude_code/normalize.py` (status / compact / rate-limit / approval / content-block helpers) and `adapter.py`'s `_handle_*` stream handlers; hook bootstrap in `backends/claude_code/runtime_hook.py` + `server_config.py::_build_remote_claude_command`.
    - Codex: `backend/src/waypoint/backends/codex/normalize.py::map_notification` and the SDK calls in `backends/codex/adapter.py::CodexAppServerAdapter`.
+   - OpenCode: `backend/src/waypoint/backends/opencode/normalize.py::map_event` and the HTTP/SSE adapter in `backends/opencode/adapter.py::OpenCodeAdapter`.
 3. If a bump breaks an event shape, prefer adding a branch in the relevant `normalize.py` over hard-pinning — the goal is for the matrix to grow, not to fork on version.
 
 Adding a brand-new coding agent (Aider, …) is its own flow — the runtime, API, and frontend dispatch by plugin id, so a new backend is "implement [`BackendPlugin`](backend/src/waypoint/backends/base.py) and register it." See [`docs/coding_agent_plugins.md`](docs/coding_agent_plugins.md) for the contract, capability descriptor, and a step-by-step recipe.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ Waypoint is a personal remote-control companion for Claude Code, Codex, and Open
 
 Waypoint runs on macOS and Linux, and should also work under WSL when the local tooling and network access are available. Some convenience scripts are still OS-specific, for example the backend LaunchAgent helper is macOS-only.
 
-## Issue Tracking
+## Issues
 
-GitHub Issues are the source of truth for active bugs and feature requests. Create leaf issues directly; tracking issues are no longer used.
-
-Use this convention when opening issues:
+Use GitHub Issues directly for active bugs and feature requests.
 
 - one leaf issue per actionable bug or feature request
 - lowercase title prefixes: `bug: ...` and `feat: ...`
@@ -45,7 +43,7 @@ To extend this matrix:
    - Claude: `backend/src/waypoint/backends/claude_code/normalize.py` (status / compact / rate-limit / approval / content-block helpers) and `adapter.py`'s `_handle_*` stream handlers; hook bootstrap in `backends/claude_code/runtime_hook.py` + `server_config.py::_build_remote_claude_command`.
    - Codex: `backend/src/waypoint/backends/codex/normalize.py::map_notification` and the SDK calls in `backends/codex/adapter.py::CodexAppServerAdapter`.
    - OpenCode: `backend/src/waypoint/backends/opencode/normalize.py::map_event` and the HTTP/SSE adapter in `backends/opencode/adapter.py::OpenCodeAdapter`.
-3. If a bump breaks an event shape, prefer adding a branch in the relevant `normalize.py` over hard-pinning — the goal is for the matrix to grow, not to fork on version.
+3. If a bump breaks an event shape, prefer adding a branch in the relevant `normalize.py` over hard-pinning.
 
 Adding a brand-new coding agent (Aider, …) is its own flow — the runtime, API, and frontend dispatch by plugin id, so a new backend is "implement [`BackendPlugin`](backend/src/waypoint/backends/base.py) and register it." See [`docs/coding_agent_plugins.md`](docs/coding_agent_plugins.md) for the contract, capability descriptor, and a step-by-step recipe.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ GitHub Issues are the source of truth for active bugs and feature requests. Crea
 Use this convention when opening issues:
 
 - one leaf issue per actionable bug or feature request
-- lowercase title prefixes: `bug: ...` and `feature request: ...`
+- lowercase title prefixes: `bug: ...` and `feat: ...`
 - label bug reports with `bug` and feature requests with `enhancement`
 
 ## Layout

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Waypoint
 
-Waypoint is a personal remote-control companion for Claude Code, Codex, and OpenCode sessions running on your Mac. It provides a private, phone-first interface over Tailscale with:
+Waypoint is a personal remote-control companion for Claude Code, Codex, and OpenCode sessions running on your machine. It provides a private, phone-first interface over Tailscale with:
 
 - a unified session list
 - chat-style transcript rendering
 - raw terminal fallback
 - managed launches for new sessions
 - tmux attachment for existing sessions
+
+Waypoint runs on macOS and Linux, and should also work under WSL when the local tooling and network access are available. Some convenience scripts are still OS-specific, for example the backend LaunchAgent helper is macOS-only.
 
 ## Issue Tracking
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,13 +31,13 @@ Prefer the YAML file for structured settings and grouped config such as named SS
 
 Waypoint can expose named SSH coding targets alongside its local launch path. The frontend backend picker keeps host URLs and SSH targets at the same level; choosing an SSH target only changes how new managed sessions launch on the currently selected Waypoint host.
 
-The current config shape supports zero or more `ssh_targets` entries with:
+A config may define zero or more `ssh_targets` entries with:
 
 - `default_backend` and `default_cwd`, which seed the frontend launch form
 - top-level backend defaults such as `host`, `port`, `password`, and `data_dir`
 - `id` and `name` for picker/UI identity
 - `ssh_destination` and optional `ssh_args`
-- `plugin_configs`, a plugin-id → per-target plugin config mapping. Presence of a key means "this target supports the plugin"; omitting `plugin_configs` entirely defaults to every registered non-fallback plugin (today: `codex`, `claude_code`, and `opencode`). Each block is validated against the plugin's `launch_target_schema` — common fields include `remote_bin` (path to the CLI on the remote host; falls back to the plugin's `cli_binary`), and codex adds `config_overrides` for the `--config K=V` flag.
+- `plugin_configs`, a plugin-id → per-target plugin config mapping. Presence of a key means "this target supports the plugin"; omitting `plugin_configs` entirely defaults to every registered non-fallback plugin (`codex`, `claude_code`, and `opencode`). Each block is validated against the plugin's `launch_target_schema` — common fields include `remote_bin` (path to the CLI on the remote host; falls back to the plugin's `cli_binary`), and codex adds `config_overrides` for the `--config K=V` flag.
 - `default_cwd`, which seeds the remote working-directory field and defaults to `~`
 - `remote_env` for secrets such as `OPENAI_API_KEY`
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -37,11 +37,11 @@ The current config shape supports zero or more `ssh_targets` entries with:
 - top-level backend defaults such as `host`, `port`, `password`, and `data_dir`
 - `id` and `name` for picker/UI identity
 - `ssh_destination` and optional `ssh_args`
-- `plugin_configs`, a plugin-id → per-target plugin config mapping. Presence of a key means "this target supports the plugin"; omitting `plugin_configs` entirely defaults to every registered non-fallback plugin (today: `codex` + `claude_code`). Each block is validated against the plugin's `launch_target_schema` — common fields include `remote_bin` (path to the CLI on the remote host; falls back to the plugin's `cli_binary`), and codex adds `config_overrides` for the `--config K=V` flag.
+- `plugin_configs`, a plugin-id → per-target plugin config mapping. Presence of a key means "this target supports the plugin"; omitting `plugin_configs` entirely defaults to every registered non-fallback plugin (today: `codex`, `claude_code`, and `opencode`). Each block is validated against the plugin's `launch_target_schema` — common fields include `remote_bin` (path to the CLI on the remote host; falls back to the plugin's `cli_binary`), and codex adds `config_overrides` for the `--config K=V` flag.
 - `default_cwd`, which seeds the remote working-directory field and defaults to `~`
 - `remote_env` for secrets such as `OPENAI_API_KEY`
 
-Managed launches use a single `cwd` value for both UI display and the actual remote working directory. When an SSH target is selected, the frontend seeds that field from the target's `default_cwd`. Remote `codex` launches use the Codex app-server over SSH, while remote `claude_code` launches use tmux plus an SSH-wrapped `claude` command.
+Managed launches use a single `cwd` value for both UI display and the actual remote working directory. When an SSH target is selected, the frontend seeds that field from the target's `default_cwd`. Remote `codex` launches use the Codex app-server over SSH, remote `claude_code` launches use tmux plus an SSH-wrapped `claude` command, and remote `opencode` launches use `opencode serve` over SSH.
 
 ## Remote Claude thread import
 


### PR DESCRIPTION
## Summary

Keep the README files aligned with the current issue workflow, supported agent version ranges, and cross-platform runtime guidance.

## Changes

### Root README
- Use `feat:` for feature issues and `bug:` for bug issues.
- Describe the current Claude Code, Codex, and OpenCode compatibility matrix.
- Document macOS, Linux, and WSL runtime support with macOS-only helper notes called out separately.
- Show the tested Claude Code and Codex CLI version ranges.

### Backend README
- Describe SSH launch targets in terms of the currently supported plugin set.
- Document remote OpenCode launches over SSH.

## Test Plan

- [x] `rtk git diff --check`
