### PR TITLE
fix: keep markdown plans inside the approval bubble on mobile

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3066,6 +3066,8 @@ html[data-theme="light"] .tool-call-run-children {
   padding: 6px 12px;
   background: rgba(15, 19, 27, 0.4);
   border-radius: var(--radius-sm);
+  min-width: 0;
+  overflow: hidden;
 }
 
 html[data-theme="light"] .approval-plan {
@@ -3157,6 +3159,14 @@ html[data-theme="light"] .approval-shell {
   line-height: 1.6;
   min-width: 0;
   max-width: 100%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.markdown-message table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .markdown-message > :first-child {


### PR DESCRIPTION
## Summary

Markdown plans rendered in the plan-approval bubble could push the bubble past the viewport on narrow screens — long URLs or pasted tokens stretched paragraphs, GFM tables rendered at intrinsic width, and the `.approval-plan` quote-block (a grid-item child of `.panel.approval` with the default `min-width: auto`) let any wide descendant stretch its track. Add a handful of CSS rules so the existing in-bubble content scrolls/wraps the same way transcript `<pre>` blocks already do.

## Changes

### Frontend

- `app/globals.css`: `.markdown-message` gains `overflow-wrap: anywhere; word-break: break-word;` so long URLs or unbroken tokens in paragraphs and list items wrap instead of stretching the line — same pattern already used by `.transcript pre` and `.markdown-pre`.
- `app/globals.css`: new `.markdown-message table` rule (`display: block; max-width: 100%; overflow-x: auto;`) so GFM tables (enabled in `MarkdownMessage` via `remarkGfm`) scroll horizontally inside the bubble instead of widening it.
- `app/globals.css`: `.approval-plan` gains `min-width: 0; overflow: hidden;` so the quote-block can't stretch its grid track when an unusually wide descendant (e.g. a non-wrapping inline) slips through.

No light-theme overrides needed — the new rules don't touch colors.

## Test Plan

- [ ] `cd frontend && npm run lint` — not run in this session
- [ ] `cd frontend && npm run build` — not run in this session
- [ ] Manual: render a plan with a long URL, a GFM table, and a paragraph with an unbroken token in a narrow viewport (≤375 px) and confirm the bubble no longer overflows — deferred to reviewer