### PR TITLE
fix: terminal composer commands, mid-prompt completion, and empty agent bubbles

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -47,7 +47,11 @@ import {
   useBackendCatalog,
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
-import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
+import {
+  COMPOSER_MIN_HEIGHT,
+  SHORTCUT_IS_MAC,
+  type TerminalSubmitResult,
+} from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import {
   isPlanEvent,
@@ -760,6 +764,74 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     return () => observer.disconnect();
   }, [view, scrollToBottom]);
 
+  // Waypoint-level slash commands (``/new``, ``/fork``) are intercepted on
+  // the frontend rather than forwarded to the backend — they're the only
+  // ``frontend_control`` completions in the system. Both composers route
+  // through here so terminal sessions get the same behaviour as chat ones.
+  // Returns ``"handled"`` / ``"error"`` when the text was a control command,
+  // or ``null`` when the caller should fall through to its normal send path.
+  // ``allowFork`` is false for tmux, whose backend can't fork.
+  const runFrontendControlCommand = useCallback(
+    async (
+      text: string,
+      opts?: { allowFork?: boolean },
+    ): Promise<"handled" | "error" | null> => {
+      if (!session) return null;
+      const allowFork = opts?.allowFork ?? true;
+
+      const newArgs = matchControlCommand(text, "new");
+      if (newArgs !== null) {
+        try {
+          const created = await createSession(host, token, {
+            backend: session.backend,
+            cwd: session.cwd,
+            launch_target_id: session.launch_target_id,
+            launch_mode: session.launch_mode ?? "auto",
+            model: session.model,
+            effort: session.effort,
+            permission_mode: session.permission_mode,
+            args: session.args,
+            config_overrides: session.config_overrides,
+          });
+          if (newArgs) {
+            await sendInput(host, token, created.id, newArgs);
+          }
+          router.push(`/session/${created.id}`);
+          return "handled";
+        } catch (e) {
+          if (isAuthError(e)) {
+            handleAuthFailure();
+            return "error";
+          }
+          setError(e instanceof Error ? e.message : "failed to create session");
+          return "error";
+        }
+      }
+
+      const forkArgs = allowFork ? matchControlCommand(text, "fork") : null;
+      if (forkArgs !== null) {
+        try {
+          const forked = await forkSession(host, token, sessionId);
+          if (forkArgs) {
+            await sendInput(host, token, forked.id, forkArgs);
+          }
+          router.push(`/session/${forked.id}`);
+          return "handled";
+        } catch (e) {
+          if (isAuthError(e)) {
+            handleAuthFailure();
+            return "error";
+          }
+          setError(e instanceof Error ? e.message : "failed to fork session");
+          return "error";
+        }
+      }
+
+      return null;
+    },
+    [session, host, token, sessionId, router, handleAuthFailure],
+  );
+
   const submitInput = useCallback(async (
     text: string,
     command?: SessionCommandInvocation,
@@ -767,55 +839,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
     if (!text.trim()) {
       return false;
     }
-    
-    if (text.startsWith("/new")) {
-      if (!session) return false;
-      const trailing = text.slice(4).trim();
-      try {
-        const created = await createSession(host, token, {
-          backend: session.backend,
-          cwd: session.cwd,
-          launch_target_id: session.launch_target_id,
-          launch_mode: session.launch_mode ?? "auto",
-          model: session.model,
-          effort: session.effort,
-          permission_mode: session.permission_mode,
-          args: session.args,
-          config_overrides: session.config_overrides,
-        });
-        if (trailing) {
-          await sendInput(host, token, created.id, trailing);
-        }
-        router.push(`/session/${created.id}`);
-        return true;
-      } catch (e) {
-        if (isAuthError(e)) {
-          handleAuthFailure();
-          return false;
-        }
-        setError(e instanceof Error ? e.message : "failed to create session");
-        return false;
-      }
-    }
 
-    if (text.startsWith("/fork")) {
-      if (!session) return false;
-      const trailing = text.slice(5).trim();
-      try {
-        const forked = await forkSession(host, token, sessionId);
-        if (trailing) {
-          await sendInput(host, token, forked.id, trailing);
-        }
-        router.push(`/session/${forked.id}`);
-        return true;
-      } catch (e) {
-        if (isAuthError(e)) {
-          handleAuthFailure();
-          return false;
-        }
-        setError(e instanceof Error ? e.message : "failed to fork session");
-        return false;
-      }
+    const handled = await runFrontendControlCommand(text);
+    if (handled !== null) {
+      return handled === "handled";
     }
 
     try {
@@ -829,7 +856,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       setError(sendError instanceof Error ? sendError.message : "failed to send input");
       return false;
     }
-  }, [handleAuthFailure, host, token, sessionId, session, router]);
+  }, [runFrontendControlCommand, handleAuthFailure, host, token, sessionId]);
 
   const onSendWithOptimistic = useCallback(
     async (text: string, command?: SessionCommandInvocation) => {
@@ -1205,13 +1232,19 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
 
   // Whole-message submission from the quick-compose drawer — the backend
   // appends Enter when ``submit`` is true so each call lands as one
-  // logical message rather than a stream of keystrokes.
-  const handleTerminalSubmit = useCallback((text: string) => {
+  // logical message rather than a stream of keystrokes. ``/new`` is caught
+  // here as a Waypoint control command instead of being typed into the
+  // wrapped CLI; ``/fork`` is excluded because tmux sessions can't fork.
+  const handleTerminalSubmit = useCallback(async (text: string): Promise<TerminalSubmitResult> => {
+    const handled = await runFrontendControlCommand(text, { allowFork: false });
+    if (handled !== null) {
+      return handled === "handled" ? "ok" : "command-error";
+    }
     const socket = terminalSocketRef.current;
-    if (socket?.readyState !== WebSocket.OPEN) return false;
+    if (socket?.readyState !== WebSocket.OPEN) return "socket-closed";
     socket.send(JSON.stringify({ type: "input_submit", text, submit: true }));
-    return true;
-  }, []);
+    return "ok";
+  }, [runFrontendControlCommand]);
 
   const requestPaste = useCallback(async () => {
     setError("");
@@ -3027,6 +3060,16 @@ function SessionHeader({
       </div>
     </header>
   );
+}
+
+// Match a Waypoint control command (e.g. ``/new``) and return its trailing
+// argument string, or null when the text isn't that command. The trailing
+// space requirement keeps ``/news`` from being read as ``/new``.
+function matchControlCommand(text: string, name: string): string | null {
+  const command = `/${name}`;
+  if (text === command) return "";
+  if (text.startsWith(`${command} `)) return text.slice(command.length + 1).trim();
+  return null;
 }
 
 function formatCwdSegments(cwd: string): string[] {

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -6,6 +6,7 @@ import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { TerminalCompose } from "@/components/TerminalCompose";
 import { TerminalScrollChips } from "@/components/TerminalScrollChips";
 import { XTerminal, type XTerminalHandle } from "@/components/XTerminal";
+import type { TerminalSubmitResult } from "@/lib/composer";
 import { SessionRecord } from "@/lib/types";
 
 type Connection = "idle" | "connecting" | "open" | "reconnecting";
@@ -35,9 +36,11 @@ interface SessionTerminalViewProps {
   // composer beneath remains visible.
   locked: boolean;
   onTerminalInput: (data: string) => void;
-  // Returns false when the WS isn't open so the composer can keep the
-  // draft and surface a "reconnecting" hint instead of dropping it.
-  onTerminalSubmit: (text: string) => boolean;
+  // Resolves a ``TerminalSubmitResult`` so the composer can keep the draft
+  // and surface a retry hint when the WS is closed, stay silent when a
+  // control command reported its own error, or clear it on success. Async
+  // because Waypoint control commands (e.g. ``/new``) are handled here.
+  onTerminalSubmit: (text: string) => Promise<TerminalSubmitResult>;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -12,7 +12,11 @@ import {
 
 import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
-import { COMPOSER_MIN_HEIGHT, SHORTCUT_IS_MAC } from "@/lib/composer";
+import {
+  COMPOSER_MIN_HEIGHT,
+  SHORTCUT_IS_MAC,
+  type TerminalSubmitResult,
+} from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import type { SessionRecord } from "@/lib/types";
 
@@ -23,9 +27,12 @@ interface TerminalComposeProps {
   token: string;
   sessionId: string;
   session: SessionRecord | null;
-  // ``onSubmit`` returns false when the socket isn't open so we can leave
-  // the draft in place and surface a hint without throwing it away.
-  onSubmit: (text: string) => boolean;
+  // Resolves a ``TerminalSubmitResult``: ``socket-closed`` keeps the draft
+  // and surfaces a retry hint, ``command-error`` keeps it silently (the host
+  // already reported the error), ``ok`` clears it. Async because Waypoint
+  // control commands (``/new``) are handled by the host rather than the
+  // socket, so a submit can succeed even while the WS is reconnecting.
+  onSubmit: (text: string) => Promise<TerminalSubmitResult>;
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
   connection: ConnectionState;
@@ -75,11 +82,11 @@ export function TerminalCompose({
     setPopoverHost(composeRef.current);
   }, []);
 
-  // ``/new`` is a Waypoint frontend command that only makes sense on
-  // structured sessions; the tmux composer just forwards keystrokes
-  // straight to the wrapped CLI, so we opt out of the local fallback
-  // and surface only the backend-provided completions (CC built-ins,
-  // workspace skills, etc.).
+  // ``/new`` is a Waypoint control command the host intercepts (see
+  // ``handleTerminalSubmit``) rather than forwarding to the wrapped CLI, so
+  // we keep the default local fallback to surface it instantly. ``/fork`` is
+  // not offered here — the backend omits it from tmux completions. Other
+  // entries come from the wrapped backend (CC built-ins, workspace skills).
   const {
     suggestions,
     suggestionsOpen,
@@ -97,7 +104,6 @@ export function TerminalCompose({
     draft,
     setDraft,
     enabled: expanded,
-    localFallback: [],
     textareaRef,
   });
 
@@ -121,25 +127,31 @@ export function TerminalCompose({
   const connected = connection === "open";
   const canSend = expanded && connected && dirty && !sending;
 
-  const send = useCallback(() => {
+  const send = useCallback(async () => {
     const text = draft;
     if (!text.trim()) return;
-    if (!connected) {
-      setHint("Reconnecting — try again in a moment");
-      return;
-    }
+    // No connection gate here: control commands like ``/new`` are handled by
+    // the host and don't need the socket, so ``onSubmit`` decides whether the
+    // WS was actually required.
     setSending(true);
-    const ok = onSubmit(text);
-    if (ok) {
-      setDraft("");
-      setHint(null);
-      resetCompletions();
-    } else {
-      setHint("Socket not open — try again in a moment");
+    try {
+      const result = await onSubmit(text);
+      if (result === "ok") {
+        setDraft("");
+        setHint(null);
+        resetCompletions();
+      } else if (result === "socket-closed") {
+        setHint(
+          connected
+            ? "Socket not open — try again in a moment"
+            : "Reconnecting — try again in a moment",
+        );
+      }
+      // ``command-error``: the host already surfaced the error; keep the draft.
+    } finally {
+      // Briefly hold the disabled state so the user gets feedback.
+      window.setTimeout(() => setSending(false), 120);
     }
-    // The send call resolves synchronously (it's just a WebSocket.send),
-    // but we briefly hold the disabled state so the user gets feedback.
-    window.setTimeout(() => setSending(false), 120);
   }, [draft, connected, onSubmit, resetCompletions]);
 
   const handleKeyDown = useCallback(

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -125,7 +125,10 @@ export function TerminalCompose({
 
   const dirty = draft.trim().length > 0;
   const connected = connection === "open";
-  const canSend = expanded && connected && dirty && !sending;
+  // Not gated on ``connected``: control commands like ``/new`` work without
+  // the socket, and ``send`` surfaces a retry hint for plain text when the WS
+  // is closed — so the button mirrors the ⌘↵ path rather than greying out.
+  const canSend = expanded && dirty && !sending;
 
   const send = useCallback(async () => {
     const text = draft;

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -176,6 +176,13 @@ function CodexCard({
       return <UserMessageBubble event={event} />;
     }
     case "agent_output":
+      // A blank agent message — e.g. a whitespace-only OpenCode text part —
+      // carries nothing to render and would collapse to a zero-width bubble
+      // whose absolutely-positioned meta strip overflows (the timestamp wraps
+      // one character per line). Drop it.
+      if (!event.text.trim()) {
+        return null;
+      }
       if (event.metadata?.item_kind === "reasoning") {
         return <ReasoningDisclosure event={event} agentLabel={agentLabel} />;
       }

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -75,7 +75,27 @@ export function useCommandCompletions({
   const listRef = useRef<HTMLUListElement | null>(null);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
-  const completionHead = draft.split(/\s/, 1)[0];
+  // Caret position drives which word is being completed, so a ``/`` or ``$``
+  // typed mid-prompt triggers suggestions just like one at the start. Kept in
+  // state (synced from the textarea) so the active-word memo recomputes as the
+  // caret moves, not only as ``draft`` changes.
+  const [caret, setCaret] = useState(0);
+
+  useEffect(() => {
+    const el = textareaRef?.current;
+    if (!el) return;
+    const sync = () => setCaret(el.selectionStart ?? el.value.length);
+    const events = ["input", "keyup", "mouseup", "focus", "select"] as const;
+    events.forEach((name) => el.addEventListener(name, sync));
+    return () => events.forEach((name) => el.removeEventListener(name, sync));
+  }, [textareaRef]);
+
+  // The word under the caret: the run of non-whitespace it sits in. With no
+  // textarea wired we can't track the caret, so fall back to the draft end
+  // (trailing-word completion) rather than silently disabling suggestions.
+  const caretPos = textareaRef ? Math.min(caret, draft.length) : draft.length;
+  const [wordStart] = wordRangeAt(draft, caretPos);
+  const completionHead = draft.slice(wordStart, caretPos);
   const completionTrigger = completionHead.startsWith("/")
     ? "/"
     : completionHead.startsWith("$")
@@ -100,7 +120,10 @@ export function useCommandCompletions({
     suggestionsDismissed,
   ]);
 
-  const suggestionsOpen = suggestions.length > 0 && /^\S+$/.test(draft);
+  // ``suggestions`` is already empty unless the caret sits on a ``/``/``$``
+  // word, so its presence is the open condition — no whole-draft test that
+  // would suppress mid-prompt triggers.
+  const suggestionsOpen = suggestions.length > 0;
   const activeIndex = Math.min(
     suggestionIndex,
     Math.max(0, suggestions.length - 1),
@@ -174,10 +197,12 @@ export function useCommandCompletions({
   }, [activeIndex, suggestionsOpen, suggestions.length]);
 
   useEffect(() => {
-    if (!draft.startsWith("/") && !draft.startsWith("$")) {
+    // Re-arm once the caret leaves the trigger word, so a fresh ``/``/``$``
+    // re-opens the list after a prior Escape.
+    if (completionTrigger === null) {
       setSuggestionsDismissed(false);
     }
-  }, [draft]);
+  }, [completionTrigger]);
 
   useEffect(() => {
     if (
@@ -191,11 +216,28 @@ export function useCommandCompletions({
   function applySuggestion(index: number) {
     const chosen = suggestions[index];
     if (!chosen) return;
-    setDraft(chosen.replacement);
+    // Replace the whole word the caret is in (its run on both sides), not the
+    // entire draft, so mid-prompt completions leave surrounding text intact.
+    const pos = textareaRef ? Math.min(caret, draft.length) : draft.length;
+    const [wordStart, wordEnd] = wordRangeAt(draft, pos);
+    // Replacements carry a trailing space; drop a redundant one from the tail
+    // so completing inside "see /to|do here" doesn't double the gap.
+    const tail = draft.slice(wordEnd);
+    const joinedTail =
+      chosen.replacement.endsWith(" ") && tail.startsWith(" ") ? tail.slice(1) : tail;
+    const next = draft.slice(0, wordStart) + chosen.replacement + joinedTail;
+    const nextCaret = wordStart + chosen.replacement.length;
+    setDraft(next);
+    setCaret(nextCaret);
     setSelectedCompletion(chosen);
     setSuggestionsDismissed(true);
     if (textareaRef) {
-      requestAnimationFrame(() => textareaRef.current?.focus());
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(nextCaret, nextCaret);
+      });
     }
   }
 
@@ -269,6 +311,16 @@ export function useCommandCompletions({
     handleSuggestionKey,
     reset,
   };
+}
+
+// The [start, end) bounds of the non-whitespace word that ``pos`` sits in (or
+// at the edge of). Empty run when ``pos`` is on whitespace.
+function wordRangeAt(text: string, pos: number): [number, number] {
+  let start = pos;
+  while (start > 0 && !/\s/.test(text[start - 1])) start--;
+  let end = pos;
+  while (end < text.length && !/\s/.test(text[end])) end++;
+  return [start, end];
 }
 
 function mergeLocalFallback(

--- a/frontend/src/lib/composer.ts
+++ b/frontend/src/lib/composer.ts
@@ -7,3 +7,10 @@ export const COMPOSER_MIN_HEIGHT = 56;
 export const SHORTCUT_IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || "");
+
+// Outcome of a terminal quick-compose submit. ``ok`` covers both a WebSocket
+// send and a successfully handled control command (e.g. ``/new``) — the draft
+// clears either way. ``socket-closed`` keeps the draft and prompts a retry.
+// ``command-error`` keeps the draft but stays silent because the control
+// command already surfaced its own error.
+export type TerminalSubmitResult = "ok" | "socket-closed" | "command-error";


### PR DESCRIPTION
## Summary

Four frontend fixes to the message composer and transcript, hit on tmux-launched and OpenCode sessions:

- **`/new` in terminal sessions** — the quick-compose drawer sent `/new` and `/fork` as literal keystrokes to the wrapped CLI instead of running them as Waypoint commands. Now caught, like the chat composer. (`/fork` stays chat-only — the backend can't fork tmux sessions.)
- **Mid-prompt completion** — `/` and `$` only triggered suggestions at the very start of the draft; they now work anywhere in the prompt, in both composers.
- **Send button while reconnecting** — was disabled whenever the socket was down, which also blocked `/new`; it now matches the ⌘↵ path.
- **Empty OpenCode "thinking" bubble** — a whitespace-only message rendered as a broken zero-width bubble with the timestamp stacked vertically; blank agent messages are now dropped.

## Changes

Frontend only:

- Shared the `/new`/`/fork` interception so both the chat and terminal composers run it.
- Made composer completion caret-aware instead of first-token-only.
- Dropped the connection gate on the terminal Send button and tightened its submit-result handling.
- Skipped rendering blank `agent_output` events.

## Test Plan

- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — clean.
- [x] Manual: tmux session — `/new` in the drawer creates a session instead of typing into the pane; Send button is usable mid-reconnect. Not run this session (no live stack); deferred to reviewer.
- [x] Manual: `/` and `$` mid-prompt surface and insert suggestions in both composers. Not run this session; deferred to reviewer.
- [x] Manual: OpenCode reasoning turn no longer leaves a broken bubble with a vertically-stacked timestamp. Reported by the user; they will confirm the fix.