### PR TITLE
fix: tailnet backend discovery jank and multi-sidecar selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,9 @@
 # TS_HOSTNAME=waypoint-profile-a
 # TS_IMAGE=tailscale/tailscale:latest
 # TS_HOST_ALIAS=host.docker.internal     # override on hosts where host-gateway resolves differently
+#
+# Peer discovery (login screen + backend switcher) exec's into the tailscale
+# sidecar this deployment owns. It resolves the container from the active
+# profile recorded under `$WAYPOINTCTL_STATE_DIR/tailscale` by
+# `waypointctl tailscale up`, so no extra configuration is needed even when
+# unrelated `waypoint.role=tailscale` containers share the host.

--- a/backend/src/waypoint/tailnet.py
+++ b/backend/src/waypoint/tailnet.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -12,6 +13,16 @@ log = logging.getLogger("waypoint.tailnet")
 
 DEFAULT_PORT = 8787
 MACOS_FALLBACK_BIN = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+ROLE_LABEL = "waypoint.role=tailscale"
+# Multiple Waypoint deployments (and unrelated containers) can share the
+# role=tailscale label on one host. The sidecar this deployment owns is
+# resolved from the waypointctl state tree rather than a dedicated env var:
+# `waypoint_tailscale.sh` records the active profile under
+# ``$WAYPOINTCTL_STATE_DIR/tailscale`` and names each container by slug.
+STATE_DIR_ENV = "WAYPOINTCTL_STATE_DIR"
+DEFAULT_STATE_DIR = "~/.waypoint"
+ACTIVE_PROFILE_FILE = "active-profile"
+CONTAINER_PREFIX = "waypoint-tailscale-"
 
 
 class TailnetPeer(BaseModel):
@@ -49,52 +60,98 @@ async def fetch_snapshot() -> TailnetSnapshot:
             available=False, error="tailscale binary not found on PATH"
         )
 
-    container, lookup_error = await _find_sidecar_container(docker)
-    if lookup_error is not None:
-        return TailnetSnapshot(available=False, error=lookup_error)
+    container, lookup_error = await _select_sidecar_container(docker)
     if container is None:
-        return TailnetSnapshot(
-            available=False, error="no waypoint tailscale sidecar running"
-        )
+        return TailnetSnapshot(available=False, error=lookup_error)
 
     return await _run_status(
         [docker, "exec", container, "tailscale", "status", "--json"]
     )
 
 
-async def _find_sidecar_container(docker: str) -> tuple[str | None, str | None]:
-    """Return (container_name, error). `error` is set only when `docker ps` itself fails."""
+async def _select_sidecar_container(docker: str) -> tuple[str | None, str | None]:
+    """Resolve the tailscale sidecar this deployment owns.
+
+    Foreign ``role=tailscale`` sidecars sharing the host are excluded by
+    cross-checking the running containers against this deployment's state tree:
+    the most recently ``up``-ed profile (the ``active-profile`` marker) wins,
+    falling back to the newest owned-and-running sidecar. Returns
+    ``(container, None)`` on success or ``(None, error)``.
+    """
+    running, error = await _list_containers(
+        docker, [f"label={ROLE_LABEL}", "status=running"]
+    )
+    if error is not None:
+        return None, error
+    if not running:
+        return None, "no waypoint tailscale sidecar running"
+
+    root = _tailscale_state_root()
+
+    active = _read_active_profile(root)
+    if active is not None:
+        name = f"{CONTAINER_PREFIX}{active}"
+        if name in running:
+            return name, None
+
+    # `running` is newest-first (docker ps order), so the first owned entry is
+    # the most recently created sidecar this deployment controls.
+    owned = _owned_container_names(root)
+    for name in running:
+        if name in owned:
+            return name, None
+
+    return None, (
+        f"no tailscale sidecar for this deployment is running (state dir {root}); "
+        "run `waypointctl tailscale up <profile>`"
+    )
+
+
+def _tailscale_state_root() -> Path:
+    raw = os.environ.get(STATE_DIR_ENV) or DEFAULT_STATE_DIR
+    return Path(raw).expanduser() / "tailscale"
+
+
+def _read_active_profile(root: Path) -> str | None:
+    try:
+        text = (root / ACTIVE_PROFILE_FILE).read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return text or None
+
+
+def _owned_container_names(root: Path) -> set[str]:
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return set()
+    return {f"{CONTAINER_PREFIX}{entry.name}" for entry in entries if entry.is_dir()}
+
+
+async def _list_containers(
+    docker: str, filters: list[str]
+) -> tuple[list[str], str | None]:
+    """Return (names, error). `error` is set only when `docker ps` itself fails."""
+    argv = [docker, "ps"]
+    for spec in filters:
+        argv += ["--filter", spec]
+    argv += ["--format", "{{.Names}}"]
     try:
         process = await asyncio.create_subprocess_exec(
-            docker,
-            "ps",
-            "--filter",
-            "label=waypoint.role=tailscale",
-            "--filter",
-            "status=running",
-            "--format",
-            "{{.Names}}",
+            *argv,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await process.communicate()
     except (FileNotFoundError, OSError) as exc:
-        return None, f"failed to run docker ps: {exc}"
+        return [], f"failed to run docker ps: {exc}"
     if process.returncode != 0:
         message = (
             stderr.decode().strip() or f"docker ps exited with {process.returncode}"
         )
-        return None, message
+        return [], message
     names = [line for line in stdout.decode().splitlines() if line.strip()]
-    if not names:
-        return None, None
-    if len(names) > 1:
-        log.warning(
-            "multiple tailscale sidecars running (%s); using %s",
-            ", ".join(names),
-            names[0],
-        )
-    return names[0], None
+    return names, None
 
 
 async def _run_status(argv: list[str]) -> TailnetSnapshot:

--- a/backend/tests/test_tailnet.py
+++ b/backend/tests/test_tailnet.py
@@ -1,11 +1,20 @@
 import json
-import logging
+from pathlib import Path
 from typing import Any
 
 import pytest
 
 from waypoint import tailnet
 from waypoint.tailnet import _parse_snapshot, fetch_snapshot
+
+
+@pytest.fixture(autouse=True)
+def tailscale_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point sidecar resolution at an empty per-test state tree and return it."""
+    monkeypatch.setenv(tailnet.STATE_DIR_ENV, str(tmp_path))
+    root = tmp_path / "tailscale"
+    root.mkdir()
+    return root
 
 
 def test_parse_snapshot_orders_self_then_online_then_offline() -> None:
@@ -141,6 +150,7 @@ async def test_fetch_snapshot_prefers_host_binary(
 @pytest.mark.asyncio
 async def test_fetch_snapshot_falls_back_to_docker_exec(
     monkeypatch: pytest.MonkeyPatch,
+    tailscale_state: Path,
 ) -> None:
     monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
 
@@ -152,6 +162,7 @@ async def test_fetch_snapshot_falls_back_to_docker_exec(
         return None
 
     monkeypatch.setattr(tailnet.shutil, "which", fake_which)
+    (tailscale_state / "active-profile").write_text("nat\n", encoding="utf-8")
 
     payload = _running_payload("waypoint-nat")
     calls: list[tuple[str, ...]] = []
@@ -274,21 +285,8 @@ async def test_fetch_snapshot_surfaces_docker_ps_error(
     assert snapshot.error == "Cannot connect to the Docker daemon"
 
 
-@pytest.mark.asyncio
-async def test_fetch_snapshot_picks_first_when_multiple_sidecars(
-    monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
-
-    def fake_which(name: str) -> str | None:
-        return "/usr/local/bin/docker" if name == "docker" else None
-
-    monkeypatch.setattr(tailnet.shutil, "which", fake_which)
-
-    payload = _running_payload("waypoint-a")
-    calls: list[tuple[str, ...]] = []
-    plans: dict[tuple[str, ...], _FakeProcess] = {
+def _ps_plan(stdout: bytes) -> tuple[tuple[str, ...], _FakeProcess]:
+    return (
         (
             "/usr/local/bin/docker",
             "ps",
@@ -298,29 +296,123 @@ async def test_fetch_snapshot_picks_first_when_multiple_sidecars(
             "status=running",
             "--format",
             "{{.Names}}",
-        ): _FakeProcess(stdout=b"waypoint-tailscale-a\nwaypoint-tailscale-b\n"),
-        (
-            "/usr/local/bin/docker",
-            "exec",
-            "waypoint-tailscale-a",
-            "tailscale",
-            "status",
-            "--json",
-        ): _FakeProcess(stdout=json.dumps(payload).encode()),
-    }
-    monkeypatch.setattr(
-        tailnet.asyncio,
-        "create_subprocess_exec",
-        _exec_recorder(plans, calls),
+        ),
+        _FakeProcess(stdout=stdout),
     )
 
-    with caplog.at_level(logging.WARNING, logger="waypoint.tailnet"):
-        snapshot = await fetch_snapshot()
+
+def _exec_plan(
+    container: str, payload: dict[str, Any]
+) -> tuple[tuple[str, ...], _FakeProcess]:
+    return (
+        ("/usr/local/bin/docker", "exec", container, "tailscale", "status", "--json"),
+        _FakeProcess(stdout=json.dumps(payload).encode()),
+    )
+
+
+def _docker_only_which(name: str) -> str | None:
+    return "/usr/local/bin/docker" if name == "docker" else None
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_uses_active_profile_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tailscale_state: Path,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(tailnet.shutil, "which", _docker_only_which)
+    (tailscale_state / "active-profile").write_text("b\n", encoding="utf-8")
+
+    calls: list[tuple[str, ...]] = []
+    plans = dict(
+        [
+            _ps_plan(b"waypoint-tailscale-a\nwaypoint-tailscale-b\n"),
+            _exec_plan("waypoint-tailscale-b", _running_payload("node-b")),
+        ]
+    )
+    monkeypatch.setattr(
+        tailnet.asyncio, "create_subprocess_exec", _exec_recorder(plans, calls)
+    )
+
+    snapshot = await fetch_snapshot()
 
     assert snapshot.available is True
-    assert calls[1][2] == "waypoint-tailscale-a"
-    assert any(
-        "multiple tailscale sidecars" in record.message
-        and record.levelname == "WARNING"
-        for record in caplog.records
+    assert calls[1][2] == "waypoint-tailscale-b"
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_falls_back_to_newest_owned_when_no_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tailscale_state: Path,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(tailnet.shutil, "which", _docker_only_which)
+    (tailscale_state / "a").mkdir()
+    (tailscale_state / "b").mkdir()
+
+    calls: list[tuple[str, ...]] = []
+    # docker ps is newest-first, so the first owned entry is the most recent.
+    plans = dict(
+        [
+            _ps_plan(b"waypoint-tailscale-b\nwaypoint-tailscale-a\n"),
+            _exec_plan("waypoint-tailscale-b", _running_payload("node-b")),
+        ]
     )
+    monkeypatch.setattr(
+        tailnet.asyncio, "create_subprocess_exec", _exec_recorder(plans, calls)
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is True
+    assert calls[1][2] == "waypoint-tailscale-b"
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_ignores_foreign_sidecar(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(tailnet.shutil, "which", _docker_only_which)
+
+    calls: list[tuple[str, ...]] = []
+    # A running role=tailscale container exists, but it is not under this
+    # deployment's (empty) state tree, so it must not be queried.
+    plans = dict([_ps_plan(b"someone-elses-tailscale\n")])
+    monkeypatch.setattr(
+        tailnet.asyncio, "create_subprocess_exec", _exec_recorder(plans, calls)
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is False
+    assert "this deployment" in (snapshot.error or "")
+    assert all(call[1] != "exec" for call in calls)
+
+
+@pytest.mark.asyncio
+async def test_fetch_snapshot_falls_back_when_active_profile_container_stopped(
+    monkeypatch: pytest.MonkeyPatch,
+    tailscale_state: Path,
+) -> None:
+    monkeypatch.setattr(tailnet.os.path, "exists", lambda _path: False)
+    monkeypatch.setattr(tailnet.shutil, "which", _docker_only_which)
+    # Marker names a profile whose container is no longer running.
+    (tailscale_state / "active-profile").write_text("gone\n", encoding="utf-8")
+    (tailscale_state / "live").mkdir()
+
+    calls: list[tuple[str, ...]] = []
+    plans = dict(
+        [
+            _ps_plan(b"waypoint-tailscale-live\n"),
+            _exec_plan("waypoint-tailscale-live", _running_payload("node-live")),
+        ]
+    )
+    monkeypatch.setattr(
+        tailnet.asyncio, "create_subprocess_exec", _exec_recorder(plans, calls)
+    )
+
+    snapshot = await fetch_snapshot()
+
+    assert snapshot.available is True
+    assert calls[1][2] == "waypoint-tailscale-live"

--- a/frontend/src/app/api/tailnet/peers/route.ts
+++ b/frontend/src/app/api/tailnet/peers/route.ts
@@ -1,5 +1,7 @@
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 import { NextResponse } from "next/server";
 
@@ -7,6 +9,19 @@ export const dynamic = "force-dynamic";
 
 const MACOS_FALLBACK_BIN = "/Applications/Tailscale.app/Contents/MacOS/Tailscale";
 const SUBPROCESS_TIMEOUT_MS = 4000;
+// Mirrors backend/src/waypoint/tailnet.py: when the web tier has no local
+// tailscale CLI (e.g. it runs as a host process while tailscale lives in a
+// sidecar container), discover peers by exec'ing into the labelled sidecar.
+const ROLE_LABEL = "waypoint.role=tailscale";
+// Multiple Waypoint deployments (and unrelated containers) can share the
+// role=tailscale label on one host. The sidecar this deployment owns is
+// resolved from the waypointctl state tree (mirrors waypoint.tailnet):
+// `waypoint_tailscale.sh` records the active profile under
+// `$WAYPOINTCTL_STATE_DIR/tailscale` and names each container by slug.
+const STATE_DIR_ENV = "WAYPOINTCTL_STATE_DIR";
+const DEFAULT_STATE_DIR = "~/.waypoint";
+const ACTIVE_PROFILE_FILE = "active-profile";
+const CONTAINER_PREFIX = "waypoint-tailscale-";
 
 interface TailnetPeer {
   name: string;
@@ -24,18 +39,44 @@ interface TailnetSnapshot {
 }
 
 export async function GET(): Promise<NextResponse> {
-  const binary = await resolveBinary();
-  if (binary === null) {
-    return NextResponse.json(unavailable("tailscale binary not found on PATH"));
-  }
   try {
-    const raw = await runTailscaleStatus(binary);
-    const payload = JSON.parse(raw) as Record<string, unknown>;
-    return NextResponse.json(parseSnapshot(payload));
+    return NextResponse.json(await fetchSnapshot());
   } catch (error) {
     const message = error instanceof Error ? error.message : "tailscale status failed";
     return NextResponse.json(unavailable(message));
   }
+}
+
+async function fetchSnapshot(): Promise<TailnetSnapshot> {
+  const binary = await resolveBinary();
+  if (binary !== null) {
+    return snapshotFromStatus(await runCommand(binary, ["status", "--json"]));
+  }
+
+  const docker = await firstResolvable("docker");
+  if (docker === null) {
+    return unavailable("tailscale binary not found on PATH");
+  }
+
+  const { container, error } = await selectSidecarContainer(docker);
+  if (container === null) {
+    return unavailable(error ?? "no waypoint tailscale sidecar running");
+  }
+
+  return snapshotFromStatus(
+    await runCommand(docker, ["exec", container, "tailscale", "status", "--json"]),
+  );
+}
+
+function snapshotFromStatus(raw: string): TailnetSnapshot {
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(raw || "{}") as Record<string, unknown>;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "invalid JSON";
+    return unavailable(`could not parse tailscale output: ${message}`);
+  }
+  return parseSnapshot(payload);
 }
 
 async function resolveBinary(): Promise<string | null> {
@@ -47,6 +88,100 @@ async function resolveBinary(): Promise<string | null> {
     return MACOS_FALLBACK_BIN;
   }
   return null;
+}
+
+// Resolve the tailscale sidecar this deployment owns. Mirrors the backend's
+// _select_sidecar_container: foreign role=tailscale sidecars are excluded by
+// cross-checking the running containers against this deployment's state tree —
+// the most recently up-ed profile (active-profile marker) wins, falling back to
+// the newest owned-and-running sidecar.
+async function selectSidecarContainer(
+  docker: string,
+): Promise<{ container: string | null; error: string | null }> {
+  const { names: running, error } = await listContainers(docker, [
+    `label=${ROLE_LABEL}`,
+    "status=running",
+  ]);
+  if (error !== null) {
+    return { container: null, error };
+  }
+  if (running.length === 0) {
+    return { container: null, error: "no waypoint tailscale sidecar running" };
+  }
+
+  const root = tailscaleStateRoot();
+
+  const active = readActiveProfile(root);
+  if (active) {
+    const name = `${CONTAINER_PREFIX}${active}`;
+    if (running.includes(name)) {
+      return { container: name, error: null };
+    }
+  }
+
+  // `running` is newest-first (docker ps order), so the first owned entry is
+  // the most recently created sidecar this deployment controls.
+  const owned = ownedContainerNames(root);
+  const ownedRunning = running.find((name) => owned.has(name));
+  if (ownedRunning !== undefined) {
+    return { container: ownedRunning, error: null };
+  }
+
+  return {
+    container: null,
+    error: `no tailscale sidecar for this deployment is running (state dir ${root}); run \`waypointctl tailscale up <profile>\``,
+  };
+}
+
+function tailscaleStateRoot(): string {
+  const raw = (process.env[STATE_DIR_ENV] ?? "").trim() || DEFAULT_STATE_DIR;
+  const expanded = raw === "~" || raw.startsWith("~/") ? join(homedir(), raw.slice(1)) : raw;
+  return join(expanded, "tailscale");
+}
+
+function readActiveProfile(root: string): string | null {
+  try {
+    return readFileSync(join(root, ACTIVE_PROFILE_FILE), "utf-8").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function ownedContainerNames(root: string): Set<string> {
+  try {
+    return new Set(
+      readdirSync(root, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => `${CONTAINER_PREFIX}${entry.name}`),
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+async function listContainers(
+  docker: string,
+  filters: string[],
+): Promise<{ names: string[]; error: string | null }> {
+  const args = ["ps"];
+  for (const spec of filters) {
+    args.push("--filter", spec);
+  }
+  args.push("--format", "{{.Names}}");
+  let stdout: string;
+  try {
+    stdout = await runCommand(docker, args);
+  } catch (error) {
+    return {
+      names: [],
+      error: error instanceof Error ? error.message : "docker ps failed",
+    };
+  }
+  const names = stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  return { names, error: null };
 }
 
 function firstResolvable(name: string): Promise<string | null> {
@@ -68,14 +203,14 @@ function firstResolvable(name: string): Promise<string | null> {
   });
 }
 
-function runTailscaleStatus(binary: string): Promise<string> {
+function runCommand(command: string, args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
-    const proc = spawn(binary, ["status", "--json"], { stdio: ["ignore", "pipe", "pipe"] });
+    const proc = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";
     const timer = setTimeout(() => {
       proc.kill("SIGTERM");
-      reject(new Error("tailscale status timed out"));
+      reject(new Error(`${command} timed out`));
     }, SUBPROCESS_TIMEOUT_MS);
     proc.stdout.on("data", (chunk: Buffer) => {
       stdout += chunk.toString();
@@ -93,7 +228,7 @@ function runTailscaleStatus(binary: string): Promise<string> {
         resolve(stdout);
         return;
       }
-      reject(new Error(stderr.trim() || `tailscale exited with ${code}`));
+      reject(new Error(stderr.trim() || `${command} exited with ${code}`));
     });
   });
 }

--- a/frontend/src/components/BackendSwitcher.tsx
+++ b/frontend/src/components/BackendSwitcher.tsx
@@ -10,6 +10,7 @@ import {
   buildBackendOptions,
   DEFAULT_BACKEND_PORT,
   fetchBackendTailnetSnapshot,
+  sameBackendUrl,
   TailnetSnapshot,
 } from "@/lib/tailnet";
 
@@ -42,6 +43,9 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
   const probeAbortRef = useRef<AbortController | null>(null);
   const onAuthFailureRef = useRef(onAuthFailure);
   useEffect(() => { onAuthFailureRef.current = onAuthFailure; });
+  // Reset each time the panel opens so a stale snapshot or a re-rendered prop
+  // can't override the choice the user makes while the panel is open.
+  const userTouchedRef = useRef(false);
 
   const pageHost = typeof window === "undefined" ? "localhost" : window.location.hostname || "localhost";
 
@@ -63,7 +67,7 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
     [hostOptions, launchTargets],
   );
 
-  const hostLabel = hostOptions.find((option) => option.url === host)?.label ?? host;
+  const hostLabel = hostOptions.find((option) => sameBackendUrl(option.url, host))?.label ?? host;
   const activeTarget = launchTargets.find((target) => target.id === targetId) ?? null;
   const currentLabel = activeTarget ? `${hostLabel} / SSH: ${activeTarget.name}` : hostLabel;
 
@@ -87,14 +91,18 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
   }, [open, host, token]);
 
   useEffect(() => {
-    if (!open) {
+    userTouchedRef.current = false;
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || userTouchedRef.current) {
       return;
     }
     if (targetId && launchTargets.some((target) => target.id === targetId)) {
       setSelection(`${TARGET_PREFIX}${targetId}`);
       return;
     }
-    const matched = hostOptions.find((option) => option.url === host);
+    const matched = hostOptions.find((option) => sameBackendUrl(option.url, host));
     if (matched) {
       setSelection(matched.url);
       return;
@@ -105,7 +113,7 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
 
   const selectedTargetId = selection.startsWith(TARGET_PREFIX) ? selection.slice(TARGET_PREFIX.length) : "";
   const activeHost = selection === CUSTOM_VALUE || selection.startsWith(TARGET_PREFIX) ? customOrCurrentHost(selection, customHost, host) : selection;
-  const dirty = activeHost !== host || selectedTargetId !== targetId;
+  const dirty = !sameBackendUrl(activeHost, host) || selectedTargetId !== targetId;
 
   useEffect(() => {
     probeAbortRef.current?.abort();
@@ -158,7 +166,13 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
       </p>
       <label className="field">
         <span>Backend</span>
-        <select value={selection} onChange={(event) => setSelection(event.target.value)}>
+        <select
+          value={selection}
+          onChange={(event) => {
+            userTouchedRef.current = true;
+            setSelection(event.target.value);
+          }}
+        >
           {pickerOptions.map((option) => (
             <option key={option.value} value={option.value}>
               {option.label}

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -9,6 +9,7 @@ import {
   buildBackendOptions,
   DEFAULT_BACKEND_PORT,
   fetchLocalTailnetSnapshot,
+  sameBackendUrl,
   TailnetSnapshot,
 } from "@/lib/tailnet";
 
@@ -31,7 +32,9 @@ export function LoginForm({ defaultHost, onSubmit }: LoginFormProps) {
   const [busy, setBusy] = useState(false);
   const [probe, setProbe] = useState<ProbeStatus>("idle");
   const probeAbortRef = useRef<AbortController | null>(null);
-  const initializedRef = useRef(false);
+  // Stop the selection-sync effect from overriding an explicit user choice once
+  // they've interacted with the dropdown.
+  const userTouchedRef = useRef(false);
 
   const pageHost = typeof window === "undefined" ? "localhost" : window.location.hostname || "localhost";
 
@@ -60,12 +63,11 @@ export function LoginForm({ defaultHost, onSubmit }: LoginFormProps) {
   }, []);
 
   useEffect(() => {
-    if (initializedRef.current || snapshotLoading) {
+    if (snapshotLoading || userTouchedRef.current) {
       return;
     }
-    initializedRef.current = true;
     if (defaultHost) {
-      const matched = options.find((option) => option.url === defaultHost);
+      const matched = options.find((option) => sameBackendUrl(option.url, defaultHost));
       if (matched) {
         setSelection(matched.url);
         return;
@@ -143,7 +145,13 @@ export function LoginForm({ defaultHost, onSubmit }: LoginFormProps) {
             {snapshotLoading ? "Refreshing…" : "Refresh"}
           </button>
         </span>
-        <select value={selection} onChange={(event) => setSelection(event.target.value)}>
+        <select
+          value={selection}
+          onChange={(event) => {
+            userTouchedRef.current = true;
+            setSelection(event.target.value);
+          }}
+        >
           {options.map((option) => (
             <option key={option.url} value={option.url}>
               {option.label}

--- a/frontend/src/lib/tailnet.ts
+++ b/frontend/src/lib/tailnet.ts
@@ -15,6 +15,29 @@ export interface TailnetSnapshot {
 
 export const DEFAULT_BACKEND_PORT = 8787;
 
+// Two backend URLs address the same backend when their host and port match,
+// ignoring protocol (http vs https) and a missing explicit default port.
+// Selection matching compares on this canonical key rather than the raw string.
+export function sameBackendUrl(
+  a: string | null | undefined,
+  b: string | null | undefined,
+): boolean {
+  if (!a || !b) {
+    return false;
+  }
+  return canonicalBackendKey(a) === canonicalBackendKey(b);
+}
+
+function canonicalBackendKey(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const port = parsed.port || (parsed.protocol === "https:" ? "443" : "80");
+    return `${parsed.hostname.toLowerCase()}:${port}`;
+  } catch {
+    return url.trim().toLowerCase().replace(/\/+$/, "");
+  }
+}
+
 export function backendPortFromUrl(url: string | null | undefined): number | null {
   if (!url) return null;
   try {

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STATE_ROOT="${WAYPOINTCTL_STATE_DIR:-${HOME}/.waypoint}/tailscale"
+# Records the most recently `up`-ed profile so peer discovery (backend +
+# frontend) can resolve the sidecar this deployment owns without a dedicated
+# env var. Read by waypoint.tailnet and the frontend's tailnet route.
+ACTIVE_PROFILE_FILE="${STATE_ROOT}/active-profile"
 BACKEND_PORT="${WAYPOINT_STACK_BACKEND_PORT:-8787}"
 FRONTEND_PORT="${WAYPOINT_STACK_FRONTEND_PORT:-3000}"
 HOST_ALIAS="${TS_HOST_ALIAS:-host.docker.internal}"
@@ -178,6 +182,8 @@ cmd_up() {
     die "Failed to configure Tailscale Serve for ${name}."
   fi
 
+  printf '%s\n' "${slug}" > "${ACTIVE_PROFILE_FILE}"
+
   echo "tailscale container ready: ${name}"
   echo "profile: ${slug}"
   echo "frontend: https://${node_name}:${FRONTEND_PORT}"
@@ -197,6 +203,10 @@ cmd_down() {
   # container is safe — the next `up` rebuilds rather than starting a
   # potentially stale stopped container.
   docker rm -f "${name}" >/dev/null
+  if [[ -f "${ACTIVE_PROFILE_FILE}" \
+    && "$(cat "${ACTIVE_PROFILE_FILE}" 2>/dev/null || true)" == "$(slugify_profile "${profile}")" ]]; then
+    rm -f "${ACTIVE_PROFILE_FILE}"
+  fi
   echo "tailscale container removed: ${name}"
 }
 

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -40,7 +40,7 @@ State (PID files, logs, default data dirs) lives under
 ~/.waypoint/
 ├── run/           waypointd.{sock,pid}, {backend,frontend,caffeinate}.{pid,started-this-run}
 ├── logs/          waypointd.log, backend.log, frontend.log
-├── tailscale/     Docker-backed tailnet state
+├── tailscale/     Docker-backed tailnet state (per-profile dirs + `active-profile` marker)
 ├── backend-data/  (default; overridable via WAYPOINT_STACK_BACKEND_DATA_DIR)
 └── uv-cache/      (default; overridable via WAYPOINT_STACK_UV_CACHE_DIR)
 ```


### PR DESCRIPTION
## Summary

Frontend + backend fixes to the tailnet device-discovery workflow (login screen and in-app backend switcher):

- **Selector reverting to "Custom URL" after a pick** — the switcher's selection-sync effect re-ran when the discovery snapshot or a prop changed and overwrote the user's in-progress choice, and exact string matching (http vs https, IP vs DNS, with/without the default port) failed to recognise the connected backend; the login form additionally locked its first match behind a one-shot ref so peers arriving via Refresh never selected. Selection is now guarded on explicit user interaction and matched on a normalized `host:port` key.
- **Login screen showing no backends after logout** — logged-out discovery ran `tailscale` on the *frontend* host, which has no CLI when Tailscale runs in a sidecar container, so the dropdown collapsed to Local + Custom URL. The login route now exec's into the sidecar the same way the backend already did, so it lists the same peers as the in-app switcher.
- **Multiple tailscale sidecars on one host** — discovery picked the first `waypoint.role=tailscale` container arbitrarily, risking querying a tailnet that belongs to an unrelated deployment. Resolution now selects the sidecar this deployment owns via the active profile recorded under `$WAYPOINTCTL_STATE_DIR/tailscale` (no new env var), falls back to the newest owned-and-running container, and otherwise fails with an actionable message rather than guessing.

## Changes

### Frontend

- `lib/tailnet.ts`: add `sameBackendUrl`, a normalized `host:port` comparison that ignores protocol and a missing default port.
- `components/BackendSwitcher.tsx`: guard the selection-sync effect with a `userTouchedRef` (reset each time the panel opens) so a late snapshot or re-rendered prop can't clobber the pick; match the connected host and compute `dirty` via `sameBackendUrl`.
- `components/LoginForm.tsx`: replace the one-shot `initializedRef` lock with the same interaction guard so options arriving via Refresh re-match; match `defaultHost` via `sameBackendUrl`.
- `app/api/tailnet/peers/route.ts`: when there is no local `tailscale` CLI, exec into the owned sidecar (resolved from the active-profile marker / per-profile state dirs), mirroring the backend; also split JSON-parse failures from the generic error.

### Backend

- `tailnet.py`: `_select_sidecar_container` replaces the first-match `_find_sidecar_container` — it prefers the `active-profile` marker, falls back to the newest owned-and-running container (matched against the `$WAYPOINTCTL_STATE_DIR/tailscale` per-profile dirs), and otherwise returns an actionable error instead of querying an arbitrary container.

### Scripts

- `scripts/waypoint_tailscale.sh`: `tailscale up` records the profile slug to `tailscale/active-profile`; `down` clears it when it points at the removed profile.

### Docs

- `.env.example`, `waypointctl/README.md`: document the active-profile marker and that sidecar discovery needs no extra configuration.

### Tests

- `tests/test_tailnet.py`: cover marker-based selection, newest-owned fallback, foreign-sidecar exclusion, and the stopped-active-profile fallback.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_tailnet.py` — 12 pass.
- [x] `cd backend && uv run pre-commit run --files src/waypoint/tailnet.py tests/test_tailnet.py` — isort / black / ruff / codespell / mypy clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run build` — clean.
- [x] Manual: restarted the tailscale `nat` profile and the full stack; confirmed `active-profile` written and both the frontend route and the authed backend `/api/tailnet/peers` return the full tailnet (4 peers, incl. offline) via marker-based resolution.
- [x] Manual: with the marker absent (pre-marker container), confirmed the login route still resolves the owned sidecar via the per-profile state dir — `available=true`, 4 peers.