### PR TITLE
fix: route Codex auto_review approvals to the guardian

### DIFF
--- a/backend/src/waypoint/backends/codex/permission_modes.py
+++ b/backend/src/waypoint/backends/codex/permission_modes.py
@@ -103,21 +103,28 @@ def codex_mode_developer_instructions(mode: str) -> str:
     )
 
 
+# Keys mirror Codex's v2 `TurnStartParams` wire format
+# (`#[serde(rename_all = "camelCase")]` in
+# `app-server-protocol/src/protocol/v2.rs`). Codex's app-server silently
+# ignores unknown fields, so snake_case overrides here are dropped on the
+# wire and the thread keeps its initial defaults — making `auto_review`
+# regress to user-routed approvals whenever the local sandbox forces an
+# escalation.
 CODEX_PERMISSION_PRESETS: dict[str, dict[str, Any]] = {
     "default": {
-        "approval_policy": "on-request",
-        "sandbox_policy": {"type": "workspaceWrite"},
-        "approvals_reviewer": "user",
+        "approvalPolicy": "on-request",
+        "sandboxPolicy": {"type": "workspaceWrite"},
+        "approvalsReviewer": "user",
     },
     "auto_review": {
-        "approval_policy": "on-request",
-        "sandbox_policy": {"type": "workspaceWrite"},
-        "approvals_reviewer": "guardian_subagent",
+        "approvalPolicy": "on-request",
+        "sandboxPolicy": {"type": "workspaceWrite"},
+        "approvalsReviewer": "guardian_subagent",
     },
     "full_access": {
-        "approval_policy": "never",
-        "sandbox_policy": {"type": "dangerFullAccess"},
-        "approvals_reviewer": "user",
+        "approvalPolicy": "never",
+        "sandboxPolicy": {"type": "dangerFullAccess"},
+        "approvalsReviewer": "user",
     },
 }
 

--- a/backend/tests/test_codex_permission_modes.py
+++ b/backend/tests/test_codex_permission_modes.py
@@ -1,0 +1,68 @@
+"""Regression tests for Codex turn-param wire format.
+
+Codex's app-server deserializes ``TurnStartParams`` with
+``rename_all = "camelCase"`` and silently drops unknown fields, so
+emitting snake_case keys here would route ``auto_review`` approvals to
+the user instead of the guardian subagent — observable only when the
+local sandbox forces an escalation.
+"""
+
+from waypoint.backends.codex.permission_modes import (
+    CODEX_PERMISSION_PRESETS,
+    codex_turn_params_for,
+)
+
+# Top-level keys the v2 TurnStartParams wire format accepts. Mirrors
+# the JSON schema in
+# ``3rdparty/codex/codex-rs/app-server-protocol/schema/json/v2/TurnStartParams.json``.
+_V2_TURN_START_KEYS = frozenset(
+    {
+        "approvalPolicy",
+        "approvalsReviewer",
+        "collaborationMode",
+        "cwd",
+        "effort",
+        "input",
+        "model",
+        "outputSchema",
+        "permissionProfile",
+        "personality",
+        "sandboxPolicy",
+        "serviceTier",
+        "summary",
+        "threadId",
+    }
+)
+
+
+def test_presets_use_v2_camel_case_wire_keys() -> None:
+    for mode, preset in CODEX_PERMISSION_PRESETS.items():
+        assert preset.keys() <= _V2_TURN_START_KEYS, (
+            f"preset {mode!r} has non-wire keys: "
+            f"{sorted(set(preset) - _V2_TURN_START_KEYS)}"
+        )
+
+
+def test_turn_params_emit_v2_camel_case_wire_keys() -> None:
+    for mode in CODEX_PERMISSION_PRESETS:
+        params = codex_turn_params_for(mode, model="gpt-5", effort="high")
+        assert params is not None
+        assert params.keys() <= _V2_TURN_START_KEYS, (
+            f"mode {mode!r} emitted non-wire keys: "
+            f"{sorted(set(params) - _V2_TURN_START_KEYS)}"
+        )
+
+
+def test_auto_review_routes_to_guardian_subagent() -> None:
+    params = codex_turn_params_for("auto_review", model="gpt-5", effort="high")
+    assert params is not None
+    assert params["approvalsReviewer"] == "guardian_subagent"
+    assert params["approvalPolicy"] == "on-request"
+    assert params["sandboxPolicy"] == {"type": "workspaceWrite"}
+
+
+def test_full_access_disables_approvals_and_sandbox() -> None:
+    params = codex_turn_params_for("full_access", model="gpt-5", effort="high")
+    assert params is not None
+    assert params["approvalPolicy"] == "never"
+    assert params["sandboxPolicy"] == {"type": "dangerFullAccess"}


### PR DESCRIPTION
## Summary

Codex's `auto_review` permission mode was silently regressing to user-routed approvals whenever the local sandbox forced an escalation — observed against a Linux host whose sandbox initialization was failing, where every command ended up as a manual approval prompt despite the session being in Auto review.

## Root Cause

`codex_turn_params_for` returned a plain `dict` whose keys were snake_case (`approval_policy`, `approvals_reviewer`, `sandbox_policy`). Codex's app-server `TurnStartParams` is `#[serde(rename_all = "camelCase")]` without `deny_unknown_fields`, so unknown fields are dropped without error. The Python SDK's `_params_dict` only re-aliases when given a Pydantic model — raw dicts pass straight through. The thread therefore retained its initial `ApprovalsReviewer::User` default and routed every escalation to the user.

The bug was latent on hosts with a healthy sandbox (macOS Seatbelt, working Linux landlock) because `approval_policy: on-request` rarely triggers an escalation when sandboxed execution succeeds.

## Changes

### Backend
- Renamed `CODEX_PERMISSION_PRESETS` keys to `approvalPolicy` / `approvalsReviewer` / `sandboxPolicy` to match the v2 wire format, with a comment pointing at the silent-drop hazard. Same fix applies to `default` and `full_access` (their overrides were also being dropped).
- Added `tests/test_codex_permission_modes.py` asserting that all presets and `codex_turn_params_for` output use only keys present in the v2 `TurnStartParams` schema, plus value checks for `auto_review` and `full_access`.

## Test Plan

- [x] `cd backend && uv run pytest` — 337 passing
- [x] `cd backend && uv run pre-commit run --files src/waypoint/backends/codex/permission_modes.py tests/test_codex_permission_modes.py` — black / isort / ruff / codespell / mypy clean
- [x] Manual: on a Linux host with a broken sandbox, start a Codex session in Auto review mode and verify commands no longer surface as manual approval prompts.