### PR TITLE
feat: add usage dashboard for rate-limit telemetry

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -39,6 +39,7 @@ from waypoint.schemas import (
 from waypoint.settings import Settings, load_settings
 from waypoint.storage import Storage
 from waypoint.tailnet import fetch_snapshot
+from waypoint.usage_dashboard import build_dashboard
 
 
 def _backend_descriptors(registry: BackendRegistry) -> list[dict[str, Any]]:
@@ -317,6 +318,32 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         session = await context.runtime.refresh_rate_limit_usage(session_id)
         return {"session": session.model_dump(mode="json")}
+
+    @app.get("/api/usage")
+    async def get_usage_dashboard(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        dashboard = build_dashboard(context.runtime.list_sessions())
+        return dashboard.model_dump(mode="json")
+
+    @app.post("/api/usage/refresh")
+    async def refresh_usage_dashboard(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        # Refresh one representative session per bucket — every session in
+        # a bucket shares the same account-level rate limit, so probing
+        # one is enough to update the bucket's snapshot.
+        dashboard = build_dashboard(context.runtime.list_sessions())
+        targets = [
+            bucket.session_ids[0] for bucket in dashboard.buckets if bucket.session_ids
+        ]
+        if targets:
+            await asyncio.gather(
+                *(context.runtime.refresh_rate_limit_usage(sid) for sid in targets),
+                return_exceptions=True,
+            )
+        refreshed = build_dashboard(context.runtime.list_sessions())
+        return refreshed.model_dump(mode="json")
 
     @app.post("/api/sessions/{session_id}/terminate")
     async def session_terminate(

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -133,6 +133,18 @@ class SessionRateLimitUsage(BaseModel):
     notes: list[str] = Field(default_factory=list)
 
 
+class UsageDashboardBucket(BaseModel):
+    backend: BackendId
+    account_key: str
+    account_label: str
+    snapshot: SessionRateLimitUsage
+    session_ids: list[str] = Field(default_factory=list)
+
+
+class UsageDashboardResponse(BaseModel):
+    buckets: list[UsageDashboardBucket] = Field(default_factory=list)
+
+
 class SessionRecord(BaseModel):
     id: str
     backend: BackendId

--- a/backend/src/waypoint/usage_dashboard.py
+++ b/backend/src/waypoint/usage_dashboard.py
@@ -75,6 +75,9 @@ def _humanise_backend(backend: BackendId) -> str:
 
 
 def build_dashboard(sessions: list[SessionRecord]) -> UsageDashboardResponse:
+    # ``session_ids[0]`` is the session that produced the freshest snapshot
+    # in the bucket — refresh paths target it so a stale/torn-down session
+    # cannot silently no-op the probe when a live one is available.
     buckets: dict[str, UsageDashboardBucket] = {}
     for session in sessions:
         snapshot = session.rate_limit_usage
@@ -91,10 +94,12 @@ def build_dashboard(sessions: list[SessionRecord]) -> UsageDashboardResponse:
                 session_ids=[session.id],
             )
             continue
-        existing.session_ids.append(session.id)
         if snapshot.updated_at > existing.snapshot.updated_at:
             existing.snapshot = snapshot
             existing.account_label = label
+            existing.session_ids.insert(0, session.id)
+        else:
+            existing.session_ids.append(session.id)
 
     ordered = sorted(
         buckets.values(),

--- a/backend/src/waypoint/usage_dashboard.py
+++ b/backend/src/waypoint/usage_dashboard.py
@@ -1,0 +1,103 @@
+"""Aggregate session rate-limit snapshots into per-account dashboard buckets.
+
+Rate limits live at the provider account level (a Claude org's 5h/weekly
+window is shared across every session signed into that org), so the
+dashboard groups by ``(backend, account_key)`` rather than per session.
+The account key is derived from the ``notes`` list on each snapshot —
+Claude carries ``org: <name>``/``org tier: <tier>``; Codex carries an
+email plus ``plan: <plan_type>``.
+"""
+
+from waypoint.schemas import (
+    BackendId,
+    SessionRateLimitUsage,
+    SessionRecord,
+    UsageDashboardBucket,
+    UsageDashboardResponse,
+)
+
+_CLAUDE_ORG_PREFIX = "org: "
+_CLAUDE_ORG_TIER_PREFIX = "org tier: "
+_PLAN_PREFIX = "plan: "
+_DEFAULT_SEED_NOTES = {"CLI OAuth", "remote OAuth"}
+
+
+def _find_prefixed(notes: list[str], prefix: str) -> str | None:
+    for note in notes:
+        if note.startswith(prefix):
+            value = note[len(prefix) :].strip()
+            if value:
+                return value
+    return None
+
+
+def _find_email(notes: list[str]) -> str | None:
+    for note in notes:
+        if note in _DEFAULT_SEED_NOTES:
+            continue
+        if note.startswith(_PLAN_PREFIX):
+            continue
+        if "@" in note and " " not in note:
+            return note
+    return None
+
+
+def account_bucket_for(
+    snapshot: SessionRateLimitUsage, *, session_id: str
+) -> tuple[str, str]:
+    """Return ``(account_key, account_label)`` for a snapshot.
+
+    Falls back to a session-scoped key when notes carry no account info,
+    so probes without org/email metadata still surface as their own
+    bucket instead of collapsing together.
+    """
+    if snapshot.source == "claude_code":
+        org = _find_prefixed(snapshot.notes, _CLAUDE_ORG_PREFIX)
+        if org is not None:
+            tier = _find_prefixed(snapshot.notes, _CLAUDE_ORG_TIER_PREFIX)
+            label = f"{org} · {tier}" if tier else org
+            return f"claude_code:{org}", label
+    elif snapshot.source == "codex":
+        email = _find_email(snapshot.notes)
+        if email is not None:
+            plan = _find_prefixed(snapshot.notes, _PLAN_PREFIX)
+            label = f"{email} · plan: {plan}" if plan else email
+            return f"codex:{email}", label
+    return f"{snapshot.source}:session:{session_id}", _humanise_backend(snapshot.source)
+
+
+def _humanise_backend(backend: BackendId) -> str:
+    if backend == "claude_code":
+        return "Claude Code"
+    if backend == "codex":
+        return "Codex"
+    return backend
+
+
+def build_dashboard(sessions: list[SessionRecord]) -> UsageDashboardResponse:
+    buckets: dict[str, UsageDashboardBucket] = {}
+    for session in sessions:
+        snapshot = session.rate_limit_usage
+        if snapshot is None:
+            continue
+        key, label = account_bucket_for(snapshot, session_id=session.id)
+        existing = buckets.get(key)
+        if existing is None:
+            buckets[key] = UsageDashboardBucket(
+                backend=snapshot.source,
+                account_key=key,
+                account_label=label,
+                snapshot=snapshot,
+                session_ids=[session.id],
+            )
+            continue
+        existing.session_ids.append(session.id)
+        if snapshot.updated_at > existing.snapshot.updated_at:
+            existing.snapshot = snapshot
+            existing.account_label = label
+
+    ordered = sorted(
+        buckets.values(),
+        key=lambda bucket: (bucket.backend, -bucket.snapshot.updated_at.timestamp()),
+    )
+    return UsageDashboardResponse(buckets=ordered)

--- a/backend/tests/test_usage_dashboard.py
+++ b/backend/tests/test_usage_dashboard.py
@@ -1,0 +1,170 @@
+from datetime import UTC, datetime, timedelta
+
+from waypoint.schemas import (
+    SessionRateLimitUsage,
+    SessionRecord,
+    UsageWindow,
+)
+from waypoint.usage_dashboard import account_bucket_for, build_dashboard
+
+
+def _snapshot(
+    *,
+    source: str,
+    notes: list[str],
+    updated_at: datetime,
+    windows: list[UsageWindow] | None = None,
+) -> SessionRateLimitUsage:
+    return SessionRateLimitUsage(
+        source=source,
+        updated_at=updated_at,
+        windows=windows or [],
+        notes=notes,
+    )
+
+
+def _session(
+    *,
+    sid: str,
+    backend: str,
+    snapshot: SessionRateLimitUsage | None,
+    updated_at: datetime | None = None,
+) -> SessionRecord:
+    now = updated_at or datetime.now(UTC)
+    return SessionRecord(
+        id=sid,
+        backend=backend,
+        source="managed",
+        title=sid,
+        cwd="~/",
+        status="running",
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=f"/tmp/{sid}.raw",
+        structured_log_path=f"/tmp/{sid}.json",
+        rate_limit_usage=snapshot,
+    )
+
+
+def test_account_bucket_claude_uses_org_and_tier() -> None:
+    snap = _snapshot(
+        source="claude_code",
+        notes=["CLI OAuth", "org: Acme", "org tier: enterprise"],
+        updated_at=datetime.now(UTC),
+    )
+    key, label = account_bucket_for(snap, session_id="s1")
+    assert key == "claude_code:Acme"
+    assert label == "Acme · enterprise"
+
+
+def test_account_bucket_claude_without_tier_falls_back_to_org_only_label() -> None:
+    snap = _snapshot(
+        source="claude_code",
+        notes=["CLI OAuth", "org: Acme"],
+        updated_at=datetime.now(UTC),
+    )
+    _, label = account_bucket_for(snap, session_id="s1")
+    assert label == "Acme"
+
+
+def test_account_bucket_codex_uses_email_and_plan() -> None:
+    snap = _snapshot(
+        source="codex",
+        notes=["CLI OAuth", "plan: education", "user@example.com"],
+        updated_at=datetime.now(UTC),
+    )
+    key, label = account_bucket_for(snap, session_id="s1")
+    assert key == "codex:user@example.com"
+    assert label == "user@example.com · plan: education"
+
+
+def test_account_bucket_no_account_info_falls_back_to_session_scope() -> None:
+    claude = _snapshot(
+        source="claude_code",
+        notes=["CLI OAuth"],
+        updated_at=datetime.now(UTC),
+    )
+    codex = _snapshot(
+        source="codex",
+        notes=["CLI OAuth"],
+        updated_at=datetime.now(UTC),
+    )
+    assert account_bucket_for(claude, session_id="s1") == (
+        "claude_code:session:s1",
+        "Claude Code",
+    )
+    assert account_bucket_for(codex, session_id="s2") == (
+        "codex:session:s2",
+        "Codex",
+    )
+
+
+def test_build_dashboard_groups_sessions_and_keeps_freshest_snapshot() -> None:
+    now = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+    older = _snapshot(
+        source="claude_code",
+        notes=["org: Acme", "org tier: enterprise"],
+        updated_at=now - timedelta(minutes=10),
+        windows=[
+            UsageWindow(id="5h", label="5h", used_percent=20.0),
+        ],
+    )
+    newer = _snapshot(
+        source="claude_code",
+        notes=["org: Acme", "org tier: enterprise"],
+        updated_at=now,
+        windows=[
+            UsageWindow(id="5h", label="5h", used_percent=42.0),
+        ],
+    )
+    sessions = [
+        _session(sid="s-old", backend="claude_code", snapshot=older),
+        _session(sid="s-new", backend="claude_code", snapshot=newer),
+    ]
+    dashboard = build_dashboard(sessions)
+    assert len(dashboard.buckets) == 1
+    bucket = dashboard.buckets[0]
+    assert bucket.account_key == "claude_code:Acme"
+    assert bucket.snapshot.updated_at == now
+    assert bucket.snapshot.windows[0].used_percent == 42.0
+    assert set(bucket.session_ids) == {"s-old", "s-new"}
+
+
+def test_build_dashboard_skips_sessions_without_snapshot() -> None:
+    sessions = [
+        _session(sid="s1", backend="claude_code", snapshot=None),
+    ]
+    dashboard = build_dashboard(sessions)
+    assert dashboard.buckets == []
+
+
+def test_build_dashboard_separates_backends_and_accounts() -> None:
+    now = datetime.now(UTC)
+    claude = _snapshot(
+        source="claude_code",
+        notes=["org: Acme", "org tier: enterprise"],
+        updated_at=now,
+    )
+    codex = _snapshot(
+        source="codex",
+        notes=["plan: pro", "user@example.com"],
+        updated_at=now,
+    )
+    codex_other = _snapshot(
+        source="codex",
+        notes=["plan: pro", "other@example.com"],
+        updated_at=now,
+    )
+    sessions = [
+        _session(sid="s1", backend="claude_code", snapshot=claude),
+        _session(sid="s2", backend="codex", snapshot=codex),
+        _session(sid="s3", backend="codex", snapshot=codex_other),
+    ]
+    dashboard = build_dashboard(sessions)
+    keys = {bucket.account_key for bucket in dashboard.buckets}
+    assert keys == {
+        "claude_code:Acme",
+        "codex:user@example.com",
+        "codex:other@example.com",
+    }

--- a/backend/tests/test_usage_dashboard.py
+++ b/backend/tests/test_usage_dashboard.py
@@ -100,6 +100,38 @@ def test_account_bucket_no_account_info_falls_back_to_session_scope() -> None:
     )
 
 
+def test_build_dashboard_lists_freshest_session_first() -> None:
+    # The refresh path probes ``session_ids[0]``; if the oldest-encountered
+    # session is exited, ``force_refresh_rate_limit_usage`` would silently
+    # no-op. Putting the freshest-snapshot session first keeps refresh
+    # pointed at the session most likely to still have live adapter state.
+    now = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
+    older = _snapshot(
+        source="claude_code",
+        notes=["org: Acme"],
+        updated_at=now - timedelta(minutes=15),
+    )
+    newer = _snapshot(
+        source="claude_code",
+        notes=["org: Acme"],
+        updated_at=now,
+    )
+    middle = _snapshot(
+        source="claude_code",
+        notes=["org: Acme"],
+        updated_at=now - timedelta(minutes=5),
+    )
+    sessions = [
+        _session(sid="s-old", backend="claude_code", snapshot=older),
+        _session(sid="s-new", backend="claude_code", snapshot=newer),
+        _session(sid="s-mid", backend="claude_code", snapshot=middle),
+    ]
+    dashboard = build_dashboard(sessions)
+    assert len(dashboard.buckets) == 1
+    assert dashboard.buckets[0].session_ids[0] == "s-new"
+    assert set(dashboard.buckets[0].session_ids) == {"s-old", "s-new", "s-mid"}
+
+
 def test_build_dashboard_groups_sessions_and_keeps_freshest_snapshot() -> None:
     now = datetime(2026, 5, 11, 12, 0, tzinfo=UTC)
     older = _snapshot(

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3704,72 +3704,370 @@ html[data-theme="light"] .usage-meta-bullet {
   color: rgba(184, 130, 14, 0.5);
 }
 
-/* ─── Usage dashboard (home-page section) ─── */
-.usage-dashboard {
+/* ─── Telemetry deck (home-page usage dashboard) ─── */
+/*  The dashboard is styled as a brass-edged instrument console:
+    a hinged toggle revealing a status strip, then an asymmetric grid
+    of instrument panels. The aesthetic borrows the same vocabulary
+    as the composer popover (serif numerals, brass rail, segmented
+    bars) and extends it with SVG dial gauges and stamped plaques. */
+
+.usage-deck {
+  --deck-tone: var(--accent);
+  --deck-paper: linear-gradient(
+      180deg,
+      rgba(18, 23, 32, 0.92),
+      rgba(10, 13, 19, 0.94)
+    ),
+    radial-gradient(
+      120% 80% at 0% 0%,
+      rgba(200, 169, 106, 0.05),
+      transparent 60%
+    );
+  --deck-paper-light: linear-gradient(
+      180deg,
+      rgba(255, 252, 244, 0.96),
+      rgba(247, 241, 228, 0.96)
+    ),
+    radial-gradient(
+      120% 80% at 0% 0%,
+      rgba(184, 130, 14, 0.06),
+      transparent 60%
+    );
+  --deck-grid: linear-gradient(
+      to right,
+      rgba(200, 169, 106, 0.045) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      rgba(200, 169, 106, 0.045) 1px,
+      transparent 1px
+    );
+  position: relative;
   padding: 0;
   overflow: hidden;
+  isolation: isolate;
+  background: var(--deck-paper);
+  border: 1px solid var(--line-strong);
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.45),
+    inset 0 0 0 1px rgba(200, 169, 106, 0.05);
 }
 
-.usage-dashboard-toggle {
+html[data-theme="light"] .usage-deck {
+  background: var(--deck-paper-light);
+  box-shadow:
+    0 20px 38px rgba(80, 60, 25, 0.16),
+    inset 0 0 0 1px rgba(184, 130, 14, 0.06);
+}
+
+.usage-deck.tone-warn {
+  --deck-tone: var(--warn);
+}
+
+.usage-deck.tone-danger {
+  --deck-tone: var(--danger);
+}
+
+/*  Top rail: thin brass strip with a subtle gradient across the deck. */
+.usage-deck::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(200, 169, 106, 0.6) 14%,
+    rgba(200, 169, 106, 0.6) 86%,
+    transparent
+  );
+  z-index: 1;
+}
+
+html[data-theme="light"] .usage-deck::before {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(184, 130, 14, 0.5) 14%,
+    rgba(184, 130, 14, 0.5) 86%,
+    transparent
+  );
+}
+
+/*  Faint engineer's-graph paper texture; very low contrast on purpose. */
+.usage-deck::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: var(--deck-grid);
+  background-size: 48px 48px;
+  background-position: top left;
+  pointer-events: none;
+  opacity: 0.55;
+  mix-blend-mode: overlay;
+  z-index: 0;
+}
+
+html[data-theme="light"] .usage-deck::after {
+  opacity: 0.35;
+  mix-blend-mode: multiply;
+}
+
+.usage-deck > * {
+  position: relative;
+  z-index: 2;
+}
+
+/* ── Toggle bar ── */
+.usage-deck-toggle {
   width: 100%;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, auto) minmax(0, 1fr) auto auto;
   align-items: center;
   gap: 14px;
-  padding: 14px 18px;
+  padding: 14px 20px;
   background: transparent;
   border: none;
-  color: var(--muted-soft);
-  font-family: var(--font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
   cursor: pointer;
   text-align: left;
-  transition: color 140ms ease, background-color 140ms ease;
+  transition:
+    color 200ms ease,
+    border-color 200ms ease,
+    background-color 200ms ease;
   -webkit-tap-highlight-color: transparent;
-}
-
-.usage-dashboard-toggle:hover {
   color: var(--text);
-  background: rgba(255, 255, 255, 0.025);
 }
 
-html[data-theme="light"] .usage-dashboard-toggle {
+.usage-deck-toggle:hover {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+html[data-theme="light"] .usage-deck-toggle:hover {
+  background: rgba(60, 45, 20, 0.025);
+}
+
+.usage-deck.is-open .usage-deck-toggle {
+  border-bottom-color: rgba(200, 169, 106, 0.22);
+}
+
+html[data-theme="light"] .usage-deck.is-open .usage-deck-toggle {
+  border-bottom-color: rgba(184, 130, 14, 0.22);
+}
+
+/*  Mini compass-rose mark with a needle that rotates with the deck tone. */
+.usage-deck-toggle-mark {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid rgba(200, 169, 106, 0.42);
+  background: radial-gradient(
+    60% 60% at 50% 40%,
+    rgba(200, 169, 106, 0.18),
+    rgba(0, 0, 0, 0) 70%
+  );
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+
+html[data-theme="light"] .usage-deck-toggle-mark {
+  border-color: rgba(184, 130, 14, 0.4);
+  background: radial-gradient(
+    60% 60% at 50% 40%,
+    rgba(184, 130, 14, 0.12),
+    rgba(0, 0, 0, 0) 70%
+  );
+}
+
+.usage-deck-toggle-mark::before,
+.usage-deck-toggle-mark::after {
+  content: "";
+  position: absolute;
+  background: rgba(200, 169, 106, 0.35);
+}
+
+html[data-theme="light"] .usage-deck-toggle-mark::before,
+html[data-theme="light"] .usage-deck-toggle-mark::after {
+  background: rgba(184, 130, 14, 0.35);
+}
+
+/*  Cardinal hairlines. */
+.usage-deck-toggle-mark::before {
+  left: 50%;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  transform: translateX(-50%);
+}
+
+.usage-deck-toggle-mark::after {
+  top: 50%;
+  left: 4px;
+  right: 4px;
+  height: 1px;
+  transform: translateY(-50%);
+}
+
+.usage-deck-toggle-needle {
+  /*  Positioned so the needle's BASE (not its midpoint) sits at the dial
+      center: `bottom: 50%` plants the bottom edge on the vertical center
+      line; `left: 50%` + `margin-left: -1px` plants its horizontal center
+      there too. With `transform-origin: 50% 100%`, rotations then pivot
+      cleanly around that base. */
+  position: absolute;
+  left: 50%;
+  bottom: 50%;
+  margin-left: -1px;
+  width: 2px;
+  height: 10px;
+  background: var(--deck-tone);
+  transform-origin: 50% 100%;
+  transform: rotate(-30deg);
+  transition: transform 600ms cubic-bezier(0.34, 1.56, 0.64, 1);
+  border-radius: 1px;
+  filter: drop-shadow(0 0 4px var(--deck-tone));
+}
+
+.usage-deck.tone-warn .usage-deck-toggle-needle {
+  transform: rotate(35deg);
+}
+
+.usage-deck.tone-danger .usage-deck-toggle-needle {
+  transform: rotate(80deg);
+}
+
+.usage-deck-toggle-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.usage-deck-toggle-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.usage-deck-toggle-title {
+  font-family: var(--font-display);
+  font-size: 1.18rem;
+  letter-spacing: 0.005em;
+  color: var(--text-strong);
+  line-height: 1.1;
+}
+
+.usage-deck.tone-warn .usage-deck-toggle-title {
+  color: var(--warn);
+}
+
+.usage-deck.tone-danger .usage-deck-toggle-title {
+  color: var(--danger);
+}
+
+.usage-deck-toggle-summary {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  color: var(--muted-soft);
+  text-transform: lowercase;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  min-width: 0;
+  text-align: right;
+}
+
+html[data-theme="light"] .usage-deck-toggle-summary {
   color: var(--muted);
 }
 
-html[data-theme="light"] .usage-dashboard-toggle:hover {
-  background: rgba(0, 0, 0, 0.03);
+.usage-deck-toggle-pips {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
 }
 
-.usage-dashboard.open .usage-dashboard-toggle {
-  color: var(--accent);
-  border-bottom: 1px solid rgba(200, 169, 106, 0.18);
+.usage-deck-pip {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.25),
+    0 0 8px var(--success);
 }
 
-.usage-dashboard-toggle-eyebrow {
-  font-weight: 600;
-  color: var(--accent);
+.usage-deck-pip.tone-warn {
+  background: var(--warn);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.25),
+    0 0 8px var(--warn);
 }
 
-.usage-dashboard-toggle-summary {
-  flex: 1;
+.usage-deck-pip.tone-danger {
+  background: var(--danger);
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.25),
+    0 0 10px var(--danger);
+  animation: deck-pip-pulse 1.6s ease-in-out infinite;
+}
+
+html[data-theme="light"] .usage-deck-pip {
+  box-shadow:
+    0 0 0 1px rgba(60, 45, 20, 0.18),
+    0 0 6px var(--success);
+}
+
+html[data-theme="light"] .usage-deck-pip.tone-warn {
+  box-shadow:
+    0 0 0 1px rgba(60, 45, 20, 0.18),
+    0 0 6px var(--warn);
+}
+
+html[data-theme="light"] .usage-deck-pip.tone-danger {
+  box-shadow:
+    0 0 0 1px rgba(60, 45, 20, 0.18),
+    0 0 8px var(--danger);
+}
+
+@keyframes deck-pip-pulse {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.55;
+    transform: scale(0.78);
+  }
+}
+
+.usage-deck-pip-extra {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
   color: var(--muted);
-  font-family: var(--font-sans);
-  font-size: 0.85rem;
-  letter-spacing: 0;
-  text-transform: none;
+  padding: 0 4px;
 }
 
-.usage-dashboard-toggle-chevron {
+.usage-deck-toggle-chevron {
   position: relative;
   width: 14px;
   height: 14px;
   flex-shrink: 0;
+  color: var(--muted);
 }
 
-.usage-dashboard-toggle-chevron::before,
-.usage-dashboard-toggle-chevron::after {
+.usage-deck-toggle-chevron::before,
+.usage-deck-toggle-chevron::after {
   content: "";
   position: absolute;
   width: 5.5px;
@@ -3777,99 +4075,899 @@ html[data-theme="light"] .usage-dashboard-toggle:hover {
   background: currentColor;
   border-radius: 1px;
   top: 50%;
-  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+  transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.usage-dashboard-toggle-chevron::before {
+.usage-deck-toggle-chevron::before {
   right: 50%;
   margin-right: -0.5px;
   transform: translateY(-50%) rotate(-45deg);
   transform-origin: right center;
 }
 
-.usage-dashboard-toggle-chevron::after {
+.usage-deck-toggle-chevron::after {
   left: 50%;
   margin-left: -0.5px;
   transform: translateY(-50%) rotate(45deg);
   transform-origin: left center;
 }
 
-.usage-dashboard.open .usage-dashboard-toggle-chevron::before {
+.usage-deck.is-open .usage-deck-toggle-chevron::before {
   transform: translateY(-50%) rotate(45deg);
 }
 
-.usage-dashboard.open .usage-dashboard-toggle-chevron::after {
+.usage-deck.is-open .usage-deck-toggle-chevron::after {
   transform: translateY(-50%) rotate(-45deg);
 }
 
-.usage-dashboard-body {
+/* ── Body ── */
+.usage-deck-body {
   display: flex;
   flex-direction: column;
-  gap: 16px;
-  padding: 16px 18px 18px;
+  gap: 18px;
+  padding: 18px 20px 22px;
+  animation: deck-body-enter 320ms cubic-bezier(0.22, 0.8, 0.36, 1) both;
 }
 
-.usage-dashboard-actions {
+@keyframes deck-body-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.usage-deck-status {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 16px;
+  border: 1px solid rgba(200, 169, 106, 0.18);
+  border-radius: var(--radius-sm);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.025), rgba(0, 0, 0, 0)),
+    rgba(8, 11, 16, 0.45);
+}
+
+html[data-theme="light"] .usage-deck-status {
+  background:
+    linear-gradient(180deg, rgba(255, 252, 244, 0.7), rgba(0, 0, 0, 0)),
+    rgba(255, 252, 244, 0.65);
+  border-color: rgba(184, 130, 14, 0.2);
+}
+
+.usage-deck-status-rivet {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 220, 150, 0.9), rgba(120, 95, 35, 0.7) 60%, rgba(0, 0, 0, 0.6) 100%);
+  box-shadow:
+    inset 0 0 2px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(0, 0, 0, 0.35);
+}
+
+html[data-theme="light"] .usage-deck-status-rivet {
+  background:
+    radial-gradient(circle at 30% 30%, rgba(255, 230, 170, 1), rgba(170, 120, 30, 0.85) 60%, rgba(80, 55, 10, 0.55) 100%);
+  box-shadow:
+    inset 0 0 2px rgba(80, 55, 10, 0.5),
+    0 0 0 1px rgba(80, 55, 10, 0.18);
+}
+
+.usage-deck-status-text {
   display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.usage-deck-status-headline {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: var(--success);
+  letter-spacing: 0.005em;
+}
+
+.usage-deck-status-headline.tone-warn {
+  color: var(--warn);
+}
+
+.usage-deck-status-headline.tone-danger {
+  color: var(--danger);
+}
+
+.usage-deck-status-detail {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  text-transform: uppercase;
+}
+
+.usage-deck-status-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
   justify-content: flex-end;
 }
 
-.usage-dashboard-error {
+.usage-deck-status-sweep {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: var(--muted-soft);
+  text-transform: lowercase;
+}
+
+.usage-deck-refresh-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 14px;
+  border: 1px solid rgba(200, 169, 106, 0.34);
+  border-radius: var(--radius-pill);
+  background: rgba(200, 169, 106, 0.06);
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    color 160ms ease,
+    transform 120ms ease;
+}
+
+.usage-deck-refresh-all:hover:not(:disabled) {
+  background: rgba(200, 169, 106, 0.12);
+  color: var(--accent-strong);
+  border-color: rgba(200, 169, 106, 0.55);
+}
+
+.usage-deck-refresh-all:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.usage-deck-refresh-all:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+html[data-theme="light"] .usage-deck-refresh-all {
+  border-color: rgba(184, 130, 14, 0.35);
+  background: rgba(184, 130, 14, 0.05);
+  color: var(--accent);
+}
+
+html[data-theme="light"] .usage-deck-refresh-all:hover:not(:disabled) {
+  background: rgba(184, 130, 14, 0.1);
+  border-color: rgba(184, 130, 14, 0.55);
+}
+
+.usage-deck-refresh-all-glyph {
+  display: inline-block;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.usage-deck-refresh-all-glyph.is-spinning {
+  animation: deck-spin 900ms linear infinite;
+}
+
+@keyframes deck-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.usage-deck-error {
   margin: 0;
-  padding: 8px 12px;
-  border-radius: 6px;
-  background: rgba(220, 80, 80, 0.1);
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: rgba(226, 108, 112, 0.1);
   color: var(--danger);
   font-family: var(--font-mono);
   font-size: 0.78rem;
+  border: 1px solid rgba(226, 108, 112, 0.3);
 }
 
-html[data-theme="light"] .usage-dashboard-error {
-  background: rgba(196, 64, 64, 0.1);
+html[data-theme="light"] .usage-deck-error {
+  background: rgba(184, 48, 56, 0.08);
+  border-color: rgba(184, 48, 56, 0.3);
 }
 
-.usage-dashboard-grid {
+/* ── Loading and empty ── */
+.usage-deck-loading {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 30px 24px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+}
+
+.usage-deck-loading-bar {
+  width: 96px;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    var(--accent) 50%,
+    transparent
+  );
+  background-size: 200% 100%;
+  animation: deck-loading 1.6s ease-in-out infinite;
+}
+
+@keyframes deck-loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.usage-deck-empty {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  align-items: center;
+  gap: 6px;
+  padding: 36px 24px;
+  text-align: center;
+  border: 1px dashed rgba(200, 169, 106, 0.2);
+  border-radius: var(--radius-sm);
 }
 
-.usage-dashboard-group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
+html[data-theme="light"] .usage-deck-empty {
+  border-color: rgba(184, 130, 14, 0.22);
 }
 
-.usage-dashboard-group-title {
+.usage-deck-empty-mark {
+  font-family: var(--font-display);
+  font-size: 2.4rem;
+  color: var(--accent);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.usage-deck-empty-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: var(--text-strong);
+}
+
+.usage-deck-empty-sub {
   margin: 0;
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: 0.74rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+/* ── Instrument grid (asymmetric on desktop) ── */
+.usage-deck-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@media (min-width: 720px) {
+  .usage-deck-grid[data-bucket-count="2"],
+  .usage-deck-grid[data-bucket-count="3"],
+  .usage-deck-grid[data-bucket-count="4"],
+  .usage-deck-grid[data-bucket-count="5"],
+  .usage-deck-grid[data-bucket-count="6"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  /*  In a multi-bucket layout, the worst-tone (first) bucket takes the
+      full row as the "hero" instrument so its dials read at full scale. */
+  .usage-deck-grid[data-bucket-count="3"] > :nth-child(1),
+  .usage-deck-grid[data-bucket-count="4"] > :nth-child(1),
+  .usage-deck-grid[data-bucket-count="5"] > :nth-child(1),
+  .usage-deck-grid[data-bucket-count="6"] > :nth-child(1) {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (min-width: 1080px) {
+  .usage-deck-grid[data-bucket-count="4"],
+  .usage-deck-grid[data-bucket-count="5"],
+  .usage-deck-grid[data-bucket-count="6"] {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .usage-deck-grid[data-bucket-count="4"] > :nth-child(1),
+  .usage-deck-grid[data-bucket-count="5"] > :nth-child(1),
+  .usage-deck-grid[data-bucket-count="6"] > :nth-child(1) {
+    grid-column: 1 / -1;
+  }
+}
+
+/* ── Instrument panel ── */
+.usage-instrument {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 14px;
+  padding: 20px 22px 18px;
+  background:
+    linear-gradient(180deg, rgba(28, 34, 46, 0.86), rgba(12, 16, 22, 0.92));
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  overflow: hidden;
+  isolation: isolate;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 0 0 1px rgba(200, 169, 106, 0.04),
+    0 10px 24px rgba(0, 0, 0, 0.35);
+  animation: instrument-enter 520ms cubic-bezier(0.22, 0.8, 0.36, 1) both;
+  animation-delay: var(--enter-delay, 0ms);
+}
+
+@keyframes instrument-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+html[data-theme="light"] .usage-instrument {
+  background:
+    linear-gradient(180deg, rgba(255, 253, 247, 0.94), rgba(244, 237, 220, 0.92));
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    inset 0 0 0 1px rgba(184, 130, 14, 0.06),
+    0 10px 20px rgba(80, 60, 25, 0.1);
+}
+
+.usage-instrument.tone-warn {
+  border-color: rgba(217, 154, 74, 0.4);
+}
+
+.usage-instrument.tone-danger {
+  border-color: rgba(226, 108, 112, 0.42);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    inset 0 0 0 1px rgba(226, 108, 112, 0.08),
+    0 10px 24px rgba(0, 0, 0, 0.4),
+    0 0 30px rgba(226, 108, 112, 0.08);
+}
+
+html[data-theme="light"] .usage-instrument.tone-warn {
+  border-color: rgba(170, 102, 24, 0.4);
+}
+
+html[data-theme="light"] .usage-instrument.tone-danger {
+  border-color: rgba(184, 48, 56, 0.38);
+}
+
+/*  Corner rivets — a touch of fabricated-instrument feel. */
+.usage-instrument-rivet {
+  position: absolute;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(220, 188, 130, 0.85),
+    rgba(110, 86, 40, 0.7) 60%,
+    rgba(0, 0, 0, 0.6) 100%
+  );
+  box-shadow:
+    inset 0 0 1px rgba(0, 0, 0, 0.5),
+    0 0 0 1px rgba(0, 0, 0, 0.35);
+  z-index: 2;
+}
+
+html[data-theme="light"] .usage-instrument-rivet {
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(255, 232, 170, 1),
+    rgba(160, 110, 30, 0.85) 60%,
+    rgba(80, 55, 10, 0.5) 100%
+  );
+  box-shadow:
+    inset 0 0 1px rgba(80, 55, 10, 0.4),
+    0 0 0 1px rgba(80, 55, 10, 0.18);
+}
+
+.usage-instrument-rivet--tl {
+  top: 8px;
+  left: 8px;
+}
+
+.usage-instrument-rivet--tr {
+  top: 8px;
+  right: 8px;
+}
+
+.usage-instrument-rivet--bl {
+  bottom: 8px;
+  left: 8px;
+}
+
+.usage-instrument-rivet--br {
+  bottom: 8px;
+  right: 8px;
+}
+
+.usage-instrument-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.usage-instrument-plaque {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.usage-instrument-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.usage-instrument-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.16rem;
+  line-height: 1.2;
+  color: var(--text-strong);
+  letter-spacing: 0.005em;
+  /*  Subtle engraved/etched look — light highlight + soft shadow */
+  text-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05),
+    0 -1px 0 rgba(0, 0, 0, 0.4);
+  word-break: break-word;
+}
+
+html[data-theme="light"] .usage-instrument-title {
+  text-shadow:
+    0 1px 0 rgba(255, 252, 244, 0.6),
+    0 -1px 0 rgba(80, 60, 20, 0.08);
+}
+
+.usage-instrument-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.usage-instrument-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
   letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(108, 201, 154, 0.3);
+  color: var(--success);
+  background: rgba(108, 201, 154, 0.06);
+}
+
+.usage-instrument-status.tone-warn {
+  color: var(--warn);
+  border-color: rgba(217, 154, 74, 0.35);
+  background: rgba(217, 154, 74, 0.06);
+}
+
+.usage-instrument-status.tone-danger {
+  color: var(--danger);
+  border-color: rgba(226, 108, 112, 0.4);
+  background: rgba(226, 108, 112, 0.06);
+}
+
+html[data-theme="light"] .usage-instrument-status {
+  border-color: rgba(37, 122, 80, 0.35);
+  background: rgba(37, 122, 80, 0.06);
+}
+
+html[data-theme="light"] .usage-instrument-status.tone-warn {
+  border-color: rgba(170, 102, 24, 0.36);
+  background: rgba(170, 102, 24, 0.06);
+}
+
+html[data-theme="light"] .usage-instrument-status.tone-danger {
+  border-color: rgba(184, 48, 56, 0.36);
+  background: rgba(184, 48, 56, 0.06);
+}
+
+.usage-instrument-status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 6px currentColor;
+}
+
+.usage-instrument-refresh {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid rgba(200, 169, 106, 0.3);
+  background: transparent;
+  color: var(--accent);
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    border-color 140ms ease,
+    transform 120ms ease;
+}
+
+.usage-instrument-refresh:hover:not(:disabled) {
+  background: rgba(200, 169, 106, 0.1);
+  border-color: rgba(200, 169, 106, 0.55);
+}
+
+.usage-instrument-refresh:active:not(:disabled) {
+  transform: rotate(-20deg);
+}
+
+.usage-instrument-refresh:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+html[data-theme="light"] .usage-instrument-refresh {
+  border-color: rgba(184, 130, 14, 0.3);
+}
+
+html[data-theme="light"] .usage-instrument-refresh:hover:not(:disabled) {
+  background: rgba(184, 130, 14, 0.08);
+  border-color: rgba(184, 130, 14, 0.55);
+}
+
+.usage-instrument-refresh-glyph {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.usage-instrument-refresh-glyph.is-spinning {
+  animation: deck-spin 900ms linear infinite;
+}
+
+.usage-instrument-body {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.usage-instrument-dials {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  width: 100%;
+  justify-items: center;
+}
+
+.usage-instrument.emphasis-primary .usage-instrument-dials {
+  gap: 32px;
+}
+
+.usage-instrument-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 18px 12px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.usage-instrument-empty-mark {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: var(--accent);
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.usage-instrument-empty p {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+}
+
+.usage-instrument-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(200, 169, 106, 0.1);
+}
+
+html[data-theme="light"] .usage-instrument-footer {
+  border-top-color: rgba(184, 130, 14, 0.12);
+}
+
+.usage-instrument-footer-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px 22px;
+}
+
+.usage-instrument-footer-cell {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.usage-instrument-footer-cell em {
+  font-style: normal;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.usage-instrument-footer-cell strong {
+  font-family: var(--font-display);
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
+.usage-instrument-notes {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.usage-instrument-note-chip {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  border: 1px solid rgba(200, 169, 106, 0.16);
+  background: rgba(200, 169, 106, 0.04);
+}
+
+html[data-theme="light"] .usage-instrument-note-chip {
+  border-color: rgba(184, 130, 14, 0.18);
+  background: rgba(184, 130, 14, 0.04);
+}
+
+/* ── Dial gauge ── */
+.usage-dial {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.usage-dial-svg {
+  width: 100%;
+  max-width: 160px;
+  height: auto;
+  display: block;
+}
+
+.usage-dial.size-md .usage-dial-svg {
+  max-width: 132px;
+}
+
+.usage-dial-bezel {
+  fill: rgba(0, 0, 0, 0);
+  stroke: rgba(200, 169, 106, 0.32);
+  stroke-width: 1.2;
+}
+
+html[data-theme="light"] .usage-dial-bezel {
+  stroke: rgba(184, 130, 14, 0.42);
+}
+
+.usage-dial-face {
+  fill: url(#usage-dial-face);
+  stroke: rgba(200, 169, 106, 0.12);
+  stroke-width: 0.8;
+}
+
+html[data-theme="light"] .usage-dial-face {
+  fill: url(#usage-dial-face-light);
+  stroke: rgba(184, 130, 14, 0.15);
+}
+
+.usage-dial-tick {
+  stroke: rgba(200, 169, 106, 0.35);
+  stroke-width: 1;
+  stroke-linecap: round;
+}
+
+.usage-dial-tick.is-major {
+  stroke: rgba(200, 169, 106, 0.7);
+  stroke-width: 1.4;
+}
+
+html[data-theme="light"] .usage-dial-tick {
+  stroke: rgba(184, 130, 14, 0.4);
+}
+
+html[data-theme="light"] .usage-dial-tick.is-major {
+  stroke: rgba(184, 130, 14, 0.75);
+}
+
+.usage-dial-track {
+  stroke: rgba(200, 169, 106, 0.18);
+}
+
+html[data-theme="light"] .usage-dial-track {
+  stroke: rgba(184, 130, 14, 0.22);
+}
+
+.usage-dial-fill {
+  stroke: var(--success);
+  filter: drop-shadow(0 0 6px rgba(108, 201, 154, 0.45));
+  /*  Stroke sweeps from 0 → full on mount. */
+  stroke-dasharray: 260 260;
+  stroke-dashoffset: 260;
+  animation: dial-fill-in 900ms cubic-bezier(0.22, 0.8, 0.36, 1) both 120ms;
+}
+
+.usage-dial.tone-warn .usage-dial-fill {
+  stroke: var(--warn);
+  filter: drop-shadow(0 0 6px rgba(217, 154, 74, 0.45));
+}
+
+.usage-dial.tone-danger .usage-dial-fill {
+  stroke: var(--danger);
+  filter: drop-shadow(0 0 8px rgba(226, 108, 112, 0.5));
+}
+
+html[data-theme="light"] .usage-dial-fill {
+  filter: drop-shadow(0 0 5px rgba(37, 122, 80, 0.35));
+}
+
+html[data-theme="light"] .usage-dial.tone-warn .usage-dial-fill {
+  filter: drop-shadow(0 0 5px rgba(170, 102, 24, 0.35));
+}
+
+html[data-theme="light"] .usage-dial.tone-danger .usage-dial-fill {
+  filter: drop-shadow(0 0 7px rgba(184, 48, 56, 0.4));
+}
+
+@keyframes dial-fill-in {
+  from {
+    stroke-dashoffset: 260;
+  }
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+
+.usage-dial-needle {
+  stroke: var(--accent-strong);
+  stroke-width: 2;
+  filter: drop-shadow(0 0 3px rgba(224, 187, 115, 0.6));
+  transform-origin: 72px 72px;
+  /*  Needle sweeps in from rest at -135° to its target position. */
+  animation: dial-needle-sweep 900ms cubic-bezier(0.22, 0.8, 0.36, 1) both 120ms;
+}
+
+.usage-dial.tone-warn .usage-dial-needle {
+  stroke: var(--warn);
+}
+
+.usage-dial.tone-danger .usage-dial-needle {
+  stroke: var(--danger);
+}
+
+@keyframes dial-needle-sweep {
+  from {
+    transform: rotate(-90deg);
+  }
+  to {
+    transform: rotate(0deg);
+  }
+}
+
+.usage-dial-hub {
+  fill: var(--accent-strong);
+  filter: drop-shadow(0 0 3px rgba(200, 169, 106, 0.55));
+}
+
+.usage-dial-hub-cap {
+  fill: rgba(8, 11, 16, 0.95);
+}
+
+html[data-theme="light"] .usage-dial-hub-cap {
+  fill: rgba(20, 16, 8, 0.85);
+}
+
+.usage-dial-empty {
+  fill: var(--muted-soft);
+  font-family: var(--font-display);
+  font-size: 28px;
+}
+
+.usage-dial-readout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  margin-top: -8px;
+}
+
+.usage-dial-percent {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 2px;
+  font-family: var(--font-display);
+  color: var(--text-strong);
+  line-height: 1;
+}
+
+.usage-dial-percent strong {
+  font-size: 1.85rem;
+  font-weight: 500;
+  font-feature-settings: "tnum";
+}
+
+.usage-dial-percent em {
+  font-size: 0.95rem;
+  font-style: normal;
+  color: var(--muted);
+}
+
+.usage-dial.tone-warn .usage-dial-percent strong {
+  color: var(--warn);
+}
+
+.usage-dial.tone-danger .usage-dial-percent strong {
+  color: var(--danger);
+}
+
+.usage-dial-label {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--muted);
 }
 
-.usage-dashboard-cards {
-  display: grid;
-  gap: 14px;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+.usage-dial-caption {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  color: var(--muted-soft);
+  text-align: center;
 }
 
-/* The .usage-panel rule positions the popover absolutely; on the
-   dashboard we want each card to flow in the grid instead, so reset
-   positioning when the panel is rendered as a dashboard card. */
-.usage-dashboard-card.usage-panel {
-  position: relative;
-  inset: auto;
-  width: auto;
-  max-width: none;
-  max-height: none;
-  margin: 0;
-  z-index: auto;
-  animation: none;
-}
-
-/* ─── Mobile: bottom-anchored sheet ─── */
+/* ── Mobile: bottom-anchored sheet for the popover; dashboard cards
+       fold to a single column with smaller dials. ── */
 @media (max-width: 540px) {
   .usage-panel {
     position: fixed;
@@ -3881,22 +4979,6 @@ html[data-theme="light"] .usage-dashboard-error {
     overflow-y: auto;
     padding: 16px 16px 14px;
     border-radius: var(--radius);
-  }
-
-  /* Dashboard cards flow inline even on mobile — the fixed-sheet
-     positioning above is only meant for the floating popover. */
-  .usage-dashboard-card.usage-panel {
-    position: relative;
-    inset: auto;
-    left: auto;
-    right: auto;
-    bottom: auto;
-    max-height: none;
-    overflow-y: visible;
-  }
-
-  .usage-dashboard-cards {
-    grid-template-columns: minmax(0, 1fr);
   }
 
   .usage-numeral strong {
@@ -3920,6 +5002,98 @@ html[data-theme="light"] .usage-dashboard-error {
 
   .usage-window-head {
     flex-wrap: wrap;
+  }
+
+  /*  Deck collapses to a single column; dials shrink and align center. */
+  .usage-deck-toggle {
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    gap: 10px;
+    padding: 12px 14px;
+  }
+
+  .usage-deck-toggle-summary {
+    display: none;
+  }
+
+  .usage-deck-toggle-title {
+    font-size: 1rem;
+  }
+
+  .usage-deck-body {
+    padding: 14px 14px 18px;
+    gap: 14px;
+  }
+
+  .usage-deck-status {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto;
+    gap: 10px 12px;
+    padding: 10px 12px;
+  }
+
+  .usage-deck-status-actions {
+    grid-column: 1 / -1;
+    justify-content: space-between;
+  }
+
+  .usage-deck-grid,
+  .usage-deck-grid[data-bucket-count="2"],
+  .usage-deck-grid[data-bucket-count="3"],
+  .usage-deck-grid[data-bucket-count="4"],
+  .usage-deck-grid[data-bucket-count="5"],
+  .usage-deck-grid[data-bucket-count="6"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .usage-deck-grid > * {
+    grid-column: auto;
+  }
+
+  .usage-instrument {
+    padding: 16px 16px 14px;
+  }
+
+  .usage-instrument-rivet {
+    width: 5px;
+    height: 5px;
+  }
+
+  .usage-instrument-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .usage-instrument-meta {
+    align-self: flex-end;
+  }
+
+  .usage-instrument-title {
+    font-size: 1.02rem;
+  }
+
+  .usage-instrument-dials {
+    grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+    gap: 14px;
+  }
+
+  .usage-instrument.emphasis-primary .usage-instrument-dials {
+    gap: 18px;
+  }
+
+  .usage-dial-svg {
+    max-width: 130px;
+  }
+
+  .usage-dial.size-md .usage-dial-svg {
+    max-width: 110px;
+  }
+
+  .usage-dial-percent strong {
+    font-size: 1.55rem;
+  }
+
+  .usage-instrument-footer-row {
+    gap: 14px 18px;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2938,17 +2938,6 @@ html[data-theme="light"] .inline-code {
   word-break: break-word;
 }
 
-.usage-card {
-  display: grid;
-  gap: 12px;
-}
-
-.usage-grid {
-  display: grid;
-  gap: 12px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
 /* ─── Scroll controls & floaters ─── */
 .scroll-controls {
   position: sticky;
@@ -3715,6 +3704,171 @@ html[data-theme="light"] .usage-meta-bullet {
   color: rgba(184, 130, 14, 0.5);
 }
 
+/* ─── Usage dashboard (home-page section) ─── */
+.usage-dashboard {
+  padding: 0;
+  overflow: hidden;
+}
+
+.usage-dashboard-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  background: transparent;
+  border: none;
+  color: var(--muted-soft);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  cursor: pointer;
+  text-align: left;
+  transition: color 140ms ease, background-color 140ms ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.usage-dashboard-toggle:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.025);
+}
+
+html[data-theme="light"] .usage-dashboard-toggle {
+  color: var(--muted);
+}
+
+html[data-theme="light"] .usage-dashboard-toggle:hover {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.usage-dashboard.open .usage-dashboard-toggle {
+  color: var(--accent);
+  border-bottom: 1px solid rgba(200, 169, 106, 0.18);
+}
+
+.usage-dashboard-toggle-eyebrow {
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.usage-dashboard-toggle-summary {
+  flex: 1;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.usage-dashboard-toggle-chevron {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.usage-dashboard-toggle-chevron::before,
+.usage-dashboard-toggle-chevron::after {
+  content: "";
+  position: absolute;
+  width: 5.5px;
+  height: 1.5px;
+  background: currentColor;
+  border-radius: 1px;
+  top: 50%;
+  transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.usage-dashboard-toggle-chevron::before {
+  right: 50%;
+  margin-right: -0.5px;
+  transform: translateY(-50%) rotate(-45deg);
+  transform-origin: right center;
+}
+
+.usage-dashboard-toggle-chevron::after {
+  left: 50%;
+  margin-left: -0.5px;
+  transform: translateY(-50%) rotate(45deg);
+  transform-origin: left center;
+}
+
+.usage-dashboard.open .usage-dashboard-toggle-chevron::before {
+  transform: translateY(-50%) rotate(45deg);
+}
+
+.usage-dashboard.open .usage-dashboard-toggle-chevron::after {
+  transform: translateY(-50%) rotate(-45deg);
+}
+
+.usage-dashboard-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 18px 18px;
+}
+
+.usage-dashboard-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.usage-dashboard-error {
+  margin: 0;
+  padding: 8px 12px;
+  border-radius: 6px;
+  background: rgba(220, 80, 80, 0.1);
+  color: var(--danger);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
+html[data-theme="light"] .usage-dashboard-error {
+  background: rgba(196, 64, 64, 0.1);
+}
+
+.usage-dashboard-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.usage-dashboard-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.usage-dashboard-group-title {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.usage-dashboard-cards {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+/* The .usage-panel rule positions the popover absolutely; on the
+   dashboard we want each card to flow in the grid instead, so reset
+   positioning when the panel is rendered as a dashboard card. */
+.usage-dashboard-card.usage-panel {
+  position: relative;
+  inset: auto;
+  width: auto;
+  max-width: none;
+  max-height: none;
+  margin: 0;
+  z-index: auto;
+  animation: none;
+}
+
 /* ─── Mobile: bottom-anchored sheet ─── */
 @media (max-width: 540px) {
   .usage-panel {
@@ -3727,6 +3881,22 @@ html[data-theme="light"] .usage-meta-bullet {
     overflow-y: auto;
     padding: 16px 16px 14px;
     border-radius: var(--radius);
+  }
+
+  /* Dashboard cards flow inline even on mobile — the fixed-sheet
+     positioning above is only meant for the floating popover. */
+  .usage-dashboard-card.usage-panel {
+    position: relative;
+    inset: auto;
+    left: auto;
+    right: auto;
+    bottom: auto;
+    max-height: none;
+    overflow-y: visible;
+  }
+
+  .usage-dashboard-cards {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .usage-numeral strong {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -10,6 +10,7 @@ import { LoginForm } from "@/components/LoginForm";
 import { SchedulePanel } from "@/components/SchedulePanel";
 import { SessionList } from "@/components/SessionList";
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { UsageDashboardSection } from "@/components/UsageDashboardSection";
 import { useTheme } from "@/lib/theme";
 import {
   attachTmux,
@@ -740,6 +741,14 @@ export default function HomePage() {
           onCreate={handleCreateSchedule}
           onCancel={handleCancelSchedule}
           onClearHistory={handleClearScheduleHistory}
+          onAuthFailure={handleAuthFailure}
+        />
+      ) : null}
+      {token ? (
+        <UsageDashboardSection
+          host={host}
+          token={token}
+          sessions={sessions}
           onAuthFailure={handleAuthFailure}
         />
       ) : null}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -63,6 +63,7 @@ import {
   type ToolPair,
 } from "@/components/TranscriptCard";
 import { useSwitcher } from "@/components/SwitcherProvider";
+import { UsageBar, UsageReadout } from "@/components/UsageReadout";
 import {
   BackendModelOption,
   BackendPermissionMode,
@@ -71,11 +72,15 @@ import {
   SessionCommandInvocation,
   SessionContextUsage,
   SessionEnvelope,
-  SessionRateLimitUsage,
   SessionRecord,
   SessionTransport,
-  UsageWindow,
 } from "@/lib/types";
+import {
+  clampPercent,
+  formatRelativeTime,
+  formatTokens,
+  rateLimitUsageTone,
+} from "@/lib/usage";
 
 const LOCAL_SLASH_COMPLETIONS: ReadonlyArray<CommandCompletion> = [
   {
@@ -132,34 +137,6 @@ const EFFORT_LABEL: Record<string, string> = {
   max: "Max",
 };
 
-const TOKEN_FORMATTER = new Intl.NumberFormat("en-US");
-const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("en", {
-  numeric: "auto",
-});
-
-function formatTokens(value: number): string {
-  return TOKEN_FORMATTER.format(value);
-}
-
-function formatRelativeTime(value: string): string {
-  const timestamp = Date.parse(value);
-  if (!Number.isFinite(timestamp)) {
-    return "Unknown";
-  }
-  const diffSeconds = Math.round((timestamp - Date.now()) / 1000);
-  const absSeconds = Math.abs(diffSeconds);
-  if (absSeconds < 60) {
-    return RELATIVE_TIME_FORMATTER.format(diffSeconds, "second");
-  }
-  if (absSeconds < 3600) {
-    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 60), "minute");
-  }
-  if (absSeconds < 86400) {
-    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 3600), "hour");
-  }
-  return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 86400), "day");
-}
-
 function contextUsagePercent(usage: SessionContextUsage): number | null {
   const windowTokens = usage.context_window_tokens;
   if (!windowTokens || windowTokens <= 0) {
@@ -179,102 +156,6 @@ function contextUsageTone(percent: number | null): "good" | "warn" | "danger" {
     return "warn";
   }
   return "good";
-}
-
-function clampPercent(percent: number | null): number | null {
-  if (percent === null) {
-    return null;
-  }
-  return Math.min(100, Math.max(0, percent));
-}
-
-function usageTone(percent: number | null): "good" | "warn" | "danger" {
-  if (percent === null) {
-    return "good";
-  }
-  if (percent >= 90) {
-    return "danger";
-  }
-  if (percent >= 70) {
-    return "warn";
-  }
-  return "good";
-}
-
-function rateLimitWindowPercent(window: UsageWindow): number | null {
-  if (window.used_percent < 0 || !Number.isFinite(window.used_percent)) {
-    return null;
-  }
-  return clampPercent(Math.round(window.used_percent));
-}
-
-function formatRateLimitWindowTokens(window: UsageWindow): string | null {
-  const parts: string[] = [];
-  if (window.used_tokens !== undefined && window.used_tokens !== null) {
-    parts.push(`${formatTokens(window.used_tokens)} used`);
-  }
-  if (window.remaining_tokens !== undefined && window.remaining_tokens !== null) {
-    parts.push(`${formatTokens(window.remaining_tokens)} left`);
-  }
-  if (
-    window.limit_tokens !== undefined &&
-    window.limit_tokens !== null &&
-    window.used_tokens !== undefined &&
-    window.used_tokens !== null
-  ) {
-    parts.push(`of ${formatTokens(window.limit_tokens)}`);
-  }
-  return parts.length > 0 ? parts.join(" · ") : null;
-}
-
-function formatRateLimitWindowReset(window: UsageWindow): string | null {
-  if (window.resets_at) {
-    return formatRelativeTime(window.resets_at);
-  }
-  return window.reset_description ?? null;
-}
-
-function rateLimitUsageTone(usage: SessionRateLimitUsage | null): "good" | "warn" | "danger" {
-  if (!usage || usage.windows.length === 0) {
-    return "good";
-  }
-  const worst = Math.max(
-    ...usage.windows.map((window) => rateLimitWindowPercent(window) ?? 0),
-  );
-  return usageTone(worst);
-}
-
-const USAGE_BAR_SEGMENTS = 14;
-
-function UsageBar({
-  percent,
-  tone,
-  disabled,
-}: {
-  percent: number | null;
-  tone: "good" | "warn" | "danger";
-  disabled?: boolean;
-}) {
-  const filled = !disabled && percent !== null
-    ? Math.min(
-        USAGE_BAR_SEGMENTS,
-        Math.max(0, Math.round((percent / 100) * USAGE_BAR_SEGMENTS)),
-      )
-    : 0;
-  return (
-    <div
-      className={`usage-bar tone-${tone}${disabled ? " is-disabled" : ""}`}
-      role="presentation"
-    >
-      {Array.from({ length: USAGE_BAR_SEGMENTS }, (_, index) => (
-        <span
-          key={index}
-          className={index < filled ? "is-filled" : ""}
-          style={{ animationDelay: `${index * 18}ms` }}
-        />
-      ))}
-    </div>
-  );
 }
 
 function contextUsageLabel(key: string): string {
@@ -1984,17 +1865,15 @@ const ReplyComposer = memo(function ReplyComposer({
       ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
       : formatTokens(contextUsage.used_tokens)
     : null;
-  const rateLimitUsageWindows = rateLimitUsage?.windows ?? [];
   const rateLimitUsageSummary = rateLimitUsage
-    ? rateLimitUsageWindows.length > 0
-      ? rateLimitUsageWindows
+    ? rateLimitUsage.windows.length > 0
+      ? rateLimitUsage.windows
           .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
           .join(" · ")
       : rateLimitUsage.notes?.length
         ? rateLimitUsage.notes.join(" · ")
         : null
     : null;
-  const rateLimitUpdatedAt = rateLimitUsage?.updated_at ?? null;
   const rateLimitSourceLabel = rateLimitUsage
     ? rateLimitUsage.notes?.length
       ? rateLimitUsage.notes.join(" · ")
@@ -2286,123 +2165,12 @@ const ReplyComposer = memo(function ReplyComposer({
                   ) : null}
 
                   {rateLimitUsage ? (
-                  <section className="usage-block">
-                    <header className="usage-block-head">
-                      <h3 className="usage-block-eyebrow">
-                        <span aria-hidden className="usage-block-mark">
-                          ◇
-                        </span>
-                        Rate limits
-                      </h3>
-                      <button
-                        type="button"
-                        className="usage-refresh"
-                        onClick={() => void onRateLimitRefresh()}
-                        disabled={rateLimitRefreshBusy}
-                        aria-label="Refresh rate limits"
-                      >
-                        <span
-                          aria-hidden
-                          className={`usage-refresh-glyph${rateLimitRefreshBusy ? " is-spinning" : ""}`}
-                        >
-                          ↻
-                        </span>
-                        {rateLimitRefreshBusy ? "Refreshing" : "Refresh"}
-                      </button>
-                    </header>
-
-                    {rateLimitUsageWindows.length > 0 ? (
-                      <ul className="usage-windows">
-                        {rateLimitUsageWindows.map((window) => {
-                          const percent = rateLimitWindowPercent(window);
-                          const tone = usageTone(percent);
-                          const resetText = formatRateLimitWindowReset(window);
-                          const tokenSummary = formatRateLimitWindowTokens(window);
-                          return (
-                            <li
-                              key={window.id}
-                              className={`usage-window tone-${tone}`}
-                            >
-                              <div className="usage-window-head">
-                                <span className="usage-window-label">
-                                  {window.label}
-                                </span>
-                                {resetText ? (
-                                  <span className="usage-window-reset">
-                                    <span aria-hidden className="usage-window-reset-glyph">
-                                      ◷
-                                    </span>
-                                    {resetText}
-                                  </span>
-                                ) : null}
-                              </div>
-                              <div className="usage-window-body">
-                                <div
-                                  className={`usage-numeral usage-numeral--sm tone-${tone}`}
-                                >
-                                  <strong>
-                                    {percent !== null ? percent : "—"}
-                                  </strong>
-                                  <em>%</em>
-                                </div>
-                                <UsageBar
-                                  percent={percent}
-                                  tone={tone}
-                                  disabled={percent === null}
-                                />
-                              </div>
-                              {tokenSummary ? (
-                                <p className="usage-window-tokens">{tokenSummary}</p>
-                              ) : null}
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    ) : (
-                      <p className="usage-empty">
-                        No quota tracked on this plan.
-                      </p>
-                    )}
-
-                    <footer className="usage-meta">
-                      <span className="usage-meta-cell">
-                        <em>updated</em>
-                        <span
-                          title={
-                            rateLimitUpdatedAt
-                              ? new Date(rateLimitUpdatedAt).toLocaleString()
-                              : "Unavailable"
-                          }
-                        >
-                          {rateLimitUpdatedAt
-                            ? formatRelativeTime(rateLimitUpdatedAt)
-                            : "—"}
-                        </span>
-                      </span>
-                      <i aria-hidden className="usage-meta-bullet">
-                        ·
-                      </i>
-                      <span className="usage-meta-cell">
-                        <em>source</em>
-                        <span>{rateLimitSourceLabel}</span>
-                      </span>
-                      {rateLimitUsage &&
-                      rateLimitUsage.credits_remaining !== null &&
-                      rateLimitUsage.credits_remaining !== undefined ? (
-                        <>
-                          <i aria-hidden className="usage-meta-bullet">
-                            ·
-                          </i>
-                          <span className="usage-meta-cell">
-                            <em>credits</em>
-                            <span>
-                              {`${rateLimitUsage.credits_currency ?? "credits"} ${rateLimitUsage.credits_remaining.toFixed(2)}`}
-                            </span>
-                          </span>
-                        </>
-                      ) : null}
-                    </footer>
-                  </section>
+                    <UsageReadout
+                      usage={rateLimitUsage}
+                      sourceLabel={rateLimitSourceLabel}
+                      onRefresh={onRateLimitRefresh}
+                      refreshing={rateLimitRefreshBusy}
+                    />
                   ) : null}
                 </div>
               ) : null}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -969,7 +969,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     : transcriptEvents;
   const transcriptItems = buildTranscriptItems(transcriptEventsForDisplay);
   const hasToolRuns = transcriptItems.some((item) => item.kind === "tool_run");
-  const usageSummary = extractUsageSummary(events);
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
     session && (session.status === "exited" || session.status === "error"),
@@ -1027,7 +1026,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           onSetTitle={handleSetTitle}
         />
       ) : null}
-      {usageSummary ? <UsageCard summary={usageSummary} /> : null}
       <div className="session-toolbar">
         <div className="segmented" role="tablist" aria-label="View">
           <button
@@ -2786,20 +2784,6 @@ function isImportantEvent(event: EventRecord): boolean {
   }
 }
 
-interface UsageSummary {
-  lastTurn: {
-    outputTokens: number | null;
-    totalCostUsd: number | null;
-    permissionDenials: number;
-    ts: string;
-  } | null;
-  rateLimit: {
-    status: string | null;
-    type: string | null;
-    ts: string;
-  } | null;
-}
-
 function SessionHeader({
   session,
   connection,
@@ -3025,98 +3009,11 @@ function TranscriptEmpty({
   );
 }
 
-function UsageCard({ summary }: { summary: UsageSummary }) {
-  return (
-    <section className="panel usage-card">
-      <div className="session-row">
-        <span className="badge fidelity structured">usage</span>
-        <span className="muted">Latest structured telemetry</span>
-      </div>
-      <div className="usage-grid">
-        <div>
-          <p className="meta">Last turn</p>
-          {summary.lastTurn ? (
-            <p className="muted">
-              {summary.lastTurn.totalCostUsd !== null ? `Cost ${formatUsd(summary.lastTurn.totalCostUsd)} · ` : ""}
-              {summary.lastTurn.outputTokens !== null
-                ? `${summary.lastTurn.outputTokens.toLocaleString()} output tokens`
-                : "No token count"}
-              {summary.lastTurn.permissionDenials > 0
-                ? ` · ${summary.lastTurn.permissionDenials} denial${summary.lastTurn.permissionDenials === 1 ? "" : "s"}`
-                : ""}
-            </p>
-          ) : (
-            <p className="muted">No turn usage yet.</p>
-          )}
-        </div>
-        <div>
-          <p className="meta">Rate limits</p>
-          {summary.rateLimit ? (
-            <p className="muted">
-              {summary.rateLimit.status ?? "unknown"}
-              {summary.rateLimit.type ? ` · ${summary.rateLimit.type}` : ""}
-            </p>
-          ) : (
-            <p className="muted">No rate-limit event yet.</p>
-          )}
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function sanitizeEvent(event: EventRecord): EventRecord {
   return {
     ...event,
     text: stripAnsi(event.text),
   };
-}
-
-function extractUsageSummary(events: EventRecord[]): UsageSummary | null {
-  let lastTurn: UsageSummary["lastTurn"] = null;
-  let rateLimit: UsageSummary["rateLimit"] = null;
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const event = events[index];
-    const metadata = asRecord(event.metadata);
-    if (!lastTurn && metadata?.method === "result") {
-      const payload = asRecord(metadata.payload);
-      const usage = asRecord(payload?.usage);
-      const permissionDenials = Array.isArray(payload?.permission_denials) ? payload.permission_denials.length : 0;
-      lastTurn = {
-        outputTokens: typeof usage?.output_tokens === "number" ? usage.output_tokens : null,
-        totalCostUsd: typeof payload?.total_cost_usd === "number" ? payload.total_cost_usd : null,
-        permissionDenials,
-        ts: event.ts,
-      };
-    }
-    if (!rateLimit && metadata?.method === "rate_limit_event") {
-      const payload = asRecord(metadata.payload);
-      const info = asRecord(payload?.rate_limit_info);
-      rateLimit = {
-        status: typeof info?.status === "string" ? info.status : null,
-        type: typeof info?.rate_limit_type === "string" ? info.rate_limit_type : null,
-        ts: event.ts,
-      };
-    }
-    if (lastTurn && rateLimit) {
-      break;
-    }
-  }
-  if (!lastTurn && !rateLimit) {
-    return null;
-  }
-  return { lastTurn, rateLimit };
-}
-
-function asRecord(value: unknown): Record<string, unknown> | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return null;
-  }
-  return value as Record<string, unknown>;
-}
-
-function formatUsd(value: number): string {
-  return `$${value.toFixed(4)}`;
 }
 
 function stripAnsi(text: string): string {

--- a/frontend/src/components/UsageDashboardSection.tsx
+++ b/frontend/src/components/UsageDashboardSection.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { UsageReadout } from "@/components/UsageReadout";
+import { humaniseBackend } from "@/lib/backends";
+import {
+  fetchUsageDashboard,
+  isAuthError,
+  refreshUsageDashboard,
+} from "@/lib/api";
+import { readUsageDashboardOpen, writeUsageDashboardOpen } from "@/lib/store";
+import {
+  Backend,
+  SessionRecord,
+  UsageDashboardBucket,
+  UsageDashboardResponse,
+} from "@/lib/types";
+import { rateLimitUsageTone } from "@/lib/usage";
+
+interface UsageDashboardSectionProps {
+  host: string;
+  token: string;
+  sessions: SessionRecord[];
+  onAuthFailure?: () => void;
+}
+
+function deriveBucketsFromSessions(
+  sessions: SessionRecord[],
+): UsageDashboardBucket[] {
+  const buckets = new Map<string, UsageDashboardBucket>();
+  for (const session of sessions) {
+    const snapshot = session.rate_limit_usage;
+    if (!snapshot) continue;
+    const { key, label } = accountBucketKey(session.id, snapshot.source, snapshot.notes ?? []);
+    const existing = buckets.get(key);
+    if (!existing) {
+      buckets.set(key, {
+        backend: snapshot.source,
+        account_key: key,
+        account_label: label,
+        snapshot,
+        session_ids: [session.id],
+      });
+      continue;
+    }
+    existing.session_ids.push(session.id);
+    if (Date.parse(snapshot.updated_at) > Date.parse(existing.snapshot.updated_at)) {
+      existing.snapshot = snapshot;
+      existing.account_label = label;
+    }
+  }
+  return Array.from(buckets.values()).sort((a, b) => {
+    if (a.backend !== b.backend) return a.backend < b.backend ? -1 : 1;
+    return Date.parse(b.snapshot.updated_at) - Date.parse(a.snapshot.updated_at);
+  });
+}
+
+function accountBucketKey(
+  sessionId: string,
+  source: Backend,
+  notes: string[],
+): { key: string; label: string } {
+  if (source === "claude_code") {
+    const org = findPrefixed(notes, "org: ");
+    if (org) {
+      const tier = findPrefixed(notes, "org tier: ");
+      return { key: `claude_code:${org}`, label: tier ? `${org} · ${tier}` : org };
+    }
+  } else if (source === "codex") {
+    const email = findEmail(notes);
+    if (email) {
+      const plan = findPrefixed(notes, "plan: ");
+      return {
+        key: `codex:${email}`,
+        label: plan ? `${email} · plan: ${plan}` : email,
+      };
+    }
+  }
+  return {
+    key: `${source}:session:${sessionId}`,
+    label: humaniseBackend(source),
+  };
+}
+
+function findPrefixed(notes: string[], prefix: string): string | null {
+  for (const note of notes) {
+    if (note.startsWith(prefix)) {
+      const value = note.slice(prefix.length).trim();
+      if (value) return value;
+    }
+  }
+  return null;
+}
+
+function findEmail(notes: string[]): string | null {
+  for (const note of notes) {
+    if (note === "CLI OAuth" || note === "remote OAuth") continue;
+    if (note.startsWith("plan: ")) continue;
+    if (note.includes("@") && !note.includes(" ")) return note;
+  }
+  return null;
+}
+
+function bucketSourceLabel(bucket: UsageDashboardBucket): string {
+  const notes = bucket.snapshot.notes ?? [];
+  if (notes.length > 0) return notes.join(" · ");
+  return humaniseBackend(bucket.backend);
+}
+
+export function UsageDashboardSection({
+  host,
+  token,
+  sessions,
+  onAuthFailure,
+}: UsageDashboardSectionProps) {
+  const [open, setOpen] = useState(false);
+  const [buckets, setBuckets] = useState<UsageDashboardBucket[] | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshingBucketId, setRefreshingBucketId] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setOpen(readUsageDashboardOpen());
+  }, []);
+
+  // WS sessions stream is the source of truth — re-derive on every change so
+  // the dashboard stays in lockstep without an extra round-trip.
+  useEffect(() => {
+    setBuckets(deriveBucketsFromSessions(sessions));
+  }, [sessions]);
+
+  // First-load hydration: hit /api/usage so the buckets show up even before
+  // the sessions WS has settled. Same shape comes back so it merges cleanly.
+  useEffect(() => {
+    if (!host || !token) return;
+    let active = true;
+    fetchUsageDashboard(host, token)
+      .then((response: UsageDashboardResponse) => {
+        if (!active) return;
+        setBuckets(response.buckets);
+      })
+      .catch((fetchError) => {
+        if (!active) return;
+        if (isAuthError(fetchError)) {
+          onAuthFailure?.();
+          return;
+        }
+        setError(
+          fetchError instanceof Error
+            ? fetchError.message
+            : "failed to fetch usage dashboard",
+        );
+      });
+    return () => {
+      active = false;
+    };
+  }, [host, token, onAuthFailure]);
+
+  const toggleOpen = useCallback(() => {
+    setOpen((current) => {
+      const next = !current;
+      writeUsageDashboardOpen(next);
+      return next;
+    });
+  }, []);
+
+  const handleRefreshAll = useCallback(async () => {
+    setRefreshing(true);
+    setError("");
+    try {
+      const response = await refreshUsageDashboard(host, token);
+      setBuckets(response.buckets);
+    } catch (refreshError) {
+      if (isAuthError(refreshError)) {
+        onAuthFailure?.();
+        return;
+      }
+      setError(
+        refreshError instanceof Error
+          ? refreshError.message
+          : "failed to refresh usage",
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  }, [host, token, onAuthFailure]);
+
+  const handleRefreshBucket = useCallback(
+    async (bucket: UsageDashboardBucket) => {
+      setRefreshingBucketId(bucket.account_key);
+      setError("");
+      try {
+        // Refresh-all is the only endpoint we have; it covers every bucket
+        // in one shot, so a per-card refresh fires the same call. The WS
+        // push merges the result back via `sessions` above.
+        const response = await refreshUsageDashboard(host, token);
+        setBuckets(response.buckets);
+      } catch (refreshError) {
+        if (isAuthError(refreshError)) {
+          onAuthFailure?.();
+          return;
+        }
+        setError(
+          refreshError instanceof Error
+            ? refreshError.message
+            : "failed to refresh usage",
+        );
+      } finally {
+        setRefreshingBucketId(null);
+      }
+    },
+    [host, token, onAuthFailure],
+  );
+
+  const groupedByBackend = new Map<Backend, UsageDashboardBucket[]>();
+  for (const bucket of buckets ?? []) {
+    const list = groupedByBackend.get(bucket.backend) ?? [];
+    list.push(bucket);
+    groupedByBackend.set(bucket.backend, list);
+  }
+
+  return (
+    <section className={`panel stack usage-dashboard${open ? " open" : ""}`}>
+      <button
+        type="button"
+        className="usage-dashboard-toggle"
+        onClick={toggleOpen}
+        aria-expanded={open}
+      >
+        <span className="usage-dashboard-toggle-eyebrow">Usage</span>
+        <span className="usage-dashboard-toggle-summary">
+          {buckets === null
+            ? "Loading…"
+            : buckets.length === 0
+              ? "No rate-limit data yet"
+              : `${buckets.length} account${buckets.length === 1 ? "" : "s"}`}
+        </span>
+        <span className="usage-dashboard-toggle-chevron" aria-hidden="true" />
+      </button>
+      {open ? (
+        <div className="usage-dashboard-body">
+          <div className="usage-dashboard-actions">
+            <button
+              type="button"
+              className="usage-refresh"
+              onClick={() => void handleRefreshAll()}
+              disabled={refreshing || buckets === null || buckets.length === 0}
+              aria-label="Refresh all rate limits"
+            >
+              <span
+                aria-hidden
+                className={`usage-refresh-glyph${refreshing ? " is-spinning" : ""}`}
+              >
+                ↻
+              </span>
+              {refreshing ? "Refreshing" : "Refresh all"}
+            </button>
+          </div>
+          {error ? (
+            <p className="usage-dashboard-error" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {buckets === null ? (
+            <p className="muted">Loading rate-limit usage…</p>
+          ) : buckets.length === 0 ? (
+            <p className="muted">
+              No rate-limit data yet — start a Claude Code or Codex session.
+            </p>
+          ) : (
+            <div className="usage-dashboard-grid">
+              {Array.from(groupedByBackend.entries()).map(([backend, list]) => (
+                <div key={backend} className="usage-dashboard-group">
+                  <h2 className="usage-dashboard-group-title">
+                    {humaniseBackend(backend)}
+                  </h2>
+                  <div className="usage-dashboard-cards">
+                    {list.map((bucket) => {
+                      const tone = rateLimitUsageTone(bucket.snapshot);
+                      return (
+                        <article
+                          key={bucket.account_key}
+                          className={`usage-dashboard-card usage-panel tone-${tone}`}
+                        >
+                          <span className="usage-panel-rail" aria-hidden="true" />
+                          <UsageReadout
+                            usage={bucket.snapshot}
+                            headerLabel={bucket.account_label}
+                            headerEyebrow={`${bucket.session_ids.length} session${bucket.session_ids.length === 1 ? "" : "s"}`}
+                            sourceLabel={bucketSourceLabel(bucket)}
+                            onRefresh={() => handleRefreshBucket(bucket)}
+                            refreshing={refreshingBucketId === bucket.account_key}
+                          />
+                        </article>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/UsageDashboardSection.tsx
+++ b/frontend/src/components/UsageDashboardSection.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { UsageReadout } from "@/components/UsageReadout";
+import { UsageInstrumentPanel } from "@/components/UsageInstrumentPanel";
 import { humaniseBackend } from "@/lib/backends";
 import {
   fetchUsageDashboard,
@@ -16,7 +16,11 @@ import {
   UsageDashboardBucket,
   UsageDashboardResponse,
 } from "@/lib/types";
-import { rateLimitUsageTone } from "@/lib/usage";
+import {
+  formatRelativeTime,
+  rateLimitUsageTone,
+  UsageTone,
+} from "@/lib/usage";
 
 interface UsageDashboardSectionProps {
   host: string;
@@ -32,7 +36,11 @@ function deriveBucketsFromSessions(
   for (const session of sessions) {
     const snapshot = session.rate_limit_usage;
     if (!snapshot) continue;
-    const { key, label } = accountBucketKey(session.id, snapshot.source, snapshot.notes ?? []);
+    const { key, label } = accountBucketKey(
+      session.id,
+      snapshot.source,
+      snapshot.notes ?? [],
+    );
     const existing = buckets.get(key);
     if (!existing) {
       buckets.set(key, {
@@ -50,10 +58,7 @@ function deriveBucketsFromSessions(
       existing.account_label = label;
     }
   }
-  return Array.from(buckets.values()).sort((a, b) => {
-    if (a.backend !== b.backend) return a.backend < b.backend ? -1 : 1;
-    return Date.parse(b.snapshot.updated_at) - Date.parse(a.snapshot.updated_at);
-  });
+  return Array.from(buckets.values()).sort(orderByToneThenBackend);
 }
 
 function accountBucketKey(
@@ -102,10 +107,73 @@ function findEmail(notes: string[]): string | null {
   return null;
 }
 
-function bucketSourceLabel(bucket: UsageDashboardBucket): string {
-  const notes = bucket.snapshot.notes ?? [];
-  if (notes.length > 0) return notes.join(" · ");
-  return humaniseBackend(bucket.backend);
+function toneRank(tone: UsageTone): number {
+  if (tone === "danger") return 0;
+  if (tone === "warn") return 1;
+  return 2;
+}
+
+function orderByToneThenBackend(
+  a: UsageDashboardBucket,
+  b: UsageDashboardBucket,
+): number {
+  const aTone = toneRank(rateLimitUsageTone(a.snapshot));
+  const bTone = toneRank(rateLimitUsageTone(b.snapshot));
+  if (aTone !== bTone) return aTone - bTone;
+  if (a.backend !== b.backend) return a.backend < b.backend ? -1 : 1;
+  return Date.parse(b.snapshot.updated_at) - Date.parse(a.snapshot.updated_at);
+}
+
+function describeStatus(buckets: UsageDashboardBucket[]): {
+  headline: string;
+  detail: string;
+  tone: UsageTone;
+  freshest: string | null;
+} {
+  if (buckets.length === 0) {
+    return {
+      headline: "Standing by",
+      detail: "No active accounts",
+      tone: "good",
+      freshest: null,
+    };
+  }
+  let danger = 0;
+  let warn = 0;
+  let freshest: number | null = null;
+  for (const bucket of buckets) {
+    const tone = rateLimitUsageTone(bucket.snapshot);
+    if (tone === "danger") danger += 1;
+    else if (tone === "warn") warn += 1;
+    const ts = Date.parse(bucket.snapshot.updated_at);
+    if (Number.isFinite(ts) && (freshest === null || ts > freshest)) {
+      freshest = ts;
+    }
+  }
+  const freshestIso =
+    freshest !== null ? new Date(freshest).toISOString() : null;
+  if (danger > 0) {
+    return {
+      headline: "Quota critical",
+      detail: `${danger} account${danger === 1 ? "" : "s"} above 90%`,
+      tone: "danger",
+      freshest: freshestIso,
+    };
+  }
+  if (warn > 0) {
+    return {
+      headline: "Approaching limit",
+      detail: `${warn} account${warn === 1 ? "" : "s"} above 70%`,
+      tone: "warn",
+      freshest: freshestIso,
+    };
+  }
+  return {
+    headline: "All clear",
+    detail: `${buckets.length} account${buckets.length === 1 ? "" : "s"} nominal`,
+    tone: "good",
+    freshest: freshestIso,
+  };
 }
 
 export function UsageDashboardSection({
@@ -124,21 +192,18 @@ export function UsageDashboardSection({
     setOpen(readUsageDashboardOpen());
   }, []);
 
-  // WS sessions stream is the source of truth — re-derive on every change so
-  // the dashboard stays in lockstep without an extra round-trip.
   useEffect(() => {
     setBuckets(deriveBucketsFromSessions(sessions));
   }, [sessions]);
 
-  // First-load hydration: hit /api/usage so the buckets show up even before
-  // the sessions WS has settled. Same shape comes back so it merges cleanly.
   useEffect(() => {
     if (!host || !token) return;
     let active = true;
     fetchUsageDashboard(host, token)
       .then((response: UsageDashboardResponse) => {
         if (!active) return;
-        setBuckets(response.buckets);
+        const ordered = [...response.buckets].sort(orderByToneThenBackend);
+        setBuckets(ordered);
       })
       .catch((fetchError) => {
         if (!active) return;
@@ -170,7 +235,7 @@ export function UsageDashboardSection({
     setError("");
     try {
       const response = await refreshUsageDashboard(host, token);
-      setBuckets(response.buckets);
+      setBuckets([...response.buckets].sort(orderByToneThenBackend));
     } catch (refreshError) {
       if (isAuthError(refreshError)) {
         onAuthFailure?.();
@@ -191,11 +256,8 @@ export function UsageDashboardSection({
       setRefreshingBucketId(bucket.account_key);
       setError("");
       try {
-        // Refresh-all is the only endpoint we have; it covers every bucket
-        // in one shot, so a per-card refresh fires the same call. The WS
-        // push merges the result back via `sessions` above.
         const response = await refreshUsageDashboard(host, token);
-        setBuckets(response.buckets);
+        setBuckets([...response.buckets].sort(orderByToneThenBackend));
       } catch (refreshError) {
         if (isAuthError(refreshError)) {
           onAuthFailure?.();
@@ -213,90 +275,119 @@ export function UsageDashboardSection({
     [host, token, onAuthFailure],
   );
 
-  const groupedByBackend = new Map<Backend, UsageDashboardBucket[]>();
-  for (const bucket of buckets ?? []) {
-    const list = groupedByBackend.get(bucket.backend) ?? [];
-    list.push(bucket);
-    groupedByBackend.set(bucket.backend, list);
-  }
+  const status = useMemo(() => describeStatus(buckets ?? []), [buckets]);
+
+  const summaryLine = useMemo(() => {
+    if (buckets === null) return "Loading…";
+    if (buckets.length === 0) return "Standing by";
+    const pieces = [`${buckets.length} account${buckets.length === 1 ? "" : "s"}`];
+    if (status.tone !== "good") pieces.push(status.detail.toLowerCase());
+    return pieces.join(" · ");
+  }, [buckets, status]);
 
   return (
-    <section className={`panel stack usage-dashboard${open ? " open" : ""}`}>
+    <section
+      className={`panel stack usage-deck tone-${status.tone}${open ? " is-open" : ""}`}
+      aria-label="Telemetry"
+    >
       <button
         type="button"
-        className="usage-dashboard-toggle"
+        className="usage-deck-toggle"
         onClick={toggleOpen}
         aria-expanded={open}
       >
-        <span className="usage-dashboard-toggle-eyebrow">Usage</span>
-        <span className="usage-dashboard-toggle-summary">
-          {buckets === null
-            ? "Loading…"
-            : buckets.length === 0
-              ? "No rate-limit data yet"
-              : `${buckets.length} account${buckets.length === 1 ? "" : "s"}`}
+        <span className="usage-deck-toggle-mark" aria-hidden>
+          <span className="usage-deck-toggle-needle" />
         </span>
-        <span className="usage-dashboard-toggle-chevron" aria-hidden="true" />
+        <span className="usage-deck-toggle-titles">
+          <span className="usage-deck-toggle-eyebrow">Telemetry</span>
+          <span className="usage-deck-toggle-title">{status.headline}</span>
+        </span>
+        <span className="usage-deck-toggle-summary">{summaryLine}</span>
+        <span className="usage-deck-toggle-pips" aria-hidden>
+          {(buckets ?? []).slice(0, 6).map((bucket) => (
+            <span
+              key={bucket.account_key}
+              className={`usage-deck-pip tone-${rateLimitUsageTone(bucket.snapshot)}`}
+            />
+          ))}
+          {(buckets?.length ?? 0) > 6 ? (
+            <span className="usage-deck-pip-extra">+{(buckets?.length ?? 0) - 6}</span>
+          ) : null}
+        </span>
+        <span className="usage-deck-toggle-chevron" aria-hidden />
       </button>
+
       {open ? (
-        <div className="usage-dashboard-body">
-          <div className="usage-dashboard-actions">
-            <button
-              type="button"
-              className="usage-refresh"
-              onClick={() => void handleRefreshAll()}
-              disabled={refreshing || buckets === null || buckets.length === 0}
-              aria-label="Refresh all rate limits"
-            >
-              <span
-                aria-hidden
-                className={`usage-refresh-glyph${refreshing ? " is-spinning" : ""}`}
-              >
-                ↻
+        <div className="usage-deck-body">
+          <div className="usage-deck-status">
+            <span className="usage-deck-status-rivet" aria-hidden />
+            <div className="usage-deck-status-text">
+              <span className={`usage-deck-status-headline tone-${status.tone}`}>
+                {status.headline}
               </span>
-              {refreshing ? "Refreshing" : "Refresh all"}
-            </button>
+              <span className="usage-deck-status-detail">{status.detail}</span>
+            </div>
+            <div className="usage-deck-status-actions">
+              {status.freshest ? (
+                <span
+                  className="usage-deck-status-sweep"
+                  title={new Date(status.freshest).toLocaleString()}
+                >
+                  Last sweep · {formatRelativeTime(status.freshest)}
+                </span>
+              ) : null}
+              <button
+                type="button"
+                className="usage-deck-refresh-all"
+                onClick={() => void handleRefreshAll()}
+                disabled={
+                  refreshing || buckets === null || buckets.length === 0
+                }
+              >
+                <span
+                  aria-hidden
+                  className={`usage-deck-refresh-all-glyph${refreshing ? " is-spinning" : ""}`}
+                >
+                  ↻
+                </span>
+                {refreshing ? "Sweeping" : "Sweep all"}
+              </button>
+            </div>
           </div>
+
           {error ? (
-            <p className="usage-dashboard-error" role="alert">
+            <p className="usage-deck-error" role="alert">
               {error}
             </p>
           ) : null}
+
           {buckets === null ? (
-            <p className="muted">Loading rate-limit usage…</p>
+            <div className="usage-deck-loading">
+              <span className="usage-deck-loading-bar" aria-hidden />
+              <span className="muted">Calibrating instruments…</span>
+            </div>
           ) : buckets.length === 0 ? (
-            <p className="muted">
-              No rate-limit data yet — start a Claude Code or Codex session.
-            </p>
+            <div className="usage-deck-empty">
+              <span className="usage-deck-empty-mark" aria-hidden>
+                ⌖
+              </span>
+              <p className="usage-deck-empty-title">No accounts in range</p>
+              <p className="usage-deck-empty-sub">
+                Start a Claude Code or Codex session to begin telemetry.
+              </p>
+            </div>
           ) : (
-            <div className="usage-dashboard-grid">
-              {Array.from(groupedByBackend.entries()).map(([backend, list]) => (
-                <div key={backend} className="usage-dashboard-group">
-                  <h2 className="usage-dashboard-group-title">
-                    {humaniseBackend(backend)}
-                  </h2>
-                  <div className="usage-dashboard-cards">
-                    {list.map((bucket) => {
-                      const tone = rateLimitUsageTone(bucket.snapshot);
-                      return (
-                        <article
-                          key={bucket.account_key}
-                          className={`usage-dashboard-card usage-panel tone-${tone}`}
-                        >
-                          <span className="usage-panel-rail" aria-hidden="true" />
-                          <UsageReadout
-                            usage={bucket.snapshot}
-                            headerLabel={bucket.account_label}
-                            headerEyebrow={`${bucket.session_ids.length} session${bucket.session_ids.length === 1 ? "" : "s"}`}
-                            sourceLabel={bucketSourceLabel(bucket)}
-                            onRefresh={() => handleRefreshBucket(bucket)}
-                            refreshing={refreshingBucketId === bucket.account_key}
-                          />
-                        </article>
-                      );
-                    })}
-                  </div>
-                </div>
+            <div className="usage-deck-grid" data-bucket-count={buckets.length}>
+              {buckets.map((bucket, i) => (
+                <UsageInstrumentPanel
+                  key={bucket.account_key}
+                  bucket={bucket}
+                  emphasis={i === 0 && buckets.length > 1 ? "primary" : "secondary"}
+                  index={i}
+                  onRefresh={() => handleRefreshBucket(bucket)}
+                  refreshing={refreshingBucketId === bucket.account_key}
+                />
               ))}
             </div>
           )}

--- a/frontend/src/components/UsageDial.tsx
+++ b/frontend/src/components/UsageDial.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { UsageTone } from "@/lib/usage";
+
+interface UsageDialProps {
+  percent: number | null;
+  tone: UsageTone;
+  label: string;
+  caption?: string | null;
+  size?: "lg" | "md";
+}
+
+const ARC_START = 135;
+const ARC_END = 405;
+const ARC_SWEEP = ARC_END - ARC_START;
+const RADIUS = 56;
+const CENTER = 72;
+const VIEWBOX = 144;
+const STROKE_WIDTH = 8;
+const TICK_COUNT = 13;
+
+function polar(angleDeg: number, r: number): [number, number] {
+  const rad = (Math.PI / 180) * angleDeg;
+  return [CENTER + r * Math.cos(rad), CENTER + r * Math.sin(rad)];
+}
+
+function arcPath(startDeg: number, endDeg: number, r: number): string {
+  const [sx, sy] = polar(startDeg, r);
+  const [ex, ey] = polar(endDeg, r);
+  const largeArc = endDeg - startDeg > 180 ? 1 : 0;
+  return `M ${sx} ${sy} A ${r} ${r} 0 ${largeArc} 1 ${ex} ${ey}`;
+}
+
+export function UsageDial({
+  percent,
+  tone,
+  label,
+  caption,
+  size = "lg",
+}: UsageDialProps) {
+  const safePercent = percent === null ? 0 : Math.max(0, Math.min(100, percent));
+  const fillEndDeg = ARC_START + (ARC_SWEEP * safePercent) / 100;
+  const needleDeg = fillEndDeg;
+  const trackPath = arcPath(ARC_START, ARC_END, RADIUS);
+  const fillPath = percent === null ? "" : arcPath(ARC_START, fillEndDeg, RADIUS);
+
+  const ticks = Array.from({ length: TICK_COUNT }, (_, i) => {
+    const angle = ARC_START + (ARC_SWEEP * i) / (TICK_COUNT - 1);
+    const inner = i % 3 === 0 ? RADIUS - 14 : RADIUS - 9;
+    const [x1, y1] = polar(angle, RADIUS - 4);
+    const [x2, y2] = polar(angle, inner);
+    return { x1, y1, x2, y2, major: i % 3 === 0, angle };
+  });
+
+  const [needleTipX, needleTipY] = polar(needleDeg, RADIUS - 6);
+  const [needleBaseX, needleBaseY] = polar(needleDeg + 180, 10);
+
+  return (
+    <div className={`usage-dial size-${size} tone-${tone}`}>
+      <svg
+        viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+        className="usage-dial-svg"
+        role="img"
+        aria-label={
+          percent === null
+            ? `${label}: no data`
+            : `${label}: ${Math.round(safePercent)}%`
+        }
+      >
+        <defs>
+          <radialGradient id="usage-dial-face" cx="50%" cy="42%" r="62%">
+            <stop offset="0%" stopColor="rgba(35, 41, 54, 0.92)" />
+            <stop offset="78%" stopColor="rgba(14, 18, 26, 0.96)" />
+            <stop offset="100%" stopColor="rgba(6, 8, 12, 1)" />
+          </radialGradient>
+          <radialGradient id="usage-dial-face-light" cx="50%" cy="42%" r="62%">
+            <stop offset="0%" stopColor="rgba(255, 252, 244, 1)" />
+            <stop offset="80%" stopColor="rgba(244, 237, 220, 1)" />
+            <stop offset="100%" stopColor="rgba(228, 216, 188, 1)" />
+          </radialGradient>
+        </defs>
+
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS + 6}
+          className="usage-dial-bezel"
+        />
+        <circle
+          cx={CENTER}
+          cy={CENTER}
+          r={RADIUS + 2}
+          className="usage-dial-face"
+        />
+
+        {ticks.map((tick, i) => (
+          <line
+            key={i}
+            x1={tick.x1}
+            y1={tick.y1}
+            x2={tick.x2}
+            y2={tick.y2}
+            className={`usage-dial-tick${tick.major ? " is-major" : ""}`}
+          />
+        ))}
+
+        <path
+          d={trackPath}
+          className="usage-dial-track"
+          fill="none"
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap="round"
+        />
+
+        {percent !== null ? (
+          <path
+            d={fillPath}
+            className="usage-dial-fill"
+            fill="none"
+            strokeWidth={STROKE_WIDTH}
+            strokeLinecap="round"
+          />
+        ) : null}
+
+        {percent !== null ? (
+          <>
+            <line
+              x1={needleBaseX}
+              y1={needleBaseY}
+              x2={needleTipX}
+              y2={needleTipY}
+              className="usage-dial-needle"
+              strokeLinecap="round"
+            />
+            <circle
+              cx={CENTER}
+              cy={CENTER}
+              r={5}
+              className="usage-dial-hub"
+            />
+            <circle
+              cx={CENTER}
+              cy={CENTER}
+              r={2}
+              className="usage-dial-hub-cap"
+            />
+          </>
+        ) : (
+          <text
+            x={CENTER}
+            y={CENTER + 4}
+            className="usage-dial-empty"
+            textAnchor="middle"
+          >
+            —
+          </text>
+        )}
+      </svg>
+
+      <div className="usage-dial-readout">
+        <span className="usage-dial-percent">
+          <strong>{percent === null ? "—" : Math.round(safePercent)}</strong>
+          <em>%</em>
+        </span>
+        <span className="usage-dial-label">{label}</span>
+        {caption ? <span className="usage-dial-caption">{caption}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/UsageInstrumentPanel.tsx
+++ b/frontend/src/components/UsageInstrumentPanel.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { UsageDial } from "@/components/UsageDial";
+import { humaniseBackend } from "@/lib/backends";
+import { UsageDashboardBucket } from "@/lib/types";
+import {
+  formatRateLimitWindowReset,
+  formatRelativeTime,
+  rateLimitUsageTone,
+  rateLimitWindowPercent,
+  usageTone,
+} from "@/lib/usage";
+
+interface UsageInstrumentPanelProps {
+  bucket: UsageDashboardBucket;
+  emphasis?: "primary" | "secondary";
+  onRefresh?: () => void | Promise<void>;
+  refreshing?: boolean;
+  index?: number;
+}
+
+function bucketDetailNotes(bucket: UsageDashboardBucket): string[] {
+  const notes = bucket.snapshot.notes ?? [];
+  return notes.filter(
+    (note) => note !== "CLI OAuth" && note !== "remote OAuth",
+  );
+}
+
+export function UsageInstrumentPanel({
+  bucket,
+  emphasis = "secondary",
+  onRefresh,
+  refreshing = false,
+  index = 0,
+}: UsageInstrumentPanelProps) {
+  const tone = rateLimitUsageTone(bucket.snapshot);
+  const windows = bucket.snapshot.windows;
+  const sessionCount = bucket.session_ids.length;
+  const detailNotes = bucketDetailNotes(bucket);
+  const updatedLabel = formatRelativeTime(bucket.snapshot.updated_at);
+  const credits = bucket.snapshot.credits_remaining;
+  const currency = bucket.snapshot.credits_currency ?? "credits";
+
+  return (
+    <article
+      className={`usage-instrument tone-${tone} emphasis-${emphasis}`}
+      style={{
+        // Stagger reveal on mount — `--enter-delay` is consumed by the
+        // CSS animation defined alongside the panel.
+        ["--enter-delay" as string]: `${index * 80}ms`,
+      }}
+    >
+      <span className="usage-instrument-rivet usage-instrument-rivet--tl" aria-hidden />
+      <span className="usage-instrument-rivet usage-instrument-rivet--tr" aria-hidden />
+      <span className="usage-instrument-rivet usage-instrument-rivet--bl" aria-hidden />
+      <span className="usage-instrument-rivet usage-instrument-rivet--br" aria-hidden />
+
+      <header className="usage-instrument-head">
+        <div className="usage-instrument-plaque">
+          <span className="usage-instrument-eyebrow">
+            {humaniseBackend(bucket.backend)}
+          </span>
+          <h3 className="usage-instrument-title">{bucket.account_label}</h3>
+        </div>
+        <div className="usage-instrument-meta">
+          <span className={`usage-instrument-status tone-${tone}`}>
+            <span aria-hidden className="usage-instrument-status-dot" />
+            {tone === "danger"
+              ? "Critical"
+              : tone === "warn"
+                ? "Approaching"
+                : "Nominal"}
+          </span>
+          {onRefresh ? (
+            <button
+              type="button"
+              className="usage-instrument-refresh"
+              onClick={() => void onRefresh()}
+              disabled={refreshing}
+              aria-label={`Refresh ${bucket.account_label}`}
+              title="Refresh"
+            >
+              <span
+                aria-hidden
+                className={`usage-instrument-refresh-glyph${refreshing ? " is-spinning" : ""}`}
+              >
+                ↻
+              </span>
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="usage-instrument-body">
+        {windows.length > 0 ? (
+          <div
+            className="usage-instrument-dials"
+            data-count={windows.length}
+          >
+            {windows.map((window, i) => {
+              const percent = rateLimitWindowPercent(window);
+              const windowTone = usageTone(percent);
+              const resetText = formatRateLimitWindowReset(window);
+              return (
+                <UsageDial
+                  key={`${window.id}-${i}`}
+                  percent={percent}
+                  tone={windowTone}
+                  label={window.label}
+                  caption={resetText ? `resets ${resetText}` : null}
+                  size={emphasis === "primary" ? "lg" : "md"}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          <div className="usage-instrument-empty">
+            <span className="usage-instrument-empty-mark">∅</span>
+            <p>No quota tracked on this plan.</p>
+          </div>
+        )}
+      </div>
+
+      <footer className="usage-instrument-footer">
+        <div className="usage-instrument-footer-row">
+          <span className="usage-instrument-footer-cell">
+            <em>Sessions</em>
+            <strong>{sessionCount}</strong>
+          </span>
+          <span className="usage-instrument-footer-cell">
+            <em>Sweep</em>
+            <strong title={new Date(bucket.snapshot.updated_at).toLocaleString()}>
+              {updatedLabel}
+            </strong>
+          </span>
+          {credits !== null && credits !== undefined ? (
+            <span className="usage-instrument-footer-cell">
+              <em>Credits</em>
+              <strong>{`${currency} ${credits.toFixed(2)}`}</strong>
+            </span>
+          ) : null}
+        </div>
+        {detailNotes.length > 0 ? (
+          <p className="usage-instrument-notes">
+            {detailNotes.map((note, i) => (
+              <span key={i} className="usage-instrument-note-chip">
+                {note}
+              </span>
+            ))}
+          </p>
+        ) : null}
+      </footer>
+    </article>
+  );
+}

--- a/frontend/src/components/UsageReadout.tsx
+++ b/frontend/src/components/UsageReadout.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { SessionRateLimitUsage } from "@/lib/types";
+import {
+  formatRateLimitWindowReset,
+  formatRateLimitWindowTokens,
+  formatRelativeTime,
+  rateLimitWindowPercent,
+  usageTone,
+  UsageTone,
+} from "@/lib/usage";
+
+const USAGE_BAR_SEGMENTS = 14;
+
+export function UsageBar({
+  percent,
+  tone,
+  disabled,
+}: {
+  percent: number | null;
+  tone: UsageTone;
+  disabled?: boolean;
+}) {
+  const filled =
+    !disabled && percent !== null
+      ? Math.min(
+          USAGE_BAR_SEGMENTS,
+          Math.max(0, Math.round((percent / 100) * USAGE_BAR_SEGMENTS)),
+        )
+      : 0;
+  return (
+    <div
+      className={`usage-bar tone-${tone}${disabled ? " is-disabled" : ""}`}
+      role="presentation"
+    >
+      {Array.from({ length: USAGE_BAR_SEGMENTS }, (_, index) => (
+        <span
+          key={index}
+          className={index < filled ? "is-filled" : ""}
+          style={{ animationDelay: `${index * 18}ms` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface UsageReadoutProps {
+  usage: SessionRateLimitUsage;
+  headerLabel?: string;
+  headerEyebrow?: string;
+  sourceLabel: string;
+  onRefresh?: () => void | Promise<void>;
+  refreshing?: boolean;
+}
+
+export function UsageReadout({
+  usage,
+  headerLabel = "Rate limits",
+  headerEyebrow,
+  sourceLabel,
+  onRefresh,
+  refreshing = false,
+}: UsageReadoutProps) {
+  const windows = usage.windows;
+  return (
+    <section className="usage-block">
+      <header className="usage-block-head">
+        <h3 className="usage-block-eyebrow">
+          <span aria-hidden className="usage-block-mark">
+            ◇
+          </span>
+          {headerLabel}
+        </h3>
+        {headerEyebrow ? (
+          <span className="usage-block-tag">{headerEyebrow}</span>
+        ) : null}
+        {onRefresh ? (
+          <button
+            type="button"
+            className="usage-refresh"
+            onClick={() => void onRefresh()}
+            disabled={refreshing}
+            aria-label={`Refresh ${headerLabel.toLowerCase()}`}
+          >
+            <span
+              aria-hidden
+              className={`usage-refresh-glyph${refreshing ? " is-spinning" : ""}`}
+            >
+              ↻
+            </span>
+            {refreshing ? "Refreshing" : "Refresh"}
+          </button>
+        ) : null}
+      </header>
+
+      {windows.length > 0 ? (
+        <ul className="usage-windows">
+          {windows.map((window) => {
+            const percent = rateLimitWindowPercent(window);
+            const tone = usageTone(percent);
+            const resetText = formatRateLimitWindowReset(window);
+            const tokenSummary = formatRateLimitWindowTokens(window);
+            return (
+              <li key={window.id} className={`usage-window tone-${tone}`}>
+                <div className="usage-window-head">
+                  <span className="usage-window-label">{window.label}</span>
+                  {resetText ? (
+                    <span className="usage-window-reset">
+                      <span aria-hidden className="usage-window-reset-glyph">
+                        ◷
+                      </span>
+                      {resetText}
+                    </span>
+                  ) : null}
+                </div>
+                <div className="usage-window-body">
+                  <div
+                    className={`usage-numeral usage-numeral--sm tone-${tone}`}
+                  >
+                    <strong>{percent !== null ? percent : "—"}</strong>
+                    <em>%</em>
+                  </div>
+                  <UsageBar
+                    percent={percent}
+                    tone={tone}
+                    disabled={percent === null}
+                  />
+                </div>
+                {tokenSummary ? (
+                  <p className="usage-window-tokens">{tokenSummary}</p>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      ) : (
+        <p className="usage-empty">No quota tracked on this plan.</p>
+      )}
+
+      <footer className="usage-meta">
+        <span className="usage-meta-cell">
+          <em>updated</em>
+          <span title={new Date(usage.updated_at).toLocaleString()}>
+            {formatRelativeTime(usage.updated_at)}
+          </span>
+        </span>
+        <i aria-hidden className="usage-meta-bullet">
+          ·
+        </i>
+        <span className="usage-meta-cell">
+          <em>source</em>
+          <span>{sourceLabel}</span>
+        </span>
+        {usage.credits_remaining !== null &&
+        usage.credits_remaining !== undefined ? (
+          <>
+            <i aria-hidden className="usage-meta-bullet">
+              ·
+            </i>
+            <span className="usage-meta-cell">
+              <em>credits</em>
+              <span>
+                {`${usage.credits_currency ?? "credits"} ${usage.credits_remaining.toFixed(2)}`}
+              </span>
+            </span>
+          </>
+        ) : null}
+      </footer>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import {
   SessionCommandInvocation,
   SessionEnvelope,
   SessionRecord,
+  UsageDashboardResponse,
 } from "@/lib/types";
 
 export class AuthError extends Error {
@@ -282,6 +283,30 @@ export async function refreshSessionRateLimitUsage(
   await ensureOk(response, "failed to refresh rate-limit usage");
   const body = await response.json();
   return body.session as SessionRecord;
+}
+
+export async function fetchUsageDashboard(
+  host: string,
+  token: string,
+): Promise<UsageDashboardResponse> {
+  const response = await fetch(`${host}/api/usage`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  await ensureOk(response, "failed to fetch usage dashboard");
+  return (await response.json()) as UsageDashboardResponse;
+}
+
+export async function refreshUsageDashboard(
+  host: string,
+  token: string,
+): Promise<UsageDashboardResponse> {
+  const response = await fetch(`${host}/api/usage/refresh`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to refresh usage dashboard");
+  return (await response.json()) as UsageDashboardResponse;
 }
 
 export async function setSessionPermissionMode(

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -5,6 +5,7 @@ const TOKEN_KEY = "waypoint.token";
 const TARGETS_KEY = "waypoint.launch-targets";
 const RECENT_CWDS_KEY = "waypoint.recent-cwds";
 const RECENT_CWDS_LIMIT = 8;
+const USAGE_DASHBOARD_OPEN_KEY = "waypoint.usage-dashboard-open";
 
 export function readHost(): string {
   if (typeof window === "undefined") {
@@ -169,6 +170,24 @@ function normalizeCwd(cwd: string): string {
   const collapsed = trimmed.replace(/\/{2,}/g, "/");
   if (collapsed === "/") return collapsed;
   return collapsed.replace(/\/+$/, "");
+}
+
+export function readUsageDashboardOpen(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return window.localStorage.getItem(USAGE_DASHBOARD_OPEN_KEY) === "1";
+}
+
+export function writeUsageDashboardOpen(open: boolean): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  if (open) {
+    window.localStorage.setItem(USAGE_DASHBOARD_OPEN_KEY, "1");
+  } else {
+    window.localStorage.removeItem(USAGE_DASHBOARD_OPEN_KEY);
+  }
 }
 
 function inferBackendHost(): string {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -52,6 +52,18 @@ export interface SessionRateLimitUsage {
   notes?: string[];
 }
 
+export interface UsageDashboardBucket {
+  backend: Backend;
+  account_key: string;
+  account_label: string;
+  snapshot: SessionRateLimitUsage;
+  session_ids: string[];
+}
+
+export interface UsageDashboardResponse {
+  buckets: UsageDashboardBucket[];
+}
+
 export interface SessionRecord {
   id: string;
   backend: Backend;

--- a/frontend/src/lib/usage.ts
+++ b/frontend/src/lib/usage.ts
@@ -1,0 +1,96 @@
+import { SessionRateLimitUsage, UsageWindow } from "@/lib/types";
+
+const TOKEN_FORMATTER = new Intl.NumberFormat("en-US");
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("en", {
+  numeric: "auto",
+});
+
+export type UsageTone = "good" | "warn" | "danger";
+
+export function formatTokens(value: number): string {
+  return TOKEN_FORMATTER.format(value);
+}
+
+export function formatRelativeTime(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    return "Unknown";
+  }
+  const diffSeconds = Math.round((timestamp - Date.now()) / 1000);
+  const absSeconds = Math.abs(diffSeconds);
+  if (absSeconds < 60) {
+    return RELATIVE_TIME_FORMATTER.format(diffSeconds, "second");
+  }
+  if (absSeconds < 3600) {
+    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 60), "minute");
+  }
+  if (absSeconds < 86400) {
+    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 3600), "hour");
+  }
+  return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 86400), "day");
+}
+
+export function clampPercent(percent: number | null): number | null {
+  if (percent === null) {
+    return null;
+  }
+  return Math.min(100, Math.max(0, percent));
+}
+
+export function usageTone(percent: number | null): UsageTone {
+  if (percent === null) {
+    return "good";
+  }
+  if (percent >= 90) {
+    return "danger";
+  }
+  if (percent >= 70) {
+    return "warn";
+  }
+  return "good";
+}
+
+export function rateLimitWindowPercent(window: UsageWindow): number | null {
+  if (window.used_percent < 0 || !Number.isFinite(window.used_percent)) {
+    return null;
+  }
+  return clampPercent(Math.round(window.used_percent));
+}
+
+export function formatRateLimitWindowTokens(window: UsageWindow): string | null {
+  const parts: string[] = [];
+  if (window.used_tokens !== undefined && window.used_tokens !== null) {
+    parts.push(`${formatTokens(window.used_tokens)} used`);
+  }
+  if (window.remaining_tokens !== undefined && window.remaining_tokens !== null) {
+    parts.push(`${formatTokens(window.remaining_tokens)} left`);
+  }
+  if (
+    window.limit_tokens !== undefined &&
+    window.limit_tokens !== null &&
+    window.used_tokens !== undefined &&
+    window.used_tokens !== null
+  ) {
+    parts.push(`of ${formatTokens(window.limit_tokens)}`);
+  }
+  return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+export function formatRateLimitWindowReset(window: UsageWindow): string | null {
+  if (window.resets_at) {
+    return formatRelativeTime(window.resets_at);
+  }
+  return window.reset_description ?? null;
+}
+
+export function rateLimitUsageTone(
+  usage: SessionRateLimitUsage | null,
+): UsageTone {
+  if (!usage || usage.windows.length === 0) {
+    return "good";
+  }
+  const worst = Math.max(
+    ...usage.windows.map((window) => rateLimitWindowPercent(window) ?? 0),
+  );
+  return usageTone(worst);
+}


### PR DESCRIPTION
## Summary

Addresses #21 (dashboard-page half). Adds a home-page "Telemetry" section that aggregates per-account rate-limit usage across all coding-agent backends and surfaces it as a brass-edged instrument deck with SVG dial gauges. Builds on the per-session popover shipped in #60.

## Changes

### Backend
- Added `backend/src/waypoint/usage_dashboard.py` with `account_bucket_for()` (Claude org+tier, Codex email+plan, session-scoped fallback) and `build_dashboard()` that groups sessions by `(backend, account_key)` and keeps the freshest snapshot per bucket.
- Added `GET /api/usage` and `POST /api/usage/refresh`. The refresh endpoint awaits the inline per-bucket probe via `runtime.refresh_rate_limit_usage` before returning, so the HTTP response carries the post-refresh dashboard rather than racing the WS push.
- `session_ids[0]` is now the session that produced the freshest snapshot; refresh targets it so a stale/torn-down session cannot silently no-op the probe when a live one is in the same bucket.
- Added `UsageDashboardBucket` / `UsageDashboardResponse` schemas and `backend/tests/test_usage_dashboard.py` (8 tests covering account-key extraction, freshest-wins, refresh ordering, empty-payload fallthrough).

### Frontend
- Extracted `frontend/src/lib/usage.ts` (`formatTokens` / `usageTone` / `rateLimitWindowPercent` / etc.) and the shared `UsageReadout` from `SessionDetail.tsx` so the popover and the dashboard render through the same readout primitive.
- Added `UsageDashboardSection` to the home page between `SchedulePanel` and `SessionList`. Collapsible, with open/closed state persisted in `localStorage`. Hydrates from `/api/usage` then re-derives buckets from the live `sessions` WS stream so the dashboard stays in lockstep without polling.
- Built the dashboard as a "telemetry deck": brass-rail panel with a compass-rose toggle mark whose needle angle/color tracks the worst-tone bucket, a status strip ("All clear" / "Approaching limit" / "Quota critical"), and an asymmetric grid where the worst-tone bucket becomes the hero instrument.
- Added `UsageDial` (semicircular SVG gauge with ticks, sweeping needle, tone-colored arc fill) and `UsageInstrumentPanel` (instrument card with corner rivets, engraved title plaque, status pill, per-card refresh, sessions/sweep/credits footer, account-note chips).
- Removed the legacy `UsageCard` ("Cost \$X.XXXX · Y output tokens") from `SessionDetail.tsx` — the dollar-cost line was the stale piece called out on #21, and the popover plus dashboard already cover the same information.
- Mobile: single-column grid, smaller dials, status strip wraps; popover bottom-sheet behavior unchanged.

## Test Plan

- [x] `cd backend && uv run pytest` — 383 passing (8 new in `test_usage_dashboard.py`)
- [x] `cd backend && uv run pre-commit run --all-files` — black / isort / ruff / codespell / mypy clean
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] Manual (local): home page → expand Telemetry → see one bucket per (backend, account); collapse persists across reload; "Sweep all" updates buckets; force-expire Claude creds → expired-note bucket renders; session detail no longer shows the dollar-cost card.