### PR TITLE
feat: add Opus 4.8 and fix OpenCode project-scoped skill discovery

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -364,7 +364,7 @@ class ClaudeCliAdapter:
         Wire format documented in tmp/docs/BACKEND_CONTROL_PROTOCOLS.md. Pass
         ``model=None`` to revert to the session default. The CLI accepts both
         shortened aliases (``opus``, ``sonnet``, ``haiku``) and full first-party
-        IDs (``claude-opus-4-7``); append ``[1m]`` for 1M-context variants.
+        IDs (``claude-opus-4-8``); append ``[1m]`` for 1M-context variants.
         """
         request_id = f"set-model-{uuid.uuid4()}"
         payload: dict[str, Any] = {"subtype": "set_model"}

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -8,15 +8,16 @@ binary; bumped manually when a new alias ships. Codex has a runtime
 from waypoint.schemas import BackendModelOption
 
 # Effort levels gated by the binary's per-model checks (`vy`/`L4_`/`k4_`):
-# opus-4-6/4-7 and sonnet-4-6 expose the full set; haiku and older opus/sonnet
-# don't accept --effort at all.
+# opus-4-6/4-7/4-8 and sonnet-4-6 expose the full set; haiku and older
+# opus/sonnet don't accept --effort at all.
 CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
 
 # Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
 # see either the human-facing alias (``opus[1m]``) or a resolved API model id
-# (``claude-opus-4-7``); normalize both to the same family so the context window
+# (``claude-opus-4-8``); normalize both to the same family so the context window
 # lookup stays stable.
 CLAUDE_MODEL_ALIASES: dict[str, str] = {
+    "claude-opus-4-8": "opus",
     "claude-opus-4-7": "opus",
     "claude-sonnet-4-6": "sonnet",
     "claude-sonnet-4-5": "sonnet",
@@ -34,7 +35,7 @@ CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
 DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     BackendModelOption(
         id="opus",
-        label="Opus 4.7",
+        label="Opus 4.8",
         description="Most capable for complex work",
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
@@ -53,7 +54,7 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     ),
     BackendModelOption(
         id="opus[1m]",
-        label="Opus 4.7 (1M context)",
+        label="Opus 4.8 (1M context)",
         description="Long sessions with large codebases",
         is_default=True,
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -1014,11 +1014,15 @@ class OpenCodeAdapter:
     async def list_commands(self, session_id: str) -> list[dict[str, Any]]:
         if not self._started:
             await self.start()
-        if session_id not in self._sessions:
+        state = self._sessions.get(session_id)
+        if state is None:
             raise OpenCodeError(f"session not found: {session_id}")
         client = self._require_client()
         try:
-            data = await client.get("/command")
+            # Scope discovery to the session's directory so project-local
+            # skills and commands resolve; without it the server falls back to
+            # its own process cwd and misses project-scoped skills.
+            data = await client.get("/command", params={"directory": state.cwd})
         except Exception as exc:
             raise OpenCodeError(f"failed to list commands: {exc}") from exc
         return data if isinstance(data, list) else []

--- a/backend/tests/test_opencode_adapter.py
+++ b/backend/tests/test_opencode_adapter.py
@@ -125,6 +125,7 @@ async def test_list_commands_reads_server_command_registry() -> None:
     class _FakeClient:
         async def get(self, path, params=None):
             assert path == "/command"
+            assert params == {"directory": "/tmp"}
             return [{"name": "review", "description": "Review changes"}]
 
     adapter._client = _FakeClient()  # type: ignore[assignment]

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3027,7 +3027,7 @@ async def test_list_backend_models_returns_curated_claude_list(tmp_path) -> None
     # Default falls back to the entry flagged is_default in the curated list
     # when no plugin_configs.claude_code.default_model_id override is present.
     assert response["default_model_id"] == "opus[1m]"
-    assert response["default_model_label"] == "Opus 4.7 (1M context)"
+    assert response["default_model_label"] == "Opus 4.8 (1M context)"
 
 
 @pytest.mark.asyncio
@@ -3041,7 +3041,7 @@ async def test_list_backend_models_honours_default_models_override(tmp_path) -> 
     runtime = SessionRuntime(settings, storage)
     response = await runtime.list_backend_models("claude_code")
     assert response["default_model_id"] == "opus"
-    assert response["default_model_label"] == "Opus 4.7"
+    assert response["default_model_label"] == "Opus 4.8"
 
 
 def _seed_session_with_events(


### PR DESCRIPTION
## Summary

Two backend changes:

- **Opus 4.8** — the Claude Code model catalog's `opus`/`opus[1m]` aliases track the latest Opus build, so this relabels them to 4.8 and adds a normalization alias for the resolved `claude-opus-4-8` id. `opus[1m]` was already flagged default, so **Opus 4.8 (1M context)** becomes the default model.
- **OpenCode project-scoped skill discovery** — `/` autocomplete dropped skills defined under the session's project directory (`.agents/skills`, `.claude/skills`, `.opencode/skill`). `list_commands` queried `/command` without a `directory` param, so the OpenCode server resolved discovery against its own process cwd instead of the session's directory and missed project-scoped skills. Now scoped to the session cwd, matching the sibling `/config/providers` and `/session` calls.

## Changes

### Claude Code

- `backends/claude_code/models.py`: relabel the `opus` and `opus[1m]` catalog entries to Opus 4.8 / Opus 4.8 (1M context), add `claude-opus-4-8` → `opus` to `CLAUDE_MODEL_ALIASES`, and refresh the effort-level comment. `opus[1m]` keeps `is_default=True`, so it stays the default.
- `backends/claude_code/adapter.py`: bump the `set_model` docstring's example id to `claude-opus-4-8`.

### OpenCode

- `backends/opencode/adapter.py`: `list_commands` resolves the session state and passes `params={"directory": state.cwd}` to `GET /command` so project-local skills and commands resolve against the session's directory.

### Tests

- `tests/test_runtime.py`: update the default-model label assertions to Opus 4.8.
- `tests/test_opencode_adapter.py`: assert `list_commands` sends the `directory` param.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_claude_cli.py tests/test_config.py` — 61 pass.
- [x] `cd backend && uv run pytest tests/test_runtime.py -k "list_backend_models or default_model"` plus the claude_cli default/set_model cases — 7 pass.
- [x] `cd backend && uv run pytest tests/test_opencode_adapter.py tests/test_opencode_plugin.py` — 48 pass.
- [x] `cd backend && uv run mypy src/waypoint/backends/opencode/adapter.py` — clean.
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on both commits — clean.
- [x] Manual: ran a live `opencode serve` (v1.15.5) and confirmed `GET /command` without `directory` omits a project-scoped `.agents/skills` skill, while `?directory=<project>` includes it (also via `/skill`).
- [x] Manual: created a dummy `.agents/skills` skill and confirmed it now appears in Waypoint's OpenCode `/` autocomplete on the running stack — confirmed by the user.