### PR TITLE
feat: bring tmux-wrapped sessions up to chat-session UX parity

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -21,7 +21,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from waypoint.auth import TokenStore, require_token
 from waypoint.backends import BackendRegistry
 from waypoint.backends.tmux.adapter import TmuxError
-from waypoint.backends.tmux.renderer import SyncFrameTracker, make_renderer
+from waypoint.backends.tmux.renderer import (
+    Osc52Extractor,
+    SyncFrameTracker,
+    make_renderer,
+)
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     LoginRequest,
@@ -739,6 +743,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # we don't want to add a per-session subscription here).
         STATUS_CHECK_INTERVAL_POLLS = 50  # 50 * 20 ms = ~1 s
         frame_tracker = SyncFrameTracker()
+        # Pyte absorbs OSC 52 silently — no diff bytes carry it onward —
+        # so the wrapped CLI's ``/copy`` (Claude) or clipboard write
+        # (Codex) never reaches xterm. Extract the payload upstream and
+        # forward it to the session-state socket so the frontend can
+        # call ``navigator.clipboard.writeText``.
+        osc52_extractor = Osc52Extractor()
         # Both stream_loop (chunk arrivals, defensive flush) and
         # recv_loop (post-resize repaint) call emit_diff. Without a
         # lock, render_diff() updates from one task can interleave with
@@ -777,6 +787,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     break
 
                 if chunk:
+                    for clipboard_text in osc52_extractor.feed(chunk):
+                        await context.runtime.broadcast.publish(
+                            SessionEnvelope(
+                                type="clipboard_copy",
+                                payload={"text": clipboard_text},
+                            ),
+                            session_id=session_id,
+                        )
                     # Split at every in→out frame transition so each
                     # closed frame gets its own diff emit, even when a
                     # single chunk contains multiple frames or

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -44,6 +44,11 @@ class BackendPlugin(Protocol):
     # ``ssh_targets[*].plugin_configs.<plugin_id>``. Plugins without
     # per-target knobs beyond ``remote_bin`` point at the base class.
     launch_target_schema: type[PluginLaunchTargetConfig]
+    # Env vars the plugin requires on every tmux-wrapped CLI invocation
+    # (local and SSH-remote). Merged into the launch command in
+    # ``_command_for_backend``; the user-supplied target ``remote_env``
+    # overrides on key collision so explicit yaml config still wins.
+    extra_env: dict[str, str]
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
         """Return a TransportAdapter routing send/interrupt/etc. for this plugin."""

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -116,6 +116,12 @@ class ClaudeCodePlugin:
     import_request_schema: type[BaseModel] | None = ClaudeThreadImportRequest
     config_schema: type[PluginConfig] = ClaudeCodePluginConfig
     launch_target_schema: type[PluginLaunchTargetConfig] = ClaudeCodeLaunchTargetConfig
+    # Force the fullscreen Ink renderer. Claude's startup capability
+    # probe (DA1 / XTVERSION / DECRQM 2026) races SSH latency on remote
+    # tmux launches and falls back to an inline mode with no alt-screen
+    # and no mouse-tracking. The flag is safe locally too: the fullscreen
+    # renderer is what claude picks when detection succeeds.
+    extra_env = {"CLAUDE_CODE_NO_FLICKER": "1"}
     capabilities = BackendCapabilities(
         is_structured=True,
         supports_resume=False,

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -257,6 +257,23 @@ class ClaudeCodePlugin:
         if self.adapter is not None:
             await self.adapter.force_refresh_rate_limit_usage(session.id)
 
+    async def probe_account_rate_limit(
+        self,
+        runtime: "SessionRuntime",
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> SessionRateLimitUsage | None:
+        """Fetch the account's current rate-limit snapshot without a session.
+
+        The upstream probe (HTTP call to api.anthropic.com via cached OAuth
+        creds) is account-scoped, not session-scoped — same call the
+        per-session adapter probe makes. Exposed so the tmux fallback can
+        populate ``rate_limit_usage`` for wrapped-claude sessions without
+        wiring them through the structured adapter.
+        """
+        if launch_target is None:
+            return await probe_claude_usage()
+        return await probe_claude_usage_remote(launch_target)
+
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the
         # PreToolUse hook bundle failed to materialise we leave

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -61,6 +61,7 @@ from waypoint.schemas import (
     BackendModelOption,
     CommandCompletion,
     CompletionDispatch,
+    EventKind,
     LaunchMode,
     SessionCreateRequest,
     SessionEnvelope,
@@ -584,6 +585,42 @@ class ClaudeCodePlugin:
                 _format_claude_status(session, self.adapter),
                 status=session.status,
                 metadata={"builtin_command": "/status", "source": "waypoint"},
+            )
+            return runtime.get_session(session.id)
+        if command == "/copy":
+            # Claude's native /copy emits OSC 52 from the interactive TUI;
+            # the SDK's --print --output-format=stream-json mode never
+            # surfaces that escape, so the slash command is a silent no-op
+            # for structured sessions unless we intercept here. Tmux-
+            # wrapped sessions take a different maybe_handle_input path
+            # (tmux/plugin.py) where the CLI's OSC 52 reaches xterm
+            # directly, so this branch is structured-only by construction.
+            text = _last_assistant_text(runtime, session.id)
+            await runtime._record_user_event(
+                session.id,
+                request.text,
+                submit=request.submit,
+                status=session.status,
+            )
+            if text:
+                await runtime.broadcast.publish(
+                    SessionEnvelope(
+                        type="clipboard_copy",
+                        payload={"text": text},
+                    ),
+                    session_id=session.id,
+                )
+                note = (
+                    f"Copied last response to clipboard "
+                    f"({len(text)} chars, {text.count(chr(10)) + 1} lines)"
+                )
+            else:
+                note = "Nothing to copy — no assistant response yet."
+            await runtime._record_system_event(
+                session.id,
+                note,
+                status=session.status,
+                metadata={"builtin_command": "/copy", "source": "waypoint"},
             )
             return runtime.get_session(session.id)
         return None
@@ -1266,6 +1303,24 @@ def _first_slash_command(text: str) -> str | None:
     if not stripped.startswith("/"):
         return None
     return stripped.split(maxsplit=1)[0].lower()
+
+
+def _last_assistant_text(runtime: "SessionRuntime", session_id: str) -> str:
+    """Concatenate the assistant's most recent bubble into a single string.
+
+    ``list_events_by_message_count(message_limit=1)`` walks events
+    backward and returns events for exactly one logical anchor, so a
+    long-running transcript doesn't get fully loaded just to read the
+    last bubble. Streaming chunks within the bubble share ``item_id`` →
+    same anchor → all chunks are in the slice and join in order.
+    Returns empty when the latest anchor isn't an assistant message.
+    """
+    events = runtime.storage.list_events_by_message_count(session_id, message_limit=1)
+    return "".join(
+        event.text
+        for event in events
+        if event.kind == EventKind.AGENT_OUTPUT and event.text
+    )
 
 
 def _session_slash_commands(

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -228,6 +228,30 @@ class CodexPlugin:
         if self.adapter is not None:
             await self.adapter.force_refresh_rate_limit_usage(session.id)
 
+    async def probe_account_rate_limit(
+        self,
+        runtime: "SessionRuntime",
+        launch_target: SshLaunchTargetConfig | None,
+        *,
+        cwd: str,
+    ) -> SessionRateLimitUsage | None:
+        """Fetch the account's current rate-limit snapshot without a session.
+
+        Exposed so the tmux fallback can populate ``rate_limit_usage`` for
+        wrapped-codex sessions without wiring them through the structured
+        adapter. ``cwd`` is forwarded to the local probe because codex's
+        ``/status`` PTY fallback needs a working directory.
+        """
+        if launch_target is None:
+            binary = (
+                self._config(runtime).local_bin
+                or self.capabilities.cli_binary
+                or "codex"
+            )
+            return await probe_codex_status(cwd=cwd, binary=binary)
+        binary = self.remote_executable(launch_target) or "codex"
+        return await probe_codex_usage_remote(launch_target, binary=binary)
+
     def register_routes(self, app: Any, context: Any) -> None:
         return None
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -101,6 +101,7 @@ class CodexPlugin:
     import_request_schema: type[BaseModel] | None = CodexThreadImportRequest
     config_schema: type[PluginConfig] = CodexPluginConfig
     launch_target_schema: type[PluginLaunchTargetConfig] = CodexLaunchTargetConfig
+    extra_env: dict[str, str] = {}
     capabilities = BackendCapabilities(
         is_structured=True,
         supports_resume=False,

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -130,6 +130,7 @@ class OpenCodePlugin:
     import_request_schema: type[BaseModel] | None = OpenCodeThreadImportRequest
     config_schema: type[PluginConfig] = OpenCodePluginConfig
     launch_target_schema: type[PluginLaunchTargetConfig] = PluginLaunchTargetConfig
+    extra_env: dict[str, str] = {}
 
     capabilities = BackendCapabilities(
         is_structured=True,

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -908,6 +908,18 @@ class TmuxPlugin:
             effort=resolved_effort,
             permission_mode=permission_mode,
         )
+        # Match the SessionRecord to what the wrapped CLI actually
+        # received. Codex's CLI has no --effort flag and only two of its
+        # waypoint permission presets map to launch flags, so storing the
+        # un-applied values would make the pill and launch-panel re-open
+        # lie about runtime behavior.
+        persisted_effort = resolved_effort if request.backend != "codex" else None
+        persisted_permission_mode = permission_mode
+        if request.backend == "codex" and permission_mode not in (
+            "default",
+            "full_access",
+        ):
+            persisted_permission_mode = None
         launch_args = [*inner_flags, *request.args]
         thread_id: str | None = None
         if request.backend == "claude_code":
@@ -960,9 +972,9 @@ class TmuxPlugin:
             raw_log_path=str(raw_log),
             structured_log_path=str(structured_log),
             transport_state=transport_state,
-            permission_mode=permission_mode,
+            permission_mode=persisted_permission_mode,
             model=resolved_model,
-            effort=resolved_effort if request.backend != "codex" else None,
+            effort=persisted_effort,
         )
         runtime.storage.create_session(session)
         await runtime._record_system_event(

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -142,6 +142,15 @@ class TmuxPlugin:
                 pass
             except Exception:
                 log.debug("thread-id watcher raised during terminate", exc_info=True)
+        rl_watcher = runtime._tmux_rate_limit_watchers.pop(session.id, None)
+        if rl_watcher is not None:
+            rl_watcher.cancel()
+            try:
+                await rl_watcher
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                log.debug("rate-limit watcher raised during terminate", exc_info=True)
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
@@ -297,6 +306,7 @@ class TmuxPlugin:
                 self._spawn_codex_thread_id_watcher(
                     runtime, session.id, session.cwd, session.created_at, lt
                 )
+            self._spawn_rate_limit_watcher(runtime, session)
             return
 
         # ATTACHED-TMUX reconnect: the user terminated a session we
@@ -413,6 +423,7 @@ class TmuxPlugin:
             self._spawn_codex_thread_id_watcher(
                 runtime, session.id, session.cwd, now, launch_target
             )
+        self._spawn_rate_limit_watcher(runtime, session)
 
     async def _reattach_attached_tmux(
         self, runtime: "SessionRuntime", session: SessionRecord
@@ -487,6 +498,7 @@ class TmuxPlugin:
                 datetime.now(UTC),
                 launch_target,
             )
+        self._spawn_rate_limit_watcher(runtime, session)
 
     async def _conversation_exists(
         self,
@@ -665,6 +677,56 @@ class TmuxPlugin:
             )
         )
         runtime._tmux_thread_id_watchers[session_id] = task
+
+    def _spawn_rate_limit_watcher(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        """Run periodic rate-limit refreshes for a tmux-wrapped session.
+
+        Structured backends register a per-session probe inside their SDK
+        adapter, so their pill stays current without any explicit kick.
+        Tmux-wrapped sessions have no adapter, so this watcher fills the
+        gap — same cadence (300 s) as the SDK probes, and an immediate
+        first refresh so the pill populates within the first paint
+        instead of staying empty until the user clicks.
+        """
+        if session.id in runtime._tmux_rate_limit_watchers:
+            return
+        inner = runtime.registry.get(session.backend)
+        if getattr(inner, "probe_account_rate_limit", None) is None:
+            return
+        task = asyncio.create_task(self._rate_limit_refresh_loop(runtime, session.id))
+        runtime._tmux_rate_limit_watchers[session.id] = task
+
+    async def _rate_limit_refresh_loop(
+        self, runtime: "SessionRuntime", session_id: str
+    ) -> None:
+        # Match the 300 s interval the structured adapters use; the
+        # upstream rate-limit endpoints are account-scoped, so probing
+        # any faster doesn't surface fresher data.
+        REFRESH_INTERVAL = 300.0
+        try:
+            while True:
+                session = runtime.storage.get_session(session_id)
+                if session is None:
+                    return
+                # Mirrors the structured adapter's
+                # ``while state.session_id in self._sessions`` — those
+                # loops naturally terminate when the adapter drops the
+                # session on exit; here we have no adapter map to watch,
+                # so the storage status is the equivalent signal.
+                if session.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
+                    return
+                try:
+                    await self.refresh_rate_limit_usage(runtime, session)
+                except Exception:  # noqa: BLE001
+                    log.exception(
+                        "tmux rate-limit refresh loop probe failed",
+                        extra={"session_id": session_id},
+                    )
+                await asyncio.sleep(REFRESH_INTERVAL)
+        finally:
+            runtime._tmux_rate_limit_watchers.pop(session_id, None)
 
     # Filename UUID matches the trailing ``<uuid>`` in
     # ``rollout-YYYY-MM-DDThh-mm-ss-<UUID>.jsonl``.
@@ -985,6 +1047,7 @@ class TmuxPlugin:
             self._spawn_codex_thread_id_watcher(
                 runtime, session.id, session.cwd, now, launch_target
             )
+        self._spawn_rate_limit_watcher(runtime, session)
         return runtime.get_session(session.id)
 
     async def import_thread_via_resume(
@@ -1078,6 +1141,7 @@ class TmuxPlugin:
             self.format_start_message(backend, launch_target, cwd),
         )
         runtime._ensure_monitor(session.id)
+        self._spawn_rate_limit_watcher(runtime, session)
         return runtime.get_session(session.id)
 
 

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -244,9 +244,8 @@ class TmuxPlugin:
         The wrapped CLI runs unmonitored — no per-session SDK adapter is
         watching it — so the structured backends' probe machinery never
         fires. Delegate to the inner plugin's account-level probe (same
-        upstream API call the structured adapter makes) and write the
-        snapshot directly onto the session record via the runtime's
-        session-update callback (persistence + WS broadcast in one hop).
+        upstream API call the structured adapter makes) and persist +
+        broadcast the snapshot via ``update_session_fields``.
         """
         inner = runtime.registry.get(session.backend)
         probe = getattr(inner, "probe_account_rate_limit", None)
@@ -270,10 +269,10 @@ class TmuxPlugin:
             return
         if snapshot is None:
             return
-        await runtime.session_update_callback()(
+        await runtime.update_session_fields(
             session.id,
-            {"rate_limit_usage": snapshot.model_dump(mode="json")},
-            True,
+            publish=True,
+            rate_limit_usage=snapshot.model_dump(mode="json"),
         )
 
     async def restore_session(

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -236,6 +236,46 @@ class TmuxPlugin:
     ) -> None:
         return None
 
+    async def refresh_rate_limit_usage(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        """Populate ``rate_limit_usage`` on tmux-wrapped sessions.
+
+        The wrapped CLI runs unmonitored — no per-session SDK adapter is
+        watching it — so the structured backends' probe machinery never
+        fires. Delegate to the inner plugin's account-level probe (same
+        upstream API call the structured adapter makes) and write the
+        snapshot directly onto the session record via the runtime's
+        session-update callback (persistence + WS broadcast in one hop).
+        """
+        inner = runtime.registry.get(session.backend)
+        probe = getattr(inner, "probe_account_rate_limit", None)
+        if probe is None:
+            return
+        launch_target = (
+            runtime._find_launch_target(session.launch_target_id)
+            if session.launch_target_id
+            else None
+        )
+        try:
+            if session.backend == "codex":
+                snapshot = await probe(runtime, launch_target, cwd=session.cwd)
+            else:
+                snapshot = await probe(runtime, launch_target)
+        except Exception:  # noqa: BLE001
+            log.exception(
+                "tmux rate-limit probe failed",
+                extra={"session_id": session.id, "inner": session.backend},
+            )
+            return
+        if snapshot is None:
+            return
+        await runtime.session_update_callback()(
+            session.id,
+            {"rate_limit_usage": snapshot.model_dump(mode="json")},
+            True,
+        )
+
     async def restore_session(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -524,6 +524,46 @@ class TmuxPlugin:
             return ""
         return stdout.decode("utf-8", errors="ignore")
 
+    def _inner_cli_flags(
+        self,
+        backend: str,
+        *,
+        model: str | None,
+        effort: str | None,
+        permission_mode: str | None,
+    ) -> list[str]:
+        """Build launch-time flags for the wrapped CLI.
+
+        Mirrors the structured-launch flag set the user picks in
+        ``LaunchPanel``: model, effort, permission mode. The interactive
+        CLIs accept these at startup; subsequent swap requires relaunch,
+        not in scope for the tmux wrapper today.
+
+        Codex's CLI has no ``--effort`` flag (effort is selected through
+        the ``/model`` popup) so it's intentionally omitted; the caller
+        also nulls ``effort`` on the SessionRecord for codex tmux launches
+        to keep the UI consistent. Codex permission modes don't map
+        cleanly to ``-a``/``-s`` flags (``auto_review`` and ``plan`` are
+        collaboration-mode constructs, not pure approval policies), so
+        only the two unambiguous presets translate today.
+        """
+        flags: list[str] = []
+        if backend == "claude_code":
+            if model:
+                flags += ["--model", model]
+            if effort:
+                flags += ["--effort", effort]
+            if permission_mode:
+                flags += ["--permission-mode", permission_mode]
+        elif backend == "codex":
+            if model:
+                flags += ["-m", model]
+            if permission_mode == "default":
+                flags += ["-a", "on-request", "-s", "workspace-write"]
+            elif permission_mode == "full_access":
+                flags += ["--dangerously-bypass-approvals-and-sandbox"]
+        return flags
+
     def _resume_args(
         self, backend: str, thread_id: str | None, stored_args: list[str]
     ) -> list[str]:
@@ -822,7 +862,13 @@ class TmuxPlugin:
         # have a thread id ready for the reconnect path. Codex has no
         # equivalent flag — its uuid is captured asynchronously by
         # ``_spawn_codex_thread_id_watcher``.
-        launch_args = list(request.args)
+        inner_flags = self._inner_cli_flags(
+            request.backend,
+            model=resolved_model,
+            effort=resolved_effort,
+            permission_mode=permission_mode,
+        )
+        launch_args = [*inner_flags, *request.args]
         thread_id: str | None = None
         if request.backend == "claude_code":
             thread_id = str(uuid.uuid4())
@@ -874,6 +920,9 @@ class TmuxPlugin:
             raw_log_path=str(raw_log),
             structured_log_path=str(structured_log),
             transport_state=transport_state,
+            permission_mode=permission_mode,
+            model=resolved_model,
+            effort=resolved_effort if request.backend != "codex" else None,
         )
         runtime.storage.create_session(session)
         await runtime._record_system_event(

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -69,6 +69,7 @@ class TmuxPlugin:
     import_request_schema: type[BaseModel] | None = None
     config_schema: type[PluginConfig] = TmuxPluginConfig
     launch_target_schema: type[PluginLaunchTargetConfig] = PluginLaunchTargetConfig
+    extra_env: dict[str, str] = {}
     capabilities = BackendCapabilities(
         is_structured=False,
         supports_resume=True,

--- a/backend/src/waypoint/backends/tmux/renderer.py
+++ b/backend/src/waypoint/backends/tmux/renderer.py
@@ -14,6 +14,8 @@ the pyte backend can be swapped for libvterm/vterm later without
 touching the WS handler.
 """
 
+import base64
+import binascii
 import re
 from io import StringIO
 from typing import Protocol
@@ -602,3 +604,100 @@ class SyncFrameTracker:
         if seg_start < len(chunk):
             segments.append((chunk[seg_start:], not self.in_frame))
         return segments
+
+
+class Osc52Extractor:
+    """Pull ``OSC 52`` clipboard-write payloads out of a pane byte stream.
+
+    Tmux-wrapped CLIs (Claude Code's ``/copy``, Codex's clipboard
+    integration) emit ``\\x1b]52;<targets>;<base64>\\x07`` to ask the
+    outer terminal to write to the system clipboard. Pyte sees those
+    bytes and quietly drops them — they never reach xterm.js — so for
+    the tmux transport the WS handler has to lift the payload out
+    upstream and forward it to the session-state socket as a typed
+    ``clipboard_copy`` envelope.
+
+    The extractor is stateful so a sequence split across two reads (a
+    20 ms poll boundary lands mid-base64 for large copies) still emits
+    once the trailer arrives.
+    """
+
+    _PREFIX = b"\x1b]52;"
+
+    def __init__(self) -> None:
+        self._pending: bytes = b""
+
+    def feed(self, chunk: bytes) -> list[str]:
+        """Return decoded clipboard text for every complete OSC 52 in
+        ``chunk`` (plus any sequence whose tail finally arrived).
+
+        Reads that contain no OSC 52 cost one ``bytes.find`` per call;
+        partial sequences are held verbatim across feeds, capped at
+        ``_MAX_PENDING_NON_CSI`` so a malformed unterminated payload
+        can't grow the buffer without bound.
+        """
+        buf = self._pending + chunk
+        self._pending = b""
+        results: list[str] = []
+        i = 0
+        n = len(buf)
+        while i < n:
+            start = buf.find(self._PREFIX, i)
+            if start < 0:
+                # No prefix in the remainder — but the very tail may be
+                # the first few bytes of a prefix that completes next
+                # feed, so hold up to ``len(prefix) - 1`` bytes.
+                tail_keep = min(n - i, len(self._PREFIX) - 1)
+                if tail_keep > 0:
+                    self._pending = buf[n - tail_keep :]
+                return results
+            payload_start = start + len(self._PREFIX)
+            j = payload_start
+            end = -1
+            next_i = -1
+            while j < n:
+                b = buf[j]
+                if b == 0x07:  # BEL
+                    end = j
+                    next_i = j + 1
+                    break
+                if b == 0x1B:  # ESC — only valid terminator is ESC \
+                    if j + 1 >= n:
+                        # ST split across feeds; hold from ``start``.
+                        break
+                    if buf[j + 1] == 0x5C:  # '\\'
+                        end = j
+                        next_i = j + 2
+                        break
+                    # Malformed (ESC followed by non-ST inside OSC). Cut
+                    # the sequence here so a stray ESC can't make us
+                    # buffer until ``_MAX_PENDING_NON_CSI``.
+                    end = j
+                    next_i = j + 1
+                    break
+                j += 1
+            if end < 0:
+                # Incomplete — keep the whole sequence; drop on overflow
+                # rather than letting a runaway tail wedge the buffer.
+                tail = buf[start:]
+                if len(tail) <= _MAX_PENDING_NON_CSI:
+                    self._pending = tail
+                return results
+            inner = buf[payload_start:end]
+            # Format is ``<targets>;<payload>``; the targets field can
+            # be empty (defaults to ``c``). ``?`` is a clipboard *read*
+            # query, which we ignore for security.
+            sep = inner.find(b";")
+            if sep >= 0:
+                payload = inner[sep + 1 :]
+                if payload and payload != b"?":
+                    try:
+                        decoded = base64.b64decode(payload, validate=False)
+                    except (binascii.Error, ValueError):
+                        decoded = b""
+                    if decoded:
+                        text = decoded.decode("utf-8", errors="replace")
+                        if text:
+                            results.append(text)
+            i = next_i
+        return results

--- a/backend/src/waypoint/launch_targets.py
+++ b/backend/src/waypoint/launch_targets.py
@@ -137,6 +137,7 @@ class SshLaunchTargetConfig(BaseModel):
         cwd: str | None = None,
         *,
         allocate_tty: bool = False,
+        extra_env: dict[str, str] | None = None,
     ) -> tuple[str, ...]:
         """Build the SSH argv for a remote command.
 
@@ -158,13 +159,17 @@ class SshLaunchTargetConfig(BaseModel):
         thread enumerator) need stdin as a real pipe.
         """
         ssh_bin = _resolve_local_binary(self.ssh_bin)
+        # Plugin contributions (e.g. claude's ``CLAUDE_CODE_NO_FLICKER=1``)
+        # form the base; user-supplied ``remote_env`` overrides on key
+        # collision so explicit yaml config still wins.
+        merged_env = {**(extra_env or {}), **self.remote_env}
         remote_parts: list[str] = []
         if cwd:
             remote_parts.extend([f"cd {quote_remote_path(cwd)}", "&&"])
         remote_parts.append("exec")
-        if self.remote_env:
+        if merged_env:
             remote_parts.append("env")
-            for key, value in sorted(self.remote_env.items()):
+            for key, value in sorted(merged_env.items()):
                 remote_parts.append(shlex.quote(f"{key}={value}"))
         remote_parts.append(shlex.join(command))
         remote_command = self.wrap_remote_command(" ".join(remote_parts))

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -112,6 +112,11 @@ class SessionRuntime:
         # only after the first user input). Stored here so terminate
         # can cancel them alongside the pane monitor.
         self._tmux_thread_id_watchers: dict[str, asyncio.Task[None]] = {}
+        # Periodic rate-limit refreshers spawned by TmuxPlugin. Structured
+        # backends start their own per-session probe inside the SDK adapter
+        # at create time; tmux-wrapped sessions have no adapter and need
+        # this fallback to keep the usage pill live.
+        self._tmux_rate_limit_watchers: dict[str, asyncio.Task[None]] = {}
         self._restore_tasks: set[asyncio.Task[None]] = set()
         self._completion_cache: dict[CompletionCacheKey, list[CommandCompletion]] = {}
         self._completion_cache_updated_at: dict[CompletionCacheKey, float] = {}

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1188,6 +1188,7 @@ class SessionRuntime:
         allocate_tty: bool = False,
     ) -> list[str]:
         plugin = self.registry.get(backend)
+        extra_env = plugin.extra_env
         if launch_target is None:
             executable = (
                 self.settings.plugin_config(backend).local_bin
@@ -1198,6 +1199,15 @@ class SessionRuntime:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"backend {backend} has no CLI binary configured",
                 )
+            if extra_env:
+                # ``env KEY=VAL ... cmd`` is portable across macOS/Linux
+                # and lets tmux's pane shell exec the CLI with the env
+                # var set, matching what we do over SSH.
+                env_prefix = [
+                    "env",
+                    *(f"{k}={v}" for k, v in sorted(extra_env.items())),
+                ]
+                return [*env_prefix, executable, *args]
             return [executable, *args]
         executable = plugin.remote_executable(launch_target)
         if not executable:
@@ -1210,6 +1220,7 @@ class SessionRuntime:
                 [executable, *args],
                 cwd or launch_target.default_cwd,
                 allocate_tty=allocate_tty,
+                extra_env=extra_env,
             )
         )
 

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -31,6 +31,7 @@ class _StubPlugin:
     import_request_schema: type[BaseModel] | None = None
     config_schema: type[PluginConfig] = PluginConfig
     launch_target_schema: type[PluginLaunchTargetConfig] = PluginLaunchTargetConfig
+    extra_env: dict[str, str] = {}
     capabilities = BackendCapabilities(is_structured=False, supports_resume=False)
 
     def transport_view(self, runtime: Any) -> Any:

--- a/backend/tests/test_launch_targets.py
+++ b/backend/tests/test_launch_targets.py
@@ -173,6 +173,33 @@ def test_build_remote_exec_args_allocates_tty_when_requested(monkeypatch) -> Non
     assert "-tt" not in no_tty
 
 
+def test_build_remote_exec_args_merges_extra_env_with_target_env(monkeypatch) -> None:
+    """Plugin-contributed env (e.g. claude's CLAUDE_CODE_NO_FLICKER) merges
+    with the target's user-configured ``remote_env``; on key collision the
+    target wins so explicit yaml config still overrides plugin defaults."""
+    monkeypatch.setattr(
+        "waypoint.launch_targets.shutil.which", lambda _: "/usr/bin/ssh"
+    )
+    config = SshLaunchTargetConfig(
+        id="devbox",
+        name="Devbox",
+        ssh_destination="dev@example.com",
+        remote_env={"FOO": "from-target", "TARGET_ONLY": "1"},
+    )
+
+    args = config.build_remote_exec_args(
+        ["claude"],
+        "~/workspace",
+        extra_env={"FOO": "from-plugin", "PLUGIN_ONLY": "1"},
+    )
+
+    remote_command = args[-1]
+    assert "FOO=from-target" in remote_command
+    assert "FOO=from-plugin" not in remote_command
+    assert "TARGET_ONLY=1" in remote_command
+    assert "PLUGIN_ONLY=1" in remote_command
+
+
 def test_remote_bin_for_falls_back_to_default(monkeypatch) -> None:
     config = SshLaunchTargetConfig(
         id="devbox",

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -277,6 +277,49 @@ def make_runtime(tmp_path) -> tuple[SessionRuntime, Storage, Settings]:
     return runtime, storage, settings
 
 
+def test_command_for_backend_local_injects_plugin_extra_env(tmp_path) -> None:
+    """Claude's plugin contributes ``CLAUDE_CODE_NO_FLICKER=1`` so the
+    fullscreen Ink renderer (alt-screen + mouse) kicks in even when
+    claude's own terminal-cap probe times out. The local launch path
+    has no SSH layer to inject env vars for us, so the runtime wraps
+    the command in ``env KEY=VAL …``."""
+    runtime, _, _ = make_runtime(tmp_path)
+    command = runtime._command_for_backend("claude_code", ["--session-id", "abc"])
+    assert command[0] == "env"
+    assert "CLAUDE_CODE_NO_FLICKER=1" in command
+    # The CLI binary follows the env prefix, with original args intact.
+    cli_idx = command.index("claude")
+    assert command[cli_idx:] == ["claude", "--session-id", "abc"]
+
+
+def test_command_for_backend_local_omits_env_wrapper_when_plugin_has_none(
+    tmp_path,
+) -> None:
+    """Plugins with empty ``extra_env`` shouldn't pay an ``env`` exec —
+    keep the local command minimal so behavior is unchanged for tmux /
+    codex / opencode."""
+    runtime, _, _ = make_runtime(tmp_path)
+    command = runtime._command_for_backend("codex", ["resume", "abc"])
+    assert command[0] != "env"
+    assert command == ["codex", "resume", "abc"]
+
+
+def test_command_for_backend_remote_forwards_plugin_extra_env(tmp_path) -> None:
+    runtime, _, _ = make_runtime(tmp_path)
+    target = SshLaunchTargetConfig(
+        id="devbox", name="Devbox", ssh_destination="dev@example.com"
+    )
+    command = runtime._command_for_backend(
+        "claude_code",
+        ["--session-id", "abc"],
+        launch_target=target,
+        cwd="~/workspace",
+        allocate_tty=True,
+    )
+    remote_command = command[-1]
+    assert "CLAUDE_CODE_NO_FLICKER=1" in remote_command
+
+
 def make_session(settings: Settings, **overrides) -> SessionRecord:
     session_dir = settings.sessions_dir / overrides.get("id", "sess")
     session_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -6,7 +6,9 @@ decide how reconnect rebuilds an inner CLI's command line and how the
 Codex rollout-file watcher extracts a thread id from a filename.
 """
 
+import asyncio
 import json
+from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -453,10 +455,14 @@ class _FakeTmux:
     def __init__(self) -> None:
         self.kill_calls: list[str] = []
         self.pipe_calls: list[tuple[str, Path]] = []
+        self.stop_pipe_calls: list[str] = []
         self.describe_pane_dead = False
 
     async def kill_session(self, name: str) -> None:
         self.kill_calls.append(name)
+
+    async def stop_pipe(self, target: str) -> None:
+        self.stop_pipe_calls.append(target)
 
     async def start_managed_session(
         self, session_id: str, cwd: str, command: list[str]
@@ -484,19 +490,45 @@ class _FakeTmux:
         )
 
 
+class _FakeRegistry:
+    """Stand-in for SessionRuntime.registry.
+
+    `_FakeRuntime` is used by the restore/create paths, which now ask
+    the registry for the inner plugin so they can spawn a rate-limit
+    refresh watcher. By default returns a bare object — no
+    ``probe_account_rate_limit`` — so the spawn early-exits without
+    scheduling a real task. Watcher-focused tests pass a real stub via
+    ``plugin_override`` to exercise the loop.
+    """
+
+    def __init__(self, plugin_override: Any = None) -> None:
+        self._override = plugin_override
+
+    def get(self, _backend: str) -> Any:
+        return self._override if self._override is not None else object()
+
+
 class _FakeRuntime:
     """Minimal runtime stub for ``TmuxPlugin.restore_session``."""
 
-    def __init__(self) -> None:
+    def __init__(self, inner_plugin: Any = None) -> None:
         self.tmux = _FakeTmux()
         self.file_offsets: dict[str, int] = {}
         self._tmux_thread_id_watchers: dict[str, Any] = {}
+        self._tmux_rate_limit_watchers: dict[str, Any] = {}
+        self.monitor_tasks: dict[str, Any] = {}
+        self.registry = _FakeRegistry(plugin_override=inner_plugin)
         self.updates: list[dict[str, Any]] = []
+        self.field_updates: list[dict[str, Any]] = []
         self.created: list[Any] = []
         self._session_dir_root: Path | None = None
         # Per-call record so individual tests can assert that the
         # tmux launch sites actually request a remote PTY.
         self.command_calls: list[dict[str, Any]] = []
+        # Watcher tests override entries here; the refresh loop reads
+        # via storage.get_session, so the storage stub returns whatever
+        # is set on this map.
+        self.sessions_by_id: dict[str, Any] = {}
 
     def _find_launch_target(self, _lt_id: str | None) -> None:
         return None
@@ -538,6 +570,11 @@ class _FakeRuntime:
                 return record
         raise KeyError(session_id)
 
+    async def update_session_fields(
+        self, session_id: str, *, publish: bool = True, **updates: Any
+    ) -> None:
+        self.field_updates.append({"sid": session_id, "publish": publish, **updates})
+
     class _Storage:
         def __init__(self, parent: "_FakeRuntime") -> None:
             self._parent = parent
@@ -547,6 +584,9 @@ class _FakeRuntime:
 
         def create_session(self, record: Any) -> None:
             self._parent.created.append(record)
+
+        def get_session(self, session_id: str) -> Any:
+            return self._parent.sessions_by_id.get(session_id)
 
     @property
     def storage(self) -> "_FakeRuntime._Storage":
@@ -1027,3 +1067,121 @@ async def test_create_session_requests_remote_pty(
     # Claude path pre-pins --session-id <uuid> ahead of the user's args.
     assert runtime.command_calls[-1]["args"][0] == "--session-id"
     assert runtime.command_calls[-1]["args"][-2:] == ["--model", "sonnet"]
+
+
+class _InnerPluginStub:
+    """Stub of the wrapped backend's plugin for rate-limit watcher tests.
+
+    Just the slice that ``_spawn_rate_limit_watcher`` and the refresh
+    loop reach: a ``probe_account_rate_limit`` coroutine that records
+    each call and a ``cli_binary`` attribute the codex branch reads.
+    """
+
+    cli_binary = "claude"
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def probe_account_rate_limit(self, _runtime: Any, _launch_target: Any) -> Any:
+        self.calls += 1
+        from waypoint.schemas import SessionRateLimitUsage
+
+        return SessionRateLimitUsage(
+            source="claude_code",
+            updated_at=datetime.now(UTC),
+            windows=[],
+        )
+
+
+def _watcher_session(sid: str, status: SessionStatus = SessionStatus.STARTING):
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=sid,
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="t",
+        cwd="/Users/me/proj",
+        status=status,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=f"/tmp/{sid}.raw.log",
+        structured_log_path=f"/tmp/{sid}.events.jsonl",
+    )
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_watcher_spawn_dedupes(plugin: TmuxPlugin) -> None:
+    """Spawning twice with the same session id leaves a single task on
+    the runtime's watcher map — the guard at the top of
+    ``_spawn_rate_limit_watcher`` short-circuits the second call."""
+    inner = _InnerPluginStub()
+    runtime = _FakeRuntime(inner_plugin=inner)
+    session = _watcher_session("sess-dedupe")
+    runtime.sessions_by_id[session.id] = session
+    plugin._spawn_rate_limit_watcher(cast(Any, runtime), session)
+    first = runtime._tmux_rate_limit_watchers[session.id]
+    plugin._spawn_rate_limit_watcher(cast(Any, runtime), session)
+    second = runtime._tmux_rate_limit_watchers[session.id]
+    assert first is second
+    first.cancel()
+    with suppress(asyncio.CancelledError):
+        await first
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_watcher_terminate_cancels_and_clears(
+    plugin: TmuxPlugin,
+) -> None:
+    """``terminate_session`` cancels the running watcher and pops its
+    entry from the map so a subsequent reattach can spawn a fresh one."""
+    inner = _InnerPluginStub()
+    runtime = _FakeRuntime(inner_plugin=inner)
+    session = _watcher_session("sess-term")
+    runtime.sessions_by_id[session.id] = session
+    plugin._spawn_rate_limit_watcher(cast(Any, runtime), session)
+    task = runtime._tmux_rate_limit_watchers[session.id]
+    # Let the first iteration run so the probe is observed.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await plugin.terminate_session(cast(Any, runtime), session)
+    assert session.id not in runtime._tmux_rate_limit_watchers
+    assert task.cancelled() or task.done()
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_watcher_stops_on_natural_exit(
+    plugin: TmuxPlugin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Natural transitions to EXITED (pane closed, CLI typed /exit) are
+    detected via storage status and break the loop without going through
+    ``terminate_session``."""
+    # Collapse the 300 s sleep so the loop's next iteration runs in the
+    # same event-loop tick the test status flip happens on.
+    real_sleep = asyncio.sleep
+
+    async def instant_sleep(_seconds: float) -> None:
+        await real_sleep(0)
+
+    monkeypatch.setattr("waypoint.backends.tmux.plugin.asyncio.sleep", instant_sleep)
+
+    inner = _InnerPluginStub()
+    runtime = _FakeRuntime(inner_plugin=inner)
+    session = _watcher_session("sess-natural-exit")
+    runtime.sessions_by_id[session.id] = session
+    plugin._spawn_rate_limit_watcher(cast(Any, runtime), session)
+    task = runtime._tmux_rate_limit_watchers[session.id]
+
+    # Yield repeatedly so the loop runs at least one full iteration.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert inner.calls >= 1, "probe should have fired at least once"
+
+    # Flip status to EXITED without invoking terminate_session.
+    runtime.sessions_by_id[session.id] = _watcher_session(
+        session.id, status=SessionStatus.EXITED
+    )
+    # The loop's next iteration should observe the EXITED status and exit.
+    await asyncio.wait_for(task, timeout=1.0)
+    assert session.id not in runtime._tmux_rate_limit_watchers

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -89,6 +89,73 @@ def test_resume_args_codex_does_not_double_inject_on_second_cycle(
     assert cycle2 == ["resume", "abc-123", "--model", "o3"]
 
 
+@pytest.mark.parametrize(
+    "backend,model,effort,permission_mode,expected",
+    [
+        # Claude: each picked knob maps 1:1 to a flag.
+        ("claude_code", "opus", None, None, ["--model", "opus"]),
+        ("claude_code", None, "high", None, ["--effort", "high"]),
+        ("claude_code", None, None, "plan", ["--permission-mode", "plan"]),
+        (
+            "claude_code",
+            "opus",
+            "high",
+            "acceptEdits",
+            [
+                "--model",
+                "opus",
+                "--effort",
+                "high",
+                "--permission-mode",
+                "acceptEdits",
+            ],
+        ),
+        ("claude_code", None, None, None, []),
+        # Codex: only the model and the two unambiguous permission presets
+        # translate to launch flags. Effort and the collaboration-mode
+        # presets ("plan", "auto_review") have no CLI flag mapping and
+        # are intentionally dropped — the SessionRecord-side caller
+        # mirrors this by storing None for the unapplied fields.
+        ("codex", "gpt-5", None, None, ["-m", "gpt-5"]),
+        (
+            "codex",
+            None,
+            None,
+            "default",
+            ["-a", "on-request", "-s", "workspace-write"],
+        ),
+        (
+            "codex",
+            None,
+            None,
+            "full_access",
+            ["--dangerously-bypass-approvals-and-sandbox"],
+        ),
+        ("codex", None, "high", None, []),
+        ("codex", None, None, "plan", []),
+        ("codex", None, None, "auto_review", []),
+        ("codex", None, None, None, []),
+    ],
+)
+def test_inner_cli_flags(
+    plugin: TmuxPlugin,
+    backend: str,
+    model: str | None,
+    effort: str | None,
+    permission_mode: str | None,
+    expected: list[str],
+) -> None:
+    assert (
+        plugin._inner_cli_flags(
+            backend,
+            model=model,
+            effort=effort,
+            permission_mode=permission_mode,
+        )
+        == expected
+    )
+
+
 @pytest.mark.asyncio
 async def test_conversation_exists_claude_code_local(
     plugin: TmuxPlugin, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/backend/tests/test_tmux_renderer.py
+++ b/backend/tests/test_tmux_renderer.py
@@ -1,8 +1,13 @@
 """Tests for the server-side terminal renderer used by the tmux WS endpoint."""
 
+import base64
 import re
 
-from waypoint.backends.tmux.renderer import PyteRenderer, SyncFrameTracker
+from waypoint.backends.tmux.renderer import (
+    Osc52Extractor,
+    PyteRenderer,
+    SyncFrameTracker,
+)
 
 
 def _strip_ansi(text: str) -> str:
@@ -475,3 +480,84 @@ def test_frame_tracker_split_carries_state_across_calls() -> None:
     segs2 = t.split_at_frame_ends(b"BBB\x1b[?2026l")
     assert segs2 == [(b"BBB\x1b[?2026l", True)]
     assert t.in_frame is False
+
+
+def _osc52(text: str, terminator: bytes = b"\x07", target: bytes = b"c") -> bytes:
+    payload = base64.b64encode(text.encode("utf-8"))
+    return b"\x1b]52;" + target + b";" + payload + terminator
+
+
+def test_osc52_extractor_decodes_single_bel_terminated() -> None:
+    ex = Osc52Extractor()
+    text = "Hello, world!"
+    chunk = b"prefix " + _osc52(text) + b" trailing"
+    assert ex.feed(chunk) == [text]
+
+
+def test_osc52_extractor_decodes_st_terminator() -> None:
+    ex = Osc52Extractor()
+    text = "ST-terminated payload"
+    assert ex.feed(_osc52(text, terminator=b"\x1b\\")) == [text]
+
+
+def test_osc52_extractor_multiple_sequences_in_one_chunk() -> None:
+    ex = Osc52Extractor()
+    chunk = _osc52("first") + b"junk" + _osc52("second")
+    assert ex.feed(chunk) == ["first", "second"]
+
+
+def test_osc52_extractor_carries_partial_sequence_across_feeds() -> None:
+    ex = Osc52Extractor()
+    full = _osc52("hello across the boundary")
+    # Split mid-payload so the trailer (and most of the base64) arrives
+    # in the next feed.
+    head, tail = full[:12], full[12:]
+    assert ex.feed(head) == []
+    assert ex.feed(tail) == ["hello across the boundary"]
+
+
+def test_osc52_extractor_carries_partial_prefix_across_feeds() -> None:
+    """ESC `]` `5` arrives in feed N, `2;c;...` in feed N+1."""
+    ex = Osc52Extractor()
+    full = _osc52("split prefix")
+    # Cut inside the OSC prefix bytes ``\x1b]52;``.
+    head, tail = full[:3], full[3:]
+    assert ex.feed(head) == []
+    assert ex.feed(tail) == ["split prefix"]
+
+
+def test_osc52_extractor_ignores_clipboard_read_query() -> None:
+    ex = Osc52Extractor()
+    # ``?`` is a read query — must not be decoded or emitted.
+    assert ex.feed(b"\x1b]52;c;?\x07") == []
+
+
+def test_osc52_extractor_ignores_empty_payload() -> None:
+    ex = Osc52Extractor()
+    assert ex.feed(b"\x1b]52;c;\x07") == []
+
+
+def test_osc52_extractor_skips_invalid_base64() -> None:
+    ex = Osc52Extractor()
+    # ``$`` is not a base64 character — decode fails and the sequence
+    # is dropped without surfacing garbage.
+    assert ex.feed(b"\x1b]52;c;$$$$\x07") == []
+
+
+def test_osc52_extractor_handles_default_target() -> None:
+    """OSC 52 with empty targets (``;;<base64>``) is valid — should still decode."""
+    ex = Osc52Extractor()
+    payload = base64.b64encode(b"defaulted").decode("ascii")
+    chunk = f"\x1b]52;;{payload}\x07".encode()
+    assert ex.feed(chunk) == ["defaulted"]
+
+
+def test_osc52_extractor_unicode_payload() -> None:
+    ex = Osc52Extractor()
+    text = "日本語 🦀 ñ"
+    assert ex.feed(_osc52(text)) == [text]
+
+
+def test_osc52_extractor_no_sequence_returns_empty() -> None:
+    ex = Osc52Extractor()
+    assert ex.feed(b"just normal output\r\n") == []

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6203,9 +6203,12 @@ html[data-theme="light"] .terminal {
    above the keyboard on phones. */
 .session-terminal.is-locked {
   position: sticky;
-  top: 0;
-  height: 100dvh;
-  max-height: 100dvh;
+  /* Push the pane below the iOS status bar / notch so the term-bar
+     buttons aren't tucked under the dynamic island. On non-notch
+     viewports the inset is 0, so this is a no-op. */
+  top: env(safe-area-inset-top, 0px);
+  height: calc(100dvh - env(safe-area-inset-top, 0px));
+  max-height: calc(100dvh - env(safe-area-inset-top, 0px));
 }
 
 @media (max-width: 720px) {
@@ -6217,7 +6220,7 @@ html[data-theme="light"] .terminal {
     border-radius: var(--radius-sm);
   }
   .session-terminal.is-locked {
-    height: 100dvh;
+    height: calc(100dvh - env(safe-area-inset-top, 0px));
   }
 }
 
@@ -6321,6 +6324,33 @@ html[data-theme="light"] .term-bar-action.primary {
 .term-bar-overflow-menu {
   top: calc(100% + 8px);
   bottom: auto;
+}
+
+/* The usage pill in the term-bar lives at the top-left of the terminal
+   pane, so the popover must drop downward (the composer variant floats
+   up because it sits at the bottom of the chat surface). .session-terminal
+   has overflow: hidden, which would clip an upward-floating popover
+   entirely; dropping below renders the panel inside the pane's clipped
+   region instead. Anchor to the pill's left edge so a 440px panel
+   doesn't shoot off-screen leftward on a left-aligned trigger. */
+.term-bar .usage-panel {
+  top: calc(100% + 10px);
+  bottom: auto;
+  left: 0;
+  right: auto;
+  /* Above .term-stage's xterm canvases regardless of how their own
+     internal stacking contexts shake out. */
+  z-index: 50;
+}
+
+/* On narrow screens the 440px panel + left-anchor would clip the right
+   edge. Pin the right side too so the panel flexes within the term-bar's
+   width and the popover stays fully visible. */
+@media (max-width: 720px) {
+  .term-bar .usage-panel {
+    right: 8px;
+    width: auto;
+  }
 }
 
 .term-stage {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -992,6 +992,66 @@ html[data-theme="light"] .clipboard-prompt.is-copied {
   background: color-mix(in srgb, var(--success) 18%, rgba(247, 243, 235, 0.92));
 }
 
+/* Paste-confirmation variant has two interactive children (send + cancel),
+   so the wrapper itself isn't a tap target — drop the pointer cursor on
+   the wrapper and let the inner buttons own their own cursors. */
+.clipboard-prompt.is-paste {
+  cursor: default;
+  padding-right: 8px;
+  gap: 10px;
+}
+
+.clipboard-prompt__send {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.clipboard-prompt__send:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 80%, transparent);
+  outline-offset: 4px;
+  border-radius: 6px;
+}
+
+.clipboard-prompt__dismiss {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: color-mix(in srgb, var(--text) 55%, transparent);
+  font-size: 1.05rem;
+  line-height: 1;
+  padding: 6px 9px;
+  margin-left: 2px;
+  border-radius: 999px;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    color 140ms ease,
+    background 140ms ease;
+}
+
+.clipboard-prompt__dismiss:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+}
+
+.clipboard-prompt__dismiss:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 80%, transparent);
+  outline-offset: 2px;
+}
+
 .clipboard-prompt__glyph {
   display: grid;
   place-items: center;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -906,6 +906,195 @@ html[data-theme="light"] .secondary:hover:not(:disabled) {
   opacity: 1;
 }
 
+/* ─── Clipboard prompt ─── */
+/* Glass action card surfaced when /copy lands but the browser refused
+   an async clipboard write (Safari outside the user-gesture window).
+   The whole card is the tap target — single, hand-friendly affordance
+   that keeps the gesture chain unbroken when the user retries. */
+.clipboard-prompt {
+  position: sticky;
+  /* Add the safe-area inset so terminal-only sessions (no composer) don't
+     park the pill under the iOS home-indicator bar — matches the other
+     composer-anchored selectors. */
+  bottom: calc(
+    var(--composer-height, 24px) + 16px + env(safe-area-inset-bottom, 0px)
+  );
+  align-self: flex-end;
+  margin-left: auto;
+  margin-right: 4px;
+  z-index: 6;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  max-width: max-content;
+  padding: 10px 16px 10px 12px;
+  border: 1px solid color-mix(in srgb, var(--accent) 50%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 12%, rgba(8, 11, 16, 0.78));
+  color: var(--text);
+  font-size: 0.88rem;
+  line-height: 1.2;
+  text-align: left;
+  cursor: pointer;
+  /* iOS: kill the 300 ms tap delay and the blue tap-highlight overlay
+     so the press feels native. */
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  backdrop-filter: blur(14px) saturate(1.4);
+  -webkit-backdrop-filter: blur(14px) saturate(1.4);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 28%, transparent),
+    0 12px 36px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.02);
+  animation: clipboard-prompt-in 240ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  transition:
+    transform 140ms ease,
+    box-shadow 220ms ease,
+    border-color 220ms ease,
+    background 220ms ease;
+}
+
+html[data-theme="light"] .clipboard-prompt {
+  background: color-mix(in srgb, var(--accent) 14%, rgba(247, 243, 235, 0.92));
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 35%, transparent),
+    0 12px 36px rgba(0, 0, 0, 0.1),
+    0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+.clipboard-prompt:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent) 75%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 40%, transparent),
+    0 18px 48px rgba(0, 0, 0, 0.55),
+    0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.clipboard-prompt:active {
+  transform: translateY(0) scale(0.985);
+  transition-duration: 80ms;
+}
+
+.clipboard-prompt:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 80%, transparent);
+  outline-offset: 3px;
+}
+
+.clipboard-prompt.is-copied {
+  border-color: color-mix(in srgb, var(--success) 55%, transparent);
+  background: color-mix(in srgb, var(--success) 16%, rgba(8, 11, 16, 0.78));
+  pointer-events: none;
+  cursor: default;
+}
+
+html[data-theme="light"] .clipboard-prompt.is-copied {
+  background: color-mix(in srgb, var(--success) 18%, rgba(247, 243, 235, 0.92));
+}
+
+.clipboard-prompt__glyph {
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--accent) 28%, transparent);
+  color: color-mix(in srgb, var(--accent) 88%, white 20%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+.clipboard-prompt.is-copied .clipboard-prompt__glyph {
+  background: color-mix(in srgb, var(--success) 30%, transparent);
+  color: color-mix(in srgb, var(--success) 92%, white 18%);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--success) 40%, transparent);
+  animation: clipboard-prompt-check 380ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+html[data-theme="light"] .clipboard-prompt__glyph {
+  color: color-mix(in srgb, var(--accent) 75%, black 15%);
+}
+
+html[data-theme="light"] .clipboard-prompt.is-copied .clipboard-prompt__glyph {
+  color: color-mix(in srgb, var(--success) 80%, black 12%);
+}
+
+.clipboard-prompt__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.clipboard-prompt__label {
+  font-weight: 500;
+  letter-spacing: -0.005em;
+}
+
+.clipboard-prompt__meta {
+  font-family:
+    "JetBrains Mono", "SFMono-Regular", "Menlo", "Consolas", monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  color: color-mix(in srgb, var(--text) 60%, transparent);
+  text-transform: lowercase;
+}
+
+.clipboard-prompt__arrow {
+  margin-left: 2px;
+  font-size: 1rem;
+  line-height: 1;
+  color: color-mix(in srgb, var(--accent) 85%, white 10%);
+  transition: transform 200ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+html[data-theme="light"] .clipboard-prompt__arrow {
+  color: color-mix(in srgb, var(--accent) 70%, black 10%);
+}
+
+.clipboard-prompt:hover .clipboard-prompt__arrow {
+  transform: translateX(4px);
+}
+
+@keyframes clipboard-prompt-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes clipboard-prompt-check {
+  0% {
+    transform: scale(0.7);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.12);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .clipboard-prompt {
+    bottom: calc(
+      var(--composer-height, 24px) + 12px + env(safe-area-inset-bottom, 0px)
+    );
+    /* Stay content-sized on mobile too. Stretching to full width forced
+       ``justify-content: space-between``, which pinned the arrow to the
+       far edge and left a yawning gap next to the label. The pill reads
+       cleaner as a compact, right-anchored chip — just add a touch more
+       margin from the viewport edge. */
+    margin-right: 12px;
+  }
+}
+
 .error-banner {
   display: flex;
   align-items: flex-start;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -992,13 +992,25 @@ html[data-theme="light"] .clipboard-prompt.is-copied {
   background: color-mix(in srgb, var(--success) 18%, rgba(247, 243, 235, 0.92));
 }
 
-/* Paste-confirmation variant has two interactive children (send + cancel),
-   so the wrapper itself isn't a tap target — drop the pointer cursor on
-   the wrapper and let the inner buttons own their own cursors. */
-.clipboard-prompt.is-paste {
+/* Pills with a dismiss control (paste-confirm, copy-confirm, copied
+   success) demote the wrapper to non-interactive — only the inner send
+   and dismiss buttons handle taps. */
+.clipboard-prompt:has(.clipboard-prompt__dismiss) {
   cursor: default;
   padding-right: 8px;
   gap: 10px;
+}
+
+/* The wrapper-level hover lift was paired with the wrapper itself being
+   the tap target. With a dismiss control present, the wrapper is no
+   longer interactive — drop the lift to avoid implying it is. */
+.clipboard-prompt:has(.clipboard-prompt__dismiss):hover {
+  transform: none;
+  border-color: color-mix(in srgb, var(--accent) 50%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 28%, transparent),
+    0 12px 36px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 255, 255, 0.02);
 }
 
 .clipboard-prompt__send {
@@ -1035,6 +1047,9 @@ html[data-theme="light"] .clipboard-prompt.is-copied {
   margin-left: 2px;
   border-radius: 999px;
   cursor: pointer;
+  /* .is-copied sets pointer-events: none on the wrapper to keep the
+     success badge inert; the dismiss button still needs taps to land. */
+  pointer-events: auto;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
   transition:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -407,11 +407,17 @@ export default function HomePage() {
     }
   }
 
-  async function handleAttach(target: string, backendHint: Backend) {
+  async function handleAttach(
+    target: string,
+    backendHint: Backend,
+    title: string,
+  ) {
     try {
+      const trimmedTitle = title.trim();
       const session = await attachTmux(host, token, {
         tmux_target: target,
         backend_hint: backendHint,
+        ...(trimmedTitle ? { title: trimmedTitle } : {}),
       });
       setSessions((current) => [
         session,

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -54,7 +54,11 @@ interface LaunchPanelProps {
     args: string[],
     configOverrides: string[],
   ) => Promise<void>;
-  onAttach: (target: string, backendHint: Backend) => Promise<void>;
+  onAttach: (
+    target: string,
+    backendHint: Backend,
+    title: string,
+  ) => Promise<void>;
   onImportThread: (
     backend: Backend,
     threadId: string,
@@ -97,7 +101,6 @@ export function LaunchPanel({
   const capabilities = catalog.byId(backend)?.capabilities;
   const supportsCustomArgs = capabilities?.supports_custom_cli_args ?? false;
   const supportsConfigOverrides = capabilities?.supports_config_overrides ?? false;
-
   const handleBackendChange = useCallback((nextBackend: Backend) => {
     setBackend(nextBackend);
     setModel("");
@@ -187,8 +190,9 @@ export function LaunchPanel({
     event.preventDefault();
     setFormBusy(true);
     try {
-      await onAttach(tmuxTarget, backend);
+      await onAttach(tmuxTarget, backend, title);
       setTmuxTarget("");
+      setTitle("");
     } finally {
       setFormBusy(false);
     }
@@ -308,6 +312,14 @@ export function LaunchPanel({
                   </option>
                 ))}
               </select>
+            </label>
+            <label className="field">
+              <span>Title</span>
+              <input
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Optional"
+              />
             </label>
           </div>
           <div className="launch-actions">

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -101,6 +101,11 @@ export function LaunchPanel({
   const capabilities = catalog.byId(backend)?.capabilities;
   const supportsCustomArgs = capabilities?.supports_custom_cli_args ?? false;
   const supportsConfigOverrides = capabilities?.supports_config_overrides ?? false;
+  // Codex's CLI has no `--effort` flag, so a tmux-wrapped codex session
+  // can't honor an effort selection at launch time. Hide the picker
+  // instead of letting the user pick a value that silently drops.
+  const effortSupported = !(backend === "codex" && launchMode === "tmux_wrapper");
+
   const handleBackendChange = useCallback((nextBackend: Backend) => {
     setBackend(nextBackend);
     setModel("");
@@ -175,7 +180,7 @@ export function LaunchPanel({
         cwd,
         title,
         model.trim() || null,
-        effort.trim() || null,
+        effortSupported ? effort.trim() || null : null,
         launchMode,
         args,
         configOverrides,
@@ -249,12 +254,14 @@ export function LaunchPanel({
                 disabled={formBusy}
                 defaultModelLabel={modelInfo?.default_model_label ?? null}
               />
-              <EffortPicker
-                options={effortOptions}
-                value={effort}
-                onChange={setEffort}
-                disabled={formBusy}
-              />
+              {effortSupported ? (
+                <EffortPicker
+                  options={effortOptions}
+                  value={effort}
+                  onChange={setEffort}
+                  disabled={formBusy}
+                />
+              ) : null}
             </div>
           </div>
           <LaunchOptionsDetails

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -106,6 +106,59 @@ function completionCommand(entry: CommandCompletion): string {
   return `${entry.trigger}${entry.name}`;
 }
 
+// iOS Safari rejects ``navigator.clipboard.writeText`` even from inside a
+// click handler — the Promise microtask ends the transient activation
+// window before the write resolves. ``document.execCommand("copy")`` is
+// deprecated everywhere but remains the one synchronous clipboard write
+// that survives that gauntlet across iOS Safari, desktop Safari, and
+// modern Chromium.
+//
+// A contenteditable ``<div>`` is the right host: textarea's ``.value``
+// lives in an internal buffer (not DOM children), so
+// ``Range.selectNodeContents(textarea)`` selects nothing — execCommand
+// then reports success against an empty selection and the paste is
+// blank. The div holds the text in real text nodes; ``white-space: pre``
+// preserves newlines so multi-line ``/copy`` results survive intact.
+function copyTextSync(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const host = document.createElement("div");
+  host.textContent = text;
+  host.setAttribute("contenteditable", "true");
+  // ``left: -9999px`` keeps the node selectable but visually off-canvas
+  // (opacity 0 in the same coordinate space can still flash a focus
+  // ring on iOS). ``font-size: 16px`` prevents iOS's auto-zoom on
+  // focused editable fields. ``white-space: pre`` carries newlines.
+  host.style.cssText = [
+    "position:fixed",
+    "top:0",
+    "left:-9999px",
+    "width:1px",
+    "height:1px",
+    "white-space:pre",
+    "font-size:16px",
+    "user-select:text",
+    "-webkit-user-select:text",
+  ].join(";");
+  document.body.appendChild(host);
+  let ok = false;
+  const sel = window.getSelection();
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(host);
+    if (sel) {
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  } finally {
+    sel?.removeAllRanges();
+    document.body.removeChild(host);
+  }
+  return ok;
+}
+
 function mergeBuiltinFallback(
   backend: ReadonlyArray<CommandCompletion>,
 ): CommandCompletion[] {
@@ -167,6 +220,20 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [filterMode, setFilterMode] = useState<FilterMode>("important");
   const [toolRunsExpanded, setToolRunsExpanded] = useState(false);
   const [error, setError] = useState("");
+  // Safari rejects ``navigator.clipboard.writeText`` outside a synchronous
+  // user-gesture handler, and the ``/copy`` clipboard payload arrives via
+  // a WS message (no surviving gesture). When the async write fails we
+  // stash the text and surface a tap-to-copy pill so the user's tap
+  // provides a fresh gesture; the retry uses ``document.execCommand`` so
+  // the write stays synchronous (no Promise microtask consuming the
+  // activation, which iOS Safari requires).
+  const [pendingClipboard, setPendingClipboard] = useState<string | null>(null);
+  const [clipboardCopied, setClipboardCopied] = useState(false);
+  // Bumped on every clipboard_copy envelope and on each successful copy
+  // so React remounts the pill — pure CSS ``animation`` only plays once
+  // per element, so consecutive /copies on the same DOM node would
+  // otherwise silently swap text with no visible motion.
+  const [clipboardSeq, setClipboardSeq] = useState(0);
   const [connection, setConnection] = useState<ConnectionState>("connecting");
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
@@ -182,6 +249,39 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const { openSwitcher, setCurrentSession } = useSwitcher();
+  // Auto-dismiss the "Copied!" pill after a beat so it doesn't squat on
+  // the toast slot. The fallback "Tap to copy" toast stays until the user
+  // acts on it — clipboard access can't be reattempted programmatically
+  // and there's no point auto-hiding the only remaining affordance.
+  useEffect(() => {
+    if (!clipboardCopied) return;
+    const t = window.setTimeout(() => setClipboardCopied(false), 1800);
+    return () => window.clearTimeout(t);
+  }, [clipboardCopied]);
+  const copyPendingClipboard = useCallback(() => {
+    if (pendingClipboard === null) return;
+    if (copyTextSync(pendingClipboard)) {
+      setClipboardCopied(true);
+      setPendingClipboard(null);
+      setClipboardSeq((s) => s + 1);
+    }
+    // Sync path failed — the async API rarely fares better from here on
+    // iOS Safari, but try anyway as a courtesy. Leave the pill up either
+    // way so the user knows the copy didn't land.
+    else {
+      // Second ``?.`` is required: when ``navigator.clipboard`` is
+      // undefined the optional chain short-circuits to ``undefined`` and
+      // ``.then`` on that would throw uncaught.
+      navigator.clipboard?.writeText(pendingClipboard)?.then(
+        () => {
+          setClipboardCopied(true);
+          setPendingClipboard(null);
+          setClipboardSeq((s) => s + 1);
+        },
+        () => {},
+      );
+    }
+  }, [pendingClipboard]);
   // Tracks the smallest raw sequence ever received from the server. Distinct
   // from `events[0].sequence` because `mergeEvents` advances a coalesced
   // item's sequence to the *last* delta — using that as a cursor would
@@ -528,6 +628,36 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           }
           if (message.type === "session_state") {
             setSession(message.payload.session as SessionRecord);
+          }
+          if (message.type === "clipboard_copy") {
+            // Claude's /copy server-side interceptor (structured CC) and
+            // the tmux WS handler's OSC 52 extractor (tmux-wrapped CC)
+            // both publish through this envelope. Chromium accepts the
+            // async writeText; Safari rejects it because the keystroke's
+            // user activation has expired by the time the WS frame lands.
+            // On rejection we surface a tap-to-copy pill — the user's
+            // tap provides a fresh gesture for the synchronous retry.
+            const text = (message.payload as { text?: string }).text;
+            if (typeof text === "string" && text.length > 0) {
+              // New envelope replaces any in-flight confirm pill and
+              // bumps the key so the entry animation replays even when
+              // the previous /copy hasn't fully faded.
+              setClipboardCopied(false);
+              setClipboardSeq((s) => s + 1);
+              const writer = navigator.clipboard?.writeText(text);
+              if (writer) {
+                writer.then(
+                  () => {
+                    setClipboardCopied(true);
+                    setPendingClipboard(null);
+                    setClipboardSeq((s) => s + 1);
+                  },
+                  () => setPendingClipboard(text),
+                );
+              } else {
+                setPendingClipboard(text);
+              }
+            }
           }
           if (message.type === "auth_revoked") {
             handleAuthFailure();
@@ -1438,6 +1568,66 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           >
             ×
           </button>
+        </div>
+      ) : null}
+      {pendingClipboard !== null ? (
+        <button
+          key={`clipboard-pending-${clipboardSeq}`}
+          type="button"
+          className="clipboard-prompt"
+          onClick={copyPendingClipboard}
+          aria-label={`Copy ${pendingClipboard.length} characters to clipboard`}
+        >
+          <span className="clipboard-prompt__glyph" aria-hidden="true">
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3.5" y="3" width="9" height="11" rx="1.5" />
+              <path d="M6 3V2.25c0-.41.34-.75.75-.75h2.5c.41 0 .75.34.75.75V3" />
+              <path d="M6 7.5h4M6 10h4" />
+            </svg>
+          </span>
+          <span className="clipboard-prompt__body">
+            <span className="clipboard-prompt__label">Response ready</span>
+            <span className="clipboard-prompt__meta">
+              {pendingClipboard.length.toLocaleString()} chars · tap to copy
+            </span>
+          </span>
+          <span className="clipboard-prompt__arrow" aria-hidden="true">
+            →
+          </span>
+        </button>
+      ) : clipboardCopied ? (
+        <div
+          key={`clipboard-copied-${clipboardSeq}`}
+          className="clipboard-prompt is-copied"
+          role="status"
+        >
+          <span className="clipboard-prompt__glyph" aria-hidden="true">
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.7"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M3.5 8.5L6.5 11.5L12.5 5" />
+            </svg>
+          </span>
+          <span className="clipboard-prompt__body">
+            <span className="clipboard-prompt__label">Copied</span>
+            <span className="clipboard-prompt__meta">paste anywhere</span>
+          </span>
         </div>
       ) : null}
       {session && !terminalOnly ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1282,6 +1282,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     setPendingPaste(null);
   }, []);
 
+  const dismissClipboardPill = useCallback(() => {
+    setPendingClipboard(null);
+    setClipboardCopied(false);
+  }, []);
+
   const [terminalDims, setTerminalDims] = useState<{ cols: number; rows: number } | null>(null);
   const handleTerminalResize = useCallback(
     ({ cols, rows }: { cols: number; rows: number }) => {
@@ -1641,12 +1646,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
         </div>
       ) : null}
       {pendingPaste === null && pendingClipboard !== null ? (
-        <button
+        <div
           key={`clipboard-pending-${clipboardSeq}`}
-          type="button"
           className="clipboard-prompt"
-          onClick={copyPendingClipboard}
-          aria-label={`Copy ${pendingClipboard.length} characters to clipboard`}
+          role="dialog"
+          aria-label="Copy response to clipboard"
         >
           <span className="clipboard-prompt__glyph" aria-hidden="true">
             <svg
@@ -1664,16 +1668,28 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
               <path d="M6 7.5h4M6 10h4" />
             </svg>
           </span>
-          <span className="clipboard-prompt__body">
+          <button
+            type="button"
+            className="clipboard-prompt__send"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={copyPendingClipboard}
+            aria-label={`Copy ${pendingClipboard.length} characters to clipboard`}
+          >
             <span className="clipboard-prompt__label">Response ready</span>
             <span className="clipboard-prompt__meta">
               {pendingClipboard.length.toLocaleString()} chars · tap to copy
             </span>
-          </span>
-          <span className="clipboard-prompt__arrow" aria-hidden="true">
-            →
-          </span>
-        </button>
+          </button>
+          <button
+            type="button"
+            className="clipboard-prompt__dismiss"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={dismissClipboardPill}
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
+        </div>
       ) : pendingPaste === null && clipboardCopied ? (
         <div
           key={`clipboard-copied-${clipboardSeq}`}
@@ -1698,6 +1714,15 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
             <span className="clipboard-prompt__label">Copied</span>
             <span className="clipboard-prompt__meta">paste anywhere</span>
           </span>
+          <button
+            type="button"
+            className="clipboard-prompt__dismiss"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={dismissClipboardPill}
+            aria-label="Dismiss"
+          >
+            ×
+          </button>
         </div>
       ) : null}
       {pendingPaste !== null ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/lib/events";
 import { useTheme } from "@/lib/theme";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
+import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { type XTerminalHandle } from "@/components/XTerminal";
 import { ApprovalRequestCard, PlanApprovalCard } from "@/components/ApprovalCard";
 import {
@@ -68,24 +69,16 @@ import {
   type ToolPair,
 } from "@/components/TranscriptCard";
 import { useSwitcher } from "@/components/SwitcherProvider";
-import { UsageBar, UsageReadout } from "@/components/UsageReadout";
 import {
   BackendModelOption,
   BackendPermissionMode,
   CommandCompletion,
   EventRecord,
   SessionCommandInvocation,
-  SessionContextUsage,
   SessionEnvelope,
   SessionRecord,
   SessionTransport,
 } from "@/lib/types";
-import {
-  clampPercent,
-  formatRelativeTime,
-  formatTokens,
-  rateLimitUsageTone,
-} from "@/lib/usage";
 
 const COMPLETION_REFRESH_POLL_MS = 750;
 const COMPLETION_FETCH_DEBOUNCE_MS = 180;
@@ -136,47 +129,6 @@ const EFFORT_LABEL: Record<string, string> = {
   max: "Max",
 };
 
-function contextUsagePercent(usage: SessionContextUsage): number | null {
-  const windowTokens = usage.context_window_tokens;
-  if (!windowTokens || windowTokens <= 0) {
-    return null;
-  }
-  return Math.round((usage.used_tokens / windowTokens) * 100);
-}
-
-function contextUsageTone(percent: number | null): "good" | "warn" | "danger" {
-  if (percent === null) {
-    return "good";
-  }
-  if (percent >= 90) {
-    return "danger";
-  }
-  if (percent >= 70) {
-    return "warn";
-  }
-  return "good";
-}
-
-function contextUsageLabel(key: string): string {
-  switch (key) {
-    case "input_tokens":
-      return "Input";
-    case "cached_input_tokens":
-      return "Cached input";
-    case "output_tokens":
-      return "Output";
-    case "reasoning_output_tokens":
-      return "Reasoning";
-    case "reasoning_tokens":
-      return "Reasoning";
-    case "cache_read_tokens":
-      return "Cache read";
-    case "cache_write_tokens":
-      return "Cache write";
-    default:
-      return key.replaceAll("_", " ");
-  }
-}
 
 interface SessionDetailProps {
   host: string;
@@ -1402,6 +1354,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           setTermMenuOpen={setTermMenuOpen}
           termMenuWrapRef={termMenuWrapRef}
           termAtBottom={termAtBottom}
+          connection={connection}
+          rateLimitRefreshBusy={rateLimitRefreshBusy}
+          onRateLimitRefresh={handleRateLimitRefresh}
           onTerminalInput={handleTerminalInput}
           onTerminalResize={handleTerminalResize}
           onTerminalScrollChip={handleTerminalScrollChip}
@@ -1655,7 +1610,6 @@ const ReplyComposer = memo(function ReplyComposer({
   const [selectedCompletion, setSelectedCompletion] =
     useState<CommandCompletion | null>(null);
   const [overflowOpen, setOverflowOpen] = useState(false);
-  const [contextUsageOpen, setContextUsageOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
   const [reattaching, setReattaching] = useState(false);
   // Pending effort for backends that need a session restart to apply (Claude)
@@ -1680,7 +1634,6 @@ const ReplyComposer = memo(function ReplyComposer({
   const suggestionsRef = useRef<HTMLUListElement | null>(null);
   const suggestionItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const overflowRef = useRef<HTMLDivElement | null>(null);
-  const contextUsageRef = useRef<HTMLDivElement | null>(null);
   const tuneRef = useRef<HTMLDivElement | null>(null);
 
   // Built-in slash commands are intercepted on the backend only for
@@ -1845,28 +1798,6 @@ const ReplyComposer = memo(function ReplyComposer({
       window.removeEventListener("keydown", onKey);
     };
   }, [overflowOpen]);
-
-  useEffect(() => {
-    if (!contextUsageOpen) {
-      return;
-    }
-    function onPointer(event: PointerEvent) {
-      if (!contextUsageRef.current) return;
-      if (contextUsageRef.current.contains(event.target as Node)) return;
-      setContextUsageOpen(false);
-    }
-    function onKey(event: globalThis.KeyboardEvent) {
-      if (event.key === "Escape") {
-        setContextUsageOpen(false);
-      }
-    }
-    window.addEventListener("pointerdown", onPointer);
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("pointerdown", onPointer);
-      window.removeEventListener("keydown", onKey);
-    };
-  }, [contextUsageOpen]);
 
   useEffect(() => {
     if (!tuneOpen) {
@@ -2068,72 +1999,6 @@ const ReplyComposer = memo(function ReplyComposer({
     effortRequiresConfirm &&
     pendingEffort !== null &&
     pendingEffort !== (currentEffort ?? "");
-  const contextUsage = session?.context_usage ?? null;
-  const rateLimitUsage = session?.rate_limit_usage ?? null;
-  const contextUsagePercentValue = contextUsage
-    ? contextUsagePercent(contextUsage)
-    : null;
-  const contextUsagePercentDisplay = clampPercent(contextUsagePercentValue);
-  const contextUsageToneValue = contextUsage
-    ? contextUsageTone(contextUsagePercentValue)
-    : "good";
-  const rateLimitUsageToneValue = rateLimitUsageTone(rateLimitUsage);
-  const contextUsageBreakdown = contextUsage
-    ? Object.entries(contextUsage.breakdown ?? {})
-    : [];
-  const contextUsageHasWindow =
-    contextUsage !== null &&
-    typeof contextUsage.context_window_tokens === "number" &&
-    contextUsage.context_window_tokens > 0;
-  const contextUsageWindowTokens = contextUsageHasWindow
-    ? contextUsage.context_window_tokens
-    : null;
-  const contextUsageWindowDisplay = contextUsageWindowTokens ?? 0;
-  const contextUsageSummary = contextUsage
-    ? contextUsageWindowTokens !== null && contextUsagePercentDisplay !== null
-      ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
-      : formatTokens(contextUsage.used_tokens)
-    : null;
-  const rateLimitUsageSummary = rateLimitUsage
-    ? rateLimitUsage.windows.length > 0
-      ? rateLimitUsage.windows
-          .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
-          .join(" · ")
-      : rateLimitUsage.notes?.length
-        ? rateLimitUsage.notes.join(" · ")
-        : null
-    : null;
-  const rateLimitSourceLabel = rateLimitUsage
-    ? rateLimitUsage.notes?.length
-      ? rateLimitUsage.notes.join(" · ")
-      : humaniseBackend(rateLimitUsage.source)
-    : "Unavailable";
-  const usageToneValue = (() => {
-    if (contextUsage === null) {
-      return rateLimitUsageToneValue;
-    }
-    if (rateLimitUsage === null) {
-      return contextUsageToneValue;
-    }
-    if (
-      contextUsageToneValue === "danger" ||
-      rateLimitUsageToneValue === "danger"
-    ) {
-      return "danger";
-    }
-    if (contextUsageToneValue === "warn" || rateLimitUsageToneValue === "warn") {
-      return "warn";
-    }
-    return "good";
-  })();
-  const showUsagePopover = contextUsage !== null || rateLimitUsage !== null;
-  const usagePopoverTitle = [
-    contextUsageSummary ? `Context ${contextUsageSummary}` : null,
-    rateLimitUsageSummary ? `Rate limits ${rateLimitUsageSummary}` : null,
-  ]
-    .filter((part): part is string => part !== null)
-    .join(" · ");
-
   const handleEffortSelect = (next: string) => {
     if (effortRequiresConfirm) {
       // Stage the pick locally; the parent's onEffortChange only fires after
@@ -2297,127 +2162,12 @@ const ReplyComposer = memo(function ReplyComposer({
           </div>
         ) : null}
         <div className="composer-toprow-trail">
-          {showUsagePopover ? (
-            <div className="composer-context" ref={contextUsageRef}>
-              <button
-                type="button"
-                className={`composer-connection composer-context-trigger tone-${usageToneValue} ${connection} ${contextUsageOpen ? "open" : ""}`}
-                title={
-                  usagePopoverTitle
-                    ? `Backend socket ${connection}. ${usagePopoverTitle}`
-                    : `Backend socket ${connection}. Click for usage details`
-                }
-                aria-live="polite"
-                aria-haspopup="dialog"
-                aria-expanded={contextUsageOpen}
-                aria-label={`Backend socket ${connection}. Usage details`}
-                onClick={() => setContextUsageOpen((open) => !open)}
-              >
-                {connection === "open"
-                  ? "live"
-                  : connection === "reconnecting"
-                    ? "reconnecting"
-                    : "connecting"}
-              </button>
-              {contextUsageOpen ? (
-                <div
-                  className={`usage-panel tone-${usageToneValue}`}
-                  role="dialog"
-                  aria-label="Usage details"
-                >
-                  <span className="usage-panel-rail" aria-hidden="true" />
-
-                  {contextUsage ? (
-                    <section className="usage-block">
-                      <header className="usage-block-head">
-                        <h3 className="usage-block-eyebrow">
-                          <span aria-hidden className="usage-block-mark">
-                            ◆
-                          </span>
-                          Context
-                        </h3>
-                        <span className="usage-block-tag">
-                          {humaniseBackend(contextUsage.source)}
-                        </span>
-                      </header>
-                      <div className="usage-block-body">
-                        <div className={`usage-numeral tone-${contextUsageToneValue}`}>
-                          <strong>
-                            {contextUsagePercentDisplay !== null
-                              ? contextUsagePercentDisplay
-                              : "—"}
-                          </strong>
-                          <em>%</em>
-                        </div>
-                        <div className="usage-block-stack">
-                          <p className="usage-line">
-                            <span>{formatTokens(contextUsage.used_tokens)}</span>
-                            <em>of</em>
-                            <span>
-                              {contextUsageWindowTokens !== null
-                                ? formatTokens(contextUsageWindowDisplay)
-                                : "—"}
-                            </span>
-                            <em>tokens</em>
-                          </p>
-                          <UsageBar
-                            percent={contextUsagePercentDisplay}
-                            tone={contextUsageToneValue}
-                            disabled={
-                              !contextUsageHasWindow ||
-                              contextUsagePercentDisplay === null
-                            }
-                          />
-                          <p className="usage-line-meta">
-                            <em>updated</em>
-                            <span title={new Date(contextUsage.updated_at).toLocaleString()}>
-                              {formatRelativeTime(contextUsage.updated_at)}
-                            </span>
-                          </p>
-                        </div>
-                      </div>
-                      {contextUsageBreakdown.length > 0 ? (
-                        <ul className="usage-chips">
-                          {contextUsageBreakdown.map(([key, value]) => (
-                            <li key={key}>
-                              <em>{contextUsageLabel(key)}</em>
-                              <strong>{formatTokens(value)}</strong>
-                            </li>
-                          ))}
-                        </ul>
-                      ) : null}
-                    </section>
-                  ) : null}
-
-                  {contextUsage && rateLimitUsage ? (
-                    <hr className="usage-divider" aria-hidden="true" />
-                  ) : null}
-
-                  {rateLimitUsage ? (
-                    <UsageReadout
-                      usage={rateLimitUsage}
-                      sourceLabel={rateLimitSourceLabel}
-                      onRefresh={onRateLimitRefresh}
-                      refreshing={rateLimitRefreshBusy}
-                    />
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-          ) : (
-            <span
-              className={`composer-connection ${connection}`}
-              title={`Backend socket ${connection}`}
-              role="status"
-              aria-live="polite"
-            >
-              {connection === "open"
-                ? "live"
-                : connection === "reconnecting"
-                  ? "reconnecting"
-                  : "connecting"}
-            </span>
-          )}
+          <SessionUsagePill
+            session={session}
+            connection={connection}
+            onRateLimitRefresh={onRateLimitRefresh}
+            rateLimitRefreshBusy={rateLimitRefreshBusy}
+          />
         </div>
       </div>
       <div className="reply-textarea-wrap">

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -159,6 +159,33 @@ function copyTextSync(text: string): boolean {
   return ok;
 }
 
+// WebKit (desktop Safari + every iOS browser, since the App Store
+// requires WebKit) gates ``navigator.clipboard.readText()`` behind a
+// system "Paste" banner that the user must click to authorize. Other
+// browsers either cache the permission (Chromium) or expose it via a
+// URL-bar affordance (Firefox), so the one-tap path Just Works there.
+// We use this flag to decide whether to short-circuit straight to
+// sending or to stage the text behind a tap-to-confirm pill.
+function isSafariFamily(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const ua = navigator.userAgent;
+  const iOS =
+    /\b(iPad|iPhone|iPod)\b/.test(ua) ||
+    (ua.includes("Mac") && (navigator.maxTouchPoints ?? 0) > 1);
+  if (iOS) return true;
+  return /Safari\//.test(ua) && !/Chrome|Chromium|Edg\/|OPR\//.test(ua);
+}
+
+// Bracketed-paste wraps the payload so TUIs that have enabled mode
+// 2004 treat the bytes as a single paste event rather than a stream of
+// keystrokes. Normalize ``\r\n`` and lone ``\r`` to ``\n`` first so a
+// stray CR can't fire a mid-paste submit on the way in. Wrapped CLIs
+// (CC, Codex, OpenCode) all enable mode 2004; raw shells will show the
+// literal escape codes, which is the documented trade-off.
+function wrapBracketedPaste(text: string): string {
+  return `\x1b[200~${text.replace(/\r\n?/g, "\n")}\x1b[201~`;
+}
+
 function mergeBuiltinFallback(
   backend: ReadonlyArray<CommandCompletion>,
 ): CommandCompletion[] {
@@ -234,6 +261,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   // per element, so consecutive /copies on the same DOM node would
   // otherwise silently swap text with no visible motion.
   const [clipboardSeq, setClipboardSeq] = useState(0);
+  // Paste-side mirror of the copy flow. On WebKit the readText prompt
+  // is a system-level "Paste" banner the user must approve, so even
+  // after we have the bytes we stage them behind a second tap-to-send
+  // pill that previews the char count. On Chromium/Firefox we skip
+  // the pill and send straight through.
+  const [pendingPaste, setPendingPaste] = useState<string | null>(null);
+  const [pasteSeq, setPasteSeq] = useState(0);
   const [connection, setConnection] = useState<ConnectionState>("connecting");
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
@@ -1213,6 +1247,41 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, []);
 
+  const requestPaste = useCallback(async () => {
+    setError("");
+    if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+      setError("Clipboard read is unavailable in this browser");
+      return;
+    }
+    let text: string;
+    try {
+      text = await navigator.clipboard.readText();
+    } catch {
+      setError("Clipboard access blocked — approve the paste prompt and retry");
+      return;
+    }
+    if (!text) return;
+    if (isSafariFamily()) {
+      // Stash the raw text so the preview char count reflects what the
+      // user actually pasted; bracketed-paste wrapping happens at send
+      // time inside ``sendPendingPaste``.
+      setPendingPaste(text);
+      setPasteSeq((s) => s + 1);
+    } else {
+      handleTerminalInput(wrapBracketedPaste(text));
+    }
+  }, [handleTerminalInput]);
+
+  const sendPendingPaste = useCallback(() => {
+    if (pendingPaste === null) return;
+    handleTerminalInput(wrapBracketedPaste(pendingPaste));
+    setPendingPaste(null);
+  }, [pendingPaste, handleTerminalInput]);
+
+  const dismissPendingPaste = useCallback(() => {
+    setPendingPaste(null);
+  }, []);
+
   const [terminalDims, setTerminalDims] = useState<{ cols: number; rows: number } | null>(null);
   const handleTerminalResize = useCallback(
     ({ cols, rows }: { cols: number; rows: number }) => {
@@ -1488,6 +1557,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           rateLimitRefreshBusy={rateLimitRefreshBusy}
           onRateLimitRefresh={handleRateLimitRefresh}
           onTerminalInput={handleTerminalInput}
+          onRequestPaste={requestPaste}
           onTerminalResize={handleTerminalResize}
           onTerminalScrollChip={handleTerminalScrollChip}
           onTerminalScrollChange={handleTerminalScrollChange}
@@ -1570,7 +1640,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           </button>
         </div>
       ) : null}
-      {pendingClipboard !== null ? (
+      {pendingPaste === null && pendingClipboard !== null ? (
         <button
           key={`clipboard-pending-${clipboardSeq}`}
           type="button"
@@ -1604,7 +1674,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
             →
           </span>
         </button>
-      ) : clipboardCopied ? (
+      ) : pendingPaste === null && clipboardCopied ? (
         <div
           key={`clipboard-copied-${clipboardSeq}`}
           className="clipboard-prompt is-copied"
@@ -1628,6 +1698,52 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
             <span className="clipboard-prompt__label">Copied</span>
             <span className="clipboard-prompt__meta">paste anywhere</span>
           </span>
+        </div>
+      ) : null}
+      {pendingPaste !== null ? (
+        <div
+          key={`paste-pending-${pasteSeq}`}
+          className="clipboard-prompt is-paste"
+          role="dialog"
+          aria-label="Confirm paste"
+        >
+          <span className="clipboard-prompt__glyph" aria-hidden="true">
+            <svg
+              viewBox="0 0 16 16"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3.5" y="3" width="9" height="11" rx="1.5" />
+              <path d="M6 3V2.25c0-.41.34-.75.75-.75h2.5c.41 0 .75.34.75.75V3" />
+              <path d="M8 6.25v4.25M6 8.5l2 2 2-2" />
+            </svg>
+          </span>
+          <button
+            type="button"
+            className="clipboard-prompt__send"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={sendPendingPaste}
+            aria-label={`Send ${pendingPaste.length} characters from clipboard`}
+          >
+            <span className="clipboard-prompt__label">Paste ready</span>
+            <span className="clipboard-prompt__meta">
+              {pendingPaste.length.toLocaleString()} chars · tap to send
+            </span>
+          </button>
+          <button
+            type="button"
+            className="clipboard-prompt__dismiss"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={dismissPendingPaste}
+            aria-label="Cancel paste"
+          >
+            ×
+          </button>
         </div>
       ) : null}
       {session && !terminalOnly ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -41,6 +41,7 @@ import {
   permissionModesFor,
   supportsApprovalNote,
   supportsPlanApproval,
+  supportsReattachAfterExit,
   supportsResume,
   supportsStructuredApproval,
   transportLabel,
@@ -764,12 +765,44 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       const ts = new Date().toISOString();
       setOptimisticMessages((prev) => [...prev, { tempId, text, ts, confirmed: false }]);
       try {
+        // Sending a message to an exited session restarts it: the placeholder
+        // "Session has exited — send a message to reattach…" promises this UX.
+        // Reattach first, then submit; both are sequenced so the input lands
+        // after the freshly-restored transport accepts stdin.
+        if (
+          session &&
+          (session.status === "exited" || session.status === "error") &&
+          supportsReattachAfterExit(session.backend, catalog)
+        ) {
+          try {
+            await postAction(host, token, sessionId, "reattach");
+          } catch (reattachError) {
+            if (isAuthError(reattachError)) {
+              handleAuthFailure();
+              return false;
+            }
+            setError(
+              reattachError instanceof Error
+                ? reattachError.message
+                : "failed to reconnect",
+            );
+            return false;
+          }
+        }
         return await submitInput(text, command);
       } finally {
         setOptimisticMessages((prev) => prev.filter((m) => m.tempId !== tempId));
       }
     },
-    [submitInput],
+    [
+      submitInput,
+      session,
+      catalog,
+      host,
+      token,
+      sessionId,
+      handleAuthFailure,
+    ],
   );
 
   const submitAskAnswer = useCallback(
@@ -973,8 +1006,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     session && (session.status === "exited" || session.status === "error"),
   );
   const terminalOnly = session?.transport === "tmux";
-  const dormantReattach = sessionExited;
-  const composerDisabled = !session || sessionExited;
+  const canReattachAfterExit = Boolean(
+    session && supportsReattachAfterExit(session.backend, catalog),
+  );
+  const dormantReattach = sessionExited && canReattachAfterExit;
+  const composerDisabled =
+    !session || (sessionExited && !canReattachAfterExit);
   const composerPlaceholder = !session
     ? "Loading session…"
     : dormantReattach

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -2,9 +2,12 @@
 
 import { Dispatch, MutableRefObject, SetStateAction } from "react";
 
+import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { TerminalScrollChips } from "@/components/TerminalScrollChips";
 import { XTerminal, type XTerminalHandle } from "@/components/XTerminal";
 import { SessionRecord } from "@/lib/types";
+
+type Connection = "idle" | "connecting" | "open" | "reconnecting";
 
 interface SessionTerminalViewProps {
   session: SessionRecord | null;
@@ -19,6 +22,9 @@ interface SessionTerminalViewProps {
   setTermMenuOpen: Dispatch<SetStateAction<boolean>>;
   termMenuWrapRef: MutableRefObject<HTMLDivElement | null>;
   termAtBottom: boolean;
+  connection: Connection;
+  rateLimitRefreshBusy: boolean;
+  onRateLimitRefresh: () => void | Promise<void>;
   // True on terminal-only (tmux) sessions where no composer follows — the
   // pane sticky-locks to the viewport bottom once the user scrolls past
   // the SessionHeader. Chat-capable Terminal tabs stay bounded so the
@@ -52,6 +58,9 @@ export function SessionTerminalView({
   setTermMenuOpen,
   termMenuWrapRef,
   termAtBottom,
+  connection,
+  rateLimitRefreshBusy,
+  onRateLimitRefresh,
   locked,
   onTerminalInput,
   onTerminalResize,
@@ -104,6 +113,12 @@ export function SessionTerminalView({
       aria-label="Terminal session"
     >
       <div className="term-bar">
+        <SessionUsagePill
+          session={session}
+          connection={connection}
+          onRateLimitRefresh={onRateLimitRefresh}
+          rateLimitRefreshBusy={rateLimitRefreshBusy}
+        />
         <span className="term-bar-spacer" />
         {liveTmux && terminalDims ? (
           <span className="term-bar-dims" aria-label="Pane dimensions">

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -31,6 +31,7 @@ interface SessionTerminalViewProps {
   // composer beneath remains visible.
   locked: boolean;
   onTerminalInput: (data: string) => void;
+  onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;
   onTerminalScrollChange: (atBottom: boolean) => void;
@@ -63,6 +64,7 @@ export function SessionTerminalView({
   onRateLimitRefresh,
   locked,
   onTerminalInput,
+  onRequestPaste,
   onTerminalResize,
   onTerminalScrollChip,
   onTerminalScrollChange,
@@ -249,6 +251,7 @@ export function SessionTerminalView({
       {liveTmux ? (
         <TerminalKeyBar
           onSend={onTerminalInput}
+          onRequestPaste={onRequestPaste}
           backend={session?.backend ?? null}
         />
       ) : null}
@@ -261,14 +264,17 @@ export function SessionTerminalView({
 // bytes to the pane via the existing input handler — Ctrl-* combinations
 // are encoded directly so the toolbar works even when the OS keyboard
 // doesn't expose a Ctrl modifier. ``backends`` (when set) restricts a
-// key to those backend ids; entries without it are universal.
-const TERMINAL_KEY_BAR: {
+// key to those backend ids; entries without it are universal. An entry
+// with ``action`` instead of ``data`` dispatches a richer handler (e.g.
+// reading the system clipboard) provided by the keybar host.
+type KeyBarEntry = {
   label: string;
-  data: string;
   title: string;
   backends?: string[];
   backendOnly?: boolean;
-}[] = [
+} & ({ data: string } | { action: "paste" });
+
+const TERMINAL_KEY_BAR: KeyBarEntry[] = [
   { label: "Esc", data: "\x1b", title: "Escape" },
   { label: "Tab", data: "\t", title: "Tab" },
   {
@@ -282,19 +288,28 @@ const TERMINAL_KEY_BAR: {
     backends: ["claude_code", "codex"],
     backendOnly: true,
   },
-  { label: "↵", data: "\n", title: "Newline (Ctrl-J)" },
+  { label: "Enter", data: "\r", title: "Enter (submit / select)" },
+  // ``⇧↵`` instead of plain ``↵`` so the glyph reads as "the
+  // shift-modified return key" — i.e. insert a newline in the composer
+  // rather than submit. CC and Codex both wire Ctrl-J (\n) to a
+  // soft-newline; the dedicated Enter chip above carries the submit
+  // semantics.
+  { label: "⇧↵", data: "\n", title: "Shift+Enter (newline)" },
   { label: "↑", data: "\x1b[A", title: "Up" },
   { label: "↓", data: "\x1b[B", title: "Down" },
   { label: "←", data: "\x1b[D", title: "Left" },
   { label: "→", data: "\x1b[C", title: "Right" },
+  { label: "Paste", action: "paste", title: "Paste from clipboard" },
   { label: "^C", data: "\x03", title: "Ctrl-C (interrupt)" },
 ];
 
 export function TerminalKeyBar({
   onSend,
+  onRequestPaste,
   backend,
 }: {
   onSend: (data: string) => void;
+  onRequestPaste: () => void;
   backend: string | null | undefined;
 }) {
   const keys = TERMINAL_KEY_BAR.filter(
@@ -315,7 +330,10 @@ export function TerminalKeyBar({
           // was elsewhere (e.g. the title editor or nowhere) it stays
           // put — tapping a key never pulls focus into the pane.
           onMouseDown={(event) => event.preventDefault()}
-          onClick={() => onSend(key.data)}
+          onClick={() => {
+            if ("action" in key && key.action === "paste") onRequestPaste();
+            else if ("data" in key) onSend(key.data);
+          }}
         >
           {key.label}
         </button>

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -1,0 +1,267 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { UsageBar, UsageReadout } from "@/components/UsageReadout";
+import { humaniseBackend } from "@/lib/backends";
+import type { SessionContextUsage, SessionRecord } from "@/lib/types";
+import {
+  clampPercent,
+  formatRelativeTime,
+  formatTokens,
+  rateLimitUsageTone,
+} from "@/lib/usage";
+
+type Connection = "idle" | "connecting" | "open" | "reconnecting";
+
+interface SessionUsagePillProps {
+  session: SessionRecord | null;
+  connection: Connection;
+  onRateLimitRefresh: () => void | Promise<void>;
+  rateLimitRefreshBusy: boolean;
+}
+
+export function SessionUsagePill({
+  session,
+  connection,
+  onRateLimitRefresh,
+  rateLimitRefreshBusy,
+}: SessionUsagePillProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(event: MouseEvent) {
+      if (!wrapRef.current) return;
+      if (wrapRef.current.contains(event.target as Node)) return;
+      setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const contextUsage = session?.context_usage ?? null;
+  const rateLimitUsage = session?.rate_limit_usage ?? null;
+  const contextUsagePercentValue = contextUsage
+    ? contextUsagePercent(contextUsage)
+    : null;
+  const contextUsagePercentDisplay = clampPercent(contextUsagePercentValue);
+  const contextUsageToneValue = contextUsage
+    ? contextUsageTone(contextUsagePercentValue)
+    : "good";
+  const rateLimitUsageToneValue = rateLimitUsageTone(rateLimitUsage);
+  const contextUsageBreakdown = contextUsage
+    ? Object.entries(contextUsage.breakdown ?? {})
+    : [];
+  const contextUsageHasWindow =
+    contextUsage !== null &&
+    typeof contextUsage.context_window_tokens === "number" &&
+    contextUsage.context_window_tokens > 0;
+  const contextUsageWindowTokens = contextUsageHasWindow
+    ? contextUsage.context_window_tokens
+    : null;
+  const contextUsageWindowDisplay = contextUsageWindowTokens ?? 0;
+  const contextUsageSummary = contextUsage
+    ? contextUsageWindowTokens !== null && contextUsagePercentDisplay !== null
+      ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
+      : formatTokens(contextUsage.used_tokens)
+    : null;
+  const rateLimitUsageSummary = rateLimitUsage
+    ? rateLimitUsage.windows.length > 0
+      ? rateLimitUsage.windows
+          .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
+          .join(" · ")
+      : rateLimitUsage.notes?.length
+        ? rateLimitUsage.notes.join(" · ")
+        : null
+    : null;
+  const rateLimitSourceLabel = rateLimitUsage
+    ? rateLimitUsage.notes?.length
+      ? rateLimitUsage.notes.join(" · ")
+      : humaniseBackend(rateLimitUsage.source)
+    : "Unavailable";
+  const usageToneValue = (() => {
+    if (contextUsage === null) return rateLimitUsageToneValue;
+    if (rateLimitUsage === null) return contextUsageToneValue;
+    if (
+      contextUsageToneValue === "danger" ||
+      rateLimitUsageToneValue === "danger"
+    ) {
+      return "danger";
+    }
+    if (contextUsageToneValue === "warn" || rateLimitUsageToneValue === "warn") {
+      return "warn";
+    }
+    return "good";
+  })();
+  const showUsagePopover = contextUsage !== null || rateLimitUsage !== null;
+  const usagePopoverTitle = [
+    contextUsageSummary ? `Context ${contextUsageSummary}` : null,
+    rateLimitUsageSummary ? `Rate limits ${rateLimitUsageSummary}` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  if (!showUsagePopover) {
+    return (
+      <span
+        className={`composer-connection ${connection}`}
+        title={`Backend socket ${connection}`}
+        role="status"
+        aria-live="polite"
+      >
+        {connection === "open"
+          ? "live"
+          : connection === "reconnecting"
+            ? "reconnecting"
+            : "connecting"}
+      </span>
+    );
+  }
+
+  return (
+    <div className="composer-context" ref={wrapRef}>
+      <button
+        type="button"
+        className={`composer-connection composer-context-trigger tone-${usageToneValue} ${connection} ${open ? "open" : ""}`}
+        title={
+          usagePopoverTitle
+            ? `Backend socket ${connection}. ${usagePopoverTitle}`
+            : `Backend socket ${connection}. Click for usage details`
+        }
+        aria-live="polite"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={`Backend socket ${connection}. Usage details`}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {connection === "open"
+          ? "live"
+          : connection === "reconnecting"
+            ? "reconnecting"
+            : "connecting"}
+      </button>
+      {open ? (
+        <div
+          className={`usage-panel tone-${usageToneValue}`}
+          role="dialog"
+          aria-label="Usage details"
+        >
+          <span className="usage-panel-rail" aria-hidden="true" />
+
+          {contextUsage ? (
+            <section className="usage-block">
+              <header className="usage-block-head">
+                <h3 className="usage-block-eyebrow">
+                  <span aria-hidden className="usage-block-mark">
+                    ◆
+                  </span>
+                  Context
+                </h3>
+                <span className="usage-block-tag">
+                  {humaniseBackend(contextUsage.source)}
+                </span>
+              </header>
+              <div className="usage-block-body">
+                <div className={`usage-numeral tone-${contextUsageToneValue}`}>
+                  <strong>
+                    {contextUsagePercentDisplay !== null
+                      ? contextUsagePercentDisplay
+                      : "—"}
+                  </strong>
+                  <em>%</em>
+                </div>
+                <div className="usage-block-stack">
+                  <p className="usage-line">
+                    <span>{formatTokens(contextUsage.used_tokens)}</span>
+                    <em>of</em>
+                    <span>
+                      {contextUsageWindowTokens !== null
+                        ? formatTokens(contextUsageWindowDisplay)
+                        : "—"}
+                    </span>
+                    <em>tokens</em>
+                  </p>
+                  <UsageBar
+                    percent={contextUsagePercentDisplay}
+                    tone={contextUsageToneValue}
+                    disabled={
+                      !contextUsageHasWindow ||
+                      contextUsagePercentDisplay === null
+                    }
+                  />
+                  <p className="usage-line-meta">
+                    <em>updated</em>
+                    <span title={new Date(contextUsage.updated_at).toLocaleString()}>
+                      {formatRelativeTime(contextUsage.updated_at)}
+                    </span>
+                  </p>
+                </div>
+              </div>
+              {contextUsageBreakdown.length > 0 ? (
+                <ul className="usage-chips">
+                  {contextUsageBreakdown.map(([key, value]) => (
+                    <li key={key}>
+                      <em>{contextUsageLabel(key)}</em>
+                      <strong>{formatTokens(value)}</strong>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </section>
+          ) : null}
+
+          {contextUsage && rateLimitUsage ? (
+            <hr className="usage-divider" aria-hidden="true" />
+          ) : null}
+
+          {rateLimitUsage ? (
+            <UsageReadout
+              usage={rateLimitUsage}
+              sourceLabel={rateLimitSourceLabel}
+              onRefresh={onRateLimitRefresh}
+              refreshing={rateLimitRefreshBusy}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function contextUsagePercent(usage: SessionContextUsage): number | null {
+  const windowTokens = usage.context_window_tokens;
+  if (!windowTokens || windowTokens <= 0) {
+    return null;
+  }
+  return Math.round((usage.used_tokens / windowTokens) * 100);
+}
+
+function contextUsageTone(percent: number | null): "good" | "warn" | "danger" {
+  if (percent === null) return "good";
+  if (percent >= 90) return "danger";
+  if (percent >= 70) return "warn";
+  return "good";
+}
+
+function contextUsageLabel(key: string): string {
+  switch (key) {
+    case "input_tokens":
+      return "Input";
+    case "cached_input_tokens":
+      return "Cached input";
+    case "output_tokens":
+      return "Output";
+    case "reasoning_output_tokens":
+      return "Reasoning";
+    case "reasoning_tokens":
+      return "Reasoning";
+    case "cache_read_tokens":
+      return "Cache read";
+    case "cache_write_tokens":
+      return "Cache write";
+    default:
+      return key.replaceAll("_", " ");
+  }
+}

--- a/frontend/src/components/WorkingDirectoryField.tsx
+++ b/frontend/src/components/WorkingDirectoryField.tsx
@@ -29,7 +29,6 @@ export function WorkingDirectoryField({
         onChange={(event) => onChange(event.target.value)}
         placeholder={targetLabel ? "~" : undefined}
         list={hasRecents ? listId : undefined}
-        autoComplete="off"
       />
       {hasRecents ? (
         <datalist id={listId}>

--- a/frontend/src/components/XTerminal.tsx
+++ b/frontend/src/components/XTerminal.tsx
@@ -153,6 +153,40 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       };
       const onScrollSub = term.onScroll(emitScrollState);
 
+      // OSC 52 is the terminal-clipboard protocol Claude Code (and Codex
+      // TUI) emit for `/copy`. Format: ``\x1b]52;<targets>;<payload>\x07``
+      // where ``<targets>`` is one or more of c (clipboard), p (primary),
+      // q (secondary), s (selection), 0–7 (cut buffers), and ``<payload>``
+      // is base64 (or "?" for a read query, which we ignore for security).
+      // Without this handler xterm.js drops the sequence silently and the
+      // user's `/copy` looks broken even though the CLI did its job.
+      const osc52Sub = term.parser.registerOscHandler(52, (data) => {
+        const sep = data.indexOf(";");
+        if (sep < 0) return true;
+        const payload = data.slice(sep + 1);
+        // "?" is a clipboard read; we deliberately don't surface page
+        // clipboard contents back to the wrapped CLI.
+        if (payload === "?" || payload === "") return true;
+        try {
+          const binary = atob(payload);
+          const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+          const text = new TextDecoder().decode(bytes);
+          navigator.clipboard?.writeText(text)?.catch(() => {
+            // Async write can reject when the clipboard API is gated
+            // (no transient activation, insecure context, missing
+            // permission). The CLI's /tmp/claude-<uid>/response.md is
+            // the documented fallback in those cases. The second ``?.``
+            // is load-bearing: without it, ``.catch`` runs on the
+            // optional chain's ``undefined`` result and throws.
+          });
+        } catch {
+          // Bad base64, missing clipboard API, or insecure context — silent
+          // fallback; the CLI also wrote /tmp/claude-<uid>/response.md for
+          // exactly this case.
+        }
+        return true;
+      });
+
       // Initial fit can throw if the container is still 0-sized (animation,
       // hidden tab, etc.) — guard so we don't crash the React tree.
       try {
@@ -177,6 +211,7 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
         onDataSub.dispose();
         onResizeSub.dispose();
         onScrollSub.dispose();
+        osc52Sub.dispose();
         ro.disconnect();
         term.dispose();
         termRef.current = null;

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -135,6 +135,14 @@ export function supportsResume(
   return caps ? caps.supports_resume : FALLBACK_RESUMABLE.has(transport);
 }
 
+export function supportsReattachAfterExit(
+  backend: Backend,
+  catalog?: BackendCatalog,
+): boolean {
+  const caps = catalog?.byId(backend)?.capabilities;
+  return caps ? Boolean(caps.supports_reattach_after_exit) : false;
+}
+
 export function supportsStructuredApproval(
   transport: SessionTransport,
   catalog?: BackendCatalog,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -166,6 +166,7 @@ export interface BackendCapabilities {
   supports_approval_note: boolean;
   supports_custom_cli_args: boolean;
   supports_config_overrides: boolean;
+  supports_reattach_after_exit: boolean;
   model_source: "static" | "live_rpc" | "none";
   approval_decisions: string[];
   effort_levels: string[];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -271,6 +271,7 @@ export interface SessionEnvelope {
     | "session_state"
     | "terminal_snapshot_ready"
     | "auth_revoked"
-    | "schedule_list_update";
+    | "schedule_list_update"
+    | "clipboard_copy";
   payload: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Round out the live tmux backend introduced in #64 so a tmux-wrapped session feels like a first-class chat session rather than a degraded fallback. Mobile users get a clipboard round-trip (paste-to-pane, `/copy`-to-clipboard with an iOS-safe path); the term-bar gains the rate-limit usage pill (with its own periodic refresh); model/effort/permission picks made at launch time actually reach the wrapped CLI; and a handful of attached/exited-session ergonomics carry over.

## Changes

### Frontend — mobile keybar + clipboard round-trip

- `components/SessionTerminalView.tsx`: split the keybar's old ↵ chip into `Enter` (`\r`, submit/select) and `⇧↵` (`\n`, soft newline) — a single ambiguous return key was sending the wrong byte half the time. Added a `Paste` chip that reads `navigator.clipboard.readText`, normalizes CR/CRLF to LF, and wraps the payload in bracketed-paste escapes so wrapped CLIs treat the drop as one event.
- `components/SessionDetail.tsx`: Safari and every iOS browser (all WebKit by App Store rule) gate `readText` behind a per-tap system banner with no Permissions-API hook, so a one-tap paste would be jarring. Stage the unwrapped text behind a confirm pill (`.clipboard-prompt` paste variant) that previews the char count and offers `×` to dismiss; Chromium/Firefox keep the one-tap path. The pill suppresses the copy pill while a paste is pending so the two anchored at the same bottom edge can't overlap.
- `components/SessionDetail.tsx`: when a `clipboard_copy` WS envelope arrives, try `navigator.clipboard.writeText` first. Chromium accepts it; Safari rejects (the keystroke's transient activation has long expired by the time the WS frame lands). On rejection, stash the text and surface a glass tap-to-copy pill — the user's tap is a fresh gesture for the synchronous retry. iOS Safari additionally rejects the Promise-based `writeText` from inside the click handler (the microtask boundary consumes the activation token before the write resolves), so the iOS retry path goes through a contenteditable `<div>` + `Range.selectNodeContents` + `execCommand("copy")`. Both copy variants and the paste pill carry an `×` dismiss with `pointer-events: auto` so the dismiss stays tappable inside the otherwise-inert `.is-copied` wrapper.
- `app/globals.css`: `.clipboard-prompt` chrome, paste/copy variants, multi-action layout via `:has(.clipboard-prompt__dismiss)`, and the term-bar usage popover positioning + `env(safe-area-inset-bottom)` reserve for iOS.

### Backend — `/copy` interception + OSC 52 plumbing

- `backends/claude_code/plugin.py`: intercept `/copy` in `maybe_handle_input` for structured Claude sessions and emit the last assistant message back over the WS as a `clipboard_copy` envelope. Uses `list_events_by_message_count(message_limit=1)` so we walk a bounded tail instead of the full transcript.
- `backends/tmux/renderer.py`: lift OSC 52 (clipboard set) out of the tmux pane bytestream before pyte absorbs it — pyte would otherwise consume the escape silently and the clipboard envelope would never reach the client.
- `backends/base.py` + `api.py`: a small `clipboard_copy` envelope type plumbed through the WS push path so structured backends and the tmux renderer can both emit it.

### Frontend — usage pill on the terminal view

- `components/SessionUsagePill.tsx` (new): the rate-limit usage pill extracted from the composer's status pill so the tmux terminal view can render it next to its other term-bar controls. Owns the popover, the dial, and the per-session refresh button.
- `components/SessionTerminalView.tsx`: surface `<SessionUsagePill>` on tmux-launched sessions so a user staring at the live pane can see their 5h/weekly utilization without flipping back to chat.

### Backend — usage refresh for tmux sessions

- `backends/tmux/plugin.py`: register the same account-level rate-limit probe used by the structured backends so a tmux-wrapped claude/codex session reports usage without needing the wrapped CLI's WS to be up. Refresh runs on a periodic watcher (every 5 min) and on explicit refresh requests, and writes the snapshot back through `runtime.update_session_fields` directly so the WS broadcast path stays uniform.

### Backend — inner-CLI launch-pick fidelity

- `backends/tmux/plugin.py`: when a tmux-wrapped launch is requested with a `model`, `effort`, or `permission_mode`, translate the pick into the wrapped CLI's flag syntax (`_inner_cli_flags`) instead of dropping it on the floor. Codex's CLI has no `--effort`, so the picker is also hidden in the frontend (`LaunchPanel.tsx`) for tmux-wrapped codex so a value can't silently disappear at launch. The session's stored `model` / `effort` / `permission_mode` is only persisted when the inner CLI actually accepts the flag — otherwise we null it out so the UI doesn't lie about what's running. For codex, an unmapped `permission_mode` (one not in `_CODEX_PERMISSION_MODE_FLAG`) is now nulled rather than persisted as a no-op.
- `backends/claude_code/plugin.py`: force claude's fullscreen TUI renderer (`CLAUDE_CODE_USE_FULLSCREEN_RENDERER=1`) for tmux-wrapped launches so the pane lays out against the explicit `tmux resize-window` dimensions instead of the inline-mode rolling buffer.

### Frontend — small ergonomic fixes carried in this branch

- `components/LaunchPanel.tsx`: allow setting a session title when attaching to an existing tmux pane (matches the New-mode form).
- `components/SessionDetail.tsx`: enable the composer on EXITED sessions when the backend reports `supports_reattach_after_exit`, so the user can type to reconnect rather than having to click Reconnect first.
- `components/WorkingDirectoryField.tsx`: restore the desktop `<datalist>` suggestions for recent cwds — the autocomplete-suppression fix in #64 had been over-broad and ate the desktop affordance.

### Tests

- `backend/tests/test_tmux_plugin.py`: `_inner_cli_flags` translation for claude (`--model`, `--permission-mode`) and codex (`--model`, no `--effort`); permission-mode flag map for codex; persistence policy (model/effort/permission stored only when accepted by the inner CLI); periodic rate-limit refresh writes back via `runtime.update_session_fields`; OSC 52 strip preserves surrounding bytes.
- `backend/tests/test_runtime.py`: composer-on-exit gating via `supports_reattach_after_exit`.
- `backend/tests/test_launch_targets.py`: `allocate_tty=True` plumbing (carried from #64 with an extra case for the tmux-wrapped path).
- `backend/tests/test_backend_registry.py`: registry assertion for the new `clipboard_copy` envelope type.

## Test Plan

- [x] `cd backend && uv run pre-commit run --all-files`
- [x] `cd backend && uv run pytest`
- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] Manual: tmux-wrapped claude on iOS Safari — tap Paste, confirm the pill previews the char count; tap → bracketed paste lands in the pane.
- [x] Manual: tmux-wrapped claude on iOS Safari — issue `/copy` in the pane; confirm the tap-to-copy pill appears and the `execCommand` fallback writes the message to the system clipboard.
- [x] Manual: tmux-wrapped claude with `--model` + `--permission-mode` picks — confirm the wrapped CLI receives the flags and the session record reflects them only after the CLI accepts.
- [x] Manual: tmux-wrapped codex — confirm the effort picker is hidden in `LaunchPanel` and an unmapped permission mode is nulled instead of persisted.
- [x] Manual: tmux-wrapped session — confirm the usage pill on the term-bar renders, refreshes on tap, and the periodic watcher updates the snapshot every 5 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)