### PR TITLE
fix: tailnet peer discovery, frontend port handling, and tailscale down cleanup

### DIFF
--- a/backend/src/waypoint/tailnet.py
+++ b/backend/src/waypoint/tailnet.py
@@ -40,26 +40,72 @@ def _resolve_binary() -> str | None:
 
 async def fetch_snapshot() -> TailnetSnapshot:
     binary = _resolve_binary()
-    if binary is None:
+    if binary is not None:
+        return await _run_status([binary, "status", "--json"])
+
+    container = await _find_sidecar_container()
+    if container is None:
         return TailnetSnapshot(
             available=False, error="tailscale binary not found on PATH"
         )
+    docker = shutil.which("docker")
+    if docker is None:
+        return TailnetSnapshot(available=False, error="docker binary not found on PATH")
+    return await _run_status(
+        [docker, "exec", container, "tailscale", "status", "--json"]
+    )
+
+
+async def _find_sidecar_container() -> str | None:
+    """Return the first running `waypoint.role=tailscale` container, if any."""
+    docker = shutil.which("docker")
+    if docker is None:
+        return None
     try:
         process = await asyncio.create_subprocess_exec(
-            binary,
-            "status",
-            "--json",
+            docker,
+            "ps",
+            "--filter",
+            "label=waypoint.role=tailscale",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, _ = await process.communicate()
+    except (FileNotFoundError, OSError):
+        return None
+    if process.returncode != 0:
+        return None
+    names = [line for line in stdout.decode().splitlines() if line.strip()]
+    if not names:
+        return None
+    if len(names) > 1:
+        log.warning(
+            "multiple tailscale sidecars running (%s); using %s",
+            ", ".join(names),
+            names[0],
+        )
+    return names[0]
+
+
+async def _run_status(argv: list[str]) -> TailnetSnapshot:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await process.communicate()
     except FileNotFoundError as exc:
         return TailnetSnapshot(
-            available=False, error=f"failed to spawn tailscale: {exc}"
+            available=False, error=f"failed to spawn {argv[0]}: {exc}"
         )
     if process.returncode != 0:
         message = (
-            stderr.decode().strip() or f"tailscale exited with {process.returncode}"
+            stderr.decode().strip() or f"{argv[0]} exited with {process.returncode}"
         )
         log.warning("tailscale status failed: %s", message)
         return TailnetSnapshot(available=False, error=message)

--- a/backend/src/waypoint/tailnet.py
+++ b/backend/src/waypoint/tailnet.py
@@ -43,24 +43,27 @@ async def fetch_snapshot() -> TailnetSnapshot:
     if binary is not None:
         return await _run_status([binary, "status", "--json"])
 
-    container = await _find_sidecar_container()
-    if container is None:
+    docker = shutil.which("docker")
+    if docker is None:
         return TailnetSnapshot(
             available=False, error="tailscale binary not found on PATH"
         )
-    docker = shutil.which("docker")
-    if docker is None:
-        return TailnetSnapshot(available=False, error="docker binary not found on PATH")
+
+    container, lookup_error = await _find_sidecar_container(docker)
+    if lookup_error is not None:
+        return TailnetSnapshot(available=False, error=lookup_error)
+    if container is None:
+        return TailnetSnapshot(
+            available=False, error="no waypoint tailscale sidecar running"
+        )
+
     return await _run_status(
         [docker, "exec", container, "tailscale", "status", "--json"]
     )
 
 
-async def _find_sidecar_container() -> str | None:
-    """Return the first running `waypoint.role=tailscale` container, if any."""
-    docker = shutil.which("docker")
-    if docker is None:
-        return None
+async def _find_sidecar_container(docker: str) -> tuple[str | None, str | None]:
+    """Return (container_name, error). `error` is set only when `docker ps` itself fails."""
     try:
         process = await asyncio.create_subprocess_exec(
             docker,
@@ -74,21 +77,24 @@ async def _find_sidecar_container() -> str | None:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, _ = await process.communicate()
-    except (FileNotFoundError, OSError):
-        return None
+        stdout, stderr = await process.communicate()
+    except (FileNotFoundError, OSError) as exc:
+        return None, f"failed to run docker ps: {exc}"
     if process.returncode != 0:
-        return None
+        message = (
+            stderr.decode().strip() or f"docker ps exited with {process.returncode}"
+        )
+        return None, message
     names = [line for line in stdout.decode().splitlines() if line.strip()]
     if not names:
-        return None
+        return None, None
     if len(names) > 1:
         log.warning(
             "multiple tailscale sidecars running (%s); using %s",
             ", ".join(names),
             names[0],
         )
-    return names[0]
+    return names[0], None
 
 
 async def _run_status(argv: list[str]) -> TailnetSnapshot:
@@ -107,7 +113,7 @@ async def _run_status(argv: list[str]) -> TailnetSnapshot:
         message = (
             stderr.decode().strip() or f"{argv[0]} exited with {process.returncode}"
         )
-        log.warning("tailscale status failed: %s", message)
+        log.warning("%s failed: %s", argv[0], message)
         return TailnetSnapshot(available=False, error=message)
     try:
         payload = json.loads(stdout.decode() or "{}")

--- a/backend/src/waypoint/tailnet.py
+++ b/backend/src/waypoint/tailnet.py
@@ -105,7 +105,7 @@ async def _run_status(argv: list[str]) -> TailnetSnapshot:
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await process.communicate()
-    except FileNotFoundError as exc:
+    except (FileNotFoundError, OSError) as exc:
         return TailnetSnapshot(
             available=False, error=f"failed to spawn {argv[0]}: {exc}"
         )

--- a/backend/tests/test_tailnet.py
+++ b/backend/tests/test_tailnet.py
@@ -1,6 +1,10 @@
+import json
 from typing import Any
 
-from waypoint.tailnet import _parse_snapshot
+import pytest
+
+from waypoint import tailnet
+from waypoint.tailnet import _parse_snapshot, fetch_snapshot
 
 
 def test_parse_snapshot_orders_self_then_online_then_offline() -> None:
@@ -68,3 +72,211 @@ def test_parse_snapshot_skips_peers_without_ipv4() -> None:
     }
     snapshot = _parse_snapshot(payload)
     assert [peer.name for peer in snapshot.peers] == ["macbook"]
+
+
+class _FakeProcess:
+    def __init__(
+        self, *, stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0
+    ):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
+def _running_payload(hostname: str) -> dict[str, Any]:
+    return {
+        "BackendState": "Running",
+        "Self": {
+            "HostName": hostname,
+            "TailscaleIPs": ["100.64.0.1"],
+            "Online": True,
+        },
+        "Peer": {},
+    }
+
+
+def _exec_recorder(
+    plans: dict[tuple[str, ...], _FakeProcess],
+    calls: list[tuple[str, ...]],
+):
+    async def fake_exec(*argv: str, **_: Any) -> _FakeProcess:
+        calls.append(argv)
+        try:
+            return plans[argv]
+        except KeyError as exc:
+            raise AssertionError(f"unexpected subprocess call: {argv}") from exc
+
+    return fake_exec
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_prefers_host_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.shutil, "which", lambda name: "/usr/bin/tailscale")
+    payload = _running_payload("host-machine")
+    calls: list[tuple[str, ...]] = []
+    plans: dict[tuple[str, ...], _FakeProcess] = {
+        ("/usr/bin/tailscale", "status", "--json"): _FakeProcess(
+            stdout=json.dumps(payload).encode()
+        ),
+    }
+    monkeypatch.setattr(
+        tailnet.asyncio,
+        "create_subprocess_exec",
+        _exec_recorder(plans, calls),
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is True
+    assert snapshot.peers[0].name == "host-machine"
+    assert calls == [("/usr/bin/tailscale", "status", "--json")]
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_falls_back_to_docker_exec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+
+    def fake_which(name: str) -> str | None:
+        if name == "tailscale":
+            return None
+        if name == "docker":
+            return "/usr/local/bin/docker"
+        return None
+
+    monkeypatch.setattr(tailnet.shutil, "which", fake_which)
+
+    payload = _running_payload("waypoint-nat")
+    calls: list[tuple[str, ...]] = []
+    plans: dict[tuple[str, ...], _FakeProcess] = {
+        (
+            "/usr/local/bin/docker",
+            "ps",
+            "--filter",
+            "label=waypoint.role=tailscale",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ): _FakeProcess(stdout=b"waypoint-tailscale-nat\n"),
+        (
+            "/usr/local/bin/docker",
+            "exec",
+            "waypoint-tailscale-nat",
+            "tailscale",
+            "status",
+            "--json",
+        ): _FakeProcess(stdout=json.dumps(payload).encode()),
+    }
+    monkeypatch.setattr(
+        tailnet.asyncio,
+        "create_subprocess_exec",
+        _exec_recorder(plans, calls),
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is True
+    assert snapshot.peers[0].name == "waypoint-nat"
+    assert calls[0][1] == "ps"
+    assert calls[1][1] == "exec"
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_reports_no_binary_when_neither_path_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(tailnet.shutil, "which", lambda _name: None)
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is False
+    assert snapshot.error == "tailscale binary not found on PATH"
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_reports_no_sidecar_when_docker_present_but_no_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/local/bin/docker" if name == "docker" else None
+
+    monkeypatch.setattr(tailnet.shutil, "which", fake_which)
+
+    calls: list[tuple[str, ...]] = []
+    plans: dict[tuple[str, ...], _FakeProcess] = {
+        (
+            "/usr/local/bin/docker",
+            "ps",
+            "--filter",
+            "label=waypoint.role=tailscale",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ): _FakeProcess(stdout=b""),
+    }
+    monkeypatch.setattr(
+        tailnet.asyncio,
+        "create_subprocess_exec",
+        _exec_recorder(plans, calls),
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is False
+    assert snapshot.error == "tailscale binary not found on PATH"
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_picks_first_when_multiple_sidecars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/local/bin/docker" if name == "docker" else None
+
+    monkeypatch.setattr(tailnet.shutil, "which", fake_which)
+
+    payload = _running_payload("waypoint-a")
+    calls: list[tuple[str, ...]] = []
+    plans: dict[tuple[str, ...], _FakeProcess] = {
+        (
+            "/usr/local/bin/docker",
+            "ps",
+            "--filter",
+            "label=waypoint.role=tailscale",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ): _FakeProcess(stdout=b"waypoint-tailscale-a\nwaypoint-tailscale-b\n"),
+        (
+            "/usr/local/bin/docker",
+            "exec",
+            "waypoint-tailscale-a",
+            "tailscale",
+            "status",
+            "--json",
+        ): _FakeProcess(stdout=json.dumps(payload).encode()),
+    }
+    monkeypatch.setattr(
+        tailnet.asyncio,
+        "create_subprocess_exec",
+        _exec_recorder(plans, calls),
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is True
+    assert calls[1][2] == "waypoint-tailscale-a"

--- a/backend/tests/test_tailnet.py
+++ b/backend/tests/test_tailnet.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from typing import Any
 
 import pytest
@@ -234,12 +235,49 @@ async def test_fetch_snapshot_reports_no_sidecar_when_docker_present_but_no_cont
     snapshot = await fetch_snapshot()
 
     assert snapshot.available is False
-    assert snapshot.error == "tailscale binary not found on PATH"
+    assert snapshot.error == "no waypoint tailscale sidecar running"
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_surfaces_docker_ps_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+
+    def fake_which(name: str) -> str | None:
+        return "/usr/local/bin/docker" if name == "docker" else None
+
+    monkeypatch.setattr(tailnet.shutil, "which", fake_which)
+
+    calls: list[tuple[str, ...]] = []
+    plans: dict[tuple[str, ...], _FakeProcess] = {
+        (
+            "/usr/local/bin/docker",
+            "ps",
+            "--filter",
+            "label=waypoint.role=tailscale",
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ): _FakeProcess(stderr=b"Cannot connect to the Docker daemon", returncode=1),
+    }
+    monkeypatch.setattr(
+        tailnet.asyncio,
+        "create_subprocess_exec",
+        _exec_recorder(plans, calls),
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is False
+    assert snapshot.error == "Cannot connect to the Docker daemon"
 
 
 @pytest.mark.asyncio
 async def test_fetch_snapshot_picks_first_when_multiple_sidecars(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
 
@@ -276,7 +314,13 @@ async def test_fetch_snapshot_picks_first_when_multiple_sidecars(
         _exec_recorder(plans, calls),
     )
 
-    snapshot = await fetch_snapshot()
+    with caplog.at_level(logging.WARNING, logger="waypoint.tailnet"):
+        snapshot = await fetch_snapshot()
 
     assert snapshot.available is True
     assert calls[1][2] == "waypoint-tailscale-a"
+    assert any(
+        "multiple tailscale sidecars" in record.message
+        and record.levelname == "WARNING"
+        for record in caplog.records
+    )

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,9 @@
 # Show the transport badge on session cards (default: hidden).
 # NEXT_PUBLIC_SHOW_TRANSPORT_BADGE=1
+
+# Port the frontend uses when inferring the default backend URL. Must
+# match WAYPOINT_STACK_BACKEND_PORT (the backend bind port). waypointctl
+# sets this automatically from WAYPOINT_STACK_BACKEND_PORT when it
+# builds and runs the frontend; override only if you're building the
+# frontend by hand.
+# NEXT_PUBLIC_BACKEND_PORT=8787

--- a/frontend/src/components/BackendSwitcher.tsx
+++ b/frontend/src/components/BackendSwitcher.tsx
@@ -4,7 +4,14 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { isAuthError, probeBackend } from "@/lib/api";
 import { LaunchTargetSummary } from "@/lib/types";
-import { BackendOption, buildBackendOptions, fetchBackendTailnetSnapshot, TailnetSnapshot } from "@/lib/tailnet";
+import {
+  backendPortFromUrl,
+  BackendOption,
+  buildBackendOptions,
+  DEFAULT_BACKEND_PORT,
+  fetchBackendTailnetSnapshot,
+  TailnetSnapshot,
+} from "@/lib/tailnet";
 
 interface BackendSwitcherProps {
   host: string;
@@ -38,9 +45,10 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
 
   const pageHost = typeof window === "undefined" ? "localhost" : window.location.hostname || "localhost";
 
+  const backendPort = backendPortFromUrl(host) ?? DEFAULT_BACKEND_PORT;
   const hostOptions = useMemo<BackendOption[]>(
-    () => buildBackendOptions(pageHost, snapshot),
-    [pageHost, snapshot],
+    () => buildBackendOptions(pageHost, snapshot, backendPort),
+    [pageHost, snapshot, backendPort],
   );
 
   const pickerOptions = useMemo<PickerOption[]>(

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -4,8 +4,10 @@ import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import { probeBackend } from "@/lib/api";
 import {
+  backendPortFromUrl,
   BackendOption,
   buildBackendOptions,
+  DEFAULT_BACKEND_PORT,
   fetchLocalTailnetSnapshot,
   TailnetSnapshot,
 } from "@/lib/tailnet";
@@ -33,9 +35,10 @@ export function LoginForm({ defaultHost, onSubmit }: LoginFormProps) {
 
   const pageHost = typeof window === "undefined" ? "localhost" : window.location.hostname || "localhost";
 
+  const backendPort = backendPortFromUrl(defaultHost) ?? DEFAULT_BACKEND_PORT;
   const options = useMemo<BackendOption[]>(
-    () => buildBackendOptions(pageHost, snapshot),
-    [pageHost, snapshot],
+    () => buildBackendOptions(pageHost, snapshot, backendPort),
+    [pageHost, snapshot, backendPort],
   );
 
   const loadSnapshot = async (signal?: AbortSignal) => {

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -193,7 +193,8 @@ export function writeUsageDashboardOpen(open: boolean): void {
 function inferBackendHost(): string {
   const protocol = window.location.protocol === "https:" ? "https:" : "http:";
   const hostname = window.location.hostname || "127.0.0.1";
-  return `${protocol}//${hostname}:8787`;
+  const port = process.env.NEXT_PUBLIC_BACKEND_PORT || "8787";
+  return `${protocol}//${hostname}:${port}`;
 }
 
 function readLaunchTargetSelections(): Record<string, string> {

--- a/frontend/src/lib/tailnet.ts
+++ b/frontend/src/lib/tailnet.ts
@@ -21,7 +21,7 @@ export function backendPortFromUrl(url: string | null | undefined): number | nul
     const parsed = new URL(url);
     if (!parsed.port) return null;
     const parsedPort = Number.parseInt(parsed.port, 10);
-    return Number.isFinite(parsedPort) ? parsedPort : null;
+    return Number.isFinite(parsedPort) && parsedPort > 0 ? parsedPort : null;
   } catch {
     return null;
   }

--- a/frontend/src/lib/tailnet.ts
+++ b/frontend/src/lib/tailnet.ts
@@ -19,11 +19,9 @@ export function backendPortFromUrl(url: string | null | undefined): number | nul
   if (!url) return null;
   try {
     const parsed = new URL(url);
-    if (parsed.port) {
-      const parsedPort = Number.parseInt(parsed.port, 10);
-      return Number.isFinite(parsedPort) ? parsedPort : null;
-    }
-    return parsed.protocol === "https:" ? 443 : parsed.protocol === "http:" ? 80 : null;
+    if (!parsed.port) return null;
+    const parsedPort = Number.parseInt(parsed.port, 10);
+    return Number.isFinite(parsedPort) ? parsedPort : null;
   } catch {
     return null;
   }

--- a/frontend/src/lib/tailnet.ts
+++ b/frontend/src/lib/tailnet.ts
@@ -15,6 +15,20 @@ export interface TailnetSnapshot {
 
 export const DEFAULT_BACKEND_PORT = 8787;
 
+export function backendPortFromUrl(url: string | null | undefined): number | null {
+  if (!url) return null;
+  try {
+    const parsed = new URL(url);
+    if (parsed.port) {
+      const parsedPort = Number.parseInt(parsed.port, 10);
+      return Number.isFinite(parsedPort) ? parsedPort : null;
+    }
+    return parsed.protocol === "https:" ? 443 : parsed.protocol === "http:" ? 80 : null;
+  } catch {
+    return null;
+  }
+}
+
 export async function fetchLocalTailnetSnapshot(signal?: AbortSignal): Promise<TailnetSnapshot> {
   const response = await fetch("/api/tailnet/peers", { cache: "no-store", signal });
   if (!response.ok) {

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -193,8 +193,11 @@ cmd_down() {
     echo "tailscale container not found: ${name}"
     return 0
   fi
-  docker stop "${name}" >/dev/null
-  echo "tailscale container stopped: ${name}"
+  # Tailnet identity lives in the mounted state dir, so removing the
+  # container is safe — the next `up` rebuilds rather than starting a
+  # potentially stale stopped container.
+  docker rm -f "${name}" >/dev/null
+  echo "tailscale container removed: ${name}"
 }
 
 cmd_status() {

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -63,7 +63,7 @@ are not supported.
 | `WAYPOINTCTL_STATE_DIR` | `~/.waypoint` | Root of the state tree. |
 | `WAYPOINTCTL_DAEMON` | unset | When `1`, route every command through `waypointd` (auto-starting it if needed). |
 | `WAYPOINT_STACK_BACKEND_HOST` | `0.0.0.0` | Backend bind host. |
-| `WAYPOINT_STACK_BACKEND_PORT` | `8787` | Backend port. |
+| `WAYPOINT_STACK_BACKEND_PORT` | `8787` | Backend port. Also forwarded to the frontend build as `NEXT_PUBLIC_BACKEND_PORT` so the picker infers the right URL; the cached build is invalidated when this changes. |
 | `WAYPOINT_STACK_CONFIG` | `backend/waypoint.yaml` | Path to backend config (relative paths resolve under `--home`). |
 | `WAYPOINT_STACK_BACKEND_DATA_DIR` | `<state-dir>/backend-data` | Backend data directory. |
 | `WAYPOINT_STACK_FRONTEND_PORT` | `3000` | Frontend port. |

--- a/waypointctl/src/waypointctl/frontend_build.py
+++ b/waypointctl/src/waypointctl/frontend_build.py
@@ -11,13 +11,20 @@ BUILD_INPUTS_RELATIVE: tuple[str, ...] = (
 )
 
 
-def is_fresh(home: Path, *, force: bool = False) -> bool:
+def is_fresh(home: Path, *, backend_port: int, force: bool = False) -> bool:
     if force:
         return False
 
     next_dir = home / "frontend" / ".next"
     marker = next_dir / "BUILD_ID"
     if not marker.exists():
+        return False
+
+    # NEXT_PUBLIC_* env vars are baked into the bundle at build time.
+    # A cached build with a different port serves a stale value to the
+    # client, so the port is part of the cache key.
+    port_marker = next_dir / "BUILD_BACKEND_PORT"
+    if not port_marker.exists() or _read_ref(port_marker) != str(backend_port):
         return False
 
     ref_file = next_dir / "BUILD_REF"
@@ -33,6 +40,14 @@ def is_fresh(home: Path, *, force: bool = False) -> bool:
             record_build_ref(home)
 
     return not _has_newer_input(home, marker)
+
+
+def record_build(home: Path, *, backend_port: int) -> None:
+    record_build_ref(home)
+    port_marker = home / "frontend" / ".next" / "BUILD_BACKEND_PORT"
+    if not port_marker.parent.exists():
+        return
+    port_marker.write_text(f"{backend_port}\n", encoding="utf-8")
 
 
 def record_build_ref(home: Path) -> None:

--- a/waypointctl/src/waypointctl/services.py
+++ b/waypointctl/src/waypointctl/services.py
@@ -161,13 +161,18 @@ class FrontendService(ManagedService):
 
         frontend_dir = self.config.home / "frontend"
         port_env = str(self.config.frontend_port)
+        backend_port_env = str(self.config.backend_port)
 
         if self.config.frontend_dev:
             log(
                 "stdout",
                 f"starting frontend in development mode on 0.0.0.0:{port_env}",
             )
-            env = dict(self.config.child_env, PORT=port_env)
+            env = dict(
+                self.config.child_env,
+                PORT=port_env,
+                NEXT_PUBLIC_BACKEND_PORT=backend_port_env,
+            )
             pid = spawn_detached(
                 ["npm", "run", "dev"],
                 cwd=frontend_dir,
@@ -176,22 +181,30 @@ class FrontendService(ManagedService):
             )
         else:
             if frontend_build.is_fresh(
-                self.config.home, force=self.config.force_frontend_build
+                self.config.home,
+                backend_port=self.config.backend_port,
+                force=self.config.force_frontend_build,
             ):
                 log("stdout", "frontend build up to date, skipping rebuild")
             else:
                 log("stdout", "building frontend")
-                build_rc = self._run_build(frontend_dir, port_env)
+                build_rc = self._run_build(frontend_dir, port_env, backend_port_env)
                 if build_rc != 0:
                     log("stderr", "frontend build failed")
                     _emit_recent_log(self.log_path, log)
                     return ServiceResult(
                         ok=False, message=f"frontend build exited with {build_rc}"
                     )
-                frontend_build.record_build_ref(self.config.home)
+                frontend_build.record_build(
+                    self.config.home, backend_port=self.config.backend_port
+                )
 
             log("stdout", f"starting frontend on 0.0.0.0:{port_env}")
-            env = dict(self.config.child_env, PORT=port_env)
+            env = dict(
+                self.config.child_env,
+                PORT=port_env,
+                NEXT_PUBLIC_BACKEND_PORT=backend_port_env,
+            )
             pid = spawn_detached(
                 ["npm", "run", "start"],
                 cwd=frontend_dir,
@@ -212,8 +225,14 @@ class FrontendService(ManagedService):
 
         return ServiceResult(ok=True)
 
-    def _run_build(self, frontend_dir: Path, port_env: str) -> int:
-        env = dict(self.config.child_env, PORT=port_env)
+    def _run_build(
+        self, frontend_dir: Path, port_env: str, backend_port_env: str
+    ) -> int:
+        env = dict(
+            self.config.child_env,
+            PORT=port_env,
+            NEXT_PUBLIC_BACKEND_PORT=backend_port_env,
+        )
         with self.log_path.open("a", encoding="utf-8") as log_file:
             proc = subprocess.run(
                 ["npm", "run", "build"],

--- a/waypointctl/tests/test_frontend_build.py
+++ b/waypointctl/tests/test_frontend_build.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from waypointctl.frontend_build import is_fresh, record_build_ref
+from waypointctl.frontend_build import is_fresh, record_build, record_build_ref
 
 
 def _make_repo(root: Path) -> None:
@@ -30,6 +30,9 @@ def _init_git(root: Path) -> None:
     subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=root, check=True, env=env)
 
 
+DEFAULT_BACKEND_PORT = 8787
+
+
 def _write_build_id(root: Path, mtime: float | None = None) -> Path:
     next_dir = root / "frontend" / ".next"
     next_dir.mkdir(parents=True, exist_ok=True)
@@ -38,6 +41,12 @@ def _write_build_id(root: Path, mtime: float | None = None) -> Path:
     if mtime is not None:
         os.utime(marker, (mtime, mtime))
     return marker
+
+
+def _write_port_marker(root: Path, port: int = DEFAULT_BACKEND_PORT) -> None:
+    next_dir = root / "frontend" / ".next"
+    next_dir.mkdir(parents=True, exist_ok=True)
+    (next_dir / "BUILD_BACKEND_PORT").write_text(f"{port}\n")
 
 
 def _current_head(root: Path) -> str:
@@ -52,12 +61,13 @@ def _current_head(root: Path) -> str:
 def test_is_fresh_force_returns_not_fresh(tmp_path: Path) -> None:
     _make_repo(tmp_path)
     _write_build_id(tmp_path)
-    assert is_fresh(tmp_path, force=True) is False
+    _write_port_marker(tmp_path)
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT, force=True) is False
 
 
 def test_is_fresh_no_build_id(tmp_path: Path) -> None:
     _make_repo(tmp_path)
-    assert is_fresh(tmp_path) is False
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is False
 
 
 def test_is_fresh_mtime_only_when_inputs_older(tmp_path: Path) -> None:
@@ -67,13 +77,15 @@ def test_is_fresh_mtime_only_when_inputs_older(tmp_path: Path) -> None:
         path = tmp_path / rel
         os.utime(path, (past, past))
     _write_build_id(tmp_path)
-    assert is_fresh(tmp_path) is True
+    _write_port_marker(tmp_path)
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is True
 
 
 def test_is_fresh_mtime_only_when_inputs_newer(tmp_path: Path) -> None:
     _make_repo(tmp_path)
     _write_build_id(tmp_path, mtime=time.time() - 60)
-    assert is_fresh(tmp_path) is False
+    _write_port_marker(tmp_path)
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is False
 
 
 def test_is_fresh_ref_match_falls_through_to_mtime(tmp_path: Path) -> None:
@@ -84,8 +96,9 @@ def test_is_fresh_ref_match_falls_through_to_mtime(tmp_path: Path) -> None:
     for rel in ("frontend/package.json", "frontend/src/index.ts"):
         os.utime(tmp_path / rel, (past, past))
     _write_build_id(tmp_path)
+    _write_port_marker(tmp_path)
     (tmp_path / "frontend" / ".next" / "BUILD_REF").write_text(head + "\n")
-    assert is_fresh(tmp_path) is True
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is True
 
 
 def test_is_fresh_ref_diverged_with_input_change(tmp_path: Path) -> None:
@@ -94,6 +107,7 @@ def test_is_fresh_ref_diverged_with_input_change(tmp_path: Path) -> None:
     initial_head = _current_head(tmp_path)
 
     _write_build_id(tmp_path)
+    _write_port_marker(tmp_path)
     (tmp_path / "frontend" / ".next" / "BUILD_REF").write_text(initial_head + "\n")
 
     (tmp_path / "frontend" / "src" / "index.ts").write_text("export const X = 1")
@@ -110,7 +124,7 @@ def test_is_fresh_ref_diverged_with_input_change(tmp_path: Path) -> None:
         ["git", "commit", "-q", "-m", "change"], cwd=tmp_path, check=True, env=env
     )
 
-    assert is_fresh(tmp_path) is False
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is False
 
 
 def test_is_fresh_ref_diverged_unrelated_change_advances_ref(tmp_path: Path) -> None:
@@ -123,6 +137,7 @@ def test_is_fresh_ref_diverged_unrelated_change_advances_ref(tmp_path: Path) -> 
     for rel in ("frontend/package.json", "frontend/src/index.ts"):
         os.utime(tmp_path / rel, (past, past))
     _write_build_id(tmp_path)
+    _write_port_marker(tmp_path)
     (tmp_path / "frontend" / ".next" / "BUILD_REF").write_text(initial_head + "\n")
 
     (tmp_path / "README.md").write_text("hi again")
@@ -139,12 +154,41 @@ def test_is_fresh_ref_diverged_unrelated_change_advances_ref(tmp_path: Path) -> 
         ["git", "commit", "-q", "-m", "docs"], cwd=tmp_path, check=True, env=env
     )
 
-    assert is_fresh(tmp_path) is True
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is True
 
     new_head = _current_head(tmp_path)
     assert (
         tmp_path / "frontend" / ".next" / "BUILD_REF"
     ).read_text().strip() == new_head
+
+
+def test_is_fresh_returns_false_when_port_marker_missing(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    past = time.time() - 60
+    for rel in ("frontend/package.json", "frontend/src/index.ts"):
+        os.utime(tmp_path / rel, (past, past))
+    _write_build_id(tmp_path)
+    # no BUILD_BACKEND_PORT marker — legacy build, must rebuild
+    assert is_fresh(tmp_path, backend_port=DEFAULT_BACKEND_PORT) is False
+
+
+def test_is_fresh_returns_false_when_backend_port_changes(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    past = time.time() - 60
+    for rel in ("frontend/package.json", "frontend/src/index.ts"):
+        os.utime(tmp_path / rel, (past, past))
+    _write_build_id(tmp_path)
+    _write_port_marker(tmp_path, port=8787)
+    assert is_fresh(tmp_path, backend_port=8797) is False
+
+
+def test_record_build_writes_port_marker(tmp_path: Path) -> None:
+    _make_repo(tmp_path)
+    _init_git(tmp_path)
+    (tmp_path / "frontend" / ".next").mkdir()
+    record_build(tmp_path, backend_port=8797)
+    port_marker = tmp_path / "frontend" / ".next" / "BUILD_BACKEND_PORT"
+    assert port_marker.read_text().strip() == "8797"
 
 
 def test_record_build_ref_writes_head(tmp_path: Path) -> None:

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -34,16 +34,21 @@ def _write_fake_docker(
     log_file: Path,
     *,
     backend_state: str = "Running",
+    container_exists: bool = False,
 ) -> Path:
     docker = bin_dir / "docker"
     log_path = shlex.quote(str(log_file))
+    inspect_exit = "0" if container_exists else "1"
     docker.write_text(
         f"""#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\\n' "$*" >> {log_path}
 case "$1" in
   inspect)
-    exit 1
+    if [[ "${{2:-}}" == "-f" ]]; then
+      printf 'true\\n'
+    fi
+    exit {inspect_exit}
     ;;
   run)
     printf 'fake-container-id\\n'
@@ -473,6 +478,82 @@ def test_helper_aborts_and_dumps_logs_when_state_stays_needs_login(
     assert "rm -f waypoint-tailscale-profile-a" in docker_log
     # tailscale serve must NOT run while state is NeedsLogin
     assert "tailscale serve" not in docker_log
+
+
+def test_helper_down_removes_container(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_tailscale_script(repo)
+    log_file = tmp_path / "docker.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_docker(bin_dir, log_file, container_exists=True)
+
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "waypoint_tailscale.sh"),
+            "down",
+            "profile-a",
+        ],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    docker_log = log_file.read_text(encoding="utf-8")
+    assert "rm -f waypoint-tailscale-profile-a" in docker_log
+    assert "stop waypoint-tailscale-profile-a" not in docker_log
+    assert (
+        "tailscale container removed: waypoint-tailscale-profile-a" in completed.stdout
+    )
+
+
+def test_helper_down_is_idempotent_when_container_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_tailscale_script(repo)
+    log_file = tmp_path / "docker.log"
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    _write_fake_docker(bin_dir, log_file, container_exists=False)
+
+    bash = shutil.which("bash") or "/bin/bash"
+    completed = subprocess.run(
+        [
+            bash,
+            str(repo / "scripts" / "waypoint_tailscale.sh"),
+            "down",
+            "profile-a",
+        ],
+        cwd=repo,
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "WAYPOINTCTL_STATE_DIR": str(tmp_path / "state"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0
+    docker_log = log_file.read_text(encoding="utf-8")
+    assert "rm -f" not in docker_log
+    assert (
+        "tailscale container not found: waypoint-tailscale-profile-a"
+        in completed.stdout
+    )
 
 
 def test_helper_rejects_degenerate_profile_names(


### PR DESCRIPTION
## Summary

Four related fixes around the Docker-backed tailscale sidecar that `waypointctl tailscale` deploys.

`/api/tailnet/peers` resolved the `tailscale` binary via `shutil.which`, which returns `None` on hosts that joined the tailnet through the sidecar — the API returned `available=false` and the frontend rendered "no peers." Once peers became available, the picker built every URL with a hardcoded `DEFAULT_BACKEND_PORT = 8787`, so a non-default `WAYPOINT_STACK_BACKEND_PORT` still produced wrong URLs. `inferBackendHost` itself also hardcoded `:8787`, so the unreachable warning fired even before the picker opened. And `waypointctl tailscale down` only stopped the sidecar container, leaving a half-state container around that the next `up` would `docker start` back into.

## Changes

### Backend

- `backend/src/waypoint/tailnet.py`: `fetch_snapshot` falls back to `docker exec <container> tailscale status --json` when the host `tailscale` binary is missing. Sidecar containers are discovered by their `waypoint.role=tailscale` label (the one `scripts/waypoint_tailscale.sh` already sets on `docker run`), so existing deployments are picked up without further config. Multiple sidecars pick the first and log a `WARNING` — per-profile selection is deferred.
- `backend/src/waypoint/tailnet.py`: three distinct error strings instead of one collapsed `"tailscale binary not found on PATH"`. Docker absent keeps the old message; `docker ps` non-zero surfaces the daemon's stderr; docker reachable but no sidecar running returns `"no waypoint tailscale sidecar running"`. Subprocess logging now uses `argv[0]` so it correctly names `docker` instead of `tailscale` on the fallback path.
- `backend/src/waypoint/tailnet.py`: `_run_status(argv)` extracts the shared `create_subprocess_exec` + parse loop so the host and docker-exec paths share one implementation. `_find_sidecar_container` returns `(name, error)` and takes the resolved docker path as an arg, removing a redundant `shutil.which` and an unreachable error branch.

### Frontend

- `frontend/src/lib/tailnet.ts`: new `backendPortFromUrl(url)` parses the explicit port out of a URL and returns `null` when there is no explicit port (or the URL is malformed/empty). No protocol-default fallback — the picker hardcodes `http://` so returning 443 for `https://host` would produce `http://peer-ip:443`, an HTTP request against an HTTPS port. Callers handle the missing-port case via `?? DEFAULT_BACKEND_PORT`.
- `frontend/src/components/BackendSwitcher.tsx`: derives the port from the active `host` prop and threads it through to `buildBackendOptions`, so peer URLs in the switcher use the same port the user is currently talking to the backend on.
- `frontend/src/components/LoginForm.tsx`: same treatment using `defaultHost`; first-time logins with no saved host fall back to `DEFAULT_BACKEND_PORT` as before.
- `frontend/src/lib/store.ts`: `inferBackendHost` now reads `process.env.NEXT_PUBLIC_BACKEND_PORT` (with `8787` as the fallback) so the *initial* backend URL also honors the configured port. Without this, the picker fix above couldn't help because the first host the frontend ever showed was already `:8787`.
- `frontend/.env.example`: documents the new `NEXT_PUBLIC_BACKEND_PORT` knob and notes that `waypointctl` sets it automatically.

### waypointctl

- `waypointctl/src/waypointctl/services.py`: passes `NEXT_PUBLIC_BACKEND_PORT=<backend_port>` to all three places that spawn npm — `npm run dev`, `npm run build`, and `npm run start` — so the same port the backend binds to is baked into the frontend bundle.
- `waypointctl/src/waypointctl/frontend_build.py`: cached builds now include a `BUILD_BACKEND_PORT` marker. `is_fresh` rejects a build whose marker is missing (legacy) or doesn't match the requested port; `record_build` writes the marker after each successful build. Without this, changing `WAYPOINT_STACK_BACKEND_PORT` would silently serve a stale bundle with the old port baked in.
- `waypointctl/README.md`: notes the auto-forwarding and cache-invalidation behavior in the env-var table.

### scripts

- `scripts/waypoint_tailscale.sh`: `cmd_down` now runs `docker rm -f` instead of `docker stop`. Tailnet identity lives in the mounted state dir under `~/.waypoint/tailscale/<profile>/`, so removal is safe — the next `up` rebuilds from a clean slate instead of `docker start`-ing a stale container that may have failed mid-configure. User-visible change: `down` prints `"tailscale container removed:"` and a follow-up `status` reports `missing` instead of `stopped`.

### Tests

- `backend/tests/test_tailnet.py`: five new tests covering host-binary preferred, docker-exec fallback success, neither path available, docker present but no sidecar running, `docker ps` daemon error, and multi-sidecar picks-first-with-warning (asserted via `caplog`).
- `waypointctl/tests/test_frontend_build.py`: updated to pass `backend_port` through `is_fresh` calls; new tests cover the missing-marker (legacy build) path, the port-mismatch invalidation, and that `record_build` writes the port marker.
- `waypointctl/tests/test_tailscale.py`: fake docker gained a `container_exists` flag so `cmd_down` can be exercised against a "real" container. New end-to-end tests confirm `down` issues `docker rm -f` (not `stop`) when the container exists and remains idempotent when it doesn't.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_tailnet.py` — 9 pass.
- [x] `cd backend && uv run pre-commit run --files src/waypoint/tailnet.py tests/test_tailnet.py` — isort/black/ruff/codespell/mypy clean.
- [x] `cd waypointctl && uv run pytest tests/test_frontend_build.py tests/test_tailscale.py` — 30 pass.
- [x] `cd backend && uv run pre-commit run --files <changed waypointctl files>` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] Manual: open the frontend on a host whose tailnet is joined via `waypointctl tailscale up <profile>` and confirm the BackendSwitcher lists the docker sidecar's tailnet peers — not run on this branch; deferred to reviewer.
- [x] Manual: set `WAYPOINT_STACK_BACKEND_PORT` to something other than 8787, run `waypointctl start`, and confirm the frontend's inferred backend URL uses the new port (no manual `WAYPOINT_STACK_FORCE_FRONTEND_BUILD=1` required) — not run on this branch; deferred to reviewer.
- [x] Manual: `waypointctl tailscale up <profile>` → `waypointctl tailscale down <profile>` → `waypointctl tailscale status <profile>` reports `missing` (not `stopped`); the next `up` rebuilds the container — not run on this branch; deferred to reviewer.