### PR TITLE
fix: honor service argument on `waypointctl start` and `stop`

### DIFF
--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -264,9 +264,11 @@ def _run_in_process(home: Path, command: str, args: list[str]) -> None:
         typer.echo(line, err=(stream == "stderr"))
 
     if command == "start":
-        result = stack.start(log)
+        target = args[0] if args else "all"
+        result = stack.start(log, target)
     elif command == "stop":
-        result = stack.stop(log)
+        target = args[0] if args else "all"
+        result = stack.stop(log, target)
     elif command == "restart":
         target = args[0] if args else "all"
         result = stack.restart(target, log)

--- a/waypointctl/src/waypointctl/daemon.py
+++ b/waypointctl/src/waypointctl/daemon.py
@@ -117,11 +117,13 @@ class WaypointDaemonHandler(socketserver.StreamRequestHandler):
                 self._send_log(DaemonLog(stream=stream, line=line))
 
         if request.command == "start":
-            result = stack.start(log)
+            target = request.args[0] if request.args else "all"
+            result = stack.start(log, target)
         elif request.command == "status":
             result = stack.status(log)
         elif request.command == "stop":
-            result = stack.stop(log)
+            target = request.args[0] if request.args else "all"
+            result = stack.stop(log, target)
         elif request.command == "restart":
             target = request.args[0] if request.args else "all"
             result = stack.restart(target, log)
@@ -162,9 +164,10 @@ class WaypointDaemonHandler(socketserver.StreamRequestHandler):
                 stack.restart(target, file_log)
 
         elif command == "stop":
+            target = request.args[0] if request.args else "all"
 
             def worker() -> None:
-                stack.stop(file_log)
+                stack.stop(file_log, target)
 
         else:
             self._send_result(

--- a/waypointctl/src/waypointctl/stack.py
+++ b/waypointctl/src/waypointctl/stack.py
@@ -22,41 +22,47 @@ class WaypointStack:
         self.frontend = FrontendService(config)
         self.caffeinate = CaffeinateService(config)
 
-    def start(self, log: LogFn) -> ServiceResult:
-        services = (self.backend, self.frontend)
+    def start(self, log: LogFn, target: str = "all") -> ServiceResult:
+        services = self._select(target)
+        if services is None:
+            return ServiceResult(ok=False, message=f"unknown service: {target}")
         for svc in services:
             svc.started_marker.unlink(missing_ok=True)
 
         results = self._parallel(services, "start", log)
         if any(not r.ok for r in results):
-            self._stop_started(log)
+            self._stop_started(services, log)
             return _aggregate(results)
 
         self.caffeinate.start(log)
         self._emit_status(log)
         return ServiceResult(ok=True)
 
-    def stop(self, log: LogFn) -> ServiceResult:
-        results = self._parallel(
-            (self.caffeinate, self.frontend, self.backend), "stop", log
+    def stop(self, log: LogFn, target: str = "all") -> ServiceResult:
+        services = self._select(target)
+        if services is None:
+            return ServiceResult(ok=False, message=f"unknown service: {target}")
+        # Caffeinate spans the whole stack — only stop it on `stop all`.
+        targets: tuple[ManagedService, ...] = (
+            (self.caffeinate, *services) if target in {"all", ""} else services
         )
+        results = self._parallel(targets, "stop", log)
         return _aggregate(results)
 
     def restart(self, target: str, log: LogFn) -> ServiceResult:
+        if self._select(target) is None:
+            return ServiceResult(ok=False, message=f"unknown service: {target}")
+        self.stop(log, target)
+        return self.start(log, target)
+
+    def _select(self, target: str) -> tuple[ManagedService, ...] | None:
         if target == "backend":
-            self.backend.stop(log)
-            result = self.backend.start(log)
-            self._emit_status(log)
-            return result
+            return (self.backend,)
         if target == "frontend":
-            self.frontend.stop(log)
-            result = self.frontend.start(log)
-            self._emit_status(log)
-            return result
+            return (self.frontend,)
         if target in {"all", ""}:
-            self.stop(log)
-            return self.start(log)
-        return ServiceResult(ok=False, message=f"unknown service: {target}")
+            return (self.backend, self.frontend)
+        return None
 
     def status(self, log: LogFn) -> ServiceResult:
         self._emit_status(log)
@@ -85,8 +91,8 @@ class WaypointStack:
         if cf_status.state == "running":
             log("stdout", _format_status(cf_status))
 
-    def _stop_started(self, log: LogFn) -> None:
-        for svc in (self.backend, self.frontend):
+    def _stop_started(self, services: tuple[ManagedService, ...], log: LogFn) -> None:
+        for svc in services:
             if svc.started_marker.exists():
                 svc.stop(log)
 

--- a/waypointctl/tests/test_stack.py
+++ b/waypointctl/tests/test_stack.py
@@ -130,6 +130,84 @@ def test_stop_runs_all_services(state_dir: Path, tmp_path: Path) -> None:
     assert caffeinate.calls == ["stop"]
 
 
+def test_start_target_backend_skips_frontend(state_dir: Path, tmp_path: Path) -> None:
+    stack = WaypointStack(_build_config(tmp_path, state_dir))
+    backend, frontend, caffeinate = _install_stubs(stack)
+
+    result = stack.start(lambda *_: None, "backend")
+
+    assert result.ok is True
+    assert backend.calls == ["start"]
+    assert frontend.calls == []
+    assert caffeinate.calls == ["start"]
+
+
+def test_start_target_frontend_skips_backend(state_dir: Path, tmp_path: Path) -> None:
+    stack = WaypointStack(_build_config(tmp_path, state_dir))
+    backend, frontend, caffeinate = _install_stubs(stack)
+
+    result = stack.start(lambda *_: None, "frontend")
+
+    assert result.ok is True
+    assert backend.calls == []
+    assert frontend.calls == ["start"]
+    assert caffeinate.calls == ["start"]
+
+
+def test_start_unknown_target(state_dir: Path, tmp_path: Path) -> None:
+    stack = WaypointStack(_build_config(tmp_path, state_dir))
+    backend, frontend, caffeinate = _install_stubs(stack)
+    result = stack.start(lambda *_: None, "teleporter")
+    assert result.ok is False
+    assert "unknown service" in result.message
+    assert backend.calls == []
+    assert frontend.calls == []
+    assert caffeinate.calls == []
+
+
+def test_stop_target_backend_leaves_frontend_and_caffeinate(
+    state_dir: Path, tmp_path: Path
+) -> None:
+    stack = WaypointStack(_build_config(tmp_path, state_dir))
+    backend, frontend, caffeinate = _install_stubs(stack)
+
+    result = stack.stop(lambda *_: None, "backend")
+
+    assert result.ok is True
+    assert backend.calls == ["stop"]
+    assert frontend.calls == []
+    assert caffeinate.calls == []
+
+
+def test_stop_unknown_target(state_dir: Path, tmp_path: Path) -> None:
+    stack = WaypointStack(_build_config(tmp_path, state_dir))
+    backend, frontend, caffeinate = _install_stubs(stack)
+    result = stack.stop(lambda *_: None, "teleporter")
+    assert result.ok is False
+    assert backend.calls == []
+    assert frontend.calls == []
+    assert caffeinate.calls == []
+
+
+def test_start_partial_failure_only_stops_started_in_target(
+    state_dir: Path, tmp_path: Path
+) -> None:
+    """A failed `start backend` must not stop an already-running frontend."""
+    stack = WaypointStack(_build_config(tmp_path, state_dir))
+    backend, frontend, caffeinate = _install_stubs(stack)
+    frontend.started_marker_value = True  # pretend frontend was already running
+
+    def failing_start(log):  # type: ignore[no-untyped-def]
+        return ServiceResult(ok=False, message="backend failed")
+
+    backend.start = failing_start  # type: ignore[method-assign]
+
+    result = stack.start(lambda *_: None, "backend")
+
+    assert result.ok is False
+    assert frontend.calls == []  # cleanup did not touch frontend
+
+
 def test_restart_target_backend(state_dir: Path, tmp_path: Path) -> None:
     stack = WaypointStack(_build_config(tmp_path, state_dir))
     backend, frontend, caffeinate = _install_stubs(stack)


### PR DESCRIPTION
## Summary

`waypointctl start backend` and `waypointctl stop backend` accepted the service argument but silently operated on the whole stack — only `restart` honored it. Both the in-process CLI and the daemon dispatch paths discarded the arg before calling `WaypointStack.start`/`stop`, which themselves took no target.

## Changes

### waypointctl

- `waypointctl/src/waypointctl/stack.py`: `WaypointStack.start` and `.stop` take a `target: str = "all"` argument and route the selected services through a single `_select` helper. `restart` now delegates to `self.stop(log, target)` + `self.start(log, target)` rather than open-coding per-target stop+start pairs. Caffeinate is stack-wide, so `stop` only signals it on `stop all`; single-service `start` still calls `caffeinate.start` (idempotent) so backend-only or frontend-only sessions still get the macOS sleep hold.
- `waypointctl/src/waypointctl/stack.py`: `_stop_started` is scoped to the services that were actually being started, so a failed `start backend` no longer tears down an already-running frontend that happened to have a stale started-marker.
- `waypointctl/src/waypointctl/cli.py`: `_run_in_process` reads `args[0]` (defaulting to `"all"`) and threads it through for both `start` and `stop`.
- `waypointctl/src/waypointctl/daemon.py`: the synchronous and deferred dispatch paths both honor `request.args[0]` for `start`/`stop`/`restart`, matching the CLI.

### Tests

- `waypointctl/tests/test_stack.py`: new cases for `start backend`, `start frontend`, `stop backend`, unknown-target rejection on both verbs, and a regression test that a failed `start backend` does not stop an already-running frontend.

## Test Plan

- [x] `cd waypointctl && uv run pytest tests/test_stack.py` — 13 pass.
- [x] `cd backend && uv run pre-commit run --files <changed files>` — isort/black/ruff/codespell/mypy clean.
- [x] Manual: `waypointctl start backend` brings up only the backend; `waypointctl status` shows `frontend: stopped`.
- [x] Manual: same for `waypointctl stop backend` against a running stack.