### PR TITLE
feat: add quick-compose drawer to the tmux terminal view

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -861,6 +861,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
                 input_bytes = b""
                 resize_target: tuple[int, int] | None = None
+                # Whole-message submissions from the quick-compose drawer.
+                # Kept separate from ``input_bytes`` so each one round-trips
+                # through ``send_input`` (which appends Enter when
+                # ``submit`` is true) instead of being concatenated with
+                # raw keystrokes.
+                submits: list[tuple[str, bool]] = []
 
                 for frame in frames:
                     try:
@@ -872,6 +878,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         data = payload.get("data", "")
                         if isinstance(data, str) and data:
                             input_bytes += data.encode("utf-8")
+                    elif kind == "input_submit":
+                        text = payload.get("text", "")
+                        if not isinstance(text, str):
+                            continue
+                        submit = bool(payload.get("submit", True))
+                        if text or submit:
+                            submits.append((text, submit))
                     elif kind == "resize":
                         try:
                             r_cols = int(payload.get("cols", 0))
@@ -884,6 +897,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 if input_bytes:
                     with suppress(TmuxError):
                         await adapter.send_bytes(pane, input_bytes)
+                for text, submit in submits:
+                    with suppress(TmuxError):
+                        await adapter.send_input(pane, text, submit=submit)
                 if resize_target is not None:
                     new_cols, new_rows = resize_target
                     renderer.resize(new_cols, new_rows)

--- a/backend/src/waypoint/backends/tmux/adapter.py
+++ b/backend/src/waypoint/backends/tmux/adapter.py
@@ -180,10 +180,17 @@ class TmuxAdapter:
         return stdout.decode()
 
     async def _send_literal_text(self, target: str, text: str) -> None:
+        # Embedded newlines go in as Ctrl-J (literal LF) so a multi-line
+        # message lands as one submission terminated by the caller's
+        # optional trailing ``Enter`` (the ``submit`` flag on
+        # ``send_input``). Splitting on ``Enter`` instead would submit
+        # each line as a separate message — Claude Code, Codex, and
+        # OpenCode all treat ``\r`` as accept-line and ``\n`` (Ctrl-J,
+        # same byte the keybar's ``⇧↵`` chip emits) as soft newline.
         normalized = text.replace("\r\n", "\n").replace("\r", "\n")
         lines = normalized.split("\n")
         for index, line in enumerate(lines):
             if line:
                 await self._run("send-keys", "-t", target, "-l", "--", line)
             if index < len(lines) - 1:
-                await self._run("send-keys", "-t", target, "Enter")
+                await self._run("send-keys", "-t", target, "C-j")

--- a/backend/tests/test_tmux.py
+++ b/backend/tests/test_tmux.py
@@ -21,7 +21,7 @@ def test_send_input_uses_literal_mode_and_submit() -> None:
     ]
 
 
-def test_send_input_preserves_multiline_text() -> None:
+def test_send_input_sends_multiline_text_as_single_submission() -> None:
     commands: list[tuple[str, ...]] = []
 
     async def fake_run(*args: str) -> str:
@@ -33,9 +33,12 @@ def test_send_input_preserves_multiline_text() -> None:
 
     asyncio.run(adapter.send_input("%2", "first line\nsecond line", submit=True))
 
+    # Embedded newlines emit as Ctrl-J (soft newline) so the TUI treats
+    # the whole block as one multi-line message terminated by the final
+    # Enter that ``submit=True`` adds.
     assert commands == [
         ("send-keys", "-t", "%2", "-l", "--", "first line"),
-        ("send-keys", "-t", "%2", "Enter"),
+        ("send-keys", "-t", "%2", "C-j"),
         ("send-keys", "-t", "%2", "-l", "--", "second line"),
         ("send-keys", "-t", "%2", "Enter"),
     ]

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7150,14 +7150,6 @@ html[data-theme="light"] .term-compose-handle:hover {
   flex: 1 1 auto;
 }
 
-/* The .composer-connection chip reused here was sized for the chat
-   composer's top row; trim the padding so it sits comfortably in a
-   denser meta row. */
-.term-compose-connection {
-  padding: 3px 9px;
-  font-size: 0.68rem;
-}
-
 .term-compose-hint {
   font-family: var(--font-mono);
   font-size: 0.72rem;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6982,6 +6982,209 @@ html[data-theme="light"] .term-keys button:hover {
   }
 }
 
+/* ─── Terminal quick-compose drawer ───
+   Hangs off the bottom edge of .session-terminal, below .term-keys. The
+   collapsed state is a thin ledge with a centered sheet-handle pill —
+   tapping it reveals a textarea + Send that round-trips one whole
+   message to the tmux pane (vs. the per-keystroke forwarding the bar
+   above does). Reuses .composer-textarea, .composer-connection,
+   .composer-shortcut, .composer-resize-handle, and the `primary send`
+   button styling from the chat composer so the two surfaces share a
+   visual vocabulary. */
+.term-compose {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--line);
+  background: linear-gradient(
+    180deg,
+    rgba(20, 24, 33, 0.78),
+    rgba(12, 15, 22, 0.9)
+  );
+  /* The handle row owns the home-indicator inset on iOS so the
+     tappable pill never sits under the system gesture area. The
+     keybar above drops its own inset (rule below) so the gap shows up
+     in exactly one place. */
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+html[data-theme="light"] .term-compose {
+  background: linear-gradient(
+    180deg,
+    rgba(248, 245, 238, 0.92),
+    rgba(240, 236, 226, 0.96)
+  );
+}
+
+/* When the drawer is rendered (liveTmux only), the keybar's own
+   safe-area inset would double-pad the gesture area. Flatten it so
+   the gap lives on .term-compose where the visible anchor is. */
+.session-terminal:has(.term-compose) .term-keys {
+  padding-bottom: 8px;
+}
+
+/* The handle ledge is the only chrome visible in the collapsed state.
+   ~14px tall with a centered 28×3 pill — deliberately quiet so the
+   default terminal aesthetic is preserved. */
+.term-compose-handle {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 14px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 120ms ease;
+}
+
+.term-compose-handle:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+html[data-theme="light"] .term-compose-handle:hover {
+  background: rgba(0, 0, 0, 0.025);
+}
+
+.term-compose-handle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 75%, transparent);
+  outline-offset: -3px;
+  border-radius: 4px;
+}
+
+.term-compose-handle-pill {
+  display: block;
+  width: 28px;
+  height: 3px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 32%, transparent);
+  transition:
+    background 160ms ease,
+    transform 200ms cubic-bezier(0.2, 0, 0, 1),
+    width 200ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.term-compose-handle:hover .term-compose-handle-pill {
+  background: color-mix(in srgb, var(--accent) 58%, transparent);
+  width: 36px;
+}
+
+.term-compose.is-open .term-compose-handle-pill {
+  background: color-mix(in srgb, var(--accent) 70%, transparent);
+  width: 36px;
+}
+
+/* The shell animates rows 0fr → 1fr so the drawer slides open without
+   reflowing the page. ``min-height: 0`` on the inner container is
+   required for the row-grid trick to clip cleanly. */
+.term-compose-shell {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 200ms cubic-bezier(0.2, 0, 0, 1);
+}
+
+.term-compose.is-open .term-compose-shell {
+  grid-template-rows: 1fr;
+}
+
+.term-compose-inner {
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 12px 10px;
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+.term-compose.is-open .term-compose-inner {
+  opacity: 1;
+  transition-delay: 80ms;
+}
+
+.term-compose-field {
+  position: relative;
+}
+
+/* The reused .composer-resize-handle sits on the top edge of the
+   textarea on desktop; the existing @media (pointer: coarse) rule on
+   the base class hides it on touch. We override the absolute offset
+   to align with the textarea's own top edge instead of the parent
+   .composer's top edge. */
+.term-compose-resize {
+  top: -6px;
+}
+
+.term-compose-textarea {
+  min-height: 72px;
+  max-height: min(36dvh, 320px);
+  /* 16px suppresses iOS Safari's auto-zoom on focus. */
+  font-size: 16px;
+}
+
+@media (min-width: 721px) {
+  .term-compose-textarea {
+    font-size: 0.92rem;
+  }
+}
+
+@media (max-width: 720px) {
+  .term-compose-textarea {
+    max-height: min(28dvh, 220px);
+  }
+}
+
+.term-compose-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.term-compose-meta-spacer {
+  flex: 1 1 auto;
+}
+
+/* The .composer-connection chip reused here was sized for the chat
+   composer's top row; trim the padding so it sits comfortably in a
+   denser meta row. */
+.term-compose-connection {
+  padding: 3px 9px;
+  font-size: 0.68rem;
+}
+
+.term-compose-hint {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--warn, var(--accent));
+}
+
+@media (max-width: 480px) {
+  .term-compose-shortcut {
+    display: none;
+  }
+}
+
+.term-compose-send {
+  /* The .primary.send base lives in the chat composer's rules; we just
+     tighten the padding for the smaller drawer footprint. */
+  padding: 6px 14px;
+  font-size: 0.82rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .term-compose-shell,
+  .term-compose-inner,
+  .term-compose-handle-pill {
+    transition: none;
+  }
+}
+
 /* ─── Launch panel (redesigned) ───
    Single card with a New / Resume / Attach segmented mode chooser. The
    body swaps content based on the selected mode. Launch-mode + custom

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -48,6 +48,7 @@ import {
   useBackendCatalog,
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
+import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
 import {
   isPlanEvent,
   itemIdForEvent,
@@ -226,12 +227,6 @@ type ConnectionState = "connecting" | "open" | "reconnecting";
 // sensible for the very first paint before the observer fires.
 const COMPOSER_HEIGHT_FALLBACK = 220;
 const COMPOSER_HEIGHT_STORAGE_KEY = "waypoint-composer-height";
-// Mirrors the mobile min-height in globals.css so the resized desktop
-// composer can never shrink below what mobile already enforces.
-const COMPOSER_MIN_HEIGHT = 56;
-const SHORTCUT_IS_MAC =
-  typeof navigator !== "undefined" &&
-  /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || "");
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
@@ -1247,6 +1242,16 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     }
   }, []);
 
+  // Whole-message submission from the quick-compose drawer — the backend
+  // appends Enter when ``submit`` is true so each call lands as one
+  // logical message rather than a stream of keystrokes.
+  const handleTerminalSubmit = useCallback((text: string) => {
+    const socket = terminalSocketRef.current;
+    if (socket?.readyState !== WebSocket.OPEN) return false;
+    socket.send(JSON.stringify({ type: "input_submit", text, submit: true }));
+    return true;
+  }, []);
+
   const requestPaste = useCallback(async () => {
     setError("");
     if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
@@ -1562,6 +1567,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           rateLimitRefreshBusy={rateLimitRefreshBusy}
           onRateLimitRefresh={handleRateLimitRefresh}
           onTerminalInput={handleTerminalInput}
+          onTerminalSubmit={handleTerminalSubmit}
           onRequestPaste={requestPaste}
           onTerminalResize={handleTerminalResize}
           onTerminalScrollChip={handleTerminalScrollChip}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -273,10 +273,13 @@ export function SessionTerminalView({
       ) : null}
       {composeEnabled ? (
         <TerminalCompose
+          session={session}
           onSubmit={onTerminalSubmit}
           expanded={composeOpen}
           onExpandedChange={setComposeOpen}
           connection={connection}
+          rateLimitRefreshBusy={rateLimitRefreshBusy}
+          onRateLimitRefresh={onRateLimitRefresh}
           refocusTerminal={refocusTerminal}
         />
       ) : null}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { Dispatch, MutableRefObject, SetStateAction, useCallback, useState } from "react";
 
 import { SessionUsagePill } from "@/components/SessionUsagePill";
+import { TerminalCompose } from "@/components/TerminalCompose";
 import { TerminalScrollChips } from "@/components/TerminalScrollChips";
 import { XTerminal, type XTerminalHandle } from "@/components/XTerminal";
 import { SessionRecord } from "@/lib/types";
@@ -31,6 +32,9 @@ interface SessionTerminalViewProps {
   // composer beneath remains visible.
   locked: boolean;
   onTerminalInput: (data: string) => void;
+  // Returns false when the WS isn't open so the composer can keep the
+  // draft and surface a "reconnecting" hint instead of dropping it.
+  onTerminalSubmit: (text: string) => boolean;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;
@@ -64,6 +68,7 @@ export function SessionTerminalView({
   onRateLimitRefresh,
   locked,
   onTerminalInput,
+  onTerminalSubmit,
   onRequestPaste,
   onTerminalResize,
   onTerminalScrollChip,
@@ -109,9 +114,20 @@ export function SessionTerminalView({
     void cb();
   };
 
+  const [composeOpen, setComposeOpen] = useState(false);
+  // The compose drawer collapses back to a hairline handle when the
+  // session isn't live, so we don't carry stale "open" state across a
+  // disconnect / view switch.
+  const composeEnabled = liveTmux;
+  const refocusTerminal = useCallback(() => {
+    terminalRef.current?.focus();
+  }, [terminalRef]);
+
   return (
     <section
-      className={`session-terminal ${locked ? "is-locked" : ""}`}
+      className={`session-terminal ${locked ? "is-locked" : ""} ${
+        composeEnabled && composeOpen ? "has-compose-open" : ""
+      }`}
       aria-label="Terminal session"
     >
       <div className="term-bar">
@@ -253,6 +269,15 @@ export function SessionTerminalView({
           onSend={onTerminalInput}
           onRequestPaste={onRequestPaste}
           backend={session?.backend ?? null}
+        />
+      ) : null}
+      {composeEnabled ? (
+        <TerminalCompose
+          onSubmit={onTerminalSubmit}
+          expanded={composeOpen}
+          onExpandedChange={setComposeOpen}
+          connection={connection}
+          refocusTerminal={refocusTerminal}
         />
       ) : null}
     </section>

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import {
+  KeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
+
+import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
+
+type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
+
+interface TerminalComposeProps {
+  // ``onSubmit`` returns false when the socket isn't open so we can leave
+  // the draft in place and surface a hint without throwing it away.
+  onSubmit: (text: string) => boolean;
+  expanded: boolean;
+  onExpandedChange: (next: boolean) => void;
+  connection: ConnectionState;
+  // Focus target when the user dismisses the drawer via Escape — the
+  // xterm canvas, so typing resumes inside the pane.
+  refocusTerminal: () => void;
+}
+
+const HEIGHT_STORAGE_KEY = "waypoint-term-compose-height";
+const HEIGHT_FALLBACK = 132;
+const HEIGHT_MAX = 320;
+
+export function TerminalCompose({
+  onSubmit,
+  expanded,
+  onExpandedChange,
+  connection,
+  refocusTerminal,
+}: TerminalComposeProps) {
+  const regionId = useId();
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [hint, setHint] = useState<string | null>(null);
+  const [textareaHeight, setTextareaHeight] = useState<number | null>(null);
+
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const handleRef = useRef<HTMLButtonElement | null>(null);
+
+  // Restore the desktop height preference on mount; mobile media query
+  // hides the resize handle so the persisted value is harmless there.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = window.localStorage.getItem(HEIGHT_STORAGE_KEY);
+      if (!stored) return;
+      const parsed = Number.parseInt(stored, 10);
+      if (Number.isFinite(parsed) && parsed >= COMPOSER_MIN_HEIGHT) {
+        setTextareaHeight(Math.min(parsed, HEIGHT_MAX));
+      }
+    } catch {
+      // localStorage can throw in private windows — fall back to default.
+    }
+  }, []);
+
+  // Auto-focus the textarea on expand; return focus to the handle when
+  // the drawer collapses so keyboard users don't lose their place.
+  useEffect(() => {
+    if (expanded) {
+      textareaRef.current?.focus();
+    }
+  }, [expanded]);
+
+  const dirty = draft.trim().length > 0;
+  const connected = connection === "open";
+  const canSend = expanded && connected && dirty && !sending;
+
+  const send = useCallback(() => {
+    const text = draft;
+    if (!text.trim()) return;
+    if (!connected) {
+      setHint("Reconnecting — try again in a moment");
+      return;
+    }
+    setSending(true);
+    const ok = onSubmit(text);
+    if (ok) {
+      setDraft("");
+      setHint(null);
+    } else {
+      setHint("Socket not open — try again in a moment");
+    }
+    // The send call resolves synchronously (it's just a WebSocket.send),
+    // but we briefly hold the disabled state so the user gets feedback.
+    window.setTimeout(() => setSending(false), 120);
+  }, [draft, connected, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onExpandedChange(false);
+        // Defer so the textarea blurs before we move focus.
+        window.setTimeout(refocusTerminal, 0);
+        return;
+      }
+      if (event.key !== "Enter" || event.shiftKey) return;
+      if (!event.metaKey && !event.ctrlKey) return;
+      event.preventDefault();
+      send();
+    },
+    [send, onExpandedChange, refocusTerminal],
+  );
+
+  const toggle = useCallback(() => {
+    onExpandedChange(!expanded);
+    if (expanded) {
+      window.setTimeout(refocusTerminal, 0);
+    }
+  }, [expanded, onExpandedChange, refocusTerminal]);
+
+  // Desktop resize handle on the top edge of the textarea. Drag-up
+  // grows; drag-down shrinks. Mirrors the chat composer's behaviour so
+  // the gesture feels identical between the two surfaces.
+  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.pointerType === "touch") return;
+    const startY = event.clientY;
+    const startHeight =
+      textareaRef.current?.getBoundingClientRect().height ?? HEIGHT_FALLBACK;
+    event.currentTarget.setPointerCapture(event.pointerId);
+    const onMove = (e: PointerEvent) => {
+      const delta = startY - e.clientY;
+      const next = Math.min(
+        HEIGHT_MAX,
+        Math.max(COMPOSER_MIN_HEIGHT, Math.round(startHeight + delta)),
+      );
+      setTextareaHeight(next);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      try {
+        if (textareaRef.current) {
+          window.localStorage.setItem(
+            HEIGHT_STORAGE_KEY,
+            String(textareaRef.current.getBoundingClientRect().height),
+          );
+        }
+      } catch {
+        // Ignore storage failures — height resets to default next load.
+      }
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+  }, []);
+
+  const shortcutLabel = SHORTCUT_IS_MAC ? "⌘↵" : "Ctrl+↵";
+
+  return (
+    <section
+      className={`term-compose ${expanded ? "is-open" : "is-closed"}`}
+      aria-label="Quick compose"
+    >
+      <button
+        ref={handleRef}
+        type="button"
+        className="term-compose-handle"
+        aria-expanded={expanded}
+        aria-controls={regionId}
+        aria-label={expanded ? "Collapse quick compose" : "Expand quick compose"}
+        title={expanded ? "Collapse" : "Quick compose"}
+        onClick={toggle}
+      >
+        <span className="term-compose-handle-pill" aria-hidden="true" />
+      </button>
+      <div className="term-compose-shell" id={regionId} aria-hidden={!expanded}>
+        <div className="term-compose-inner">
+          <div className="term-compose-field">
+            <div
+              className="composer-resize-handle term-compose-resize"
+              onPointerDown={handlePointerDown}
+              aria-hidden="true"
+            />
+            <textarea
+              ref={textareaRef}
+              className="composer-textarea term-compose-textarea"
+              style={textareaHeight ? { height: textareaHeight } : undefined}
+              rows={3}
+              value={draft}
+              onChange={(event) => {
+                setDraft(event.target.value);
+                if (hint) setHint(null);
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Type a message — sent in one shot to the pane"
+              aria-label="Message to send to terminal"
+              tabIndex={expanded ? 0 : -1}
+            />
+          </div>
+          <div className="term-compose-meta">
+            <span
+              className={`composer-connection term-compose-connection ${
+                connection === "open"
+                  ? "open"
+                  : connection === "reconnecting"
+                    ? "reconnecting"
+                    : connection === "connecting"
+                      ? "connecting"
+                      : ""
+              }`}
+            >
+              {connection === "open"
+                ? "connected"
+                : connection === "reconnecting"
+                  ? "reconnecting"
+                  : connection === "connecting"
+                    ? "connecting"
+                    : "idle"}
+            </span>
+            {hint ? (
+              <span className="term-compose-hint" role="status">
+                {hint}
+              </span>
+            ) : null}
+            <span className="term-compose-meta-spacer" />
+            <span className="composer-shortcut term-compose-shortcut" aria-hidden="true">
+              <kbd>{shortcutLabel}</kbd>
+              <span>send</span>
+            </span>
+            <button
+              type="button"
+              className="primary send term-compose-send"
+              onClick={send}
+              disabled={!canSend}
+              tabIndex={expanded ? 0 : -1}
+            >
+              {sending ? "Sending…" : "Send"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -10,17 +10,22 @@ import {
   useState,
 } from "react";
 
+import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
+import type { SessionRecord } from "@/lib/types";
 
 type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
 
 interface TerminalComposeProps {
+  session: SessionRecord | null;
   // ``onSubmit`` returns false when the socket isn't open so we can leave
   // the draft in place and surface a hint without throwing it away.
   onSubmit: (text: string) => boolean;
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
   connection: ConnectionState;
+  rateLimitRefreshBusy: boolean;
+  onRateLimitRefresh: () => void | Promise<void>;
   // Focus target when the user dismisses the drawer via Escape — the
   // xterm canvas, so typing resumes inside the pane.
   refocusTerminal: () => void;
@@ -31,10 +36,13 @@ const HEIGHT_FALLBACK = 132;
 const HEIGHT_MAX = 320;
 
 export function TerminalCompose({
+  session,
   onSubmit,
   expanded,
   onExpandedChange,
   connection,
+  rateLimitRefreshBusy,
+  onRateLimitRefresh,
   refocusTerminal,
 }: TerminalComposeProps) {
   const regionId = useId();
@@ -61,14 +69,6 @@ export function TerminalCompose({
       // localStorage can throw in private windows — fall back to default.
     }
   }, []);
-
-  // Auto-focus the textarea on expand; return focus to the handle when
-  // the drawer collapses so keyboard users don't lose their place.
-  useEffect(() => {
-    if (expanded) {
-      textareaRef.current?.focus();
-    }
-  }, [expanded]);
 
   const dirty = draft.trim().length > 0;
   const connected = connection === "open";
@@ -193,31 +193,18 @@ export function TerminalCompose({
                 if (hint) setHint(null);
               }}
               onKeyDown={handleKeyDown}
-              placeholder="Type a message — sent in one shot to the pane"
+              placeholder="Type a message"
               aria-label="Message to send to terminal"
               tabIndex={expanded ? 0 : -1}
             />
           </div>
           <div className="term-compose-meta">
-            <span
-              className={`composer-connection term-compose-connection ${
-                connection === "open"
-                  ? "open"
-                  : connection === "reconnecting"
-                    ? "reconnecting"
-                    : connection === "connecting"
-                      ? "connecting"
-                      : ""
-              }`}
-            >
-              {connection === "open"
-                ? "connected"
-                : connection === "reconnecting"
-                  ? "reconnecting"
-                  : connection === "connecting"
-                    ? "connecting"
-                    : "idle"}
-            </span>
+            <SessionUsagePill
+              session={session}
+              connection={connection}
+              onRateLimitRefresh={onRateLimitRefresh}
+              rateLimitRefreshBusy={rateLimitRefreshBusy}
+            />
             {hint ? (
               <span className="term-compose-hint" role="status">
                 {hint}

--- a/frontend/src/lib/composer.ts
+++ b/frontend/src/lib/composer.ts
@@ -1,0 +1,9 @@
+// Shared between the chat ``ReplyComposer`` and the terminal quick-compose
+// drawer so both surfaces honor the same minimum height and platform
+// shortcut label.
+
+export const COMPOSER_MIN_HEIGHT = 56;
+
+export const SHORTCUT_IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || "");


### PR DESCRIPTION
## Summary

Add a collapsible quick-compose drawer below the tmux terminal pane so a multi-line draft is edited locally and submitted in one WS frame, instead of forwarding each keystroke. Restores parity with the chat composer for laggy tailnet links. Default state is a hairline handle ledge so the terminal aesthetic is preserved when collapsed.

Addresses #69.

## Changes

### Backend

- `api.py`: terminal `recv_loop` handles a new `{type:"input_submit", text, submit}` frame, routed through `adapter.send_input`. Kept separate from the per-keystroke `input` accumulator so each submission is one logical message.
- `backends/tmux/adapter.py`: `_send_literal_text` now uses `C-j` (soft newline, same byte as the keybar's `⇧↵` chip) between split lines instead of `Enter`, so multi-line drafts from the drawer land as one submission terminated by the trailing `Enter` from `submit=True`.
- `tests/test_tmux.py`: updated multi-line test to assert the new sequence.

### Frontend

- `components/TerminalCompose.tsx` (new): the drawer. Collapsed state is just a handle ledge; expanded reveals a textarea + Send, reusing the chat composer's CSS classes (`.composer-textarea`, `.composer-resize-handle`, `.composer-shortcut`, `.primary`) and the `SessionUsagePill` for the status pill. Cmd/Ctrl+Enter sends, Esc collapses and refocuses the xterm, desktop resize handle persists height under `waypoint-term-compose-height`.
- `lib/composer.ts` (new): shared `SHORTCUT_IS_MAC` / `COMPOSER_MIN_HEIGHT` between the chat composer and the drawer.
- `components/SessionDetail.tsx`: new `handleTerminalSubmit` sends the `input_submit` frame.
- `components/SessionTerminalView.tsx`: mounts the drawer when `liveTmux`; toggles `has-compose-open` on the parent so the home-indicator safe-area inset hops from the keybar to the drawer.
- `app/globals.css`: drawer section with handle ledge, expand animation, mobile / desktop max-height clamps, light-theme overrides, and a `prefers-reduced-motion` short-circuit.

## Test Plan

- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run build` — clean.
- [x] `cd backend && uv run pre-commit run --files <changed files>` — isort / black / ruff / codespell / mypy clean.
- [x] `cd backend && uv run pytest` — 507 pass; 4 deselected failures in `tests/test_rate_limits.py` are pre-existing on `main`.
- [x] Manual: opened a tmux Claude Code session, expanded the drawer, typed a multi-line draft, Cmd+Enter submitted it as one message; status pill opens the usage popover; Esc collapses; resize persists across reloads.