### PR TITLE
feat: let the personal assistant manage its own deployment

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -50,8 +50,8 @@ COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
 # The assistant's charter. Written into AGENTS.md / CLAUDE.md in the
 # assistant's managed working directory so the backend loads it silently as
 # project context — no visible first message, no wasted startup turn.
-# References the `waypoint` CLI, which the runtime expects on the assistant
-# process's PATH.
+# References the `waypoint` / `waypointctl` CLIs, which the runtime expects on
+# the assistant process's PATH.
 ASSISTANT_CHARTER = """\
 # Waypoint personal assistant
 
@@ -76,9 +76,32 @@ Your job:
   Run `waypoint sessions --help` for the full surface. Prefer the CLI over
   guessing about session state.
 
+Managing your own deployment — you run on this Waypoint stack and can update
+it with `waypointctl` (the stack supervisor) and `uv`, both on your PATH.
+These commands affect the deployment you are running on, so treat them as
+confirm-first. In particular, restarting the backend interrupts every running
+session, including you — your current turn ends and the user has to reconnect.
+- Update from the remote: the repo is at `$WAYPOINT_HOME`. First check it is
+  safe with `git -C "$WAYPOINT_HOME" status`; if the tree is dirty or not on
+  `main`, stop and tell the user rather than pulling. Otherwise
+  `git -C "$WAYPOINT_HOME" pull --ff-only origin main`.
+- Apply changed dependencies: if the pull touched backend deps,
+  `cd "$WAYPOINT_HOME/backend" && uv sync`. Frontend deps install on
+  `waypointctl start`. If `waypointctl/` itself changed, reinstall it with
+  `uv tool install "$WAYPOINT_HOME/waypointctl" --reinstall` (use --reinstall,
+  not --force: it rebuilds from source even though the version is unchanged).
+- Restart to apply: a frontend-only change is safe via
+  `waypointctl restart frontend`. For a backend (or full-stack) change, first
+  review active work with `waypoint sessions list`, surface anything running
+  or waiting on input, get the user's confirmation, then
+  `waypointctl restart backend` (or `waypointctl restart` for both) — expect
+  your own connection to drop and that you cannot observe completion.
+- Verify with `waypointctl status` and `waypointctl logs backend` (or
+  `frontend`).
+
 Be concise and act before narrating. Do not take destructive or irreversible
-actions (terminating sessions, deleting files) without confirming with the
-user first."""
+actions (terminating sessions, deleting files, pulling updates, restarting the
+stack) without confirming with the user first."""
 
 log = logging.getLogger("waypoint.runtime")
 

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3380,6 +3380,7 @@ def test_prepare_assistant_workspace_writes_charter_files(tmp_path) -> None:
         text = (workspace_path / name).read_text(encoding="utf-8")
         assert "Waypoint personal assistant" in text
         assert "waypoint sessions list" in text
+        assert "waypointctl restart" in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The personal assistant runs on the Waypoint stack and can already inspect the host and manage coding sessions via the `waypoint` CLI. This extends its charter so it can also keep its own deployment up to date — pull from the remote, apply dependency changes, and restart the stack with `waypointctl` — under a confirm-first safety posture. The charter ships into the assistant's `AGENTS.md` / `CLAUDE.md` (loaded silently as project context), so this is purely an instruction change to the assistant, not new runtime behavior.

## Changes

### Backend

- `runtime.py`: add a "Managing your own deployment" section to `ASSISTANT_CHARTER`. It documents: updating from the remote at `$WAYPOINT_HOME` with `git pull --ff-only origin main` (after a clean-tree / on-`main` check); applying changed deps with `uv sync` in `backend/` and reinstalling `waypointctl` via `uv tool install "$WAYPOINT_HOME/waypointctl" --reinstall` (`--reinstall`, not `--force`, so it rebuilds from source despite the unchanged version); and restarting with `waypointctl restart frontend` (safe) vs `restart backend`/`restart` (reviews `waypoint sessions list` and confirms first, since a backend restart interrupts every session including the assistant itself). The closing safety line now also gates pulling updates and restarting the stack on user confirmation.
- `tests/test_runtime.py`: assert the rendered charter files include the `waypointctl restart` guidance.

## Test Plan

- [x] `cd backend && uv run pytest` — 537 pass; the 4 `tests/test_rate_limits.py` failures are pre-existing on `main` (keychain / messages-API header parsing), unrelated to this branch.
- [x] `cd backend && uv run pytest tests/test_runtime.py -k assistant_workspace` — the charter-files test passes with the new `waypointctl restart` assertion.
- [x] `cd backend && uv run mypy src/waypoint/runtime.py` — clean.
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on the commit — clean.
- [x] Verified the resolved facts the charter relies on: `$WAYPOINT_HOME` is the repo (origin → `main`); `waypointctl` is a `uv tool` install (`uv tool list`); `uv tool install --help` confirms `--reinstall` implies `--refresh` (rebuild from source) while `--force` does not; the backend declares no extras, so `uv sync` already covers it.