### PR TITLE
feat: enrich slash-command autocomplete across plugins

### DIFF
--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -23,6 +23,7 @@ class PermissionModeSpec(_FrozenModel):
 class SlashCommandSpec(_FrozenModel):
     name: str
     description: str | None = None
+    argument_hint: str | None = None
 
 
 class BackendCapabilities(_FrozenModel):

--- a/backend/src/waypoint/backends/claude_code/commands.py
+++ b/backend/src/waypoint/backends/claude_code/commands.py
@@ -40,7 +40,7 @@ def frontmatter(path):
         key, value = raw.split(":", 1)
         key = key.strip()
         value = value.strip().strip("\"'")
-        if key in {"name", "description"} and value:
+        if key in {"name", "description", "argument-hint"} and value:
             data[key] = value
     return data
 
@@ -65,7 +65,33 @@ def custom_commands():
             yield {
                 "name": name,
                 "description": meta.get("description") if isinstance(meta.get("description"), str) else None,
+                "argument_hint": meta.get("argument-hint") if isinstance(meta.get("argument-hint"), str) else None,
                 "source": "custom_command",
+                "path": str(path),
+            }
+
+
+def user_skills():
+    # Workspace skills win over user skills on name collision: order
+    # matters here.
+    roots = [Path(cwd) / ".claude" / "skills", Path.home() / ".claude" / "skills"]
+    seen = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.glob("*/SKILL.md")):
+            meta = frontmatter(path)
+            name = meta.get("name") if isinstance(meta.get("name"), str) else None
+            if not name:
+                name = path.parent.name
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            yield {
+                "name": name,
+                "description": meta.get("description") if isinstance(meta.get("description"), str) else None,
+                "argument_hint": meta.get("argument-hint") if isinstance(meta.get("argument-hint"), str) else None,
+                "source": "user_skill",
                 "path": str(path),
             }
 
@@ -116,12 +142,13 @@ def plugin_skills():
             yield {
                 "name": name,
                 "description": description if isinstance(description, str) else None,
+                "argument_hint": meta.get("argument-hint") if isinstance(meta.get("argument-hint"), str) else None,
                 "source": "plugin_skill",
                 "path": path,
             }
 
 
-print(json.dumps([*custom_commands(), *plugin_skills()]))
+print(json.dumps([*custom_commands(), *user_skills(), *plugin_skills()]))
 """
 
 
@@ -143,6 +170,7 @@ async def list_claude_command_completions(
 async def _list_local_records(cwd: str, claude_bin: str) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     records.extend(_local_custom_commands(cwd))
+    records.extend(_local_user_skills(cwd))
     records.extend(await _local_plugin_skills(claude_bin))
     return records
 
@@ -167,7 +195,39 @@ def _local_custom_commands(cwd: str) -> list[dict[str, Any]]:
                 {
                     "name": name,
                     "description": _string_or_none(meta.get("description")),
+                    "argument_hint": _string_or_none(meta.get("argument-hint")),
                     "source": "custom_command",
+                    "path": str(path),
+                }
+            )
+    return records
+
+
+def _local_user_skills(cwd: str) -> list[dict[str, Any]]:
+    # Workspace `<cwd>/.claude/skills/` wins over `~/.claude/skills/` on
+    # name collision, matching how the Claude CLI itself resolves
+    # overlapping skill names.
+    roots = [
+        Path(cwd).expanduser() / ".claude" / "skills",
+        Path.home() / ".claude" / "skills",
+    ]
+    records: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for root in roots:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.glob("*/SKILL.md")):
+            meta = _frontmatter(path)
+            name = _string_or_none(meta.get("name")) or path.parent.name
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            records.append(
+                {
+                    "name": name,
+                    "description": _string_or_none(meta.get("description")),
+                    "argument_hint": _string_or_none(meta.get("argument-hint")),
+                    "source": "user_skill",
                     "path": str(path),
                 }
             )
@@ -211,6 +271,7 @@ async def _local_plugin_skills(claude_bin: str) -> list[dict[str, Any]]:
                 {
                     "name": name,
                     "description": _string_or_none(meta.get("description")),
+                    "argument_hint": _string_or_none(meta.get("argument-hint")),
                     "source": "plugin_skill",
                     "path": str(path),
                 }
@@ -274,6 +335,7 @@ def _records_to_completions(
         if command in seen:
             continue
         source = _string_or_none(record.get("source")) or "custom_command"
+        kind = "skill" if source in {"plugin_skill", "user_skill"} else "command"
         completions.append(
             CommandCompletion(
                 id=f"claude_code:{source}:{name}",
@@ -281,9 +343,10 @@ def _records_to_completions(
                 replacement=f"{command} ",
                 name=name,
                 description=_string_or_none(record.get("description")),
-                kind="skill" if source == "plugin_skill" else "command",
+                kind=kind,
                 source=source,
                 dispatch=CompletionDispatch.PLAIN_TEXT,
+                argument_hint=_string_or_none(record.get("argument_hint")),
                 metadata={"path": record.get("path")} if record.get("path") else {},
             )
         )

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -122,6 +122,7 @@ class CodexPlugin:
             SlashCommandSpec(
                 name="plan",
                 description="Switch to Codex Plan mode or plan the provided prompt",
+                argument_hint="[prompt]",
             ),
         ),
         badges={"glyph": "X", "color": "#34d399"},

--- a/backend/src/waypoint/backends/completions.py
+++ b/backend/src/waypoint/backends/completions.py
@@ -26,6 +26,7 @@ def static_slash_completions(
                 kind="command",
                 source="builtin",
                 dispatch=CompletionDispatch.PLAIN_TEXT,
+                argument_hint=spec.argument_hint,
             )
         )
     return completions

--- a/backend/src/waypoint/builtin_completions.py
+++ b/backend/src/waypoint/builtin_completions.py
@@ -1,0 +1,41 @@
+from waypoint.backends.capabilities import BackendCapabilities
+from waypoint.schemas import CommandCompletion, CompletionDispatch
+
+_NEW = CommandCompletion(
+    id="waypoint:builtin:new",
+    trigger="/",
+    replacement="/new ",
+    name="new",
+    description="Start a new session with the same settings",
+    kind="session_control",
+    source="waypoint",
+    dispatch=CompletionDispatch.FRONTEND_CONTROL,
+)
+_FORK = CommandCompletion(
+    id="waypoint:builtin:fork",
+    trigger="/",
+    replacement="/fork ",
+    name="fork",
+    description="Fork this session into a new branch",
+    kind="session_control",
+    source="waypoint",
+    dispatch=CompletionDispatch.FRONTEND_CONTROL,
+)
+
+
+def waypoint_builtin_completions(
+    capabilities: BackendCapabilities,
+    *,
+    trigger: str,
+) -> list[CommandCompletion]:
+    """Waypoint-level completions surfaced for every plugin.
+
+    Dispatch is ``FRONTEND_CONTROL`` so the frontend handles them locally
+    without round-tripping through the backend command pipeline.
+    """
+    if trigger != "/":
+        return []
+    completions = [_NEW]
+    if capabilities.supports_fork:
+        completions.append(_FORK)
+    return completions

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -484,11 +484,10 @@ class SessionRuntime:
             self._warm_command_completions(refreshed)
 
     def _warm_command_completions(self, session: SessionRecord) -> None:
-        # Remote discovery can involve SSH and user-specific shell startup.
-        # Keep automatic warming local; remote sessions still use the same
-        # stale-while-revalidate path when the user opens autocomplete.
-        if session.launch_target_id is not None:
-            return
+        # SSH-launched sessions pay an upfront discovery cost (a one-off
+        # remote shell + plugin-list call), traded for an instant first
+        # `/` press in the composer. Stale-while-revalidate handles
+        # subsequent refreshes the same way it does for local sessions.
         try:
             transport = self.transport_for(session)
         except KeyError:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -18,6 +18,7 @@ from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
 from waypoint.backends.tmux.normalize import TerminalNormalizer
+from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.scheduler import Scheduler
@@ -408,6 +409,7 @@ class SessionRuntime:
         session = self.get_session(session_id)
         plugin = self.registry.plugin_for(session)
         key = (session.id, trigger)
+        builtins = waypoint_builtin_completions(plugin.capabilities, trigger=trigger)
         if force_refresh:
             completions = await self._refresh_command_completion_cache(
                 session,
@@ -416,7 +418,7 @@ class SessionRuntime:
             )
             return (
                 self._filter_command_completions(
-                    completions,
+                    self._merge_builtins(builtins, completions),
                     trigger=trigger,
                     prefix=prefix,
                 ),
@@ -437,12 +439,41 @@ class SessionRuntime:
                 trigger=trigger,
                 prefix=prefix,
             )
-            return cached, key in self._completion_refresh_tasks
+            return (
+                self._filter_command_completions(
+                    self._merge_builtins(builtins, cached),
+                    trigger=trigger,
+                    prefix=prefix,
+                ),
+                key in self._completion_refresh_tasks,
+            )
 
         return (
-            self._filter_command_completions(cached, trigger=trigger, prefix=prefix),
+            self._filter_command_completions(
+                self._merge_builtins(builtins, cached),
+                trigger=trigger,
+                prefix=prefix,
+            ),
             key in self._completion_refresh_tasks,
         )
+
+    @staticmethod
+    def _merge_builtins(
+        builtins: list[CommandCompletion],
+        plugin_completions: list[CommandCompletion],
+    ) -> list[CommandCompletion]:
+        if not builtins:
+            return list(plugin_completions)
+        # Waypoint built-ins win on name collision — the user-facing
+        # `/new` should always open the Waypoint new-session UI, even
+        # for backends (e.g. opencode) that also expose their own
+        # backend-scoped `/new`.
+        seen = {f"{item.trigger}{item.name}" for item in builtins}
+        return [*builtins] + [
+            item
+            for item in plugin_completions
+            if f"{item.trigger}{item.name}" not in seen
+        ]
 
     async def _restore_session_and_warm_completions(
         self, plugin: Any, session: SessionRecord

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -481,13 +481,19 @@ class SessionRuntime:
         await plugin.restore_session(self, session)
         refreshed = self.storage.get_session(session.id)
         if refreshed is not None:
-            self._warm_command_completions(refreshed)
+            # Boot-restore warming is fire-and-forget for every persisted
+            # session, so we skip remote targets to avoid fanning out
+            # SSH/plugin-list probes against hosts the user may never
+            # open. New SSH sessions still warm eagerly via
+            # ``create_session`` / fork; reattached ones fall back to
+            # stale-while-revalidate on the first `/` press.
+            self._warm_command_completions(refreshed, include_remote=False)
 
-    def _warm_command_completions(self, session: SessionRecord) -> None:
-        # SSH-launched sessions pay an upfront discovery cost (a one-off
-        # remote shell + plugin-list call), traded for an instant first
-        # `/` press in the composer. Stale-while-revalidate handles
-        # subsequent refreshes the same way it does for local sessions.
+    def _warm_command_completions(
+        self, session: SessionRecord, *, include_remote: bool = True
+    ) -> None:
+        if not include_remote and session.launch_target_id is not None:
+            return
         try:
             transport = self.transport_for(session)
         except KeyError:

--- a/backend/tests/test_claude_commands.py
+++ b/backend/tests/test_claude_commands.py
@@ -82,3 +82,78 @@ async def test_list_claude_command_completions_reads_plugin_skills(
     assert [item.name for item in completions] == ["frontend-design"]
     assert completions[0].kind == "skill"
     assert completions[0].source == "plugin_skill"
+
+
+@pytest.mark.asyncio
+async def test_list_claude_command_completions_reads_user_skills(
+    tmp_path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    skill_dir = home / ".claude" / "skills" / "create-pr"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: create-pr\ndescription: Open a PR\nargument-hint: <branch>\n---\n",
+        encoding="utf-8",
+    )
+
+    completions = await list_claude_command_completions(
+        cwd=str(tmp_path / "repo"),
+        claude_bin=str(tmp_path / "missing-claude"),
+        prefix="/create",
+    )
+
+    assert [item.name for item in completions] == ["create-pr"]
+    assert completions[0].kind == "skill"
+    assert completions[0].source == "user_skill"
+    assert completions[0].argument_hint == "<branch>"
+
+
+@pytest.mark.asyncio
+async def test_list_claude_command_completions_workspace_skill_overrides_home(
+    tmp_path, monkeypatch
+) -> None:
+    home = tmp_path / "home"
+    monkeypatch.setenv("HOME", str(home))
+    repo = tmp_path / "repo"
+    (home / ".claude" / "skills" / "shared").mkdir(parents=True)
+    (home / ".claude" / "skills" / "shared" / "SKILL.md").write_text(
+        "---\nname: shared\ndescription: Home variant\n---\n",
+        encoding="utf-8",
+    )
+    (repo / ".claude" / "skills" / "shared").mkdir(parents=True)
+    (repo / ".claude" / "skills" / "shared" / "SKILL.md").write_text(
+        "---\nname: shared\ndescription: Workspace variant\n---\n",
+        encoding="utf-8",
+    )
+
+    completions = await list_claude_command_completions(
+        cwd=str(repo),
+        claude_bin=str(tmp_path / "missing-claude"),
+        prefix="/shared",
+    )
+
+    assert len(completions) == 1
+    assert completions[0].description == "Workspace variant"
+
+
+@pytest.mark.asyncio
+async def test_list_claude_command_completions_propagates_command_argument_hint(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    command_dir = repo / ".claude" / "commands"
+    command_dir.mkdir(parents=True)
+    (command_dir / "review.md").write_text(
+        "---\ndescription: Review a branch\nargument-hint: <branch>\n---\n",
+        encoding="utf-8",
+    )
+
+    completions = await list_claude_command_completions(
+        cwd=str(repo),
+        claude_bin=str(tmp_path / "missing-claude"),
+        prefix="/rev",
+    )
+
+    assert completions[0].argument_hint == "<branch>"

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -667,6 +667,89 @@ async def test_handle_input_drops_unknown_completion_invocation(tmp_path) -> Non
 
 
 @pytest.mark.asyncio
+async def test_get_command_completions_injects_waypoint_builtins(
+    monkeypatch, tmp_path
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+
+    async def fake_dynamic_completions(**_kwargs: Any) -> list[Any]:
+        return []
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.list_claude_command_completions",
+        fake_dynamic_completions,
+    )
+    fake = FakeClaudeAdapter()
+    fake.slash_commands["claude-sess"] = ()
+    _claude_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        id="claude-sess",
+        backend="claude_code",
+        transport="claude_cli",
+        thread_id="claude-thread",
+    )
+    storage.create_session(session)
+
+    completions = await runtime.list_command_completions(
+        session.id, trigger="/", prefix="", force_refresh=True
+    )
+
+    names = [item.name for item in completions]
+    assert "new" in names
+    assert "fork" in names
+    new_entry = next(item for item in completions if item.name == "new")
+    fork_entry = next(item for item in completions if item.name == "fork")
+    assert new_entry.dispatch == CompletionDispatch.FRONTEND_CONTROL
+    assert new_entry.source == "waypoint"
+    assert fork_entry.dispatch == CompletionDispatch.FRONTEND_CONTROL
+
+
+@pytest.mark.asyncio
+async def test_get_command_completions_skips_fork_for_tmux(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    session = make_session(
+        settings,
+        id="tmux-sess",
+        backend="tmux",
+        transport="tmux",
+        thread_id=None,
+    )
+    storage.create_session(session)
+
+    completions = await runtime.list_command_completions(
+        session.id, trigger="/", prefix="", force_refresh=True
+    )
+
+    names = [item.name for item in completions]
+    assert "new" in names
+    assert "fork" not in names
+
+
+@pytest.mark.asyncio
+async def test_get_command_completions_omits_builtins_for_non_slash_trigger(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+
+    class FakeAdapter:
+        async def list_skills(
+            self, session_id: str, *, force_reload: bool = False
+        ) -> list[dict[str, Any]]:
+            return []
+
+    _codex_plugin(runtime).adapter = cast(Any, FakeAdapter())
+    session = make_session(settings)
+    storage.create_session(session)
+
+    completions = await runtime.list_command_completions(
+        session.id, trigger="$", prefix="", force_refresh=True
+    )
+
+    assert all(item.source != "waypoint" for item in completions)
+
+
+@pytest.mark.asyncio
 async def test_get_command_completions_returns_cache_while_refreshing(
     tmp_path,
 ) -> None:

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -770,6 +770,46 @@ def test_warm_command_completions_runs_for_ssh_sessions(monkeypatch, tmp_path) -
     assert calls == [("remote-sess", "/"), ("remote-sess", "$")]
 
 
+def test_warm_command_completions_skips_remote_on_boot_restore(
+    monkeypatch, tmp_path
+) -> None:
+    runtime, _storage, settings = make_runtime(tmp_path)
+    session = make_session(
+        settings,
+        id="remote-sess",
+        backend="codex",
+        transport="codex_app_server",
+        launch_target_id="remote-host",
+    )
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        runtime,
+        "_ensure_command_completion_refresh",
+        lambda sess, *, trigger: calls.append((sess.id, trigger)),
+    )
+    runtime._warm_command_completions(session, include_remote=False)
+
+    assert calls == []
+
+
+def test_warm_command_completions_runs_for_local_on_boot_restore(
+    monkeypatch, tmp_path
+) -> None:
+    runtime, _storage, settings = make_runtime(tmp_path)
+    session = make_session(settings, id="local-sess")
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        runtime,
+        "_ensure_command_completion_refresh",
+        lambda sess, *, trigger: calls.append((sess.id, trigger)),
+    )
+    runtime._warm_command_completions(session, include_remote=False)
+
+    assert calls == [("local-sess", "/"), ("local-sess", "$")]
+
+
 def test_warm_command_completions_skips_unstructured_transports(
     monkeypatch, tmp_path
 ) -> None:

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -749,6 +749,50 @@ async def test_get_command_completions_omits_builtins_for_non_slash_trigger(
     assert all(item.source != "waypoint" for item in completions)
 
 
+def test_warm_command_completions_runs_for_ssh_sessions(monkeypatch, tmp_path) -> None:
+    runtime, _storage, settings = make_runtime(tmp_path)
+    session = make_session(
+        settings,
+        id="remote-sess",
+        backend="codex",
+        transport="codex_app_server",
+        launch_target_id="remote-host",
+    )
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        runtime,
+        "_ensure_command_completion_refresh",
+        lambda sess, *, trigger: calls.append((sess.id, trigger)),
+    )
+    runtime._warm_command_completions(session)
+
+    assert calls == [("remote-sess", "/"), ("remote-sess", "$")]
+
+
+def test_warm_command_completions_skips_unstructured_transports(
+    monkeypatch, tmp_path
+) -> None:
+    runtime, _storage, settings = make_runtime(tmp_path)
+    session = make_session(
+        settings,
+        id="tmux-sess",
+        backend="tmux",
+        transport="tmux",
+        thread_id=None,
+    )
+
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        runtime,
+        "_ensure_command_completion_refresh",
+        lambda sess, *, trigger: calls.append((sess.id, trigger)),
+    )
+    runtime._warm_command_completions(session)
+
+    assert calls == []
+
+
 @pytest.mark.asyncio
 async def test_get_command_completions_returns_cache_while_refreshing(
     tmp_path,
@@ -1347,6 +1391,14 @@ async def test_create_session_uses_structured_claude_for_ssh_target(
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.build_remote_claude_launch_factory",
         lambda *args, **kwargs: "remote-launch-factory",
+    )
+
+    async def fake_dynamic_completions(**_kwargs: Any) -> list[Any]:
+        return []
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.list_claude_command_completions",
+        fake_dynamic_completions,
     )
 
     session = await runtime.create_session(

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6134,6 +6134,14 @@ html[data-theme="light"] .slash-suggestion.active {
   color: var(--accent-cool);
 }
 
+.slash-hint {
+  margin-left: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-weight: 400;
+}
+
 .slash-desc {
   font-size: 0.8rem;
   color: var(--muted);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2220,7 +2220,12 @@ const ReplyComposer = memo(function ReplyComposer({
                   }}
                   onMouseEnter={() => setSuggestionIndex(index)}
                 >
-                  <span className="slash-name">{completionCommand(entry)}</span>
+                  <span className="slash-name">
+                    {completionCommand(entry)}
+                    {entry.argument_hint ? (
+                      <span className="slash-hint">{entry.argument_hint}</span>
+                    ) : null}
+                  </span>
                   <span className="slash-desc">{entry.description}</span>
                 </button>
               </li>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -82,49 +82,11 @@ import {
   rateLimitUsageTone,
 } from "@/lib/usage";
 
-const LOCAL_SLASH_COMPLETIONS: ReadonlyArray<CommandCompletion> = [
-  {
-    id: "waypoint:new",
-    trigger: "/",
-    replacement: "/new ",
-    name: "new",
-    description: "Start a new session with the same settings",
-    kind: "session_control",
-    source: "waypoint",
-    dispatch: "frontend_control",
-    metadata: {},
-  },
-  {
-    id: "waypoint:fork",
-    trigger: "/",
-    replacement: "/fork ",
-    name: "fork",
-    description: "Fork this session into a new branch",
-    kind: "session_control",
-    source: "waypoint",
-    dispatch: "frontend_control",
-    metadata: {},
-  },
-];
 const COMPLETION_REFRESH_POLL_MS = 750;
 const COMPLETION_FETCH_DEBOUNCE_MS = 180;
 
 function completionCommand(entry: CommandCompletion): string {
   return `${entry.trigger}${entry.name}`;
-}
-
-function mergeCompletions(
-  primary: ReadonlyArray<CommandCompletion>,
-  secondary: ReadonlyArray<CommandCompletion>,
-): CommandCompletion[] {
-  const merged = new Map<string, CommandCompletion>();
-  for (const entry of [...primary, ...secondary]) {
-    const key = `${entry.trigger}${entry.name}`;
-    if (!merged.has(key)) {
-      merged.set(key, entry);
-    }
-  }
-  return [...merged.values()];
 }
 
 const EFFORT_LABEL: Record<string, string> = {
@@ -1466,10 +1428,7 @@ const ReplyComposer = memo(function ReplyComposer({
       ? "$"
       : null;
   const suggestions = supportsSlash && !suggestionsDismissed
-    ? mergeCompletions(
-        completionTrigger === "/" ? LOCAL_SLASH_COMPLETIONS : [],
-        backendCompletions,
-      ).filter(
+    ? backendCompletions.filter(
         (entry) =>
           completionTrigger !== null &&
           completionCommand(entry).startsWith(completionHead),

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -85,8 +85,50 @@ import {
 const COMPLETION_REFRESH_POLL_MS = 750;
 const COMPLETION_FETCH_DEBOUNCE_MS = 180;
 
+// Baseline so the two core Waypoint actions stay visible during the
+// debounced fetch or if the request fails. Backend entries with the
+// same trigger+name override these (e.g. for per-plugin capability
+// gating).
+const LOCAL_BUILTIN_FALLBACK: ReadonlyArray<CommandCompletion> = [
+  {
+    id: "waypoint:builtin:new",
+    trigger: "/",
+    replacement: "/new ",
+    name: "new",
+    description: "Start a new session with the same settings",
+    kind: "session_control",
+    source: "waypoint",
+    dispatch: "frontend_control",
+    metadata: {},
+  },
+  {
+    id: "waypoint:builtin:fork",
+    trigger: "/",
+    replacement: "/fork ",
+    name: "fork",
+    description: "Fork this session into a new branch",
+    kind: "session_control",
+    source: "waypoint",
+    dispatch: "frontend_control",
+    metadata: {},
+  },
+];
+
 function completionCommand(entry: CommandCompletion): string {
   return `${entry.trigger}${entry.name}`;
+}
+
+function mergeBuiltinFallback(
+  backend: ReadonlyArray<CommandCompletion>,
+): CommandCompletion[] {
+  const seen = new Set(backend.map(completionCommand));
+  const merged = [...backend];
+  for (const entry of LOCAL_BUILTIN_FALLBACK) {
+    if (!seen.has(completionCommand(entry))) {
+      merged.push(entry);
+    }
+  }
+  return merged;
 }
 
 const EFFORT_LABEL: Record<string, string> = {
@@ -1428,7 +1470,10 @@ const ReplyComposer = memo(function ReplyComposer({
       ? "$"
       : null;
   const suggestions = supportsSlash && !suggestionsDismissed
-    ? backendCompletions.filter(
+    ? (completionTrigger === "/"
+        ? mergeBuiltinFallback(backendCompletions)
+        : backendCompletions
+      ).filter(
         (entry) =>
           completionTrigger !== null &&
           completionCommand(entry).startsWith(completionHead),

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -85,10 +85,11 @@ import {
 const COMPLETION_REFRESH_POLL_MS = 750;
 const COMPLETION_FETCH_DEBOUNCE_MS = 180;
 
-// Baseline so the two core Waypoint actions stay visible during the
-// debounced fetch or if the request fails. Backend entries with the
-// same trigger+name override these (e.g. for per-plugin capability
-// gating).
+// `/new` is universal across every backend, so it stays visible during
+// the debounced fetch or if the request fails. `/fork` is gated on
+// per-plugin `supports_fork` capability and is left to the backend
+// response — showing it locally would surface it for tmux sessions
+// where the action would 400 on submit.
 const LOCAL_BUILTIN_FALLBACK: ReadonlyArray<CommandCompletion> = [
   {
     id: "waypoint:builtin:new",
@@ -96,17 +97,6 @@ const LOCAL_BUILTIN_FALLBACK: ReadonlyArray<CommandCompletion> = [
     replacement: "/new ",
     name: "new",
     description: "Start a new session with the same settings",
-    kind: "session_control",
-    source: "waypoint",
-    dispatch: "frontend_control",
-    metadata: {},
-  },
-  {
-    id: "waypoint:builtin:fork",
-    trigger: "/",
-    replacement: "/fork ",
-    name: "fork",
-    description: "Fork this session into a new branch",
     kind: "session_control",
     source: "waypoint",
     dispatch: "frontend_control",


### PR DESCRIPTION
## Summary

Make the composer's autocomplete more comprehensive across every backend. Discover user and workspace Claude Code skills, propagate `argument-hint` frontmatter, lift `/new` (and capability-gated `/fork`) out of a frontend hardcode into a runtime-level injection so every plugin gets them for free, and warm slash discovery on session create so the first `/` press on a new SSH session feels instant.

## Changes

### Backend

- `backends/claude_code/commands.py`: scan `~/.claude/skills/<name>/SKILL.md` and `<cwd>/.claude/skills/<name>/SKILL.md` alongside the existing plugin-bundled walk; workspace wins on name collision so the CLI's own resolution order is preserved. Mirrored in the remote `_REMOTE_SCRIPT` so SSH sessions see the same surface. Records now carry `argument_hint` through to `CommandCompletion`, sourced from the `argument-hint` frontmatter key on commands and skills alike.
- `backends/capabilities.py` + `backends/completions.py`: added `SlashCommandSpec.argument_hint` and propagated it through `static_slash_completions`. Populated on Codex's `/plan` since it explicitly takes a prompt.
- `builtin_completions.py` (new): runtime-level Waypoint completions — `/new` for every plugin, `/fork` only when `capabilities.supports_fork`. Dispatch is `FRONTEND_CONTROL` so they're handled locally without round-tripping the command pipeline.
- `runtime.py`: `get_command_completions` merges built-ins with each plugin's response (built-ins win on collision so a backend-scoped `/new` can't shadow the Waypoint UI action). `_warm_command_completions` now takes an `include_remote` flag — `True` for user-initiated `create_session` / fork paths (instant `/` on a newly-attached SSH session), `False` from `_restore_session_and_warm_completions` so boot doesn't fan out remote plugin-list probes across every persisted session.

### Frontend

- `components/SessionDetail.tsx`: render `entry.argument_hint` as a muted mono span next to the command name in each suggestion row. Backend is now the source of truth for completions, with a tiny `/new`-only `LOCAL_BUILTIN_FALLBACK` so the universal action stays visible during the 180ms debounce or on request failure; `/fork` is omitted from the fallback so the backend's `supports_fork` gating isn't bypassed for tmux sessions.
- `app/globals.css`: added `.slash-hint` styling.

### Tests

- `tests/test_claude_commands.py`: three new tests cover user-skill discovery, workspace-overrides-home precedence, and argument-hint propagation on commands.
- `tests/test_runtime.py`: new tests cover `/new`+`/fork` injection on the structured path, `/fork` omission for tmux, `$` trigger ignoring built-ins, and the `include_remote` boot-restore behaviour for local vs. SSH sessions. Patched the SSH `create_session` test so it stubs `list_claude_command_completions` (the warm path now exercises it).

## Test Plan

- [x] `cd backend && uv run pytest` — 393 passing (10 new, all green)
- [x] `cd backend && uv run pre-commit run --all-files` — black / isort / ruff / codespell / mypy clean
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] Manual end-to-end: pending — needs a running stack to confirm the suggestion row renders argument hints and user/workspace SKILL.md files appear in a Claude Code session.