### PR TITLE
fix: kill orphaned frontend descendants on stop

### DIFF
--- a/scripts/waypoint.sh
+++ b/scripts/waypoint.sh
@@ -371,6 +371,7 @@ wait_for_exit() {
 # Recursively print descendant PIDs of ${1}, deepest first.
 collect_descendants() {
   local parent="$1"
+  [[ "${parent}" =~ ^[0-9]+$ ]] || return 0
   local children child
   children=$(pgrep -P "${parent}" 2>/dev/null) || true
   for child in ${children}; do
@@ -379,43 +380,60 @@ collect_descendants() {
   done
 }
 
-# Stop a process and every descendant. We track only the npm/uv leader
-# in pid files, but `npm run start` forks `sh -c 'next start'` which
-# forks `node next-server`; on Linux the leader's signal forwarder
-# doesn't always propagate before its own death, so the next-server
-# grandchild gets reparented to PID 1 and keeps the port. Walking the
-# tree avoids relying on npm's forwarding behavior.
+# Stop a process and every descendant captured at snapshot time. We
+# track only the npm/uv leader in pid files, but `npm run start`
+# forks `sh -c 'next start'` which forks `node next-server`; on
+# Linux the leader's signal forwarder doesn't always propagate
+# before its own death, so the next-server grandchild gets reparented
+# to PID 1 and keeps the port. Signaling each process directly avoids
+# depending on the leader's forwarder.
+#
+# Limitations:
+#   * Snapshots descendants once. Children spawned after the snapshot
+#     (or that double-fork / setsid into a new session) are missed.
+#     For our process tree (npm/sh/node, uv/python — none fork
+#     dynamically post-boot) this is not observed in practice.
+#   * Numeric PID validation reduces but does not eliminate PID-reuse
+#     races between TERM and KILL.
 kill_process_tree() {
   local pid="$1"
-  local descendants
-  descendants=$(collect_descendants "${pid}")
+  [[ "${pid}" =~ ^[0-9]+$ ]] || return 0
 
-  # SIGTERM children first so the leader sees them gone via SIGCHLD
-  # and shuts down cleanly, then signal the leader itself.
-  if [[ -n "${descendants}" ]]; then
-    while IFS= read -r d; do
-      [[ -n "${d}" ]] && kill "${d}" >/dev/null 2>&1 || true
-    done <<<"${descendants}"
-  fi
-  kill "${pid}" >/dev/null 2>&1 || true
+  local pids p deadline any_alive
+  pids=$(
+    {
+      collect_descendants "${pid}"
+      printf '%s\n' "${pid}"
+    } | grep -E '^[0-9]+$' || true
+  )
+  [[ -n "${pids}" ]] || return 0
 
-  if wait_for_exit "${pid}"; then
-    if [[ -n "${descendants}" ]]; then
-      while IFS= read -r d; do
-        if [[ -n "${d}" ]] && is_pid_running "${d}"; then
-          kill -9 "${d}" >/dev/null 2>&1 || true
-        fi
-      done <<<"${descendants}"
+  for p in ${pids}; do
+    kill -- "${p}" >/dev/null 2>&1 || true
+  done
+
+  # Single shared deadline so a child mid-graceful-shutdown isn't
+  # SIGKILLed just because the leader exited fast.
+  deadline=$((SECONDS + 10))
+  while (( SECONDS < deadline )); do
+    any_alive=false
+    for p in ${pids}; do
+      if is_pid_running "${p}"; then
+        any_alive=true
+        break
+      fi
+    done
+    if [[ "${any_alive}" == false ]]; then
+      return 0
     fi
-    return 0
-  fi
+    sleep 1
+  done
 
-  if [[ -n "${descendants}" ]]; then
-    while IFS= read -r d; do
-      [[ -n "${d}" ]] && kill -9 "${d}" >/dev/null 2>&1 || true
-    done <<<"${descendants}"
-  fi
-  kill -9 "${pid}" >/dev/null 2>&1 || true
+  for p in ${pids}; do
+    if is_pid_running "${p}"; then
+      kill -9 -- "${p}" >/dev/null 2>&1 || true
+    fi
+  done
 }
 
 # macOS-only sleep inhibitor. We hold a `caffeinate -i -s` process for

--- a/scripts/waypoint.sh
+++ b/scripts/waypoint.sh
@@ -368,6 +368,56 @@ wait_for_exit() {
   ! is_pid_running "${pid}"
 }
 
+# Recursively print descendant PIDs of ${1}, deepest first.
+collect_descendants() {
+  local parent="$1"
+  local children child
+  children=$(pgrep -P "${parent}" 2>/dev/null) || true
+  for child in ${children}; do
+    collect_descendants "${child}"
+    printf '%s\n' "${child}"
+  done
+}
+
+# Stop a process and every descendant. We track only the npm/uv leader
+# in pid files, but `npm run start` forks `sh -c 'next start'` which
+# forks `node next-server`; on Linux the leader's signal forwarder
+# doesn't always propagate before its own death, so the next-server
+# grandchild gets reparented to PID 1 and keeps the port. Walking the
+# tree avoids relying on npm's forwarding behavior.
+kill_process_tree() {
+  local pid="$1"
+  local descendants
+  descendants=$(collect_descendants "${pid}")
+
+  # SIGTERM children first so the leader sees them gone via SIGCHLD
+  # and shuts down cleanly, then signal the leader itself.
+  if [[ -n "${descendants}" ]]; then
+    while IFS= read -r d; do
+      [[ -n "${d}" ]] && kill "${d}" >/dev/null 2>&1 || true
+    done <<<"${descendants}"
+  fi
+  kill "${pid}" >/dev/null 2>&1 || true
+
+  if wait_for_exit "${pid}"; then
+    if [[ -n "${descendants}" ]]; then
+      while IFS= read -r d; do
+        if [[ -n "${d}" ]] && is_pid_running "${d}"; then
+          kill -9 "${d}" >/dev/null 2>&1 || true
+        fi
+      done <<<"${descendants}"
+    fi
+    return 0
+  fi
+
+  if [[ -n "${descendants}" ]]; then
+    while IFS= read -r d; do
+      [[ -n "${d}" ]] && kill -9 "${d}" >/dev/null 2>&1 || true
+    done <<<"${descendants}"
+  fi
+  kill -9 "${pid}" >/dev/null 2>&1 || true
+}
+
 # macOS-only sleep inhibitor. We hold a `caffeinate -i -s` process for
 # the lifetime of the stack so scheduled sessions and phone clients
 # don't lose the host on idle/system sleep. `-d`/`-m` are intentionally
@@ -436,10 +486,7 @@ stop_service() {
   fi
 
   echo "stopping ${service} (pid ${pid})"
-  kill "${pid}" >/dev/null 2>&1 || true
-  if ! wait_for_exit "${pid}"; then
-    kill -9 "${pid}" >/dev/null 2>&1 || true
-  fi
+  kill_process_tree "${pid}"
 
   rm -f "$(pid_file_for "${service}")"
 }
@@ -523,6 +570,7 @@ start_stack() {
   require_command "curl"
   require_command "lsof"
   require_command "npm"
+  require_command "pgrep"
   require_command "uv"
 
   ensure_state_dirs


### PR DESCRIPTION
## Summary

Addresses #56.

`scripts/waypoint.sh stop` was leaving an orphaned `next-server` process behind on Linux, blocking the frontend port and breaking subsequent `start`. The bug was reported on Ubuntu and was hard to repro on macOS due to timing differences in npm's signal forwarder under `nohup`.

## Root Cause

`start_frontend` runs `nohup env PORT=… npm run start &` and stores `$!`, which is the npm leader. `npm run start` execs `sh -c 'next start'`, which forks `node …/next-server`. We then track only the npm PID. `stop_service` did `kill ${pid}` → wait → `kill -9 ${pid}` against that PID, relying on npm forwarding signals to its descendants.

Under `nohup` on Linux, that forwarder is racy: when the npm parent gets `SIGKILL` before the forward fires, the `next-server` grandchild is reparented to PID 1 and keeps the listening socket on `${FRONTEND_PORT}`. Subsequent `start` then trips the `port_in_use` guard and aborts. macOS rarely loses the race in practice, which is why it didn't repro locally.

## Changes

- Added `collect_descendants` (recursive `pgrep -P`) and `kill_process_tree` helpers in `scripts/waypoint.sh`. `stop_service` now signals every process in the captured tree directly so termination no longer depends on npm's signal forwarder.
- Snapshot once, then `SIGTERM` every PID, then wait for all of them under one shared 10s deadline before escalating to `SIGKILL`. Children mid-graceful-shutdown (e.g. Next's HTTP-drain on `SIGTERM`) get their full grace window even if the leader exits fast.
- Validate PIDs as numeric and pass `--` to `kill` as defense against malformed pid files. PID-reuse remains a small unavoidable race, documented in the helper comment.
- Added `pgrep` to `start_stack`'s required commands so a missing binary fails loudly instead of silently degrading.

## Test Plan

- [x] `bash -n scripts/waypoint.sh`
- [x] Manual: synthetic process tree where the leader ignores `SIGTERM` — `kill_process_tree` escalates and reaps the entire tree.
- [x] Manual: synthetic process tree where the leader exits fast and a child has a 3s graceful `SIGTERM` handler — the child runs to completion before the function returns; no premature `SIGKILL`.
- [ ] Manual on Linux: `./scripts/waypoint.sh start && ./scripts/waypoint.sh stop`, then `pgrep -af next-server` should return nothing and `lsof -iTCP:${WAYPOINT_STACK_FRONTEND_PORT:-3000}` should be clean.