### PR TITLE
fix: compact message bubbles with a bottom-right meta strip

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2232,6 +2232,87 @@ html[data-theme="light"] .transcript.codex.agent_output {
   font-variant-numeric: tabular-nums;
 }
 
+/* WhatsApp-style meta strip — identity badge, timestamp, and copy button
+ * absolutely positioned at the bubble's bottom-right corner. Paired with
+ * the inline `::after` reserve below, the last text line wraps around
+ * the meta so a single-line message stays a single row instead of
+ * gaining a dedicated footer row. */
+.transcript-meta {
+  position: absolute;
+  bottom: 6px;
+  right: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.transcript-meta .badge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  opacity: 0.85;
+}
+
+.transcript-meta .role-time {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--muted-soft);
+  letter-spacing: 0.04em;
+  font-variant-numeric: tabular-nums;
+  opacity: 0.8;
+}
+
+.transcript-meta .message-copy {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  opacity: 0.55;
+}
+
+.transcript:hover .transcript-meta .message-copy,
+.transcript:focus-within .transcript-meta .message-copy,
+.transcript-meta .message-copy:focus-visible {
+  opacity: 1;
+}
+
+/* Tighter padding for chat bubbles — the editorial 18px panel padding
+ * suits tool cards and disclosures but wastes space around plain text. */
+.transcript.codex.user_input,
+.transcript.codex.agent_output {
+  position: relative;
+  padding: 8px 14px;
+}
+
+/* Reserve inline space at the end of the last paragraph so the meta
+ * strip (absolutely positioned at the bottom-right) lands in cleared
+ * space rather than overlapping text. The width is `--meta-reserve`,
+ * set on the bubble at runtime by `useMetaReserve` to the meta's
+ * actual measured width + a 16px gap, so the browser's line-breaker
+ * decides crisply whether the last line has room for the meta or
+ * needs to wrap. The hardcoded fallback only applies during the
+ * first paint before the ResizeObserver fires. */
+.transcript.codex.user_input .markdown-message > p:last-child::after,
+.transcript.codex.agent_output .markdown-message > p:last-child::after {
+  content: "\200B";
+  display: inline-block;
+  width: var(--meta-reserve, 132px);
+  height: 1em;
+  vertical-align: bottom;
+  pointer-events: none;
+}
+
+/* When the message ends with a block-level child (code fence, list,
+ * table, etc.) the inline phantom doesn't apply, so reserve vertical
+ * space via padding so the meta clears the block. */
+.transcript.codex.user_input:has(.markdown-message > *:last-child:not(p)),
+.transcript.codex.agent_output:has(.markdown-message > *:last-child:not(p)),
+.transcript.codex.user_input.ask-answer-summary {
+  padding-bottom: 30px;
+}
+
 .message-copy {
   margin-left: auto;
   display: inline-flex;
@@ -2279,7 +2360,8 @@ html[data-theme="light"] .transcript.codex.agent_output {
 @media (hover: none) {
   /* No hover on touch — the button has to read clearly without the
    * brighten-on-hover step the desktop relies on. */
-  .message-copy {
+  .message-copy,
+  .transcript-meta .message-copy {
     opacity: 1;
   }
 }

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -1,4 +1,10 @@
-import { memo, useState } from "react";
+import {
+  memo,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 
 import { fidelityFor, transportLabel } from "@/lib/backends";
 import { EventRecord, SessionTransport } from "@/lib/types";
@@ -39,6 +45,32 @@ export interface AskAnswerEntry {
   notes?: string;
 }
 
+// Measure the meta strip's real width and surface it as `--meta-reserve`
+// on the bubble, so the inline phantom at the end of the last paragraph
+// can be sized to exactly the meta's footprint plus a small gap. With
+// this, the browser's line-breaker decides cleanly whether the meta fits
+// on the last line (no overlap) or has to wrap to its own row (no
+// hardcoded 116px guess that sometimes lets text bleed under the meta).
+function useMetaReserve(gap: number = 16) {
+  const metaRef = useRef<HTMLDivElement | null>(null);
+  const [width, setWidth] = useState<number | null>(null);
+  useLayoutEffect(() => {
+    const node = metaRef.current;
+    if (!node || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? 0;
+      if (w > 0) setWidth(Math.ceil(w));
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
+  const style =
+    width != null
+      ? ({ "--meta-reserve": `${width + gap}px` } as CSSProperties)
+      : undefined;
+  return { metaRef, style };
+}
+
 export function PendingUserInputCard({
   text,
   ts,
@@ -48,15 +80,18 @@ export function PendingUserInputCard({
   ts: string;
   confirmed?: boolean;
 }) {
+  const { metaRef, style } = useMetaReserve();
   return (
     <article
       className={`panel transcript codex user_input${confirmed ? " pending-optimistic persisted" : " pending-optimistic"}`}
+      aria-label="Message from you"
+      style={style}
     >
-      <div className="transcript-role">
+      <MarkdownMessage text={text} />
+      <div ref={metaRef} className="transcript-meta">
         <span className="badge user">you</span>
         <span className="role-time">{formatTime(ts)}</span>
       </div>
-      <MarkdownMessage text={text} />
     </article>
   );
 }
@@ -138,31 +173,13 @@ function CodexCard({
       if (event.metadata?.kind === "ask_user_question_answer") {
         return <AskAnswerSummaryCard event={event} />;
       }
-      return (
-        <article className="panel transcript codex user_input">
-          <div className="transcript-role">
-            <span className="badge user">you</span>
-            <span className="role-time">{formatTime(event.ts)}</span>
-            <CopyMessageButton text={event.text} />
-          </div>
-          <MarkdownMessage text={event.text} />
-        </article>
-      );
+      return <UserMessageBubble event={event} />;
     }
     case "agent_output":
       if (event.metadata?.item_kind === "reasoning") {
         return <ReasoningDisclosure event={event} agentLabel={agentLabel} />;
       }
-      return (
-        <article className="panel transcript codex agent_output">
-          <div className="transcript-role">
-            <span className="badge agent">{agentLabel}</span>
-            <span className="role-time">{formatTime(event.ts)}</span>
-            <CopyMessageButton text={event.text} />
-          </div>
-          <MarkdownMessage text={event.text} />
-        </article>
-      );
+      return <AgentMessageBubble event={event} agentLabel={agentLabel} />;
     case "tool_call": {
       const ask = parseAskUserQuestion(event);
       if (ask) {
@@ -213,6 +230,48 @@ function CodexCard({
     default:
       return <HeuristicCard event={event} />;
   }
+}
+
+function UserMessageBubble({ event }: { event: EventRecord }) {
+  const { metaRef, style } = useMetaReserve();
+  return (
+    <article
+      className="panel transcript codex user_input"
+      aria-label="Message from you"
+      style={style}
+    >
+      <MarkdownMessage text={event.text} />
+      <div ref={metaRef} className="transcript-meta">
+        <span className="badge user">you</span>
+        <span className="role-time">{formatTime(event.ts)}</span>
+        <CopyMessageButton text={event.text} />
+      </div>
+    </article>
+  );
+}
+
+function AgentMessageBubble({
+  event,
+  agentLabel,
+}: {
+  event: EventRecord;
+  agentLabel: string;
+}) {
+  const { metaRef, style } = useMetaReserve();
+  return (
+    <article
+      className="panel transcript codex agent_output"
+      aria-label={`Message from ${agentLabel}`}
+      style={style}
+    >
+      <MarkdownMessage text={event.text} />
+      <div ref={metaRef} className="transcript-meta">
+        <span className="badge agent">{agentLabel}</span>
+        <span className="role-time">{formatTime(event.ts)}</span>
+        <CopyMessageButton text={event.text} />
+      </div>
+    </article>
+  );
 }
 
 function CommandStatusCard({
@@ -1039,12 +1098,10 @@ function AskAnswerSummaryCard({ event }: { event: EventRecord }) {
     .filter((item) => item.question);
 
   return (
-    <article className="panel transcript codex user_input ask-answer-summary">
-      <div className="transcript-role">
-        <span className="badge user">you</span>
-        <span className="badge neutral ask-answer-chip">answered</span>
-        <span className="role-time">{formatTime(event.ts)}</span>
-      </div>
+    <article
+      className="panel transcript codex user_input ask-answer-summary"
+      aria-label="Your answers"
+    >
       {answers.length > 0 ? (
         <ul className="ask-answer-list">
           {answers.map((entry, index) => (
@@ -1069,6 +1126,11 @@ function AskAnswerSummaryCard({ event }: { event: EventRecord }) {
         // rendering the raw `"Q"="A"` string Claude received.
         <pre className="ask-answer-fallback">{event.text}</pre>
       )}
+      <div className="transcript-meta">
+        <span className="badge user">you</span>
+        <span className="badge neutral ask-answer-chip">answered</span>
+        <span className="role-time">{formatTime(event.ts)}</span>
+      </div>
     </article>
   );
 }


### PR DESCRIPTION
## Summary

Every message bubble reserved a full row at the top for a badge, timestamp, and copy button — a one-line reply rendered as ~94px tall against ~22px of actual text. Move the same three elements into a `.transcript-meta` strip absolutely positioned at the bubble's bottom-right corner, and reserve inline space at the end of the last paragraph (sized via `ResizeObserver` to the meta's real footprint plus a 16px gap) so the browser's line-breaker decides cleanly whether the meta sits beside the last line or wraps to its own short line.

## Changes

### Frontend

- `components/TranscriptCard.tsx`: extract `UserMessageBubble` and `AgentMessageBubble` from `CodexCard`'s `switch` so each owns its hook call (hooks rules forbid the in-branch case bodies). `PendingUserInputCard` and `AskAnswerSummaryCard` follow the same pattern. The meta strip now lives **after** the markdown body in DOM; identity is preserved via `aria-label="Message from {speaker}"` on the `<article>` so screen readers still announce the speaker before the body regardless of DOM order.
- `components/TranscriptCard.tsx`: new `useMetaReserve` hook attaches a `ResizeObserver` to the meta element and writes `--meta-reserve: <measured + 16px>px` onto the bubble's inline `style`. The hardcoded `132px` fallback only applies for the single paint before the observer fires.
- `app/globals.css`: drop the old `.transcript-role` top header for `user_input` and `agent_output`; tighten panel padding from `18px` to `8px 14px`. New `.transcript-meta` rule is absolute-positioned at `bottom: 6px; right: 12px` with a smaller badge (`0.6rem`) and a 26px copy button.
- `app/globals.css`: `.markdown-message > p:last-child::after` injects a zero-width-space inline-block of `width: var(--meta-reserve, 132px)` so the browser sees the meta's footprint when deciding whether the last text line has room. When the body ends in a block child (code fence, list, table) — and for `.ask-answer-summary` which has no `.markdown-message` wrapper — reserve vertical space via `padding-bottom: 30px` on the bubble via `:has(.markdown-message > *:last-child:not(p))`.

Tool, reasoning, todo, and status cards keep their existing `.transcript-role` header — their badges carry tool name and state, not just speaker identity, so the bottom-meta pattern doesn't fit.

Addresses the **Make the block shorter** bullet of #31.

## Test Plan

- [x] `cd frontend && npm run lint`
- [x] `cd frontend && npm run build`
- [x] Manual: spot-check single-line user / agent messages, multi-line replies, code-fenced replies, and the ask-answer summary across desktop and mobile widths to confirm no overlap and the meta lands cleanly