### PR TITLE
chore: migrate the waypoint CLI to Typer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ cd backend
 
 Backend config precedence:
 
-- CLI flags such as `waypoint serve --host ... --port ... --config ...`
+- CLI flags such as `waypoint --config ... serve --host ... --port ...` (`--config` is a top-level option, before the command)
 - `WAYPOINT_*` environment variables (set in your shell, systemd unit, or LaunchAgent)
 - values from `backend/waypoint.yaml`
 - built-in defaults

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "pydantic>=2.11.0",
   "pyte>=0.8.2",
   "PyYAML>=6.0.0",
+  "typer>=0.12.0",
   "uvicorn>=0.35.0",
   "websockets>=15.0.0",
 ]

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1,10 +1,11 @@
-import argparse
 import asyncio
 import json
 import shutil
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
+import typer
 import uvicorn
 
 from waypoint.api import AppContext, create_app
@@ -15,7 +16,7 @@ from waypoint.settings import Settings, load_settings
 
 
 def _backend_choices() -> list[str]:
-    """Backend ids accepted by ``session start`` / ``session attach``.
+    """Backend ids accepted by ``session`` / ``sessions`` launch commands.
 
     Excludes managed-launch fallback wrappers (capabilities flag
     ``is_fallback_for_managed_launch``) — those are routed to via the
@@ -28,180 +29,322 @@ def _backend_choices() -> list[str]:
     ]
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="waypoint")
-    subparsers = parser.add_subparsers(dest="command", required=True)
+def _validate_backend(value: str | None) -> str | None:
+    if value is None:
+        return None
+    choices = _backend_choices()
+    if value not in choices:
+        raise typer.BadParameter(
+            f"unknown backend: {value!r} (choose from {', '.join(choices)})"
+        )
+    return value
 
-    serve = subparsers.add_parser("serve")
-    serve.add_argument("--host", default=None)
-    serve.add_argument("--port", type=int, default=None)
-    serve.add_argument("--config", default=None)
 
-    doctor = subparsers.add_parser("doctor")
-    doctor.add_argument("--config", default=None)
+def _complete_backend(incomplete: str) -> list[str]:
+    return [choice for choice in _backend_choices() if choice.startswith(incomplete)]
 
-    reset = subparsers.add_parser(
-        "reset",
-        help="Wipe runtime data (sessions, events, tokens, schedules, logs). Config is untouched.",
+
+# Reusable option/argument aliases keep the command signatures readable and
+# the `--backend` validation/completion consistent across `session` and
+# `sessions`.
+BackendOption = Annotated[
+    str,
+    typer.Option(callback=_validate_backend, autocompletion=_complete_backend),
+]
+BackendHintOption = Annotated[
+    str | None,
+    typer.Option(callback=_validate_backend, autocompletion=_complete_backend),
+]
+
+app = typer.Typer(
+    help="Waypoint backend control CLI.",
+    no_args_is_help=True,
+    add_completion=True,
+)
+session_app = typer.Typer(
+    help="Launch sessions via an in-process runtime (one-shot, no running server).",
+    no_args_is_help=True,
+)
+sessions_app = typer.Typer(
+    help="Manage sessions on a running Waypoint server over HTTP.",
+    no_args_is_help=True,
+)
+app.add_typer(session_app, name="session")
+app.add_typer(sessions_app, name="sessions")
+
+
+@app.callback()
+def _root(
+    ctx: typer.Context,
+    config: Annotated[
+        str | None,
+        typer.Option("--config", help="Path to waypoint.yaml.", metavar="PATH"),
+    ] = None,
+) -> None:
+    # Stash the raw config path; commands resolve Settings lazily so `--help`
+    # and shell completion don't read the config file.
+    ctx.obj = {"config": config}
+
+
+def _settings_from_arg(raw: str | None) -> Settings:
+    return load_settings(Path(raw).expanduser() if raw else None)
+
+
+def _settings_from_ctx(ctx: typer.Context) -> Settings:
+    config = ctx.obj.get("config") if ctx.obj else None
+    return _settings_from_arg(config)
+
+
+@app.command()
+def serve(
+    ctx: typer.Context,
+    host: Annotated[str | None, typer.Option(help="Bind host override.")] = None,
+    port: Annotated[int | None, typer.Option(help="Bind port override.")] = None,
+) -> None:
+    """Run the API server."""
+    settings = _settings_from_ctx(ctx)
+    fastapi_app = create_app(settings)
+    context = fastapi_app.state.context
+    # Issue a local token the same-host `waypoint sessions` CLI (and the
+    # personal assistant shelling out to it) can read without the password.
+    # 0600 in the data dir; treat it as a secret.
+    token = context.tokens.issue().token
+    token_path = write_cli_token(context.settings, token)
+    typer.echo(f"wrote CLI token to {token_path}")
+    bind_host = host or context.settings.host
+    bind_port = port or context.settings.port
+    # Cap graceful-shutdown so a stuck websocket can never hold uvicorn past
+    # Ctrl+C. The first SIGINT triggers shutdown; any in-flight ws connection
+    # that doesn't close on cancel within this window gets force-closed.
+    uvicorn.run(
+        fastapi_app, host=bind_host, port=bind_port, timeout_graceful_shutdown=5
     )
-    reset.add_argument("--config", default=None)
-    reset.add_argument(
-        "--yes",
-        action="store_true",
-        help="Confirm destruction. Without this flag the command is a dry run.",
+
+
+@app.command()
+def doctor(ctx: typer.Context) -> None:
+    """Report the resolved config path and discovered CLI binaries."""
+    run_doctor(_settings_from_ctx(ctx))
+
+
+@app.command()
+def reset(
+    ctx: typer.Context,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            help="Confirm destruction. Without this flag the command is a dry run.",
+        ),
+    ] = False,
+) -> None:
+    """Wipe runtime data (sessions, events, tokens, schedules, logs). Config is untouched."""
+    run_reset(_settings_from_ctx(ctx), confirmed=yes)
+
+
+@session_app.command("start")
+def session_start(
+    ctx: typer.Context,
+    backend: BackendOption,
+    cwd: Annotated[str, typer.Option(help="Working directory for the session.")],
+    launch_target_id: Annotated[str | None, typer.Option()] = None,
+    title: Annotated[str | None, typer.Option()] = None,
+    args: Annotated[list[str] | None, typer.Argument()] = None,
+) -> None:
+    """Start a session in-process and print it as JSON."""
+    asyncio.run(
+        _session_start(
+            _settings_from_ctx(ctx),
+            backend=backend,
+            cwd=cwd,
+            launch_target_id=launch_target_id,
+            title=title,
+            args=args or [],
+        )
     )
 
-    session = subparsers.add_parser("session")
-    session.add_argument("--config", default=None)
-    session_subparsers = session.add_subparsers(dest="session_command", required=True)
 
-    backend_choices = _backend_choices()
-    start = session_subparsers.add_parser("start")
-    start.add_argument("--backend", choices=backend_choices, required=True)
-    start.add_argument("--cwd", required=True)
-    start.add_argument("--launch-target-id")
-    start.add_argument("--title")
-    start.add_argument("args", nargs="*")
-
-    attach = session_subparsers.add_parser("attach")
-    attach.add_argument("--tmux", required=True)
-    attach.add_argument("--backend-hint", choices=backend_choices)
-    attach.add_argument("--title")
-
-    # ``sessions`` (plural) drives an already-running server over HTTP,
-    # unlike ``session`` (singular) which spins up an in-process runtime.
-    # This is the surface the personal assistant uses to manage agents.
-    sessions = subparsers.add_parser(
-        "sessions", help="Manage sessions on a running Waypoint server over HTTP."
+@session_app.command("attach")
+def session_attach(
+    ctx: typer.Context,
+    tmux: Annotated[str, typer.Option(help="Target tmux pane/session.")],
+    backend_hint: BackendHintOption = None,
+    title: Annotated[str | None, typer.Option()] = None,
+) -> None:
+    """Attach an existing tmux pane as a session."""
+    asyncio.run(
+        _session_attach(
+            _settings_from_ctx(ctx),
+            tmux=tmux,
+            backend_hint=backend_hint,
+            title=title,
+        )
     )
-    sessions.add_argument("--config", default=None)
-    sessions_sub = sessions.add_subparsers(dest="sessions_command", required=True)
-
-    sessions_sub.add_parser("list", help="List all sessions.")
-
-    show = sessions_sub.add_parser("show", help="Show one session.")
-    show.add_argument("session_id")
-
-    events = sessions_sub.add_parser("events", help="Show a session's transcript.")
-    events.add_argument("session_id")
-    events.add_argument("--messages", type=int, default=None)
-    events.add_argument("--before-sequence", type=int, default=None)
-
-    sessions_start = sessions_sub.add_parser("start", help="Launch a new session.")
-    sessions_start.add_argument("--backend", choices=backend_choices, required=True)
-    sessions_start.add_argument("--cwd", required=True)
-    sessions_start.add_argument("--launch-target-id")
-    sessions_start.add_argument("--title")
-    sessions_start.add_argument("--model")
-    sessions_start.add_argument("--effort")
-    sessions_start.add_argument("--permission-mode")
-    sessions_start.add_argument("args", nargs="*")
-
-    send = sessions_sub.add_parser("send", help="Send a message to a session.")
-    send.add_argument("session_id")
-    send.add_argument("text")
-
-    interrupt = sessions_sub.add_parser("interrupt", help="Interrupt a session.")
-    interrupt.add_argument("session_id")
-
-    terminate = sessions_sub.add_parser("terminate", help="Terminate a session.")
-    terminate.add_argument("session_id")
-
-    approve = sessions_sub.add_parser("approve", help="Respond to an approval request.")
-    approve.add_argument("session_id")
-    approve.add_argument("decision")
-    approve.add_argument("--text")
-    approve.add_argument("--approval-id")
-
-    return parser
 
 
-def main() -> None:
-    parser = build_parser()
-    args = parser.parse_args()
-    if args.command == "serve":
-        app = create_app(_settings_from_arg(args.config))
-        context = app.state.context
-        # Issue a local token the same-host `waypoint sessions` CLI (and the
-        # personal assistant shelling out to it) can read without the
-        # password. 0600 in the data dir; treat it as a secret.
-        token = context.tokens.issue().token
-        token_path = write_cli_token(context.settings, token)
-        print(f"wrote CLI token to {token_path}")
-        host = args.host or context.settings.host
-        port = args.port or context.settings.port
-        # Cap graceful-shutdown so a stuck websocket can never hold uvicorn
-        # past Ctrl+C. The first SIGINT triggers shutdown; any in-flight ws
-        # connection that doesn't close on cancel within this window gets
-        # force-closed.
-        uvicorn.run(app, host=host, port=port, timeout_graceful_shutdown=5)
-        return
-    if args.command == "doctor":
-        run_doctor(_settings_from_arg(args.config))
-        return
-    if args.command == "reset":
-        run_reset(_settings_from_arg(args.config), confirmed=args.yes)
-        return
-    if args.command == "session":
-        asyncio.run(run_session_command(args))
-        return
-    if args.command == "sessions":
-        run_sessions_command(args)
-        return
-    parser.error("unknown command")
+async def _session_start(
+    settings: Settings,
+    *,
+    backend: str,
+    cwd: str,
+    launch_target_id: str | None,
+    title: str | None,
+    args: list[str],
+) -> None:
+    context = AppContext(settings)
+    context.settings.ensure_dirs()
+    try:
+        session = await context.runtime.create_session(
+            SessionCreateRequest(
+                backend=backend,
+                cwd=cwd,
+                launch_target_id=launch_target_id,
+                title=title,
+                args=list(args),
+            )
+        )
+        typer.echo(json.dumps({"session": session.model_dump(mode="json")}, indent=2))
+    finally:
+        await context.runtime.stop()
 
 
-def run_sessions_command(args: argparse.Namespace) -> None:
-    settings = _settings_from_arg(args.config)
+async def _session_attach(
+    settings: Settings,
+    *,
+    tmux: str,
+    backend_hint: str | None,
+    title: str | None,
+) -> None:
+    context = AppContext(settings)
+    context.settings.ensure_dirs()
+    try:
+        payload: dict[str, Any] = {"tmux_target": tmux, "title": title}
+        if backend_hint:
+            payload["backend_hint"] = backend_hint
+        session = await context.runtime.attach_tmux(
+            SessionAttachRequest.model_validate(payload)
+        )
+        typer.echo(json.dumps({"session": session.model_dump(mode="json")}, indent=2))
+    finally:
+        await context.runtime.stop()
+
+
+def _emit(settings: Settings, run: Callable[[WaypointClient], Any]) -> None:
+    """Run a client call against the live server and print the JSON result."""
     try:
         with WaypointClient(settings) as client:
-            result = _dispatch_sessions_command(client, args)
+            result = run(client)
     except WaypointError as exc:
-        raise SystemExit(f"error: {exc}") from exc
-    print(json.dumps(result, indent=2))
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo(json.dumps(result, indent=2))
 
 
-def _dispatch_sessions_command(client: WaypointClient, args: argparse.Namespace) -> Any:
-    command = args.sessions_command
-    if command == "list":
-        return {"sessions": client.list_sessions()}
-    if command == "show":
-        return {"session": client.get_session(args.session_id)}
-    if command == "events":
-        return client.get_events(
-            args.session_id,
-            messages=args.messages,
-            before_sequence=args.before_sequence,
-        )
-    if command == "start":
-        return {
-            "session": client.create_session(
-                backend=args.backend,
-                cwd=args.cwd,
-                launch_target_id=args.launch_target_id,
-                title=args.title,
-                model=args.model,
-                effort=args.effort,
-                permission_mode=args.permission_mode,
-                args=list(args.args),
+@sessions_app.command("list")
+def sessions_list(ctx: typer.Context) -> None:
+    """List all sessions."""
+    _emit(_settings_from_ctx(ctx), lambda c: {"sessions": c.list_sessions()})
+
+
+@sessions_app.command("show")
+def sessions_show(
+    ctx: typer.Context, session_id: Annotated[str, typer.Argument()]
+) -> None:
+    """Show one session."""
+    _emit(_settings_from_ctx(ctx), lambda c: {"session": c.get_session(session_id)})
+
+
+@sessions_app.command("events")
+def sessions_events(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    messages: Annotated[int | None, typer.Option()] = None,
+    before_sequence: Annotated[int | None, typer.Option()] = None,
+) -> None:
+    """Show a session's transcript."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: c.get_events(
+            session_id, messages=messages, before_sequence=before_sequence
+        ),
+    )
+
+
+@sessions_app.command("start")
+def sessions_start(
+    ctx: typer.Context,
+    backend: BackendOption,
+    cwd: Annotated[str, typer.Option(help="Working directory for the session.")],
+    launch_target_id: Annotated[str | None, typer.Option()] = None,
+    title: Annotated[str | None, typer.Option()] = None,
+    model: Annotated[str | None, typer.Option()] = None,
+    effort: Annotated[str | None, typer.Option()] = None,
+    permission_mode: Annotated[str | None, typer.Option()] = None,
+    args: Annotated[list[str] | None, typer.Argument()] = None,
+) -> None:
+    """Launch a new session on the running server."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "session": c.create_session(
+                backend=backend,
+                cwd=cwd,
+                launch_target_id=launch_target_id,
+                title=title,
+                model=model,
+                effort=effort,
+                permission_mode=permission_mode,
+                args=list(args or []),
             )
-        }
-    if command == "send":
-        return {"session": client.send_input(args.session_id, args.text)}
-    if command == "interrupt":
-        return {"session": client.interrupt(args.session_id)}
-    if command == "terminate":
-        return {"session": client.terminate(args.session_id)}
-    if command == "approve":
-        return {
-            "session": client.approve(
-                args.session_id,
-                args.decision,
-                text=args.text,
-                approval_id=args.approval_id,
+        },
+    )
+
+
+@sessions_app.command("send")
+def sessions_send(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    text: Annotated[str, typer.Argument()],
+) -> None:
+    """Send a message to a session."""
+    _emit(
+        _settings_from_ctx(ctx), lambda c: {"session": c.send_input(session_id, text)}
+    )
+
+
+@sessions_app.command("interrupt")
+def sessions_interrupt(
+    ctx: typer.Context, session_id: Annotated[str, typer.Argument()]
+) -> None:
+    """Interrupt a session."""
+    _emit(_settings_from_ctx(ctx), lambda c: {"session": c.interrupt(session_id)})
+
+
+@sessions_app.command("terminate")
+def sessions_terminate(
+    ctx: typer.Context, session_id: Annotated[str, typer.Argument()]
+) -> None:
+    """Terminate a session."""
+    _emit(_settings_from_ctx(ctx), lambda c: {"session": c.terminate(session_id)})
+
+
+@sessions_app.command("approve")
+def sessions_approve(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    decision: Annotated[str, typer.Argument()],
+    text: Annotated[str | None, typer.Option()] = None,
+    approval_id: Annotated[str | None, typer.Option()] = None,
+) -> None:
+    """Respond to an approval request."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "session": c.approve(
+                session_id, decision, text=text, approval_id=approval_id
             )
-        }
-    raise SystemExit(f"unknown sessions command: {command}")
+        },
+    )
 
 
 def run_reset(settings: Settings | None = None, *, confirmed: bool) -> None:
@@ -263,32 +406,5 @@ def run_doctor(settings: Settings | None = None) -> None:
     print(json.dumps(checks, indent=2))
 
 
-async def run_session_command(args: argparse.Namespace) -> None:
-    context = AppContext(_settings_from_arg(args.config))
-    context.settings.ensure_dirs()
-    try:
-        if args.session_command == "start":
-            session = await context.runtime.create_session(
-                SessionCreateRequest(
-                    backend=args.backend,
-                    cwd=args.cwd,
-                    launch_target_id=args.launch_target_id,
-                    title=args.title,
-                    args=list(args.args),
-                )
-            )
-            print(json.dumps({"session": session.model_dump(mode="json")}, indent=2))
-        elif args.session_command == "attach":
-            payload: dict[str, Any] = {"tmux_target": args.tmux, "title": args.title}
-            if args.backend_hint:
-                payload["backend_hint"] = args.backend_hint
-            session = await context.runtime.attach_tmux(
-                SessionAttachRequest.model_validate(payload)
-            )
-            print(json.dumps({"session": session.model_dump(mode="json")}, indent=2))
-    finally:
-        await context.runtime.stop()
-
-
-def _settings_from_arg(raw: str | None) -> Settings:
-    return load_settings(Path(raw).expanduser() if raw else None)
+def main() -> None:
+    app()

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from waypoint.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The test host may itself run Waypoint, whose WAYPOINT_* env vars would
+    # otherwise override the per-test config file (notably data_dir).
+    for var in (
+        "WAYPOINT_DATA_DIR",
+        "WAYPOINT_CONFIG_PATH",
+        "WAYPOINT_HOST",
+        "WAYPOINT_PORT",
+        "WAYPOINT_PASSWORD",
+        "WAYPOINT_CORS_ORIGINS",
+        "WAYPOINT_CORS_ORIGIN_REGEX",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "waypoint.yaml"
+    cfg.write_text(
+        f"default_backend: codex\ndata_dir: {tmp_path / 'data'}\n", encoding="utf-8"
+    )
+    return cfg
+
+
+def test_help_lists_command_groups() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for name in ("serve", "doctor", "reset", "session", "sessions"):
+        assert name in result.stdout
+
+
+def test_config_is_a_top_level_option(tmp_path: Path) -> None:
+    # `--config` lives on the root app, before the command.
+    result = runner.invoke(app, ["--config", str(_config(tmp_path)), "reset"])
+    assert result.exit_code == 0
+    assert "Nothing to reset" in result.stdout
+
+
+def test_reset_requires_yes_to_delete(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    (tmp_path / "data").mkdir()
+    (tmp_path / "data" / "waypoint.db").write_text("x", encoding="utf-8")
+    result = runner.invoke(app, ["--config", str(cfg), "reset"])
+    assert result.exit_code == 0
+    assert "Would remove" in result.stdout
+    assert (tmp_path / "data" / "waypoint.db").exists()
+
+
+def test_unknown_backend_is_rejected(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "bogus",
+            "--cwd",
+            "/tmp",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown backend" in result.output
+
+
+def test_doctor_reports_config_path(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["--config", str(_config(tmp_path)), "doctor"])
+    assert result.exit_code == 0
+    assert "config_path" in result.stdout

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -440,6 +440,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/cd/de45b239ea3bdf626f982a00c14bfcf2e12d261c510ba7db62c5969a27cd/librt-0.9.0-cp314-cp314t-win32.whl", hash = "sha256:a9c63e04d003bc0fb6a03b348018b9a3002f98268200e22cc80f146beac5dc40", size = 52453, upload-time = "2026-04-09T16:06:05.229Z" },
     { url = "https://files.pythonhosted.org/packages/7f/f9/bfb32ae428aa75c0c533915622176f0a17d6da7b72b5a3c6363685914f70/librt-0.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f162af66a2ed3f7d1d161a82ca584efd15acd9c1cff190a373458c32f7d42118", size = 60044, upload-time = "2026-04-09T16:06:06.398Z" },
     { url = "https://files.pythonhosted.org/packages/aa/47/7d70414bcdbb3bc1f458a8d10558f00bbfdb24e5a11740fc8197e12c3255/librt-0.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a4b25c6c25cac5d0d9d6d6da855195b254e0021e513e0249f0e3b444dc6e0e61", size = 50009, upload-time = "2026-04-09T16:06:07.995Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -970,6 +991,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
@@ -995,6 +1029,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1005,6 +1048,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.26.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/ed/ef06584ccdd5c410df0837951ecd7e15d9a6144ea1bd4c73cecab1a89891/typer-0.26.7.tar.gz", hash = "sha256:e314a34c617e419c091b2830dda3ea1f257134ff593061a8f5b9717ab8dddb3a", size = 201709, upload-time = "2026-06-03T07:18:06.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/2201973529af2c954de0bb725323c3aaed6d7f0ceee8f550dec9185df013/typer-0.26.7-py3-none-any.whl", hash = "sha256:5c87cfbc5d34491c5346ebf49c23e18d56ccb863268d3a8d592b26087c2f5e58", size = 122456, upload-time = "2026-06-03T07:18:05.732Z" },
 ]
 
 [[package]]
@@ -1076,6 +1134,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyte" },
     { name = "pyyaml" },
+    { name = "typer" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
@@ -1099,6 +1158,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pyte", specifier = ">=0.8.2" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "websockets", specifier = ">=15.0.0" },
 ]


### PR DESCRIPTION
## Summary

Rebuild the `waypoint` backend CLI on Typer instead of argparse, for consistency with `waypointctl` (already Typer) and to get richer `--help` and shell completion. The parsing layer is swapped while the business-logic functions are preserved, so behavior is unchanged except for one deliberate move: **`--config` is now a top-level option** (`waypoint --config X <command>`) rather than per-command. The assistant charter and the `waypoint sessions …` examples don't pass `--config` (they rely on env / the local token file), and `waypointctl` doesn't either, so nothing in-repo breaks; external callers of `waypoint serve --config X` / `waypoint sessions --config X …` must move the flag before the command.

## Changes

### Backend

- `cli.py`: rewritten as a Typer app. `serve` / `doctor` / `reset` are `@app.command()`s; `session` (in-process) and `sessions` (HTTP client) are `add_typer` sub-apps. A top-level `@app.callback()` stashes the raw `--config` path in `ctx.obj` and commands resolve `Settings` lazily (so `--help`/completion don't read the config file). `main()` calls `app()`, so the `[project.scripts] waypoint` entry point is unchanged.
- `--backend` stays a free `str` validated against the live registry via a Typer callback (`_validate_backend` raising `typer.BadParameter`) with an `autocompletion` callback, rather than a static enum — new backends need no CLI edit, matching how the rest of the codebase dispatches by plugin id.
- The logic functions are kept intact: `run_reset`, `run_doctor`, and the session/sessions actions (now small `_session_start` / `_session_attach` coroutines and an `_emit` helper that runs a `WaypointClient` call and prints the JSON result). `sessions` output stays raw `json.dumps` for the assistant to parse.
- `pyproject.toml` / `uv.lock`: add `typer>=0.12.0` (pulls in `rich` / `shellingham`; enables `--install-completion`).
- `tests/test_cli.py` (new): `typer.testing.CliRunner` smoke tests covering the command listing, the top-level `--config`, the reset dry-run gate, `--backend` rejection, and `doctor`.

### Docs

- `README.md`: note that `--config` is a top-level option (`waypoint --config … serve …`).

## Test Plan

- [x] `cd backend && uv run pytest` — 537 pass; the 4 `tests/test_rate_limits.py` failures are pre-existing on `main` (keychain / messages-API header parsing), unrelated to this branch.
- [x] `cd backend && uv run pytest tests/test_cli.py tests/test_cli_reset.py tests/test_client.py` — 14 pass (new smoke tests + the preserved `run_reset` / `WaypointClient` tests).
- [x] `cd backend && uv run mypy src/waypoint/cli.py` — clean.
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on the commit — clean.
- [x] Manual: `uv run waypoint --help` and `waypoint sessions --help` render the expected command groups; `waypoint sessions start --backend bogus --cwd /tmp` is rejected with `Invalid value for '--backend': unknown backend: 'bogus'`.