### PR TITLE
feat: add session rate-limit usage panel

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -310,6 +310,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session = await context.runtime.reattach(session_id)
         return {"session": session.model_dump(mode="json")}
 
+    @app.post("/api/sessions/{session_id}/rate-limit-usage/refresh")
+    async def session_refresh_rate_limit_usage(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        session = await context.runtime.refresh_rate_limit_usage(session_id)
+        return {"session": session.model_dump(mode="json")}
+
     @app.post("/api/sessions/{session_id}/terminate")
     async def session_terminate(
         session_id: str,

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -35,7 +35,12 @@ from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_AUTO_APPROVE_MODES,
     CLAUDE_PERMISSION_MODES,
 )
-from waypoint.schemas import EventKind, SessionContextUsage, SessionStatus
+from waypoint.schemas import (
+    EventKind,
+    SessionContextUsage,
+    SessionRateLimitUsage,
+    SessionStatus,
+)
 
 log = logging.getLogger("waypoint.claude_cli")
 
@@ -227,6 +232,12 @@ class ClaudeSessionState:
     model: str | None = None
     context_usage_snapshot: SessionContextUsage | None = None
     context_usage_signature: tuple[int, int | None] | None = None
+    rate_limit_usage_snapshot: SessionRateLimitUsage | None = None
+    rate_limit_usage_signature: str | None = None
+    rate_limit_probe: Callable[[], Awaitable[SessionRateLimitUsage | None]] | None = (
+        None
+    )
+    rate_limit_refresh_task: asyncio.Task[None] | None = None
     # Reasoning effort. Claude's CLI accepts `--effort <level>` at launch
     # only — there is no in-process control_request to swap it — so changing
     # this value at runtime requires terminating and respawning the process
@@ -370,6 +381,24 @@ class ClaudeCliAdapter:
     def session_model(self, session_id: str) -> str | None:
         state = self._sessions.get(session_id)
         return state.model if state is not None else None
+
+    async def register_rate_limit_probe(
+        self,
+        session_id: str,
+        probe: Callable[[], Awaitable[SessionRateLimitUsage | None]],
+        *,
+        refresh_interval_seconds: float = 60.0,
+    ) -> None:
+        state = self._require_session(session_id)
+        state.rate_limit_probe = probe
+        if state.rate_limit_refresh_task is not None:
+            state.rate_limit_refresh_task.cancel()
+        state.rate_limit_refresh_task = asyncio.create_task(
+            self._refresh_rate_limit_usage_loop(
+                state, refresh_interval_seconds=refresh_interval_seconds
+            )
+        )
+        await self._refresh_rate_limit_usage(state)
 
     def session_slash_commands(self, session_id: str) -> tuple[str, ...]:
         state = self._sessions.get(session_id)
@@ -851,6 +880,10 @@ class ClaudeCliAdapter:
         if state is None:
             return False
         state.closing = True
+        if state.rate_limit_refresh_task is not None:
+            state.rate_limit_refresh_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await state.rate_limit_refresh_task
         # Resolve any pending approvals as deny so the hook unblocks.
         for pending in list(state.pending.values()):
             if not pending.future.done():
@@ -1416,6 +1449,53 @@ class ClaudeCliAdapter:
             state.session_id,
             {"context_usage": snapshot.model_dump(mode="json")},
             False,
+        )
+
+    async def _refresh_rate_limit_usage_loop(
+        self, state: ClaudeSessionState, *, refresh_interval_seconds: float
+    ) -> None:
+        try:
+            while state.session_id in self._sessions:
+                await self._refresh_rate_limit_usage(state)
+                await asyncio.sleep(refresh_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "claude rate-limit refresh loop failed",
+                extra={"session_id": state.session_id},
+            )
+
+    async def _refresh_rate_limit_usage(self, state: ClaudeSessionState) -> None:
+        probe = state.rate_limit_probe
+        if probe is None:
+            return
+        try:
+            snapshot = await probe()
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "claude rate-limit probe failed",
+                extra={"session_id": state.session_id},
+            )
+            return
+        if snapshot is None:
+            return
+        await self._publish_rate_limit_usage(state, snapshot)
+
+    async def _publish_rate_limit_usage(
+        self, state: ClaudeSessionState, snapshot: SessionRateLimitUsage
+    ) -> None:
+        signature = json.dumps(snapshot.model_dump(mode="json"), sort_keys=True)
+        if state.rate_limit_usage_signature == signature:
+            return
+        state.rate_limit_usage_signature = signature
+        state.rate_limit_usage_snapshot = snapshot
+        if self._on_session_update is None:
+            return
+        await self._on_session_update(
+            state.session_id,
+            {"rate_limit_usage": snapshot.model_dump(mode="json")},
+            True,
         )
 
     async def _refresh_context_usage(self, state: ClaudeSessionState) -> None:

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -399,6 +399,14 @@ class ClaudeCliAdapter:
             )
         )
 
+    async def force_refresh_rate_limit_usage(self, session_id: str) -> None:
+        # User-driven path: run the registered probe inline so the caller's
+        # response carries the fresh snapshot instead of racing the WS push.
+        state = self._sessions.get(session_id)
+        if state is None:
+            return
+        await self._refresh_rate_limit_usage(state)
+
     def session_slash_commands(self, session_id: str) -> tuple[str, ...]:
         state = self._sessions.get(session_id)
         return state.slash_commands if state is not None else ()

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -398,7 +398,6 @@ class ClaudeCliAdapter:
                 state, refresh_interval_seconds=refresh_interval_seconds
             )
         )
-        await self._refresh_rate_limit_usage(state)
 
     def session_slash_commands(self, session_id: str) -> tuple[str, ...]:
         state = self._sessions.get(session_id)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -242,6 +242,11 @@ class ClaudeCodePlugin:
             else None
         )
         await self._register_rate_limit_probe(runtime, session.id, launch_target)
+        # Run the probe inline so the caller's HTTP response carries the
+        # post-refresh snapshot — otherwise the response races the WS push
+        # from the periodic loop and the UI sees stale data.
+        if self.adapter is not None:
+            await self.adapter.force_refresh_rate_limit_usage(session.id)
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -34,7 +34,10 @@ from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_PERMISSION_MODES,
     claude_permission_mode_label,
 )
-from waypoint.backends.claude_code.rate_limits import probe_claude_usage
+from waypoint.backends.claude_code.rate_limits import (
+    probe_claude_usage,
+    probe_claude_usage_remote,
+)
 from waypoint.backends.claude_code.remote import build_remote_claude_launch_factory
 from waypoint.backends.claude_code.runtime_hook import (
     ClaudeHookBundle,
@@ -203,12 +206,42 @@ class ClaudeCodePlugin:
             session_id, _probe, refresh_interval_seconds=300.0
         )
 
+    async def _register_remote_rate_limit_probe(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        launch_target: SshLaunchTargetConfig,
+    ) -> None:
+        if self.adapter is None:
+            return
+
+        async def _probe() -> SessionRateLimitUsage | None:
+            return await probe_claude_usage_remote(launch_target)
+
+        await self.adapter.register_rate_limit_probe(
+            session_id, _probe, refresh_interval_seconds=300.0
+        )
+
+    async def _register_rate_limit_probe(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> None:
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(runtime, session_id)
+            return
+        await self._register_remote_rate_limit_probe(runtime, session_id, launch_target)
+
     async def refresh_rate_limit_usage(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        if session.launch_target_id is not None:
-            return
-        await self._register_local_rate_limit_probe(runtime, session.id)
+        launch_target = (
+            runtime._find_launch_target(session.launch_target_id)
+            if session.launch_target_id
+            else None
+        )
+        await self._register_rate_limit_probe(runtime, session.id, launch_target)
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the
@@ -698,8 +731,7 @@ class ClaudeCodePlugin:
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
-        if launch_target is None:
-            await self._register_local_rate_limit_probe(runtime, new_session_id)
+        await self._register_rate_limit_probe(runtime, new_session_id, launch_target)
         await runtime._record_system_event(
             new_session_id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id)
@@ -776,8 +808,11 @@ class ClaudeCodePlugin:
             )
             return
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
-        if session.launch_target_id is None:
-            await self._register_local_rate_limit_probe(runtime, session.id)
+        await self._register_rate_limit_probe(
+            runtime,
+            session.id,
+            runtime._find_launch_target(session.launch_target_id),
+        )
         await runtime._record_system_event(
             session.id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id),
@@ -961,8 +996,7 @@ class ClaudeCodePlugin:
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
-        if launch_target is None:
-            await self._register_local_rate_limit_probe(runtime, session.id)
+        await self._register_rate_limit_probe(runtime, session.id, launch_target)
         await runtime._record_system_event(
             session.id,
             self.format_start_message(claude_session_id, request.cwd, launch_target),
@@ -1077,8 +1111,7 @@ class ClaudeCodePlugin:
         if launch_target is not None and self.thread_enumerator is not None:
             self.thread_enumerator.invalidate(launch_target.id)
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
-        if launch_target is None:
-            await self._register_local_rate_limit_probe(runtime, session.id)
+        await self._register_rate_limit_probe(runtime, session.id, launch_target)
         await runtime._record_system_event(
             session.id,
             self.format_import_message(cwd, launch_target),

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -203,6 +203,13 @@ class ClaudeCodePlugin:
             session_id, _probe, refresh_interval_seconds=300.0
         )
 
+    async def refresh_rate_limit_usage(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        if session.launch_target_id is not None:
+            return
+        await self._register_local_rate_limit_probe(runtime, session.id)
+
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the
         # PreToolUse hook bundle failed to materialise we leave

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -34,6 +34,7 @@ from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_PERMISSION_MODES,
     claude_permission_mode_label,
 )
+from waypoint.backends.claude_code.rate_limits import probe_claude_usage
 from waypoint.backends.claude_code.remote import build_remote_claude_launch_factory
 from waypoint.backends.claude_code.runtime_hook import (
     ClaudeHookBundle,
@@ -59,6 +60,7 @@ from waypoint.schemas import (
     SessionCreateRequest,
     SessionEnvelope,
     SessionInputRequest,
+    SessionRateLimitUsage,
     SessionRecord,
     SessionSource,
     SessionStatus,
@@ -187,6 +189,20 @@ class ClaudeCodePlugin:
                 detail="claude adapter is not initialized",
             )
         return self.adapter
+
+    async def _register_local_rate_limit_probe(
+        self, runtime: "SessionRuntime", session_id: str
+    ) -> None:
+        if self.adapter is None:
+            return
+
+        async def _probe() -> SessionRateLimitUsage | None:
+            return await probe_claude_usage()
+
+        register_probe = getattr(self.adapter, "register_rate_limit_probe", None)
+        if not callable(register_probe):
+            return
+        await register_probe(session_id, _probe)
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the
@@ -602,6 +618,11 @@ class ClaudeCodePlugin:
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="claude adapter is not initialized",
             )
+        launch_target = (
+            runtime._find_launch_target(session.launch_target_id)
+            if session.launch_target_id
+            else None
+        )
         thread_id = session.transport_state.get("thread_id")
         if not thread_id:
             raise HTTPException(
@@ -671,6 +692,8 @@ class ClaudeCodePlugin:
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(runtime, new_session_id)
         await runtime._record_system_event(
             new_session_id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id)
@@ -747,6 +770,8 @@ class ClaudeCodePlugin:
             )
             return
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+        if session.launch_target_id is None:
+            await self._register_local_rate_limit_probe(runtime, session.id)
         await runtime._record_system_event(
             session.id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id),
@@ -930,6 +955,8 @@ class ClaudeCodePlugin:
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(runtime, session.id)
         await runtime._record_system_event(
             session.id,
             self.format_start_message(claude_session_id, request.cwd, launch_target),
@@ -1044,6 +1071,8 @@ class ClaudeCodePlugin:
         if launch_target is not None and self.thread_enumerator is not None:
             self.thread_enumerator.invalidate(launch_target.id)
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(runtime, session.id)
         await runtime._record_system_event(
             session.id,
             self.format_import_message(cwd, launch_target),

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -199,10 +199,9 @@ class ClaudeCodePlugin:
         async def _probe() -> SessionRateLimitUsage | None:
             return await probe_claude_usage()
 
-        register_probe = getattr(self.adapter, "register_rate_limit_probe", None)
-        if not callable(register_probe):
-            return
-        await register_probe(session_id, _probe)
+        await self.adapter.register_rate_limit_probe(
+            session_id, _probe, refresh_interval_seconds=300.0
+        )
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import platform
 import re
 import subprocess
-from datetime import UTC, datetime
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -14,12 +16,19 @@ from urllib.request import Request, urlopen
 
 from waypoint.schemas import SessionRateLimitUsage, UsageWindow
 
+log = logging.getLogger("waypoint.claude_code.rate_limits")
+
+_CLAUDE_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+_CLAUDE_MESSAGES_MODEL = "claude-haiku-4-5-20251001"
+_CLAUDE_MESSAGES_VERSION = "2023-06-01"
 _WINDOWS: tuple[tuple[str, str, int], ...] = (
     ("five_hour", "5h", 5 * 60),
     ("seven_day", "Weekly", 7 * 24 * 60),
     ("seven_day_opus", "Opus", 7 * 24 * 60),
     ("seven_day_sonnet", "Sonnet", 7 * 24 * 60),
 )
+_CLAUDE_USER_AGENT: str | None = None
+_CLAUDE_USER_AGENT_RESOLVED = False
 
 
 def parse_claude_usage_payload(
@@ -75,37 +84,223 @@ async def probe_claude_usage(
     resolved_env = env if env is not None else dict(os.environ)
     credentials = _read_cli_credentials_for_env(resolved_env)
     if credentials is None:
+        log.warning("claude rate-limit probe found no CLI credentials")
         return None
-    access_token, credential_note = credentials
+    access_token, expires_at, credential_note = credentials
+    if _is_access_token_expired(expires_at):
+        log.info(
+            "claude rate-limit probe: cached access token is expired; "
+            "skipping HTTP call and surfacing expiry"
+        )
+        return _expired_credentials_snapshot(credential_note, resolved_env)
+    response = await asyncio.wait_for(
+        asyncio.to_thread(_fetch_claude_messages_usage, access_token),
+        timeout=timeout_seconds,
+    )
+    if response is None:
+        log.warning("claude rate-limit request failed before receiving a response")
+        return None
+    notes = [credential_note, *_read_oauth_account_notes(resolved_env)]
+    usage = parse_claude_rate_limit_headers(
+        response.headers,
+        now=datetime.now(UTC),
+        notes=_unique_notes(notes),
+    )
+    if usage is not None:
+        return usage
+    if response.status == 401:
+        log.warning(
+            "claude rate-limit response was unauthenticated "
+            f"(status=401 preview={response.body[:240].decode('utf-8', errors='replace')!r})",
+        )
+        return _expired_credentials_snapshot(credential_note, resolved_env)
+    if response.status == 429:
+        retry_after = _header_value(response.headers, "Retry-After")
+        if retry_after:
+            notes.append(f"rate limited; retry after {retry_after}s")
+        else:
+            notes.append("rate limited")
+        log.warning(
+            "claude rate-limit response was throttled "
+            f"(status={response.status} retry_after={retry_after!r} "
+            f"preview={response.body[:240].decode('utf-8', errors='replace')!r})",
+        )
+        return SessionRateLimitUsage(
+            source="claude_code",
+            updated_at=datetime.now(UTC),
+            windows=[],
+            notes=_unique_notes(notes),
+        )
+    if response.status != 200:
+        log.warning(
+            "claude rate-limit response was not successful "
+            f"(status={response.status} "
+            f"preview={response.body[:240].decode('utf-8', errors='replace')!r})",
+        )
+        return None
+    log.warning(
+        "claude rate-limit response did not include usable rate-limit headers "
+        f"(status={response.status} "
+        f"headers={sorted(_normalize_headers(response.headers).keys())})",
+    )
+    return None
+
+
+_EXPIRED_CREDENTIALS_NOTE = "credentials expired — run `claude` to refresh"
+_EXPIRY_SKEW = timedelta(seconds=60)
+
+
+def _is_access_token_expired(expires_at: datetime | None) -> bool:
+    # Missing expiry: matches the reference Swift app (assume valid; let the
+    # API tell us otherwise).
+    if expires_at is None:
+        return False
+    return expires_at <= datetime.now(UTC) + _EXPIRY_SKEW
+
+
+def _expired_credentials_snapshot(
+    credential_note: str, env: dict[str, str]
+) -> SessionRateLimitUsage:
+    return SessionRateLimitUsage(
+        source="claude_code",
+        updated_at=datetime.now(UTC),
+        windows=[],
+        notes=_unique_notes(
+            [
+                credential_note,
+                _EXPIRED_CREDENTIALS_NOTE,
+                *_read_oauth_account_notes(env),
+            ]
+        ),
+    )
+
+
+def parse_claude_rate_limit_headers(
+    headers: dict[str, str] | Any,
+    *,
+    now: datetime | None = None,
+    notes: list[str] | None = None,
+) -> SessionRateLimitUsage | None:
+    normalized = _normalize_headers(headers)
+    windows: list[UsageWindow] = []
+    for window_id, label, minutes, header_prefix in (
+        ("five_hour", "5h", 5 * 60, "5h"),
+        ("seven_day", "Weekly", 7 * 24 * 60, "7d"),
+    ):
+        utilization = _header_value(
+            normalized, f"anthropic-ratelimit-unified-{header_prefix}-utilization"
+        )
+        resets_at = _header_value(
+            normalized, f"anthropic-ratelimit-unified-{header_prefix}-reset"
+        )
+        percent = _parse_utilization(utilization)
+        if percent is None:
+            continue
+        reset_at = _parse_iso_datetime_from_unix_seconds(resets_at)
+        if reset_at is not None and reset_at < (now or datetime.now(UTC)):
+            percent = 0.0
+        windows.append(
+            UsageWindow(
+                id=window_id,
+                label=label,
+                used_percent=percent,
+                window_minutes=minutes,
+                resets_at=reset_at,
+            )
+        )
+    if not windows:
+        return None
+    return SessionRateLimitUsage(
+        source="claude_code",
+        updated_at=now or datetime.now(UTC),
+        windows=windows,
+        notes=list(notes or ["CLI creds"]),
+    )
+
+
+def _claude_user_agent() -> str:
+    global _CLAUDE_USER_AGENT
+    global _CLAUDE_USER_AGENT_RESOLVED
+    if _CLAUDE_USER_AGENT_RESOLVED:
+        return _CLAUDE_USER_AGENT or "claude-code/2.1.5"
+    _CLAUDE_USER_AGENT_RESOLVED = True
+    try:
+        completed = subprocess.run(
+            ["claude", "--version"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        _CLAUDE_USER_AGENT = "claude-code/2.1.5"
+        return _CLAUDE_USER_AGENT
+    if completed.returncode != 0:
+        _CLAUDE_USER_AGENT = "claude-code/2.1.5"
+        return _CLAUDE_USER_AGENT
+    match = re.search(r"\d+(?:\.\d+)+(?:[-+][A-Za-z0-9.-]+)?", completed.stdout)
+    version = (
+        match.group(0)
+        if match is not None
+        else completed.stdout.strip().split()[0] if completed.stdout.strip() else ""
+    )
+    _CLAUDE_USER_AGENT = f"claude-code/{version}" if version else "claude-code/2.1.5"
+    return _CLAUDE_USER_AGENT
+
+
+def _fetch_claude_messages_usage(access_token: str) -> _ClaudeHTTPResponse | None:
     request = Request(
-        "https://api.anthropic.com/api/oauth/usage",
-        method="GET",
+        _CLAUDE_MESSAGES_URL,
+        data=json.dumps(
+            {
+                "model": _CLAUDE_MESSAGES_MODEL,
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "hi"}],
+            }
+        ).encode("utf-8"),
+        method="POST",
         headers={
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
-            "User-Agent": "claude-code/2.1.5",
+            "User-Agent": _claude_user_agent(),
             "anthropic-beta": "oauth-2025-04-20",
+            "anthropic-version": _CLAUDE_MESSAGES_VERSION,
+            "Accept": "application/json",
         },
     )
-    response = await asyncio.wait_for(
-        asyncio.to_thread(_fetch_url, request), timeout=timeout_seconds
-    )
-    if response is None:
-        return None
-    return parse_claude_usage_payload(response, notes=[credential_note])
+    return _fetch_url(request)
 
 
-def _fetch_url(request: Request) -> bytes | None:
+@dataclass(frozen=True)
+class _ClaudeHTTPResponse:
+    status: int
+    headers: dict[str, str]
+    body: bytes
+
+
+def _fetch_url(request: Request) -> _ClaudeHTTPResponse | None:
     try:
         with urlopen(request, timeout=30) as response:
-            if getattr(response, "status", 200) != 200:
-                return None
-            return response.read()
-    except (HTTPError, URLError, OSError):
+            headers = {key: value for key, value in response.headers.items()}
+            return _ClaudeHTTPResponse(
+                status=getattr(response, "status", 200),
+                headers=headers,
+                body=response.read(),
+            )
+    except HTTPError as exc:
+        headers = {key: value for key, value in getattr(exc, "headers", {}).items()}
+        try:
+            body = exc.read() if exc.fp is not None else b""
+        except OSError:
+            body = b""
+        return _ClaudeHTTPResponse(status=exc.code, headers=headers, body=body)
+    except (URLError, OSError):
         return None
 
 
-def _read_cli_credentials_for_env(env: dict[str, str]) -> tuple[str, str] | None:
+def _read_cli_credentials_for_env(
+    env: dict[str, str],
+) -> tuple[str, datetime | None, str] | None:
     for path in _credential_paths(env):
         if not path.is_file():
             continue
@@ -113,14 +308,92 @@ def _read_cli_credentials_for_env(env: dict[str, str]) -> tuple[str, str] | None
             raw = path.read_text(encoding="utf-8")
         except OSError:
             continue
-        token = _extract_access_token(raw)
-        if token:
-            return token, "CLI creds"
+        parsed = _extract_oauth_fields(raw)
+        if parsed is not None:
+            access_token, expires_at = parsed
+            return access_token, expires_at, "CLI creds"
 
-    token = _read_keychain_access_token(env)
-    if token:
-        return token, "CLI creds"
+    keychain_raw = _read_keychain_access_token(env)
+    if keychain_raw:
+        parsed = _extract_oauth_fields(keychain_raw)
+        if parsed is not None:
+            access_token, expires_at = parsed
+            return access_token, expires_at, "CLI creds"
+        # Legacy path: keychain entry held a bare token rather than the JSON
+        # blob. We have no expiry hint in that case.
+        return keychain_raw, None, "CLI creds"
     return None
+
+
+def _read_oauth_account_notes(env: dict[str, str]) -> list[str]:
+    account = _read_oauth_account(env)
+    if account is None:
+        return []
+    notes: list[str] = []
+    organization_name = account.get("organizationName")
+    if isinstance(organization_name, str) and organization_name.strip():
+        notes.append(f"org: {organization_name.strip()}")
+    user_tier = account.get("userRateLimitTier")
+    if isinstance(user_tier, str) and user_tier.strip():
+        notes.append(f"user tier: {user_tier.strip()}")
+    org_tier = account.get("organizationRateLimitTier")
+    if isinstance(org_tier, str) and org_tier.strip():
+        notes.append(f"org tier: {org_tier.strip()}")
+    return notes
+
+
+def _normalize_headers(headers: dict[str, str] | Any) -> dict[str, str]:
+    if hasattr(headers, "items"):
+        return {str(key).lower(): str(value) for key, value in headers.items()}
+    return {}
+
+
+def _header_value(headers: dict[str, str] | Any, name: str) -> str | None:
+    normalized = _normalize_headers(headers)
+    value = normalized.get(name.lower())
+    if value is None:
+        return None
+    cleaned = value.strip()
+    return cleaned or None
+
+
+def _read_oauth_account(env: dict[str, str]) -> dict[str, Any] | None:
+    path = _claude_config_path(env)
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    account = payload.get("oauthAccount")
+    if not isinstance(account, dict):
+        return None
+    return account
+
+
+def _claude_config_path(env: dict[str, str]) -> Path:
+    base = env.get("CLAUDE_CONFIG_DIR")
+    if base:
+        return Path(base).expanduser() / ".claude.json"
+    return Path.home() / ".claude.json"
+
+
+def _unique_notes(notes: list[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for note in notes:
+        cleaned = note.strip()
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        unique.append(cleaned)
+    return unique
 
 
 def _credential_paths(env: dict[str, str]) -> tuple[Path, ...]:
@@ -149,28 +422,34 @@ def _read_keychain_access_token(env: dict[str, str]) -> str | None:
 def _read_keychain_access_token_for_service(
     service: str, env: dict[str, str]
 ) -> str | None:
-    try:
-        completed = subprocess.run(
-            [
-                "security",
-                "find-generic-password",
-                "-s",
-                service,
-                "-a",
-                env.get("USER", ""),
-                "-w",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=3,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if completed.returncode != 0:
-        return None
-    token = completed.stdout.strip()
-    return token or None
+    for args in (
+        [
+            "security",
+            "find-generic-password",
+            "-s",
+            service,
+            "-a",
+            env.get("USER", ""),
+            "-w",
+        ],
+        ["security", "find-generic-password", "-s", service, "-w"],
+    ):
+        try:
+            completed = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                timeout=3,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if completed.returncode != 0:
+            continue
+        token = completed.stdout.strip()
+        if token:
+            return token
+    return None
 
 
 _HASHED_KEYCHAIN_SERVICE_NAME: str | None = None
@@ -206,7 +485,7 @@ def _discover_hashed_keychain_service_name() -> str | None:
     return _HASHED_KEYCHAIN_SERVICE_NAME
 
 
-def _extract_access_token(raw: str) -> str | None:
+def _extract_oauth_fields(raw: str) -> tuple[str, datetime | None] | None:
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
@@ -217,7 +496,47 @@ def _extract_access_token(raw: str) -> str | None:
     if not isinstance(oauth, dict):
         return None
     token = oauth.get("accessToken")
-    return token if isinstance(token, str) and token else None
+    if not isinstance(token, str) or not token:
+        return None
+    return token, _parse_expires_at(oauth.get("expiresAt"))
+
+
+def _parse_expires_at(value: Any) -> datetime | None:
+    # Claude Code CLI stores expiresAt in milliseconds since epoch; older
+    # builds used seconds. Treat values > 1e12 as ms, per the reference Swift
+    # app (ClaudeCodeSyncService.swift:587-589).
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        epoch = float(value)
+    elif isinstance(value, str):
+        try:
+            epoch = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    seconds = epoch / 1000.0 if epoch > 1e12 else epoch
+    try:
+        return datetime.fromtimestamp(seconds, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _parse_iso_datetime_from_unix_seconds(value: Any) -> datetime | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(value, str):
+        try:
+            return datetime.fromtimestamp(float(value), tz=UTC)
+        except ValueError:
+            return None
+    return None
 
 
 def _parse_utilization(value: Any) -> float | None:

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -135,11 +135,15 @@ def _credential_paths(env: dict[str, str]) -> tuple[Path, ...]:
 def _read_keychain_access_token(env: dict[str, str]) -> str | None:
     if platform.system() != "Darwin":
         return None
-    for service in _resolve_keychain_service_names(env):
-        token = _read_keychain_access_token_for_service(service, env)
-        if token:
-            return token
-    return None
+    token = _read_keychain_access_token_for_service(
+        _canonical_keychain_service_name(), env
+    )
+    if token:
+        return token
+    discovered = _discover_hashed_keychain_service_name()
+    if discovered is None:
+        return None
+    return _read_keychain_access_token_for_service(discovered, env)
 
 
 def _read_keychain_access_token_for_service(
@@ -169,15 +173,19 @@ def _read_keychain_access_token_for_service(
     return token or None
 
 
-def _resolve_keychain_service_names(env: dict[str, str]) -> tuple[str, ...]:
-    services = ["Claude Code-credentials"]
-    discovered = _discover_hashed_keychain_service_name(env)
-    if discovered and discovered not in services:
-        services.append(discovered)
-    return tuple(services)
+_HASHED_KEYCHAIN_SERVICE_NAME: str | None = None
+_HASHED_KEYCHAIN_SERVICE_NAME_RESOLVED = False
 
 
-def _discover_hashed_keychain_service_name(env: dict[str, str]) -> str | None:
+def _canonical_keychain_service_name() -> str:
+    return "Claude Code-credentials"
+
+
+def _discover_hashed_keychain_service_name() -> str | None:
+    global _HASHED_KEYCHAIN_SERVICE_NAME_RESOLVED
+    global _HASHED_KEYCHAIN_SERVICE_NAME
+    if _HASHED_KEYCHAIN_SERVICE_NAME_RESOLVED:
+        return _HASHED_KEYCHAIN_SERVICE_NAME
     try:
         completed = subprocess.run(
             ["security", "dump-keychain"],
@@ -189,9 +197,13 @@ def _discover_hashed_keychain_service_name(env: dict[str, str]) -> str | None:
     except (OSError, subprocess.TimeoutExpired):
         return None
     if completed.returncode != 0:
+        _HASHED_KEYCHAIN_SERVICE_NAME_RESOLVED = True
         return None
-    match = re.search(r'Claude Code-credentials-[^"\s]+', completed.stdout)
-    return match.group(0) if match else None
+    match = re.search(r"(Claude Code-credentials-[^\"\s]+)", completed.stdout)
+    if match is not None:
+        _HASHED_KEYCHAIN_SERVICE_NAME = match.group(1)
+    _HASHED_KEYCHAIN_SERVICE_NAME_RESOLVED = True
+    return _HASHED_KEYCHAIN_SERVICE_NAME
 
 
 def _extract_access_token(raw: str) -> str | None:

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.resources
 import json
 import logging
 import os
@@ -14,6 +15,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import SessionRateLimitUsage, UsageWindow
 
 log = logging.getLogger("waypoint.claude_code.rate_limits")
@@ -100,30 +102,160 @@ async def probe_claude_usage(
     if response is None:
         log.warning("claude rate-limit request failed before receiving a response")
         return None
-    notes = [credential_note, *_read_oauth_account_notes(resolved_env)]
+    return _build_messages_snapshot(
+        status=response.status,
+        headers=response.headers,
+        body=response.body,
+        credential_note=credential_note,
+        account_notes=_read_oauth_account_notes(resolved_env),
+    )
+
+
+async def probe_claude_usage_remote(
+    launch_target: SshLaunchTargetConfig,
+    *,
+    timeout_seconds: float = 30.0,
+) -> SessionRateLimitUsage | None:
+    payload = await _run_remote_probe_script(launch_target, timeout_seconds)
+    if payload is None:
+        return None
+    error = payload.get("error")
+    account_notes = _string_list(payload.get("oauth_account_notes"))
+    credential_note = "remote CLI creds"
+    if error == "no_credentials":
+        log.warning("claude remote rate-limit probe found no CLI credentials")
+        return None
+    if error == "expired":
+        log.info(
+            "claude remote rate-limit probe: cached access token expired; "
+            "skipping HTTP and surfacing expiry"
+        )
+        return _expired_credentials_snapshot_from_notes(credential_note, account_notes)
+    if error == "network":
+        log.warning(
+            "claude remote rate-limit probe network error "
+            f"(preview={payload.get('body_preview')!r})"
+        )
+        return None
+    if error == "internal":
+        log.warning(
+            f"claude remote rate-limit probe internal error: {payload.get('message')!r}"
+        )
+        return None
+    status = payload.get("status")
+    headers = payload.get("headers")
+    body_preview = payload.get("body_preview", "")
+    if not isinstance(status, int) or not isinstance(headers, dict):
+        log.warning("claude remote rate-limit probe returned malformed payload")
+        return None
+    return _build_messages_snapshot(
+        status=status,
+        headers={str(k): str(v) for k, v in headers.items()},
+        body=body_preview.encode("utf-8") if isinstance(body_preview, str) else b"",
+        credential_note=credential_note,
+        account_notes=account_notes,
+    )
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+_REMOTE_PROBE_SCRIPT_BYTES: bytes | None = None
+
+
+def _remote_probe_script_bytes() -> bytes:
+    global _REMOTE_PROBE_SCRIPT_BYTES
+    if _REMOTE_PROBE_SCRIPT_BYTES is None:
+        _REMOTE_PROBE_SCRIPT_BYTES = (
+            importlib.resources.files("waypoint.backends.claude_code")
+            .joinpath("remote_probe_script.py")
+            .read_bytes()
+        )
+    return _REMOTE_PROBE_SCRIPT_BYTES
+
+
+async def _run_remote_probe_script(
+    launch_target: SshLaunchTargetConfig, timeout_seconds: float
+) -> dict[str, Any] | None:
+    argv = launch_target.build_remote_exec_args(["python3", "-"])
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (OSError, FileNotFoundError) as exc:
+        log.warning(f"claude remote rate-limit probe failed to spawn ssh: {exc!r}")
+        return None
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(_remote_probe_script_bytes()), timeout=timeout_seconds
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        log.warning("claude remote rate-limit probe timed out")
+        return None
+    if proc.returncode != 0:
+        log.warning(
+            "claude remote rate-limit probe exited non-zero "
+            f"(rc={proc.returncode} stderr={stderr[:240]!r})"
+        )
+        return None
+    text = stdout.decode("utf-8", errors="replace").strip()
+    if not text:
+        log.warning("claude remote rate-limit probe produced no output")
+        return None
+    last_line = text.splitlines()[-1]
+    try:
+        decoded = json.loads(last_line)
+    except json.JSONDecodeError:
+        log.warning(
+            "claude remote rate-limit probe produced non-JSON output "
+            f"(last_line={last_line[:240]!r})"
+        )
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    return decoded
+
+
+def _build_messages_snapshot(
+    *,
+    status: int,
+    headers: dict[str, str],
+    body: bytes,
+    credential_note: str,
+    account_notes: list[str],
+) -> SessionRateLimitUsage | None:
+    notes = [credential_note, *account_notes]
     usage = parse_claude_rate_limit_headers(
-        response.headers,
+        headers,
         now=datetime.now(UTC),
         notes=_unique_notes(notes),
     )
     if usage is not None:
         return usage
-    if response.status == 401:
+    if status == 401:
         log.warning(
             "claude rate-limit response was unauthenticated "
-            f"(status=401 preview={response.body[:240].decode('utf-8', errors='replace')!r})",
+            f"(status=401 preview={body[:240].decode('utf-8', errors='replace')!r})",
         )
-        return _expired_credentials_snapshot(credential_note, resolved_env)
-    if response.status == 429:
-        retry_after = _header_value(response.headers, "Retry-After")
+        return _expired_credentials_snapshot_from_notes(credential_note, account_notes)
+    if status == 429:
+        retry_after = _header_value(headers, "Retry-After")
         if retry_after:
             notes.append(f"rate limited; retry after {retry_after}s")
         else:
             notes.append("rate limited")
         log.warning(
             "claude rate-limit response was throttled "
-            f"(status={response.status} retry_after={retry_after!r} "
-            f"preview={response.body[:240].decode('utf-8', errors='replace')!r})",
+            f"(status={status} retry_after={retry_after!r} "
+            f"preview={body[:240].decode('utf-8', errors='replace')!r})",
         )
         return SessionRateLimitUsage(
             source="claude_code",
@@ -131,17 +263,16 @@ async def probe_claude_usage(
             windows=[],
             notes=_unique_notes(notes),
         )
-    if response.status != 200:
+    if status != 200:
         log.warning(
             "claude rate-limit response was not successful "
-            f"(status={response.status} "
-            f"preview={response.body[:240].decode('utf-8', errors='replace')!r})",
+            f"(status={status} "
+            f"preview={body[:240].decode('utf-8', errors='replace')!r})",
         )
         return None
     log.warning(
         "claude rate-limit response did not include usable rate-limit headers "
-        f"(status={response.status} "
-        f"headers={sorted(_normalize_headers(response.headers).keys())})",
+        f"(status={status} headers={sorted(_normalize_headers(headers).keys())})",
     )
     return None
 
@@ -161,16 +292,20 @@ def _is_access_token_expired(expires_at: datetime | None) -> bool:
 def _expired_credentials_snapshot(
     credential_note: str, env: dict[str, str]
 ) -> SessionRateLimitUsage:
+    return _expired_credentials_snapshot_from_notes(
+        credential_note, _read_oauth_account_notes(env)
+    )
+
+
+def _expired_credentials_snapshot_from_notes(
+    credential_note: str, account_notes: list[str]
+) -> SessionRateLimitUsage:
     return SessionRateLimitUsage(
         source="claude_code",
         updated_at=datetime.now(UTC),
         windows=[],
         notes=_unique_notes(
-            [
-                credential_note,
-                _EXPIRED_CREDENTIALS_NOTE,
-                *_read_oauth_account_notes(env),
-            ]
+            [credential_note, _EXPIRED_CREDENTIALS_NOTE, *account_notes]
         ),
     )
 

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import platform
+import re
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+from waypoint.schemas import SessionRateLimitUsage, UsageWindow
+
+_WINDOWS: tuple[tuple[str, str, int], ...] = (
+    ("five_hour", "5h", 5 * 60),
+    ("seven_day", "Weekly", 7 * 24 * 60),
+    ("seven_day_opus", "Opus", 7 * 24 * 60),
+    ("seven_day_sonnet", "Sonnet", 7 * 24 * 60),
+)
+
+
+def parse_claude_usage_payload(
+    payload: bytes | dict[str, Any],
+    *,
+    now: datetime | None = None,
+    notes: list[str] | None = None,
+) -> SessionRateLimitUsage | None:
+    if isinstance(payload, bytes):
+        try:
+            raw = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+    else:
+        raw = payload
+    if not isinstance(raw, dict):
+        return None
+
+    windows: list[UsageWindow] = []
+    for key, label, minutes in _WINDOWS:
+        window = raw.get(key)
+        if not isinstance(window, dict):
+            continue
+        percent = _parse_utilization(window.get("utilization"))
+        if percent is None:
+            continue
+        windows.append(
+            UsageWindow(
+                id=key,
+                label=label,
+                used_percent=percent,
+                window_minutes=minutes,
+                resets_at=_parse_iso_datetime(window.get("resets_at")),
+            )
+        )
+
+    if not windows:
+        return None
+
+    return SessionRateLimitUsage(
+        source="claude_code",
+        updated_at=now or datetime.now(UTC),
+        windows=windows,
+        notes=list(notes or ["CLI creds"]),
+    )
+
+
+async def probe_claude_usage(
+    *,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float = 30.0,
+) -> SessionRateLimitUsage | None:
+    resolved_env = env if env is not None else dict(os.environ)
+    credentials = _read_cli_credentials_for_env(resolved_env)
+    if credentials is None:
+        return None
+    access_token, credential_note = credentials
+    request = Request(
+        "https://api.anthropic.com/api/oauth/usage",
+        method="GET",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "User-Agent": "claude-code/2.1.5",
+            "anthropic-beta": "oauth-2025-04-20",
+        },
+    )
+    response = await asyncio.wait_for(
+        asyncio.to_thread(_fetch_url, request), timeout=timeout_seconds
+    )
+    if response is None:
+        return None
+    return parse_claude_usage_payload(response, notes=[credential_note])
+
+
+def _fetch_url(request: Request) -> bytes | None:
+    try:
+        with urlopen(request, timeout=30) as response:
+            if getattr(response, "status", 200) != 200:
+                return None
+            return response.read()
+    except (HTTPError, URLError, OSError):
+        return None
+
+
+def _read_cli_credentials_for_env(env: dict[str, str]) -> tuple[str, str] | None:
+    for path in _credential_paths(env):
+        if not path.is_file():
+            continue
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        token = _extract_access_token(raw)
+        if token:
+            return token, "CLI creds"
+
+    token = _read_keychain_access_token(env)
+    if token:
+        return token, "CLI creds"
+    return None
+
+
+def _credential_paths(env: dict[str, str]) -> tuple[Path, ...]:
+    base = env.get("CLAUDE_CONFIG_DIR")
+    root = Path(base).expanduser() if base else Path.home() / ".claude"
+    return (
+        root / ".credentials.json",
+        root / "credentials.json",
+    )
+
+
+def _read_keychain_access_token(env: dict[str, str]) -> str | None:
+    if platform.system() != "Darwin":
+        return None
+    for service in _resolve_keychain_service_names(env):
+        token = _read_keychain_access_token_for_service(service, env)
+        if token:
+            return token
+    return None
+
+
+def _read_keychain_access_token_for_service(
+    service: str, env: dict[str, str]
+) -> str | None:
+    try:
+        completed = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                service,
+                "-a",
+                env.get("USER", ""),
+                "-w",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    token = completed.stdout.strip()
+    return token or None
+
+
+def _resolve_keychain_service_names(env: dict[str, str]) -> tuple[str, ...]:
+    services = ["Claude Code-credentials"]
+    discovered = _discover_hashed_keychain_service_name(env)
+    if discovered and discovered not in services:
+        services.append(discovered)
+    return tuple(services)
+
+
+def _discover_hashed_keychain_service_name(env: dict[str, str]) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["security", "dump-keychain"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    match = re.search(r'Claude Code-credentials-[^"\s]+', completed.stdout)
+    return match.group(0) if match else None
+
+
+def _extract_access_token(raw: str) -> str | None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    oauth = payload.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    token = oauth.get("accessToken")
+    return token if isinstance(token, str) and token else None
+
+
+def _parse_utilization(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        percent = float(value)
+        if 0.0 <= percent <= 1.0:
+            percent *= 100.0
+        return max(0.0, min(100.0, percent))
+    if isinstance(value, str):
+        cleaned = value.strip().replace("%", "")
+        try:
+            percent = float(cleaned)
+        except ValueError:
+            return None
+        if 0.0 <= percent <= 1.0:
+            percent *= 100.0
+        return max(0.0, min(100.0, percent))
+    return None
+
+
+def _parse_iso_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None

--- a/backend/src/waypoint/backends/claude_code/remote_probe_script.py
+++ b/backend/src/waypoint/backends/claude_code/remote_probe_script.py
@@ -1,0 +1,253 @@
+"""Remote rate-limit probe for Claude Code.
+
+Designed to be piped to ``python3 -`` over SSH on a remote launch
+target. Reads the locally-stored OAuth token (``~/.claude/.credentials.json``
+or the macOS keychain), calls the Anthropic Messages API, and prints a
+single JSON line to stdout describing the response (or an error
+sentinel) so the backend can build a ``SessionRateLimitUsage`` from it.
+
+Stdlib-only; targets Python 3.8+ so it runs on most pre-installed
+remote interpreters without a virtualenv.
+
+Output schema (always one line of JSON on stdout, ``\\n``-terminated):
+
+    {"status": int, "headers": {str: str}, "body_preview": str,
+     "oauth_account_notes": [str], "expires_at": float | None}
+    {"error": "no_credentials" | "expired" | "network" | "internal", ...}
+"""
+
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+CLAUDE_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+CLAUDE_MESSAGES_MODEL = "claude-haiku-4-5-20251001"
+CLAUDE_MESSAGES_VERSION = "2023-06-01"
+EXPIRY_SKEW_SECONDS = 60
+HTTP_TIMEOUT = 25
+BODY_PREVIEW_BYTES = 240
+
+
+def emit(payload):
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def credential_paths():
+    base = os.environ.get("CLAUDE_CONFIG_DIR")
+    root = os.path.expanduser(base) if base else os.path.expanduser("~/.claude")
+    return [
+        os.path.join(root, ".credentials.json"),
+        os.path.expanduser("~/.config/claude/.credentials.json"),
+    ]
+
+
+def claude_config_path():
+    base = os.environ.get("CLAUDE_CONFIG_DIR")
+    if base:
+        return os.path.join(os.path.expanduser(base), ".claude.json")
+    return os.path.expanduser("~/.claude.json")
+
+
+def parse_expires_at(value):
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        epoch = float(value)
+    except (TypeError, ValueError):
+        return None
+    return epoch / 1000.0 if epoch > 1e12 else epoch
+
+
+def extract_oauth_fields(raw):
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    oauth = payload.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        return None
+    token = oauth.get("accessToken")
+    if not isinstance(token, str) or not token:
+        return None
+    return token, parse_expires_at(oauth.get("expiresAt"))
+
+
+def _run_security(args, timeout):
+    try:
+        return subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _read_keychain_for_service(service):
+    user = os.environ.get("USER", "")
+    for args in (
+        ["security", "find-generic-password", "-s", service, "-a", user, "-w"],
+        ["security", "find-generic-password", "-s", service, "-w"],
+    ):
+        completed = _run_security(args, timeout=3)
+        if completed is None or completed.returncode != 0:
+            continue
+        token = completed.stdout.strip()
+        if token:
+            return token
+    return None
+
+
+def _discover_hashed_keychain_service():
+    completed = _run_security(["security", "dump-keychain"], timeout=5)
+    if completed is None or completed.returncode != 0:
+        return None
+    match = re.search(r"(Claude Code-credentials-[^\"\s]+)", completed.stdout)
+    return match.group(1) if match is not None else None
+
+
+def read_keychain_token():
+    if platform.system() != "Darwin":
+        return None
+    token = _read_keychain_for_service("Claude Code-credentials")
+    if token:
+        return token
+    discovered = _discover_hashed_keychain_service()
+    if discovered:
+        return _read_keychain_for_service(discovered)
+    return None
+
+
+def read_oauth_account_notes():
+    path = claude_config_path()
+    if not os.path.isfile(path):
+        return []
+    try:
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    account = payload.get("oauthAccount")
+    if not isinstance(account, dict):
+        return []
+    notes = []
+    for key, prefix in (
+        ("organizationName", "org"),
+        ("userRateLimitTier", "user tier"),
+        ("organizationRateLimitTier", "org tier"),
+    ):
+        value = account.get(key)
+        if isinstance(value, str) and value.strip():
+            notes.append(f"{prefix}: {value.strip()}")
+    return notes
+
+
+def read_credentials():
+    for path in credential_paths():
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read()
+        except OSError:
+            continue
+        parsed = extract_oauth_fields(raw)
+        if parsed is not None:
+            return parsed
+    keychain = read_keychain_token()
+    if keychain:
+        parsed = extract_oauth_fields(keychain)
+        if parsed is not None:
+            return parsed
+        return keychain, None
+    return None
+
+
+def fetch_messages(token):
+    body = json.dumps(
+        {
+            "model": CLAUDE_MESSAGES_MODEL,
+            "max_tokens": 1,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+    ).encode("utf-8")
+    request = Request(
+        CLAUDE_MESSAGES_URL,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": "Bearer " + token,
+            "Content-Type": "application/json",
+            "User-Agent": "claude-code/remote-probe",
+            "anthropic-beta": "oauth-2025-04-20",
+            "anthropic-version": CLAUDE_MESSAGES_VERSION,
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT) as response:
+            status_code = getattr(response, "status", 200)
+            headers = {key: value for key, value in response.headers.items()}
+            return status_code, headers, response.read(BODY_PREVIEW_BYTES)
+    except HTTPError as exc:
+        headers = {key: value for key, value in getattr(exc, "headers", {}).items()}
+        try:
+            payload = exc.read() if exc.fp is not None else b""
+        except OSError:
+            payload = b""
+        return exc.code, headers, payload[:BODY_PREVIEW_BYTES]
+    except (URLError, OSError) as exc:
+        return None, {}, str(exc).encode("utf-8")
+
+
+def main():
+    creds = read_credentials()
+    if creds is None:
+        emit({"error": "no_credentials"})
+        return
+    token, expires_at = creds
+    notes = read_oauth_account_notes()
+    if expires_at is not None and expires_at <= time.time() + EXPIRY_SKEW_SECONDS:
+        emit(
+            {
+                "error": "expired",
+                "expires_at": expires_at,
+                "oauth_account_notes": notes,
+            }
+        )
+        return
+    status_code, headers, body = fetch_messages(token)
+    if status_code is None:
+        emit(
+            {
+                "error": "network",
+                "body_preview": body.decode("utf-8", errors="replace"),
+                "oauth_account_notes": notes,
+            }
+        )
+        return
+    emit(
+        {
+            "status": status_code,
+            "headers": headers,
+            "body_preview": body.decode("utf-8", errors="replace"),
+            "oauth_account_notes": notes,
+            "expires_at": expires_at,
+        }
+    )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001
+        emit({"error": "internal", "message": repr(exc)})

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -305,6 +305,14 @@ class CodexAppServerAdapter:
             )
         )
 
+    async def force_refresh_rate_limit_usage(self, session_id: str) -> None:
+        # User-driven path: run the registered probe inline so the caller's
+        # response carries the fresh snapshot instead of racing the WS push.
+        state = self._sessions.get(session_id)
+        if state is None:
+            return
+        await self._refresh_rate_limit_usage(state)
+
     async def _spawn_session(
         self,
         session_id: str,

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -304,7 +304,6 @@ class CodexAppServerAdapter:
                 state, refresh_interval_seconds=refresh_interval_seconds
             )
         )
-        await self._refresh_rate_limit_usage(state)
 
     async def _spawn_session(
         self,

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import shutil
 import threading
@@ -24,7 +25,12 @@ from waypoint.backends.codex.normalize import (
     plan_metadata_for_item,
 )
 from waypoint.backends.diff_preview import DiffPreviewPayload, preview_to_metadata
-from waypoint.schemas import EventKind, SessionContextUsage, SessionStatus
+from waypoint.schemas import (
+    EventKind,
+    SessionContextUsage,
+    SessionRateLimitUsage,
+    SessionStatus,
+)
 
 log = logging.getLogger("waypoint.codex")
 
@@ -163,6 +169,12 @@ class CodexSessionState:
     # the override survives restarts and turn reuse.
     effort: str | None = None
     context_usage_signature: tuple[int, int | None] | None = None
+    rate_limit_usage_snapshot: SessionRateLimitUsage | None = None
+    rate_limit_usage_signature: str | None = None
+    rate_limit_probe: Callable[[], Awaitable[SessionRateLimitUsage | None]] | None = (
+        None
+    )
+    rate_limit_refresh_task: asyncio.Task[None] | None = None
 
 
 class CodexAppServerAdapter:
@@ -275,6 +287,24 @@ class CodexAppServerAdapter:
         state.thread_id = forked.thread.id
         state.model = model or getattr(forked, "model", None)
         return state.thread_id
+
+    async def register_rate_limit_probe(
+        self,
+        session_id: str,
+        probe: Callable[[], Awaitable[SessionRateLimitUsage | None]],
+        *,
+        refresh_interval_seconds: float = 60.0,
+    ) -> None:
+        state = self._require_session(session_id)
+        state.rate_limit_probe = probe
+        if state.rate_limit_refresh_task is not None:
+            state.rate_limit_refresh_task.cancel()
+        state.rate_limit_refresh_task = asyncio.create_task(
+            self._refresh_rate_limit_usage_loop(
+                state, refresh_interval_seconds=refresh_interval_seconds
+            )
+        )
+        await self._refresh_rate_limit_usage(state)
 
     async def _spawn_session(
         self,
@@ -549,6 +579,10 @@ class CodexAppServerAdapter:
         state = self._sessions.pop(session_id, None)
         if state is None:
             return False
+        if state.rate_limit_refresh_task is not None:
+            state.rate_limit_refresh_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await state.rate_limit_refresh_task
         if state.pending_approval is not None:
             state.pending_approval.response = {"decision": "decline"}
             state.pending_approval.event.set()
@@ -721,6 +755,53 @@ class CodexAppServerAdapter:
         await self._on_session_update(
             state.session_id,
             {"context_usage": snapshot.model_dump(mode="json")},
+            True,
+        )
+
+    async def _refresh_rate_limit_usage_loop(
+        self, state: CodexSessionState, *, refresh_interval_seconds: float
+    ) -> None:
+        try:
+            while state.session_id in self._sessions:
+                await self._refresh_rate_limit_usage(state)
+                await asyncio.sleep(refresh_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "codex rate-limit refresh loop failed",
+                extra={"session_id": state.session_id},
+            )
+
+    async def _refresh_rate_limit_usage(self, state: CodexSessionState) -> None:
+        probe = state.rate_limit_probe
+        if probe is None:
+            return
+        try:
+            snapshot = await probe()
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "codex rate-limit probe failed",
+                extra={"session_id": state.session_id},
+            )
+            return
+        if snapshot is None:
+            return
+        await self._publish_rate_limit_usage(state, snapshot)
+
+    async def _publish_rate_limit_usage(
+        self, state: CodexSessionState, snapshot: SessionRateLimitUsage
+    ) -> None:
+        signature = json.dumps(snapshot.model_dump(mode="json"), sort_keys=True)
+        if state.rate_limit_usage_signature == signature:
+            return
+        state.rate_limit_usage_signature = signature
+        state.rate_limit_usage_snapshot = snapshot
+        if self._on_session_update is None:
+            return
+        await self._on_session_update(
+            state.session_id,
+            {"rate_limit_usage": snapshot.model_dump(mode="json")},
             True,
         )
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -170,10 +170,9 @@ class CodexPlugin:
         async def _probe() -> SessionRateLimitUsage | None:
             return await probe_codex_status(cwd=cwd, binary=binary)
 
-        register_probe = getattr(self.adapter, "register_rate_limit_probe", None)
-        if not callable(register_probe):
-            return
-        await register_probe(session_id, _probe)
+        await self.adapter.register_rate_limit_probe(
+            session_id, _probe, refresh_interval_seconds=300.0
+        )
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -174,6 +174,13 @@ class CodexPlugin:
             session_id, _probe, refresh_interval_seconds=300.0
         )
 
+    async def refresh_rate_limit_usage(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        if session.launch_target_id is not None:
+            return
+        await self._register_local_rate_limit_probe(runtime, session.id, session.cwd)
+
     def register_routes(self, app: Any, context: Any) -> None:
         return None
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -37,7 +37,10 @@ from waypoint.backends.codex.permission_modes import (
     CODEX_PLAN_MODE,
     codex_turn_params_for,
 )
-from waypoint.backends.codex.rate_limits import probe_codex_status
+from waypoint.backends.codex.rate_limits import (
+    probe_codex_status,
+    probe_codex_usage_remote,
+)
 from waypoint.backends.codex.remote import build_remote_codex_client_factory
 from waypoint.backends.codex.schemas import (
     CodexThreadImportRequest,
@@ -174,12 +177,46 @@ class CodexPlugin:
             session_id, _probe, refresh_interval_seconds=300.0
         )
 
+    async def _register_remote_rate_limit_probe(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        launch_target: SshLaunchTargetConfig,
+    ) -> None:
+        if self.adapter is None:
+            return
+        binary = self.remote_executable(launch_target) or "codex"
+
+        async def _probe() -> SessionRateLimitUsage | None:
+            return await probe_codex_usage_remote(launch_target, binary=binary)
+
+        await self.adapter.register_rate_limit_probe(
+            session_id, _probe, refresh_interval_seconds=300.0
+        )
+
+    async def _register_rate_limit_probe(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        cwd: str,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> None:
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(runtime, session_id, cwd)
+            return
+        await self._register_remote_rate_limit_probe(runtime, session_id, launch_target)
+
     async def refresh_rate_limit_usage(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        if session.launch_target_id is not None:
-            return
-        await self._register_local_rate_limit_probe(runtime, session.id, session.cwd)
+        launch_target = (
+            runtime._find_launch_target(session.launch_target_id)
+            if session.launch_target_id
+            else None
+        )
+        await self._register_rate_limit_probe(
+            runtime, session.id, session.cwd, launch_target
+        )
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None
@@ -619,10 +656,12 @@ class CodexPlugin:
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
-        if session.launch_target_id is None:
-            await self._register_local_rate_limit_probe(
-                runtime, new_session_id, session.cwd
-            )
+        await self._register_rate_limit_probe(
+            runtime,
+            new_session_id,
+            session.cwd,
+            runtime._find_launch_target(session.launch_target_id),
+        )
         await runtime._record_system_event(
             new_session_id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id)
@@ -693,10 +732,12 @@ class CodexPlugin:
             )
             return
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
-        if session.launch_target_id is None:
-            await self._register_local_rate_limit_probe(
-                runtime, session.id, session.cwd
-            )
+        await self._register_rate_limit_probe(
+            runtime,
+            session.id,
+            session.cwd,
+            runtime._find_launch_target(session.launch_target_id),
+        )
         await runtime._record_system_event(
             session.id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id),
@@ -983,10 +1024,9 @@ class CodexPlugin:
             transport_state={**session.transport_state, "thread_id": thread_id},
             status=SessionStatus.IDLE,
         )
-        if launch_target is None:
-            await self._register_local_rate_limit_probe(
-                runtime, session.id, session.cwd
-            )
+        await self._register_rate_limit_probe(
+            runtime, session.id, session.cwd, launch_target
+        )
         await runtime._record_system_event(
             session.id,
             self.format_start_message(request.cwd, launch_target),
@@ -1086,8 +1126,7 @@ class CodexPlugin:
                 detail=f"failed to import codex thread: {exc}",
             ) from exc
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
-        if launch_target is None:
-            await self._register_local_rate_limit_probe(runtime, session.id, cwd)
+        await self._register_rate_limit_probe(runtime, session.id, cwd, launch_target)
         await runtime._record_system_event(
             session.id,
             self.format_import_message(cwd, launch_target),

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -217,6 +217,11 @@ class CodexPlugin:
         await self._register_rate_limit_probe(
             runtime, session.id, session.cwd, launch_target
         )
+        # Run the probe inline so the caller's HTTP response carries the
+        # post-refresh snapshot — otherwise the response races the WS push
+        # from the periodic loop and the UI sees stale data.
+        if self.adapter is not None:
+            await self.adapter.force_refresh_rate_limit_usage(session.id)
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -37,6 +37,7 @@ from waypoint.backends.codex.permission_modes import (
     CODEX_PLAN_MODE,
     codex_turn_params_for,
 )
+from waypoint.backends.codex.rate_limits import probe_codex_status
 from waypoint.backends.codex.remote import build_remote_codex_client_factory
 from waypoint.backends.codex.schemas import (
     CodexThreadImportRequest,
@@ -52,6 +53,7 @@ from waypoint.schemas import (
     EventRecord,
     SessionCreateRequest,
     SessionInputRequest,
+    SessionRateLimitUsage,
     SessionRecord,
     SessionSource,
     SessionStatus,
@@ -152,6 +154,26 @@ class CodexPlugin:
     def _require_adapter(self) -> CodexAppServerAdapter:
         assert self.adapter is not None, "codex plugin adapter not initialized"
         return self.adapter
+
+    async def _register_local_rate_limit_probe(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        cwd: str,
+    ) -> None:
+        if self.adapter is None:
+            return
+        binary = (
+            self._config(runtime).local_bin or self.capabilities.cli_binary or "codex"
+        )
+
+        async def _probe() -> SessionRateLimitUsage | None:
+            return await probe_codex_status(cwd=cwd, binary=binary)
+
+        register_probe = getattr(self.adapter, "register_rate_limit_probe", None)
+        if not callable(register_probe):
+            return
+        await register_probe(session_id, _probe)
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None
@@ -591,6 +613,10 @@ class CodexPlugin:
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
+        if session.launch_target_id is None:
+            await self._register_local_rate_limit_probe(
+                runtime, new_session_id, session.cwd
+            )
         await runtime._record_system_event(
             new_session_id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id)
@@ -661,6 +687,10 @@ class CodexPlugin:
             )
             return
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+        if session.launch_target_id is None:
+            await self._register_local_rate_limit_probe(
+                runtime, session.id, session.cwd
+            )
         await runtime._record_system_event(
             session.id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id),
@@ -947,6 +977,10 @@ class CodexPlugin:
             transport_state={**session.transport_state, "thread_id": thread_id},
             status=SessionStatus.IDLE,
         )
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(
+                runtime, session.id, session.cwd
+            )
         await runtime._record_system_event(
             session.id,
             self.format_start_message(request.cwd, launch_target),
@@ -1046,6 +1080,8 @@ class CodexPlugin:
                 detail=f"failed to import codex thread: {exc}",
             ) from exc
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+        if launch_target is None:
+            await self._register_local_rate_limit_probe(runtime, session.id, cwd)
         await runtime._record_system_event(
             session.id,
             self.format_import_message(cwd, launch_target),

--- a/backend/src/waypoint/backends/codex/rate_limits.py
+++ b/backend/src/waypoint/backends/codex/rate_limits.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import importlib.resources
 import json
 import logging
 import os
@@ -24,6 +25,7 @@ try:
 except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 is unsupported here
     tomllib = None  # type: ignore[assignment]
 
+from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import SessionRateLimitUsage, UsageWindow
 
 log = logging.getLogger("waypoint.codex.rate_limits")
@@ -150,6 +152,105 @@ async def probe_codex_status(
             extra={"cwd": cwd, "binary": resolved},
         )
     return snapshot
+
+
+_REMOTE_PROBE_CODEX_BIN_ENV = "WAYPOINT_REMOTE_PROBE_CODEX_BIN"
+_REMOTE_PROBE_SCRIPT_BYTES: bytes | None = None
+
+
+def _remote_probe_script_bytes() -> bytes:
+    global _REMOTE_PROBE_SCRIPT_BYTES
+    if _REMOTE_PROBE_SCRIPT_BYTES is None:
+        _REMOTE_PROBE_SCRIPT_BYTES = (
+            importlib.resources.files("waypoint.backends.codex")
+            .joinpath("remote_probe_script.py")
+            .read_bytes()
+        )
+    return _REMOTE_PROBE_SCRIPT_BYTES
+
+
+async def probe_codex_usage_remote(
+    launch_target: SshLaunchTargetConfig,
+    *,
+    binary: str = "codex",
+    timeout_seconds: float = 30.0,
+) -> SessionRateLimitUsage | None:
+    payload = await _run_remote_probe_script(launch_target, binary, timeout_seconds)
+    if payload is None:
+        return None
+    error = payload.get("error")
+    if error == "no_data":
+        log.warning("codex remote rate-limit probe yielded no data")
+        return None
+    if error == "internal":
+        log.warning(
+            f"codex remote rate-limit probe internal error: {payload.get('message')!r}"
+        )
+        return None
+    raw = payload.get("payload")
+    if isinstance(raw, dict):
+        snapshot = parse_codex_usage_payload(raw, notes=["remote OAuth"])
+        if snapshot is not None:
+            return snapshot
+    status_text = payload.get("status_text")
+    if isinstance(status_text, str) and status_text.strip():
+        snapshot = parse_codex_status(status_text)
+        if snapshot is not None:
+            snapshot.notes = list(snapshot.notes) + ["remote /status"]
+            return snapshot
+    log.warning("codex remote rate-limit probe returned unparsable payload")
+    return None
+
+
+async def _run_remote_probe_script(
+    launch_target: SshLaunchTargetConfig,
+    binary: str,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    argv = launch_target.build_remote_exec_args(
+        ["env", f"{_REMOTE_PROBE_CODEX_BIN_ENV}={binary}", "python3", "-"]
+    )
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except (OSError, FileNotFoundError) as exc:
+        log.warning(f"codex remote rate-limit probe failed to spawn ssh: {exc!r}")
+        return None
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(_remote_probe_script_bytes()), timeout=timeout_seconds
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        log.warning("codex remote rate-limit probe timed out")
+        return None
+    if proc.returncode != 0:
+        log.warning(
+            "codex remote rate-limit probe exited non-zero "
+            f"(rc={proc.returncode} stderr={stderr[:240]!r})"
+        )
+        return None
+    text = stdout.decode("utf-8", errors="replace").strip()
+    if not text:
+        log.warning("codex remote rate-limit probe produced no output")
+        return None
+    last_line = text.splitlines()[-1]
+    try:
+        decoded = json.loads(last_line)
+    except json.JSONDecodeError:
+        log.warning(
+            "codex remote rate-limit probe produced non-JSON output "
+            f"(last_line={last_line[:240]!r})"
+        )
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    return decoded
 
 
 async def _probe_codex_oauth_usage(

--- a/backend/src/waypoint/backends/codex/rate_limits.py
+++ b/backend/src/waypoint/backends/codex/rate_limits.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import re
+import select
+import shutil
+import signal
+import subprocess
+import time
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+
+from waypoint.schemas import SessionRateLimitUsage, UsageWindow
+
+_WINDOW_LABELS: dict[str, tuple[str, int]] = {
+    "5h limit": ("5h", 5 * 60),
+    "weekly limit": ("Weekly", 7 * 24 * 60),
+}
+_PERCENT_LEFT_RE = re.compile(r"(?i)(\d{1,3}(?:\.\d+)?)\s*%\s*left")
+_PERCENT_USED_RE = re.compile(r"(?i)(\d{1,3}(?:\.\d+)?)\s*%\s*used")
+_CREDITS_RE = re.compile(r"(?i)credits:\s*\$?\s*([0-9][0-9,]*(?:\.[0-9]+)?)")
+
+
+def parse_codex_status(
+    text: str, *, now: datetime | None = None
+) -> SessionRateLimitUsage | None:
+    clean = _strip_ansi(text).strip()
+    if not clean:
+        return None
+
+    windows: list[UsageWindow] = []
+    for line in clean.splitlines():
+        lowered = line.lower()
+        for needle, (label, minutes) in _WINDOW_LABELS.items():
+            if needle not in lowered:
+                continue
+            percent = _parse_percent_used(line)
+            if percent is None:
+                continue
+            reset_description = _extract_reset_description(line)
+            windows.append(
+                UsageWindow(
+                    id=needle.replace(" ", "-"),
+                    label=label,
+                    used_percent=percent,
+                    window_minutes=minutes,
+                    reset_description=reset_description,
+                )
+            )
+            break
+
+    credits_remaining = None
+    credits_currency = None
+    credits_line = _first_matching_line(clean, "credits:")
+    if credits_line is not None:
+        match = _CREDITS_RE.search(credits_line)
+        if match is not None:
+            try:
+                credits_remaining = float(match.group(1).replace(",", ""))
+            except ValueError:
+                credits_remaining = None
+            credits_currency = "credits"
+            if "$" in credits_line:
+                credits_currency = "USD"
+
+    if not windows and credits_remaining is None:
+        return None
+
+    return SessionRateLimitUsage(
+        source="codex",
+        updated_at=now or datetime.now(UTC),
+        windows=windows,
+        credits_remaining=credits_remaining,
+        credits_currency=credits_currency,
+        notes=["CLI status"],
+    )
+
+
+async def probe_codex_status(
+    *,
+    cwd: str,
+    binary: str,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float = 8.0,
+) -> SessionRateLimitUsage | None:
+    resolved = _resolve_binary(binary)
+    if resolved is None:
+        return None
+    text = await asyncio.to_thread(
+        _run_codex_status,
+        resolved,
+        cwd,
+        env if env is not None else dict(os.environ),
+        timeout_seconds,
+    )
+    return parse_codex_status(text)
+
+
+def _run_codex_status(
+    binary: str,
+    cwd: str,
+    env: dict[str, str],
+    timeout_seconds: float,
+) -> str:
+    import pty
+
+    master_fd, slave_fd = pty.openpty()
+    proc: subprocess.Popen[bytes] | None = None
+    try:
+        proc = subprocess.Popen(
+            [binary],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            cwd=str(Path(cwd).expanduser()),
+            env=env,
+            start_new_session=True,
+        )
+    except Exception:
+        os.close(master_fd)
+        os.close(slave_fd)
+        raise
+
+    os.close(slave_fd)
+    try:
+        time.sleep(0.35)
+        try:
+            os.write(master_fd, b"/status\r")
+        except OSError:
+            pass
+
+        deadline = time.monotonic() + timeout_seconds
+        settled_at: float | None = None
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([master_fd], [], [], 0.1)
+            if ready:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError as exc:
+                    if exc.errno in {errno.EIO, errno.EBADF}:
+                        break
+                    raise
+                if chunk:
+                    buffer.extend(chunk)
+                    settled_at = None
+                    continue
+                break
+            if proc.poll() is not None:
+                if settled_at is None:
+                    settled_at = time.monotonic() + 0.5
+                elif time.monotonic() >= settled_at:
+                    break
+        return buffer.decode("utf-8", errors="replace")
+    finally:
+        if proc is not None and proc.poll() is None:
+            with suppress(Exception):
+                os.write(master_fd, b"/exit\r")
+            with suppress(Exception):
+                proc.terminate()
+            deadline = time.monotonic() + 1.0
+            while proc.poll() is None and time.monotonic() < deadline:
+                time.sleep(0.05)
+            if proc.poll() is None:
+                with suppress(Exception):
+                    os.kill(proc.pid, signal.SIGKILL)
+        with suppress(Exception):
+            os.close(master_fd)
+
+
+def _resolve_binary(binary: str) -> str | None:
+    if not binary:
+        return None
+    if "/" in binary:
+        path = Path(binary).expanduser()
+        return str(path) if path.is_file() and os.access(path, os.X_OK) else None
+    return shutil.which(binary)
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", text)
+
+
+def _first_matching_line(text: str, needle: str) -> str | None:
+    for line in text.splitlines():
+        if needle in line.lower():
+            return line
+    return None
+
+
+def _parse_percent_used(line: str) -> float | None:
+    match = _PERCENT_USED_RE.search(line)
+    if match is not None:
+        try:
+            return _clamp_percent(float(match.group(1)))
+        except ValueError:
+            return None
+    match = _PERCENT_LEFT_RE.search(line)
+    if match is not None:
+        try:
+            return _clamp_percent(100.0 - float(match.group(1)))
+        except ValueError:
+            return None
+    return None
+
+
+def _clamp_percent(percent: float) -> float:
+    return max(0.0, min(100.0, percent))
+
+
+def _extract_reset_description(line: str) -> str | None:
+    match = re.search(r"(?i)\breset(?:s)?(?:\s+at|\s+in)?\s*(.*)$", line)
+    if match is not None:
+        candidate = match.group(1).strip(" :.-\t)")
+        return candidate or None
+    parens = re.findall(r"\(([^()]*)\)", line)
+    if parens:
+        candidate = parens[-1].strip(" :.-\t)")
+        return candidate or None
+    return None

--- a/backend/src/waypoint/backends/codex/rate_limits.py
+++ b/backend/src/waypoint/backends/codex/rate_limits.py
@@ -190,7 +190,7 @@ async def probe_codex_usage_remote(
     raw = payload.get("payload")
     if isinstance(raw, dict):
         snapshot = parse_codex_usage_payload(raw, notes=["remote OAuth"])
-        if snapshot is not None:
+        if snapshot is not None and _oauth_snapshot_is_actionable(snapshot):
             return snapshot
     status_text = payload.get("status_text")
     if isinstance(status_text, str) and status_text.strip():
@@ -310,7 +310,29 @@ async def _probe_codex_oauth_usage(
             "codex OAuth usage response did not yield a snapshot "
             f"(bytes={len(response)} preview={preview!r})",
         )
-    return snapshot
+        return None
+    if _oauth_snapshot_is_actionable(snapshot):
+        return snapshot
+    # Empty payload with no plan/email metadata — likely a schema drift or
+    # account-id mismatch. Fall through to /status so the caller can try the
+    # PTY scrape rather than rendering a blank panel.
+    return None
+
+
+def _oauth_snapshot_is_actionable(snapshot: SessionRateLimitUsage) -> bool:
+    if snapshot.windows:
+        return True
+    if snapshot.credits_remaining is not None:
+        return True
+    # "CLI OAuth" is the default seed note; only metadata that came from the
+    # payload itself counts as confirmation we hit a real account (e.g.
+    # education-plan accounts return rate_limit=null but include plan/email).
+    for note in snapshot.notes:
+        if note == "CLI OAuth" or note == "remote OAuth":
+            continue
+        if note.startswith("plan:") or "@" in note:
+            return True
+    return False
 
 
 def parse_codex_usage_payload(

--- a/backend/src/waypoint/backends/codex/rate_limits.py
+++ b/backend/src/waypoint/backends/codex/rate_limits.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import json
+import logging
 import os
 import re
 import select
@@ -10,18 +12,53 @@ import signal
 import subprocess
 import time
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 is unsupported here
+    tomllib = None  # type: ignore[assignment]
 
 from waypoint.schemas import SessionRateLimitUsage, UsageWindow
+
+log = logging.getLogger("waypoint.codex.rate_limits")
 
 _WINDOW_LABELS: dict[str, tuple[str, int]] = {
     "5h limit": ("5h", 5 * 60),
     "weekly limit": ("Weekly", 7 * 24 * 60),
 }
+_DEFAULT_CHATGPT_BASE_URL = "https://chatgpt.com/backend-api/"
+_CHATGPT_USAGE_PATH = "/wham/usage"
+_CODEX_USAGE_PATH = "/api/codex/usage"
+_CODEX_OAUTH_REFRESH_ENDPOINT = "https://auth.openai.com/oauth/token"
+_CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
 _PERCENT_LEFT_RE = re.compile(r"(?i)(\d{1,3}(?:\.\d+)?)\s*%\s*left")
 _PERCENT_USED_RE = re.compile(r"(?i)(\d{1,3}(?:\.\d+)?)\s*%\s*used")
 _CREDITS_RE = re.compile(r"(?i)credits:\s*\$?\s*([0-9][0-9,]*(?:\.[0-9]+)?)")
+_CACHED_OAUTH_CREDENTIALS: _CodexOAuthCredentials | None = None
+_CACHED_OAUTH_ACCOUNT_ID: str | None = None
+
+
+@dataclass(frozen=True)
+class _CodexOAuthCredentials:
+    access_token: str
+    refresh_token: str
+    account_id: str | None
+    last_refresh: datetime | None
+
+    @property
+    def needs_refresh(self) -> bool:
+        if not self.refresh_token:
+            return False
+        if self.last_refresh is None:
+            return True
+        eight_days = 8 * 24 * 60 * 60
+        return (datetime.now(UTC) - self.last_refresh).total_seconds() > eight_days
 
 
 def parse_codex_status(
@@ -86,17 +123,449 @@ async def probe_codex_status(
     env: dict[str, str] | None = None,
     timeout_seconds: float = 8.0,
 ) -> SessionRateLimitUsage | None:
+    resolved_env = env if env is not None else dict(os.environ)
+
+    snapshot = await _probe_codex_oauth_usage(resolved_env)
+    if snapshot is not None:
+        return snapshot
+
     resolved = _resolve_binary(binary)
     if resolved is None:
+        log.warning(
+            "codex rate-limit probe could not resolve codex binary",
+            extra={"cwd": cwd, "binary": binary},
+        )
         return None
     text = await asyncio.to_thread(
         _run_codex_status,
         resolved,
         cwd,
-        env if env is not None else dict(os.environ),
+        resolved_env,
         timeout_seconds,
     )
-    return parse_codex_status(text)
+    snapshot = parse_codex_status(text)
+    if snapshot is None:
+        log.warning(
+            "codex rate-limit probe returned no usable snapshot",
+            extra={"cwd": cwd, "binary": resolved},
+        )
+    return snapshot
+
+
+async def _probe_codex_oauth_usage(
+    env: dict[str, str],
+    timeout_seconds: float = 15.0,
+) -> SessionRateLimitUsage | None:
+    credentials = _load_oauth_credentials(env)
+    if credentials is None:
+        log.warning("codex OAuth credentials not found")
+        return None
+
+    global _CACHED_OAUTH_ACCOUNT_ID
+    global _CACHED_OAUTH_CREDENTIALS
+    if (
+        _CACHED_OAUTH_CREDENTIALS is not None
+        and credentials.account_id is not None
+        and _CACHED_OAUTH_ACCOUNT_ID == credentials.account_id
+    ):
+        credentials = _CACHED_OAUTH_CREDENTIALS
+
+    if credentials.needs_refresh:
+        refreshed = await _refresh_oauth_credentials(credentials)
+        if refreshed is not None:
+            credentials = refreshed
+            _CACHED_OAUTH_CREDENTIALS = refreshed
+            _CACHED_OAUTH_ACCOUNT_ID = refreshed.account_id
+
+    request = Request(
+        _resolve_usage_url(env),
+        method="GET",
+        headers={
+            "Authorization": f"Bearer {credentials.access_token}",
+            "Accept": "application/json",
+            "Accept-Language": "en-US,en;q=0.9",
+            "User-Agent": "codex-cli",
+        },
+    )
+    if credentials.account_id:
+        request.add_header("ChatGPT-Account-Id", credentials.account_id)
+
+    response = await asyncio.wait_for(
+        asyncio.to_thread(_fetch_url, request), timeout=timeout_seconds
+    )
+    if response is None:
+        log.warning(
+            "codex OAuth usage request failed before receiving a response",
+            extra={"usage_url": _resolve_usage_url(env)},
+        )
+        return None
+    snapshot = parse_codex_usage_payload(
+        response,
+        notes=[note for note in ["CLI OAuth"] if note],
+    )
+    if snapshot is None:
+        preview = response.decode("utf-8", errors="replace")[:240]
+        log.warning(
+            "codex OAuth usage response did not yield a snapshot "
+            f"(bytes={len(response)} preview={preview!r})",
+        )
+    return snapshot
+
+
+def parse_codex_usage_payload(
+    payload: bytes | dict[str, Any],
+    *,
+    now: datetime | None = None,
+    notes: list[str] | None = None,
+) -> SessionRateLimitUsage | None:
+    if isinstance(payload, bytes):
+        try:
+            raw = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+    else:
+        raw = payload
+    if not isinstance(raw, dict):
+        return None
+
+    windows = _collect_codex_windows(raw)
+    credits_remaining, credits_currency = _parse_credits(raw.get("credits"))
+
+    notes_out = list(notes or ["CLI OAuth"])
+    plan_type = raw.get("plan_type")
+    if isinstance(plan_type, str) and plan_type:
+        notes_out.append(f"plan: {plan_type}")
+    account_email = raw.get("email")
+    if isinstance(account_email, str) and account_email:
+        notes_out.append(account_email)
+
+    return SessionRateLimitUsage(
+        source="codex",
+        updated_at=now or datetime.now(UTC),
+        windows=windows,
+        credits_remaining=credits_remaining,
+        credits_currency=credits_currency,
+        notes=notes_out,
+    )
+
+
+def _collect_codex_windows(raw: dict[str, Any]) -> list[UsageWindow]:
+    windows: list[tuple[int, UsageWindow]] = []
+    for path, candidate in _iter_window_candidates(raw):
+        window = _parse_codex_window(candidate, path=path)
+        if window is None:
+            continue
+        sort_key = 2
+        if window.label == "5h":
+            sort_key = 0
+        elif window.label == "Weekly":
+            sort_key = 1
+        windows.append((sort_key, window))
+    windows.sort(key=lambda item: (item[0], item[1].label, item[1].id))
+    return [window for _, window in windows]
+
+
+def _iter_window_candidates(
+    value: Any, path: tuple[str, ...] = ()
+) -> list[tuple[tuple[str, ...], dict[str, Any]]]:
+    candidates: list[tuple[tuple[str, ...], dict[str, Any]]] = []
+    if isinstance(value, dict):
+        if "used_percent" in value:
+            candidates.append((path, value))
+        for key, child in value.items():
+            candidates.extend(_iter_window_candidates(child, path + (str(key),)))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            candidates.extend(_iter_window_candidates(child, path + (str(index),)))
+    return candidates
+
+
+def _parse_codex_window(
+    candidate: dict[str, Any], *, path: tuple[str, ...]
+) -> UsageWindow | None:
+    used_percent = _parse_percent_value(candidate.get("used_percent"))
+    if used_percent is None:
+        return None
+
+    limit_seconds = _parse_int(candidate.get("limit_window_seconds"))
+    window_minutes = None
+    if limit_seconds is not None and limit_seconds > 0:
+        window_minutes = limit_seconds // 60
+    elif (minutes := _parse_int(candidate.get("window_minutes"))) is not None:
+        window_minutes = minutes
+
+    resets_at = _parse_epoch_datetime(candidate.get("reset_at"))
+    label, window_id = _codex_window_label(
+        path=path, window_minutes=window_minutes, limit_seconds=limit_seconds
+    )
+    return UsageWindow(
+        id=window_id,
+        label=label,
+        used_percent=used_percent,
+        window_minutes=window_minutes,
+        resets_at=resets_at,
+    )
+
+
+def _codex_window_label(
+    *,
+    path: tuple[str, ...],
+    window_minutes: int | None,
+    limit_seconds: int | None,
+) -> tuple[str, str]:
+    duration = (
+        limit_seconds
+        if limit_seconds is not None
+        else (window_minutes * 60 if window_minutes is not None else None)
+    )
+    joined_path = ".".join(path).lower()
+    if duration == 5 * 60 * 60 or "5h" in joined_path or "session" in joined_path:
+        return "5h", "five-hour"
+    if duration == 7 * 24 * 60 * 60 or "week" in joined_path:
+        return "Weekly", "weekly"
+    if path:
+        tail = path[-1].replace("_", " ").strip()
+        if tail:
+            return tail.title(), tail.replace(" ", "-")
+    return "Window", "window"
+
+
+def _parse_credits(raw: Any) -> tuple[float | None, str | None]:
+    if not isinstance(raw, dict):
+        return None, None
+    balance = raw.get("balance")
+    if isinstance(balance, str):
+        try:
+            balance = float(balance.replace(",", ""))
+        except ValueError:
+            return None, None
+    if isinstance(balance, (int, float)):
+        return float(balance), "USD"
+    return None, None
+
+
+def _parse_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_percent_value(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        percent = float(value)
+        if 0.0 <= percent <= 1.0:
+            percent *= 100.0
+        return _clamp_percent(percent)
+    if isinstance(value, str):
+        cleaned = value.strip().replace("%", "")
+        try:
+            percent = float(cleaned)
+        except ValueError:
+            return None
+        if 0.0 <= percent <= 1.0:
+            percent *= 100.0
+        return _clamp_percent(percent)
+    return None
+
+
+def _parse_epoch_datetime(value: Any) -> datetime | None:
+    epoch = _parse_int(value)
+    if epoch is None:
+        return None
+    try:
+        return datetime.fromtimestamp(epoch, tz=UTC)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _fetch_url(request: Request) -> bytes | None:
+    try:
+        with urlopen(request, timeout=30) as response:
+            if getattr(response, "status", 200) != 200:
+                return None
+            return response.read()
+    except (HTTPError, URLError, OSError):
+        return None
+
+
+async def _refresh_oauth_credentials(
+    credentials: _CodexOAuthCredentials,
+) -> _CodexOAuthCredentials | None:
+    if not credentials.refresh_token:
+        return None
+
+    body = {
+        "client_id": _CODEX_OAUTH_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": credentials.refresh_token,
+        "scope": "openid profile email",
+    }
+    request = Request(
+        _CODEX_OAUTH_REFRESH_ENDPOINT,
+        data=json.dumps(body).encode("utf-8"),
+        method="POST",
+        headers={"Content-Type": "application/json"},
+    )
+    response = await asyncio.to_thread(_fetch_url, request)
+    if response is None:
+        return None
+    try:
+        raw = json.loads(response.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    access_token = raw.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        return None
+    refresh_token = raw.get("refresh_token")
+    if not isinstance(refresh_token, str) or not refresh_token:
+        refresh_token = credentials.refresh_token
+    return _CodexOAuthCredentials(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=credentials.account_id,
+        last_refresh=datetime.now(UTC),
+    )
+
+
+def _load_oauth_credentials(env: dict[str, str]) -> _CodexOAuthCredentials | None:
+    path = _codex_auth_path(env)
+    if not path.is_file():
+        return None
+    try:
+        raw = path.read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    api_key = payload.get("OPENAI_API_KEY")
+    if isinstance(api_key, str) and api_key.strip():
+        return _CodexOAuthCredentials(
+            access_token=api_key.strip(),
+            refresh_token="",
+            account_id=None,
+            last_refresh=None,
+        )
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+    access_token = _string_value(tokens, "access_token", "accessToken")
+    refresh_token = _string_value(tokens, "refresh_token", "refreshToken") or ""
+    account_id = _string_value(tokens, "account_id", "accountId")
+    if account_id is None:
+        account_id = _string_value(payload, "chatgpt_account_id", "chatgptAccountId")
+    if not access_token:
+        return None
+    return _CodexOAuthCredentials(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        account_id=account_id,
+        last_refresh=_parse_last_refresh(payload.get("last_refresh")),
+    )
+
+
+def _codex_auth_path(env: dict[str, str]) -> Path:
+    codex_home = env.get("CODEX_HOME")
+    if codex_home and codex_home.strip():
+        root = Path(codex_home).expanduser()
+    else:
+        root = Path.home() / ".codex"
+    return root / "auth.json"
+
+
+def _resolve_usage_url(env: dict[str, str]) -> str:
+    base_url = _resolve_chatgpt_base_url(env)
+    normalized = _normalize_chatgpt_base_url(base_url)
+    path = _CHATGPT_USAGE_PATH if "/backend-api" in normalized else _CODEX_USAGE_PATH
+    return f"{normalized}{path}"
+
+
+def _resolve_chatgpt_base_url(env: dict[str, str]) -> str:
+    contents = _load_config_contents(env)
+    if contents:
+        parsed = _parse_chatgpt_base_url(contents)
+        if parsed:
+            return parsed
+    return _DEFAULT_CHATGPT_BASE_URL
+
+
+def _normalize_chatgpt_base_url(value: str) -> str:
+    trimmed = value.strip() or _DEFAULT_CHATGPT_BASE_URL
+    while trimmed.endswith("/"):
+        trimmed = trimmed[:-1]
+    if (
+        trimmed.startswith("https://chatgpt.com")
+        or trimmed.startswith("https://chat.openai.com")
+    ) and "/backend-api" not in trimmed:
+        trimmed += "/backend-api"
+    return trimmed
+
+
+def _parse_chatgpt_base_url(contents: str) -> str | None:
+    if tomllib is None:
+        return None
+    try:
+        parsed = tomllib.loads(contents)
+    except Exception:  # noqa: BLE001
+        return None
+    value = parsed.get("chatgpt_base_url")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _load_config_contents(env: dict[str, str]) -> str | None:
+    root = (
+        Path(env.get("CODEX_HOME", "")).expanduser()
+        if env.get("CODEX_HOME")
+        else Path.home() / ".codex"
+    )
+    config = root / "config.toml"
+    try:
+        return config.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def _string_value(
+    dictionary: dict[str, Any],
+    snake_case_key: str,
+    camel_case_key: str,
+) -> str | None:
+    value = dictionary.get(snake_case_key)
+    if isinstance(value, str) and value:
+        return value
+    value = dictionary.get(camel_case_key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _parse_last_refresh(raw: Any) -> datetime | None:
+    if not isinstance(raw, str) or not raw:
+        return None
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
 
 
 def _run_codex_status(
@@ -111,7 +580,7 @@ def _run_codex_status(
     proc: subprocess.Popen[bytes] | None = None
     try:
         proc = subprocess.Popen(
-            [binary],
+            [binary, "-s", "read-only", "-a", "untrusted"],
             stdin=slave_fd,
             stdout=slave_fd,
             stderr=slave_fd,

--- a/backend/src/waypoint/backends/codex/remote_probe_script.py
+++ b/backend/src/waypoint/backends/codex/remote_probe_script.py
@@ -1,0 +1,310 @@
+"""Remote rate-limit probe for Codex.
+
+Designed to be piped to ``python3 -`` over SSH on a remote launch
+target. First tries the OAuth path (``~/.codex/auth.json`` →
+``chatgpt.com/backend-api/wham/usage``). If that yields nothing,
+spawns ``codex -s read-only -a untrusted`` with a local PTY on the
+remote, drives ``/status``, and emits the captured TUI output for the
+backend to parse with ``parse_codex_status``.
+
+Stdlib-only; targets Python 3.8+. ``tomllib`` (3.11+) is used when
+available to read ``config.toml`` for a custom ``chatgpt_base_url``;
+older interpreters fall back to a regex.
+
+The ``WAYPOINT_REMOTE_PROBE_CODEX_BIN`` env var (set by the SSH caller)
+selects the remote ``codex`` binary path; defaults to ``codex``.
+
+Output schema (always one line of JSON on stdout, ``\\n``-terminated):
+
+    {"payload": {usage-json from server}, "usage_url": str}
+    {"status_text": "..."}    # /status PTY scrape
+    {"error": "no_data" | "internal", ...}
+"""
+
+import json
+import os
+import pty
+import re
+import select
+import signal
+import subprocess
+import sys
+import time
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+try:
+    import tomllib
+except ImportError:
+    tomllib = None  # type: ignore[assignment]
+
+DEFAULT_CHATGPT_BASE_URL = "https://chatgpt.com/backend-api/"
+CHATGPT_USAGE_PATH = "/wham/usage"
+CODEX_USAGE_PATH = "/api/codex/usage"
+OAUTH_REFRESH_ENDPOINT = "https://auth.openai.com/oauth/token"
+OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+HTTP_TIMEOUT = 25
+CODEX_BIN_ENV = "WAYPOINT_REMOTE_PROBE_CODEX_BIN"
+STATUS_TIMEOUT = 8.0
+
+
+def emit(payload):
+    sys.stdout.write(json.dumps(payload) + "\n")
+    sys.stdout.flush()
+
+
+def codex_home():
+    base = os.environ.get("CODEX_HOME")
+    if base and base.strip():
+        return os.path.expanduser(base)
+    return os.path.expanduser("~/.codex")
+
+
+def auth_path():
+    return os.path.join(codex_home(), "auth.json")
+
+
+def config_path():
+    return os.path.join(codex_home(), "config.toml")
+
+
+def _string_value(mapping, snake_case_key, camel_case_key):
+    value = mapping.get(snake_case_key)
+    if isinstance(value, str) and value:
+        return value
+    value = mapping.get(camel_case_key)
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def load_credentials():
+    path = auth_path()
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path, encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+
+    api_key = payload.get("OPENAI_API_KEY")
+    if isinstance(api_key, str) and api_key.strip():
+        return {
+            "access_token": api_key.strip(),
+            "refresh_token": "",
+            "account_id": None,
+        }
+
+    tokens = payload.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+    access_token = _string_value(tokens, "access_token", "accessToken")
+    if not access_token:
+        return None
+    account_id = _string_value(tokens, "account_id", "accountId") or _string_value(
+        payload, "chatgpt_account_id", "chatgptAccountId"
+    )
+    return {
+        "access_token": access_token,
+        "refresh_token": _string_value(tokens, "refresh_token", "refreshToken") or "",
+        "account_id": account_id,
+    }
+
+
+def _resolve_chatgpt_base_url():
+    path = config_path()
+    try:
+        with open(path, encoding="utf-8") as handle:
+            contents = handle.read()
+    except OSError:
+        return DEFAULT_CHATGPT_BASE_URL
+    if tomllib is not None:
+        try:
+            parsed = tomllib.loads(contents)
+        except Exception:  # noqa: BLE001
+            parsed = None
+        if isinstance(parsed, dict):
+            value = parsed.get("chatgpt_base_url")
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    match = re.search(
+        r'^\s*chatgpt_base_url\s*=\s*"([^"]+)"', contents, flags=re.MULTILINE
+    )
+    if match is not None:
+        return match.group(1).strip()
+    return DEFAULT_CHATGPT_BASE_URL
+
+
+def _normalize_chatgpt_base_url(value):
+    trimmed = value.strip() or DEFAULT_CHATGPT_BASE_URL
+    while trimmed.endswith("/"):
+        trimmed = trimmed[:-1]
+    if (
+        trimmed.startswith("https://chatgpt.com")
+        or trimmed.startswith("https://chat.openai.com")
+    ) and "/backend-api" not in trimmed:
+        trimmed += "/backend-api"
+    return trimmed
+
+
+def resolve_usage_url():
+    base = _normalize_chatgpt_base_url(_resolve_chatgpt_base_url())
+    path = CHATGPT_USAGE_PATH if "/backend-api" in base else CODEX_USAGE_PATH
+    return base + path
+
+
+def _post_json(url, payload, headers):
+    body = json.dumps(payload).encode("utf-8")
+    request = Request(url, data=body, method="POST", headers=headers)
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT) as response:
+            if getattr(response, "status", 200) != 200:
+                return None
+            return json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def refresh_credentials(credentials):
+    if not credentials.get("refresh_token"):
+        return credentials
+    refreshed = _post_json(
+        OAUTH_REFRESH_ENDPOINT,
+        {
+            "client_id": OAUTH_CLIENT_ID,
+            "grant_type": "refresh_token",
+            "refresh_token": credentials["refresh_token"],
+            "scope": "openid profile email",
+        },
+        {"Content-Type": "application/json"},
+    )
+    if not isinstance(refreshed, dict):
+        return credentials
+    access_token = refreshed.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        return credentials
+    new_refresh = refreshed.get("refresh_token")
+    return {
+        "access_token": access_token,
+        "refresh_token": (
+            new_refresh
+            if isinstance(new_refresh, str) and new_refresh
+            else credentials["refresh_token"]
+        ),
+        "account_id": credentials.get("account_id"),
+    }
+
+
+def fetch_usage(credentials, usage_url):
+    headers = {
+        "Authorization": "Bearer " + credentials["access_token"],
+        "Accept": "application/json",
+        "Accept-Language": "en-US,en;q=0.9",
+        "User-Agent": "codex-cli",
+    }
+    if credentials.get("account_id"):
+        headers["ChatGPT-Account-Id"] = credentials["account_id"]
+    request = Request(usage_url, method="GET", headers=headers)
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT) as response:
+            if getattr(response, "status", 200) != 200:
+                return None
+            return json.loads(response.read().decode("utf-8"))
+    except (HTTPError, URLError, OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def run_codex_status_pty(timeout_seconds=STATUS_TIMEOUT):
+    binary = os.environ.get(CODEX_BIN_ENV) or "codex"
+    master_fd, slave_fd = pty.openpty()
+    proc = None
+    try:
+        try:
+            proc = subprocess.Popen(
+                [binary, "-s", "read-only", "-a", "untrusted"],
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                start_new_session=True,
+            )
+        except OSError:
+            os.close(master_fd)
+            os.close(slave_fd)
+            return None
+        os.close(slave_fd)
+        time.sleep(0.35)
+        try:
+            os.write(master_fd, b"/status\r")
+        except OSError:
+            pass
+        deadline = time.monotonic() + timeout_seconds
+        settled_at = None
+        buffer = bytearray()
+        while time.monotonic() < deadline:
+            ready, _, _ = select.select([master_fd], [], [], 0.1)
+            if ready:
+                try:
+                    chunk = os.read(master_fd, 4096)
+                except OSError:
+                    break
+                if chunk:
+                    buffer.extend(chunk)
+                    settled_at = None
+                    continue
+                break
+            if proc.poll() is not None:
+                if settled_at is None:
+                    settled_at = time.monotonic() + 0.5
+                elif time.monotonic() >= settled_at:
+                    break
+        return buffer.decode("utf-8", errors="replace")
+    finally:
+        if proc is not None and proc.poll() is None:
+            try:
+                os.write(master_fd, b"/exit\r")
+            except OSError:
+                pass
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+            stop = time.monotonic() + 1.0
+            while proc.poll() is None and time.monotonic() < stop:
+                time.sleep(0.05)
+            if proc.poll() is None:
+                try:
+                    os.kill(proc.pid, signal.SIGKILL)
+                except OSError:
+                    pass
+        try:
+            os.close(master_fd)
+        except OSError:
+            pass
+
+
+def main():
+    credentials = load_credentials()
+    if credentials is not None:
+        credentials = refresh_credentials(credentials)
+        usage_url = resolve_usage_url()
+        payload = fetch_usage(credentials, usage_url)
+        if payload is not None:
+            emit({"payload": payload, "usage_url": usage_url})
+            return
+
+    status_text = run_codex_status_pty()
+    if status_text and status_text.strip():
+        emit({"status_text": status_text})
+        return
+
+    emit({"error": "no_data"})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001
+        emit({"error": "internal", "message": repr(exc)})

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging
 import os
 from datetime import UTC, datetime
@@ -377,15 +378,20 @@ class OpenCodePlugin:
             def _on_server_died(active_session_ids: list[str]) -> None:
                 self._handle_server_died(runtime, key, active_session_ids)
 
-            adapter = OpenCodeAdapter(
-                emit_event=runtime._emit_adapter_event,
-                on_session_update=runtime.session_update_callback(),
-                launch_target=launch_target,
-                on_agent_changed=_on_agent_changed,
-                on_server_died=_on_server_died,
-                workdir=key[1],
-                extra_args=custom_args,
-            )
+            session_update_callback = getattr(runtime, "session_update_callback", None)
+            adapter_kwargs: dict[str, Any] = {
+                "emit_event": runtime._emit_adapter_event,
+                "launch_target": launch_target,
+                "on_agent_changed": _on_agent_changed,
+                "on_server_died": _on_server_died,
+                "workdir": key[1],
+                "extra_args": custom_args,
+            }
+            if callable(session_update_callback):
+                adapter_params = inspect.signature(OpenCodeAdapter).parameters
+                if "on_session_update" in adapter_params:
+                    adapter_kwargs["on_session_update"] = session_update_callback()
+            adapter = OpenCodeAdapter(**adapter_kwargs)
             self._adapters[key] = adapter
             return adapter
 

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1,5 +1,4 @@
 import asyncio
-import inspect
 import logging
 import os
 from datetime import UTC, datetime
@@ -379,19 +378,19 @@ class OpenCodePlugin:
                 self._handle_server_died(runtime, key, active_session_ids)
 
             session_update_callback = getattr(runtime, "session_update_callback", None)
-            adapter_kwargs: dict[str, Any] = {
-                "emit_event": runtime._emit_adapter_event,
-                "launch_target": launch_target,
-                "on_agent_changed": _on_agent_changed,
-                "on_server_died": _on_server_died,
-                "workdir": key[1],
-                "extra_args": custom_args,
-            }
-            if callable(session_update_callback):
-                adapter_params = inspect.signature(OpenCodeAdapter).parameters
-                if "on_session_update" in adapter_params:
-                    adapter_kwargs["on_session_update"] = session_update_callback()
-            adapter = OpenCodeAdapter(**adapter_kwargs)
+            adapter = OpenCodeAdapter(
+                emit_event=runtime._emit_adapter_event,
+                on_session_update=(
+                    session_update_callback()
+                    if callable(session_update_callback)
+                    else None
+                ),
+                launch_target=launch_target,
+                on_agent_changed=_on_agent_changed,
+                on_server_died=_on_server_died,
+                workdir=key[1],
+                extra_args=custom_args,
+            )
             self._adapters[key] = adapter
             return adapter
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -630,6 +630,14 @@ class SessionRuntime:
         session = self.get_session(session_id)
         return await self._reattach_session(session)
 
+    async def refresh_rate_limit_usage(self, session_id: str) -> SessionRecord:
+        session = self.get_session(session_id)
+        plugin = self.registry.plugin_for(session)
+        refresher = getattr(plugin, "refresh_rate_limit_usage", None)
+        if callable(refresher):
+            await refresher(self, session)
+        return self.get_session(session_id)
+
     async def _reattach_session(self, session: SessionRecord) -> SessionRecord:
         # ERROR sessions reach this path while the prior adapter state may
         # still be in `_sessions` — the stream/process watchers emit the

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -112,6 +112,27 @@ class SessionContextUsage(BaseModel):
     breakdown: dict[str, int] = Field(default_factory=dict)
 
 
+class UsageWindow(BaseModel):
+    id: str
+    label: str
+    used_percent: float
+    used_tokens: int | None = None
+    limit_tokens: int | None = None
+    remaining_tokens: int | None = None
+    window_minutes: int | None = None
+    resets_at: datetime | None = None
+    reset_description: str | None = None
+
+
+class SessionRateLimitUsage(BaseModel):
+    source: BackendId
+    updated_at: datetime
+    windows: list[UsageWindow] = Field(default_factory=list)
+    credits_remaining: float | None = None
+    credits_currency: str | None = None
+    notes: list[str] = Field(default_factory=list)
+
+
 class SessionRecord(BaseModel):
     id: str
     backend: BackendId
@@ -144,6 +165,7 @@ class SessionRecord(BaseModel):
     # the field. Empty list = none.
     config_overrides: list[str] = Field(default_factory=list)
     context_usage: SessionContextUsage | None = None
+    rate_limit_usage: SessionRateLimitUsage | None = None
 
 
 class EventRecord(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -119,7 +119,8 @@ class Storage:
                 effort TEXT,
                 args TEXT NOT NULL DEFAULT '[]',
                 config_overrides TEXT NOT NULL DEFAULT '[]',
-                context_usage TEXT
+                context_usage TEXT,
+                rate_limit_usage TEXT
             );
 
             CREATE TABLE IF NOT EXISTS events (
@@ -164,6 +165,7 @@ class Storage:
             "sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
         self._ensure_column("sessions", "context_usage", "TEXT")
+        self._ensure_column("sessions", "rate_limit_usage", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -181,8 +183,9 @@ class Storage:
                 id, backend, source, transport, title, cwd, launch_target_id,
                 repo_name, branch, status, created_at, updated_at, last_event_at,
                 raw_log_path, structured_log_path, transport_state, pinned_at,
-                permission_mode, model, effort, args, config_overrides, context_usage
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                permission_mode, model, effort, args, config_overrides, context_usage,
+                rate_limit_usage
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -210,6 +213,11 @@ class Storage:
                 (
                     json.dumps(session.context_usage.model_dump(mode="json"))
                     if session.context_usage is not None
+                    else None
+                ),
+                (
+                    json.dumps(session.rate_limit_usage.model_dump(mode="json"))
+                    if session.rate_limit_usage is not None
                     else None
                 ),
             ),
@@ -622,6 +630,18 @@ class Storage:
                 payload["context_usage"] = None
         else:
             payload["context_usage"] = None
+        raw_rate_limit_usage = payload.get("rate_limit_usage")
+        if raw_rate_limit_usage:
+            try:
+                parsed_rate_limit_usage = json.loads(raw_rate_limit_usage)
+            except json.JSONDecodeError:
+                parsed_rate_limit_usage = None
+            if isinstance(parsed_rate_limit_usage, dict):
+                payload["rate_limit_usage"] = parsed_rate_limit_usage
+            else:
+                payload["rate_limit_usage"] = None
+        else:
+            payload["rate_limit_usage"] = None
         return SessionRecord.model_validate(payload)
 
     def _schedule_from_row(self, row: sqlite3.Row) -> ScheduledSessionRecord:

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -566,6 +566,7 @@ async def test_get_or_create_adapter_keys_by_cwd(
         def __init__(
             self,
             emit_event,
+            on_session_update=None,
             launch_target=None,
             on_agent_changed=None,
             on_server_died=None,
@@ -611,6 +612,7 @@ async def test_get_or_create_adapter_normalizes_equivalent_cwds(
         def __init__(
             self,
             emit_event,
+            on_session_update=None,
             launch_target=None,
             on_agent_changed=None,
             on_server_died=None,

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -10,13 +10,16 @@ from waypoint.backends.claude_code.rate_limits import (
     parse_claude_rate_limit_headers,
     parse_claude_usage_payload,
     probe_claude_usage,
+    probe_claude_usage_remote,
 )
 from waypoint.backends.codex.rate_limits import (
     _load_oauth_credentials,
     _resolve_usage_url,
     parse_codex_status,
     parse_codex_usage_payload,
+    probe_codex_usage_remote,
 )
+from waypoint.launch_targets import SshLaunchTargetConfig
 
 
 def test_parse_codex_status_extracts_windows_and_credits() -> None:
@@ -417,3 +420,183 @@ def test_parse_codex_usage_payload_emits_empty_snapshot_for_education_plan() -> 
         "plan: education",
         "noppanat@example.com",
     ]
+
+
+def _ssh_target() -> SshLaunchTargetConfig:
+    return SshLaunchTargetConfig(
+        id="rover",
+        name="rover",
+        ssh_destination="user@rover.lan",
+        ssh_args=["-o", "ControlMaster=no"],
+        remote_shell="",
+    )
+
+
+def test_probe_claude_usage_remote_parses_messages_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "status": 200,
+        "headers": {
+            "anthropic-ratelimit-unified-5h-utilization": "0.4",
+            "anthropic-ratelimit-unified-5h-reset": str(
+                datetime(2026, 5, 12, 13, 0, tzinfo=UTC).timestamp()
+            ),
+            "anthropic-ratelimit-unified-7d-utilization": "0.92",
+            "anthropic-ratelimit-unified-7d-reset": str(
+                datetime(2026, 5, 19, 1, 0, tzinfo=UTC).timestamp()
+            ),
+        },
+        "body_preview": "{}",
+        "oauth_account_notes": ["org: lumid", "user tier: default_claude_max_5x"],
+        "expires_at": None,
+    }
+
+    async def _fake_runner(launch_target, timeout_seconds):
+        assert launch_target.ssh_destination == "user@rover.lan"
+        return payload
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_claude_usage_remote(_ssh_target()))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert [w.label for w in snapshot.windows] == ["5h", "Weekly"]
+    assert snapshot.windows[0].used_percent == 40.0
+    assert snapshot.windows[1].used_percent == 92.0
+    assert snapshot.notes == [
+        "remote CLI creds",
+        "org: lumid",
+        "user tier: default_claude_max_5x",
+    ]
+
+
+def test_probe_claude_usage_remote_handles_expired_sentinel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_runner(launch_target, timeout_seconds):
+        return {
+            "error": "expired",
+            "expires_at": 1700000000.0,
+            "oauth_account_notes": ["org: lumid"],
+        }
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_claude_usage_remote(_ssh_target()))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert snapshot.windows == []
+    assert snapshot.notes == [
+        "remote CLI creds",
+        "credentials expired — run `claude` to refresh",
+        "org: lumid",
+    ]
+
+
+def test_probe_claude_usage_remote_handles_no_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_runner(launch_target, timeout_seconds):
+        return {"error": "no_credentials"}
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_claude_usage_remote(_ssh_target()))
+    assert snapshot is None
+
+
+def test_probe_claude_usage_remote_surfaces_401_as_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_runner(launch_target, timeout_seconds):
+        return {
+            "status": 401,
+            "headers": {},
+            "body_preview": '{"type":"error"}',
+            "oauth_account_notes": [],
+            "expires_at": None,
+        }
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_claude_usage_remote(_ssh_target()))
+    assert snapshot is not None
+    assert snapshot.windows == []
+    assert "credentials expired" in snapshot.notes[1]
+
+
+def test_probe_codex_usage_remote_parses_oauth_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_runner(launch_target, binary, timeout_seconds):
+        return {
+            "payload": {
+                "plan_type": "pro",
+                "rate_limit": {
+                    "primary_window": {
+                        "used_percent": 30,
+                        "limit_window_seconds": 18000,
+                    }
+                },
+                "email": "user@example.com",
+            },
+            "usage_url": "https://chatgpt.com/backend-api/wham/usage",
+        }
+
+    monkeypatch.setattr(
+        "waypoint.backends.codex.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_codex_usage_remote(_ssh_target(), binary="codex"))
+    assert snapshot is not None
+    assert snapshot.source == "codex"
+    assert [w.label for w in snapshot.windows] == ["5h"]
+    assert snapshot.windows[0].used_percent == 30.0
+    assert "remote OAuth" in snapshot.notes
+    assert "plan: pro" in snapshot.notes
+
+
+def test_probe_codex_usage_remote_falls_back_to_status_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_text = (
+        "Credits: $5.00\n"
+        "5h limit: 12% used (resets in 1h)\n"
+        "Weekly limit: 80% left, resets at 2026-05-11 00:00 UTC\n"
+    )
+
+    async def _fake_runner(launch_target, binary, timeout_seconds):
+        return {"status_text": status_text}
+
+    monkeypatch.setattr(
+        "waypoint.backends.codex.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_codex_usage_remote(_ssh_target(), binary="codex"))
+    assert snapshot is not None
+    assert snapshot.credits_remaining == 5.0
+    assert [w.label for w in snapshot.windows] == ["5h", "Weekly"]
+    assert "remote /status" in snapshot.notes
+
+
+def test_probe_codex_usage_remote_returns_none_for_no_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _fake_runner(launch_target, binary, timeout_seconds):
+        return {"error": "no_data"}
+
+    monkeypatch.setattr(
+        "waypoint.backends.codex.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_codex_usage_remote(_ssh_target(), binary="codex"))
+    assert snapshot is None

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -1,0 +1,93 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from waypoint.backends.claude_code.rate_limits import (
+    _read_cli_credentials_for_env,
+    parse_claude_usage_payload,
+)
+from waypoint.backends.codex.rate_limits import parse_codex_status
+
+
+def test_parse_codex_status_extracts_windows_and_credits() -> None:
+    snapshot = parse_codex_status("""
+        \x1b[32mCredits: $12.34\x1b[0m
+        5h limit: 42% used (resets in 2h 10m)
+        Weekly limit: 73% left, resets at 2026-05-11 12:00 UTC
+        """)
+    assert snapshot is not None
+    assert snapshot.source == "codex"
+    assert snapshot.credits_currency == "USD"
+    assert snapshot.credits_remaining == 12.34
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly"]
+    assert snapshot.windows[0].used_percent == 42.0
+    assert snapshot.windows[0].reset_description == "2h 10m"
+    assert snapshot.windows[1].used_percent == 27.0
+    assert snapshot.windows[1].reset_description == "2026-05-11 12:00 UTC"
+
+
+def test_parse_claude_usage_payload_normalizes_windows() -> None:
+    snapshot = parse_claude_usage_payload(
+        {
+            "five_hour": {
+                "utilization": 0.54,
+                "resets_at": "2026-05-10T12:34:56Z",
+            },
+            "seven_day": {
+                "utilization": "81.2",
+                "resets_at": "2026-05-12T01:00:00Z",
+            },
+            "seven_day_opus": {
+                "utilization": 0.12,
+                "resets_at": "2026-05-12T01:00:00Z",
+            },
+        },
+        now=datetime(2026, 5, 10, 8, 0, tzinfo=UTC),
+        notes=["CLI creds"],
+    )
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert snapshot.updated_at == datetime(2026, 5, 10, 8, 0, tzinfo=UTC)
+    assert snapshot.notes == ["CLI creds"]
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly", "Opus"]
+    assert snapshot.windows[0].used_percent == 54.0
+    assert snapshot.windows[0].window_minutes == 300
+    assert snapshot.windows[0].resets_at == datetime(
+        2026, 5, 10, 12, 34, 56, tzinfo=UTC
+    )
+    assert snapshot.windows[1].used_percent == 81.2
+    assert snapshot.windows[2].used_percent == 12.0
+
+
+def test_read_cli_credentials_prefers_file_before_keychain(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / ".credentials.json").write_text(
+        '{"claudeAiOauth":{"accessToken":"file-token"}}',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_keychain_access_token",
+        lambda env: "keychain-token",
+    )
+    result = _read_cli_credentials_for_env({"CLAUDE_CONFIG_DIR": str(claude_dir)})
+    assert result is not None
+    token, note = result
+    assert token == "file-token"
+    assert note == "CLI creds"
+
+
+def test_read_cli_credentials_falls_back_to_keychain(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_keychain_access_token",
+        lambda env: "keychain-token",
+    )
+    result = _read_cli_credentials_for_env({})
+    assert result is not None
+    token, note = result
+    assert token == "keychain-token"
+    assert note == "CLI creds"

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -1,12 +1,22 @@
-from datetime import UTC, datetime
+import asyncio
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
 from waypoint.backends.claude_code.rate_limits import (
+    _ClaudeHTTPResponse,
     _read_cli_credentials_for_env,
+    _read_oauth_account_notes,
+    parse_claude_rate_limit_headers,
     parse_claude_usage_payload,
+    probe_claude_usage,
 )
-from waypoint.backends.codex.rate_limits import parse_codex_status
+from waypoint.backends.codex.rate_limits import (
+    _load_oauth_credentials,
+    _resolve_usage_url,
+    parse_codex_status,
+    parse_codex_usage_payload,
+)
 
 
 def test_parse_codex_status_extracts_windows_and_credits() -> None:
@@ -24,6 +34,84 @@ def test_parse_codex_status_extracts_windows_and_credits() -> None:
     assert snapshot.windows[0].reset_description == "2h 10m"
     assert snapshot.windows[1].used_percent == 27.0
     assert snapshot.windows[1].reset_description == "2026-05-11 12:00 UTC"
+
+
+def test_parse_codex_usage_payload_extracts_windows_and_credits() -> None:
+    snapshot = parse_codex_usage_payload(
+        {
+            "plan_type": "education",
+            "rate_limit": {
+                "primary_window": {
+                    "used_percent": 22,
+                    "reset_at": 1766948068,
+                    "limit_window_seconds": 18000,
+                },
+                "secondary_window": {
+                    "used_percent": 43,
+                    "reset_at": 1767407914,
+                    "limit_window_seconds": 604800,
+                },
+            },
+            "credits": {
+                "has_credits": True,
+                "unlimited": False,
+                "balance": 42.5,
+            },
+            "email": "noppanat@example.com",
+        },
+        now=datetime(2026, 5, 10, 8, 0, tzinfo=UTC),
+        notes=["CLI OAuth"],
+    )
+    assert snapshot is not None
+    assert snapshot.source == "codex"
+    assert snapshot.updated_at == datetime(2026, 5, 10, 8, 0, tzinfo=UTC)
+    assert snapshot.notes == ["CLI OAuth", "plan: education", "noppanat@example.com"]
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly"]
+    assert snapshot.windows[0].used_percent == 22.0
+    assert snapshot.windows[0].window_minutes == 300
+    assert snapshot.windows[0].resets_at == datetime.fromtimestamp(1766948068, tz=UTC)
+    assert snapshot.windows[1].used_percent == 43.0
+    assert snapshot.windows[1].window_minutes == 10080
+    assert snapshot.credits_remaining == 42.5
+    assert snapshot.credits_currency == "USD"
+
+
+def test_load_oauth_credentials_reads_auth_json(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text(
+        """
+        {
+          "tokens": {
+            "access_token": "access-token",
+            "refresh_token": "refresh-token",
+            "account_id": "account-123"
+          },
+          "last_refresh": "2026-05-01T12:34:56Z"
+        }
+        """,
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    creds = _load_oauth_credentials({"CODEX_HOME": str(codex_home)})
+    assert creds is not None
+    assert creds.access_token == "access-token"
+    assert creds.refresh_token == "refresh-token"
+    assert creds.account_id == "account-123"
+    assert creds.last_refresh == datetime(2026, 5, 1, 12, 34, 56, tzinfo=UTC)
+
+
+def test_resolve_usage_url_prefers_chatgpt_backend_api(tmp_path) -> None:
+    codex_home = tmp_path / ".codex"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        'chatgpt_base_url = "https://chatgpt.com/"\n',
+        encoding="utf-8",
+    )
+    url = _resolve_usage_url({"CODEX_HOME": str(codex_home)})
+    assert url == "https://chatgpt.com/backend-api/wham/usage"
 
 
 def test_parse_claude_usage_payload_normalizes_windows() -> None:
@@ -65,7 +153,7 @@ def test_read_cli_credentials_prefers_file_before_keychain(
     claude_dir = tmp_path / ".claude"
     claude_dir.mkdir()
     (claude_dir / ".credentials.json").write_text(
-        '{"claudeAiOauth":{"accessToken":"file-token"}}',
+        '{"claudeAiOauth":{"accessToken":"file-token","expiresAt":1893456000000}}',
         encoding="utf-8",
     )
     monkeypatch.setattr(
@@ -74,20 +162,258 @@ def test_read_cli_credentials_prefers_file_before_keychain(
     )
     result = _read_cli_credentials_for_env({"CLAUDE_CONFIG_DIR": str(claude_dir)})
     assert result is not None
-    token, note = result
+    token, expires_at, note = result
     assert token == "file-token"
+    assert expires_at == datetime(2030, 1, 1, tzinfo=UTC)
     assert note == "CLI creds"
 
 
-def test_read_cli_credentials_falls_back_to_keychain(
+def test_read_cli_credentials_falls_back_to_keychain_json_blob(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._read_keychain_access_token",
-        lambda env: "keychain-token",
+        lambda env: (
+            '{"claudeAiOauth":{"accessToken":"keychain-token",'
+            '"expiresAt":1893456000000}}'
+        ),
     )
     result = _read_cli_credentials_for_env({})
     assert result is not None
-    token, note = result
+    token, expires_at, note = result
     assert token == "keychain-token"
+    assert expires_at == datetime(2030, 1, 1, tzinfo=UTC)
     assert note == "CLI creds"
+
+
+def test_read_cli_credentials_keychain_legacy_bare_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_keychain_access_token",
+        lambda env: "bare-token-no-json",
+    )
+    result = _read_cli_credentials_for_env({})
+    assert result is not None
+    token, expires_at, note = result
+    assert token == "bare-token-no-json"
+    assert expires_at is None
+    assert note == "CLI creds"
+
+
+def test_read_oauth_account_notes_extract_tiers(tmp_path) -> None:
+    claude_dir = tmp_path / ".claude"
+    claude_dir.mkdir()
+    (claude_dir / ".claude.json").write_text(
+        """
+        {
+          "oauthAccount": {
+            "organizationName": "lumid",
+            "userRateLimitTier": "default_claude_max_5x",
+            "organizationRateLimitTier": "default_raven"
+          }
+        }
+        """,
+        encoding="utf-8",
+    )
+    notes = _read_oauth_account_notes({"CLAUDE_CONFIG_DIR": str(claude_dir)})
+    assert notes == [
+        "org: lumid",
+        "user tier: default_claude_max_5x",
+        "org tier: default_raven",
+    ]
+
+
+def test_parse_claude_rate_limit_headers_extracts_windows() -> None:
+    snapshot = parse_claude_rate_limit_headers(
+        {
+            "Anthropic-RateLimit-Unified-5h-Utilization": "0.25",
+            "Anthropic-RateLimit-Unified-5h-Reset": str(
+                datetime(2026, 5, 10, 13, 0, tzinfo=UTC).timestamp()
+            ),
+            "anthropic-ratelimit-unified-7d-utilization": "81.2",
+            "anthropic-ratelimit-unified-7d-reset": str(
+                datetime(2026, 5, 12, 1, 0, tzinfo=UTC).timestamp()
+            ),
+        },
+        now=datetime(2026, 5, 10, 8, 0, tzinfo=UTC),
+        notes=["CLI creds"],
+    )
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert snapshot.updated_at == datetime(2026, 5, 10, 8, 0, tzinfo=UTC)
+    assert snapshot.notes == ["CLI creds"]
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly"]
+    assert snapshot.windows[0].used_percent == 25.0
+    assert snapshot.windows[0].resets_at == datetime(2026, 5, 10, 13, 0, tzinfo=UTC)
+    assert snapshot.windows[1].used_percent == 81.2
+    assert snapshot.windows[1].resets_at == datetime(2026, 5, 12, 1, 0, tzinfo=UTC)
+
+
+def test_probe_claude_usage_surfaces_rate_limit_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_cli_credentials_for_env",
+        lambda env: ("access-token", None, "CLI creds"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._claude_user_agent",
+        lambda: "claude-code/2.1.136",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
+        lambda env: ["org: lumid", "user tier: default_claude_max_5x"],
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
+        lambda request: _ClaudeHTTPResponse(
+            status=429,
+            headers={"Retry-After": "42"},
+            body=b'{"error":{"type":"rate_limit_error"}}',
+        ),
+    )
+
+    snapshot = asyncio.run(probe_claude_usage(env={}))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert snapshot.windows == []
+    assert snapshot.notes == [
+        "CLI creds",
+        "org: lumid",
+        "user tier: default_claude_max_5x",
+        "rate limited; retry after 42s",
+    ]
+
+
+def test_probe_claude_usage_parses_messages_api_headers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_cli_credentials_for_env",
+        lambda env: ("access-token", None, "CLI creds"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._claude_user_agent",
+        lambda: "claude-code/2.1.136",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
+        lambda env: ["org: lumid", "user tier: default_claude_max_5x"],
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
+        lambda request: _ClaudeHTTPResponse(
+            status=200,
+            headers={
+                "anthropic-ratelimit-unified-5h-utilization": "0.25",
+                "anthropic-ratelimit-unified-5h-reset": str(
+                    datetime(2026, 5, 12, 13, 0, tzinfo=UTC).timestamp()
+                ),
+                "anthropic-ratelimit-unified-7d-utilization": "0.812",
+                "anthropic-ratelimit-unified-7d-reset": str(
+                    datetime(2026, 5, 19, 1, 0, tzinfo=UTC).timestamp()
+                ),
+            },
+            body=b'{"content":[{"type":"text","text":"hi"}]}',
+        ),
+    )
+
+    snapshot = asyncio.run(probe_claude_usage(env={}))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly"]
+    assert snapshot.windows[0].used_percent == 25.0
+    assert snapshot.windows[1].used_percent == 81.2
+    assert snapshot.notes == [
+        "CLI creds",
+        "org: lumid",
+        "user tier: default_claude_max_5x",
+    ]
+
+
+def test_probe_claude_usage_bails_when_token_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expired_at = datetime.now(UTC) - timedelta(hours=1)
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_cli_credentials_for_env",
+        lambda env: ("access-token", expired_at, "CLI creds"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
+        lambda env: ["org: lumid"],
+    )
+
+    def _should_not_be_called(request: object) -> object:
+        raise AssertionError("HTTP call must not happen when token is expired")
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
+        _should_not_be_called,
+    )
+    snapshot = asyncio.run(probe_claude_usage(env={}))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert snapshot.windows == []
+    assert snapshot.notes == [
+        "CLI creds",
+        "credentials expired — run `claude` to refresh",
+        "org: lumid",
+    ]
+
+
+def test_probe_claude_usage_surfaces_401_as_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_cli_credentials_for_env",
+        lambda env: ("access-token", None, "CLI creds"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._claude_user_agent",
+        lambda: "claude-code/2.1.136",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
+        lambda env: [],
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
+        lambda request: _ClaudeHTTPResponse(
+            status=401,
+            headers={},
+            body=b'{"type":"error","error":{"type":"authentication_error",'
+            b'"message":"Invalid bearer token"}}',
+        ),
+    )
+    snapshot = asyncio.run(probe_claude_usage(env={}))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert snapshot.windows == []
+    assert snapshot.notes == [
+        "CLI creds",
+        "credentials expired — run `claude` to refresh",
+    ]
+
+
+def test_parse_codex_usage_payload_emits_empty_snapshot_for_education_plan() -> None:
+    snapshot = parse_codex_usage_payload(
+        {
+            "plan_type": "education",
+            "rate_limit": None,
+            "code_review_rate_limit": None,
+            "additional_rate_limits": None,
+            "email": "noppanat@example.com",
+        },
+        now=datetime(2026, 5, 11, 0, 0, tzinfo=UTC),
+    )
+    assert snapshot is not None
+    assert snapshot.source == "codex"
+    assert snapshot.windows == []
+    assert snapshot.credits_remaining is None
+    assert snapshot.notes == [
+        "CLI OAuth",
+        "plan: education",
+        "noppanat@example.com",
+    ]

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -14,12 +14,14 @@ from waypoint.backends.claude_code.rate_limits import (
 )
 from waypoint.backends.codex.rate_limits import (
     _load_oauth_credentials,
+    _oauth_snapshot_is_actionable,
     _resolve_usage_url,
     parse_codex_status,
     parse_codex_usage_payload,
     probe_codex_usage_remote,
 )
 from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import SessionRateLimitUsage, UsageWindow
 
 
 def test_parse_codex_status_extracts_windows_and_credits() -> None:
@@ -600,3 +602,52 @@ def test_probe_codex_usage_remote_returns_none_for_no_data(
     )
     snapshot = asyncio.run(probe_codex_usage_remote(_ssh_target(), binary="codex"))
     assert snapshot is None
+
+
+def test_oauth_snapshot_is_actionable_recognizes_useful_data() -> None:
+    now = datetime(2026, 5, 11, tzinfo=UTC)
+
+    def _snap(**kwargs: object) -> SessionRateLimitUsage:
+        return SessionRateLimitUsage(source="codex", updated_at=now, **kwargs)
+
+    assert _oauth_snapshot_is_actionable(
+        _snap(
+            windows=[UsageWindow(id="five_hour", label="5h", used_percent=10.0)],
+            notes=["CLI OAuth"],
+        )
+    )
+    assert _oauth_snapshot_is_actionable(
+        _snap(credits_remaining=42.5, credits_currency="USD", notes=["CLI OAuth"])
+    )
+    assert _oauth_snapshot_is_actionable(_snap(notes=["CLI OAuth", "plan: education"]))
+    assert _oauth_snapshot_is_actionable(_snap(notes=["CLI OAuth", "user@example.com"]))
+    # Default seed notes only — no real signal that we hit a real account.
+    assert not _oauth_snapshot_is_actionable(_snap(notes=["CLI OAuth"]))
+    assert not _oauth_snapshot_is_actionable(_snap(notes=["remote OAuth"]))
+    assert not _oauth_snapshot_is_actionable(_snap(notes=[]))
+
+
+def test_probe_codex_usage_remote_falls_back_when_oauth_payload_is_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    status_text = "5h limit: 12% used (resets in 1h)\nWeekly limit: 80% left\n"
+
+    async def _fake_runner(launch_target, binary, timeout_seconds):
+        return {
+            "payload": {
+                "rate_limit": None,
+                "additional_rate_limits": None,
+            },
+            "status_text": status_text,
+        }
+
+    monkeypatch.setattr(
+        "waypoint.backends.codex.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_codex_usage_remote(_ssh_target(), binary="codex"))
+    # OAuth payload had no actionable data, so the runner should have fallen
+    # through to the /status text instead of returning the empty snapshot.
+    assert snapshot is not None
+    assert [w.label for w in snapshot.windows] == ["5h", "Weekly"]
+    assert "remote /status" in snapshot.notes

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -105,6 +105,15 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         self.terminate_calls.append(session_id)
         return True
 
+    async def register_rate_limit_probe(
+        self,
+        session_id: str,
+        probe: Any,
+        *,
+        refresh_interval_seconds: float = 60.0,
+    ) -> None:
+        return None
+
     async def restore_session(
         self,
         session_id: str,
@@ -203,6 +212,15 @@ class FakeCodexRuntimeAdapter(FakeStructuredAdapter):
     async def terminate_session(self, session_id: str) -> bool:
         self.terminate_calls.append(session_id)
         return True
+
+    async def register_rate_limit_probe(
+        self,
+        session_id: str,
+        probe: Any,
+        *,
+        refresh_interval_seconds: float = 60.0,
+    ) -> None:
+        return None
 
     async def restore_session(
         self,

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -95,6 +95,8 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         self.permission_mode_calls: list[tuple[str, str]] = []
         self.model_calls: list[tuple[str, str | None]] = []
         self.effort_calls: list[tuple[str, str | None]] = []
+        self.register_rate_limit_calls: list[str] = []
+        self.force_refresh_rate_limit_calls: list[str] = []
         self.modes: dict[str, str] = {}
         self.models: dict[str, str | None] = {}
         self.efforts: dict[str, str | None] = {}
@@ -112,7 +114,10 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         *,
         refresh_interval_seconds: float = 60.0,
     ) -> None:
-        return None
+        self.register_rate_limit_calls.append(session_id)
+
+    async def force_refresh_rate_limit_usage(self, session_id: str) -> None:
+        self.force_refresh_rate_limit_calls.append(session_id)
 
     async def restore_session(
         self,
@@ -206,6 +211,8 @@ class FakeCodexRuntimeAdapter(FakeStructuredAdapter):
         self.terminate_calls: list[str] = []
         self.model_calls: list[tuple[str, str | None]] = []
         self.effort_calls: list[tuple[str, str | None]] = []
+        self.register_rate_limit_calls: list[str] = []
+        self.force_refresh_rate_limit_calls: list[str] = []
         self.models: dict[str, str | None] = {}
         self.efforts: dict[str, str | None] = {}
 
@@ -220,7 +227,10 @@ class FakeCodexRuntimeAdapter(FakeStructuredAdapter):
         *,
         refresh_interval_seconds: float = 60.0,
     ) -> None:
-        return None
+        self.register_rate_limit_calls.append(session_id)
+
+    async def force_refresh_rate_limit_usage(self, session_id: str) -> None:
+        self.force_refresh_rate_limit_calls.append(session_id)
 
     async def restore_session(
         self,
@@ -2675,3 +2685,38 @@ def test_session_events_page_collapses_codex_style_delta_run(tmp_path) -> None:
     assert page.events[0].sequence == 1
     assert len(page.events) == 51
     assert page.has_more is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_rate_limit_usage_runs_probe_inline_for_claude(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeClaudeAdapter()
+    _claude_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(settings, backend="claude_code", transport="claude_cli")
+    storage.create_session(session)
+
+    await runtime.refresh_rate_limit_usage(session.id)
+
+    # The probe is registered first so the periodic loop is set up, then
+    # immediately forced inline so the response carries the fresh snapshot
+    # instead of racing the WS push.
+    assert fake.register_rate_limit_calls == [session.id]
+    assert fake.force_refresh_rate_limit_calls == [session.id]
+
+
+@pytest.mark.asyncio
+async def test_refresh_rate_limit_usage_runs_probe_inline_for_codex(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(settings, backend="codex", transport="codex_app_server")
+    storage.create_session(session)
+
+    await runtime.refresh_rate_limit_usage(session.id)
+
+    assert fake.register_rate_limit_calls == [session.id]
+    assert fake.force_refresh_rate_limit_calls == [session.id]

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -5,9 +5,11 @@ from waypoint.schemas import (
     EventKind,
     EventRecord,
     SessionContextUsage,
+    SessionRateLimitUsage,
     SessionRecord,
     SessionSource,
     SessionStatus,
+    UsageWindow,
 )
 from waypoint.storage import Storage
 
@@ -35,6 +37,21 @@ def test_storage_round_trip(tmp_path) -> None:
             source="codex",
             breakdown={"input_tokens": 1024, "output_tokens": 1024},
         ),
+        rate_limit_usage=SessionRateLimitUsage(
+            source="claude_code",
+            updated_at=now,
+            windows=[
+                UsageWindow(
+                    id="five_hour",
+                    label="5h",
+                    used_percent=42.0,
+                    used_tokens=420,
+                    remaining_tokens=580,
+                    limit_tokens=1000,
+                )
+            ],
+            notes=["CLI creds"],
+        ),
     )
     storage.create_session(session)
     event = EventRecord(
@@ -59,6 +76,11 @@ def test_storage_round_trip(tmp_path) -> None:
         "input_tokens": 1024,
         "output_tokens": 1024,
     }
+    assert loaded.rate_limit_usage is not None
+    assert loaded.rate_limit_usage.source == "claude_code"
+    assert loaded.rate_limit_usage.windows[0].label == "5h"
+    assert loaded.rate_limit_usage.windows[0].used_percent == 42.0
+    assert loaded.rate_limit_usage.windows[0].remaining_tokens == 580
     events = storage.list_events("session-1")
     assert len(events) == 1
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3159,7 +3159,7 @@ html[data-theme="light"] .composer-context-trigger.tone-danger {
   position: absolute;
   right: 0;
   bottom: calc(100% + 8px);
-  width: min(360px, calc(100vw - 32px));
+  width: min(420px, calc(100vw - 32px));
   padding: 14px;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius-sm);
@@ -3283,6 +3283,113 @@ html[data-theme="light"] .composer-context-meter {
 .composer-context-breakdown {
   padding-top: 12px;
   border-top: 1px solid var(--line);
+}
+
+.composer-usage-section {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+}
+
+.composer-rate-list {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.composer-rate-card {
+  display: grid;
+  gap: 8px;
+  padding: 10px 11px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 11, 16, 0.45);
+}
+
+html[data-theme="light"] .composer-rate-card {
+  background: rgba(235, 230, 218, 0.72);
+}
+
+.composer-rate-card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+}
+
+.composer-rate-card-head strong {
+  color: var(--text-strong);
+  font-size: 0.84rem;
+}
+
+.composer-rate-card-head span {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  flex: 0 0 auto;
+}
+
+.composer-rate-card-meter {
+  height: 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(8, 11, 16, 0.42);
+}
+
+html[data-theme="light"] .composer-rate-card-meter {
+  background: rgba(235, 230, 218, 0.8);
+}
+
+.composer-rate-card-meter > span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--success), #79d6ff);
+}
+
+.composer-rate-card.tone-warn .composer-rate-card-meter > span {
+  background: linear-gradient(90deg, var(--warn), #f0c46b);
+}
+
+.composer-rate-card.tone-danger .composer-rate-card-meter > span {
+  background: linear-gradient(90deg, var(--danger), #ff8f70);
+}
+
+.composer-rate-card-body {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 10px;
+}
+
+.composer-rate-card-body > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.composer-rate-card-body span,
+.composer-usage-empty {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.composer-rate-card-body strong {
+  font-size: 0.8rem;
+  color: var(--accent-strong);
+  word-break: break-word;
+}
+
+.composer-usage-empty {
+  margin: 0;
+  padding: 2px 0 0;
 }
 
 .composer-connection::before {
@@ -4745,6 +4852,10 @@ html[data-theme="light"] .terminal {
 
   .composer-context-breakdown {
     display: none;
+  }
+
+  .composer-rate-card-body {
+    grid-template-columns: 1fr;
   }
 
   .composer-context-source {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3155,162 +3155,457 @@ html[data-theme="light"] .composer-context-trigger.tone-danger {
   box-shadow: 0 0 0 1px rgba(184, 48, 56, 0.08) inset;
 }
 
-.composer-context-popover {
+/* ─── Usage panel (composer popover) ─── */
+.usage-panel {
   position: absolute;
   right: 0;
-  bottom: calc(100% + 8px);
-  width: min(420px, calc(100vw - 32px));
-  padding: 14px;
+  bottom: calc(100% + 10px);
+  width: min(440px, calc(100vw - 24px));
+  padding: 18px 20px 16px;
   border: 1px solid var(--line-strong);
-  border-radius: var(--radius-sm);
-  background: rgba(14, 17, 24, 0.98);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.48);
-  backdrop-filter: blur(14px);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg, rgba(20, 24, 32, 0.96), rgba(11, 14, 19, 0.96)),
+    radial-gradient(120% 90% at 0% 0%, rgba(200, 169, 106, 0.08), transparent 65%);
+  box-shadow:
+    0 28px 56px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(200, 169, 106, 0.06) inset;
+  backdrop-filter: blur(20px);
   display: grid;
-  gap: 12px;
+  gap: 18px;
   z-index: 30;
+  overflow: hidden;
+  animation: usage-panel-enter 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
 
-html[data-theme="light"] .composer-context-popover {
-  background: rgba(252, 249, 242, 0.98);
-  box-shadow: 0 12px 32px rgba(60, 45, 20, 0.15);
+@keyframes usage-panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
 }
 
-.composer-context-head {
+html[data-theme="light"] .usage-panel {
+  background:
+    linear-gradient(180deg, rgba(255, 252, 244, 0.97), rgba(247, 242, 232, 0.97)),
+    radial-gradient(120% 90% at 0% 0%, rgba(184, 130, 14, 0.07), transparent 65%);
+  box-shadow:
+    0 18px 40px rgba(60, 45, 20, 0.18),
+    0 0 0 1px rgba(184, 130, 14, 0.05) inset;
+}
+
+/* Decorative brass rail down the left edge */
+.usage-panel-rail {
+  position: absolute;
+  left: 0;
+  top: 18px;
+  bottom: 18px;
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(200, 169, 106, 0.55) 18%,
+    rgba(200, 169, 106, 0.55) 82%,
+    transparent
+  );
+  border-radius: 0 2px 2px 0;
+  pointer-events: none;
+}
+
+html[data-theme="light"] .usage-panel-rail {
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(184, 130, 14, 0.45) 18%,
+    rgba(184, 130, 14, 0.45) 82%,
+    transparent
+  );
+}
+
+.usage-block {
+  display: grid;
+  gap: 14px;
+  min-width: 0;
+}
+
+.usage-block-head {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
   min-width: 0;
 }
 
-.composer-context-titles {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-
-.composer-context-kicker {
+.usage-block-eyebrow {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-family: var(--font-mono);
-  font-size: 0.66rem;
-  letter-spacing: 0.18em;
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
   text-transform: uppercase;
-  color: var(--muted-soft);
+  color: var(--accent-strong);
+  font-weight: 500;
 }
 
-.composer-context-titles strong {
-  font-size: 1rem;
-  color: var(--text-strong);
-  line-height: 1.2;
-  word-break: break-word;
+.usage-block-mark {
+  color: var(--accent);
+  font-size: 0.78em;
+  transform: translateY(-1px);
+  text-shadow: 0 0 8px rgba(200, 169, 106, 0.4);
 }
 
-.composer-context-source {
+html[data-theme="light"] .usage-block-mark {
+  text-shadow: none;
+}
+
+.usage-block-tag {
   flex: 0 0 auto;
-  padding: 4px 8px;
-  border-radius: var(--radius-pill);
+  padding: 3px 9px;
   border: 1px solid var(--line);
-  background: rgba(8, 11, 16, 0.45);
+  border-radius: var(--radius-pill);
+  background: rgba(8, 11, 16, 0.5);
   color: var(--muted);
   font-family: var(--font-mono);
-  font-size: 0.66rem;
-  letter-spacing: 0.1em;
+  font-size: 0.62rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
-html[data-theme="light"] .composer-context-source {
-  background: rgba(235, 230, 218, 0.75);
-}
-
-.composer-context-meter {
-  height: 8px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(8, 11, 16, 0.44);
-}
-
-html[data-theme="light"] .composer-context-meter {
+html[data-theme="light"] .usage-block-tag {
   background: rgba(235, 230, 218, 0.78);
 }
 
-.composer-context-meter > span {
-  display: block;
-  height: 100%;
-  width: 0;
-  border-radius: inherit;
-  background: linear-gradient(90deg, var(--success), #79d6ff);
-}
-
-.composer-context-popover.tone-warn .composer-context-meter > span {
-  background: linear-gradient(90deg, var(--warn), #f0c46b);
-}
-
-.composer-context-popover.tone-danger .composer-context-meter > span {
-  background: linear-gradient(90deg, var(--danger), #ff8f70);
-}
-
-.composer-context-grid,
-.composer-context-breakdown {
-  display: grid;
-  gap: 10px 12px;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.composer-context-grid > div,
-.composer-context-breakdown > div {
-  display: grid;
-  gap: 4px;
-  min-width: 0;
-}
-
-.composer-context-grid span,
-.composer-context-breakdown span {
+/* Refresh button — brass-tinted, subtle hover */
+.usage-refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 11px;
+  border: 1px solid rgba(200, 169, 106, 0.32);
+  border-radius: var(--radius-pill);
+  background: rgba(200, 169, 106, 0.06);
+  color: var(--accent-strong);
   font-family: var(--font-mono);
   font-size: 0.62rem;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: var(--muted-soft);
+  cursor: pointer;
+  transition:
+    background-color 160ms ease,
+    border-color 160ms ease;
 }
 
-.composer-context-grid strong,
-.composer-context-breakdown strong {
-  font-size: 0.82rem;
-  color: var(--accent-strong);
-  word-break: break-word;
+.usage-refresh:hover:not(:disabled) {
+  background: rgba(200, 169, 106, 0.12);
+  border-color: rgba(200, 169, 106, 0.5);
 }
 
-.composer-context-breakdown {
-  padding-top: 12px;
-  border-top: 1px solid var(--line);
+.usage-refresh:disabled {
+  opacity: 0.55;
+  cursor: wait;
 }
 
-.composer-usage-section {
+html[data-theme="light"] .usage-refresh {
+  background: rgba(184, 130, 14, 0.07);
+  border-color: rgba(184, 130, 14, 0.3);
+}
+
+html[data-theme="light"] .usage-refresh:hover:not(:disabled) {
+  background: rgba(184, 130, 14, 0.14);
+}
+
+.usage-refresh-glyph {
+  display: inline-block;
+  font-size: 0.95em;
+  line-height: 1;
+}
+
+.usage-refresh-glyph.is-spinning {
+  animation: usage-spin 900ms linear infinite;
+}
+
+@keyframes usage-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Two-column layout: oversized numeral + readout stack */
+.usage-block-body {
   display: grid;
-  gap: 12px;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 18px;
+  align-items: center;
   min-width: 0;
 }
 
-.composer-rate-list {
-  display: grid;
-  gap: 10px;
-  min-width: 0;
+.usage-numeral {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 3px;
+  font-family: var(--font-display);
+  font-feature-settings: "lnum", "tnum";
+  letter-spacing: -0.02em;
+  color: var(--success);
+  line-height: 0.9;
 }
 
-.composer-rate-card {
+.usage-numeral strong {
+  font-weight: 500;
+  font-size: 3rem;
+}
+
+.usage-numeral em {
+  font-style: normal;
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+  color: currentColor;
+  opacity: 0.72;
+}
+
+.usage-numeral--sm strong {
+  font-size: 1.85rem;
+}
+
+.usage-numeral--sm em {
+  font-size: 0.7rem;
+}
+
+.usage-numeral.tone-warn {
+  color: var(--warn);
+}
+
+.usage-numeral.tone-danger {
+  color: var(--danger);
+}
+
+.usage-block-stack {
   display: grid;
   gap: 8px;
-  padding: 10px 11px;
+  min-width: 0;
+}
+
+.usage-line {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+}
+
+.usage-line span {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.usage-line em {
+  font-style: normal;
+  color: var(--muted-soft);
+  font-size: 0.66rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.usage-line-meta {
+  margin: 0;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+}
+
+.usage-line-meta em {
+  font-style: normal;
+  color: var(--muted-soft);
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.usage-line-meta span {
+  color: var(--muted);
+}
+
+/* Segmented bar — instrument-panel feel */
+.usage-bar {
+  display: flex;
+  gap: 2px;
+  height: 10px;
+  width: 100%;
+}
+
+.usage-bar > span {
+  flex: 1;
+  background: rgba(120, 138, 168, 0.16);
+  border-radius: 1px;
+  transition: background-color 220ms ease;
+}
+
+html[data-theme="light"] .usage-bar > span {
+  background: rgba(90, 78, 58, 0.14);
+}
+
+.usage-bar > span.is-filled {
+  background: var(--success);
+  box-shadow: 0 0 6px rgba(108, 201, 154, 0.4);
+  animation: usage-segment-in 280ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+
+.usage-bar.tone-warn > span.is-filled {
+  background: var(--warn);
+  box-shadow: 0 0 6px rgba(217, 154, 74, 0.45);
+}
+
+.usage-bar.tone-danger > span.is-filled {
+  background: var(--danger);
+  box-shadow: 0 0 6px rgba(226, 108, 112, 0.5);
+}
+
+html[data-theme="light"] .usage-bar > span.is-filled {
+  background: var(--success);
+  box-shadow: none;
+}
+
+html[data-theme="light"] .usage-bar.tone-warn > span.is-filled {
+  background: var(--warn);
+}
+
+html[data-theme="light"] .usage-bar.tone-danger > span.is-filled {
+  background: var(--danger);
+}
+
+.usage-bar.is-disabled > span {
+  opacity: 0.5;
+}
+
+@keyframes usage-segment-in {
+  from {
+    transform: scaleY(0.4);
+    opacity: 0;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+/* Context breakdown chips — wraps below the readout */
+.usage-chips {
+  list-style: none;
+  margin: 0;
+  padding: 12px 0 0;
+  border-top: 1px dashed rgba(200, 169, 106, 0.22);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 18px;
+}
+
+html[data-theme="light"] .usage-chips {
+  border-top-color: rgba(184, 130, 14, 0.22);
+}
+
+.usage-chips li {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.usage-chips em {
+  font-style: normal;
+  color: var(--muted-soft);
+  font-size: 0.6rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.usage-chips strong {
+  color: var(--text);
+  font-weight: 600;
+}
+
+/* Hairline brass divider between sections */
+.usage-divider {
+  border: none;
+  height: 1px;
+  margin: 0;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(200, 169, 106, 0.3) 12%,
+    rgba(200, 169, 106, 0.3) 88%,
+    transparent
+  );
+}
+
+html[data-theme="light"] .usage-divider {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(184, 130, 14, 0.25) 12%,
+    rgba(184, 130, 14, 0.25) 88%,
+    transparent
+  );
+}
+
+/* Rate-limit window cards */
+.usage-windows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.usage-window {
+  position: relative;
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px 12px 16px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
-  background: rgba(8, 11, 16, 0.45);
+  background: rgba(8, 11, 16, 0.4);
+  overflow: hidden;
 }
 
-html[data-theme="light"] .composer-rate-card {
-  background: rgba(235, 230, 218, 0.72);
+html[data-theme="light"] .usage-window {
+  background: rgba(255, 252, 245, 0.55);
 }
 
-.composer-rate-card-head {
+/* Tone-driven left accent stripe on each window */
+.usage-window::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 12px;
+  bottom: 12px;
+  width: 2px;
+  background: var(--success);
+  border-radius: 0 2px 2px 0;
+  opacity: 0.7;
+}
+
+.usage-window.tone-warn::before {
+  background: var(--warn);
+}
+
+.usage-window.tone-danger::before {
+  background: var(--danger);
+}
+
+.usage-window-head {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
@@ -3318,78 +3613,144 @@ html[data-theme="light"] .composer-rate-card {
   min-width: 0;
 }
 
-.composer-rate-card-head strong {
-  color: var(--text-strong);
-  font-size: 0.84rem;
-}
-
-.composer-rate-card-head span {
-  color: var(--muted);
+.usage-window-label {
   font-family: var(--font-mono);
-  font-size: 0.66rem;
-  letter-spacing: 0.08em;
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  flex: 0 0 auto;
+  color: var(--text-strong);
 }
 
-.composer-rate-card-meter {
-  height: 6px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  overflow: hidden;
-  background: rgba(8, 11, 16, 0.42);
+.usage-window-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  text-align: right;
 }
 
-html[data-theme="light"] .composer-rate-card-meter {
-  background: rgba(235, 230, 218, 0.8);
+.usage-window-reset-glyph {
+  color: var(--accent);
+  font-size: 0.95em;
+  transform: translateY(-0.5px);
 }
 
-.composer-rate-card-meter > span {
-  display: block;
-  width: 0;
-  height: 100%;
-  border-radius: inherit;
-  background: linear-gradient(90deg, var(--success), #79d6ff);
-}
-
-.composer-rate-card.tone-warn .composer-rate-card-meter > span {
-  background: linear-gradient(90deg, var(--warn), #f0c46b);
-}
-
-.composer-rate-card.tone-danger .composer-rate-card-meter > span {
-  background: linear-gradient(90deg, var(--danger), #ff8f70);
-}
-
-.composer-rate-card-body {
+.usage-window-body {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 8px 10px;
-}
-
-.composer-rate-card-body > div {
-  display: grid;
-  gap: 4px;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
   min-width: 0;
 }
 
-.composer-rate-card-body span,
-.composer-usage-empty {
+.usage-window-tokens {
+  margin: 0;
   font-family: var(--font-mono);
-  font-size: 0.62rem;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--muted-soft);
+  font-size: 0.66rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
 }
 
-.composer-rate-card-body strong {
-  font-size: 0.8rem;
-  color: var(--accent-strong);
+/* Empty-state when no windows are tracked */
+.usage-empty {
+  margin: 0;
+  padding: 16px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted-soft);
+  letter-spacing: 0.08em;
+  text-align: center;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(8, 11, 16, 0.25);
+}
+
+html[data-theme="light"] .usage-empty {
+  background: rgba(235, 230, 218, 0.4);
+}
+
+/* Status footer — single-line monospace readout with bullet separators */
+.usage-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+}
+
+.usage-meta-cell {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+}
+
+.usage-meta-cell em {
+  font-style: normal;
+  color: var(--muted-soft);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.usage-meta-cell > span {
+  color: var(--text);
+  letter-spacing: 0.04em;
   word-break: break-word;
 }
 
-.composer-usage-empty {
-  margin: 0;
-  padding: 2px 0 0;
+.usage-meta-bullet {
+  font-style: normal;
+  color: rgba(200, 169, 106, 0.45);
+  font-size: 0.85em;
+}
+
+html[data-theme="light"] .usage-meta-bullet {
+  color: rgba(184, 130, 14, 0.5);
+}
+
+/* ─── Mobile: bottom-anchored sheet ─── */
+@media (max-width: 540px) {
+  .usage-panel {
+    position: fixed;
+    left: 12px;
+    right: 12px;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 86px);
+    width: auto;
+    max-height: min(72vh, calc(100vh - 200px));
+    overflow-y: auto;
+    padding: 16px 16px 14px;
+    border-radius: var(--radius);
+  }
+
+  .usage-numeral strong {
+    font-size: 2.5rem;
+  }
+
+  .usage-numeral--sm strong {
+    font-size: 1.55rem;
+  }
+
+  .usage-block-body,
+  .usage-window-body {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+  }
+
+  .usage-refresh {
+    padding: 7px 12px;
+    font-size: 0.66rem;
+  }
+
+  .usage-window-head {
+    flex-wrap: wrap;
+  }
 }
 
 .composer-connection::before {
@@ -4833,34 +5194,6 @@ html[data-theme="light"] .terminal {
   .composer-tune-restart-apply {
     font-size: 0.68rem;
     padding: 6px 10px;
-  }
-
-  .composer-context-popover {
-    width: min(320px, calc(100vw - 24px));
-    padding: 12px;
-    gap: 10px;
-  }
-
-  .composer-context-head {
-    gap: 10px;
-  }
-
-  .composer-context-grid {
-    gap: 8px 10px;
-    grid-template-columns: 1fr;
-  }
-
-  .composer-context-breakdown {
-    display: none;
-  }
-
-  .composer-rate-card-body {
-    grid-template-columns: 1fr;
-  }
-
-  .composer-context-source {
-    font-size: 0.6rem;
-    letter-spacing: 0.08em;
   }
 
   .composer-shortcut {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -207,8 +207,7 @@ function rateLimitWindowPercent(window: UsageWindow): number | null {
   return clampPercent(Math.round(window.used_percent));
 }
 
-function formatRateLimitWindowValue(window: UsageWindow): string {
-  const used = formatTokens(Math.round(window.used_percent));
+function formatRateLimitWindowTokens(window: UsageWindow): string | null {
   const parts: string[] = [];
   if (window.used_tokens !== undefined && window.used_tokens !== null) {
     parts.push(`${formatTokens(window.used_tokens)} used`);
@@ -224,10 +223,7 @@ function formatRateLimitWindowValue(window: UsageWindow): string {
   ) {
     parts.push(`of ${formatTokens(window.limit_tokens)}`);
   }
-  if (parts.length > 0) {
-    return `${used}% used · ${parts.join(" · ")}`;
-  }
-  return `${used}% used`;
+  return parts.length > 0 ? parts.join(" · ") : null;
 }
 
 function formatRateLimitWindowReset(window: UsageWindow): string | null {
@@ -2237,6 +2233,7 @@ const ReplyComposer = memo(function ReplyComposer({
                           const percent = rateLimitWindowPercent(window);
                           const tone = usageTone(percent);
                           const resetText = formatRateLimitWindowReset(window);
+                          const tokenSummary = formatRateLimitWindowTokens(window);
                           return (
                             <article
                               key={window.id}
@@ -2256,10 +2253,12 @@ const ReplyComposer = memo(function ReplyComposer({
                                 />
                               </div>
                               <div className="composer-rate-card-body">
-                                <div>
-                                  <span>Usage</span>
-                                  <strong>{formatRateLimitWindowValue(window)}</strong>
-                                </div>
+                                {tokenSummary ? (
+                                  <div>
+                                    <span>Tokens</span>
+                                    <strong>{tokenSummary}</strong>
+                                  </div>
+                                ) : null}
                                 <div>
                                   <span>Reset</span>
                                   <strong>{resetText ?? "Unavailable"}</strong>
@@ -2302,7 +2301,7 @@ const ReplyComposer = memo(function ReplyComposer({
                         </div>
                         <div>
                           <span>Windows</span>
-                          <strong>{formatTokens(rateLimitUsageWindows.length)} tracked</strong>
+                          <strong>{rateLimitUsageWindows.length} tracked</strong>
                         </div>
                       </div>
                     </section>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1929,6 +1929,12 @@ const ReplyComposer = memo(function ReplyComposer({
         .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
         .join(" · ")
     : null;
+  const rateLimitUpdatedAt = rateLimitUsage?.updated_at ?? null;
+  const rateLimitSourceLabel = rateLimitUsage
+    ? rateLimitUsage.notes?.length
+      ? rateLimitUsage.notes[0]
+      : humaniseBackend(rateLimitUsage.source)
+    : "Unavailable";
   const usageToneValue = (() => {
     if (contextUsage === null) {
       return rateLimitUsageToneValue;
@@ -2213,99 +2219,98 @@ const ReplyComposer = memo(function ReplyComposer({
                       ) : null}
                     </section>
                   ) : null}
-                  {rateLimitUsage ? (
-                    <section className="composer-usage-section">
-                      <div className="composer-context-head">
-                        <div className="composer-context-titles">
-                          <span className="composer-context-kicker">Rate limits</span>
-                          <strong>
-                            {rateLimitUsageSummary ?? "Unavailable"}
-                          </strong>
-                        </div>
-                        <span className="composer-context-source">
-                          {rateLimitUsage.notes?.length
-                            ? rateLimitUsage.notes.join(" · ")
-                            : humaniseBackend(rateLimitUsage.source)}
-                        </span>
+                  <section className="composer-usage-section">
+                    <div className="composer-context-head">
+                      <div className="composer-context-titles">
+                        <span className="composer-context-kicker">Rate limits</span>
+                        <strong>
+                          {rateLimitUsageSummary ?? "Unavailable"}
+                        </strong>
                       </div>
-                      <div className="composer-rate-list">
-                        {rateLimitUsageWindows.map((window) => {
-                          const percent = rateLimitWindowPercent(window);
-                          const tone = usageTone(percent);
-                          const resetText = formatRateLimitWindowReset(window);
-                          const tokenSummary = formatRateLimitWindowTokens(window);
-                          return (
-                            <article
-                              key={window.id}
-                              className={`composer-rate-card tone-${tone}`}
-                            >
-                              <div className="composer-rate-card-head">
-                                <strong>{window.label}</strong>
-                                <span>
-                                  {percent !== null ? `${percent}% used` : "Unavailable"}
-                                </span>
-                              </div>
-                              <div className="composer-rate-card-meter" aria-hidden="true">
-                                <span
-                                  style={{
-                                    width: percent !== null ? `${percent}%` : "0%",
-                                  }}
-                                />
-                              </div>
-                              <div className="composer-rate-card-body">
-                                {tokenSummary ? (
-                                  <div>
-                                    <span>Tokens</span>
-                                    <strong>{tokenSummary}</strong>
-                                  </div>
-                                ) : null}
-                                <div>
-                                  <span>Reset</span>
-                                  <strong>{resetText ?? "Unavailable"}</strong>
-                                </div>
-                              </div>
-                            </article>
-                          );
-                        })}
-                        {rateLimitUsageWindows.length === 0 ? (
-                          <p className="composer-usage-empty">
-                            Rate-limit data is unavailable.
-                          </p>
-                        ) : null}
-                      </div>
-                      <div className="composer-context-grid">
-                        <div>
-                          <span>Updated</span>
-                          <strong
-                            title={new Date(rateLimitUsage.updated_at).toLocaleString()}
+                      <span className="composer-context-source">
+                        {rateLimitSourceLabel}
+                      </span>
+                    </div>
+                    <div className="composer-rate-list">
+                      {rateLimitUsageWindows.map((window) => {
+                        const percent = rateLimitWindowPercent(window);
+                        const tone = usageTone(percent);
+                        const resetText = formatRateLimitWindowReset(window);
+                        const tokenSummary = formatRateLimitWindowTokens(window);
+                        return (
+                          <article
+                            key={window.id}
+                            className={`composer-rate-card tone-${tone}`}
                           >
-                            {formatRelativeTime(rateLimitUsage.updated_at)}
-                          </strong>
-                        </div>
-                        <div>
-                          <span>Source</span>
-                          <strong>
-                            {rateLimitUsage.notes?.length
-                              ? rateLimitUsage.notes[0]
-                              : "Unavailable"}
-                          </strong>
-                        </div>
-                        <div>
-                          <span>Credits</span>
-                          <strong>
-                            {rateLimitUsage.credits_remaining !== null &&
-                            rateLimitUsage.credits_remaining !== undefined
-                              ? `${rateLimitUsage.credits_currency ?? "credits"} ${rateLimitUsage.credits_remaining.toFixed(2)}`
-                              : "Unavailable"}
-                          </strong>
-                        </div>
-                        <div>
-                          <span>Windows</span>
-                          <strong>{rateLimitUsageWindows.length} tracked</strong>
-                        </div>
+                            <div className="composer-rate-card-head">
+                              <strong>{window.label}</strong>
+                              <span>
+                                {percent !== null ? `${percent}% used` : "Unavailable"}
+                              </span>
+                            </div>
+                            <div className="composer-rate-card-meter" aria-hidden="true">
+                              <span
+                                style={{
+                                  width: percent !== null ? `${percent}%` : "0%",
+                                }}
+                              />
+                            </div>
+                            <div className="composer-rate-card-body">
+                              {tokenSummary ? (
+                                <div>
+                                  <span>Tokens</span>
+                                  <strong>{tokenSummary}</strong>
+                                </div>
+                              ) : null}
+                              <div>
+                                <span>Reset</span>
+                                <strong>{resetText ?? "Unavailable"}</strong>
+                              </div>
+                            </div>
+                          </article>
+                        );
+                      })}
+                      {rateLimitUsageWindows.length === 0 ? (
+                        <p className="composer-usage-empty">
+                          Rate-limit data is unavailable.
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="composer-context-grid">
+                      <div>
+                        <span>Updated</span>
+                        <strong
+                          title={
+                            rateLimitUpdatedAt
+                              ? new Date(rateLimitUpdatedAt).toLocaleString()
+                              : "Unavailable"
+                          }
+                        >
+                          {rateLimitUpdatedAt
+                            ? formatRelativeTime(rateLimitUpdatedAt)
+                            : "Unavailable"}
+                        </strong>
                       </div>
-                    </section>
-                  ) : null}
+                      <div>
+                        <span>Source</span>
+                        <strong>{rateLimitSourceLabel}</strong>
+                      </div>
+                      <div>
+                        <span>Credits</span>
+                        <strong>
+                          {rateLimitUsage &&
+                          rateLimitUsage.credits_remaining !== null &&
+                          rateLimitUsage.credits_remaining !== undefined
+                            ? `${rateLimitUsage.credits_currency ?? "credits"} ${rateLimitUsage.credits_remaining.toFixed(2)}`
+                            : "Unavailable"}
+                        </strong>
+                      </div>
+                      <div>
+                        <span>Windows</span>
+                        <strong>{rateLimitUsageWindows.length} tracked</strong>
+                      </div>
+                    </div>
+                  </section>
                 </div>
               ) : null}
             </div>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -27,6 +27,7 @@ import {
   forkSession,
   isAuthError,
   postAction,
+  refreshSessionRateLimitUsage,
   sendInput,
   setSessionEffort,
   setSessionModel,
@@ -243,6 +244,39 @@ function rateLimitUsageTone(usage: SessionRateLimitUsage | null): "good" | "warn
   return usageTone(worst);
 }
 
+const USAGE_BAR_SEGMENTS = 14;
+
+function UsageBar({
+  percent,
+  tone,
+  disabled,
+}: {
+  percent: number | null;
+  tone: "good" | "warn" | "danger";
+  disabled?: boolean;
+}) {
+  const filled = !disabled && percent !== null
+    ? Math.min(
+        USAGE_BAR_SEGMENTS,
+        Math.max(0, Math.round((percent / 100) * USAGE_BAR_SEGMENTS)),
+      )
+    : 0;
+  return (
+    <div
+      className={`usage-bar tone-${tone}${disabled ? " is-disabled" : ""}`}
+      role="presentation"
+    >
+      {Array.from({ length: USAGE_BAR_SEGMENTS }, (_, index) => (
+        <span
+          key={index}
+          className={index < filled ? "is-filled" : ""}
+          style={{ animationDelay: `${index * 18}ms` }}
+        />
+      ))}
+    </div>
+  );
+}
+
 function contextUsageLabel(key: string): string {
   switch (key) {
     case "input_tokens":
@@ -311,6 +345,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [defaultEffort, setDefaultEffort] = useState<string | null>(null);
   const [modelBusy, setModelBusy] = useState(false);
   const [effortBusy, setEffortBusy] = useState(false);
+  const [rateLimitRefreshBusy, setRateLimitRefreshBusy] = useState(false);
   const [approvalPageIndex, setApprovalPageIndex] = useState(0);
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
@@ -933,6 +968,26 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, [handleAuthFailure, host, token, sessionId]);
 
+  const handleRateLimitRefresh = useCallback(async () => {
+    setRateLimitRefreshBusy(true);
+    try {
+      const updated = await refreshSessionRateLimitUsage(host, token, sessionId);
+      setSession(updated);
+    } catch (refreshError) {
+      if (isAuthError(refreshError)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(
+        refreshError instanceof Error
+          ? refreshError.message
+          : "failed to refresh rate-limit usage",
+      );
+    } finally {
+      setRateLimitRefreshBusy(false);
+    }
+  }, [handleAuthFailure, host, sessionId, token]);
+
   const removeFromList = useCallback(async () => {
     if (!window.confirm("Delete this session and its transcript? This cannot be undone.")) {
       return;
@@ -1336,6 +1391,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         canTerminate={Boolean(session && !sessionExited)}
         connection={connection}
         disabled={composerDisabled}
+        rateLimitRefreshBusy={rateLimitRefreshBusy}
         dormant={dormantReattach}
         placeholder={composerPlaceholder}
         agentBusy={agentBusy}
@@ -1375,6 +1431,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         onModelChange={handleModelChange}
         onEffortChange={handleEffortChange}
         onRefresh={refresh}
+        onRateLimitRefresh={handleRateLimitRefresh}
         onReattach={reattach}
         onResume={resumeSession}
         onSwitchSession={openSwitcher}
@@ -1401,6 +1458,7 @@ interface ReplyComposerProps {
   canTerminate: boolean;
   connection: ConnectionState;
   disabled: boolean;
+  rateLimitRefreshBusy: boolean;
   dormant: boolean;
   placeholder: string;
   modeBusy: boolean;
@@ -1425,6 +1483,7 @@ interface ReplyComposerProps {
   onModelChange: (model: string) => void | Promise<void>;
   onEffortChange: (effort: string) => void | Promise<void>;
   onRefresh: () => void;
+  onRateLimitRefresh: () => void | Promise<void>;
   onReattach: () => void | Promise<void>;
   onResume: () => void | Promise<void>;
   onSwitchSession: () => void;
@@ -1445,6 +1504,7 @@ const ReplyComposer = memo(function ReplyComposer({
   canTerminate,
   connection,
   disabled,
+  rateLimitRefreshBusy,
   dormant,
   placeholder,
   modeBusy,
@@ -1468,6 +1528,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onModelChange,
   onEffortChange,
   onRefresh,
+  onRateLimitRefresh,
   onReattach,
   onResume,
   onSwitchSession,
@@ -1925,14 +1986,18 @@ const ReplyComposer = memo(function ReplyComposer({
     : null;
   const rateLimitUsageWindows = rateLimitUsage?.windows ?? [];
   const rateLimitUsageSummary = rateLimitUsage
-    ? rateLimitUsageWindows
-        .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
-        .join(" · ")
+    ? rateLimitUsageWindows.length > 0
+      ? rateLimitUsageWindows
+          .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
+          .join(" · ")
+      : rateLimitUsage.notes?.length
+        ? rateLimitUsage.notes.join(" · ")
+        : null
     : null;
   const rateLimitUpdatedAt = rateLimitUsage?.updated_at ?? null;
   const rateLimitSourceLabel = rateLimitUsage
     ? rateLimitUsage.notes?.length
-      ? rateLimitUsage.notes[0]
+      ? rateLimitUsage.notes.join(" · ")
       : humaniseBackend(rateLimitUsage.source)
     : "Unavailable";
   const usageToneValue = (() => {
@@ -2148,138 +2213,161 @@ const ReplyComposer = memo(function ReplyComposer({
               </button>
               {contextUsageOpen ? (
                 <div
-                  className={`composer-context-popover tone-${usageToneValue}`}
+                  className={`usage-panel tone-${usageToneValue}`}
                   role="dialog"
                   aria-label="Usage details"
                 >
+                  <span className="usage-panel-rail" aria-hidden="true" />
+
                   {contextUsage ? (
-                    <section className="composer-usage-section">
-                      <div className="composer-context-head">
-                        <div className="composer-context-titles">
-                          <span className="composer-context-kicker">Context</span>
-                          <strong>
-                            {contextUsageSummary ??
-                              formatTokens(contextUsage.used_tokens)}
-                          </strong>
-                        </div>
-                        <span className="composer-context-source">
+                    <section className="usage-block">
+                      <header className="usage-block-head">
+                        <h3 className="usage-block-eyebrow">
+                          <span aria-hidden className="usage-block-mark">
+                            ◆
+                          </span>
+                          Context
+                        </h3>
+                        <span className="usage-block-tag">
                           {humaniseBackend(contextUsage.source)}
                         </span>
-                      </div>
-                      <div className="composer-context-meter" aria-hidden="true">
-                        <span
-                          style={{
-                            width:
-                              contextUsageHasWindow &&
-                              contextUsagePercentDisplay !== null
-                                ? `${contextUsagePercentDisplay}%`
-                                : "0%",
-                          }}
-                        />
-                      </div>
-                      <div className="composer-context-grid">
-                        <div>
-                          <span>Used</span>
-                          <strong>{formatTokens(contextUsage.used_tokens)} tokens</strong>
-                        </div>
-                        <div>
-                          <span>Window</span>
-                          <strong>
-                            {contextUsageWindowTokens !== null
-                              ? `${formatTokens(contextUsageWindowDisplay)} tokens`
-                              : "Unavailable"}
-                          </strong>
-                        </div>
-                        <div>
-                          <span>Percent</span>
+                      </header>
+                      <div className="usage-block-body">
+                        <div className={`usage-numeral tone-${contextUsageToneValue}`}>
                           <strong>
                             {contextUsagePercentDisplay !== null
-                              ? `${contextUsagePercentDisplay}% used`
-                              : "Unavailable"}
+                              ? contextUsagePercentDisplay
+                              : "—"}
                           </strong>
+                          <em>%</em>
                         </div>
-                        <div>
-                          <span>Updated</span>
-                          <strong
-                            title={new Date(contextUsage.updated_at).toLocaleString()}
-                          >
-                            {formatRelativeTime(contextUsage.updated_at)}
-                          </strong>
+                        <div className="usage-block-stack">
+                          <p className="usage-line">
+                            <span>{formatTokens(contextUsage.used_tokens)}</span>
+                            <em>of</em>
+                            <span>
+                              {contextUsageWindowTokens !== null
+                                ? formatTokens(contextUsageWindowDisplay)
+                                : "—"}
+                            </span>
+                            <em>tokens</em>
+                          </p>
+                          <UsageBar
+                            percent={contextUsagePercentDisplay}
+                            tone={contextUsageToneValue}
+                            disabled={
+                              !contextUsageHasWindow ||
+                              contextUsagePercentDisplay === null
+                            }
+                          />
+                          <p className="usage-line-meta">
+                            <em>updated</em>
+                            <span title={new Date(contextUsage.updated_at).toLocaleString()}>
+                              {formatRelativeTime(contextUsage.updated_at)}
+                            </span>
+                          </p>
                         </div>
                       </div>
                       {contextUsageBreakdown.length > 0 ? (
-                        <div className="composer-context-breakdown">
+                        <ul className="usage-chips">
                           {contextUsageBreakdown.map(([key, value]) => (
-                            <div key={key}>
-                              <span>{contextUsageLabel(key)}</span>
+                            <li key={key}>
+                              <em>{contextUsageLabel(key)}</em>
                               <strong>{formatTokens(value)}</strong>
-                            </div>
+                            </li>
                           ))}
-                        </div>
+                        </ul>
                       ) : null}
                     </section>
                   ) : null}
-                  <section className="composer-usage-section">
-                    <div className="composer-context-head">
-                      <div className="composer-context-titles">
-                        <span className="composer-context-kicker">Rate limits</span>
-                        <strong>
-                          {rateLimitUsageSummary ?? "Unavailable"}
-                        </strong>
-                      </div>
-                      <span className="composer-context-source">
-                        {rateLimitSourceLabel}
-                      </span>
-                    </div>
-                    <div className="composer-rate-list">
-                      {rateLimitUsageWindows.map((window) => {
-                        const percent = rateLimitWindowPercent(window);
-                        const tone = usageTone(percent);
-                        const resetText = formatRateLimitWindowReset(window);
-                        const tokenSummary = formatRateLimitWindowTokens(window);
-                        return (
-                          <article
-                            key={window.id}
-                            className={`composer-rate-card tone-${tone}`}
-                          >
-                            <div className="composer-rate-card-head">
-                              <strong>{window.label}</strong>
-                              <span>
-                                {percent !== null ? `${percent}% used` : "Unavailable"}
-                              </span>
-                            </div>
-                            <div className="composer-rate-card-meter" aria-hidden="true">
-                              <span
-                                style={{
-                                  width: percent !== null ? `${percent}%` : "0%",
-                                }}
-                              />
-                            </div>
-                            <div className="composer-rate-card-body">
-                              {tokenSummary ? (
-                                <div>
-                                  <span>Tokens</span>
-                                  <strong>{tokenSummary}</strong>
-                                </div>
-                              ) : null}
-                              <div>
-                                <span>Reset</span>
-                                <strong>{resetText ?? "Unavailable"}</strong>
+
+                  {contextUsage && rateLimitUsage ? (
+                    <hr className="usage-divider" aria-hidden="true" />
+                  ) : null}
+
+                  {rateLimitUsage ? (
+                  <section className="usage-block">
+                    <header className="usage-block-head">
+                      <h3 className="usage-block-eyebrow">
+                        <span aria-hidden className="usage-block-mark">
+                          ◇
+                        </span>
+                        Rate limits
+                      </h3>
+                      <button
+                        type="button"
+                        className="usage-refresh"
+                        onClick={() => void onRateLimitRefresh()}
+                        disabled={rateLimitRefreshBusy}
+                        aria-label="Refresh rate limits"
+                      >
+                        <span
+                          aria-hidden
+                          className={`usage-refresh-glyph${rateLimitRefreshBusy ? " is-spinning" : ""}`}
+                        >
+                          ↻
+                        </span>
+                        {rateLimitRefreshBusy ? "Refreshing" : "Refresh"}
+                      </button>
+                    </header>
+
+                    {rateLimitUsageWindows.length > 0 ? (
+                      <ul className="usage-windows">
+                        {rateLimitUsageWindows.map((window) => {
+                          const percent = rateLimitWindowPercent(window);
+                          const tone = usageTone(percent);
+                          const resetText = formatRateLimitWindowReset(window);
+                          const tokenSummary = formatRateLimitWindowTokens(window);
+                          return (
+                            <li
+                              key={window.id}
+                              className={`usage-window tone-${tone}`}
+                            >
+                              <div className="usage-window-head">
+                                <span className="usage-window-label">
+                                  {window.label}
+                                </span>
+                                {resetText ? (
+                                  <span className="usage-window-reset">
+                                    <span aria-hidden className="usage-window-reset-glyph">
+                                      ◷
+                                    </span>
+                                    {resetText}
+                                  </span>
+                                ) : null}
                               </div>
-                            </div>
-                          </article>
-                        );
-                      })}
-                      {rateLimitUsageWindows.length === 0 ? (
-                        <p className="composer-usage-empty">
-                          Rate-limit data is unavailable.
-                        </p>
-                      ) : null}
-                    </div>
-                    <div className="composer-context-grid">
-                      <div>
-                        <span>Updated</span>
-                        <strong
+                              <div className="usage-window-body">
+                                <div
+                                  className={`usage-numeral usage-numeral--sm tone-${tone}`}
+                                >
+                                  <strong>
+                                    {percent !== null ? percent : "—"}
+                                  </strong>
+                                  <em>%</em>
+                                </div>
+                                <UsageBar
+                                  percent={percent}
+                                  tone={tone}
+                                  disabled={percent === null}
+                                />
+                              </div>
+                              {tokenSummary ? (
+                                <p className="usage-window-tokens">{tokenSummary}</p>
+                              ) : null}
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    ) : (
+                      <p className="usage-empty">
+                        No quota tracked on this plan.
+                      </p>
+                    )}
+
+                    <footer className="usage-meta">
+                      <span className="usage-meta-cell">
+                        <em>updated</em>
+                        <span
                           title={
                             rateLimitUpdatedAt
                               ? new Date(rateLimitUpdatedAt).toLocaleString()
@@ -2288,29 +2376,34 @@ const ReplyComposer = memo(function ReplyComposer({
                         >
                           {rateLimitUpdatedAt
                             ? formatRelativeTime(rateLimitUpdatedAt)
-                            : "Unavailable"}
-                        </strong>
-                      </div>
-                      <div>
-                        <span>Source</span>
-                        <strong>{rateLimitSourceLabel}</strong>
-                      </div>
-                      <div>
-                        <span>Credits</span>
-                        <strong>
-                          {rateLimitUsage &&
-                          rateLimitUsage.credits_remaining !== null &&
-                          rateLimitUsage.credits_remaining !== undefined
-                            ? `${rateLimitUsage.credits_currency ?? "credits"} ${rateLimitUsage.credits_remaining.toFixed(2)}`
-                            : "Unavailable"}
-                        </strong>
-                      </div>
-                      <div>
-                        <span>Windows</span>
-                        <strong>{rateLimitUsageWindows.length} tracked</strong>
-                      </div>
-                    </div>
+                            : "—"}
+                        </span>
+                      </span>
+                      <i aria-hidden className="usage-meta-bullet">
+                        ·
+                      </i>
+                      <span className="usage-meta-cell">
+                        <em>source</em>
+                        <span>{rateLimitSourceLabel}</span>
+                      </span>
+                      {rateLimitUsage &&
+                      rateLimitUsage.credits_remaining !== null &&
+                      rateLimitUsage.credits_remaining !== undefined ? (
+                        <>
+                          <i aria-hidden className="usage-meta-bullet">
+                            ·
+                          </i>
+                          <span className="usage-meta-cell">
+                            <em>credits</em>
+                            <span>
+                              {`${rateLimitUsage.credits_currency ?? "credits"} ${rateLimitUsage.credits_remaining.toFixed(2)}`}
+                            </span>
+                          </span>
+                        </>
+                      ) : null}
+                    </footer>
                   </section>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -70,8 +70,10 @@ import {
   SessionCommandInvocation,
   SessionContextUsage,
   SessionEnvelope,
+  SessionRateLimitUsage,
   SessionRecord,
   SessionTransport,
+  UsageWindow,
 } from "@/lib/types";
 
 const LOCAL_SLASH_COMPLETIONS: ReadonlyArray<CommandCompletion> = [
@@ -183,6 +185,66 @@ function clampPercent(percent: number | null): number | null {
     return null;
   }
   return Math.min(100, Math.max(0, percent));
+}
+
+function usageTone(percent: number | null): "good" | "warn" | "danger" {
+  if (percent === null) {
+    return "good";
+  }
+  if (percent >= 90) {
+    return "danger";
+  }
+  if (percent >= 70) {
+    return "warn";
+  }
+  return "good";
+}
+
+function rateLimitWindowPercent(window: UsageWindow): number | null {
+  if (window.used_percent < 0 || !Number.isFinite(window.used_percent)) {
+    return null;
+  }
+  return clampPercent(Math.round(window.used_percent));
+}
+
+function formatRateLimitWindowValue(window: UsageWindow): string {
+  const used = formatTokens(Math.round(window.used_percent));
+  const parts: string[] = [];
+  if (window.used_tokens !== undefined && window.used_tokens !== null) {
+    parts.push(`${formatTokens(window.used_tokens)} used`);
+  }
+  if (window.remaining_tokens !== undefined && window.remaining_tokens !== null) {
+    parts.push(`${formatTokens(window.remaining_tokens)} left`);
+  }
+  if (
+    window.limit_tokens !== undefined &&
+    window.limit_tokens !== null &&
+    window.used_tokens !== undefined &&
+    window.used_tokens !== null
+  ) {
+    parts.push(`of ${formatTokens(window.limit_tokens)}`);
+  }
+  if (parts.length > 0) {
+    return `${used}% used · ${parts.join(" · ")}`;
+  }
+  return `${used}% used`;
+}
+
+function formatRateLimitWindowReset(window: UsageWindow): string | null {
+  if (window.resets_at) {
+    return formatRelativeTime(window.resets_at);
+  }
+  return window.reset_description ?? null;
+}
+
+function rateLimitUsageTone(usage: SessionRateLimitUsage | null): "good" | "warn" | "danger" {
+  if (!usage || usage.windows.length === 0) {
+    return "good";
+  }
+  const worst = Math.max(
+    ...usage.windows.map((window) => rateLimitWindowPercent(window) ?? 0),
+  );
+  return usageTone(worst);
 }
 
 function contextUsageLabel(key: string): string {
@@ -1840,6 +1902,7 @@ const ReplyComposer = memo(function ReplyComposer({
     pendingEffort !== null &&
     pendingEffort !== (currentEffort ?? "");
   const contextUsage = session?.context_usage ?? null;
+  const rateLimitUsage = session?.rate_limit_usage ?? null;
   const contextUsagePercentValue = contextUsage
     ? contextUsagePercent(contextUsage)
     : null;
@@ -1847,6 +1910,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const contextUsageToneValue = contextUsage
     ? contextUsageTone(contextUsagePercentValue)
     : "good";
+  const rateLimitUsageToneValue = rateLimitUsageTone(rateLimitUsage);
   const contextUsageBreakdown = contextUsage
     ? Object.entries(contextUsage.breakdown ?? {})
     : [];
@@ -1863,6 +1927,37 @@ const ReplyComposer = memo(function ReplyComposer({
       ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
       : formatTokens(contextUsage.used_tokens)
     : null;
+  const rateLimitUsageWindows = rateLimitUsage?.windows ?? [];
+  const rateLimitUsageSummary = rateLimitUsage
+    ? rateLimitUsageWindows
+        .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
+        .join(" · ")
+    : null;
+  const usageToneValue = (() => {
+    if (contextUsage === null) {
+      return rateLimitUsageToneValue;
+    }
+    if (rateLimitUsage === null) {
+      return contextUsageToneValue;
+    }
+    if (
+      contextUsageToneValue === "danger" ||
+      rateLimitUsageToneValue === "danger"
+    ) {
+      return "danger";
+    }
+    if (contextUsageToneValue === "warn" || rateLimitUsageToneValue === "warn") {
+      return "warn";
+    }
+    return "good";
+  })();
+  const showUsagePopover = contextUsage !== null || rateLimitUsage !== null;
+  const usagePopoverTitle = [
+    contextUsageSummary ? `Context ${contextUsageSummary}` : null,
+    rateLimitUsageSummary ? `Rate limits ${rateLimitUsageSummary}` : null,
+  ]
+    .filter((part): part is string => part !== null)
+    .join(" · ");
 
   const handleEffortSelect = (next: string) => {
     if (effortRequiresConfirm) {
@@ -2027,20 +2122,20 @@ const ReplyComposer = memo(function ReplyComposer({
           </div>
         ) : null}
         <div className="composer-toprow-trail">
-          {contextUsage ? (
+          {showUsagePopover ? (
             <div className="composer-context" ref={contextUsageRef}>
               <button
                 type="button"
-                className={`composer-connection composer-context-trigger tone-${contextUsageToneValue} ${connection} ${contextUsageOpen ? "open" : ""}`}
+                className={`composer-connection composer-context-trigger tone-${usageToneValue} ${connection} ${contextUsageOpen ? "open" : ""}`}
                 title={
-                  contextUsageSummary
-                    ? `Backend socket ${connection}. Context ${contextUsageSummary}`
-                    : `Backend socket ${connection}. Click for context usage`
+                  usagePopoverTitle
+                    ? `Backend socket ${connection}. ${usagePopoverTitle}`
+                    : `Backend socket ${connection}. Click for usage details`
                 }
                 aria-live="polite"
                 aria-haspopup="dialog"
                 aria-expanded={contextUsageOpen}
-                aria-label={`Backend socket ${connection}. Context usage details`}
+                aria-label={`Backend socket ${connection}. Usage details`}
                 onClick={() => setContextUsageOpen((open) => !open)}
               >
                 {connection === "open"
@@ -2050,64 +2145,167 @@ const ReplyComposer = memo(function ReplyComposer({
                     : "connecting"}
               </button>
               {contextUsageOpen ? (
-                <div className={`composer-context-popover tone-${contextUsageToneValue}`} role="dialog" aria-label="Context usage">
-                  <div className="composer-context-head">
-                    <div className="composer-context-titles">
-                      <span className="composer-context-kicker">Context</span>
-                      <strong>
-                        {contextUsageSummary ?? formatTokens(contextUsage.used_tokens)}
-                      </strong>
-                    </div>
-                    <span className="composer-context-source">
-                      {humaniseBackend(contextUsage.source)}
-                    </span>
-                  </div>
-                  <div className="composer-context-meter" aria-hidden="true">
-                    <span
-                      style={{
-                        width: contextUsageHasWindow && contextUsagePercentDisplay !== null
-                          ? `${contextUsagePercentDisplay}%`
-                          : "0%",
-                      }}
-                    />
-                  </div>
-                  <div className="composer-context-grid">
-                    <div>
-                      <span>Used</span>
-                      <strong>{formatTokens(contextUsage.used_tokens)} tokens</strong>
-                    </div>
-                    <div>
-                      <span>Window</span>
-                      <strong>
-                        {contextUsageWindowTokens !== null
-                          ? `${formatTokens(contextUsageWindowDisplay)} tokens`
-                          : "Unavailable"}
-                      </strong>
-                    </div>
-                    <div>
-                      <span>Percent</span>
-                      <strong>
-                        {contextUsagePercentDisplay !== null
-                          ? `${contextUsagePercentDisplay}% used`
-                          : "Unavailable"}
-                      </strong>
-                    </div>
-                    <div>
-                      <span>Updated</span>
-                      <strong title={new Date(contextUsage.updated_at).toLocaleString()}>
-                        {formatRelativeTime(contextUsage.updated_at)}
-                      </strong>
-                    </div>
-                  </div>
-                  {contextUsageBreakdown.length > 0 ? (
-                    <div className="composer-context-breakdown">
-                      {contextUsageBreakdown.map(([key, value]) => (
-                        <div key={key}>
-                          <span>{contextUsageLabel(key)}</span>
-                          <strong>{formatTokens(value)}</strong>
+                <div
+                  className={`composer-context-popover tone-${usageToneValue}`}
+                  role="dialog"
+                  aria-label="Usage details"
+                >
+                  {contextUsage ? (
+                    <section className="composer-usage-section">
+                      <div className="composer-context-head">
+                        <div className="composer-context-titles">
+                          <span className="composer-context-kicker">Context</span>
+                          <strong>
+                            {contextUsageSummary ??
+                              formatTokens(contextUsage.used_tokens)}
+                          </strong>
                         </div>
-                      ))}
-                    </div>
+                        <span className="composer-context-source">
+                          {humaniseBackend(contextUsage.source)}
+                        </span>
+                      </div>
+                      <div className="composer-context-meter" aria-hidden="true">
+                        <span
+                          style={{
+                            width:
+                              contextUsageHasWindow &&
+                              contextUsagePercentDisplay !== null
+                                ? `${contextUsagePercentDisplay}%`
+                                : "0%",
+                          }}
+                        />
+                      </div>
+                      <div className="composer-context-grid">
+                        <div>
+                          <span>Used</span>
+                          <strong>{formatTokens(contextUsage.used_tokens)} tokens</strong>
+                        </div>
+                        <div>
+                          <span>Window</span>
+                          <strong>
+                            {contextUsageWindowTokens !== null
+                              ? `${formatTokens(contextUsageWindowDisplay)} tokens`
+                              : "Unavailable"}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Percent</span>
+                          <strong>
+                            {contextUsagePercentDisplay !== null
+                              ? `${contextUsagePercentDisplay}% used`
+                              : "Unavailable"}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Updated</span>
+                          <strong
+                            title={new Date(contextUsage.updated_at).toLocaleString()}
+                          >
+                            {formatRelativeTime(contextUsage.updated_at)}
+                          </strong>
+                        </div>
+                      </div>
+                      {contextUsageBreakdown.length > 0 ? (
+                        <div className="composer-context-breakdown">
+                          {contextUsageBreakdown.map(([key, value]) => (
+                            <div key={key}>
+                              <span>{contextUsageLabel(key)}</span>
+                              <strong>{formatTokens(value)}</strong>
+                            </div>
+                          ))}
+                        </div>
+                      ) : null}
+                    </section>
+                  ) : null}
+                  {rateLimitUsage ? (
+                    <section className="composer-usage-section">
+                      <div className="composer-context-head">
+                        <div className="composer-context-titles">
+                          <span className="composer-context-kicker">Rate limits</span>
+                          <strong>
+                            {rateLimitUsageSummary ?? "Unavailable"}
+                          </strong>
+                        </div>
+                        <span className="composer-context-source">
+                          {rateLimitUsage.notes?.length
+                            ? rateLimitUsage.notes.join(" · ")
+                            : humaniseBackend(rateLimitUsage.source)}
+                        </span>
+                      </div>
+                      <div className="composer-rate-list">
+                        {rateLimitUsageWindows.map((window) => {
+                          const percent = rateLimitWindowPercent(window);
+                          const tone = usageTone(percent);
+                          const resetText = formatRateLimitWindowReset(window);
+                          return (
+                            <article
+                              key={window.id}
+                              className={`composer-rate-card tone-${tone}`}
+                            >
+                              <div className="composer-rate-card-head">
+                                <strong>{window.label}</strong>
+                                <span>
+                                  {percent !== null ? `${percent}% used` : "Unavailable"}
+                                </span>
+                              </div>
+                              <div className="composer-rate-card-meter" aria-hidden="true">
+                                <span
+                                  style={{
+                                    width: percent !== null ? `${percent}%` : "0%",
+                                  }}
+                                />
+                              </div>
+                              <div className="composer-rate-card-body">
+                                <div>
+                                  <span>Usage</span>
+                                  <strong>{formatRateLimitWindowValue(window)}</strong>
+                                </div>
+                                <div>
+                                  <span>Reset</span>
+                                  <strong>{resetText ?? "Unavailable"}</strong>
+                                </div>
+                              </div>
+                            </article>
+                          );
+                        })}
+                        {rateLimitUsageWindows.length === 0 ? (
+                          <p className="composer-usage-empty">
+                            Rate-limit data is unavailable.
+                          </p>
+                        ) : null}
+                      </div>
+                      <div className="composer-context-grid">
+                        <div>
+                          <span>Updated</span>
+                          <strong
+                            title={new Date(rateLimitUsage.updated_at).toLocaleString()}
+                          >
+                            {formatRelativeTime(rateLimitUsage.updated_at)}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Source</span>
+                          <strong>
+                            {rateLimitUsage.notes?.length
+                              ? rateLimitUsage.notes[0]
+                              : "Unavailable"}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Credits</span>
+                          <strong>
+                            {rateLimitUsage.credits_remaining !== null &&
+                            rateLimitUsage.credits_remaining !== undefined
+                              ? `${rateLimitUsage.credits_currency ?? "credits"} ${rateLimitUsage.credits_remaining.toFixed(2)}`
+                              : "Unavailable"}
+                          </strong>
+                        </div>
+                        <div>
+                          <span>Windows</span>
+                          <strong>{formatTokens(rateLimitUsageWindows.length)} tracked</strong>
+                        </div>
+                      </div>
+                    </section>
                   ) : null}
                 </div>
               ) : null}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -267,6 +267,23 @@ export async function postAction(
   await ensureOk(response, `failed to ${action}`);
 }
 
+export async function refreshSessionRateLimitUsage(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionRecord> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/rate-limit-usage/refresh`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to refresh rate-limit usage");
+  const body = await response.json();
+  return body.session as SessionRecord;
+}
+
 export async function setSessionPermissionMode(
   host: string,
   token: string,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -31,6 +31,27 @@ export interface SessionContextUsage {
   breakdown?: Record<string, number>;
 }
 
+export interface UsageWindow {
+  id: string;
+  label: string;
+  used_percent: number;
+  used_tokens?: number | null;
+  limit_tokens?: number | null;
+  remaining_tokens?: number | null;
+  window_minutes?: number | null;
+  resets_at?: string | null;
+  reset_description?: string | null;
+}
+
+export interface SessionRateLimitUsage {
+  source: Backend;
+  updated_at: string;
+  windows: UsageWindow[];
+  credits_remaining?: number | null;
+  credits_currency?: string | null;
+  notes?: string[];
+}
+
 export interface SessionRecord {
   id: string;
   backend: Backend;
@@ -57,6 +78,7 @@ export interface SessionRecord {
   model?: string | null;
   effort?: string | null;
   context_usage?: SessionContextUsage | null;
+  rate_limit_usage?: SessionRateLimitUsage | null;
   args: string[];
   config_overrides: string[];
 }


### PR DESCRIPTION
## Summary

Addresses #21 (session-widget half). Adds a rate-limit usage panel behind the composer connection pill that shows current 5h / weekly utilization (plus credits for Codex) for Claude Code and Codex sessions, including sessions launched on a remote SSH target. The standalone dashboard page is out of scope here.

## Changes

### Backend

- Added `SessionRateLimitUsage` and `UsageWindow` to the session schema + storage; broadcast the snapshot to the frontend through the existing session-update path so the popover updates without a poll.
- Implemented per-backend probes that match how each CLI authenticates:
  - **Claude Code:** read `~/.claude/.credentials.json` (or macOS keychain via `security find-generic-password`, including the hashed `Claude Code-credentials-<hash>` service name), check `expiresAt` with a 60s skew, POST `/v1/messages`, and parse `anthropic-ratelimit-unified-{5h,7d}-{utilization,reset}` headers. Expired tokens and 401 responses surface as a "credentials expired — run `claude` to refresh" snapshot rather than a silent failure.
  - **Codex:** read `~/.codex/auth.json`, rotate the refresh token via `auth.openai.com/oauth/token` when stale, hit `chatgpt.com/backend-api/wham/usage`, and walk the JSON for windows with `used_percent`. Falls through to a `codex -s read-only -a untrusted` PTY scrape only when the OAuth payload carries no actionable data (no windows, no credits, no plan/email metadata) — education-plan accounts that legitimately return `rate_limit: null` keep their plan/email notes.
- Per-session refresh loop runs every 5 min in each adapter; signature dedup avoids redundant pushes.
- Added `POST /api/sessions/{id}/rate-limit-usage/refresh` for on-demand refresh. The handler awaits an inline `force_refresh_rate_limit_usage` on the adapter before returning so the HTTP response carries the post-refresh snapshot instead of racing the WS push.
- **Remote sessions:** when `session.launch_target_id` resolves to an `SshLaunchTargetConfig`, the plugin registers a remote probe that pipes a stdlib-only Python script (`remote_probe_script.py` per backend) to `python3 -` over SSH. Credentials never leave the remote — the script reads the remote's own `~/.claude/.credentials.json` / `~/.codex/auth.json` (with macOS keychain fallback on Darwin remotes) and emits a JSON envelope on stdout that the backend translates into the same `SessionRateLimitUsage` shape. Codex's remote script also performs the `/status` PTY scrape locally on the remote when OAuth yields nothing.
- Plugin dispatch (`_register_rate_limit_probe`) chooses local vs. remote at registration and is shared across all four lifecycle hooks (start, restore, fork, import) so the four backends stay in sync.

### Frontend

- Added a popover panel behind the existing connection-pill that renders the snapshot as a navigation-instrument readout: serif percentage numerals over 14-segment bars, brass hairline divider, mono metadata footer (source, account notes, updated-at).
- Tone-coloured bars (good / warn / danger) match the trigger pill colour; bars use `var(--success | --warn | --danger)` with light-theme overrides so segments stay visible in both themes.
- Refresh button calls the new endpoint and replaces the trigger with a spinning brass glyph while in flight.
- Mobile (≤540px viewport): switches to a bottom-sheet via `position: fixed` + `env(safe-area-inset-bottom)` so the panel stays reachable on phones.
- Added `refreshSessionRateLimitUsage` to the API client.

## Test Plan

- [x] `cd backend && uv run pytest` — 375 passing (15 new in `test_rate_limits.py`, 2 new in `test_runtime.py`)
- [x] `cd backend && uv run pre-commit run --all-files` — black / isort / ruff / codespell / mypy clean
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] Manual (local): Claude Code session with valid OAuth — popover shows windows + org/tier notes; force-expire via `expiresAt: 0` — popover surfaces the expired note without an HTTP call; Codex education-plan account — popover shows plan/email notes with empty windows.
- [x] Manual (remote): pending — needs an SSH launch target with Claude/Codex installed on the remote host.