### PR TITLE
feat: add a personal assistant with a sessions CLI and UI page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Use GitHub Issues directly for active bugs and feature requests.
 - `frontend/` — Next.js PWA client
 - `3rdparty/codex/` — pinned Codex submodule used for the local app-server SDK
 
+A single long-lived **personal assistant** thread — which answers host questions, grounds itself in your running sessions, and manages them via the `waypoint sessions` CLI — can be enabled in `waypoint.yaml`; see [`docs/personal_assistant.md`](docs/personal_assistant.md).
+
 ## Supported agent versions
 
 Waypoint speaks to Claude Code, Codex, and OpenCode through wire formats that change between releases (stream-json envelopes, codex app-server RPCs, hook-event shapes, REST/SSE event streams). Bumps outside the tested range are likely to work but are not guaranteed.

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -133,6 +133,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             default_cwd=context.settings.default_cwd,
             launch_targets=context.runtime.launch_target_summaries(),
             backends=_backend_descriptors(context.runtime.registry),
+            assistant=context.runtime.assistant_summary(),
         )
 
     @app.get("/api/backends")

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -284,6 +284,16 @@ class BackendPlugin(Protocol):
         """
         ...
 
+    def native_thread_id(self, session: SessionRecord) -> str | None:
+        """Return the backend-native thread/conversation id, if any.
+
+        Generic code never reads ``transport_state`` keys directly; this
+        exposes the id a user would pass to the raw CLI (e.g. ``claude
+        --resume <id>``) so it can be surfaced for recovery. Plugins
+        without a resumable native id return ``None``.
+        """
+        ...
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -287,6 +287,10 @@ class ClaudeCodePlugin:
         if self.adapter is not None:
             await self.adapter.terminate_session(session.id)
 
+    def native_thread_id(self, session: SessionRecord) -> str | None:
+        thread_id = session.transport_state.get("thread_id")
+        return thread_id if isinstance(thread_id, str) else None
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -274,6 +274,10 @@ class CodexPlugin:
         if self.adapter is not None:
             await self.adapter.terminate_session(session.id)
 
+    def native_thread_id(self, session: SessionRecord) -> str | None:
+        thread_id = session.transport_state.get("thread_id")
+        return thread_id if isinstance(thread_id, str) else None
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -610,8 +610,9 @@ class OpenCodePlugin:
             existing.cancel()
 
     def native_thread_id(self, session: SessionRecord) -> str | None:
-        thread_id = session.transport_state.get("thread_id")
-        return thread_id if isinstance(thread_id, str) else None
+        # OpenCode keys its native conversation id as ``opencode_session_id``.
+        session_id = session.transport_state.get("opencode_session_id")
+        return session_id if isinstance(session_id, str) else None
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -609,6 +609,10 @@ class OpenCodePlugin:
         if existing is not None and not existing.done():
             existing.cancel()
 
+    def native_thread_id(self, session: SessionRecord) -> str | None:
+        thread_id = session.transport_state.get("thread_id")
+        return thread_id if isinstance(thread_id, str) else None
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -152,6 +152,10 @@ class TmuxPlugin:
             except Exception:
                 log.debug("rate-limit watcher raised during terminate", exc_info=True)
 
+    def native_thread_id(self, session: SessionRecord) -> str | None:
+        thread_id = session.transport_state.get("thread_id")
+        return thread_id if isinstance(thread_id, str) else None
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -9,6 +9,7 @@ import uvicorn
 
 from waypoint.api import AppContext, create_app
 from waypoint.backends.registry import get_registry
+from waypoint.client import WaypointClient, WaypointError, write_cli_token
 from waypoint.schemas import SessionAttachRequest, SessionCreateRequest
 from waypoint.settings import Settings, load_settings
 
@@ -67,6 +68,51 @@ def build_parser() -> argparse.ArgumentParser:
     attach.add_argument("--backend-hint", choices=backend_choices)
     attach.add_argument("--title")
 
+    # ``sessions`` (plural) drives an already-running server over HTTP,
+    # unlike ``session`` (singular) which spins up an in-process runtime.
+    # This is the surface the personal assistant uses to manage agents.
+    sessions = subparsers.add_parser(
+        "sessions", help="Manage sessions on a running Waypoint server over HTTP."
+    )
+    sessions.add_argument("--config", default=None)
+    sessions_sub = sessions.add_subparsers(dest="sessions_command", required=True)
+
+    sessions_sub.add_parser("list", help="List all sessions.")
+
+    show = sessions_sub.add_parser("show", help="Show one session.")
+    show.add_argument("session_id")
+
+    events = sessions_sub.add_parser("events", help="Show a session's transcript.")
+    events.add_argument("session_id")
+    events.add_argument("--messages", type=int, default=None)
+    events.add_argument("--before-sequence", type=int, default=None)
+
+    sessions_start = sessions_sub.add_parser("start", help="Launch a new session.")
+    sessions_start.add_argument("--backend", choices=backend_choices, required=True)
+    sessions_start.add_argument("--cwd", required=True)
+    sessions_start.add_argument("--launch-target-id")
+    sessions_start.add_argument("--title")
+    sessions_start.add_argument("--model")
+    sessions_start.add_argument("--effort")
+    sessions_start.add_argument("--permission-mode")
+    sessions_start.add_argument("args", nargs="*")
+
+    send = sessions_sub.add_parser("send", help="Send a message to a session.")
+    send.add_argument("session_id")
+    send.add_argument("text")
+
+    interrupt = sessions_sub.add_parser("interrupt", help="Interrupt a session.")
+    interrupt.add_argument("session_id")
+
+    terminate = sessions_sub.add_parser("terminate", help="Terminate a session.")
+    terminate.add_argument("session_id")
+
+    approve = sessions_sub.add_parser("approve", help="Respond to an approval request.")
+    approve.add_argument("session_id")
+    approve.add_argument("decision")
+    approve.add_argument("--text")
+    approve.add_argument("--approval-id")
+
     return parser
 
 
@@ -75,8 +121,15 @@ def main() -> None:
     args = parser.parse_args()
     if args.command == "serve":
         app = create_app(_settings_from_arg(args.config))
-        host = args.host or app.state.context.settings.host
-        port = args.port or app.state.context.settings.port
+        context = app.state.context
+        # Issue a local token the same-host `waypoint sessions` CLI (and the
+        # personal assistant shelling out to it) can read without the
+        # password. 0600 in the data dir; treat it as a secret.
+        token = context.tokens.issue().token
+        token_path = write_cli_token(context.settings, token)
+        print(f"wrote CLI token to {token_path}")
+        host = args.host or context.settings.host
+        port = args.port or context.settings.port
         # Cap graceful-shutdown so a stuck websocket can never hold uvicorn
         # past Ctrl+C. The first SIGINT triggers shutdown; any in-flight ws
         # connection that doesn't close on cancel within this window gets
@@ -92,7 +145,63 @@ def main() -> None:
     if args.command == "session":
         asyncio.run(run_session_command(args))
         return
+    if args.command == "sessions":
+        run_sessions_command(args)
+        return
     parser.error("unknown command")
+
+
+def run_sessions_command(args: argparse.Namespace) -> None:
+    settings = _settings_from_arg(args.config)
+    try:
+        with WaypointClient(settings) as client:
+            result = _dispatch_sessions_command(client, args)
+    except WaypointError as exc:
+        raise SystemExit(f"error: {exc}") from exc
+    print(json.dumps(result, indent=2))
+
+
+def _dispatch_sessions_command(client: WaypointClient, args: argparse.Namespace) -> Any:
+    command = args.sessions_command
+    if command == "list":
+        return {"sessions": client.list_sessions()}
+    if command == "show":
+        return {"session": client.get_session(args.session_id)}
+    if command == "events":
+        return client.get_events(
+            args.session_id,
+            messages=args.messages,
+            before_sequence=args.before_sequence,
+        )
+    if command == "start":
+        return {
+            "session": client.create_session(
+                backend=args.backend,
+                cwd=args.cwd,
+                launch_target_id=args.launch_target_id,
+                title=args.title,
+                model=args.model,
+                effort=args.effort,
+                permission_mode=args.permission_mode,
+                args=list(args.args),
+            )
+        }
+    if command == "send":
+        return {"session": client.send_input(args.session_id, args.text)}
+    if command == "interrupt":
+        return {"session": client.interrupt(args.session_id)}
+    if command == "terminate":
+        return {"session": client.terminate(args.session_id)}
+    if command == "approve":
+        return {
+            "session": client.approve(
+                args.session_id,
+                args.decision,
+                text=args.text,
+                approval_id=args.approval_id,
+            )
+        }
+    raise SystemExit(f"unknown sessions command: {command}")
 
 
 def run_reset(settings: Settings | None = None, *, confirmed: bool) -> None:

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -1,0 +1,217 @@
+"""Thin HTTP client for a running Waypoint backend.
+
+Used by the ``waypoint sessions`` CLI (and the personal assistant, which
+shells out to it) to inspect and manage sessions over the API rather than
+spinning up a second in-process runtime against the same storage. Auth
+resolves, in order: ``WAYPOINT_TOKEN`` env, the server-issued local token
+file, then a password login (caching the result to the token file).
+"""
+
+import os
+from pathlib import Path
+from typing import Any, Self
+
+import httpx
+
+from waypoint.settings import Settings
+
+CLI_TOKEN_FILENAME = "cli-token"
+
+
+class WaypointError(RuntimeError):
+    """Raised for transport failures and non-2xx API responses."""
+
+
+def cli_token_path(settings: Settings) -> Path:
+    return settings.data_dir / CLI_TOKEN_FILENAME
+
+
+def write_cli_token(settings: Settings, token: str) -> Path:
+    """Persist ``token`` to the local token file with 0600 permissions."""
+    path = cli_token_path(settings)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(token, encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def base_url(settings: Settings) -> str:
+    # The CLI runs on the same host as the server; a wildcard bind address
+    # isn't connectable, so dial loopback instead.
+    host = settings.host
+    if host in ("0.0.0.0", "::", ""):
+        host = "127.0.0.1"
+    return f"http://{host}:{settings.port}"
+
+
+class WaypointClient:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        token: str | None = None,
+        client: httpx.Client | None = None,
+    ) -> None:
+        self.settings = settings
+        self._token = token
+        self._client = client or httpx.Client(base_url=base_url(settings), timeout=30.0)
+        self._owns_client = client is None
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    # ── auth ────────────────────────────────────────────────────────────
+
+    def token(self) -> str:
+        if self._token is None:
+            self._token = self._resolve_token()
+        return self._token
+
+    def _resolve_token(self) -> str:
+        env_token = os.environ.get("WAYPOINT_TOKEN")
+        if env_token:
+            return env_token
+        path = cli_token_path(self.settings)
+        if path.exists():
+            cached = path.read_text(encoding="utf-8").strip()
+            if cached:
+                return cached
+        return self._login()
+
+    def _login(self) -> str:
+        password = os.environ.get("WAYPOINT_PASSWORD") or self.settings.password
+        try:
+            response = self._client.post("/api/auth/login", json={"password": password})
+        except httpx.HTTPError as exc:
+            raise WaypointError(f"cannot reach Waypoint API: {exc}") from exc
+        if response.status_code != httpx.codes.OK:
+            raise WaypointError(
+                "login failed (set WAYPOINT_PASSWORD or WAYPOINT_TOKEN): "
+                f"{response.status_code}"
+            )
+        token = str(response.json()["token"])
+        self._token = token
+        try:
+            write_cli_token(self.settings, token)
+        except OSError:
+            pass
+        return token
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> httpx.Response:
+        headers = {"Authorization": f"Bearer {self.token()}"}
+        try:
+            response = self._client.request(method, path, headers=headers, **kwargs)
+            # A stale cached/env token gets one transparent re-login + retry.
+            if response.status_code == httpx.codes.UNAUTHORIZED:
+                self._token = None
+                headers = {"Authorization": f"Bearer {self._login()}"}
+                response = self._client.request(method, path, headers=headers, **kwargs)
+        except httpx.HTTPError as exc:
+            raise WaypointError(f"{method} {path} failed: {exc}") from exc
+        if response.status_code >= httpx.codes.BAD_REQUEST:
+            raise WaypointError(
+                f"{method} {path} -> {response.status_code}: {response.text}"
+            )
+        return response
+
+    # ── sessions ────────────────────────────────────────────────────────
+
+    def list_sessions(self) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = self._request("GET", "/api/sessions").json()[
+            "sessions"
+        ]
+        return data
+
+    def get_session(self, session_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "GET", f"/api/sessions/{session_id}"
+        ).json()["session"]
+        return data
+
+    def get_events(
+        self,
+        session_id: str,
+        *,
+        messages: int | None = None,
+        before_sequence: int | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, int] = {}
+        if messages is not None:
+            params["messages"] = messages
+        if before_sequence is not None:
+            params["before_sequence"] = before_sequence
+        data: dict[str, Any] = self._request(
+            "GET", f"/api/sessions/{session_id}/events", params=params
+        ).json()
+        return data
+
+    def create_session(
+        self,
+        *,
+        backend: str,
+        cwd: str,
+        launch_target_id: str | None = None,
+        title: str | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        permission_mode: str | None = None,
+        args: list[str] | None = None,
+    ) -> dict[str, Any]:
+        body = {
+            "backend": backend,
+            "cwd": cwd,
+            "launch_target_id": launch_target_id,
+            "title": title,
+            "model": model,
+            "effort": effort,
+            "permission_mode": permission_mode,
+            "args": args or [],
+        }
+        data: dict[str, Any] = self._request("POST", "/api/sessions", json=body).json()[
+            "session"
+        ]
+        return data
+
+    def send_input(
+        self, session_id: str, text: str, *, submit: bool = True
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST",
+            f"/api/sessions/{session_id}/input",
+            json={"text": text, "submit": submit},
+        ).json()["session"]
+        return data
+
+    def interrupt(self, session_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", f"/api/sessions/{session_id}/interrupt"
+        ).json()["session"]
+        return data
+
+    def terminate(self, session_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", f"/api/sessions/{session_id}/terminate"
+        ).json()["session"]
+        return data
+
+    def approve(
+        self,
+        session_id: str,
+        decision: str,
+        *,
+        text: str | None = None,
+        approval_id: str | None = None,
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST",
+            f"/api/sessions/{session_id}/approve",
+            json={"decision": decision, "text": text, "approval_id": approval_id},
+        ).json()["session"]
+        return data

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -47,35 +47,38 @@ from waypoint.transports import TransportAdapter
 TMUX_TRANSPORT_ID = "tmux"
 COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
 
-# Opening message sent to a freshly created assistant thread. Delivered as
-# the first user turn because backends expose no generic system-prompt
-# channel; phrased so the model absorbs its role without burning a turn on
-# a monologue. References the `waypoint` CLI, which the runtime expects on
-# the assistant process's PATH.
+# The assistant's charter. Written into AGENTS.md / CLAUDE.md in the
+# assistant's managed working directory so the backend loads it silently as
+# project context — no visible first message, no wasted startup turn.
+# References the `waypoint` CLI, which the runtime expects on the assistant
+# process's PATH.
 ASSISTANT_CHARTER = """\
-You are the Waypoint personal assistant — a single, long-lived thread the \
-user talks to from a dedicated page in the Waypoint app.
+# Waypoint personal assistant
+
+You are the Waypoint personal assistant — a single, long-lived thread the
+user talks to from a dedicated page in the Waypoint app. These are standing
+instructions; act on them whenever the user writes to you.
 
 Your job:
-- Answer questions about this host machine. You have full shell access in \
-this session; run commands to inspect the environment, files, processes, \
-and tooling rather than guessing.
-- Ground answers in the user's Waypoint coding sessions (the agents they \
-run). Inspect and manage them with the `waypoint` CLI, which is on your \
-PATH:
+- Answer questions about this host machine. You have full shell access; run
+  commands to inspect the environment, files, processes, and tooling rather
+  than guessing. Your working directory is a scratch space — operate across
+  the host as needed.
+- Ground answers in the user's Waypoint coding sessions (the agents they
+  run). Inspect and manage them with the `waypoint` CLI, which is on your
+  PATH:
   - `waypoint sessions list` — all sessions and their status.
   - `waypoint sessions show <id>` — details of one session.
   - `waypoint sessions events <id>` — a session's transcript.
   - `waypoint sessions start --backend <id> --cwd <path>` — launch a new agent.
   - `waypoint sessions send <id> <text>` — send a message to a session.
   - `waypoint sessions interrupt|terminate <id>` — control a session.
-  Run `waypoint sessions --help` for the full surface. Prefer the CLI over \
-guessing about session state.
+  Run `waypoint sessions --help` for the full surface. Prefer the CLI over
+  guessing about session state.
 
-Be concise and act before narrating. Do not take destructive or \
-irreversible actions (terminating sessions, deleting files) without \
-confirming with the user first. Acknowledge briefly, then wait for the \
-user's first question."""
+Be concise and act before narrating. Do not take destructive or irreversible
+actions (terminating sessions, deleting files) without confirming with the
+user first."""
 
 log = logging.getLogger("waypoint.runtime")
 
@@ -387,34 +390,35 @@ class SessionRuntime:
             if assistant.permission_mode
             else None
         )
+        workspace = self._prepare_assistant_workspace()
         request = SessionCreateRequest(
             backend=backend,
-            cwd=assistant.cwd,
+            cwd=workspace,
             title="Personal Assistant",
             model=assistant.model,
             effort=assistant.effort,
             permission_mode=permission_mode,
         )
         session = await self.create_session(request)
-        promoted = self.storage.update_session(
+        return self.storage.update_session(
             session.id,
             source=SessionSource.ASSISTANT,
             pinned_at=datetime.now(UTC),
         )
-        await self._send_assistant_charter(promoted)
-        return promoted
 
-    async def _send_assistant_charter(self, session: SessionRecord) -> None:
-        """Seed a fresh assistant thread with its role. Best-effort."""
-        try:
-            await self.handle_input(
-                session.id, SessionInputRequest(text=ASSISTANT_CHARTER, submit=True)
-            )
-        except Exception:
-            log.exception(
-                "failed to send assistant charter",
-                extra={"session_id": session.id},
-            )
+    def _prepare_assistant_workspace(self) -> str:
+        """Materialise the assistant's working dir and its charter files.
+
+        The charter ships as ``AGENTS.md`` / ``CLAUDE.md`` (read silently by
+        the backend as project context) rather than a visible first message.
+        The directory is a scratch cwd — shell access reaches the whole host
+        regardless — so host inspection is unaffected.
+        """
+        workspace = self.settings.data_dir / "assistant"
+        workspace.mkdir(parents=True, exist_ok=True)
+        for name in ("AGENTS.md", "CLAUDE.md"):
+            (workspace / name).write_text(ASSISTANT_CHARTER, encoding="utf-8")
+        return str(workspace)
 
     def is_assistant_session(self, session: SessionRecord) -> bool:
         return session.source == SessionSource.ASSISTANT

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -357,12 +357,18 @@ class SessionRuntime:
                 )
             self.assistant_session_id = None
             return
+        # Reuse only a thread that matches the configured backend, is alive,
+        # and already lives in the managed workspace — the last clause
+        # migrates assistants created by older builds (different cwd, charter
+        # sent as a visible message) to a fresh, silently-chartered thread.
+        workspace = str(self._assistant_workspace_dir())
         live = next(
             (
                 session
                 for session in existing
                 if session.backend == target_backend
                 and session.status not in {SessionStatus.EXITED, SessionStatus.ERROR}
+                and session.cwd == workspace
             ),
             None,
         )
@@ -406,6 +412,9 @@ class SessionRuntime:
             pinned_at=datetime.now(UTC),
         )
 
+    def _assistant_workspace_dir(self) -> Path:
+        return self.settings.data_dir / "assistant"
+
     def _prepare_assistant_workspace(self) -> str:
         """Materialise the assistant's working dir and its charter files.
 
@@ -414,7 +423,7 @@ class SessionRuntime:
         The directory is a scratch cwd — shell access reaches the whole host
         regardless — so host inspection is unaffected.
         """
-        workspace = self.settings.data_dir / "assistant"
+        workspace = self._assistant_workspace_dir()
         workspace.mkdir(parents=True, exist_ok=True)
         for name in ("AGENTS.md", "CLAUDE.md"):
             (workspace / name).write_text(ASSISTANT_CHARTER, encoding="utf-8")

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -23,6 +23,7 @@ from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.scheduler import Scheduler
 from waypoint.schemas import (
+    AssistantSummary,
     CommandCompletion,
     EventKind,
     EventRecord,
@@ -45,6 +46,36 @@ from waypoint.transports import TransportAdapter
 
 TMUX_TRANSPORT_ID = "tmux"
 COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
+
+# Opening message sent to a freshly created assistant thread. Delivered as
+# the first user turn because backends expose no generic system-prompt
+# channel; phrased so the model absorbs its role without burning a turn on
+# a monologue. References the `waypoint` CLI, which the runtime expects on
+# the assistant process's PATH.
+ASSISTANT_CHARTER = """\
+You are the Waypoint personal assistant — a single, long-lived thread the \
+user talks to from a dedicated page in the Waypoint app.
+
+Your job:
+- Answer questions about this host machine. You have full shell access in \
+this session; run commands to inspect the environment, files, processes, \
+and tooling rather than guessing.
+- Ground answers in the user's Waypoint coding sessions (the agents they \
+run). Inspect and manage them with the `waypoint` CLI, which is on your \
+PATH:
+  - `waypoint sessions list` — all sessions and their status.
+  - `waypoint sessions show <id>` — details of one session.
+  - `waypoint sessions events <id>` — a session's transcript.
+  - `waypoint sessions start --backend <id> --cwd <path>` — launch a new agent.
+  - `waypoint sessions send <id> <text>` — send a message to a session.
+  - `waypoint sessions interrupt|terminate <id>` — control a session.
+  Run `waypoint sessions --help` for the full surface. Prefer the CLI over \
+guessing about session state.
+
+Be concise and act before narrating. Do not take destructive or \
+irreversible actions (terminating sessions, deleting files) without \
+confirming with the user first. Acknowledge briefly, then wait for the \
+user's first question."""
 
 log = logging.getLogger("waypoint.runtime")
 
@@ -124,6 +155,10 @@ class SessionRuntime:
             CompletionCacheKey, asyncio.Task[list[CommandCompletion]]
         ] = {}
         self.file_offsets: dict[str, int] = {}
+        # Id of the personal-assistant singleton, populated by
+        # ``_ensure_assistant_session`` during ``start``. ``None`` when the
+        # assistant is disabled or its bootstrap failed.
+        self.assistant_session_id: str | None = None
         self.registry = registry or get_registry()
         self._transports: dict[str, TransportAdapter] = {
             plugin.transport_id: plugin.transport_view(self)
@@ -152,6 +187,13 @@ class SessionRuntime:
             )
             self._restore_tasks.add(task)
             task.add_done_callback(self._restore_tasks.discard)
+        # Bring up the personal-assistant singleton after scheduling
+        # restores so a still-alive assistant is reused rather than
+        # recreated. A bootstrap failure must never abort startup.
+        try:
+            await self._ensure_assistant_session()
+        except Exception:
+            log.exception("failed to ensure the assistant session")
         await self.scheduler.start()
 
     async def stop(self) -> None:
@@ -288,6 +330,109 @@ class SessionRuntime:
         )
         self._warm_command_completions(session)
         return session
+
+    async def _ensure_assistant_session(self) -> None:
+        """Create / reuse / replace the personal-assistant singleton.
+
+        Reuses a still-alive assistant whose backend matches the
+        configured one. Otherwise demotes any stale assistant rows to
+        ``MANAGED`` (preserving their transcripts as ordinary sessions —
+        never destructive) and creates a fresh assistant. When the
+        assistant is disabled, all assistant rows are released back to
+        ``MANAGED`` and no singleton is tracked.
+        """
+        target_backend = self.settings.assistant_backend()
+        existing = [
+            session
+            for session in self.storage.list_sessions()
+            if session.source == SessionSource.ASSISTANT
+        ]
+        if target_backend is None:
+            for session in existing:
+                self.storage.update_session(
+                    session.id, source=SessionSource.MANAGED, pinned_at=None
+                )
+            self.assistant_session_id = None
+            return
+        live = next(
+            (
+                session
+                for session in existing
+                if session.backend == target_backend
+                and session.status not in {SessionStatus.EXITED, SessionStatus.ERROR}
+            ),
+            None,
+        )
+        if live is not None:
+            self.assistant_session_id = live.id
+            for session in existing:
+                if session.id != live.id:
+                    self.storage.update_session(
+                        session.id, source=SessionSource.MANAGED, pinned_at=None
+                    )
+            return
+        for session in existing:
+            self.storage.update_session(
+                session.id, source=SessionSource.MANAGED, pinned_at=None
+            )
+        created = await self._create_assistant_session(target_backend)
+        self.assistant_session_id = created.id
+
+    async def _create_assistant_session(self, backend: str) -> SessionRecord:
+        assistant = self.settings.assistant
+        assert assistant is not None  # guarded by assistant_backend()
+        plugin = self.registry.get(backend)
+        permission_mode = (
+            plugin.validate_permission_mode(assistant.permission_mode)
+            if assistant.permission_mode
+            else None
+        )
+        request = SessionCreateRequest(
+            backend=backend,
+            cwd=assistant.cwd,
+            title="Personal Assistant",
+            model=assistant.model,
+            effort=assistant.effort,
+            permission_mode=permission_mode,
+        )
+        session = await self.create_session(request)
+        promoted = self.storage.update_session(
+            session.id,
+            source=SessionSource.ASSISTANT,
+            pinned_at=datetime.now(UTC),
+        )
+        await self._send_assistant_charter(promoted)
+        return promoted
+
+    async def _send_assistant_charter(self, session: SessionRecord) -> None:
+        """Seed a fresh assistant thread with its role. Best-effort."""
+        try:
+            await self.handle_input(
+                session.id, SessionInputRequest(text=ASSISTANT_CHARTER, submit=True)
+            )
+        except Exception:
+            log.exception(
+                "failed to send assistant charter",
+                extra={"session_id": session.id},
+            )
+
+    def is_assistant_session(self, session: SessionRecord) -> bool:
+        return session.source == SessionSource.ASSISTANT
+
+    def assistant_summary(self) -> AssistantSummary | None:
+        session_id = self.assistant_session_id
+        if session_id is None:
+            return None
+        session = self.storage.get_session(session_id)
+        if session is None:
+            return None
+        plugin = self.registry.plugin_for(session)
+        return AssistantSummary(
+            session_id=session.id,
+            backend=session.backend,
+            native_thread_id=plugin.native_thread_id(session),
+            status=session.status,
+        )
 
     async def fork_session(self, session_id: str) -> SessionRecord:
         session = self.get_session(session_id)
@@ -682,6 +827,11 @@ class SessionRuntime:
 
     async def terminate(self, session_id: str) -> SessionRecord:
         session = self.get_session(session_id)
+        if session.source == SessionSource.ASSISTANT:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="the assistant session cannot be terminated",
+            )
         if session.status == SessionStatus.EXITED:
             return session
         # Route through the plugin (not the transport) so a session whose
@@ -750,6 +900,11 @@ class SessionRuntime:
 
     async def delete(self, session_id: str, *, force: bool = False) -> None:
         session = self.get_session(session_id)
+        if session.source == SessionSource.ASSISTANT:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="the assistant session cannot be deleted",
+            )
         if session.status != SessionStatus.EXITED:
             if force:
                 # Last-resort path for sessions whose adapter is wedged

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -41,6 +41,10 @@ SessionTransportId = Annotated[str, BeforeValidator(_validate_transport_id)]
 class SessionSource(StrEnum):
     MANAGED = "managed"
     ATTACHED_TMUX = "attached_tmux"
+    # The personal-assistant singleton. Created and kept alive by the
+    # runtime, protected from deletion/termination via the public API,
+    # and surfaced on its own UI page rather than the session list.
+    ASSISTANT = "assistant"
 
 
 class LaunchMode(StrEnum):
@@ -215,6 +219,16 @@ class LaunchTargetSummary(BaseModel):
     default_cwd: str | None = None
 
 
+class AssistantSummary(BaseModel):
+    session_id: str
+    backend: BackendId
+    # Backend-native conversation id (e.g. the value for `claude --resume`).
+    # Surfaced alongside ``session_id`` so a user can recover the thread
+    # outside the app. ``None`` when the backend has no resumable id.
+    native_thread_id: str | None = None
+    status: SessionStatus
+
+
 class MeResponse(BaseModel):
     authenticated: bool = True
     default_backend: BackendId = "codex"
@@ -224,6 +238,9 @@ class MeResponse(BaseModel):
     # consumers (the frontend's bootstrap, auth shell) hydrate the
     # backend picker without a second round-trip.
     backends: list[dict[str, Any]] = Field(default_factory=list)
+    # The personal-assistant singleton, when enabled. The frontend uses
+    # this to locate and render the dedicated assistant page.
+    assistant: AssistantSummary | None = None
 
 
 class EventsPageResponse(BaseModel):

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from waypoint.backends.plugin_config import PluginConfig
 from waypoint.backends.registry import get_registry
@@ -67,6 +67,31 @@ def _default_backend_id() -> str:
     return plugins[0].id if plugins else "tmux"
 
 
+class AssistantConfig(BaseModel):
+    """Configuration for the personal-assistant singleton session.
+
+    The assistant is a long-lived session of an ordinary coding backend
+    (chosen by ``backend``, falling back to ``default_backend``) that the
+    runtime creates and keeps alive on its own. ``model`` / ``effort`` /
+    ``permission_mode`` seed the initial thread; the user can override them
+    live from the assistant UI, so these are defaults, not a lockdown.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = True
+    # ``None`` resolves to the top-level ``default_backend`` at bootstrap.
+    backend: BackendId | None = None
+    model: str | None = None
+    effort: str | None = None
+    # Home by default so the assistant can answer host-environment
+    # questions; cwd is not required to be a repo.
+    cwd: str = "~/"
+    # Defaults to the backend's most permissive mode at bootstrap (an
+    # assistant that prompts for every action is unusable as a chat).
+    permission_mode: str | None = None
+
+
 class Settings(BaseModel):
     host: str = "127.0.0.1"
     port: int = 8787
@@ -97,6 +122,10 @@ class Settings(BaseModel):
     # surfaces N visible bubbles regardless of how many raw events the
     # backend emitted per message.
     chat_page_messages: int = Field(default=20, ge=1, le=200)
+    # Personal-assistant singleton. ``None`` (the default) means no
+    # assistant is created. A present block is enabled unless it sets
+    # ``enabled: false``.
+    assistant: AssistantConfig | None = None
 
     @field_validator("plugin_configs", mode="before")
     @classmethod
@@ -133,6 +162,16 @@ class Settings(BaseModel):
         if cfg is not None:
             return cfg
         return get_registry().get(plugin_id).config_schema()
+
+    def assistant_backend(self) -> str | None:
+        """Effective backend id for the assistant, or ``None`` when disabled.
+
+        Falls back to ``default_backend`` when the assistant block omits an
+        explicit ``backend``.
+        """
+        if self.assistant is None or not self.assistant.enabled:
+            return None
+        return self.assistant.backend or self.default_backend
 
     def ensure_dirs(self) -> None:
         self.data_dir.mkdir(parents=True, exist_ok=True)

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -84,11 +84,9 @@ class AssistantConfig(BaseModel):
     backend: BackendId | None = None
     model: str | None = None
     effort: str | None = None
-    # Home by default so the assistant can answer host-environment
-    # questions; cwd is not required to be a repo.
-    cwd: str = "~/"
-    # Defaults to the backend's most permissive mode at bootstrap (an
-    # assistant that prompts for every action is unusable as a chat).
+    # Permission mode passed through to the backend. ``None`` lets the
+    # backend pick its default (which usually prompts for approvals — set an
+    # autonomous mode here for an unattended assistant).
     permission_mode: str | None = None
 
 

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -46,6 +46,9 @@ class _StubPlugin:
     async def terminate_session(self, runtime: Any, session: Any) -> None:
         return None
 
+    def native_thread_id(self, session: Any) -> str | None:
+        return None
+
     def on_session_deleted(self, runtime: Any, session: Any) -> None:
         return None
 

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from waypoint.client import WaypointClient, WaypointError, cli_token_path
+from waypoint.settings import Settings
+
+VALID_TOKEN = "valid-token"
+
+
+def _settings(tmp_path: Path) -> Settings:
+    settings = Settings(data_dir=tmp_path / "data", password="hunter2")
+    settings.ensure_dirs()
+    return settings
+
+
+def _make_handler(state: dict) -> "httpx.MockTransport":
+    state.setdefault("logins", 0)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            body = json.loads(request.content)
+            if body.get("password") != "hunter2":
+                return httpx.Response(401, json={"detail": "invalid password"})
+            state["logins"] += 1
+            return httpx.Response(200, json={"token": VALID_TOKEN, "expires_at": "x"})
+        if request.headers.get("Authorization") != f"Bearer {VALID_TOKEN}":
+            return httpx.Response(401, json={"detail": "invalid token"})
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            return httpx.Response(200, json={"sessions": [{"id": "s1"}]})
+        if request.url.path == "/api/sessions" and request.method == "POST":
+            payload = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "new", **payload}})
+        if request.url.path == "/api/sessions/s1/input":
+            return httpx.Response(200, json={"session": {"id": "s1"}})
+        if request.url.path == "/api/sessions/missing":
+            return httpx.Response(404, json={"detail": "session not found"})
+        return httpx.Response(200, json={"session": {"id": "ok"}})
+
+    return httpx.MockTransport(handler)
+
+
+def _client(
+    settings: Settings, state: dict, *, token: str | None = None
+) -> WaypointClient:
+    http = httpx.Client(transport=_make_handler(state), base_url="http://test")
+    return WaypointClient(settings, token=token, client=http)
+
+
+def test_uses_explicit_env_token_without_login(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        assert client.list_sessions() == [{"id": "s1"}]
+    assert state["logins"] == 0
+
+
+def test_reads_cached_token_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WAYPOINT_TOKEN", raising=False)
+    settings = _settings(tmp_path)
+    cli_token_path(settings).write_text(VALID_TOKEN, encoding="utf-8")
+    state: dict = {}
+    with _client(settings, state) as client:
+        assert client.list_sessions() == [{"id": "s1"}]
+    assert state["logins"] == 0
+
+
+def test_logs_in_with_password_and_caches_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WAYPOINT_TOKEN", raising=False)
+    monkeypatch.delenv("WAYPOINT_PASSWORD", raising=False)
+    settings = _settings(tmp_path)
+    state: dict = {}
+    with _client(settings, state) as client:
+        assert client.list_sessions() == [{"id": "s1"}]
+    assert state["logins"] == 1
+    cached = cli_token_path(settings)
+    assert cached.read_text(encoding="utf-8").strip() == VALID_TOKEN
+    assert oct(cached.stat().st_mode)[-3:] == "600"
+
+
+def test_stale_token_triggers_relogin_and_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WAYPOINT_TOKEN", raising=False)
+    monkeypatch.delenv("WAYPOINT_PASSWORD", raising=False)
+    settings = _settings(tmp_path)
+    state: dict = {}
+    with _client(settings, state, token="stale") as client:
+        assert client.list_sessions() == [{"id": "s1"}]
+    assert state["logins"] == 1
+
+
+def test_create_session_posts_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        session = client.create_session(backend="codex", cwd="/tmp", model="gpt-5")
+    assert session["backend"] == "codex"
+    assert session["model"] == "gpt-5"
+
+
+def test_error_response_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        with pytest.raises(WaypointError):
+            client.get_session("missing")

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -145,6 +145,101 @@ def test_load_settings_parses_plugin_configs(
     assert [model.id for model in claude_config.models] == ["opus"]
 
 
+def test_assistant_defaults_to_none_when_block_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text("default_backend: codex\n", encoding="utf-8")
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    settings = load_settings()
+    assert settings.assistant is None
+    assert settings.assistant_backend() is None
+
+
+def test_assistant_block_enables_and_resolves_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text(
+        "\n".join(
+            [
+                "default_backend: codex",
+                "assistant:",
+                "  model: opus",
+                "  effort: high",
+                "  permission_mode: bypassPermissions",
+                "  backend: claude_code",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    settings = load_settings()
+    assert settings.assistant is not None
+    assert settings.assistant.enabled is True
+    assert settings.assistant_backend() == "claude_code"
+
+
+def test_assistant_backend_falls_back_to_default_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text(
+        "default_backend: claude_code\nassistant:\n  model: opus\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    settings = load_settings()
+    assert settings.assistant_backend() == "claude_code"
+
+
+def test_assistant_disabled_block_resolves_to_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text(
+        "default_backend: codex\nassistant:\n  enabled: false\n  backend: claude_code\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    settings = load_settings()
+    assert settings.assistant is not None
+    assert settings.assistant.enabled is False
+    assert settings.assistant_backend() is None
+
+
+def test_assistant_rejects_unknown_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text(
+        "assistant:\n  backend: not_a_backend\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    with pytest.raises(ValidationError):
+        load_settings()
+
+
+def test_assistant_rejects_unknown_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text(
+        "assistant:\n  bogus: 1\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    with pytest.raises(ValidationError):
+        load_settings()
+
+
 def test_load_settings_rejects_unknown_plugin_id(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -30,7 +30,7 @@ from waypoint.schemas import (
     SessionSource,
     SessionStatus,
 )
-from waypoint.settings import Settings
+from waypoint.settings import AssistantConfig, Settings
 from waypoint.storage import Storage
 
 
@@ -3182,3 +3182,183 @@ async def test_refresh_rate_limit_usage_runs_probe_inline_for_codex(
 
     assert fake.register_rate_limit_calls == [session.id]
     assert fake.force_refresh_rate_limit_calls == [session.id]
+
+
+def _make_assistant_row(storage, settings, *, session_id, backend, status, transport):
+    session = make_session(
+        settings,
+        id=session_id,
+        backend=backend,
+        transport=transport,
+        status=status,
+    )
+    storage.create_session(session)
+    return storage.update_session(
+        session_id, source=SessionSource.ASSISTANT, pinned_at=datetime.now(UTC)
+    )
+
+
+@pytest.mark.asyncio
+async def test_assistant_disabled_demotes_existing_rows(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = None
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+    )
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id is None
+    demoted = storage.get_session("codex-assistant")
+    assert demoted is not None
+    assert demoted.source == SessionSource.MANAGED
+    assert demoted.pinned_at is None
+
+
+@pytest.mark.asyncio
+async def test_assistant_reuses_live_matching_session(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+    )
+
+    async def _fail_create(backend: str) -> Any:  # pragma: no cover - must not run
+        raise AssertionError("should not recreate a live assistant")
+
+    runtime._create_assistant_session = _fail_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "codex-assistant"
+    kept = storage.get_session("codex-assistant")
+    assert kept is not None
+    assert kept.source == SessionSource.ASSISTANT
+
+
+@pytest.mark.asyncio
+async def test_assistant_recreates_when_backend_changes(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="claude_code")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+    )
+
+    async def _fake_create(backend: str) -> SessionRecord:
+        assert backend == "claude_code"
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="claude-assistant",
+            backend="claude_code",
+            status=SessionStatus.STARTING,
+            transport="claude_cli",
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "claude-assistant"
+    old = storage.get_session("codex-assistant")
+    assert old is not None
+    assert old.source == SessionSource.MANAGED
+
+
+@pytest.mark.asyncio
+async def test_assistant_recreates_when_prior_thread_exited(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-dead",
+        backend="codex",
+        status=SessionStatus.EXITED,
+        transport="codex_app_server",
+    )
+
+    async def _fake_create(backend: str) -> SessionRecord:
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="codex-fresh",
+            backend="codex",
+            status=SessionStatus.STARTING,
+            transport="codex_app_server",
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "codex-fresh"
+    dead = storage.get_session("codex-dead")
+    assert dead is not None
+    assert dead.source == SessionSource.MANAGED
+
+
+@pytest.mark.asyncio
+async def test_delete_and_terminate_protect_assistant(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+    )
+
+    with pytest.raises(HTTPException) as delete_exc:
+        await runtime.delete("codex-assistant")
+    assert delete_exc.value.status_code == 403
+
+    with pytest.raises(HTTPException) as terminate_exc:
+        await runtime.terminate("codex-assistant")
+    assert terminate_exc.value.status_code == 403
+
+    assert storage.get_session("codex-assistant") is not None
+
+
+@pytest.mark.asyncio
+async def test_assistant_summary_reports_native_thread_id(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+    )
+    runtime.assistant_session_id = "codex-assistant"
+
+    summary = runtime.assistant_summary()
+
+    assert summary is not None
+    assert summary.session_id == "codex-assistant"
+    assert summary.backend == "codex"
+    assert summary.native_thread_id == "thread-1"
+    assert summary.status == SessionStatus.IDLE
+
+
+def test_assistant_summary_is_none_when_untracked(tmp_path) -> None:
+    runtime, _, _ = make_runtime(tmp_path)
+    assert runtime.assistant_session_id is None
+    assert runtime.assistant_summary() is None

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3362,3 +3362,14 @@ def test_assistant_summary_is_none_when_untracked(tmp_path) -> None:
     runtime, _, _ = make_runtime(tmp_path)
     assert runtime.assistant_session_id is None
     assert runtime.assistant_summary() is None
+
+
+def test_prepare_assistant_workspace_writes_charter_files(tmp_path) -> None:
+    runtime, _, settings = make_runtime(tmp_path)
+    workspace = runtime._prepare_assistant_workspace()
+    workspace_path = Path(workspace)
+    assert workspace_path == settings.data_dir / "assistant"
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        text = (workspace_path / name).read_text(encoding="utf-8")
+        assert "Waypoint personal assistant" in text
+        assert "waypoint sessions list" in text

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3184,7 +3184,9 @@ async def test_refresh_rate_limit_usage_runs_probe_inline_for_codex(
     assert fake.force_refresh_rate_limit_calls == [session.id]
 
 
-def _make_assistant_row(storage, settings, *, session_id, backend, status, transport):
+def _make_assistant_row(
+    storage, settings, *, session_id, backend, status, transport, cwd=None
+):
     session = make_session(
         settings,
         id=session_id,
@@ -3193,9 +3195,13 @@ def _make_assistant_row(storage, settings, *, session_id, backend, status, trans
         status=status,
     )
     storage.create_session(session)
-    return storage.update_session(
-        session_id, source=SessionSource.ASSISTANT, pinned_at=datetime.now(UTC)
-    )
+    updates: dict[str, Any] = {
+        "source": SessionSource.ASSISTANT,
+        "pinned_at": datetime.now(UTC),
+    }
+    if cwd is not None:
+        updates["cwd"] = cwd
+    return storage.update_session(session_id, **updates)
 
 
 @pytest.mark.asyncio
@@ -3231,6 +3237,7 @@ async def test_assistant_reuses_live_matching_session(tmp_path) -> None:
         backend="codex",
         status=SessionStatus.IDLE,
         transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
     )
 
     async def _fail_create(backend: str) -> Any:  # pragma: no cover - must not run
@@ -3373,3 +3380,40 @@ def test_prepare_assistant_workspace_writes_charter_files(tmp_path) -> None:
         text = (workspace_path / name).read_text(encoding="utf-8")
         assert "Waypoint personal assistant" in text
         assert "waypoint sessions list" in text
+
+
+@pytest.mark.asyncio
+async def test_assistant_recreates_when_cwd_is_not_workspace(tmp_path) -> None:
+    # A live, backend-matching assistant from an older build (cwd not the
+    # managed workspace) is migrated: demoted and recreated fresh.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-legacy",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd="/home/someone",
+    )
+
+    async def _fake_create(backend: str) -> SessionRecord:
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="codex-fresh",
+            backend="codex",
+            status=SessionStatus.STARTING,
+            transport="codex_app_server",
+            cwd=str(runtime._assistant_workspace_dir()),
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "codex-fresh"
+    legacy = storage.get_session("codex-legacy")
+    assert legacy is not None
+    assert legacy.source == SessionSource.MANAGED

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -55,8 +55,7 @@ plugin_configs:
 #   backend: claude_code          # defaults to `default_backend`
 #   model: opus                   # must exist in the backend's catalogue
 #   effort: high                  # ignored by backends without an effort knob
-#   cwd: ~/                       # home, so it can inspect the host
-#   permission_mode: bypassPermissions  # defaults to the backend's most permissive mode
+#   permission_mode: bypassPermissions  # backend default (usually prompts) if unset
 
 ssh_targets:
   - id: devbox

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -43,6 +43,21 @@ plugin_configs:
     # cli_args:
     #   - "--max-iterations=50"
 
+# Personal-assistant singleton. Omit this block entirely to disable it.
+# When present (and `enabled` is not false) the runtime keeps a single
+# long-lived session of `backend` alive, reachable from the assistant UI
+# page. It can answer host-environment questions, inspect Waypoint
+# sessions, and manage them via the `waypoint sessions` CLI. `model`,
+# `effort`, and `permission_mode` seed the thread; the UI can override
+# them live. Switching `backend` replaces the thread on next restart.
+# assistant:
+#   enabled: true
+#   backend: claude_code          # defaults to `default_backend`
+#   model: opus                   # must exist in the backend's catalogue
+#   effort: high                  # ignored by backends without an effort knob
+#   cwd: ~/                       # home, so it can inspect the host
+#   permission_mode: bypassPermissions  # defaults to the backend's most permissive mode
+
 ssh_targets:
   - id: devbox
     name: SSH coding backend

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -1,0 +1,82 @@
+# Personal assistant
+
+The personal assistant is a single, long-lived conversation thread, separate
+from the coding sessions you launch for tasks. It runs an ordinary coding
+backend but is created and kept alive by the runtime, reachable from a
+dedicated page in the app. Use it to ask about the host machine, to ground
+questions in your running Waypoint sessions, and to spin up or steer those
+sessions on your behalf.
+
+It is not a new backend — it reuses the existing plugin, runtime, storage, and
+streaming machinery. Its only distinguishing traits are a dedicated session
+`source`, deletion/termination protection, and the out-of-band tooling
+described below.
+
+## Enabling it
+
+Add an `assistant` block to `waypoint.yaml` (see `backend/waypoint.example.yaml`):
+
+```yaml
+assistant:
+  enabled: true                       # omit the whole block to disable
+  backend: claude_code                # defaults to `default_backend`
+  model: opus                         # must exist in the backend's catalogue
+  effort: high                        # ignored by backends without an effort knob
+  cwd: ~/                             # home, so it can inspect the host
+  permission_mode: bypassPermissions  # see the security note below
+```
+
+`model`, `effort`, and `permission_mode` seed the thread; they can be changed
+live from the assistant page, so treat them as defaults rather than a lockdown.
+The block is enabled by default when present — set `enabled: false` to keep the
+config but turn the assistant off.
+
+## Lifecycle
+
+- On startup the runtime reuses a still-alive assistant whose backend matches
+  the configured one.
+- If the configured backend changed, or the previous thread exited and cannot
+  be reattached, a fresh thread is created. The previous thread is **demoted to
+  an ordinary session** (its transcript is preserved and it becomes deletable),
+  never destroyed.
+- The assistant cannot be deleted or terminated through the API.
+
+Both the Waypoint session id and the backend-native thread id (e.g. the value
+for `claude --resume`) are surfaced on the assistant page and via `/api/me`, so
+the thread can be recovered outside the app if needed.
+
+## Managing sessions: the `waypoint sessions` CLI
+
+The assistant manages your coding sessions through the `waypoint` CLI, which
+talks to the running server over HTTP (distinct from the in-process `waypoint
+session` commands):
+
+```
+waypoint sessions list
+waypoint sessions show <id>
+waypoint sessions events <id> [--messages N] [--before-sequence S]
+waypoint sessions start --backend <id> --cwd <path> [--model M] [--effort E]
+waypoint sessions send <id> <text>
+waypoint sessions interrupt|terminate <id>
+waypoint sessions approve <id> <decision> [--text T] [--approval-id A]
+```
+
+Output is JSON. The same `WaypointClient` (in `waypoint.client`) backs the CLI
+and can be imported directly.
+
+### Authentication
+
+`waypoint serve` writes a token to `<data_dir>/cli-token` (mode `0600`) on
+startup. The CLI resolves auth in order: the `WAYPOINT_TOKEN` env var, that
+token file, then a password login (`WAYPOINT_PASSWORD` or the configured
+password), caching the result back to the file. On the same host the assistant
+needs no secret — it reads the token file.
+
+## Security
+
+The assistant is high-privilege: it has shell access to the host (to answer
+environment questions) and can create, message, and terminate other agent
+sessions. Run it in an autonomous `permission_mode` so it isn't blocked on
+per-action approvals — but understand the blast radius before exposing the
+service beyond localhost. The `cli-token` file grants full API access,
+equivalent to the password; treat it as a secret.

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -22,7 +22,6 @@ assistant:
   backend: claude_code                # defaults to `default_backend`
   model: opus                         # must exist in the backend's catalogue
   effort: high                        # ignored by backends without an effort knob
-  cwd: ~/                             # home, so it can inspect the host
   permission_mode: bypassPermissions  # see the security note below
 ```
 
@@ -30,6 +29,13 @@ assistant:
 live from the assistant page, so treat them as defaults rather than a lockdown.
 The block is enabled by default when present — set `enabled: false` to keep the
 config but turn the assistant off.
+
+The assistant always runs in a managed working directory (`<data_dir>/assistant`),
+so it has no `cwd` setting. Its charter is written there as `AGENTS.md` /
+`CLAUDE.md` and loaded silently by the backend as project context — there is no
+visible bootstrap message in the transcript. The working directory is only a
+scratch cwd; shell access reaches the whole host, so host inspection is
+unaffected.
 
 ## Lifecycle
 

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -31,10 +31,14 @@ function CopyField({ label, value }: { label: string; value: string }) {
         className="assistant-id-value"
         onClick={copy}
         title={`Copy ${label}`}
+        aria-label={copied ? `${label} copied` : `Copy ${label}`}
         type="button"
       >
         <code>{value}</code>
-        <span className="assistant-id-copy" aria-hidden="true">
+        <span
+          className={`assistant-id-copy${copied ? " is-copied" : ""}`}
+          aria-hidden="true"
+        >
           {copied ? "copied" : "copy"}
         </span>
       </button>
@@ -122,10 +126,11 @@ export default function AssistantPage() {
               <span className="assistant-glyph" aria-hidden="true">
                 ✦
               </span>
-              <div>
+              <div className="assistant-banner-text">
                 <p className="assistant-banner-eyebrow">{assistant.backend}</p>
                 <p className="assistant-banner-note">
-                  One persistent thread. Recover it anytime with the ids below.
+                  One persistent thread. Recover it anytime with the session id
+                  below.
                 </p>
               </div>
               <span className={`assistant-status assistant-status-${assistant.status}`}>
@@ -173,13 +178,17 @@ export default function AssistantPage() {
       ) : null}
 
       {state === "loading" ? (
-        <section className="panel bordered assistant-empty">
+        <section className="panel bordered assistant-loading" aria-busy="true">
+          <span className="assistant-spinner" aria-hidden="true" />
           <p className="muted">Loading assistant…</p>
         </section>
       ) : null}
 
       {state === "error" ? (
         <section className="panel bordered assistant-empty">
+          <span className="assistant-glyph assistant-glyph-lg" aria-hidden="true">
+            ✦
+          </span>
           <h2>Couldn’t load the assistant</h2>
           <p className="muted">
             The backend didn’t respond. Check that Waypoint is running, then{" "}

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+
+import { SessionDetail } from "@/components/SessionDetail";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { fetchMe, isAuthError } from "@/lib/api";
+import { clearToken, readHost, readToken } from "@/lib/store";
+import { useTheme } from "@/lib/theme";
+import { AssistantSummary } from "@/lib/types";
+
+type LoadState = "loading" | "ready" | "disabled" | "error";
+
+function CopyField({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = useCallback(() => {
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1400);
+    });
+  }, [value]);
+  return (
+    <div className="assistant-id">
+      <span className="assistant-id-label">{label}</span>
+      <button
+        className="assistant-id-value"
+        onClick={copy}
+        title={`Copy ${label}`}
+        type="button"
+      >
+        <code>{value}</code>
+        <span className="assistant-id-copy" aria-hidden="true">
+          {copied ? "copied" : "copy"}
+        </span>
+      </button>
+    </div>
+  );
+}
+
+export default function AssistantPage() {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const [host, setHost] = useState("");
+  const [token, setToken] = useState("");
+  const [assistant, setAssistant] = useState<AssistantSummary | null>(null);
+  const [state, setState] = useState<LoadState>("loading");
+
+  const handleAuthFailure = useCallback(() => {
+    clearToken();
+    setToken("");
+    router.replace("/");
+  }, [router]);
+
+  useEffect(() => {
+    const currentHost = readHost();
+    const currentToken = readToken();
+    setHost(currentHost);
+    setToken(currentToken);
+    if (!currentHost || !currentToken) {
+      router.replace("/");
+      return;
+    }
+    let active = true;
+    fetchMe(currentHost, currentToken)
+      .then((me) => {
+        if (!active) return;
+        if (me.assistant) {
+          setAssistant(me.assistant);
+          setState("ready");
+        } else {
+          setState("disabled");
+        }
+      })
+      .catch((err) => {
+        if (!active) return;
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return;
+        }
+        setState("error");
+      });
+    return () => {
+      active = false;
+    };
+  }, [router, handleAuthFailure]);
+
+  return (
+    <main className="page-shell has-composer">
+      <header className="app-bar">
+        <div className="app-bar-brand">
+          <Link className="app-bar-mark" href="/" aria-label="Waypoint home">
+            <Image
+              src={theme === "light" ? "/waypoint-light.svg" : "/waypoint.svg"}
+              alt=""
+              width={38}
+              height={38}
+              priority
+            />
+          </Link>
+          <div className="app-bar-titles">
+            <p className="app-bar-eyebrow">Waypoint · assistant</p>
+            <h1 className="app-bar-title">Personal assistant</h1>
+          </div>
+        </div>
+        <div className="app-bar-meta">
+          <Link className="back-link" href="/">
+            ← all sessions
+          </Link>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      {state === "ready" && assistant ? (
+        <>
+          <section className="assistant-banner" aria-label="Assistant thread details">
+            <div className="assistant-banner-lead">
+              <span className="assistant-glyph" aria-hidden="true">
+                ✦
+              </span>
+              <div>
+                <p className="assistant-banner-eyebrow">{assistant.backend}</p>
+                <p className="assistant-banner-note">
+                  One persistent thread. Recover it anytime with the ids below.
+                </p>
+              </div>
+              <span className={`assistant-status assistant-status-${assistant.status}`}>
+                {assistant.status.replace("_", " ")}
+              </span>
+            </div>
+            <div className="assistant-ids">
+              <CopyField label="session id" value={assistant.session_id} />
+              {assistant.native_thread_id ? (
+                <CopyField label="thread id" value={assistant.native_thread_id} />
+              ) : null}
+            </div>
+          </section>
+          {host && token ? (
+            <SessionDetail
+              host={host}
+              token={token}
+              sessionId={assistant.session_id}
+              onAuthFailure={handleAuthFailure}
+            />
+          ) : null}
+        </>
+      ) : null}
+
+      {state === "disabled" ? (
+        <section className="panel bordered assistant-empty">
+          <span className="assistant-glyph assistant-glyph-lg" aria-hidden="true">
+            ✦
+          </span>
+          <h2>No assistant configured</h2>
+          <p className="muted">
+            Add an <code>assistant</code> block to <code>waypoint.yaml</code> and
+            restart the backend to bring up your personal assistant.
+          </p>
+          <pre className="assistant-snippet">
+            <code>{`assistant:
+  backend: claude_code
+  model: opus
+  permission_mode: bypassPermissions`}</code>
+          </pre>
+        </section>
+      ) : null}
+
+      {state === "loading" ? (
+        <section className="panel bordered assistant-empty">
+          <p className="muted">Loading assistant…</p>
+        </section>
+      ) : null}
+
+      {state === "error" ? (
+        <section className="panel bordered assistant-empty">
+          <h2>Couldn’t load the assistant</h2>
+          <p className="muted">
+            The backend didn’t respond. Check that Waypoint is running, then{" "}
+            <Link className="back-link" href="/assistant">
+              retry
+            </Link>
+            .
+          </p>
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -131,9 +131,15 @@ export default function AssistantPage() {
               </span>
             </div>
             <div className="assistant-ids">
-              <CopyField label="session id" value={assistant.session_id} />
+              {/* Lead with the backend's own session/thread id (the one you'd
+                  pass to `claude --resume` etc.); keep the Waypoint id for the
+                  CLI and URL. */}
+              <CopyField
+                label="session id"
+                value={assistant.native_thread_id ?? assistant.session_id}
+              />
               {assistant.native_thread_id ? (
-                <CopyField label="thread id" value={assistant.native_thread_id} />
+                <CopyField label="waypoint id" value={assistant.session_id} />
               ) : null}
             </div>
           </section>

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -8,12 +8,23 @@ import { useCallback, useEffect, useState } from "react";
 import { SessionDetail } from "@/components/SessionDetail";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { fetchMe, isAuthError } from "@/lib/api";
+import { humaniseBackend } from "@/lib/backends";
 import { copyText } from "@/lib/clipboard";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
-import { AssistantSummary } from "@/lib/types";
+import { AssistantSummary, SessionStatus } from "@/lib/types";
 
 type LoadState = "loading" | "ready" | "disabled" | "error";
+
+const STATUS_LABELS: Record<SessionStatus, string> = {
+  starting: "Starting…",
+  idle: "Ready",
+  waiting_input: "Waiting on you",
+  running: "Working…",
+  interrupted: "Interrupted",
+  exited: "Stopped",
+  error: "Error",
+};
 
 function CopyField({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
@@ -60,16 +71,17 @@ export default function AssistantPage() {
     router.replace("/");
   }, [router]);
 
-  useEffect(() => {
+  const load = useCallback(() => {
     const currentHost = readHost();
     const currentToken = readToken();
     setHost(currentHost);
     setToken(currentToken);
     if (!currentHost || !currentToken) {
       router.replace("/");
-      return;
+      return () => {};
     }
     let active = true;
+    setState("loading");
     fetchMe(currentHost, currentToken)
       .then((me) => {
         if (!active) return;
@@ -92,6 +104,8 @@ export default function AssistantPage() {
       active = false;
     };
   }, [router, handleAuthFailure]);
+
+  useEffect(() => load(), [load]);
 
   return (
     <main className="page-shell has-composer">
@@ -121,26 +135,30 @@ export default function AssistantPage() {
 
       {state === "ready" && assistant ? (
         <>
-          <section className="assistant-banner" aria-label="Assistant thread details">
+          <section className="assistant-banner" aria-label="Assistant details">
             <div className="assistant-banner-lead">
               <span className="assistant-glyph" aria-hidden="true">
                 ✦
               </span>
               <div className="assistant-banner-text">
-                <p className="assistant-banner-eyebrow">{assistant.backend}</p>
+                <p className="assistant-banner-eyebrow">
+                  {humaniseBackend(assistant.backend)}
+                </p>
                 <p className="assistant-banner-note">
-                  One persistent thread. Recover it anytime with the session id
-                  below.
+                  Your persistent assistant — ask about this host or your running
+                  sessions.
                 </p>
               </div>
-              <span className={`assistant-status assistant-status-${assistant.status}`}>
-                {assistant.status.replace("_", " ")}
+              <span
+                className={`assistant-status assistant-status-${assistant.status}`}
+              >
+                {STATUS_LABELS[assistant.status] ?? assistant.status}
               </span>
             </div>
-            <div className="assistant-ids">
-              {/* The backend's own session/thread id (the one you'd pass to
-                  `claude --resume` etc.), falling back to the Waypoint id only
-                  when the backend exposes none. */}
+            {/* The backend's own session/thread id (for `claude --resume` and
+                the like) is a recovery fallback, not headline info — keep it as
+                a quiet footnote. */}
+            <div className="assistant-banner-foot">
               <CopyField
                 label="session id"
                 value={assistant.native_thread_id ?? assistant.session_id}
@@ -153,6 +171,7 @@ export default function AssistantPage() {
               token={token}
               sessionId={assistant.session_id}
               onAuthFailure={handleAuthFailure}
+              assistant
             />
           ) : null}
         </>
@@ -165,15 +184,19 @@ export default function AssistantPage() {
           </span>
           <h2>No assistant configured</h2>
           <p className="muted">
-            Add an <code>assistant</code> block to <code>waypoint.yaml</code> and
-            restart the backend to bring up your personal assistant.
+            Your assistant isn’t set up yet. On the host, add an{" "}
+            <code>assistant</code> block to <code>waypoint.yaml</code> and restart
+            the backend.
           </p>
-          <pre className="assistant-snippet">
-            <code>{`assistant:
+          <details className="assistant-snippet-details">
+            <summary>Show config example</summary>
+            <pre className="assistant-snippet">
+              <code>{`assistant:
   backend: claude_code
   model: opus
   permission_mode: bypassPermissions`}</code>
-          </pre>
+            </pre>
+          </details>
         </section>
       ) : null}
 
@@ -191,12 +214,12 @@ export default function AssistantPage() {
           </span>
           <h2>Couldn’t load the assistant</h2>
           <p className="muted">
-            The backend didn’t respond. Check that Waypoint is running, then{" "}
-            <Link className="back-link" href="/assistant">
-              retry
-            </Link>
-            .
+            The backend didn’t respond. Check that Waypoint is running, then
+            retry.
           </p>
+          <button type="button" className="primary" onClick={() => load()}>
+            Retry
+          </button>
         </section>
       ) : null}
     </main>

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useState } from "react";
 import { SessionDetail } from "@/components/SessionDetail";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { fetchMe, isAuthError } from "@/lib/api";
+import { copyText } from "@/lib/clipboard";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
 import { AssistantSummary } from "@/lib/types";
@@ -17,7 +18,8 @@ type LoadState = "loading" | "ready" | "disabled" | "error";
 function CopyField({ label, value }: { label: string; value: string }) {
   const [copied, setCopied] = useState(false);
   const copy = useCallback(() => {
-    void navigator.clipboard?.writeText(value).then(() => {
+    void copyText(value).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       window.setTimeout(() => setCopied(false), 1400);
     });

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -133,16 +133,13 @@ export default function AssistantPage() {
               </span>
             </div>
             <div className="assistant-ids">
-              {/* Lead with the backend's own session/thread id (the one you'd
-                  pass to `claude --resume` etc.); keep the Waypoint id for the
-                  CLI and URL. */}
+              {/* The backend's own session/thread id (the one you'd pass to
+                  `claude --resume` etc.), falling back to the Waypoint id only
+                  when the backend exposes none. */}
               <CopyField
                 label="session id"
                 value={assistant.native_thread_id ?? assistant.session_id}
               />
-              {assistant.native_thread_id ? (
-                <CopyField label="waypoint id" value={assistant.session_id} />
-              ) : null}
             </div>
           </section>
           {host && token ? (

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8729,10 +8729,34 @@ html[data-theme="light"]
   }
 }
 
-.assistant-ids {
-  display: flex;
-  flex-wrap: wrap;
+/* Quiet footnote row carrying the recovery id below a hairline — secondary
+   to the lead, not the banner's headline. */
+.assistant-banner-foot {
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.assistant-banner-foot .assistant-id {
+  flex-direction: row;
+  align-items: center;
   gap: 10px;
+}
+
+.assistant-banner-foot .assistant-id-label {
+  flex: none;
+}
+
+.assistant-banner-foot .assistant-id-value {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px 5px 10px;
+  background: transparent;
+  border-color: color-mix(in srgb, var(--line) 75%, transparent);
+}
+
+.assistant-banner-foot .assistant-id-value code {
+  font-size: 0.74rem;
+  color: var(--muted);
 }
 
 .assistant-id {
@@ -8900,4 +8924,99 @@ html[data-theme="light"]
   .assistant-spinner {
     animation: none;
   }
+}
+
+/* Assistant empty-thread zero-state — leads with capabilities + tappable
+   example prompts so the assistant's value props aren't invisible. */
+.assistant-welcome {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  padding: 40px 20px 48px;
+}
+
+.assistant-welcome-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: 15px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 20%, transparent),
+    0 0 0 8px color-mix(in srgb, var(--accent) 7%, transparent);
+  color: var(--accent-strong);
+  font-size: 1.45rem;
+}
+
+.assistant-welcome-title {
+  margin: 6px 0 0;
+  font-family: var(--font-display);
+  font-size: 1.18rem;
+  color: var(--text-strong);
+}
+
+.assistant-welcome-sub {
+  margin: 0;
+  max-width: 46ch;
+  color: var(--muted-soft);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+.assistant-welcome-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.assistant-welcome-prompt {
+  padding: 9px 15px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line);
+  background: var(--bg-card-soft);
+  color: var(--text);
+  font-size: 0.83rem;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease,
+    transform 0.16s ease;
+}
+
+.assistant-welcome-prompt:hover {
+  border-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, var(--bg-card-soft));
+  transform: translateY(-1px);
+}
+
+.assistant-welcome-prompt:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+/* Config example is a power-user fallback on the disabled state — tuck it
+   behind a disclosure rather than front-loading YAML on a phone. */
+.assistant-snippet-details {
+  width: 100%;
+  max-width: 440px;
+}
+
+.assistant-snippet-details > summary {
+  cursor: pointer;
+  font-size: 0.82rem;
+  color: var(--accent-strong);
+  margin-bottom: 10px;
+}
+
+.assistant-snippet-details .assistant-snippet {
+  margin-top: 0;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8513,7 +8513,12 @@ html[data-theme="light"]
   padding: 12px 18px;
   border-radius: var(--radius-pill);
   border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
-  background: var(--bg-card);
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent) 12%, var(--bg-card)),
+      var(--bg-card)
+    );
   color: var(--accent-strong);
   font-family: var(--font-mono);
   font-size: 0.78rem;
@@ -8522,18 +8527,50 @@ html[data-theme="light"]
   text-decoration: none;
   box-shadow: var(--shadow);
   backdrop-filter: blur(8px);
-  transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease;
+  transition:
+    transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1),
+    border-color 0.16s ease,
+    background 0.16s ease,
+    box-shadow 0.16s ease;
 }
 
 .assistant-fab:hover {
   transform: translateY(-2px);
-  background: color-mix(in srgb, var(--accent) 14%, var(--bg-card));
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-card));
   border-color: var(--accent);
+  box-shadow:
+    var(--shadow),
+    0 0 0 1px color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+.assistant-fab:active {
+  transform: translateY(0);
 }
 
 .assistant-fab-glyph {
   font-size: 1.05rem;
   line-height: 1;
+  /* A slow, low-key shimmer signals the assistant is "alive" without
+     drawing the eye away from the primary session deck. */
+  animation: assistant-glyph-shimmer 4.2s ease-in-out infinite;
+}
+
+@keyframes assistant-glyph-shimmer {
+  0%,
+  100% {
+    opacity: 0.78;
+    transform: scale(1) rotate(0deg);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.12) rotate(18deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-fab-glyph {
+    animation: none;
+  }
 }
 
 @media (max-width: 640px) {
@@ -8552,53 +8589,87 @@ html[data-theme="light"]
 }
 
 .assistant-banner {
+  position: relative;
   display: flex;
   flex-direction: column;
-  gap: 14px;
-  padding: 16px 18px;
-  background: var(--bg-card);
+  gap: 16px;
+  padding: 18px 20px;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--accent) 7%, var(--bg-card)),
+      var(--bg-card) 55%
+    );
   border: 1px solid var(--line);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
+  overflow: hidden;
+}
+
+/* A thin accent rail along the top edge marks this as the assistant's own
+   surface and ties it to the gold accent without competing with content. */
+.assistant-banner::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--accent) 70%, transparent) 30%,
+    color-mix(in srgb, var(--accent-cool) 60%, transparent) 75%,
+    transparent
+  );
+  opacity: 0.7;
 }
 
 .assistant-banner-lead {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
 }
 
 .assistant-glyph {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 34px;
-  height: 34px;
+  width: 36px;
+  height: 36px;
   flex: none;
   border-radius: 11px;
   background: color-mix(in srgb, var(--accent) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
   color: var(--accent-strong);
   font-size: 1.1rem;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+.assistant-banner-text {
+  min-width: 0;
 }
 
 .assistant-banner-eyebrow {
   margin: 0;
-  font-family: var(--font-mono);
-  font-size: 0.92rem;
+  font-family: var(--font-display);
+  font-size: 1.04rem;
   color: var(--text-strong);
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
 .assistant-banner-note {
-  margin: 2px 0 0;
+  margin: 3px 0 0;
   color: var(--muted-soft);
   font-size: 0.82rem;
+  line-height: 1.4;
 }
 
 .assistant-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   margin-left: auto;
   align-self: flex-start;
-  padding: 4px 11px;
+  padding: 4px 12px;
   border-radius: var(--radius-pill);
   border: 1px solid var(--line);
   font-family: var(--font-mono);
@@ -8606,12 +8677,29 @@ html[data-theme="light"]
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--muted);
+  white-space: nowrap;
+}
+
+.assistant-status::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
 }
 
 .assistant-status-running,
 .assistant-status-starting {
   color: var(--accent-cool);
   border-color: color-mix(in srgb, var(--accent-cool) 45%, var(--line));
+}
+
+.assistant-status-running::before,
+.assistant-status-starting::before {
+  animation: pulse-running 1.8s ease-in-out infinite;
+  background: var(--accent-cool);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent-cool) 50%, transparent);
 }
 
 .assistant-status-idle {
@@ -8625,9 +8713,20 @@ html[data-theme="light"]
   border-color: color-mix(in srgb, var(--warn) 45%, var(--line));
 }
 
+.assistant-status-waiting_input::before,
+.assistant-status-interrupted::before {
+  animation: pulse-warn 1.8s ease-in-out infinite;
+}
+
 .assistant-status-error {
   color: var(--danger);
   border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-status::before {
+    animation: none !important;
+  }
 }
 
 .assistant-ids {
@@ -8639,8 +8738,9 @@ html[data-theme="light"]
 .assistant-id {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   min-width: 0;
+  flex: 1;
 }
 
 .assistant-id-label {
@@ -8654,18 +8754,28 @@ html[data-theme="light"]
 .assistant-id-value {
   display: inline-flex;
   align-items: center;
+  justify-content: space-between;
   gap: 10px;
   max-width: 100%;
-  padding: 6px 10px;
+  padding: 8px 10px 8px 12px;
   background: var(--bg-card-soft);
   border: 1px solid var(--line);
   border-radius: 10px;
   cursor: pointer;
-  transition: border-color 0.18s ease;
+  transition:
+    border-color 0.18s ease,
+    background 0.18s ease;
 }
 
 .assistant-id-value:hover {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-card-soft));
+}
+
+.assistant-id-value:focus-visible {
+  outline: none;
   border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 .assistant-id-value code {
@@ -8679,52 +8789,115 @@ html[data-theme="light"]
 
 .assistant-id-copy {
   flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   font-family: var(--font-mono);
   font-size: 0.62rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--accent-strong);
+  transition: color 0.18s ease;
+}
+
+/* Leading caret marks the chip as the copy affordance; flips to a check
+   on success, swapping to the success token for an unmistakable cue. */
+.assistant-id-copy::before {
+  content: "⧉";
+  font-size: 0.82rem;
+  line-height: 1;
+}
+
+.assistant-id-copy.is-copied {
+  color: var(--success);
+}
+
+.assistant-id-copy.is-copied::before {
+  content: "✓";
 }
 
 .assistant-empty {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   text-align: center;
-  padding: 40px 24px;
+  padding: 48px 24px;
 }
 
 .assistant-empty h2 {
   margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.22rem;
+  color: var(--text-strong);
 }
 
 .assistant-empty .muted {
   max-width: 46ch;
+  line-height: 1.5;
 }
 
 .assistant-glyph-lg {
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
-  font-size: 1.7rem;
+  width: 56px;
+  height: 56px;
+  border-radius: 18px;
+  font-size: 1.8rem;
+  /* Soft accent halo grounds the empty/disabled state and echoes the
+     page's radial atmosphere. */
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--accent) 20%, transparent),
+    0 0 0 8px color-mix(in srgb, var(--accent) 8%, transparent);
 }
 
 .assistant-snippet {
   width: 100%;
-  max-width: 420px;
-  margin: 4px 0 0;
-  padding: 14px 16px;
+  max-width: 440px;
+  margin: 6px 0 0;
+  padding: 16px 18px;
   text-align: left;
-  background: var(--bg-card-soft);
+  background: var(--bg-input);
   border: 1px solid var(--line);
   border-radius: 12px;
   overflow-x: auto;
+  box-shadow: var(--shadow-soft);
 }
 
 .assistant-snippet code {
   font-family: var(--font-mono);
   font-size: 0.8rem;
+  line-height: 1.6;
   color: var(--text);
   white-space: pre;
+}
+
+/* Loading state — a calm spinner in the accent tone, matching the
+   page's other in-flight indicators. */
+.assistant-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 56px 24px;
+  color: var(--muted);
+}
+
+.assistant-spinner {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--accent) 22%, var(--line));
+  border-top-color: var(--accent-strong);
+  animation: assistant-spin 0.8s linear infinite;
+}
+
+@keyframes assistant-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .assistant-spinner {
+    animation: none;
+  }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8498,3 +8498,203 @@ html[data-theme="light"]
     display: none;
   }
 }
+
+/* ─── Personal assistant ─── */
+.assistant-nav-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+
+.assistant-nav-link:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: var(--accent);
+}
+
+.assistant-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.assistant-banner-lead {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.assistant-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  flex: none;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent-strong);
+  font-size: 1.1rem;
+}
+
+.assistant-banner-eyebrow {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  color: var(--text-strong);
+  letter-spacing: 0.02em;
+}
+
+.assistant-banner-note {
+  margin: 2px 0 0;
+  color: var(--muted-soft);
+  font-size: 0.82rem;
+}
+
+.assistant-status {
+  margin-left: auto;
+  align-self: flex-start;
+  padding: 4px 11px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.assistant-status-running,
+.assistant-status-starting {
+  color: var(--accent-cool);
+  border-color: color-mix(in srgb, var(--accent-cool) 45%, var(--line));
+}
+
+.assistant-status-idle {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 45%, var(--line));
+}
+
+.assistant-status-waiting_input,
+.assistant-status-interrupted {
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 45%, var(--line));
+}
+
+.assistant-status-error {
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
+}
+
+.assistant-ids {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.assistant-id {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.assistant-id-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.assistant-id-value {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 100%;
+  padding: 6px 10px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  cursor: pointer;
+  transition: border-color 0.18s ease;
+}
+
+.assistant-id-value:hover {
+  border-color: var(--accent);
+}
+
+.assistant-id-value code {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.assistant-id-copy {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.assistant-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  padding: 40px 24px;
+}
+
+.assistant-empty h2 {
+  margin: 0;
+}
+
+.assistant-empty .muted {
+  max-width: 46ch;
+}
+
+.assistant-glyph-lg {
+  width: 52px;
+  height: 52px;
+  border-radius: 16px;
+  font-size: 1.7rem;
+}
+
+.assistant-snippet {
+  width: 100%;
+  max-width: 420px;
+  margin: 4px 0 0;
+  padding: 14px 16px;
+  text-align: left;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  overflow-x: auto;
+}
+
+.assistant-snippet code {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text);
+  white-space: pre;
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8500,25 +8500,55 @@ html[data-theme="light"]
 }
 
 /* ─── Personal assistant ─── */
-.assistant-nav-link {
+/* Floating action button, fixed to the bottom-right of the home page for
+   one-tap access. Collapses to a circular glyph on narrow/touch viewports. */
+.assistant-fab {
+  position: fixed;
+  right: max(20px, env(safe-area-inset-right));
+  bottom: max(20px, env(safe-area-inset-bottom));
+  z-index: 40;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 12px;
+  gap: 9px;
+  padding: 12px 18px;
   border-radius: var(--radius-pill);
-  border: 1px solid color-mix(in srgb, var(--accent) 45%, var(--line));
+  border: 1px solid color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: var(--bg-card);
   color: var(--accent-strong);
   font-family: var(--font-mono);
-  font-size: 0.74rem;
+  font-size: 0.78rem;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-decoration: none;
-  transition: border-color 0.18s ease, background 0.18s ease;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+  transition: transform 0.16s ease, border-color 0.16s ease, background 0.16s ease;
 }
 
-.assistant-nav-link:hover {
-  background: color-mix(in srgb, var(--accent) 12%, transparent);
+.assistant-fab:hover {
+  transform: translateY(-2px);
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-card));
   border-color: var(--accent);
+}
+
+.assistant-fab-glyph {
+  font-size: 1.05rem;
+  line-height: 1;
+}
+
+@media (max-width: 640px) {
+  .assistant-fab {
+    padding: 0;
+    width: 52px;
+    height: 52px;
+    justify-content: center;
+  }
+  .assistant-fab-label {
+    display: none;
+  }
+  .assistant-fab-glyph {
+    font-size: 1.3rem;
+  }
 }
 
 .assistant-banner {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -705,11 +705,6 @@ export default function HomePage() {
         <div className="app-bar-meta">
           <span className={`app-bar-status ${connection}`}>{connectionLabel}</span>
           {host ? <span className="muted">{host}</span> : null}
-          {token && assistant ? (
-            <Link className="assistant-nav-link" href="/assistant">
-              <span aria-hidden="true">✦</span> Assistant
-            </Link>
-          ) : null}
           <ThemeToggle />
         </div>
       </header>
@@ -784,6 +779,18 @@ export default function HomePage() {
           onSetPinned={handleSetPinned}
           onSetTitle={handleSetTitle}
         />
+      ) : null}
+      {token && assistant ? (
+        <Link
+          className="assistant-fab"
+          href="/assistant"
+          aria-label="Open personal assistant"
+        >
+          <span className="assistant-fab-glyph" aria-hidden="true">
+            ✦
+          </span>
+          <span className="assistant-fab-label">Assistant</span>
+        </Link>
       ) : null}
     </main>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
@@ -45,6 +46,7 @@ import {
 } from "@/lib/store";
 import { isManagedLaunchWrapper, useBackendCatalog } from "@/lib/backends";
 import {
+  AssistantSummary,
   Backend,
   BackendDescriptor,
   LaunchTargetSummary,
@@ -108,6 +110,7 @@ export default function HomePage() {
   const [host, setHost] = useState("");
   const [token, setToken] = useState("");
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
+  const [assistant, setAssistant] = useState<AssistantSummary | null>(null);
   const [error, setError] = useState("");
   const [connection, setConnection] = useState<ConnectionState>("idle");
   const [defaultBackend, setDefaultBackend] = useState<Backend>("codex");
@@ -189,6 +192,7 @@ export default function HomePage() {
         setDefaultBackend(me.default_backend);
         setDefaultCwd(me.default_cwd || "~/");
         setLaunchTargets(me.launch_targets);
+        setAssistant(me.assistant ?? null);
         if (me.backends && me.backends.length > 0) {
           setBackendDescriptors(me.backends);
         }
@@ -701,6 +705,11 @@ export default function HomePage() {
         <div className="app-bar-meta">
           <span className={`app-bar-status ${connection}`}>{connectionLabel}</span>
           {host ? <span className="muted">{host}</span> : null}
+          {token && assistant ? (
+            <Link className="assistant-nav-link" href="/assistant">
+              <span aria-hidden="true">✦</span> Assistant
+            </Link>
+          ) : null}
           <ThemeToggle />
         </div>
       </header>
@@ -768,7 +777,7 @@ export default function HomePage() {
       ) : null}
       {token ? (
         <SessionList
-          sessions={sessions}
+          sessions={sessions.filter((session) => session.source !== "assistant")}
           onDelete={handleDelete}
           onDeleteExited={handleDeleteExited}
           onTerminate={handleTerminate}

--- a/frontend/src/components/CopyMessageButton.tsx
+++ b/frontend/src/components/CopyMessageButton.tsx
@@ -1,26 +1,6 @@
 import { useCallback, useState } from "react";
 
-function legacyCopy(text: string): boolean {
-  // execCommand("copy") has different security gating than the async API:
-  // it works on plain-HTTP origins and when document focus is ambiguous,
-  // as long as the call originates from a user gesture. It returns false
-  // (rather than throwing) when the host browser refuses.
-  const el = document.createElement("textarea");
-  el.value = text;
-  el.setAttribute("readonly", "");
-  el.style.position = "fixed";
-  el.style.opacity = "0";
-  document.body.appendChild(el);
-  el.select();
-  let ok = false;
-  try {
-    ok = document.execCommand("copy");
-  } catch {
-    ok = false;
-  }
-  document.body.removeChild(el);
-  return ok;
-}
+import { copyText } from "@/lib/clipboard";
 
 export function CopyMessageButton({
   text,
@@ -31,21 +11,7 @@ export function CopyMessageButton({
 }) {
   const [copied, setCopied] = useState(false);
   const onCopy = useCallback(async () => {
-    if (!text) return;
-    let ok = false;
-    if (navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text);
-        ok = true;
-      } catch {
-        // writeText can reject at runtime when the document loses focus or
-        // the user denied clipboard-write permission. Fall back before giving
-        // up so the button still works in plain-HTTP development contexts.
-        ok = legacyCopy(text);
-      }
-    } else {
-      ok = legacyCopy(text);
-    }
+    const ok = await copyText(text);
     if (!ok) return;
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1500);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -182,6 +182,11 @@ interface SessionDetailProps {
   token: string;
   sessionId: string;
   onAuthFailure?: () => void;
+  // Renders the persistent personal-assistant variant: suppresses task-session
+  // chrome (cwd, transport/source badges, rename) and destructive/branching
+  // actions (terminate, delete, /new, /fork), and shows a capability-led empty
+  // state instead of "Waiting for the agent…".
+  assistant?: boolean;
 }
 
 type ViewMode = "chat" | "terminal";
@@ -197,7 +202,7 @@ const COMPOSER_HEIGHT_STORAGE_KEY = "waypoint-composer-height";
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-export function SessionDetail({ host, token, sessionId, onAuthFailure }: SessionDetailProps) {
+export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant = false }: SessionDetailProps) {
   const router = useRouter();
   const catalog = useBackendCatalog(host || null, token || null, null);
   const [session, setSession] = useState<SessionRecord | null>(null);
@@ -775,12 +780,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
   const runFrontendControlCommand = useCallback(
     async (
       text: string,
-      opts?: { allowFork?: boolean },
+      opts?: { allowFork?: boolean; allowNew?: boolean },
     ): Promise<"handled" | "error" | null> => {
       if (!session) return null;
       const allowFork = opts?.allowFork ?? true;
+      const allowNew = opts?.allowNew ?? true;
 
-      const newArgs = matchControlCommand(text, "new");
+      const newArgs = allowNew ? matchControlCommand(text, "new") : null;
       if (newArgs !== null) {
         try {
           const created = await createSession(host, token, {
@@ -841,7 +847,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       return false;
     }
 
-    const handled = await runFrontendControlCommand(text);
+    // The persistent assistant isn't a launchpad — `/new` and `/fork` would
+    // spawn stray managed sessions, so let them flow to the agent as text.
+    const handled = await runFrontendControlCommand(text, {
+      allowFork: !assistant,
+      allowNew: !assistant,
+    });
     if (handled !== null) {
       return handled === "handled";
     }
@@ -857,7 +868,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
       setError(sendError instanceof Error ? sendError.message : "failed to send input");
       return false;
     }
-  }, [runFrontendControlCommand, handleAuthFailure, host, token, sessionId]);
+  }, [runFrontendControlCommand, handleAuthFailure, host, token, sessionId, assistant]);
 
   const onSendWithOptimistic = useCallback(
     async (text: string, command?: SessionCommandInvocation) => {
@@ -1384,6 +1395,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           connection={connection}
           modelOptions={modelOptions}
           onSetTitle={handleSetTitle}
+          assistant={assistant}
         />
       ) : (
         <div className="session-loading muted" role="status" aria-live="polite">
@@ -1522,7 +1534,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
                 );
               })
             : session && optimisticMessages.length === 0 && !pendingPlanApprovalEvent
-              ? (
+              ? assistant && session.status !== "exited" ? (
+                <AssistantWelcome onPick={onSendWithOptimistic} />
+              ) : (
                 <TranscriptEmpty
                   status={session.status}
                   filterMode={filterMode}
@@ -1837,6 +1851,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure }: Session
           onSwitchSession={openSwitcher}
           onSend={onSendWithOptimistic}
           onTerminate={terminate}
+          assistant={assistant}
         />
       ) : null}
     </section>
@@ -1890,6 +1905,7 @@ interface ReplyComposerProps {
   onSwitchSession: () => void;
   onSend: (text: string, command?: SessionCommandInvocation) => Promise<boolean>;
   onTerminate: () => void | Promise<void>;
+  assistant: boolean;
 }
 
 const ReplyComposer = memo(function ReplyComposer({
@@ -1935,6 +1951,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onSwitchSession,
   onSend,
   onTerminate,
+  assistant,
 }: ReplyComposerProps) {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
@@ -2490,8 +2507,12 @@ const ReplyComposer = memo(function ReplyComposer({
                       {toolRunsExpanded ? "Collapse tools" : "Expand tools"}
                     </button>
                   ) : null}
-                  <div className="composer-overflow-separator" />
-                  {canTerminate ? (
+                  {/* The assistant is a protected singleton — no terminate or
+                      delete (the backend rejects both anyway). */}
+                  {!assistant && (canTerminate || canDelete) ? (
+                    <div className="composer-overflow-separator" />
+                  ) : null}
+                  {!assistant && canTerminate ? (
                     <button
                       type="button"
                       role="menuitem"
@@ -2505,7 +2526,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       Terminate session
                     </button>
                   ) : null}
-                  {canDelete ? (
+                  {!assistant && canDelete ? (
                     <button
                       type="button"
                       role="menuitem"
@@ -2946,11 +2967,13 @@ function SessionHeader({
   connection,
   modelOptions,
   onSetTitle,
+  assistant = false,
 }: {
   session: SessionRecord;
   connection: ConnectionState;
   modelOptions: BackendModelOption[];
   onSetTitle?: (title: string) => void | Promise<void>;
+  assistant?: boolean;
 }) {
   const cwdSegments = formatCwdSegments(session.cwd);
   const target = session.launch_target_id ?? null;
@@ -2998,7 +3021,7 @@ function SessionHeader({
           ) : (
             <>
               <h2 className="session-header-title">{session.title}</h2>
-              {onSetTitle ? (
+              {onSetTitle && !assistant ? (
                 <button
                   className="link-button edit-title-btn"
                   type="button"
@@ -3022,27 +3045,35 @@ function SessionHeader({
           </span>
         </span>
       </div>
-      <p className="session-header-cwd" title={session.cwd}>
-        {cwdSegments.map((segment, index) => (
-          <span key={index}>
-            {index > 0 ? <span className="cwd-sep" aria-hidden>/</span> : null}
-            <span className={index === cwdSegments.length - 1 ? "cwd-leaf" : "cwd-segment"}>
-              {segment}
+      {/* cwd / transport / source frame a task session; for the persistent
+          assistant they're noise — keep just which backend + model answers. */}
+      {!assistant ? (
+        <p className="session-header-cwd" title={session.cwd}>
+          {cwdSegments.map((segment, index) => (
+            <span key={index}>
+              {index > 0 ? <span className="cwd-sep" aria-hidden>/</span> : null}
+              <span className={index === cwdSegments.length - 1 ? "cwd-leaf" : "cwd-segment"}>
+                {segment}
+              </span>
             </span>
-          </span>
-        ))}
-        {target ? <span className="session-header-target"> · {target}</span> : null}
-      </p>
+          ))}
+          {target ? <span className="session-header-target"> · {target}</span> : null}
+        </p>
+      ) : null}
       <div className="session-header-tags">
         <span className={`badge ${session.backend}`}>
           {humaniseBackend(session.backend)}
         </span>
-        <span className={`badge transport ${session.transport}`}>
-          {transportLabel(session.transport)}
-        </span>
-        <span className={`badge fidelity ${fidelityFor(session.transport)}`}>
-          {fidelityFor(session.transport)}
-        </span>
+        {!assistant ? (
+          <>
+            <span className={`badge transport ${session.transport}`}>
+              {transportLabel(session.transport)}
+            </span>
+            <span className={`badge fidelity ${fidelityFor(session.transport)}`}>
+              {fidelityFor(session.transport)}
+            </span>
+          </>
+        ) : null}
         {session.model ? (
           <span className="badge model" title={`Model: ${session.model}`}>
             {modelOptions.find((opt) => opt.id === session.model)?.label ?? session.model}
@@ -3053,14 +3084,57 @@ function SessionHeader({
             {session.effort}
           </span>
         ) : null}
-        <span className="session-header-meta">
-          {sourceLabel}
-          {typeof session.transport_state?.thread_id === "string"
-            ? ` · ${session.transport_state.thread_id}`
-            : null}
-        </span>
+        {!assistant ? (
+          <span className="session-header-meta">
+            {sourceLabel}
+            {typeof session.transport_state?.thread_id === "string"
+              ? ` · ${session.transport_state.thread_id}`
+              : null}
+          </span>
+        ) : null}
       </div>
     </header>
+  );
+}
+
+// The assistant's two value props — host Q&A and session management — are
+// invisible in a blank chat, so the empty thread leads with tappable example
+// prompts that send on tap.
+const ASSISTANT_EXAMPLE_PROMPTS = [
+  "List my Waypoint sessions and their status",
+  "What's using CPU and memory on this host right now?",
+  "Summarize what my running agents are working on",
+  "Which sessions are idle or exited?",
+];
+
+function AssistantWelcome({
+  onPick,
+}: {
+  onPick: (text: string) => void | Promise<unknown>;
+}) {
+  return (
+    <div className="assistant-welcome">
+      <span className="assistant-welcome-glyph" aria-hidden="true">
+        ✦
+      </span>
+      <p className="assistant-welcome-title">Ask your assistant</p>
+      <p className="assistant-welcome-sub">
+        It can answer questions about this host and inspect or manage your
+        Waypoint sessions. Try one:
+      </p>
+      <div className="assistant-welcome-prompts">
+        {ASSISTANT_EXAMPLE_PROMPTS.map((prompt) => (
+          <button
+            key={prompt}
+            type="button"
+            className="assistant-welcome-prompt"
+            onClick={() => void onPick(prompt)}
+          >
+            {prompt}
+          </button>
+        ))}
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,37 @@
+// Clipboard helper that survives plain-HTTP origins and Safari. The async
+// Clipboard API (`navigator.clipboard`) is unavailable in non-secure contexts
+// (Waypoint is reached over http on a tailnet) and Safari rejects it outside a
+// trusted gesture, so fall back to the legacy `execCommand("copy")` path.
+
+function legacyCopy(text: string): boolean {
+  const el = document.createElement("textarea");
+  el.value = text;
+  el.setAttribute("readonly", "");
+  el.style.position = "fixed";
+  el.style.opacity = "0";
+  document.body.appendChild(el);
+  el.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(el);
+  return ok;
+}
+
+export async function copyText(text: string): Promise<boolean> {
+  if (!text) return false;
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // writeText can reject at runtime when the document loses focus or the
+      // user denied clipboard-write permission. Fall back before giving up.
+      return legacyCopy(text);
+    }
+  }
+  return legacyCopy(text);
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -4,7 +4,7 @@
 // hand-mirroring per-backend constants.
 export type Backend = string;
 export type SessionTransport = string;
-export type SessionSource = "managed" | "attached_tmux";
+export type SessionSource = "managed" | "attached_tmux" | "assistant";
 export type LaunchMode = "auto" | "direct" | "tmux_wrapper";
 export type SessionStatus =
   | "starting"
@@ -185,12 +185,20 @@ export interface BackendDescriptor {
   capabilities: BackendCapabilities;
 }
 
+export interface AssistantSummary {
+  session_id: string;
+  backend: Backend;
+  native_thread_id: string | null;
+  status: SessionStatus;
+}
+
 export interface MeResponse {
   authenticated: boolean;
   default_backend: Backend;
   default_cwd: string;
   launch_targets: LaunchTargetSummary[];
   backends?: BackendDescriptor[];
+  assistant?: AssistantSummary | null;
 }
 
 export interface EventsPage {


### PR DESCRIPTION
## Summary

Add a personal assistant to Waypoint: a single, long-lived conversation thread, separate from the coding sessions you launch for tasks, that answers questions about the host machine, grounds itself in your running Waypoint sessions, and creates/manages those sessions on your behalf. It is **not** a new backend — it reuses the existing plugin, runtime, storage, and streaming machinery; its only distinguishing traits are a dedicated session `source`, deletion/termination protection, and out-of-band tooling.

- **Configured in `waypoint.yaml`** — an optional `assistant:` block picks the backend (defaulting to `default_backend`), model, effort, and permission mode. Omit it to disable; present means enabled unless `enabled: false`.
- **A managed singleton session** — the runtime creates and keeps one assistant thread alive, restoring it like any session on restart, reusing it when alive, and recreating it fresh (demoting the old one to a normal session, never deleting) when the backend changed or the thread died.
- **A `waypoint sessions` CLI** — a thin HTTP client over the session API (`list` / `show` / `events` / `start` / `send` / `interrupt` / `terminate` / `approve`) that the assistant shells out to. `waypoint serve` writes a local `cli-token` so the same-host CLI authenticates without the password.
- **A dedicated `/assistant` page** — reuses `SessionDetail` (chat + terminal, with live model/effort/permission pickers) and surfaces the backend's own session id for recovery. A floating button on the home page opens it.
- **Silent charter** — the assistant's role is delivered as `AGENTS.md` / `CLAUDE.md` in a managed working directory and loaded by the backend as project context, so there is no visible bootstrap message and no wasted startup turn.

## Changes

### Backend

- `settings.py`: add `AssistantConfig` and `Settings.assistant`; `assistant_backend()` resolves the effective backend or `None` when disabled/absent.
- `schemas.py`: add `SessionSource.ASSISTANT` and an `AssistantSummary` (session id, backend, `native_thread_id`, status) exposed on `MeResponse`.
- `runtime.py`: `_ensure_assistant_session` (run at startup after restores) creates/reuses/recreates the singleton — reusing only a live, backend-matching thread that already lives in the managed workspace, otherwise demoting stale threads and creating fresh; `_prepare_assistant_workspace` materialises `<data_dir>/assistant` with the charter files; `delete`/`terminate` return 403 for the assistant; `assistant_summary()` feeds `/api/me`.
- `backends/base.py` + each plugin: add a `native_thread_id` method exposing the backend's resumable id without the runtime reading `transport_state` keys (claude/codex/tmux read `thread_id`; opencode reads `opencode_session_id`).
- `client.py` (new): `WaypointClient`, an httpx wrapper over the session API with auth resolving `WAYPOINT_TOKEN` → local `cli-token` file → password login (cached).
- `cli.py`: add the `waypoint sessions` command group (distinct from the in-process `session` group) and write the `0600` `cli-token` on `serve`.
- `api.py`: include the assistant summary in `/api/me`.

### Frontend

- `app/assistant/page.tsx` (new): the assistant page — app-bar, a recovery banner (backend, status pill, copyable backend session id), and loading/disabled/error states, rendering `SessionDetail` for the singleton.
- `app/page.tsx`: a floating action button to the assistant (shown when configured) and filtering the assistant out of the home session list.
- `lib/clipboard.ts` (new): a `copyText` helper that falls back to `execCommand("copy")` when `navigator.clipboard` is unavailable (plain-HTTP origins) or rejects (Safari); `CopyMessageButton` routes through it too.
- `lib/types.ts`: add `AssistantSummary`, extend `SessionSource` and `MeResponse`.
- `app/globals.css`: the assistant section (banner, status pill, FAB, copy chip, empty/loading/error states) — all colors via design tokens/`color-mix` for dark/light parity, motion gated behind `prefers-reduced-motion`.

### Docs

- `docs/personal_assistant.md` (new) + README pointer; `backend/waypoint.example.yaml` documents the `assistant:` block.

## Test Plan

- [x] `cd backend && uv run pytest` — 530 pass; the 4 `tests/test_rate_limits.py` failures are pre-existing on `main` (keychain / messages-API header parsing), unrelated to this branch.
- [x] Added backend tests: assistant bootstrap matrix (reuse / recreate-on-backend-change / recreate-on-exit / workspace-cwd migration / disabled-demote), delete & terminate 403 protection, `assistant_summary`, workspace charter files (`test_runtime.py`); `assistant:` config parsing and validation (`test_config.py`); `WaypointClient` auth ladder and requests (`test_client.py`).
- [x] `cd backend && uv run mypy` (via pre-commit on changed files, each commit) — isort / black / ruff / codespell / mypy clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — clean; `/assistant` route compiles.
- [x] Manual (isolated deployment, separate port + data dir): `waypoint serve` wrote the `0600` `cli-token`; `/api/me` returned the assistant summary with its `native_thread_id`; `waypoint sessions list`/`show` authenticated via the token file with no password; `DELETE` and `terminate` on the assistant both returned 403.
- [x] Live: confirmed the non-destructive demotion path — a stale assistant thread was demoted to a normal session and a fresh one created on restart.
- [ ] Live verification of the latest three commits (OpenCode native-id resolution, the Safari/HTTP copy fix, and the UI polish) is pending a stack restart — they pass lint/build/mypy but were not yet exercised on the running stack this session.