### PR TITLE
feat: add live context usage popover

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -7,12 +7,18 @@ import os
 import shutil
 import uuid
 from collections import deque
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from waypoint.backends.claude_code.models import (
+    claude_context_window_for_model,
+    claude_model_family,
+    normalize_claude_model_id,
+)
 from waypoint.backends.claude_code.normalize import (
     format_approval_text,
     format_compact_boundary,
@@ -29,7 +35,7 @@ from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_AUTO_APPROVE_MODES,
     CLAUDE_PERMISSION_MODES,
 )
-from waypoint.schemas import EventKind, SessionStatus
+from waypoint.schemas import EventKind, SessionContextUsage, SessionStatus
 
 log = logging.getLogger("waypoint.claude_cli")
 
@@ -141,6 +147,7 @@ EmitEvent = Callable[
     Coroutine[Any, Any, None],
 ]
 InitCallback = Callable[[str, dict[str, Any]], None]
+SessionUpdateCallback = Callable[[str, dict[str, Any], bool], Awaitable[Any]]
 LaunchFactory = Callable[
     [str, str, str, bool, str, str | None, str | None, list[str], str | None],
     "ClaudeLaunchSpec",
@@ -218,6 +225,8 @@ class ClaudeSessionState:
     last_plan_content: str | None = None
     closing: bool = False
     model: str | None = None
+    context_usage_snapshot: SessionContextUsage | None = None
+    context_usage_signature: tuple[int, int | None] | None = None
     # Reasoning effort. Claude's CLI accepts `--effort <level>` at launch
     # only — there is no in-process control_request to swap it — so changing
     # this value at runtime requires terminating and respawning the process
@@ -249,6 +258,8 @@ class ClaudeCliAdapter:
         binary: str | None = None,
         launch_factory: LaunchFactory | None = None,
         on_init: InitCallback | None = None,
+        on_session_update: SessionUpdateCallback | None = None,
+        default_model_id: str | None = None,
     ) -> None:
         self._emit_event = emit_event
         self._hook_settings_path = hook_settings_path
@@ -258,6 +269,8 @@ class ClaudeCliAdapter:
         self._binary = binary
         self._launch_factory = launch_factory
         self._on_init = on_init
+        self._on_session_update = on_session_update
+        self._default_model_id = normalize_claude_model_id(default_model_id)
         self._sessions: dict[str, ClaudeSessionState] = {}
         self._approval_lock = asyncio.Lock()
 
@@ -349,7 +362,10 @@ class ClaudeCliAdapter:
         await self._send_control_request(session_id, request_id, payload)
         state = self._sessions.get(session_id)
         if state is not None:
-            state.model = model or None
+            previous_model = state.model
+            state.model = self._effective_model_id(model)
+            if state.model != previous_model:
+                await self._refresh_context_usage(state)
 
     def session_model(self, session_id: str) -> str | None:
         state = self._sessions.get(session_id)
@@ -941,7 +957,7 @@ class ClaudeCliAdapter:
             stderr_task=asyncio.create_task(asyncio.sleep(0)),
             wait_task=asyncio.create_task(asyncio.sleep(0)),
             permission_mode=resolved_mode,
-            model=model,
+            model=self._effective_model_id(model),
             effort=effort or None,
             custom_args=list(effective_custom_args),
             launch_factory=launch_factory,
@@ -1192,6 +1208,17 @@ class ClaudeCliAdapter:
                     for command in slash_commands
                     if isinstance(command, str) and command
                 )
+            model = self._effective_model_id(event.get("model"))
+            if model is not None:
+                current_family = claude_model_family(state.model)
+                incoming_family = claude_model_family(model)
+                if (
+                    state.model is None
+                    or current_family != incoming_family
+                    or model.endswith("[1m]")
+                ):
+                    state.model = model
+                    await self._refresh_context_usage(state)
             if self._on_init is not None:
                 self._on_init(state.session_id, event)
             # Claude's stream-json mode emits `init` at the start of every
@@ -1268,6 +1295,7 @@ class ClaudeCliAdapter:
     ) -> None:
         message = event.get("message") or {}
         message_id = str(message.get("id") or "")
+        usage = message.get("usage") or event.get("usage") or {}
         for block in iter_content_blocks(message.get("content")):
             block_type = block.get("type")
             if block_type == "text":
@@ -1313,6 +1341,13 @@ class ClaudeCliAdapter:
             elif block_type == "thinking":
                 # Optional surface; hide behind an opt-in later if too noisy.
                 continue
+        snapshot = _context_usage_snapshot_from_message(
+            state.model,
+            usage if isinstance(usage, dict) else {},
+        )
+        if snapshot is not None:
+            state.context_usage_snapshot = snapshot
+            await self._publish_context_usage(state, snapshot)
 
     async def _handle_user(
         self, state: ClaudeSessionState, event: dict[str, Any]
@@ -1372,6 +1407,36 @@ class ClaudeCliAdapter:
             SessionStatus.ERROR if is_error else SessionStatus.IDLE,
         )
 
+    async def _publish_context_usage(
+        self, state: ClaudeSessionState, snapshot: SessionContextUsage
+    ) -> None:
+        signature = (snapshot.used_tokens, snapshot.context_window_tokens)
+        if state.context_usage_signature == signature:
+            return
+        state.context_usage_signature = signature
+        if self._on_session_update is None:
+            return
+        await self._on_session_update(
+            state.session_id,
+            {"context_usage": snapshot.model_dump(mode="json")},
+            False,
+        )
+
+    async def _refresh_context_usage(self, state: ClaudeSessionState) -> None:
+        snapshot = state.context_usage_snapshot
+        if snapshot is None:
+            return
+        model = state.model or self._default_model_id
+        if model is None:
+            return
+        refreshed = snapshot.model_copy(
+            update={"context_window_tokens": claude_context_window_for_model(model)}
+        )
+        if refreshed.context_window_tokens is None:
+            return
+        state.context_usage_snapshot = refreshed
+        await self._publish_context_usage(state, refreshed)
+
     def _map_decision(self, decision: str) -> str:
         lowered = decision.strip().lower()
         if lowered in {"approve", "accept", "yes", "y", "allow", "acceptforsession"}:
@@ -1383,3 +1448,64 @@ class ClaudeCliAdapter:
             return self._sessions[session_id]
         except KeyError as exc:
             raise ClaudeCliError(f"claude session not active: {session_id}") from exc
+
+    def _effective_model_id(self, model: str | None) -> str | None:
+        normalized = normalize_claude_model_id(model)
+        if normalized is not None:
+            return normalized
+        return self._default_model_id
+
+
+def _context_usage_snapshot_from_message(
+    model: str | None, usage: dict[str, Any]
+) -> SessionContextUsage | None:
+    input_tokens = _non_negative_int(usage.get("input_tokens"))
+    cache_read_input_tokens = _non_negative_int(usage.get("cache_read_input_tokens"))
+    cache_creation_input_tokens = _non_negative_int(
+        usage.get("cache_creation_input_tokens")
+    )
+    output_tokens = _non_negative_int(usage.get("output_tokens"))
+
+    used_tokens = sum(
+        value
+        for value in (
+            input_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+        )
+        if value is not None
+    )
+    if used_tokens <= 0:
+        return None
+
+    context_window_tokens = claude_context_window_for_model(model)
+    if context_window_tokens is None:
+        return None
+
+    breakdown = {
+        key: value
+        for key, value in {
+            "input_tokens": input_tokens,
+            "cache_read_tokens": cache_read_input_tokens,
+            "cache_creation_tokens": cache_creation_input_tokens,
+            "output_tokens": output_tokens,
+        }.items()
+        if value is not None
+    }
+    return SessionContextUsage(
+        used_tokens=used_tokens,
+        context_window_tokens=context_window_tokens,
+        updated_at=datetime.now(UTC),
+        source="claude_code",
+        breakdown=breakdown,
+    )
+
+
+def _non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, float) and value.is_integer():
+        return max(0, int(value))
+    return None

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -1212,11 +1212,7 @@ class ClaudeCliAdapter:
             if model is not None:
                 current_family = claude_model_family(state.model)
                 incoming_family = claude_model_family(model)
-                if (
-                    state.model is None
-                    or current_family != incoming_family
-                    or model.endswith("[1m]")
-                ):
+                if state.model is None or current_family != incoming_family:
                     state.model = model
                     await self._refresh_context_usage(state)
             if self._on_init is not None:
@@ -1429,11 +1425,16 @@ class ClaudeCliAdapter:
         model = state.model or self._default_model_id
         if model is None:
             return
-        refreshed = snapshot.model_copy(
-            update={"context_window_tokens": claude_context_window_for_model(model)}
-        )
-        if refreshed.context_window_tokens is None:
+        context_window_tokens = claude_context_window_for_model(model)
+        if context_window_tokens is None:
             return
+        if snapshot.context_window_tokens == context_window_tokens:
+            return
+        # Bump only the window here; used_tokens is recomputed from the next
+        # assistant turn under the active model.
+        refreshed = snapshot.model_copy(
+            update={"context_window_tokens": context_window_tokens}
+        )
         state.context_usage_snapshot = refreshed
         await self._publish_context_usage(state, refreshed)
 

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -12,6 +12,25 @@ from waypoint.schemas import BackendModelOption
 # don't accept --effort at all.
 CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
 
+# Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
+# see either the human-facing alias (``opus[1m]``) or a resolved API model id
+# (``claude-opus-4-7``); normalize both to the same family so the context window
+# lookup stays stable.
+CLAUDE_MODEL_ALIASES: dict[str, str] = {
+    "claude-opus-4-7": "opus",
+    "claude-sonnet-4-6": "sonnet",
+    "claude-sonnet-4-5": "sonnet",
+    "claude-haiku-4-5": "haiku",
+}
+
+CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
+    "opus": 200_000,
+    "sonnet": 200_000,
+    "haiku": 200_000,
+    "opus[1m]": 1_000_000,
+    "sonnet[1m]": 1_000_000,
+}
+
 DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     BackendModelOption(
         id="opus",
@@ -48,3 +67,49 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         default_effort="high",
     ),
 )
+
+
+def normalize_claude_model_id(model: str | None) -> str | None:
+    if model is None or not isinstance(model, str):
+        return None
+    candidate = model.strip()
+    if not candidate:
+        return None
+    if candidate in CLAUDE_CONTEXT_WINDOWS:
+        return candidate
+    normalized = CLAUDE_MODEL_ALIASES.get(candidate)
+    if normalized is not None:
+        return normalized
+    if candidate.startswith("claude-opus-"):
+        return "opus"
+    if candidate.startswith("claude-sonnet-"):
+        return "sonnet"
+    if candidate.startswith("claude-haiku-"):
+        return "haiku"
+    return candidate
+
+
+def claude_model_family(model: str | None) -> str | None:
+    normalized = normalize_claude_model_id(model)
+    if normalized is None:
+        return None
+    return normalized.split("[", 1)[0]
+
+
+def claude_context_window_for_model(model: str | None) -> int | None:
+    normalized = normalize_claude_model_id(model)
+    if normalized is None:
+        return None
+    if normalized in CLAUDE_CONTEXT_WINDOWS:
+        return CLAUDE_CONTEXT_WINDOWS[normalized]
+    family = claude_model_family(normalized)
+    if family is None:
+        return None
+    return CLAUDE_CONTEXT_WINDOWS.get(family)
+
+
+def claude_default_model_id() -> str | None:
+    for option in DEFAULT_CLAUDE_MODELS:
+        if option.is_default:
+            return option.id
+    return None

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -27,6 +27,7 @@ from waypoint.backends.claude_code.commands import list_claude_command_completio
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
+    claude_default_model_id,
 )
 from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_PERMISSION_MODE_SPECS,
@@ -82,6 +83,7 @@ class ClaudeCodePluginConfig(PluginConfig):
     models: list[BackendModelOption] = Field(
         default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
     )
+    default_model_id: str | None = Field(default_factory=claude_default_model_id)
     # Network-failure ceiling (seconds) for the PreToolUse hook's HTTP
     # request — *not* a deadline on user response time, which is
     # unbounded. Sized as the upper bound for "the SSH reverse tunnel
@@ -164,6 +166,8 @@ class ClaudeCodePlugin:
             hook_url=hook_url,
             default_hook_timeout_seconds=self._config(runtime).hook_timeout_seconds,
             on_init=runtime.handle_completion_source_init,
+            on_session_update=runtime.session_update_callback(),
+            default_model_id=self._config(runtime).default_model_id,
         )
         self.thread_enumerator = RemoteClaudeThreadEnumerator(
             hook.thread_enumerator_path

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -34,7 +34,7 @@ ApprovalDecisionHandler = Callable[
 ]
 ApprovalCallback = Callable[[str, dict[str, Any] | None], dict[str, Any]]
 ClientFactory = Callable[[str, ApprovalCallback], AppServerClient]
-SessionUpdateCallback = Callable[[str, dict[str, Any]], Awaitable[Any]]
+SessionUpdateCallback = Callable[[str, dict[str, Any], bool], Awaitable[Any]]
 
 
 def _extract_tool_name(item_type: str | None, item: dict[str, Any]) -> str | None:
@@ -721,6 +721,7 @@ class CodexAppServerAdapter:
         await self._on_session_update(
             state.session_id,
             {"context_usage": snapshot.model_dump(mode="json")},
+            False,
         )
 
     def _require_session(self, session_id: str) -> CodexSessionState:

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -4,9 +4,10 @@ import asyncio
 import logging
 import shutil
 import threading
-from collections.abc import Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from typing import Any
 
 from codex_app_server.client import AppServerClient, AppServerConfig
@@ -23,7 +24,7 @@ from waypoint.backends.codex.normalize import (
     plan_metadata_for_item,
 )
 from waypoint.backends.diff_preview import DiffPreviewPayload, preview_to_metadata
-from waypoint.schemas import EventKind, SessionStatus
+from waypoint.schemas import EventKind, SessionContextUsage, SessionStatus
 
 log = logging.getLogger("waypoint.codex")
 
@@ -33,6 +34,7 @@ ApprovalDecisionHandler = Callable[
 ]
 ApprovalCallback = Callable[[str, dict[str, Any] | None], dict[str, Any]]
 ClientFactory = Callable[[str, ApprovalCallback], AppServerClient]
+SessionUpdateCallback = Callable[[str, dict[str, Any]], Awaitable[Any]]
 
 
 def _extract_tool_name(item_type: str | None, item: dict[str, Any]) -> str | None:
@@ -160,15 +162,18 @@ class CodexSessionState:
     # Same shape as `model` for reasoning-effort: re-emit on each turn_start so
     # the override survives restarts and turn reuse.
     effort: str | None = None
+    context_usage_signature: tuple[int, int | None] | None = None
 
 
 class CodexAppServerAdapter:
     def __init__(
         self,
         emit_event: ApprovalDecisionHandler,
+        on_session_update: SessionUpdateCallback | None = None,
         client_factory: ClientFactory | None = None,
     ) -> None:
         self._emit_event = emit_event
+        self._on_session_update = on_session_update
         self._client_factory = client_factory or default_client_factory
         self._sessions: dict[str, CodexSessionState] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -571,6 +576,11 @@ class CodexAppServerAdapter:
                     state, state.client.next_notification
                 )
                 payload = payload_to_dict(notification.payload)
+                if notification.method == "thread/tokenUsage/updated":
+                    snapshot = _context_usage_snapshot_from_thread_token_usage(payload)
+                    if snapshot is not None:
+                        await self._publish_context_usage(state, snapshot)
+                    continue
                 kind, text, status = map_notification(notification.method, payload)
                 if kind is not None and text:
                     if notification.method == "item/commandExecution/outputDelta":
@@ -699,6 +709,20 @@ class CodexAppServerAdapter:
         async with state.transport_lock:
             return await asyncio.to_thread(func, *args)
 
+    async def _publish_context_usage(
+        self, state: CodexSessionState, snapshot: SessionContextUsage
+    ) -> None:
+        signature = (snapshot.used_tokens, snapshot.context_window_tokens)
+        if state.context_usage_signature == signature:
+            return
+        state.context_usage_signature = signature
+        if self._on_session_update is None:
+            return
+        await self._on_session_update(
+            state.session_id,
+            {"context_usage": snapshot.model_dump(mode="json")},
+        )
+
     def _require_session(self, session_id: str) -> CodexSessionState:
         try:
             return self._sessions[session_id]
@@ -714,3 +738,49 @@ class CodexAppServerAdapter:
         if lowered in {"cancel"}:
             return "cancel"
         return "decline"
+
+
+def _context_usage_snapshot_from_thread_token_usage(
+    payload: dict[str, Any],
+) -> SessionContextUsage | None:
+    token_usage = payload.get("tokenUsage") or payload.get("token_usage")
+    if not isinstance(token_usage, dict):
+        return None
+
+    last = token_usage.get("last")
+    if not isinstance(last, dict):
+        return None
+
+    used_tokens = _positive_int(last.get("totalTokens"))
+    if used_tokens is None:
+        return None
+
+    context_window_tokens = _positive_int(token_usage.get("modelContextWindow"))
+    breakdown = {
+        key: value
+        for key, value in {
+            "input_tokens": _positive_int(last.get("inputTokens")),
+            "cached_input_tokens": _positive_int(last.get("cachedInputTokens")),
+            "output_tokens": _positive_int(last.get("outputTokens")),
+            "reasoning_output_tokens": _positive_int(last.get("reasoningOutputTokens")),
+        }.items()
+        if value is not None
+    }
+    return SessionContextUsage(
+        used_tokens=used_tokens,
+        context_window_tokens=context_window_tokens,
+        updated_at=datetime.now(UTC),
+        source="codex",
+        breakdown=breakdown,
+    )
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float) and value.is_integer():
+        int_value = int(value)
+        return int_value if int_value > 0 else None
+    return None

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -721,7 +721,7 @@ class CodexAppServerAdapter:
         await self._on_session_update(
             state.session_id,
             {"context_usage": snapshot.model_dump(mode="json")},
-            False,
+            True,
         )
 
     def _require_session(self, session_id: str) -> CodexSessionState:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -139,7 +139,15 @@ class CodexPlugin:
         # external bootstrap. The plugin owns the adapter so every call
         # site reads ``self.adapter`` instead of reaching into the
         # runtime.
-        self.adapter = CodexAppServerAdapter(runtime._emit_adapter_event)
+        async def _update_session_fields(
+            session_id: str, updates: dict[str, Any]
+        ) -> Any:
+            return await runtime.update_session_fields(session_id, **updates)
+
+        self.adapter = CodexAppServerAdapter(
+            runtime._emit_adapter_event,
+            _update_session_fields,
+        )
 
     async def shutdown(self, runtime: "SessionRuntime") -> None:
         if self.adapter is not None:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -139,14 +139,9 @@ class CodexPlugin:
         # external bootstrap. The plugin owns the adapter so every call
         # site reads ``self.adapter`` instead of reaching into the
         # runtime.
-        async def _update_session_fields(
-            session_id: str, updates: dict[str, Any]
-        ) -> Any:
-            return await runtime.update_session_fields(session_id, **updates)
-
         self.adapter = CodexAppServerAdapter(
             runtime._emit_adapter_event,
-            _update_session_fields,
+            runtime.session_update_callback(),
         )
 
     async def shutdown(self, runtime: "SessionRuntime") -> None:

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -63,7 +63,7 @@ EmitEvent = Callable[
     Any,
 ]
 SessionUpdateCallback = Callable[
-    [str, dict[str, Any]],
+    [str, dict[str, Any], bool],
     Awaitable[Any],
 ]
 
@@ -91,6 +91,11 @@ class OpenCodeSessionState:
     effort: str | None = None
     pre_plan_mode: str | None = None
     context_window_by_model: dict[tuple[str, str], int] = field(default_factory=dict)
+    context_usage_pending_tokens: dict[tuple[str, str], dict[str, Any]] = field(
+        default_factory=dict
+    )
+    context_window_lookup_pending: set[tuple[str, str]] = field(default_factory=set)
+    context_window_lookup_failed: set[tuple[str, str]] = field(default_factory=set)
     context_usage_signature: tuple[int, int | None] | None = None
     closing: bool = False
 
@@ -667,51 +672,83 @@ class OpenCodeAdapter:
         if not isinstance(model_id, str) or not model_id:
             return
 
-        context_window_tokens = await self._context_window_for_model(
-            state, provider_id, model_id
-        )
-        if context_window_tokens is None:
+        key = (provider_id, model_id)
+        state.context_usage_pending_tokens[key] = tokens
+
+        context_window_tokens = state.context_window_by_model.get(key)
+        if context_window_tokens is not None:
+            await self._publish_context_usage(
+                state,
+                provider_id,
+                model_id,
+                tokens,
+                context_window_tokens,
+                publish=False,
+            )
             return
 
-        snapshot = _context_usage_snapshot_from_message(
-            provider_id,
-            model_id,
-            tokens,
-            context_window_tokens,
-        )
-        if snapshot is None:
+        if (
+            key in state.context_window_lookup_failed
+            or key in state.context_window_lookup_pending
+        ):
             return
 
-        signature = (snapshot.used_tokens, snapshot.context_window_tokens)
-        if state.context_usage_signature == signature:
-            return
-        state.context_usage_signature = signature
-        if self._on_session_update is None:
-            return
-        await self._on_session_update(
-            state.session_id,
-            {"context_usage": snapshot.model_dump(mode="json")},
+        state.context_window_lookup_pending.add(key)
+        asyncio.create_task(
+            self._resolve_context_window_and_publish(
+                state,
+                provider_id,
+                model_id,
+            )
         )
 
-    async def _context_window_for_model(
-        self, state: OpenCodeSessionState, provider_id: str, model_id: str
+    async def _resolve_context_window_and_publish(
+        self,
+        state: OpenCodeSessionState,
+        provider_id: str,
+        model_id: str,
     ) -> int | None:
         key = (provider_id, model_id)
-        cached = state.context_window_by_model.get(key)
-        if cached is not None:
-            return cached
-
-        client = self._require_client()
         try:
-            payload = await client.get(
-                "/config/providers", params={"directory": state.cwd}
+            context_window_tokens = await self._context_window_for_model(
+                state, provider_id, model_id
             )
         except Exception as exc:  # noqa: BLE001
             log.debug(
                 "failed to fetch opencode context window",
                 extra={"session_id": state.session_id, "error": str(exc)},
             )
+            context_window_tokens = None
+        finally:
+            state.context_window_lookup_pending.discard(key)
+
+        if context_window_tokens is None:
+            state.context_window_lookup_failed.add(key)
             return None
+
+        current_state = self._sessions.get(state.session_id)
+        if current_state is not state or state.closing:
+            return None
+
+        state.context_window_by_model[key] = context_window_tokens
+        tokens = state.context_usage_pending_tokens.get(key)
+        if tokens is None:
+            return None
+        await self._publish_context_usage(
+            state,
+            provider_id,
+            model_id,
+            tokens,
+            context_window_tokens,
+            publish=True,
+        )
+        return None
+
+    async def _context_window_for_model(
+        self, state: OpenCodeSessionState, provider_id: str, model_id: str
+    ) -> int | None:
+        client = self._require_client()
+        payload = await client.get("/config/providers", params={"directory": state.cwd})
 
         if not isinstance(payload, dict):
             return None
@@ -735,9 +772,39 @@ class OpenCodeAdapter:
                 continue
             context = _positive_int(limit.get("context"))
             if context is not None:
-                state.context_window_by_model[key] = context
-            return context
+                return context
         return None
+
+    async def _publish_context_usage(
+        self,
+        state: OpenCodeSessionState,
+        provider_id: str,
+        model_id: str,
+        tokens: dict[str, Any],
+        context_window_tokens: int,
+        *,
+        publish: bool,
+    ) -> None:
+        snapshot = _context_usage_snapshot_from_message(
+            provider_id,
+            model_id,
+            tokens,
+            context_window_tokens,
+        )
+        if snapshot is None:
+            return
+
+        signature = (snapshot.used_tokens, snapshot.context_window_tokens)
+        if state.context_usage_signature == signature:
+            return
+        state.context_usage_signature = signature
+        if self._on_session_update is None:
+            return
+        await self._on_session_update(
+            state.session_id,
+            {"context_usage": snapshot.model_dump(mode="json")},
+            publish,
+        )
 
     def _tag_part_type(
         self,
@@ -1179,6 +1246,9 @@ class OpenCodeAdapter:
         self._remote_sessions.pop(state.opencode_session_id, None)
         state.pending_permission_ids.clear()
         state.pending_question_ids.clear()
+        state.context_usage_pending_tokens.clear()
+        state.context_window_lookup_pending.clear()
+        state.context_window_lookup_failed.clear()
         for part_id, owner in list(self._part_sessions.items()):
             if owner == session_id:
                 self._part_sessions.pop(part_id, None)
@@ -1204,6 +1274,10 @@ class OpenCodeAdapter:
             self._terminate_server_process()
             await self._await_server_process_exit()
             self._server_process = None
+        for state in self._sessions.values():
+            state.context_usage_pending_tokens.clear()
+            state.context_window_lookup_pending.clear()
+            state.context_window_lookup_failed.clear()
         self._sessions.clear()
         self._remote_sessions.clear()
         self._part_sessions.clear()
@@ -1252,8 +1326,6 @@ def _context_usage_snapshot_from_message(
         value
         for value in (
             input_tokens,
-            output_tokens,
-            reasoning_tokens,
             cache_read_tokens,
             cache_write_tokens,
         )

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -6,9 +6,10 @@ import re
 import shutil
 import signal
 import time
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -20,7 +21,7 @@ from waypoint.backends.opencode.client import (
 from waypoint.backends.opencode.normalize import map_event
 from waypoint.backends.opencode.remote import build_remote_serve_args
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.schemas import EventKind, SessionStatus
+from waypoint.schemas import EventKind, SessionContextUsage, SessionStatus
 
 log = logging.getLogger("waypoint.opencode")
 
@@ -61,6 +62,10 @@ EmitEvent = Callable[
     [str, EventKind, str, dict[str, Any], SessionStatus],
     Any,
 ]
+SessionUpdateCallback = Callable[
+    [str, dict[str, Any]],
+    Awaitable[Any],
+]
 
 
 class OpenCodeError(RuntimeError):
@@ -85,6 +90,8 @@ class OpenCodeSessionState:
     agent: str | None = None
     effort: str | None = None
     pre_plan_mode: str | None = None
+    context_window_by_model: dict[tuple[str, str], int] = field(default_factory=dict)
+    context_usage_signature: tuple[int, int | None] | None = None
     closing: bool = False
 
 
@@ -96,6 +103,7 @@ class OpenCodeAdapter:
     def __init__(
         self,
         emit_event: EmitEvent,
+        on_session_update: SessionUpdateCallback | None = None,
         binary: str | None = None,
         host: str = DEFAULT_HOST,
         port: int = DEFAULT_PORT,
@@ -106,6 +114,7 @@ class OpenCodeAdapter:
         extra_args: tuple[str, ...] = (),
     ) -> None:
         self._emit_event = emit_event
+        self._on_session_update = on_session_update
         self._binary = binary
         self._host = host
         self._port = port
@@ -505,6 +514,8 @@ class OpenCodeAdapter:
         if "sessionID" not in properties:
             properties = {**properties, "sessionID": state.opencode_session_id}
         self._update_pending_state(state, event_type, properties)
+        if event_type == "message.updated":
+            await self._maybe_update_context_usage(state, properties)
         properties = self._tag_part_type(state, event_type, properties)
 
         kind, text, metadata = map_event(event_type, properties)
@@ -632,6 +643,101 @@ class OpenCodeAdapter:
                 state.pending_question_ids = [
                     item for item in state.pending_question_ids if item != request_id
                 ]
+
+    async def _maybe_update_context_usage(
+        self,
+        state: OpenCodeSessionState,
+        properties: dict[str, Any],
+    ) -> None:
+        info = properties.get("info")
+        if not isinstance(info, dict):
+            return
+        if info.get("role") != "assistant":
+            return
+        tokens = info.get("tokens")
+        if not isinstance(tokens, dict):
+            return
+        if _positive_int(tokens.get("output")) is None:
+            return
+
+        provider_id = info.get("providerID")
+        model_id = info.get("modelID")
+        if not isinstance(provider_id, str) or not provider_id:
+            return
+        if not isinstance(model_id, str) or not model_id:
+            return
+
+        context_window_tokens = await self._context_window_for_model(
+            state, provider_id, model_id
+        )
+        if context_window_tokens is None:
+            return
+
+        snapshot = _context_usage_snapshot_from_message(
+            provider_id,
+            model_id,
+            tokens,
+            context_window_tokens,
+        )
+        if snapshot is None:
+            return
+
+        signature = (snapshot.used_tokens, snapshot.context_window_tokens)
+        if state.context_usage_signature == signature:
+            return
+        state.context_usage_signature = signature
+        if self._on_session_update is None:
+            return
+        await self._on_session_update(
+            state.session_id,
+            {"context_usage": snapshot.model_dump(mode="json")},
+        )
+
+    async def _context_window_for_model(
+        self, state: OpenCodeSessionState, provider_id: str, model_id: str
+    ) -> int | None:
+        key = (provider_id, model_id)
+        cached = state.context_window_by_model.get(key)
+        if cached is not None:
+            return cached
+
+        client = self._require_client()
+        try:
+            payload = await client.get(
+                "/config/providers", params={"directory": state.cwd}
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.debug(
+                "failed to fetch opencode context window",
+                extra={"session_id": state.session_id, "error": str(exc)},
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        providers = payload.get("providers")
+        if not isinstance(providers, list):
+            return None
+
+        for provider in providers:
+            if not isinstance(provider, dict):
+                continue
+            if provider.get("id") != provider_id:
+                continue
+            models = provider.get("models")
+            if not isinstance(models, dict):
+                continue
+            model = models.get(model_id)
+            if not isinstance(model, dict):
+                continue
+            limit = model.get("limit")
+            if not isinstance(limit, dict):
+                continue
+            context = _positive_int(limit.get("context"))
+            if context is not None:
+                state.context_window_by_model[key] = context
+            return context
+        return None
 
     def _tag_part_type(
         self,
@@ -1118,4 +1224,80 @@ def build_adapter(
     port: int = DEFAULT_PORT,
     workdir: str | None = None,
 ) -> OpenCodeAdapter:
-    return OpenCodeAdapter(emit_event, binary, host, port, workdir=workdir)
+    return OpenCodeAdapter(
+        emit_event,
+        binary=binary,
+        host=host,
+        port=port,
+        workdir=workdir,
+    )
+
+
+def _context_usage_snapshot_from_message(
+    _provider_id: str,
+    _model_id: str,
+    tokens: dict[str, Any],
+    context_window_tokens: int,
+) -> SessionContextUsage | None:
+    input_tokens = _non_negative_int(tokens.get("input"))
+    output_tokens = _non_negative_int(tokens.get("output"))
+    reasoning_tokens = _non_negative_int(tokens.get("reasoning"))
+    cache = tokens.get("cache")
+    if not isinstance(cache, dict):
+        cache = {}
+    cache_read_tokens = _non_negative_int(cache.get("read"))
+    cache_write_tokens = _non_negative_int(cache.get("write"))
+
+    used_tokens = sum(
+        value
+        for value in (
+            input_tokens,
+            output_tokens,
+            reasoning_tokens,
+            cache_read_tokens,
+            cache_write_tokens,
+        )
+        if value is not None
+    )
+    if used_tokens <= 0:
+        return None
+
+    breakdown = {
+        key: value
+        for key, value in {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "reasoning_tokens": reasoning_tokens,
+            "cache_read_tokens": cache_read_tokens,
+            "cache_write_tokens": cache_write_tokens,
+        }.items()
+        if value is not None
+    }
+    return SessionContextUsage(
+        used_tokens=used_tokens,
+        context_window_tokens=context_window_tokens,
+        updated_at=datetime.now(UTC),
+        source="opencode",
+        breakdown=breakdown,
+    )
+
+
+def _non_negative_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return max(0, value)
+    if isinstance(value, float) and value.is_integer():
+        return max(0, int(value))
+    return None
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float) and value.is_integer():
+        int_value = int(value)
+        return int_value if int_value > 0 else None
+    return None

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -28,6 +28,7 @@ log = logging.getLogger("waypoint.opencode")
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 0
 DEFAULT_TIMEOUT_SECONDS = 60.0
+CONTEXT_WINDOW_LOOKUP_RETRY_SECONDS = 60.0
 
 PERMISSION_REPLIES = {"once", "always", "reject"}
 # OpenCode's reply schema is strictly {once|always|reject}. Waypoint and the
@@ -95,7 +96,9 @@ class OpenCodeSessionState:
         default_factory=dict
     )
     context_window_lookup_pending: set[tuple[str, str]] = field(default_factory=set)
-    context_window_lookup_failed: set[tuple[str, str]] = field(default_factory=set)
+    context_window_lookup_failed: dict[tuple[str, str], float] = field(
+        default_factory=dict
+    )
     context_usage_signature: tuple[int, int | None] | None = None
     closing: bool = False
 
@@ -131,6 +134,7 @@ class OpenCodeAdapter:
         self._sessions: dict[str, OpenCodeSessionState] = {}
         self._remote_sessions: dict[str, str] = {}
         self._part_sessions: dict[str, str] = {}
+        self._context_window_lookup_tasks: set[asyncio.Task[None]] = set()
 
         self._server_process: asyncio.subprocess.Process | None = None
         self._sse_task: asyncio.Task[None] | None = None
@@ -677,6 +681,7 @@ class OpenCodeAdapter:
 
         context_window_tokens = state.context_window_by_model.get(key)
         if context_window_tokens is not None:
+            state.context_window_lookup_failed.pop(key, None)
             await self._publish_context_usage(
                 state,
                 provider_id,
@@ -687,27 +692,32 @@ class OpenCodeAdapter:
             )
             return
 
-        if (
-            key in state.context_window_lookup_failed
-            or key in state.context_window_lookup_pending
-        ):
+        failed_at = state.context_window_lookup_failed.get(key)
+        if failed_at is not None:
+            if time.monotonic() - failed_at < CONTEXT_WINDOW_LOOKUP_RETRY_SECONDS:
+                return
+            state.context_window_lookup_failed.pop(key, None)
+
+        if key in state.context_window_lookup_pending:
             return
 
         state.context_window_lookup_pending.add(key)
-        asyncio.create_task(
+        task = asyncio.create_task(
             self._resolve_context_window_and_publish(
                 state,
                 provider_id,
                 model_id,
             )
         )
+        self._context_window_lookup_tasks.add(task)
+        task.add_done_callback(self._context_window_lookup_tasks.discard)
 
     async def _resolve_context_window_and_publish(
         self,
         state: OpenCodeSessionState,
         provider_id: str,
         model_id: str,
-    ) -> int | None:
+    ) -> None:
         key = (provider_id, model_id)
         try:
             context_window_tokens = await self._context_window_for_model(
@@ -723,17 +733,18 @@ class OpenCodeAdapter:
             state.context_window_lookup_pending.discard(key)
 
         if context_window_tokens is None:
-            state.context_window_lookup_failed.add(key)
-            return None
+            state.context_window_lookup_failed[key] = time.monotonic()
+            return
 
         current_state = self._sessions.get(state.session_id)
         if current_state is not state or state.closing:
-            return None
+            return
 
         state.context_window_by_model[key] = context_window_tokens
+        state.context_window_lookup_failed.pop(key, None)
         tokens = state.context_usage_pending_tokens.get(key)
         if tokens is None:
-            return None
+            return
         await self._publish_context_usage(
             state,
             provider_id,
@@ -742,7 +753,6 @@ class OpenCodeAdapter:
             context_window_tokens,
             publish=True,
         )
-        return None
 
     async def _context_window_for_model(
         self, state: OpenCodeSessionState, provider_id: str, model_id: str
@@ -796,8 +806,10 @@ class OpenCodeAdapter:
 
         signature = (snapshot.used_tokens, snapshot.context_window_tokens)
         if state.context_usage_signature == signature:
+            state.context_usage_pending_tokens.pop((provider_id, model_id), None)
             return
         state.context_usage_signature = signature
+        state.context_usage_pending_tokens.pop((provider_id, model_id), None)
         if self._on_session_update is None:
             return
         await self._on_session_update(
@@ -1262,6 +1274,13 @@ class OpenCodeAdapter:
         return True
 
     async def shutdown(self) -> None:
+        if self._context_window_lookup_tasks:
+            for task in list(self._context_window_lookup_tasks):
+                task.cancel()
+            for task in list(self._context_window_lookup_tasks):
+                with suppress(asyncio.CancelledError, Exception):
+                    await task
+            self._context_window_lookup_tasks.clear()
         if self._sse_task is not None:
             self._sse_task.cancel()
             with suppress(asyncio.CancelledError):

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -377,14 +377,9 @@ class OpenCodePlugin:
             def _on_server_died(active_session_ids: list[str]) -> None:
                 self._handle_server_died(runtime, key, active_session_ids)
 
-            async def _update_session_fields(
-                session_id: str, updates: dict[str, Any]
-            ) -> Any:
-                return await runtime.update_session_fields(session_id, **updates)
-
             adapter = OpenCodeAdapter(
                 emit_event=runtime._emit_adapter_event,
-                on_session_update=_update_session_fields,
+                on_session_update=runtime.session_update_callback(),
                 launch_target=launch_target,
                 on_agent_changed=_on_agent_changed,
                 on_server_died=_on_server_died,

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -377,8 +377,14 @@ class OpenCodePlugin:
             def _on_server_died(active_session_ids: list[str]) -> None:
                 self._handle_server_died(runtime, key, active_session_ids)
 
+            async def _update_session_fields(
+                session_id: str, updates: dict[str, Any]
+            ) -> Any:
+                return await runtime.update_session_fields(session_id, **updates)
+
             adapter = OpenCodeAdapter(
                 emit_event=runtime._emit_adapter_event,
+                on_session_update=_update_session_fields,
                 launch_target=launch_target,
                 on_agent_changed=_on_agent_changed,
                 on_server_died=_on_server_died,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -5,6 +5,7 @@ import re
 import secrets
 import shutil
 from collections import defaultdict
+from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -1034,11 +1035,24 @@ class SessionRuntime:
         await self._publish_event(persisted)
 
     async def update_session_fields(
-        self, session_id: str, **updates: Any
+        self, session_id: str, *, publish: bool = True, **updates: Any
     ) -> SessionRecord:
         session = self.storage.update_session(session_id, **updates)
-        await self._publish_session_state(session_id)
+        if publish:
+            await self._publish_session_state(session_id)
         return session
+
+    def session_update_callback(
+        self,
+    ) -> Callable[[str, dict[str, Any], bool], Awaitable[SessionRecord]]:
+        async def _update_session_fields(
+            session_id: str, updates: dict[str, Any], publish: bool
+        ) -> SessionRecord:
+            return await self.update_session_fields(
+                session_id, publish=publish, **updates
+            )
+
+        return _update_session_fields
 
     async def _publish_event(self, event: EventRecord) -> None:
         await self.broadcast.publish(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1033,6 +1033,13 @@ class SessionRuntime:
         self._append_structured_log(session_id, persisted)
         await self._publish_event(persisted)
 
+    async def update_session_fields(
+        self, session_id: str, **updates: Any
+    ) -> SessionRecord:
+        session = self.storage.update_session(session_id, **updates)
+        await self._publish_session_state(session_id)
+        return session
+
     async def _publish_event(self, event: EventRecord) -> None:
         await self.broadcast.publish(
             SessionEnvelope(
@@ -1041,13 +1048,16 @@ class SessionRuntime:
             ),
             session_id=event.session_id,
         )
-        session = self.get_session(event.session_id)
+        await self._publish_session_state(event.session_id)
+
+    async def _publish_session_state(self, session_id: str) -> None:
+        session = self.get_session(session_id)
         await self.broadcast.publish(
             SessionEnvelope(
                 type="session_state",
                 payload={"session": session.model_dump(mode="json")},
             ),
-            session_id=event.session_id,
+            session_id=session_id,
         )
         await self.broadcast.publish(
             SessionEnvelope(

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -104,6 +104,14 @@ class SessionCompletionsResponse(BaseModel):
     refreshing: bool = False
 
 
+class SessionContextUsage(BaseModel):
+    used_tokens: int
+    context_window_tokens: int | None = None
+    updated_at: datetime
+    source: BackendId
+    breakdown: dict[str, int] = Field(default_factory=dict)
+
+
 class SessionRecord(BaseModel):
     id: str
     backend: BackendId
@@ -135,6 +143,7 @@ class SessionRecord(BaseModel):
     # Codex uses this for ``--config K=V`` entries; other backends ignore
     # the field. Empty list = none.
     config_overrides: list[str] = Field(default_factory=list)
+    context_usage: SessionContextUsage | None = None
 
 
 class EventRecord(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -118,7 +118,8 @@ class Storage:
                 model TEXT,
                 effort TEXT,
                 args TEXT NOT NULL DEFAULT '[]',
-                config_overrides TEXT NOT NULL DEFAULT '[]'
+                config_overrides TEXT NOT NULL DEFAULT '[]',
+                context_usage TEXT
             );
 
             CREATE TABLE IF NOT EXISTS events (
@@ -162,6 +163,7 @@ class Storage:
         self._ensure_column(
             "sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
+        self._ensure_column("sessions", "context_usage", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -179,8 +181,8 @@ class Storage:
                 id, backend, source, transport, title, cwd, launch_target_id,
                 repo_name, branch, status, created_at, updated_at, last_event_at,
                 raw_log_path, structured_log_path, transport_state, pinned_at,
-                permission_mode, model, effort, args, config_overrides
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                permission_mode, model, effort, args, config_overrides, context_usage
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -205,6 +207,11 @@ class Storage:
                 session.effort,
                 json.dumps(list(session.args)),
                 json.dumps(list(session.config_overrides)),
+                (
+                    json.dumps(session.context_usage.model_dump(mode="json"))
+                    if session.context_usage is not None
+                    else None
+                ),
             ),
         )
         self.connection.commit()
@@ -603,6 +610,18 @@ class Storage:
         payload["config_overrides"] = (
             parsed_overrides if isinstance(parsed_overrides, list) else []
         )
+        raw_context_usage = payload.get("context_usage")
+        if raw_context_usage:
+            try:
+                parsed_context_usage = json.loads(raw_context_usage)
+            except json.JSONDecodeError:
+                parsed_context_usage = None
+            if isinstance(parsed_context_usage, dict):
+                payload["context_usage"] = parsed_context_usage
+            else:
+                payload["context_usage"] = None
+        else:
+            payload["context_usage"] = None
         return SessionRecord.model_validate(payload)
 
     def _schedule_from_row(self, row: sqlite3.Row) -> ScheduledSessionRecord:
@@ -635,6 +654,8 @@ class Storage:
     def _serialize_field(self, value: Any) -> Any:
         if isinstance(value, datetime):
             return value.isoformat()
+        if hasattr(value, "model_dump"):
+            return json.dumps(value.model_dump(mode="json"))
         if isinstance(value, dict):
             return json.dumps(value)
         return value

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -450,6 +450,34 @@ async def test_dispatch_system_init_preserves_1m_default_model() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_system_init_refreshes_context_window_on_family_change() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    state.model = "sonnet"
+
+    calls: list[str] = []
+
+    async def fake_refresh(target_state: ClaudeSessionState) -> None:
+        calls.append(target_state.session_id)
+
+    adapter._refresh_context_usage = fake_refresh  # type: ignore[assignment]
+
+    await adapter._dispatch(
+        state,
+        {
+            "type": "system",
+            "subtype": "init",
+            "model": "opus",
+            "session_id": "claude-uuid",
+        },
+    )
+
+    assert state.model == "opus"
+    assert calls == ["sess"]
+
+
+@pytest.mark.asyncio
 async def test_dispatch_assistant_emits_context_usage_snapshot() -> None:
     emitted: list = []
     session_updates: list[tuple[str, dict[str, Any], bool]] = []

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -11,6 +11,10 @@ from waypoint.backends.claude_code.adapter import (
     ClaudeSessionState,
     claude_cli_mode_for,
 )
+from waypoint.backends.claude_code.models import (
+    DEFAULT_CLAUDE_MODELS,
+    claude_default_model_id,
+)
 from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
 from waypoint.schemas import EventKind, SessionStatus
 
@@ -76,9 +80,15 @@ class FakeProcess:
 
 def _make_adapter(
     emitted: list[tuple[str, EventKind, str, dict[str, Any], SessionStatus]],
+    session_updates: list[tuple[str, dict[str, Any], bool]] | None = None,
 ) -> ClaudeCliAdapter:
     async def emit(session_id, kind, text, metadata, status):
         emitted.append((session_id, kind, text, metadata, status))
+
+    async def update(session_id: str, updates: dict[str, Any], publish: bool) -> Any:
+        if session_updates is not None:
+            session_updates.append((session_id, updates, publish))
+        return updates
 
     return ClaudeCliAdapter(
         emit,
@@ -86,6 +96,7 @@ def _make_adapter(
         hook_secret="test-secret",
         hook_url="http://127.0.0.1:8787",
         default_hook_timeout_seconds=3600,
+        on_session_update=update if session_updates is not None else None,
     )
 
 
@@ -376,6 +387,12 @@ def test_hook_timeout_default_is_finite() -> None:
     assert 0 < config.hook_timeout_seconds < 24 * 3600
 
 
+def test_claude_default_model_id_comes_from_catalog() -> None:
+    default_option = next(opt for opt in DEFAULT_CLAUDE_MODELS if opt.is_default)
+    assert claude_default_model_id() == default_option.id
+    assert ClaudeCodePluginConfig().default_model_id == default_option.id
+
+
 @pytest.mark.asyncio
 async def test_send_input_reports_dead_process_with_stderr_tail() -> None:
     emitted: list = []
@@ -409,6 +426,140 @@ async def test_dispatch_system_init_records_runtime_slash_commands() -> None:
     )
 
     assert adapter.session_slash_commands("sess") == ("clear", "compact", "usage")
+    assert state.model == "sonnet"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_system_init_preserves_1m_default_model() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    state.model = "opus[1m]"
+
+    await adapter._dispatch(
+        state,
+        {
+            "type": "system",
+            "subtype": "init",
+            "model": "opus",
+            "session_id": "claude-uuid",
+        },
+    )
+
+    assert state.model == "opus[1m]"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_assistant_emits_context_usage_snapshot() -> None:
+    emitted: list = []
+    session_updates: list[tuple[str, dict[str, Any], bool]] = []
+    adapter = _make_adapter(emitted, session_updates=session_updates)
+    state, _ = _attach_state(adapter)
+    state.model = "opus[1m]"
+
+    await adapter._dispatch(
+        state,
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "usage": {
+                    "input_tokens": 11,
+                    "cache_read_input_tokens": 3,
+                    "cache_creation_input_tokens": 5,
+                    "output_tokens": 7,
+                },
+                "content": [{"type": "text", "text": "Working on it"}],
+            },
+        },
+    )
+
+    assert emitted[0][1] == EventKind.AGENT_OUTPUT
+    assert len(session_updates) == 1
+    session_id, payload, publish = session_updates[0]
+    assert session_id == "sess"
+    assert publish is False
+    context_usage = payload["context_usage"]
+    assert context_usage["used_tokens"] == 19
+    assert context_usage["context_window_tokens"] == 1_000_000
+    assert context_usage["source"] == "claude_code"
+    assert context_usage["breakdown"] == {
+        "input_tokens": 11,
+        "cache_read_tokens": 3,
+        "cache_creation_tokens": 5,
+        "output_tokens": 7,
+    }
+    assert isinstance(context_usage["updated_at"], str)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_assistant_dedupes_context_usage_snapshot() -> None:
+    emitted: list = []
+    session_updates: list[tuple[str, dict[str, Any], bool]] = []
+    adapter = _make_adapter(emitted, session_updates=session_updates)
+    state, _ = _attach_state(adapter)
+    state.model = "sonnet"
+
+    event = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "usage": {
+                "input_tokens": 8,
+                "cache_read_input_tokens": 2,
+                "cache_creation_input_tokens": 1,
+                "output_tokens": 6,
+            },
+            "content": [{"type": "text", "text": "Still going"}],
+        },
+    }
+
+    await adapter._dispatch(state, event)
+    await adapter._dispatch(state, event)
+
+    assert len(session_updates) == 1
+    assert state.context_usage_signature == (11, 200_000)
+
+
+@pytest.mark.asyncio
+async def test_set_model_refreshes_context_window_immediately() -> None:
+    emitted: list = []
+    session_updates: list[tuple[str, dict[str, Any], bool]] = []
+    adapter = _make_adapter(emitted, session_updates=session_updates)
+    state, _ = _attach_state(adapter)
+    state.model = "opus"
+
+    await adapter._dispatch(
+        state,
+        {
+            "type": "assistant",
+            "message": {
+                "id": "msg_1",
+                "usage": {
+                    "input_tokens": 11,
+                    "cache_read_input_tokens": 3,
+                    "cache_creation_input_tokens": 5,
+                    "output_tokens": 7,
+                },
+                "content": [{"type": "text", "text": "Working on it"}],
+            },
+        },
+    )
+    assert session_updates[-1][1]["context_usage"]["context_window_tokens"] == 200_000
+
+    captured: list[dict[str, Any]] = []
+
+    async def fake_send(session_id: str, request_id: str, request: dict) -> dict:
+        captured.append(request)
+        return {"subtype": "ack"}
+
+    object.__setattr__(adapter, "_send_control_request", fake_send)
+    await adapter.set_model("sess", "opus[1m]")
+
+    assert captured[-1] == {"subtype": "set_model", "model": "opus[1m]"}
+    assert state.model == "opus[1m]"
+    assert len(session_updates) == 2
+    assert session_updates[-1][1]["context_usage"]["context_window_tokens"] == 1_000_000
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -964,5 +964,5 @@ async def test_context_usage_snapshot_deduplicates_repeated_updates() -> None:
     await adapter._publish_context_usage(state, snapshot)
 
     assert calls == [
-        ("sess", {"context_usage": snapshot.model_dump(mode="json")}, False)
+        ("sess", {"context_usage": snapshot.model_dump(mode="json")}, True)
     ]

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -2,12 +2,14 @@ import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, cast
 
 import pytest
+from codex_app_server.client import AppServerClient
 
 from waypoint.backends.codex.adapter import (
     CodexAppServerAdapter,
+    CodexSessionState,
     _context_usage_snapshot_from_thread_token_usage,
 )
 from waypoint.schemas import EventKind, SessionStatus
@@ -914,3 +916,53 @@ def test_context_usage_snapshot_uses_thread_token_usage_totals() -> None:
     }
     assert isinstance(snapshot.updated_at, datetime)
     assert snapshot.updated_at.tzinfo is UTC
+
+
+@pytest.mark.asyncio
+async def test_context_usage_snapshot_deduplicates_repeated_updates() -> None:
+    calls: list[tuple[str, dict[str, Any], bool]] = []
+
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def on_session_update(
+        session_id: str, updates: dict[str, Any], publish: bool
+    ) -> Any:
+        calls.append((session_id, updates, publish))
+        return None
+
+    fake = FakeAppServerClient()
+    adapter = CodexAppServerAdapter(
+        _emit,
+        on_session_update=on_session_update,
+        client_factory=lambda *_: cast(AppServerClient, fake),
+    )
+    state = CodexSessionState(
+        session_id="sess",
+        cwd="/tmp",
+        client=cast(AppServerClient, fake),
+        transport_lock=asyncio.Lock(),
+        thread_id="thread-1",
+    )
+    snapshot = _context_usage_snapshot_from_thread_token_usage(
+        {
+            "tokenUsage": {
+                "last": {
+                    "totalTokens": 4096,
+                    "inputTokens": 2048,
+                    "cachedInputTokens": 256,
+                    "outputTokens": 1536,
+                    "reasoningOutputTokens": 256,
+                },
+                "modelContextWindow": 8192,
+            }
+        }
+    )
+    assert snapshot is not None
+
+    await adapter._publish_context_usage(state, snapshot)
+    await adapter._publish_context_usage(state, snapshot)
+
+    assert calls == [
+        ("sess", {"context_usage": snapshot.model_dump(mode="json")}, False)
+    ]

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -1,11 +1,15 @@
 import asyncio
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
-from waypoint.backends.codex.adapter import CodexAppServerAdapter
+from waypoint.backends.codex.adapter import (
+    CodexAppServerAdapter,
+    _context_usage_snapshot_from_thread_token_usage,
+)
 from waypoint.schemas import EventKind, SessionStatus
 
 
@@ -880,3 +884,33 @@ def test_map_decision_table() -> None:
     assert adapter._map_decision("acceptForSession") == "acceptForSession"
     assert adapter._map_decision("cancel") == "cancel"
     assert adapter._map_decision("anything-else") == "decline"
+
+
+def test_context_usage_snapshot_uses_thread_token_usage_totals() -> None:
+    snapshot = _context_usage_snapshot_from_thread_token_usage(
+        {
+            "tokenUsage": {
+                "last": {
+                    "totalTokens": 4096,
+                    "inputTokens": 2048,
+                    "cachedInputTokens": 256,
+                    "outputTokens": 1536,
+                    "reasoningOutputTokens": 256,
+                },
+                "modelContextWindow": 8192,
+            }
+        }
+    )
+
+    assert snapshot is not None
+    assert snapshot.used_tokens == 4096
+    assert snapshot.context_window_tokens == 8192
+    assert snapshot.source == "codex"
+    assert snapshot.breakdown == {
+        "input_tokens": 2048,
+        "cached_input_tokens": 256,
+        "output_tokens": 1536,
+        "reasoning_output_tokens": 256,
+    }
+    assert isinstance(snapshot.updated_at, datetime)
+    assert snapshot.updated_at.tzinfo is UTC

--- a/backend/tests/test_opencode_adapter.py
+++ b/backend/tests/test_opencode_adapter.py
@@ -6,6 +6,7 @@ from waypoint.backends.opencode.adapter import (
     OpenCodeAdapter,
     OpenCodeError,
     OpenCodeSessionState,
+    _context_usage_snapshot_from_message,
 )
 
 
@@ -320,3 +321,29 @@ async def test_listen_events_treats_mid_session_eof_as_server_death() -> None:
 
     assert seen == [{"type": "server.connected", "properties": {"sessionID": "ses_1"}}]
     assert died.is_set()
+
+
+def test_context_usage_snapshot_aggregates_token_categories() -> None:
+    snapshot = _context_usage_snapshot_from_message(
+        "opencode",
+        "opencode/minimax-m2.5-free",
+        {
+            "input": 120,
+            "output": 30,
+            "reasoning": 20,
+            "cache": {"read": 15, "write": 5},
+        },
+        4096,
+    )
+
+    assert snapshot is not None
+    assert snapshot.used_tokens == 190
+    assert snapshot.context_window_tokens == 4096
+    assert snapshot.source == "opencode"
+    assert snapshot.breakdown == {
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "reasoning_tokens": 20,
+        "cache_read_tokens": 15,
+        "cache_write_tokens": 5,
+    }

--- a/backend/tests/test_opencode_adapter.py
+++ b/backend/tests/test_opencode_adapter.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Any, cast
 
 import pytest
 
@@ -337,10 +338,75 @@ def test_context_usage_snapshot_aggregates_token_categories() -> None:
     )
 
     assert snapshot is not None
-    assert snapshot.used_tokens == 190
+    assert snapshot.used_tokens == 140
     assert snapshot.context_window_tokens == 4096
     assert snapshot.source == "opencode"
     assert snapshot.breakdown == {
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "reasoning_tokens": 20,
+        "cache_read_tokens": 15,
+        "cache_write_tokens": 5,
+    }
+
+
+@pytest.mark.asyncio
+async def test_context_usage_snapshot_deduplicates_cached_updates() -> None:
+    calls: list[tuple[str, dict[str, object], bool]] = []
+
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def on_session_update(
+        session_id: str, updates: dict[str, object], publish: bool
+    ) -> object:
+        calls.append((session_id, updates, publish))
+        return None
+
+    adapter = OpenCodeAdapter(
+        emit_event=_emit,
+        on_session_update=on_session_update,
+    )
+    state = OpenCodeSessionState(
+        session_id="local-1",
+        cwd="/tmp",
+        opencode_session_id="ses_1",
+    )
+    state.context_window_by_model[("opencode", "opencode/minimax-m2.5-free")] = 4096
+
+    properties = {
+        "sessionID": "ses_1",
+        "info": {
+            "role": "assistant",
+            "providerID": "opencode",
+            "modelID": "opencode/minimax-m2.5-free",
+            "tokens": {
+                "input": 120,
+                "output": 30,
+                "reasoning": 20,
+                "cache": {"read": 15, "write": 5},
+            },
+        },
+    }
+
+    await adapter._maybe_update_context_usage(state, properties)
+    await adapter._maybe_update_context_usage(state, properties)
+
+    snapshot = _context_usage_snapshot_from_message(
+        "opencode",
+        "opencode/minimax-m2.5-free",
+        properties["info"]["tokens"],  # type: ignore[index]
+        4096,
+    )
+    assert snapshot is not None
+    assert len(calls) == 1
+    assert calls[0][0] == "local-1"
+    assert calls[0][2] is False
+    context_usage = cast(dict[str, Any], calls[0][1]["context_usage"])
+    assert context_usage["used_tokens"] == 140
+    assert context_usage["context_window_tokens"] == 4096
+    assert context_usage["source"] == "opencode"
+    assert context_usage["breakdown"] == {
         "input_tokens": 120,
         "output_tokens": 30,
         "reasoning_tokens": 20,

--- a/backend/tests/test_opencode_adapter.py
+++ b/backend/tests/test_opencode_adapter.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import Any, cast
 
 import pytest
@@ -392,13 +393,6 @@ async def test_context_usage_snapshot_deduplicates_cached_updates() -> None:
     await adapter._maybe_update_context_usage(state, properties)
     await adapter._maybe_update_context_usage(state, properties)
 
-    snapshot = _context_usage_snapshot_from_message(
-        "opencode",
-        "opencode/minimax-m2.5-free",
-        properties["info"]["tokens"],  # type: ignore[index]
-        4096,
-    )
-    assert snapshot is not None
     assert len(calls) == 1
     assert calls[0][0] == "local-1"
     assert calls[0][2] is False
@@ -413,3 +407,174 @@ async def test_context_usage_snapshot_deduplicates_cached_updates() -> None:
         "cache_read_tokens": 15,
         "cache_write_tokens": 5,
     }
+
+
+@pytest.mark.asyncio
+async def test_context_usage_background_lookup_publishes_once_ready() -> None:
+    calls: list[tuple[str, dict[str, object], bool]] = []
+
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def on_session_update(
+        session_id: str, updates: dict[str, object], publish: bool
+    ) -> object:
+        calls.append((session_id, updates, publish))
+        return None
+
+    class _FakeClient:
+        async def get(self, path, params=None):
+            assert path == "/config/providers"
+            return {
+                "providers": [
+                    {
+                        "id": "opencode",
+                        "models": {
+                            "opencode/minimax-m2.5-free": {"limit": {"context": 4096}}
+                        },
+                    }
+                ]
+            }
+
+    adapter = OpenCodeAdapter(
+        emit_event=_emit,
+        on_session_update=on_session_update,
+    )
+    adapter._client = _FakeClient()  # type: ignore[assignment]
+    state = OpenCodeSessionState(
+        session_id="local-1",
+        cwd="/tmp",
+        opencode_session_id="ses_1",
+    )
+    adapter._register_session(state)
+    properties = {
+        "sessionID": "ses_1",
+        "info": {
+            "role": "assistant",
+            "providerID": "opencode",
+            "modelID": "opencode/minimax-m2.5-free",
+            "tokens": {
+                "input": 120,
+                "output": 30,
+                "reasoning": 20,
+                "cache": {"read": 15, "write": 5},
+            },
+        },
+    }
+
+    await adapter._maybe_update_context_usage(state, properties)
+
+    for _ in range(100):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+
+    assert len(calls) == 1
+    assert calls[0][0] == "local-1"
+    assert calls[0][2] is True
+    context_usage = cast(dict[str, Any], calls[0][1]["context_usage"])
+    assert context_usage["used_tokens"] == 140
+    assert context_usage["context_window_tokens"] == 4096
+    assert context_usage["source"] == "opencode"
+    assert context_usage["breakdown"] == {
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "reasoning_tokens": 20,
+        "cache_read_tokens": 15,
+        "cache_write_tokens": 5,
+    }
+    assert (
+        state.context_window_by_model[("opencode", "opencode/minimax-m2.5-free")]
+        == 4096
+    )
+    assert (
+        "opencode",
+        "opencode/minimax-m2.5-free",
+    ) not in state.context_usage_pending_tokens
+    assert state.context_window_lookup_pending == set()
+    assert not adapter._context_window_lookup_tasks
+
+
+@pytest.mark.asyncio
+async def test_context_window_lookup_failure_retries_after_ttl() -> None:
+    calls: list[tuple[str, dict[str, object], bool]] = []
+
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def on_session_update(
+        session_id: str, updates: dict[str, object], publish: bool
+    ) -> object:
+        calls.append((session_id, updates, publish))
+        return None
+
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.fail_first = True
+
+        async def get(self, path, params=None):
+            assert path == "/config/providers"
+            if self.fail_first:
+                self.fail_first = False
+                raise RuntimeError("temporary outage")
+            return {
+                "providers": [
+                    {
+                        "id": "opencode",
+                        "models": {
+                            "opencode/minimax-m2.5-free": {"limit": {"context": 4096}}
+                        },
+                    }
+                ]
+            }
+
+    adapter = OpenCodeAdapter(
+        emit_event=_emit,
+        on_session_update=on_session_update,
+    )
+    client = _FakeClient()
+    adapter._client = client  # type: ignore[assignment]
+    state = OpenCodeSessionState(
+        session_id="local-1",
+        cwd="/tmp",
+        opencode_session_id="ses_1",
+    )
+    adapter._register_session(state)
+    key = ("opencode", "opencode/minimax-m2.5-free")
+    properties = {
+        "sessionID": "ses_1",
+        "info": {
+            "role": "assistant",
+            "providerID": key[0],
+            "modelID": key[1],
+            "tokens": {
+                "input": 120,
+                "output": 30,
+                "reasoning": 20,
+                "cache": {"read": 15, "write": 5},
+            },
+        },
+    }
+
+    await adapter._maybe_update_context_usage(state, properties)
+    for _ in range(100):
+        if (
+            key in state.context_window_lookup_failed
+            and not state.context_window_lookup_pending
+        ):
+            break
+        await asyncio.sleep(0.01)
+    assert key in state.context_window_lookup_failed
+    assert not calls
+
+    state.context_window_lookup_failed[key] = time.monotonic() - 2 * 60.0
+    await adapter._maybe_update_context_usage(state, properties)
+
+    for _ in range(100):
+        if calls:
+            break
+        await asyncio.sleep(0.01)
+
+    assert len(calls) == 1
+    assert calls[0][2] is True
+    assert state.context_window_by_model[key] == 4096

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1259,7 +1259,7 @@ async def test_create_session_uses_structured_claude_for_ssh_target(
             session.transport_state["thread_id"],
             "remote-launch-factory",
             "default",
-            None,
+            "opus[1m]",
             None,
         )
     ]

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from waypoint.schemas import (
     EventKind,
     EventRecord,
+    SessionContextUsage,
     SessionRecord,
     SessionSource,
     SessionStatus,
@@ -27,6 +28,13 @@ def test_storage_round_trip(tmp_path) -> None:
         last_event_at=now,
         raw_log_path="/tmp/raw.log",
         structured_log_path="/tmp/events.jsonl",
+        context_usage=SessionContextUsage(
+            used_tokens=2048,
+            context_window_tokens=8192,
+            updated_at=now,
+            source="codex",
+            breakdown={"input_tokens": 1024, "output_tokens": 1024},
+        ),
     )
     storage.create_session(session)
     event = EventRecord(
@@ -44,6 +52,13 @@ def test_storage_round_trip(tmp_path) -> None:
     assert loaded.cwd == "/tmp"
     assert loaded.launch_target_id == "devbox"
     assert loaded.status == SessionStatus.RUNNING
+    assert loaded.context_usage is not None
+    assert loaded.context_usage.used_tokens == 2048
+    assert loaded.context_usage.context_window_tokens == 8192
+    assert loaded.context_usage.breakdown == {
+        "input_tokens": 1024,
+        "output_tokens": 1024,
+    }
     events = storage.list_events("session-1")
     assert len(events) == 1
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3115,6 +3115,46 @@ html[data-theme="light"] .composer-context-trigger.open {
   box-shadow: 0 0 0 1px rgba(184, 130, 14, 0.08) inset;
 }
 
+.composer-context-trigger.tone-good {
+  color: var(--text);
+}
+
+.composer-context-trigger.tone-good::before {
+  background: var(--success);
+}
+
+.composer-context-trigger.tone-warn {
+  color: var(--warn);
+  border-color: rgba(217, 154, 74, 0.4);
+  box-shadow: 0 0 0 1px rgba(217, 154, 74, 0.08) inset;
+}
+
+.composer-context-trigger.tone-warn::before {
+  background: var(--warn);
+  box-shadow: 0 0 0 3px rgba(217, 154, 74, 0.18);
+}
+
+html[data-theme="light"] .composer-context-trigger.tone-warn {
+  border-color: rgba(170, 102, 24, 0.38);
+  box-shadow: 0 0 0 1px rgba(170, 102, 24, 0.08) inset;
+}
+
+.composer-context-trigger.tone-danger {
+  color: var(--danger);
+  border-color: rgba(226, 108, 112, 0.42);
+  box-shadow: 0 0 0 1px rgba(226, 108, 112, 0.1) inset;
+}
+
+.composer-context-trigger.tone-danger::before {
+  background: var(--danger);
+  box-shadow: 0 0 0 3px rgba(226, 108, 112, 0.18);
+}
+
+html[data-theme="light"] .composer-context-trigger.tone-danger {
+  border-color: rgba(184, 48, 56, 0.38);
+  box-shadow: 0 0 0 1px rgba(184, 48, 56, 0.08) inset;
+}
+
 .composer-context-popover {
   position: absolute;
   right: 0;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3084,6 +3084,167 @@ html[data-theme="light"] .composer-connection {
   background: rgba(235, 230, 218, 0.75);
 }
 
+.composer-context {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.composer-context-trigger {
+  appearance: none;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.composer-context-trigger:hover {
+  transform: translateY(-1px);
+}
+
+.composer-context-trigger.open {
+  color: var(--text-strong);
+  border-color: rgba(200, 169, 106, 0.32);
+  box-shadow: 0 0 0 1px rgba(200, 169, 106, 0.08) inset;
+}
+
+html[data-theme="light"] .composer-context-trigger.open {
+  border-color: rgba(184, 130, 14, 0.28);
+  box-shadow: 0 0 0 1px rgba(184, 130, 14, 0.08) inset;
+}
+
+.composer-context-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 8px);
+  width: min(360px, calc(100vw - 32px));
+  padding: 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: rgba(14, 17, 24, 0.98);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(14px);
+  display: grid;
+  gap: 12px;
+  z-index: 30;
+}
+
+html[data-theme="light"] .composer-context-popover {
+  background: rgba(252, 249, 242, 0.98);
+  box-shadow: 0 12px 32px rgba(60, 45, 20, 0.15);
+}
+
+.composer-context-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.composer-context-titles {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.composer-context-kicker {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.composer-context-titles strong {
+  font-size: 1rem;
+  color: var(--text-strong);
+  line-height: 1.2;
+  word-break: break-word;
+}
+
+.composer-context-source {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line);
+  background: rgba(8, 11, 16, 0.45);
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+html[data-theme="light"] .composer-context-source {
+  background: rgba(235, 230, 218, 0.75);
+}
+
+.composer-context-meter {
+  height: 8px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(8, 11, 16, 0.44);
+}
+
+html[data-theme="light"] .composer-context-meter {
+  background: rgba(235, 230, 218, 0.78);
+}
+
+.composer-context-meter > span {
+  display: block;
+  height: 100%;
+  width: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--success), #79d6ff);
+}
+
+.composer-context-popover.tone-warn .composer-context-meter > span {
+  background: linear-gradient(90deg, var(--warn), #f0c46b);
+}
+
+.composer-context-popover.tone-danger .composer-context-meter > span {
+  background: linear-gradient(90deg, var(--danger), #ff8f70);
+}
+
+.composer-context-grid,
+.composer-context-breakdown {
+  display: grid;
+  gap: 10px 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.composer-context-grid > div,
+.composer-context-breakdown > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.composer-context-grid span,
+.composer-context-breakdown span {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.composer-context-grid strong,
+.composer-context-breakdown strong {
+  font-size: 0.82rem;
+  color: var(--accent-strong);
+  word-break: break-word;
+}
+
+.composer-context-breakdown {
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
 .composer-connection::before {
   content: "";
   width: 7px;
@@ -4525,6 +4686,30 @@ html[data-theme="light"] .terminal {
   .composer-tune-restart-apply {
     font-size: 0.68rem;
     padding: 6px 10px;
+  }
+
+  .composer-context-popover {
+    width: min(320px, calc(100vw - 24px));
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .composer-context-head {
+    gap: 10px;
+  }
+
+  .composer-context-grid {
+    gap: 8px 10px;
+    grid-template-columns: 1fr;
+  }
+
+  .composer-context-breakdown {
+    display: none;
+  }
+
+  .composer-context-source {
+    font-size: 0.6rem;
+    letter-spacing: 0.08em;
   }
 
   .composer-shortcut {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -68,6 +68,7 @@ import {
   CommandCompletion,
   EventRecord,
   SessionCommandInvocation,
+  SessionContextUsage,
   SessionEnvelope,
   SessionRecord,
   SessionTransport,
@@ -127,6 +128,54 @@ const EFFORT_LABEL: Record<string, string> = {
   xhigh: "Extra high",
   max: "Max",
 };
+
+const TOKEN_FORMATTER = new Intl.NumberFormat("en-US");
+
+function formatTokens(value: number): string {
+  return TOKEN_FORMATTER.format(value);
+}
+
+function contextUsagePercent(usage: SessionContextUsage): number | null {
+  const windowTokens = usage.context_window_tokens;
+  if (!windowTokens || windowTokens <= 0) {
+    return null;
+  }
+  return Math.round((usage.used_tokens / windowTokens) * 100);
+}
+
+function contextUsageTone(percent: number | null): "good" | "warn" | "danger" {
+  if (percent === null) {
+    return "good";
+  }
+  if (percent >= 90) {
+    return "danger";
+  }
+  if (percent >= 70) {
+    return "warn";
+  }
+  return "good";
+}
+
+function contextUsageLabel(key: string): string {
+  switch (key) {
+    case "input_tokens":
+      return "Input";
+    case "cached_input_tokens":
+      return "Cached input";
+    case "output_tokens":
+      return "Output";
+    case "reasoning_output_tokens":
+      return "Reasoning";
+    case "reasoning_tokens":
+      return "Reasoning";
+    case "cache_read_tokens":
+      return "Cache read";
+    case "cache_write_tokens":
+      return "Cache write";
+    default:
+      return key.replaceAll("_", " ");
+  }
+}
 
 interface SessionDetailProps {
   host: string;
@@ -1190,6 +1239,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         host={host}
         token={token}
         sessionId={sessionId}
+        session={session}
         permissionModeOptions={
           session ? permissionModesFor(session.backend, catalog) : []
         }
@@ -1252,6 +1302,7 @@ interface ReplyComposerProps {
   host: string;
   token: string;
   sessionId: string;
+  session: SessionRecord | null;
   agentBusy: boolean;
   permissionModeOptions: readonly BackendPermissionMode[];
   hasToolRuns: boolean;
@@ -1298,6 +1349,7 @@ const ReplyComposer = memo(function ReplyComposer({
   host,
   token,
   sessionId,
+  session,
   agentBusy,
   permissionModeOptions,
   canDelete,
@@ -1345,6 +1397,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const [selectedCompletion, setSelectedCompletion] =
     useState<CommandCompletion | null>(null);
   const [overflowOpen, setOverflowOpen] = useState(false);
+  const [contextUsageOpen, setContextUsageOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
   const [reattaching, setReattaching] = useState(false);
   // Pending effort for backends that need a session restart to apply (Claude)
@@ -1369,6 +1422,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const suggestionsRef = useRef<HTMLUListElement | null>(null);
   const suggestionItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const overflowRef = useRef<HTMLDivElement | null>(null);
+  const contextUsageRef = useRef<HTMLDivElement | null>(null);
   const tuneRef = useRef<HTMLDivElement | null>(null);
 
   // Built-in slash commands are intercepted on the backend only for
@@ -1533,6 +1587,28 @@ const ReplyComposer = memo(function ReplyComposer({
       window.removeEventListener("keydown", onKey);
     };
   }, [overflowOpen]);
+
+  useEffect(() => {
+    if (!contextUsageOpen) {
+      return;
+    }
+    function onPointer(event: PointerEvent) {
+      if (!contextUsageRef.current) return;
+      if (contextUsageRef.current.contains(event.target as Node)) return;
+      setContextUsageOpen(false);
+    }
+    function onKey(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        setContextUsageOpen(false);
+      }
+    }
+    window.addEventListener("pointerdown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointerdown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [contextUsageOpen]);
 
   useEffect(() => {
     if (!tuneOpen) {
@@ -1734,6 +1810,28 @@ const ReplyComposer = memo(function ReplyComposer({
     effortRequiresConfirm &&
     pendingEffort !== null &&
     pendingEffort !== (currentEffort ?? "");
+  const contextUsage = session?.context_usage ?? null;
+  const contextUsagePercentValue = contextUsage
+    ? contextUsagePercent(contextUsage)
+    : null;
+  const contextUsageToneValue = contextUsage
+    ? contextUsageTone(contextUsagePercentValue)
+    : "good";
+  const contextUsageBreakdown = contextUsage
+    ? Object.entries(contextUsage.breakdown ?? {})
+    : [];
+  const contextUsageHasWindow =
+    contextUsage !== null &&
+    typeof contextUsage.context_window_tokens === "number" &&
+    contextUsage.context_window_tokens > 0;
+  const contextUsageWindowTokens = contextUsageHasWindow
+    ? contextUsage.context_window_tokens
+    : null;
+  const contextUsageSummary = contextUsage
+    ? contextUsageHasWindow && contextUsagePercentValue !== null
+      ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowTokens ?? 0)} (${Math.max(0, contextUsagePercentValue)}%)`
+      : formatTokens(contextUsage.used_tokens)
+    : null;
 
   const handleEffortSelect = (next: string) => {
     if (effortRequiresConfirm) {
@@ -1898,18 +1996,105 @@ const ReplyComposer = memo(function ReplyComposer({
           </div>
         ) : null}
         <div className="composer-toprow-trail">
-          <span
-            className={`composer-connection ${connection}`}
-            title={`Backend socket ${connection}`}
-            role="status"
-            aria-live="polite"
-          >
-            {connection === "open"
-              ? "live"
-              : connection === "reconnecting"
-                ? "reconnecting"
-                : "connecting"}
-          </span>
+          {contextUsage ? (
+            <div className="composer-context" ref={contextUsageRef}>
+              <button
+                type="button"
+                className={`composer-connection composer-context-trigger ${connection} ${contextUsageOpen ? "open" : ""}`}
+                title={
+                  contextUsageSummary
+                    ? `Backend socket ${connection}. Context ${contextUsageSummary}`
+                    : `Backend socket ${connection}. Click for context usage`
+                }
+                aria-live="polite"
+                aria-haspopup="dialog"
+                aria-expanded={contextUsageOpen}
+                aria-label={`Backend socket ${connection}. Context usage details`}
+                onClick={() => setContextUsageOpen((open) => !open)}
+              >
+                {connection === "open"
+                  ? "live"
+                  : connection === "reconnecting"
+                    ? "reconnecting"
+                    : "connecting"}
+              </button>
+              {contextUsageOpen ? (
+                <div className={`composer-context-popover tone-${contextUsageToneValue}`} role="dialog" aria-label="Context usage">
+                  <div className="composer-context-head">
+                    <div className="composer-context-titles">
+                      <span className="composer-context-kicker">Context</span>
+                      <strong>
+                        {contextUsageSummary ?? formatTokens(contextUsage.used_tokens)}
+                      </strong>
+                    </div>
+                    <span className="composer-context-source">
+                      {humaniseBackend(contextUsage.source)}
+                    </span>
+                  </div>
+                  <div className="composer-context-meter" aria-hidden="true">
+                    <span
+                      style={{
+                        width: contextUsageHasWindow && contextUsagePercentValue !== null
+                          ? `${Math.min(100, Math.max(0, contextUsagePercentValue))}%`
+                          : "0%",
+                      }}
+                    />
+                  </div>
+                  <div className="composer-context-grid">
+                    <div>
+                      <span>Used</span>
+                      <strong>{formatTokens(contextUsage.used_tokens)} tokens</strong>
+                    </div>
+                    <div>
+                      <span>Window</span>
+                      <strong>
+                        {contextUsageHasWindow
+                          ? `${formatTokens(contextUsage.context_window_tokens ?? 0)} tokens`
+                          : "Unavailable"}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>Percent</span>
+                      <strong>
+                        {contextUsagePercentValue !== null
+                          ? `${Math.max(0, contextUsagePercentValue)}% used`
+                          : "Unavailable"}
+                      </strong>
+                    </div>
+                    <div>
+                      <span>Updated</span>
+                      <strong>
+                        {new Date(contextUsage.updated_at).toLocaleString()}
+                      </strong>
+                    </div>
+                  </div>
+                  {contextUsageBreakdown.length > 0 ? (
+                    <div className="composer-context-breakdown">
+                      {contextUsageBreakdown.map(([key, value]) => (
+                        <div key={key}>
+                          <span>{contextUsageLabel(key)}</span>
+                          <strong>{formatTokens(value)}</strong>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <span
+              className={`composer-connection ${connection}`}
+              title={`Backend socket ${connection}`}
+              role="status"
+              aria-live="polite"
+            >
+              {connection === "open"
+                ? "live"
+                : connection === "reconnecting"
+                  ? "reconnecting"
+                  : "connecting"}
+            </span>
+          )}
         </div>
       </div>
       <div className="reply-textarea-wrap">

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -130,9 +130,31 @@ const EFFORT_LABEL: Record<string, string> = {
 };
 
 const TOKEN_FORMATTER = new Intl.NumberFormat("en-US");
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("en", {
+  numeric: "auto",
+});
 
 function formatTokens(value: number): string {
   return TOKEN_FORMATTER.format(value);
+}
+
+function formatRelativeTime(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return "Unknown";
+  }
+  const diffSeconds = Math.round((timestamp - Date.now()) / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+  if (absSeconds < 60) {
+    return RELATIVE_TIME_FORMATTER.format(diffSeconds, "second");
+  }
+  if (absSeconds < 3600) {
+    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 60), "minute");
+  }
+  if (absSeconds < 86400) {
+    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 3600), "hour");
+  }
+  return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 86400), "day");
 }
 
 function contextUsagePercent(usage: SessionContextUsage): number | null {
@@ -154,6 +176,13 @@ function contextUsageTone(percent: number | null): "good" | "warn" | "danger" {
     return "warn";
   }
   return "good";
+}
+
+function clampPercent(percent: number | null): number | null {
+  if (percent === null) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, percent));
 }
 
 function contextUsageLabel(key: string): string {
@@ -1814,6 +1843,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const contextUsagePercentValue = contextUsage
     ? contextUsagePercent(contextUsage)
     : null;
+  const contextUsagePercentDisplay = clampPercent(contextUsagePercentValue);
   const contextUsageToneValue = contextUsage
     ? contextUsageTone(contextUsagePercentValue)
     : "good";
@@ -1827,9 +1857,10 @@ const ReplyComposer = memo(function ReplyComposer({
   const contextUsageWindowTokens = contextUsageHasWindow
     ? contextUsage.context_window_tokens
     : null;
+  const contextUsageWindowDisplay = contextUsageWindowTokens ?? 0;
   const contextUsageSummary = contextUsage
-    ? contextUsageHasWindow && contextUsagePercentValue !== null
-      ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowTokens ?? 0)} (${Math.max(0, contextUsagePercentValue)}%)`
+    ? contextUsageWindowTokens !== null && contextUsagePercentDisplay !== null
+      ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
       : formatTokens(contextUsage.used_tokens)
     : null;
 
@@ -2000,7 +2031,7 @@ const ReplyComposer = memo(function ReplyComposer({
             <div className="composer-context" ref={contextUsageRef}>
               <button
                 type="button"
-                className={`composer-connection composer-context-trigger ${connection} ${contextUsageOpen ? "open" : ""}`}
+                className={`composer-connection composer-context-trigger tone-${contextUsageToneValue} ${connection} ${contextUsageOpen ? "open" : ""}`}
                 title={
                   contextUsageSummary
                     ? `Backend socket ${connection}. Context ${contextUsageSummary}`
@@ -2034,8 +2065,8 @@ const ReplyComposer = memo(function ReplyComposer({
                   <div className="composer-context-meter" aria-hidden="true">
                     <span
                       style={{
-                        width: contextUsageHasWindow && contextUsagePercentValue !== null
-                          ? `${Math.min(100, Math.max(0, contextUsagePercentValue))}%`
+                        width: contextUsageHasWindow && contextUsagePercentDisplay !== null
+                          ? `${contextUsagePercentDisplay}%`
                           : "0%",
                       }}
                     />
@@ -2048,23 +2079,23 @@ const ReplyComposer = memo(function ReplyComposer({
                     <div>
                       <span>Window</span>
                       <strong>
-                        {contextUsageHasWindow
-                          ? `${formatTokens(contextUsage.context_window_tokens ?? 0)} tokens`
+                        {contextUsageWindowTokens !== null
+                          ? `${formatTokens(contextUsageWindowDisplay)} tokens`
                           : "Unavailable"}
                       </strong>
                     </div>
                     <div>
                       <span>Percent</span>
                       <strong>
-                        {contextUsagePercentValue !== null
-                          ? `${Math.max(0, contextUsagePercentValue)}% used`
+                        {contextUsagePercentDisplay !== null
+                          ? `${contextUsagePercentDisplay}% used`
                           : "Unavailable"}
                       </strong>
                     </div>
                     <div>
                       <span>Updated</span>
-                      <strong>
-                        {new Date(contextUsage.updated_at).toLocaleString()}
+                      <strong title={new Date(contextUsage.updated_at).toLocaleString()}>
+                        {formatRelativeTime(contextUsage.updated_at)}
                       </strong>
                     </div>
                   </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -23,6 +23,14 @@ export type EventKind =
   | "system_note"
   | "raw_terminal_chunk";
 
+export interface SessionContextUsage {
+  used_tokens: number;
+  context_window_tokens?: number | null;
+  updated_at: string;
+  source: Backend;
+  breakdown?: Record<string, number>;
+}
+
 export interface SessionRecord {
   id: string;
   backend: Backend;
@@ -48,6 +56,7 @@ export interface SessionRecord {
   permission_mode?: string | null;
   model?: string | null;
   effort?: string | null;
+  context_usage?: SessionContextUsage | null;
   args: string[];
   config_overrides: string[];
 }


### PR DESCRIPTION
## Summary

Addresses #34. Adds live context usage snapshots for Codex and OpenCode, then surfaces the current usage behind the composer status pill as an overflow popover. Claude Code remains hidden when no trustworthy live usage signal is available.

## Changes

### Backend
- Added a shared session context-usage snapshot to the session schema, storage layer, and runtime broadcast path.
- Normalized Codex `thread/tokenUsage/updated` payloads into the shared snapshot shape.
- Normalized OpenCode `usage_update` data into the same snapshot shape.
- Kept Claude Code unchanged so it does not synthesize a live context estimate from unrelated telemetry.

### Frontend
- Kept the composer status pill compact and moved context usage behind an overflow popover anchored to that pill.
- Rendered used tokens, context window, percentage, update time, and optional breakdown rows in the popover.
- Added responsive styling so the popover stays readable on narrow screens.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_storage.py tests/test_codex_app_server.py tests/test_opencode_adapter.py`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`