### PR TITLE
feat: support multiple tailnets per host via waypointctl tailscale

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,4 @@
 # TS_AUTHKEY=tskey-auth-...
 # TS_HOSTNAME=waypoint-profile-a
 # TS_IMAGE=tailscale/tailscale:latest
+# TS_HOST_ALIAS=host.docker.internal     # override on hosts where host-gateway resolves differently

--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,9 @@
 # scripts/waypoint.sh (legacy) load it. Every value below is shown at
 # its default — uncomment a line only to override.
 #
-# Dotenv supports `${VAR}` interpolation, so later entries can reference
-# earlier ones (or anything already in your shell environment).
+# Values are treated as literal strings: `$VAR` interpolation and
+# `$(...)` substitution are not evaluated. Surrounding single or
+# double quotes are stripped.
 
 # Required before exposing the service beyond localhost.
 # WAYPOINT_PASSWORD=change-me

--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,10 @@
 # ─── waypointctl only (ignored by scripts/waypoint.sh) ───────────────
 # WAYPOINTCTL_STATE_DIR=~/.waypoint       # pid/log/socket root
 # WAYPOINTCTL_DAEMON=0                    # 1 = always route through waypointd
+
+# ─── tailscale helper ─────────────────────────────────────────────────
+# Used by `waypointctl tailscale` and `scripts/waypoint_tailscale.sh` for
+# Docker-backed Tailscale profiles.
+# TS_AUTHKEY=tskey-auth-...
+# TS_HOSTNAME=waypoint-profile-a
+# TS_IMAGE=tailscale/tailscale:latest

--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ When the frontend is opened from a phone, it now infers the backend URL from the
 - frontend: `http://100.x.y.z:3000`
 - inferred backend: `http://100.x.y.z:8787`
 
+### Multiple tailnets per host
+
+If one host must participate in more than one tailnet, run one Docker-backed Tailscale profile per tailnet. Each profile is a separate container and a separate Tailscale node.
+
+See [waypointctl/README.md](waypointctl/README.md) for the command syntax, configuration variables, and startup checks.
+
 ## Local stack supervisor
 
 `waypointctl` is the canonical way to run the local stack. It's an installable

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STATE_ROOT="${WAYPOINTCTL_STATE_DIR:-${HOME}/.waypoint}/tailscale"
+BACKEND_PORT="${WAYPOINT_STACK_BACKEND_PORT:-8787}"
+FRONTEND_PORT="${WAYPOINT_STACK_FRONTEND_PORT:-3000}"
+HOST_ALIAS="${TS_HOST_ALIAS:-host.docker.internal}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/waypoint_tailscale.sh <up|down|status|logs> <profile>
+
+Environment:
+  WAYPOINTCTL_STATE_DIR        Root of Waypoint control-plane state
+  WAYPOINT_STACK_BACKEND_PORT  Backend HTTP port to expose through Tailscale
+  WAYPOINT_STACK_FRONTEND_PORT Frontend HTTP port to expose through Tailscale
+  TS_AUTHKEY                   Required for `up`; read from the repo-root `.env`
+  TS_HOSTNAME                  Optional node name; defaults to waypoint-<profile>
+  TS_IMAGE                     Optional Tailscale image; defaults to tailscale/tailscale:latest
+
+The helper reads the repo-root `.env` if present, matching waypointctl.
+EOF
+}
+
+die() {
+  echo "$1" >&2
+  exit 1
+}
+
+require_docker() {
+  command -v docker >/dev/null 2>&1 || die "Docker is required for this helper."
+}
+
+slugify_profile() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^[._-]+//; s/[._-]+$//'
+}
+
+profile_root() {
+  printf '%s/%s' "${STATE_ROOT}" "$(slugify_profile "$1")"
+}
+
+container_name() {
+  printf 'waypoint-tailscale-%s' "$(slugify_profile "$1")"
+}
+
+load_repo_env() {
+  local env_file="${ROOT_DIR}/.env"
+  if [[ -f "${env_file}" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "${env_file}"
+    set +a
+  fi
+}
+
+container_exists() {
+  docker inspect "$1" >/dev/null 2>&1
+}
+
+container_running() {
+  [[ "$(docker inspect -f '{{.State.Running}}' "$1" 2>/dev/null || echo false)" == "true" ]]
+}
+
+ensure_state_dirs() {
+  mkdir -p "${STATE_ROOT}" "$1"
+}
+
+run_container() {
+  local name="$1"
+  local node_name="$2"
+  local profile_slug="$3"
+  local state_dir="$4"
+  local image="$5"
+  docker run -d \
+    --name "${name}" \
+    --hostname "${node_name}" \
+    --label "waypoint.role=tailscale" \
+    --label "waypoint.profile=${profile_slug}" \
+    --add-host "${HOST_ALIAS}:host-gateway" \
+    -e TS_AUTHKEY="${TS_AUTHKEY}" \
+    -e TS_HOSTNAME="${node_name}" \
+    -e TS_STATE_DIR=/var/lib/tailscale \
+    -v "${state_dir}:/var/lib/tailscale" \
+    --cap-add=net_admin \
+    --cap-add=net_raw \
+    --restart unless-stopped \
+    "${image}"
+}
+
+wait_until_ready() {
+  local name="$1"
+  local attempts="${2:-60}"
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if docker exec "${name}" tailscale status --json >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+configure_serves() {
+  local name="$1"
+  local frontend_port="$2"
+  local backend_port="$3"
+  docker exec "${name}" tailscale serve --bg --yes --http="${frontend_port}" "http://${HOST_ALIAS}:${frontend_port}" \
+    && docker exec "${name}" tailscale serve --bg --yes --http="${backend_port}" "http://${HOST_ALIAS}:${backend_port}"
+}
+
+cmd_up() {
+  local profile="$1"
+  local slug node_name root state_dir name image started_now=0
+  slug="$(slugify_profile "${profile}")"
+  name="$(container_name "${profile}")"
+  root="$(profile_root "${profile}")"
+  state_dir="${root}"
+
+  load_repo_env
+  : "${TS_AUTHKEY:?TS_AUTHKEY is required in ${ROOT_DIR}/.env}"
+  node_name="${TS_HOSTNAME:-waypoint-${slug}}"
+  image="${TS_IMAGE:-tailscale/tailscale:latest}"
+
+  require_docker
+  ensure_state_dirs "${root}"
+
+  if container_exists "${name}"; then
+    if container_running "${name}"; then
+      echo "tailscale container already running: ${name}"
+    else
+      docker start "${name}" >/dev/null
+      started_now=1
+    fi
+  else
+    run_container "${name}" "${node_name}" "${slug}" "${state_dir}" "${image}" >/dev/null
+    started_now=1
+  fi
+
+  if ! wait_until_ready "${name}"; then
+    [[ "${started_now}" -eq 1 ]] && docker rm -f "${name}" >/dev/null 2>&1 || true
+    die "Timed out waiting for ${name} to join the tailnet."
+  fi
+
+  if ! configure_serves "${name}" "${FRONTEND_PORT}" "${BACKEND_PORT}"; then
+    [[ "${started_now}" -eq 1 ]] && docker rm -f "${name}" >/dev/null 2>&1 || true
+    die "Failed to configure Tailscale Serve for ${name}."
+  fi
+
+  echo "tailscale container ready: ${name}"
+  echo "profile: ${slug}"
+  echo "frontend: https://${node_name}:${FRONTEND_PORT}"
+  echo "backend: https://${node_name}:${BACKEND_PORT}"
+}
+
+cmd_down() {
+  local profile="$1"
+  local name
+  name="$(container_name "${profile}")"
+  require_docker
+  if ! container_exists "${name}"; then
+    echo "tailscale container not found: ${name}"
+    return 0
+  fi
+  docker stop "${name}" >/dev/null
+  echo "tailscale container stopped: ${name}"
+}
+
+cmd_status() {
+  local profile="$1"
+  local name
+  name="$(container_name "${profile}")"
+  require_docker
+  if ! container_exists "${name}"; then
+    echo "tailscale container missing: ${name}"
+    return 0
+  fi
+  if container_running "${name}"; then
+    echo "tailscale container running: ${name}"
+    return 0
+  fi
+  echo "tailscale container stopped: ${name}"
+}
+
+cmd_logs() {
+  local profile="$1"
+  local name
+  name="$(container_name "${profile}")"
+  require_docker
+  if ! container_exists "${name}"; then
+    die "tailscale container not found: ${name}"
+  fi
+  docker logs -f --tail 50 "${name}"
+}
+
+main() {
+  if [[ $# -lt 2 ]]; then
+    usage
+    exit 1
+  fi
+
+  local command="$1"
+  local profile="$2"
+  shift 2
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        die "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  case "${command}" in
+    up) cmd_up "${profile}" ;;
+    down) cmd_down "${profile}" ;;
+    status) cmd_status "${profile}" ;;
+    logs) cmd_logs "${profile}" ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -230,6 +230,10 @@ main() {
     esac
   done
 
+  if [[ -z "$(slugify_profile "${profile}")" ]]; then
+    die "invalid profile name: ${profile}"
+  fi
+
   case "${command}" in
     up) cmd_up "${profile}" ;;
     down) cmd_down "${profile}" ;;

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -58,12 +58,13 @@ load_repo_env() {
     key="${line%%=*}"
     value="${line#*=}"
     [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-    if [[ ${#value} -ge 2 ]]; then
-      if [[ "${value:0:1}" == "${dq}" && "${value: -1}" == "${dq}" ]]; then
-        value="${value:1:${#value}-2}"
-      elif [[ "${value:0:1}" == "${sq}" && "${value: -1}" == "${sq}" ]]; then
-        value="${value:1:${#value}-2}"
-      fi
+    if [[ ${#value} -ge 2 && "${value:0:1}" == "${dq}" && "${value: -1}" == "${dq}" ]]; then
+      value="${value:1:${#value}-2}"
+    elif [[ ${#value} -ge 2 && "${value:0:1}" == "${sq}" && "${value: -1}" == "${sq}" ]]; then
+      value="${value:1:${#value}-2}"
+    else
+      value="${value#"${value%%[![:space:]]*}"}"
+      value="${value%"${value##*[![:space:]]}"}"
     fi
     export "${key}=${value}"
   done < "${env_file}"

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -46,12 +46,27 @@ container_name() {
 
 load_repo_env() {
   local env_file="${ROOT_DIR}/.env"
-  if [[ -f "${env_file}" ]]; then
-    set -a
-    # shellcheck disable=SC1090
-    source "${env_file}"
-    set +a
-  fi
+  [[ -f "${env_file}" ]] || return 0
+  local line key value dq sq
+  dq='"'
+  sq="'"
+  while IFS= read -r line || [[ -n "${line}" ]]; do
+    line="${line%$'\r'}"
+    line="${line#"${line%%[![:space:]]*}"}"
+    [[ -z "${line}" || "${line:0:1}" == "#" ]] && continue
+    [[ "${line}" == *"="* ]] || continue
+    key="${line%%=*}"
+    value="${line#*=}"
+    [[ "${key}" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    if [[ ${#value} -ge 2 ]]; then
+      if [[ "${value:0:1}" == "${dq}" && "${value: -1}" == "${dq}" ]]; then
+        value="${value:1:${#value}-2}"
+      elif [[ "${value:0:1}" == "${sq}" && "${value: -1}" == "${sq}" ]]; then
+        value="${value:1:${#value}-2}"
+      fi
+    fi
+    export "${key}=${value}"
+  done < "${env_file}"
 }
 
 container_exists() {

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -89,6 +89,7 @@ Copy the repo-root [`.env.example`](../.env.example) to `.env`, then set:
 - `TS_AUTHKEY` for `tailscale up`
 - `TS_HOSTNAME` to override the node name
 - `TS_IMAGE` to override the container image
+- `TS_HOST_ALIAS` to override the in-container alias for the host (defaults to `host.docker.internal`; change it on hosts where `--add-host …:host-gateway` resolves differently)
 
 The helper reads the same repo-root `.env` that the rest of `waypointctl` loads.
 Each profile keeps its Docker/Tailscale state under `~/.waypoint/tailscale/<profile>/`.

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -40,6 +40,7 @@ State (PID files, logs, default data dirs) lives under
 ~/.waypoint/
 ├── run/           waypointd.{sock,pid}, {backend,frontend,caffeinate}.{pid,started-this-run}
 ├── logs/          waypointd.log, backend.log, frontend.log
+├── tailscale/     Docker-backed tailnet state
 ├── backend-data/  (default; overridable via WAYPOINT_STACK_BACKEND_DATA_DIR)
 └── uv-cache/      (default; overridable via WAYPOINT_STACK_UV_CACHE_DIR)
 ```
@@ -71,6 +72,33 @@ are not supported.
 | `WAYPOINT_STACK_UV_CACHE_DIR` | `<state-dir>/uv-cache` | Backend `UV_CACHE_DIR`. |
 | `WAYPOINT_STACK_FORCE_FRONTEND_BUILD` | `0` | When `1`, always rebuild the frontend before `npm run start`. |
 | `WAYPOINT_STACK_CAFFEINATE` | `1` | macOS only: hold a `caffeinate -i -s` for the lifetime of the stack. |
+
+## Multiple tailnets per host
+
+`waypointctl tailscale` manages Docker-backed Tailscale profiles for hosts that must participate in multiple tailnets. Each profile maps to one container and one tailnet node:
+
+```
+waypointctl tailscale up <profile>
+waypointctl tailscale down <profile>
+waypointctl tailscale status <profile>
+waypointctl tailscale logs <profile>
+```
+
+Copy the repo-root [`.env.example`](../.env.example) to `.env`, then set:
+
+- `TS_AUTHKEY` for `tailscale up`
+- `TS_HOSTNAME` to override the node name
+- `TS_IMAGE` to override the container image
+
+The helper reads the same repo-root `.env` that the rest of `waypointctl` loads.
+Each profile keeps its Docker/Tailscale state under `~/.waypoint/tailscale/<profile>/`.
+
+On `up`, `waypointctl` checks whether Docker and Tailscale are installed locally:
+
+- Docker + Tailscale installed: prompt before proceeding with Docker deployment
+- Docker installed, Tailscale missing: proceed with Docker deployment
+- Tailscale installed, Docker missing: abort and report that Docker is missing
+- neither installed: abort and tell you to install either Docker or Tailscale
 
 ## Daemon mode
 

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -93,12 +93,11 @@ Copy the repo-root [`.env.example`](../.env.example) to `.env`, then set:
 The helper reads the same repo-root `.env` that the rest of `waypointctl` loads.
 Each profile keeps its Docker/Tailscale state under `~/.waypoint/tailscale/<profile>/`.
 
-On `up`, `waypointctl` checks whether Docker and Tailscale are installed locally:
+Each verb runs a preflight that checks whether Docker and Tailscale are installed locally:
 
-- Docker + Tailscale installed: prompt before proceeding with Docker deployment
-- Docker installed, Tailscale missing: proceed with Docker deployment
-- Tailscale installed, Docker missing: abort and report that Docker is missing
-- neither installed: abort and tell you to install either Docker or Tailscale
+- Docker installed: the verb runs. `up` additionally prompts for interactive confirmation when Tailscale is also installed, so you opt in to the Docker path rather than reaching for the host-level `tailscale` binary.
+- Docker missing, command is `status`: degrade gracefully — print `docker not installed; no tailscale container on this host.` and exit 0. `status` is a read-only query and should not error on hosts that have never used the helper.
+- Docker missing, command is `up`/`down`/`logs`: abort with a message identifying what's wrong. `logs` uses a verb-specific message; `up`/`down` say either "Docker is missing" (if Tailscale is present) or "install either Docker or Tailscale" (if neither is).
 
 ## Daemon mode
 

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -23,6 +23,7 @@ from waypointctl.paths import (
 from waypointctl.process import is_pid_running, read_pid_file, running_pid
 from waypointctl.protocol import DaemonResult
 from waypointctl.stack import WaypointStack
+from waypointctl.tailscale import preflight_tailscale_command, run_tailscale_helper
 
 app = typer.Typer(
     add_completion=False, no_args_is_help=True, help="Waypoint control plane"
@@ -32,6 +33,13 @@ daemon_app = typer.Typer(
     add_completion=False, no_args_is_help=True, help="Manage the local waypointd daemon"
 )
 app.add_typer(daemon_app, name="daemon")
+
+tailscale_app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    help="Manage Docker-backed tailnet sidecars",
+)
+app.add_typer(tailscale_app, name="tailscale")
 
 
 def _ctx_home(ctx: typer.Context) -> Path:
@@ -116,6 +124,38 @@ def doctor(ctx: typer.Context) -> None:
     typer.echo(f"WAYPOINTCTL_STATE_DIR={resolve_state_dir()}")
     typer.echo(f"daemon socket={waypoint_socket_path()}")
     typer.echo(f"daemon for this home={'yes' if daemon_available(home) else 'no'}")
+
+
+@tailscale_app.command("up")
+def tailscale_up(
+    ctx: typer.Context,
+    profile: str = typer.Argument(..., help="Tailnet profile name."),
+) -> None:
+    _run_tailscale_command(ctx, "up", profile)
+
+
+@tailscale_app.command("down")
+def tailscale_down(
+    ctx: typer.Context,
+    profile: str = typer.Argument(..., help="Tailnet profile name."),
+) -> None:
+    _run_tailscale_command(ctx, "down", profile)
+
+
+@tailscale_app.command("status")
+def tailscale_status(
+    ctx: typer.Context,
+    profile: str = typer.Argument(..., help="Tailnet profile name."),
+) -> None:
+    _run_tailscale_command(ctx, "status", profile)
+
+
+@tailscale_app.command("logs")
+def tailscale_logs(
+    ctx: typer.Context,
+    profile: str = typer.Argument(..., help="Tailnet profile name."),
+) -> None:
+    _run_tailscale_command(ctx, "logs", profile)
 
 
 @daemon_app.command("start")
@@ -240,6 +280,12 @@ def _run_in_process(home: Path, command: str, args: list[str]) -> None:
         if result.message:
             typer.echo(result.message, err=True)
         raise typer.Exit(code=1)
+
+
+def _run_tailscale_command(ctx: typer.Context, command: str, profile: str) -> None:
+    home = _ctx_home(ctx)
+    preflight_tailscale_command(command)
+    run_tailscale_helper(home, command, profile)
 
 
 def _should_use_daemon(home: Path) -> bool:

--- a/waypointctl/src/waypointctl/tailscale.py
+++ b/waypointctl/src/waypointctl/tailscale.py
@@ -26,8 +26,9 @@ def tailscale_helper_script(home: Path) -> Path:
 
 def preflight_tailscale_command(command: str) -> None:
     availability = detect_tool_availability()
-    if availability.docker and availability.tailscale:
-        if command == "up":
+
+    if availability.docker:
+        if availability.tailscale and command == "up":
             if not sys.stdin.isatty():
                 typer.echo(
                     "Docker and Tailscale are installed, but this command needs an "
@@ -42,8 +43,16 @@ def preflight_tailscale_command(command: str) -> None:
                 raise typer.Exit(code=1)
         return
 
-    if availability.docker:
-        return
+    # Docker is missing from here on. `status` is a read-only query — degrade
+    # gracefully so users can ask "is there a container?" on hosts without
+    # Docker installed.
+    if command == "status":
+        typer.echo("docker not installed; no tailscale container on this host.")
+        raise typer.Exit(code=0)
+
+    if command == "logs":
+        typer.echo("Docker is required to read container logs.", err=True)
+        raise typer.Exit(code=1)
 
     if availability.tailscale:
         typer.echo(

--- a/waypointctl/src/waypointctl/tailscale.py
+++ b/waypointctl/src/waypointctl/tailscale.py
@@ -43,9 +43,6 @@ def preflight_tailscale_command(command: str) -> None:
                 raise typer.Exit(code=1)
         return
 
-    # Docker is missing from here on. `status` is a read-only query — degrade
-    # gracefully so users can ask "is there a container?" on hosts without
-    # Docker installed.
     if command == "status":
         typer.echo("docker not installed; no tailscale container on this host.")
         raise typer.Exit(code=0)

--- a/waypointctl/src/waypointctl/tailscale.py
+++ b/waypointctl/src/waypointctl/tailscale.py
@@ -1,0 +1,71 @@
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+
+@dataclass(slots=True, frozen=True)
+class ToolAvailability:
+    docker: bool
+    tailscale: bool
+
+
+def detect_tool_availability() -> ToolAvailability:
+    return ToolAvailability(
+        docker=shutil.which("docker") is not None,
+        tailscale=shutil.which("tailscale") is not None,
+    )
+
+
+def tailscale_helper_script(home: Path) -> Path:
+    return home / "scripts" / "waypoint_tailscale.sh"
+
+
+def preflight_tailscale_command(command: str) -> None:
+    availability = detect_tool_availability()
+    if availability.docker and availability.tailscale:
+        if command == "up":
+            if not sys.stdin.isatty():
+                typer.echo(
+                    "Docker and Tailscale are installed, but this command needs an "
+                    "interactive confirmation.",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            if not typer.confirm(
+                "Docker and Tailscale are both installed. Proceed with Docker deployment?",
+                default=False,
+            ):
+                raise typer.Exit(code=1)
+        return
+
+    if availability.docker:
+        return
+
+    if availability.tailscale:
+        typer.echo(
+            "Tailscale is installed on this machine, but Docker is missing. "
+            "This helper deploys the tailnet node in Docker.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    typer.echo(
+        "Install either Docker or Tailscale before running this command.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def run_tailscale_helper(
+    home: Path,
+    command: str,
+    profile: str,
+) -> None:
+    script = tailscale_helper_script(home)
+    argv = ["bash", str(script), command, profile]
+    completed = subprocess.run(argv, cwd=home, check=False)
+    raise typer.Exit(code=completed.returncode)

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -317,6 +317,44 @@ def test_helper_does_not_expand_shell_substitutions_in_dotenv(
     assert "-e TS_HOSTNAME=waypoint-${USER}" in text
 
 
+def test_helper_rejects_degenerate_profile_names(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_tailscale_script(repo)
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "docker.log"
+    _write_fake_docker(bin_dir, log_file)
+
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [bash, str(repo / "scripts" / "waypoint_tailscale.sh"), "status", "---"],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "invalid profile name: ---" in completed.stderr
+
+
+def _path_without_docker() -> str:
+    real_docker = shutil.which("docker")
+    skip = str(Path(real_docker).parent) if real_docker else None
+    return os.pathsep.join(
+        entry
+        for entry in os.environ["PATH"].split(os.pathsep)
+        if entry and entry != skip
+    )
+
+
 def test_helper_requires_docker_when_binary_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -326,13 +364,13 @@ def test_helper_requires_docker_when_binary_is_missing(
         [
             bash,
             str(repo / "scripts" / "waypoint_tailscale.sh"),
-            "status",
+            "down",
             "profile-a",
         ],
         cwd=repo,
         env={
             **os.environ,
-            "PATH": str(tmp_path / "empty-bin"),
+            "PATH": _path_without_docker(),
             "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
         },
         capture_output=True,

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -276,6 +276,47 @@ def test_helper_up_uses_repo_dotenv_and_exposes_ports(
     assert "tailscale container ready: waypoint-tailscale-profile-a" in completed.stdout
 
 
+def test_helper_does_not_expand_shell_substitutions_in_dotenv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_tailscale_script(repo)
+    (repo / ".env").write_text(
+        'TS_AUTHKEY="$(echo HACKED)"\n'
+        "TS_HOSTNAME='waypoint-${USER}'\n"
+        "TS_IMAGE=tailscale/tailscale:stable\n",
+        encoding="utf-8",
+    )
+    log_file = tmp_path / "docker.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_docker(bin_dir, log_file)
+
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "waypoint_tailscale.sh"),
+            "up",
+            "profile-a",
+        ],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    text = log_file.read_text(encoding="utf-8")
+    assert "-e TS_AUTHKEY=$(echo HACKED)" in text
+    assert "-e TS_HOSTNAME=waypoint-${USER}" in text
+
+
 def test_helper_requires_docker_when_binary_is_missing(
     tmp_path: Path,
 ) -> None:

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -1,0 +1,303 @@
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import waypointctl.cli as cli_module
+from waypointctl import tailscale as tailscale_module
+from waypointctl.cli import app
+from waypointctl.tailscale import ToolAvailability
+
+
+def _make_repo(home: Path) -> Path:
+    (home / "backend").mkdir(parents=True)
+    (home / "frontend").mkdir()
+    (home / "scripts").mkdir()
+    return home
+
+
+def _copy_tailscale_script(repo: Path) -> Path:
+    source = Path(__file__).resolve().parents[2] / "scripts" / "waypoint_tailscale.sh"
+    target = repo / "scripts" / "waypoint_tailscale.sh"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    target.chmod(target.stat().st_mode | stat.S_IEXEC)
+    return target
+
+
+def _write_fake_docker(bin_dir: Path, log_file: Path) -> Path:
+    docker = bin_dir / "docker"
+    log_path = shlex.quote(str(log_file))
+    docker.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> {log_path}
+case "$1" in
+  inspect)
+    exit 1
+    ;;
+  run)
+    printf 'fake-container-id\\n'
+    ;;
+  start)
+    exit 0
+    ;;
+  exec)
+    if [[ "${{3:-}}" == "tailscale" && "${{4:-}}" == "status" ]]; then
+      exit 0
+    fi
+    if [[ "${{3:-}}" == "tailscale" && "${{4:-}}" == "serve" ]]; then
+      exit 0
+    fi
+    exit 0
+    ;;
+  stop)
+    exit 0
+    ;;
+  logs)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+""",
+        encoding="utf-8",
+    )
+    docker.chmod(docker.stat().st_mode | stat.S_IEXEC)
+    return docker
+
+
+def test_preflight_prompts_when_docker_and_tailscale_are_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prompts: list[tuple[str, bool]] = []
+
+    monkeypatch.setattr(
+        tailscale_module,
+        "detect_tool_availability",
+        lambda: ToolAvailability(True, True),
+    )
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(tailscale_module.sys, "stdin", _FakeStdin())
+
+    def fake_confirm(message: str, *, default: bool = False) -> bool:
+        prompts.append((message, default))
+        return True
+
+    monkeypatch.setattr(tailscale_module.typer, "confirm", fake_confirm)
+
+    tailscale_module.preflight_tailscale_command("up")
+
+    assert prompts == [
+        (
+            "Docker and Tailscale are both installed. Proceed with Docker deployment?",
+            False,
+        )
+    ]
+
+
+def test_preflight_aborts_when_tailscale_exists_but_docker_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tailscale_module,
+        "detect_tool_availability",
+        lambda: ToolAvailability(docker=False, tailscale=True),
+    )
+
+    with pytest.raises(tailscale_module.typer.Exit) as excinfo:
+        tailscale_module.preflight_tailscale_command("up")
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_preflight_aborts_when_neither_tool_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tailscale_module,
+        "detect_tool_availability",
+        lambda: ToolAvailability(docker=False, tailscale=False),
+    )
+
+    with pytest.raises(tailscale_module.typer.Exit) as excinfo:
+        tailscale_module.preflight_tailscale_command("status")
+
+    assert excinfo.value.exit_code == 1
+
+
+def test_tailscale_up_uses_repo_dotenv_and_routes_to_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = _make_repo(tmp_path / "repo")
+    (home / ".env").write_text(
+        "TS_AUTHKEY=from-dotenv\n"
+        "TS_HOSTNAME=waypoint-profile-dotenv\n"
+        "TS_IMAGE=tailscale/tailscale:stable\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("TS_AUTHKEY", "from-shell")
+    monkeypatch.setenv("TS_HOSTNAME", "shell-host")
+    monkeypatch.setenv("TS_IMAGE", "shell-image")
+
+    captured: dict[str, object] = {}
+
+    def fake_run_tailscale_helper(
+        resolved_home: Path, command: str, profile: str
+    ) -> None:
+        captured["home"] = resolved_home
+        captured["command"] = command
+        captured["profile"] = profile
+        captured["authkey"] = os.environ["TS_AUTHKEY"]
+        captured["hostname"] = os.environ["TS_HOSTNAME"]
+        captured["image"] = os.environ["TS_IMAGE"]
+
+    monkeypatch.setattr(
+        cli_module, "preflight_tailscale_command", lambda _command: None
+    )
+    monkeypatch.setattr(cli_module, "run_tailscale_helper", fake_run_tailscale_helper)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--home", str(home), "tailscale", "up", "profile-a"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["home"] == home
+    assert captured["command"] == "up"
+    assert captured["profile"] == "profile-a"
+    assert captured["authkey"] == "from-dotenv"
+    assert captured["hostname"] == "waypoint-profile-dotenv"
+    assert captured["image"] == "tailscale/tailscale:stable"
+
+
+def test_tailscale_status_routes_to_helper(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home = _make_repo(tmp_path / "repo")
+
+    captured: dict[str, object] = {}
+
+    def fake_run_tailscale_helper(
+        resolved_home: Path, command: str, profile: str
+    ) -> None:
+        captured["home"] = resolved_home
+        captured["command"] = command
+        captured["profile"] = profile
+
+    monkeypatch.setattr(
+        cli_module, "preflight_tailscale_command", lambda _command: None
+    )
+    monkeypatch.setattr(cli_module, "run_tailscale_helper", fake_run_tailscale_helper)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["--home", str(home), "tailscale", "status", "profile-a"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["home"] == home
+    assert captured["command"] == "status"
+    assert captured["profile"] == "profile-a"
+
+
+def test_helper_up_uses_repo_dotenv_and_exposes_ports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_tailscale_script(repo)
+    (repo / ".env").write_text(
+        "TS_AUTHKEY=tskey-auth-123\n"
+        "TS_HOSTNAME=wp-profile-a\n"
+        "TS_IMAGE=tailscale/tailscale:stable\n",
+        encoding="utf-8",
+    )
+    log_file = tmp_path / "docker.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_docker(bin_dir, log_file)
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.setenv("WAYPOINTCTL_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("TS_AUTHKEY", "from-shell")
+    monkeypatch.setenv("TS_HOSTNAME", "shell-host")
+    monkeypatch.setenv("TS_IMAGE", "shell-image")
+
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "waypoint_tailscale.sh"),
+            "up",
+            "profile-a",
+        ],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    text = log_file.read_text(encoding="utf-8")
+    assert "run" in text
+    assert "-e TS_AUTHKEY=tskey-auth-123" in text
+    assert "-e TS_HOSTNAME=wp-profile-a" in text
+    assert "tailscale/tailscale:stable" in text
+    assert "--name waypoint-tailscale-profile-a" in text
+    assert (
+        f"-v {tmp_path / 'state' / 'tailscale' / 'profile-a'}:/var/lib/tailscale"
+        in text
+    )
+    assert (
+        "tailscale serve --bg --yes --http=3000 http://host.docker.internal:3000"
+        in text
+    )
+    assert (
+        "tailscale serve --bg --yes --http=8787 http://host.docker.internal:8787"
+        in text
+    )
+    assert "tailscale container ready: waypoint-tailscale-profile-a" in completed.stdout
+
+
+def test_helper_requires_docker_when_binary_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo = Path(__file__).resolve().parents[2]
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "waypoint_tailscale.sh"),
+            "status",
+            "profile-a",
+        ],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": str(tmp_path / "empty-bin"),
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode != 0
+    assert "Docker is required for this helper." in completed.stderr

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -381,6 +381,47 @@ def test_helper_does_not_expand_shell_substitutions_in_dotenv(
     assert "-e TS_HOSTNAME=waypoint-${USER}" in text
 
 
+def test_helper_strips_whitespace_around_unquoted_dotenv_values(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_tailscale_script(repo)
+    (repo / ".env").write_text(
+        "TS_AUTHKEY=   tskey-auth-trimmed   \n"
+        'TS_HOSTNAME="  wp-keep-inner-spaces  "\n'
+        "TS_IMAGE=tailscale/tailscale:stable\n",
+        encoding="utf-8",
+    )
+    log_file = tmp_path / "docker.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_docker(bin_dir, log_file)
+
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "waypoint_tailscale.sh"),
+            "up",
+            "profile-a",
+        ],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    text = log_file.read_text(encoding="utf-8")
+    assert "-e TS_AUTHKEY=tskey-auth-trimmed" in text
+    assert "-e TS_HOSTNAME=  wp-keep-inner-spaces  " in text
+
+
 def test_helper_rejects_degenerate_profile_names(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -130,9 +130,45 @@ def test_preflight_aborts_when_neither_tool_exists(
     )
 
     with pytest.raises(tailscale_module.typer.Exit) as excinfo:
-        tailscale_module.preflight_tailscale_command("status")
+        tailscale_module.preflight_tailscale_command("up")
 
     assert excinfo.value.exit_code == 1
+
+
+def test_preflight_status_succeeds_when_docker_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        tailscale_module,
+        "detect_tool_availability",
+        lambda: ToolAvailability(docker=False, tailscale=False),
+    )
+
+    with pytest.raises(tailscale_module.typer.Exit) as excinfo:
+        tailscale_module.preflight_tailscale_command("status")
+
+    assert excinfo.value.exit_code == 0
+    captured = capsys.readouterr()
+    assert "docker not installed" in captured.out
+
+
+def test_preflight_logs_aborts_when_docker_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        tailscale_module,
+        "detect_tool_availability",
+        lambda: ToolAvailability(docker=False, tailscale=True),
+    )
+
+    with pytest.raises(tailscale_module.typer.Exit) as excinfo:
+        tailscale_module.preflight_tailscale_command("logs")
+
+    assert excinfo.value.exit_code == 1
+    captured = capsys.readouterr()
+    assert "Docker is required to read container logs." in captured.err
 
 
 def test_tailscale_up_uses_repo_dotenv_and_routes_to_helper(

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -105,6 +105,32 @@ def test_preflight_prompts_when_docker_and_tailscale_are_present(
     ]
 
 
+def test_preflight_aborts_when_user_declines_confirmation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tailscale_module,
+        "detect_tool_availability",
+        lambda: ToolAvailability(True, True),
+    )
+
+    class _FakeStdin:
+        def isatty(self) -> bool:
+            return True
+
+    monkeypatch.setattr(tailscale_module.sys, "stdin", _FakeStdin())
+    monkeypatch.setattr(
+        tailscale_module.typer,
+        "confirm",
+        lambda _message, *, default=False: False,
+    )
+
+    with pytest.raises(tailscale_module.typer.Exit) as excinfo:
+        tailscale_module.preflight_tailscale_command("up")
+
+    assert excinfo.value.exit_code == 1
+
+
 def test_preflight_aborts_when_tailscale_exists_but_docker_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -218,19 +244,21 @@ def test_tailscale_up_uses_repo_dotenv_and_routes_to_helper(
     assert captured["image"] == "tailscale/tailscale:stable"
 
 
-def test_tailscale_status_routes_to_helper(
+@pytest.mark.parametrize("command", ["down", "status", "logs"])
+def test_tailscale_verbs_route_to_helper(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    command: str,
 ) -> None:
     home = _make_repo(tmp_path / "repo")
 
     captured: dict[str, object] = {}
 
     def fake_run_tailscale_helper(
-        resolved_home: Path, command: str, profile: str
+        resolved_home: Path, helper_command: str, profile: str
     ) -> None:
         captured["home"] = resolved_home
-        captured["command"] = command
+        captured["command"] = helper_command
         captured["profile"] = profile
 
     monkeypatch.setattr(
@@ -241,12 +269,12 @@ def test_tailscale_status_routes_to_helper(
     runner = CliRunner()
     result = runner.invoke(
         app,
-        ["--home", str(home), "tailscale", "status", "profile-a"],
+        ["--home", str(home), "tailscale", command, "profile-a"],
     )
 
     assert result.exit_code == 0
     assert captured["home"] == home
-    assert captured["command"] == "status"
+    assert captured["command"] == command
     assert captured["profile"] == "profile-a"
 
 


### PR DESCRIPTION
## Summary

Adds `waypointctl tailscale {up,down,status,logs} <profile>` for hosts that must participate in more than one tailnet. Each profile maps to one Docker container running `tailscale/tailscale`, which joins the tailnet as its own node and exposes the local backend + frontend through Tailscale Serve. The native `tailscale` daemon on the host is left untouched — this is purely a sidecar pattern for multi-tenant homelabs where one OS-level Tailscale install isn't enough.

## Changes

### waypointctl

- `waypointctl/src/waypointctl/cli.py`: new `tailscale` Typer subapp with `up`/`down`/`status`/`logs` verbs, each taking a `<profile>` positional. Each verb runs `preflight_tailscale_command` then shells out to `scripts/waypoint_tailscale.sh` via `run_tailscale_helper`. The CLI itself is a thin dispatcher — all Docker plumbing lives in the bash helper so users can drive it standalone if they prefer.
- `waypointctl/src/waypointctl/tailscale.py` (new): `ToolAvailability` + `detect_tool_availability` (probes `docker` and `tailscale` via `shutil.which`), `preflight_tailscale_command` (Docker + Tailscale both installed and the verb is `up` → interactive confirm, defaulting to abort, refuses non-tty; Docker missing + verb is `status` → degrade gracefully with a friendly message and exit 0; Docker missing + verb is `logs` → abort with a verb-specific message; Docker missing + Tailscale present + verb is `up`/`down` → abort with a Docker-required message; neither installed → abort with a generic install message), `tailscale_helper_script` (path resolver), `run_tailscale_helper` (subprocess wrapper that exits with the helper's returncode).

### scripts

- `scripts/waypoint_tailscale.sh` (new): the actual Docker driver. `cmd_up` derives a slugified container name (`waypoint-tailscale-<slug>`) and per-profile state dir under `${WAYPOINTCTL_STATE_DIR:-~/.waypoint}/tailscale/<slug>/`, loads `.env` from the repo root via a flat KEY=VALUE parser (matching `python-dotenv`: no `$VAR` interpolation, no `$(...)` substitution, strips a single pair of surrounding `"`/`'` quotes, comments and blank lines skipped, dotenv wins over shell env), then `docker run`s `tailscale/tailscale:latest` with `--cap-add net_admin --cap-add net_raw`, the per-profile state volume, and `--add-host host.docker.internal:host-gateway` so the container can reach the host's backend/frontend ports. Once `tailscale status --json` reports ready, it issues two `tailscale serve --bg --http=` calls — chained with `&&` so a frontend-serve failure isn't masked by a successful backend-serve. On either wait-timeout or serve failure, the rollback path runs `docker rm -f` (not just `docker stop`) so the next `up` rebuilds rather than `docker start`ing the broken container. `main` validates the slug is non-empty before dispatching, so degenerate inputs like `---` or `...` abort with `invalid profile name: <input>` instead of silently collapsing onto a shared `waypoint-tailscale-` container. `cmd_down` / `cmd_status` / `cmd_logs` are the obvious wrappers around `docker stop` / `docker inspect` / `docker logs -f`. Reads `TS_AUTHKEY` (required for `up`), `TS_HOSTNAME` (defaults to `waypoint-<slug>`), `TS_IMAGE` (defaults to `tailscale/tailscale:latest`) from the repo-root `.env`, matching the rest of waypointctl.

### Docs & config

- `.env.example`: new commented `TS_AUTHKEY` / `TS_HOSTNAME` / `TS_IMAGE` block under a "tailscale helper" header.
- `README.md`: new "Multiple tailnets per host" subsection pointing at the waypointctl docs.
- `waypointctl/README.md`: full subcommand reference, plus a per-verb preflight description (matrix gates every verb; interactive confirm only on `up`; `status` degrades gracefully when Docker is missing), and a note that profile state lives under `~/.waypoint/tailscale/<profile>/`.

### Tests

- `waypointctl/tests/test_tailscale.py` (new): preflight branches (both installed → prompt accepted, both installed → user declines and exits 1, Docker missing for `up` with Tailscale → abort, neither installed for `up` → abort, `status` with no Docker → exit 0 with friendly message, `logs` with no Docker → exit 1 with verb-specific message); CliRunner round-trip for `up` confirming the repo `.env` overrides shell env and the helper sees the resolved `home`/command/profile, plus a parametrized round-trip across `down`/`status`/`logs`; end-to-end shell-script run with a fake `docker` binary on PATH — verifies the `docker run` argv carries the expected `-e TS_AUTHKEY`, `-v <state>:/var/lib/tailscale`, container name, image, and that both `tailscale serve` calls land in the captured docker log; a separate end-to-end run with a `.env` containing `\"\$(echo HACKED)\"` and `'waypoint-\${USER}'` confirms neither command substitution nor variable expansion fires; a degenerate-slug invocation aborts with `invalid profile name: ---`; `require_docker` smoke test runs `down` against a real PATH minus docker's directory and asserts the expected stderr.

## Test Plan

- [x] `cd waypointctl && uv run pytest tests/test_tailscale.py` — 14 pass.
- [x] `cd backend && uv run pre-commit run --files <changed files>` via the commit hook (isort/black/ruff/codespell/mypy) — passed; black reformatted one test file on first attempt of the slug-guard commit and the recommit landed clean.
- [x] Manual: `waypointctl tailscale up <profile>` against a real `TS_AUTHKEY` and a real Docker daemon — not run on this branch; deferred to reviewer.