### PR TITLE
feat: add slash-command autocomplete to the tmux quick-compose drawer

### DIFF
--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -208,6 +208,21 @@ class TmuxPlugin:
         prefix: str = "",
         force_refresh: bool = False,
     ) -> list[CommandCompletion]:
+        # Tmux is a transport, not a backend in the user-visible sense:
+        # the wrapped CLI (Claude Code, Codex, OpenCode, …) is what
+        # actually interprets slash commands. Delegate so the quick
+        # compose surfaces the wrapped backend's built-ins and any
+        # workspace skills it advertises. Pure-tmux sessions (rare —
+        # ``backend == "tmux"``) fall back to the local static list.
+        if session.backend != self.id and runtime.registry.has_backend(session.backend):
+            wrapped = runtime.registry.get(session.backend)
+            return await wrapped.list_command_completions(
+                runtime,
+                session,
+                trigger=trigger,
+                prefix=prefix,
+                force_refresh=force_refresh,
+            )
         if trigger != "/":
             return []
         return static_slash_completions(self.id, self.capabilities, prefix=prefix)

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6995,6 +6995,11 @@ html[data-theme="light"] .term-keys button:hover {
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
+  /* Anchor for popovers that escape ``.term-compose-inner``'s
+     ``overflow: hidden`` (slash suggestions, usage-pill panel) — both
+     render outside the clipped subtree but absolutely-positioned
+     against this element so they float just above the drawer. */
+  position: relative;
   border-top: 1px solid var(--line);
   background: linear-gradient(
     180deg,
@@ -7150,24 +7155,46 @@ html[data-theme="light"] .term-compose-handle:hover {
   flex: 1 1 auto;
 }
 
-/* The usage pill lives at the left edge of the drawer's meta row. The
-   composer default anchors the popover to the right (it grows leftward
-   from a pill that sits at the right of the chat composer), which here
-   would shoot 440px off-screen to the left of the pane. Anchor the
-   panel to the pill's left edge so it grows rightward, and bump it
-   above the textarea above (z-index 50 matches the term-bar variant). */
-.term-compose .usage-panel {
-  left: 0;
+/* SessionUsagePill portals its panel into ``.term-compose`` to escape
+   the ``overflow: hidden`` on ``.term-compose-inner`` (without the
+   portal the panel is clipped at the textarea boundary regardless of
+   z-index). Once portaled, the panel positions against the drawer's
+   outer box: float upward above the drawer, anchor to the left to
+   match the pill's left-aligned home in the meta row, and float over
+   the term-stage above the drawer. */
+.term-compose > .usage-panel {
+  left: 8px;
   right: auto;
+  bottom: calc(100% + 8px);
   z-index: 50;
 }
 
 /* On narrow screens the 440px panel would overflow the right edge of
    the pane; pin the right side so it flexes within the drawer width. */
 @media (max-width: 720px) {
-  .term-compose .usage-panel {
+  .term-compose > .usage-panel {
     right: 8px;
     width: auto;
+  }
+}
+
+/* The slash-suggestions list also escapes the clipped subtree by
+   rendering as a child of ``.term-compose``. Its default anchoring
+   (``left: 0; right: 0; bottom: calc(100% + 6px)``) places it above
+   the textarea but inside the clipped wrapper — here it instead
+   floats above the entire drawer, aligned with the textarea inset
+   inside. */
+.term-compose > .slash-suggestions {
+  left: 12px;
+  right: 12px;
+  bottom: calc(100% + 6px);
+  z-index: 50;
+}
+
+@media (max-width: 720px) {
+  .term-compose > .slash-suggestions {
+    left: 8px;
+    right: 8px;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7150,6 +7150,27 @@ html[data-theme="light"] .term-compose-handle:hover {
   flex: 1 1 auto;
 }
 
+/* The usage pill lives at the left edge of the drawer's meta row. The
+   composer default anchors the popover to the right (it grows leftward
+   from a pill that sits at the right of the chat composer), which here
+   would shoot 440px off-screen to the left of the pane. Anchor the
+   panel to the pill's left edge so it grows rightward, and bump it
+   above the textarea above (z-index 50 matches the term-bar variant). */
+.term-compose .usage-panel {
+  left: 0;
+  right: auto;
+  z-index: 50;
+}
+
+/* On narrow screens the 440px panel would overflow the right edge of
+   the pane; pin the right side so it flexes within the drawer width. */
+@media (max-width: 720px) {
+  .term-compose .usage-panel {
+    right: 8px;
+    width: auto;
+  }
+}
+
 .term-compose-hint {
   font-family: var(--font-mono);
   font-size: 0.72rem;

--- a/frontend/src/components/CommandSuggestions.tsx
+++ b/frontend/src/components/CommandSuggestions.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { forwardRef, MutableRefObject } from "react";
+
+import type { CommandCompletion } from "@/lib/types";
+
+export function commandLabel(entry: CommandCompletion): string {
+  return `${entry.trigger}${entry.name}`;
+}
+
+interface CommandSuggestionsProps {
+  suggestions: ReadonlyArray<CommandCompletion>;
+  activeIndex: number;
+  itemRefs: MutableRefObject<Array<HTMLButtonElement | null>>;
+  onApply: (index: number) => void;
+  onHover: (index: number) => void;
+}
+
+export const CommandSuggestions = forwardRef<HTMLUListElement, CommandSuggestionsProps>(
+  function CommandSuggestions(
+    { suggestions, activeIndex, itemRefs, onApply, onHover },
+    ref,
+  ) {
+    return (
+      <ul className="slash-suggestions" role="listbox" ref={ref}>
+        {suggestions.map((entry, index) => (
+          <li key={entry.id}>
+            <button
+              ref={(node) => {
+                itemRefs.current[index] = node;
+              }}
+              type="button"
+              role="option"
+              aria-selected={index === activeIndex}
+              className={`slash-suggestion ${index === activeIndex ? "active" : ""}`}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onApply(index);
+              }}
+              onMouseEnter={() => onHover(index)}
+            >
+              <span className="slash-name">
+                {commandLabel(entry)}
+                {entry.argument_hint ? (
+                  <span className="slash-hint">{entry.argument_hint}</span>
+                ) : null}
+              </span>
+              <span className="slash-desc">{entry.description}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    );
+  },
+);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -23,7 +23,6 @@ import {
   fetchBackendModels,
   fetchEvents,
   fetchSession,
-  fetchSessionCompletionsResponse,
   fetchTerminalSnapshot,
   forkSession,
   isAuthError,
@@ -49,6 +48,7 @@ import {
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
 import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
+import { useCommandCompletions } from "@/lib/composer-completions";
 import {
   isPlanEvent,
   itemIdForEvent,
@@ -59,6 +59,7 @@ import {
 import { useTheme } from "@/lib/theme";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
+import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { type XTerminalHandle } from "@/components/XTerminal";
 import { ApprovalRequestCard, PlanApprovalCard } from "@/components/ApprovalCard";
 import {
@@ -73,39 +74,12 @@ import { useSwitcher } from "@/components/SwitcherProvider";
 import {
   BackendModelOption,
   BackendPermissionMode,
-  CommandCompletion,
   EventRecord,
   SessionCommandInvocation,
   SessionEnvelope,
   SessionRecord,
   SessionTransport,
 } from "@/lib/types";
-
-const COMPLETION_REFRESH_POLL_MS = 750;
-const COMPLETION_FETCH_DEBOUNCE_MS = 180;
-
-// `/new` is universal across every backend, so it stays visible during
-// the debounced fetch or if the request fails. `/fork` is gated on
-// per-plugin `supports_fork` capability and is left to the backend
-// response — showing it locally would surface it for tmux sessions
-// where the action would 400 on submit.
-const LOCAL_BUILTIN_FALLBACK: ReadonlyArray<CommandCompletion> = [
-  {
-    id: "waypoint:builtin:new",
-    trigger: "/",
-    replacement: "/new ",
-    name: "new",
-    description: "Start a new session with the same settings",
-    kind: "session_control",
-    source: "waypoint",
-    dispatch: "frontend_control",
-    metadata: {},
-  },
-];
-
-function completionCommand(entry: CommandCompletion): string {
-  return `${entry.trigger}${entry.name}`;
-}
 
 // iOS Safari rejects ``navigator.clipboard.writeText`` even from inside a
 // click handler — the Promise microtask ends the transient activation
@@ -185,19 +159,6 @@ function isSafariFamily(): boolean {
 // literal escape codes, which is the documented trade-off.
 function wrapBracketedPaste(text: string): string {
   return `\x1b[200~${text.replace(/\r\n?/g, "\n")}\x1b[201~`;
-}
-
-function mergeBuiltinFallback(
-  backend: ReadonlyArray<CommandCompletion>,
-): CommandCompletion[] {
-  const seen = new Set(backend.map(completionCommand));
-  const merged = [...backend];
-  for (const entry of LOCAL_BUILTIN_FALLBACK) {
-    if (!seen.has(completionCommand(entry))) {
-      merged.push(entry);
-    }
-  }
-  return merged;
 }
 
 const EFFORT_LABEL: Record<string, string> = {
@@ -1939,13 +1900,6 @@ const ReplyComposer = memo(function ReplyComposer({
 }: ReplyComposerProps) {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
-  const [suggestionIndex, setSuggestionIndex] = useState(0);
-  const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
-  const [backendCompletions, setBackendCompletions] = useState<
-    CommandCompletion[]
-  >([]);
-  const [selectedCompletion, setSelectedCompletion] =
-    useState<CommandCompletion | null>(null);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
   const [reattaching, setReattaching] = useState(false);
@@ -1968,8 +1922,6 @@ const ReplyComposer = memo(function ReplyComposer({
   }, []);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const composerRef = useRef<HTMLElement | null>(null);
-  const suggestionsRef = useRef<HTMLUListElement | null>(null);
-  const suggestionItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const overflowRef = useRef<HTMLDivElement | null>(null);
   const tuneRef = useRef<HTMLDivElement | null>(null);
 
@@ -1980,112 +1932,26 @@ const ReplyComposer = memo(function ReplyComposer({
   const supportsSlash =
     transport !== null && fidelityFor(transport) === "structured";
 
-  const completionHead = draft.split(/\s/, 1)[0];
-  const completionTrigger = completionHead.startsWith("/")
-    ? "/"
-    : completionHead.startsWith("$")
-      ? "$"
-      : null;
-  const suggestions = supportsSlash && !suggestionsDismissed
-    ? (completionTrigger === "/"
-        ? mergeBuiltinFallback(backendCompletions)
-        : backendCompletions
-      ).filter(
-        (entry) =>
-          completionTrigger !== null &&
-          completionCommand(entry).startsWith(completionHead),
-      )
-    : [];
-  const suggestionsOpen = suggestions.length > 0 && /^\S+$/.test(draft);
-  const activeIndex = Math.min(suggestionIndex, Math.max(0, suggestions.length - 1));
-
-  useEffect(() => {
-    if (!supportsSlash || completionTrigger === null) {
-      setBackendCompletions([]);
-      return;
-    }
-    const controller = new AbortController();
-    let debounceTimer: number | null = null;
-    let pollTimer: number | null = null;
-    const loadCompletions = () => {
-      debounceTimer = null;
-      fetchSessionCompletionsResponse(
-        host,
-        token,
-        sessionId,
-        completionTrigger,
-        completionHead,
-        false,
-        controller.signal,
-      )
-        .then((payload) => {
-          if (controller.signal.aborted) {
-            return;
-          }
-          setBackendCompletions(payload.completions);
-          if (payload.refreshing) {
-            pollTimer = window.setTimeout(
-              loadCompletions,
-              COMPLETION_REFRESH_POLL_MS,
-            );
-          }
-        })
-        .catch((error) => {
-          if (error instanceof DOMException && error.name === "AbortError") {
-            return;
-          }
-          setBackendCompletions([]);
-        });
-    };
-    debounceTimer = window.setTimeout(
-      loadCompletions,
-      COMPLETION_FETCH_DEBOUNCE_MS,
-    );
-    return () => {
-      controller.abort();
-      if (debounceTimer !== null) {
-        window.clearTimeout(debounceTimer);
-      }
-      if (pollTimer !== null) {
-        window.clearTimeout(pollTimer);
-      }
-    };
-  }, [host, token, sessionId, supportsSlash, completionTrigger, completionHead]);
-
-  useEffect(() => {
-    setSuggestionIndex(0);
-  }, [completionHead]);
-
-  useEffect(() => {
-    if (!suggestionsOpen) return;
-    const active = suggestionItemRefs.current[activeIndex];
-    const list = suggestionsRef.current;
-    if (!active || !list) return;
-    const activeTop = active.offsetTop;
-    const activeBottom = activeTop + active.offsetHeight;
-    const visibleTop = list.scrollTop;
-    const visibleBottom = visibleTop + list.clientHeight;
-    if (activeTop < visibleTop) {
-      list.scrollTop = activeTop;
-    } else if (activeBottom > visibleBottom) {
-      list.scrollTop = activeBottom - list.clientHeight;
-    }
-  }, [activeIndex, suggestionsOpen, suggestions.length]);
-
-  useEffect(() => {
-    if (!draft.startsWith("/") && !draft.startsWith("$")) {
-      setSuggestionsDismissed(false);
-    }
-  }, [draft]);
-
-  useEffect(() => {
-    if (
-      selectedCompletion &&
-      !draft.startsWith(completionCommand(selectedCompletion))
-    ) {
-      setSelectedCompletion(null);
-    }
-  }, [draft, selectedCompletion]);
+  const {
+    suggestions,
+    suggestionsOpen,
+    activeIndex,
+    setActiveIndex,
+    listRef: suggestionsRef,
+    itemRefs: suggestionItemRefs,
+    applySuggestion,
+    selectedCommandInvocation,
+    handleSuggestionKey,
+    reset: resetCompletions,
+  } = useCommandCompletions({
+    host,
+    token,
+    sessionId,
+    draft,
+    setDraft,
+    enabled: supportsSlash,
+    textareaRef,
+  });
 
   // Publish the composer's actual height as a CSS custom property so the
   // transcript end-spacer and floating "Jump to latest" pill can position
@@ -2198,34 +2064,6 @@ const ReplyComposer = memo(function ReplyComposer({
     handle.addEventListener("pointercancel", finishDrag);
   };
 
-  function selectedCommandInvocation(text: string): SessionCommandInvocation | undefined {
-    if (!selectedCompletion || selectedCompletion.dispatch === "frontend_control") {
-      return undefined;
-    }
-    const command = completionCommand(selectedCompletion);
-    if (text !== command && !text.startsWith(`${command} `)) {
-      return undefined;
-    }
-    return {
-      completion_id: selectedCompletion.id,
-      name: selectedCompletion.name,
-      arguments: text.slice(command.length).trim(),
-      dispatch: selectedCompletion.dispatch,
-      metadata: selectedCompletion.metadata,
-    };
-  }
-
-  function applySuggestion(index: number) {
-    const chosen = suggestions[index];
-    if (!chosen) {
-      return;
-    }
-    setDraft(chosen.replacement);
-    setSelectedCompletion(chosen);
-    setSuggestionsDismissed(true);
-    requestAnimationFrame(() => textareaRef.current?.focus());
-  }
-
   async function handleSend() {
     const text = draft.trim();
     if (!text) {
@@ -2233,10 +2071,10 @@ const ReplyComposer = memo(function ReplyComposer({
     }
     setSending(true);
     setDraft("");
-    setSelectedCompletion(null);
-    setSuggestionsDismissed(false);
+    const invocation = selectedCommandInvocation(text);
+    resetCompletions();
     try {
-      const sent = await onSend(text, selectedCommandInvocation(text));
+      const sent = await onSend(text, invocation);
       if (!sent) {
         setDraft(text);
       }
@@ -2260,30 +2098,8 @@ const ReplyComposer = memo(function ReplyComposer({
       }
       return;
     }
-    if (suggestionsOpen) {
-      if (
-        event.key === "Tab" ||
-        (event.key === "Enter" && !(event.metaKey || event.ctrlKey) && !event.shiftKey)
-      ) {
-        event.preventDefault();
-        applySuggestion(activeIndex);
-        return;
-      }
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setSuggestionIndex((index) => Math.min(suggestions.length - 1, index + 1));
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setSuggestionIndex((index) => Math.max(0, index - 1));
-        return;
-      }
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setSuggestionsDismissed(true);
-        return;
-      }
+    if (handleSuggestionKey(event)) {
+      return;
     }
     // Treat Cmd+Enter (mac) and Ctrl+Enter (windows/linux) as the send
     // shortcut. Plain Enter inserts a newline as expected.
@@ -2521,34 +2337,14 @@ const ReplyComposer = memo(function ReplyComposer({
           aria-label="Reply"
         />
         {suggestionsOpen ? (
-          <ul className="slash-suggestions" role="listbox" ref={suggestionsRef}>
-            {suggestions.map((entry, index) => (
-              <li key={entry.id}>
-                <button
-                  ref={(node) => {
-                    suggestionItemRefs.current[index] = node;
-                  }}
-                  type="button"
-                  role="option"
-                  aria-selected={index === activeIndex}
-                  className={`slash-suggestion ${index === activeIndex ? "active" : ""}`}
-                  onMouseDown={(event) => {
-                    event.preventDefault();
-                    applySuggestion(index);
-                  }}
-                  onMouseEnter={() => setSuggestionIndex(index)}
-                >
-                  <span className="slash-name">
-                    {completionCommand(entry)}
-                    {entry.argument_hint ? (
-                      <span className="slash-hint">{entry.argument_hint}</span>
-                    ) : null}
-                  </span>
-                  <span className="slash-desc">{entry.description}</span>
-                </button>
-              </li>
-            ))}
-          </ul>
+          <CommandSuggestions
+            ref={suggestionsRef}
+            suggestions={suggestions}
+            activeIndex={activeIndex}
+            itemRefs={suggestionItemRefs}
+            onApply={applySuggestion}
+            onHover={setActiveIndex}
+          />
         ) : null}
       </div>
       <div className="composer-actions">

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1511,6 +1511,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       ) : null}
       {session && activeView === "terminal" ? (
         <SessionTerminalView
+          host={host}
+          token={token}
+          sessionId={sessionId}
           session={session}
           liveTmux={liveTmux}
           terminalRef={terminalRef}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -11,6 +11,9 @@ import { SessionRecord } from "@/lib/types";
 type Connection = "idle" | "connecting" | "open" | "reconnecting";
 
 interface SessionTerminalViewProps {
+  host: string;
+  token: string;
+  sessionId: string;
   session: SessionRecord | null;
   liveTmux: boolean;
   terminalRef: MutableRefObject<XTerminalHandle | null>;
@@ -51,6 +54,9 @@ interface SessionTerminalViewProps {
 }
 
 export function SessionTerminalView({
+  host,
+  token,
+  sessionId,
   session,
   liveTmux,
   terminalRef,
@@ -273,6 +279,9 @@ export function SessionTerminalView({
       ) : null}
       {composeEnabled ? (
         <TerminalCompose
+          host={host}
+          token={token}
+          sessionId={sessionId}
           session={session}
           onSubmit={onTerminalSubmit}
           expanded={composeOpen}

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { UsageBar, UsageReadout } from "@/components/UsageReadout";
 import { humaniseBackend } from "@/lib/backends";
@@ -19,6 +20,12 @@ interface SessionUsagePillProps {
   connection: Connection;
   onRateLimitRefresh: () => void | Promise<void>;
   rateLimitRefreshBusy: boolean;
+  // When provided, the popover panel is portaled into this element
+  // instead of rendering as a sibling of the trigger button. Used by
+  // the tmux quick-compose drawer where the trigger lives inside an
+  // ``overflow: hidden`` ancestor — portaling escapes the clip so the
+  // panel can float above the drawer.
+  popoverContainer?: HTMLElement | null;
 }
 
 export function SessionUsagePill({
@@ -26,15 +33,22 @@ export function SessionUsagePill({
   connection,
   onRateLimitRefresh,
   rateLimitRefreshBusy,
+  popoverContainer,
 }: SessionUsagePillProps) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) return;
     function onDocClick(event: MouseEvent) {
-      if (!wrapRef.current) return;
-      if (wrapRef.current.contains(event.target as Node)) return;
+      const target = event.target as Node | null;
+      if (!target) return;
+      if (wrapRef.current?.contains(target)) return;
+      // Once portaled, the panel is no longer a descendant of the
+      // wrapper — check it separately so clicks inside the panel
+      // don't dismiss it.
+      if (panelRef.current?.contains(target)) return;
       setOpen(false);
     }
     document.addEventListener("mousedown", onDocClick);
@@ -120,6 +134,9 @@ export function SessionUsagePill({
     );
   }
 
+  const renderPanel = (node: React.ReactNode): React.ReactNode =>
+    popoverContainer ? createPortal(node, popoverContainer) : node;
+
   return (
     <div className="composer-context" ref={wrapRef}>
       <button
@@ -142,8 +159,9 @@ export function SessionUsagePill({
             ? "reconnecting"
             : "connecting"}
       </button>
-      {open ? (
+      {open ? renderPanel(
         <div
+          ref={panelRef}
           className={`usage-panel tone-${usageToneValue}`}
           role="dialog"
           aria-label="Usage details"

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -10,13 +10,18 @@ import {
   useState,
 } from "react";
 
+import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
+import { useCommandCompletions } from "@/lib/composer-completions";
 import type { SessionRecord } from "@/lib/types";
 
 type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
 
 interface TerminalComposeProps {
+  host: string;
+  token: string;
+  sessionId: string;
   session: SessionRecord | null;
   // ``onSubmit`` returns false when the socket isn't open so we can leave
   // the draft in place and surface a hint without throwing it away.
@@ -36,6 +41,9 @@ const HEIGHT_FALLBACK = 132;
 const HEIGHT_MAX = 320;
 
 export function TerminalCompose({
+  host,
+  token,
+  sessionId,
   session,
   onSubmit,
   expanded,
@@ -53,6 +61,32 @@ export function TerminalCompose({
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
+
+  // ``/new`` is a Waypoint frontend command that only makes sense on
+  // structured sessions; the tmux composer just forwards keystrokes
+  // straight to the wrapped CLI, so we opt out of the local fallback
+  // and surface only the backend-provided completions (CC built-ins,
+  // workspace skills, etc.).
+  const {
+    suggestions,
+    suggestionsOpen,
+    activeIndex,
+    setActiveIndex,
+    listRef: suggestionsRef,
+    itemRefs: suggestionItemRefs,
+    applySuggestion,
+    handleSuggestionKey,
+    reset: resetCompletions,
+  } = useCommandCompletions({
+    host,
+    token,
+    sessionId,
+    draft,
+    setDraft,
+    enabled: expanded,
+    localFallback: [],
+    textareaRef,
+  });
 
   // Restore the desktop height preference on mount; mobile media query
   // hides the resize handle so the persisted value is harmless there.
@@ -86,16 +120,22 @@ export function TerminalCompose({
     if (ok) {
       setDraft("");
       setHint(null);
+      resetCompletions();
     } else {
       setHint("Socket not open — try again in a moment");
     }
     // The send call resolves synchronously (it's just a WebSocket.send),
     // but we briefly hold the disabled state so the user gets feedback.
     window.setTimeout(() => setSending(false), 120);
-  }, [draft, connected, onSubmit]);
+  }, [draft, connected, onSubmit, resetCompletions]);
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      // The suggestions menu owns Tab/Enter/Arrows/Esc when open, so
+      // Esc-to-dismiss takes precedence over Esc-to-collapse-drawer.
+      if (handleSuggestionKey(event)) {
+        return;
+      }
       if (event.key === "Escape") {
         event.preventDefault();
         onExpandedChange(false);
@@ -108,7 +148,7 @@ export function TerminalCompose({
       event.preventDefault();
       send();
     },
-    [send, onExpandedChange, refocusTerminal],
+    [handleSuggestionKey, send, onExpandedChange, refocusTerminal],
   );
 
   const toggle = useCallback(() => {
@@ -197,6 +237,16 @@ export function TerminalCompose({
               aria-label="Message to send to terminal"
               tabIndex={expanded ? 0 : -1}
             />
+            {suggestionsOpen ? (
+              <CommandSuggestions
+                ref={suggestionsRef}
+                suggestions={suggestions}
+                activeIndex={activeIndex}
+                itemRefs={suggestionItemRefs}
+                onApply={applySuggestion}
+                onHover={setActiveIndex}
+              />
+            ) : null}
           </div>
           <div className="term-compose-meta">
             <SessionUsagePill

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -61,6 +61,19 @@ export function TerminalCompose({
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
+  // Host for popovers that need to escape ``.term-compose-inner``'s
+  // ``overflow: hidden`` clip (the grid-row open animation requires it).
+  // The slash-suggestions list and the SessionUsagePill panel both
+  // anchor against this element, which is the outer drawer container
+  // and lives outside the clipped subtree.
+  const composeRef = useRef<HTMLElement | null>(null);
+  // ``popoverContainer`` only takes effect once the section ref is
+  // attached, which happens on first commit. Mirror it into state so
+  // SessionUsagePill re-renders with a valid host after mount.
+  const [popoverHost, setPopoverHost] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setPopoverHost(composeRef.current);
+  }, []);
 
   // ``/new`` is a Waypoint frontend command that only makes sense on
   // structured sessions; the tmux composer just forwards keystrokes
@@ -199,6 +212,7 @@ export function TerminalCompose({
 
   return (
     <section
+      ref={composeRef}
       className={`term-compose ${expanded ? "is-open" : "is-closed"}`}
       aria-label="Quick compose"
     >
@@ -237,16 +251,6 @@ export function TerminalCompose({
               aria-label="Message to send to terminal"
               tabIndex={expanded ? 0 : -1}
             />
-            {suggestionsOpen ? (
-              <CommandSuggestions
-                ref={suggestionsRef}
-                suggestions={suggestions}
-                activeIndex={activeIndex}
-                itemRefs={suggestionItemRefs}
-                onApply={applySuggestion}
-                onHover={setActiveIndex}
-              />
-            ) : null}
           </div>
           <div className="term-compose-meta">
             <SessionUsagePill
@@ -254,6 +258,7 @@ export function TerminalCompose({
               connection={connection}
               onRateLimitRefresh={onRateLimitRefresh}
               rateLimitRefreshBusy={rateLimitRefreshBusy}
+              popoverContainer={popoverHost}
             />
             {hint ? (
               <span className="term-compose-hint" role="status">
@@ -277,6 +282,16 @@ export function TerminalCompose({
           </div>
         </div>
       </div>
+      {suggestionsOpen ? (
+        <CommandSuggestions
+          ref={suggestionsRef}
+          suggestions={suggestions}
+          activeIndex={activeIndex}
+          itemRefs={suggestionItemRefs}
+          onApply={applySuggestion}
+          onHover={setActiveIndex}
+        />
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -1,0 +1,287 @@
+"use client";
+
+import type { KeyboardEvent, RefObject } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { commandLabel } from "@/components/CommandSuggestions";
+import { fetchSessionCompletionsResponse } from "@/lib/api";
+import type {
+  CommandCompletion,
+  SessionCommandInvocation,
+} from "@/lib/types";
+
+const COMPLETION_FETCH_DEBOUNCE_MS = 180;
+const COMPLETION_REFRESH_POLL_MS = 750;
+
+// `/new` works on every structured backend so we surface it locally
+// while the debounced fetch is in flight or if the request fails. Tmux
+// sessions don't support `/new`, so the term composer opts out of this
+// fallback (`localFallback: []`).
+export const SLASH_NEW_FALLBACK: CommandCompletion = {
+  id: "waypoint:builtin:new",
+  trigger: "/",
+  replacement: "/new ",
+  name: "new",
+  description: "Start a new session with the same settings",
+  kind: "session_control",
+  source: "waypoint",
+  dispatch: "frontend_control",
+  metadata: {},
+};
+
+interface UseCommandCompletionsOptions {
+  host: string;
+  token: string;
+  sessionId: string;
+  draft: string;
+  setDraft: (next: string) => void;
+  enabled: boolean;
+  // Override the local fallback list. Chat composer uses ``/new``; the
+  // tmux composer passes ``[]`` because its backend doesn't accept it.
+  localFallback?: ReadonlyArray<CommandCompletion>;
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
+}
+
+export interface CommandCompletionsState {
+  suggestions: ReadonlyArray<CommandCompletion>;
+  suggestionsOpen: boolean;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  selectedCompletion: CommandCompletion | null;
+  listRef: RefObject<HTMLUListElement | null>;
+  itemRefs: RefObject<Array<HTMLButtonElement | null>>;
+  applySuggestion: (index: number) => void;
+  selectedCommandInvocation: (text: string) => SessionCommandInvocation | undefined;
+  handleSuggestionKey: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  reset: () => void;
+}
+
+export function useCommandCompletions({
+  host,
+  token,
+  sessionId,
+  draft,
+  setDraft,
+  enabled,
+  localFallback = [SLASH_NEW_FALLBACK],
+  textareaRef,
+}: UseCommandCompletionsOptions): CommandCompletionsState {
+  const [suggestionIndex, setSuggestionIndex] = useState(0);
+  const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
+  const [backendCompletions, setBackendCompletions] = useState<CommandCompletion[]>([]);
+  const [selectedCompletion, setSelectedCompletion] =
+    useState<CommandCompletion | null>(null);
+
+  const listRef = useRef<HTMLUListElement | null>(null);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  const completionHead = draft.split(/\s/, 1)[0];
+  const completionTrigger = completionHead.startsWith("/")
+    ? "/"
+    : completionHead.startsWith("$")
+      ? "$"
+      : null;
+
+  const suggestions = useMemo<ReadonlyArray<CommandCompletion>>(() => {
+    if (!enabled || suggestionsDismissed || completionTrigger === null) {
+      return [];
+    }
+    const pool =
+      completionTrigger === "/"
+        ? mergeLocalFallback(backendCompletions, localFallback)
+        : backendCompletions;
+    return pool.filter((entry) => commandLabel(entry).startsWith(completionHead));
+  }, [
+    backendCompletions,
+    completionHead,
+    completionTrigger,
+    enabled,
+    localFallback,
+    suggestionsDismissed,
+  ]);
+
+  const suggestionsOpen = suggestions.length > 0 && /^\S+$/.test(draft);
+  const activeIndex = Math.min(
+    suggestionIndex,
+    Math.max(0, suggestions.length - 1),
+  );
+
+  useEffect(() => {
+    if (!enabled || completionTrigger === null) {
+      setBackendCompletions([]);
+      return;
+    }
+    const controller = new AbortController();
+    let debounceTimer: number | null = null;
+    let pollTimer: number | null = null;
+    const loadCompletions = () => {
+      debounceTimer = null;
+      fetchSessionCompletionsResponse(
+        host,
+        token,
+        sessionId,
+        completionTrigger,
+        completionHead,
+        false,
+        controller.signal,
+      )
+        .then((payload) => {
+          if (controller.signal.aborted) return;
+          setBackendCompletions(payload.completions);
+          if (payload.refreshing) {
+            pollTimer = window.setTimeout(
+              loadCompletions,
+              COMPLETION_REFRESH_POLL_MS,
+            );
+          }
+        })
+        .catch((error) => {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          setBackendCompletions([]);
+        });
+    };
+    debounceTimer = window.setTimeout(
+      loadCompletions,
+      COMPLETION_FETCH_DEBOUNCE_MS,
+    );
+    return () => {
+      controller.abort();
+      if (debounceTimer !== null) window.clearTimeout(debounceTimer);
+      if (pollTimer !== null) window.clearTimeout(pollTimer);
+    };
+  }, [host, token, sessionId, enabled, completionTrigger, completionHead]);
+
+  useEffect(() => {
+    setSuggestionIndex(0);
+  }, [completionHead]);
+
+  useEffect(() => {
+    if (!suggestionsOpen) return;
+    const active = itemRefs.current[activeIndex];
+    const list = listRef.current;
+    if (!active || !list) return;
+    const activeTop = active.offsetTop;
+    const activeBottom = activeTop + active.offsetHeight;
+    const visibleTop = list.scrollTop;
+    const visibleBottom = visibleTop + list.clientHeight;
+    if (activeTop < visibleTop) {
+      list.scrollTop = activeTop;
+    } else if (activeBottom > visibleBottom) {
+      list.scrollTop = activeBottom - list.clientHeight;
+    }
+  }, [activeIndex, suggestionsOpen, suggestions.length]);
+
+  useEffect(() => {
+    if (!draft.startsWith("/") && !draft.startsWith("$")) {
+      setSuggestionsDismissed(false);
+    }
+  }, [draft]);
+
+  useEffect(() => {
+    if (
+      selectedCompletion &&
+      !draft.startsWith(commandLabel(selectedCompletion))
+    ) {
+      setSelectedCompletion(null);
+    }
+  }, [draft, selectedCompletion]);
+
+  function applySuggestion(index: number) {
+    const chosen = suggestions[index];
+    if (!chosen) return;
+    setDraft(chosen.replacement);
+    setSelectedCompletion(chosen);
+    setSuggestionsDismissed(true);
+    if (textareaRef) {
+      requestAnimationFrame(() => textareaRef.current?.focus());
+    }
+  }
+
+  function selectedCommandInvocation(
+    text: string,
+  ): SessionCommandInvocation | undefined {
+    if (!selectedCompletion || selectedCompletion.dispatch === "frontend_control") {
+      return undefined;
+    }
+    const command = commandLabel(selectedCompletion);
+    if (text !== command && !text.startsWith(`${command} `)) {
+      return undefined;
+    }
+    return {
+      completion_id: selectedCompletion.id,
+      name: selectedCompletion.name,
+      arguments: text.slice(command.length).trim(),
+      dispatch: selectedCompletion.dispatch,
+      metadata: selectedCompletion.metadata,
+    };
+  }
+
+  function handleSuggestionKey(
+    event: KeyboardEvent<HTMLTextAreaElement>,
+  ): boolean {
+    if (!suggestionsOpen) return false;
+    if (
+      event.key === "Tab" ||
+      (event.key === "Enter" &&
+        !(event.metaKey || event.ctrlKey) &&
+        !event.shiftKey)
+    ) {
+      event.preventDefault();
+      applySuggestion(activeIndex);
+      return true;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setSuggestionIndex((index) => Math.min(suggestions.length - 1, index + 1));
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setSuggestionIndex((index) => Math.max(0, index - 1));
+      return true;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setSuggestionsDismissed(true);
+      return true;
+    }
+    return false;
+  }
+
+  function reset() {
+    setSelectedCompletion(null);
+    setSuggestionsDismissed(false);
+    setSuggestionIndex(0);
+  }
+
+  return {
+    suggestions,
+    suggestionsOpen,
+    activeIndex,
+    setActiveIndex: setSuggestionIndex,
+    selectedCompletion,
+    listRef,
+    itemRefs,
+    applySuggestion,
+    selectedCommandInvocation,
+    handleSuggestionKey,
+    reset,
+  };
+}
+
+function mergeLocalFallback(
+  backend: ReadonlyArray<CommandCompletion>,
+  fallback: ReadonlyArray<CommandCompletion>,
+): CommandCompletion[] {
+  if (fallback.length === 0) return [...backend];
+  const seen = new Set(backend.map(commandLabel));
+  const merged = [...backend];
+  for (const entry of fallback) {
+    if (!seen.has(commandLabel(entry))) {
+      merged.push(entry);
+    }
+  }
+  return merged;
+}


### PR DESCRIPTION
## Summary

The quick-compose drawer in tmux sessions was a plain textarea — CC's built-in slash commands (`/help`, `/clear`, `/init`, …) and workspace skills under `.claude/commands` / `.claude/skills` were discoverable only by typing them blind into the wrapped TUI. The drawer now surfaces the same backend-provided completion list the chat composer shows on structured sessions. `/` and `$` trigger the menu, Tab/Enter accepts, Arrows navigate, Esc dismisses (a second Esc collapses the drawer).

The same change also fixes a latent bug from #74: the `SessionUsagePill` popover in the drawer was clipped by `.term-compose-inner`'s `overflow: hidden` (required for the open animation). Both popovers — the new suggestions list and the existing usage panel — now render outside that clip so they actually appear above the drawer.

## Changes

### Backend

- `backends/tmux/plugin.py`: `list_command_completions` delegates to `runtime.registry.get(session.backend)` when the session wraps another backend (CC, Codex, OpenCode). The tmux transport has no slash commands of its own; the wrapped CLI is what interprets them, so a CC-in-tmux session now returns CC's static built-ins, `/status`, and the dynamic results of `list_claude_command_completions` (custom commands + user skills + plugin skills). Pure tmux sessions (`backend == "tmux"`, rare) still fall back to the local static list.

### Frontend

- `lib/composer-completions.ts` (new): `useCommandCompletions` hook owning the fetch debouncing (180 ms), refresh polling (750 ms), dismissal tracking, scroll-into-view, key handling, and `selectedCommandInvocation` logic that previously lived inline in `ReplyComposer`. Callers can opt out of the local `/new` fallback via `localFallback: []` — the tmux drawer sets this since `/new` is a Waypoint frontend command, not something the wrapped CLI understands.
- `components/CommandSuggestions.tsx` (new): the `<ul.slash-suggestions>` listbox markup, extracted from `ReplyComposer`. Pure rendering — refs and callbacks come from the hook.
- `components/SessionDetail.tsx`: `ReplyComposer` refactored onto the new hook + component (no behavioural change). Threads `host`/`token`/`sessionId` through to `SessionTerminalView` so the drawer can hit `/api/sessions/{id}/completions`.
- `components/SessionTerminalView.tsx`: forwards `host`/`token`/`sessionId` to the drawer.
- `components/TerminalCompose.tsx`: mounts the same hook + listbox, gated on `enabled: expanded` so the endpoint isn't polled while the drawer is collapsed. When suggestions are open they own Tab/Enter/Arrows/Esc — Esc-to-dismiss the menu takes precedence over Esc-to-collapse the drawer (closing now requires a second Esc, matching the chat composer). The list renders as a child of `.term-compose` (sibling of `.term-compose-shell`) to escape `.term-compose-inner`'s `overflow: hidden`. The component also exposes a ref to the outer section, passed to `SessionUsagePill` as the portal host.
- `components/SessionUsagePill.tsx`: accepts an optional `popoverContainer` prop and uses `createPortal` to render its panel into that host. The outside-click handler tracks the portaled panel through a separate ref so clicks inside it don't dismiss the popover.
- `app/globals.css`: `.term-compose` gets `position: relative` so both popovers anchor against the drawer's outer box. `.term-compose > .usage-panel` and `.term-compose > .slash-suggestions` float above the drawer (`bottom: calc(100% + Npx)`) with left-aligned anchoring matching the pill's home in the meta row; narrow-screen overrides pin both edges so the 440 px panel doesn't overflow.

## Test Plan

- [x] \`cd frontend && npm run lint\` — clean.
- [x] \`cd frontend && npx tsc --noEmit\` — clean.
- [x] \`cd frontend && npm run build\` — clean.
- [x] \`cd backend && uv run pre-commit run --files src/waypoint/backends/tmux/plugin.py tests/test_tmux.py\` — isort / black / ruff / codespell / mypy clean.
- [x] \`cd backend && uv run pytest --deselect tests/test_rate_limits.py\` — 487 pass; the 24 deselected failures in \`tests/test_rate_limits.py\` are pre-existing on \`main\`.
- [x] Manual: tmux CC session — typed \`/\`, suggestion list populated with \`/new\`, \`/status\`, and the workspace's custom commands / skills; Tab and click both accept; Arrows navigate; Esc dismisses, second Esc collapses; Cmd+Enter sends; usage pill popover opens above the drawer and clicks inside it no longer dismiss the panel; both popovers stay visible and anchor to the drawer's left edge.