### PR TITLE
feat: make the personal assistant's backend and lifecycle controllable at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Use GitHub Issues directly for active bugs and feature requests.
 - `frontend/` — Next.js PWA client
 - `3rdparty/codex/` — pinned Codex submodule used for the local app-server SDK
 
-A single long-lived **personal assistant** thread — which answers host questions, grounds itself in your running sessions, and manages them via the `waypoint sessions` CLI — can be enabled in `waypoint.yaml`; see [`docs/personal_assistant.md`](docs/personal_assistant.md).
+A single long-lived **personal assistant** thread — which answers host questions, grounds itself in your running sessions, and manages them via the `waypoint sessions` CLI — can be enabled in `waypoint.yaml`. Its coding backend, model, and permission mode are switchable on the fly, and the thread can be terminated, reattached, or context-cleared from the assistant page; see [`docs/personal_assistant.md`](docs/personal_assistant.md).
 
 ## Supported agent versions
 

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -28,6 +28,8 @@ from waypoint.backends.tmux.renderer import (
 )
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
+    AssistantResetRequest,
+    AssistantSummary,
     LoginRequest,
     MeResponse,
     ScheduleCreateRequest,
@@ -135,6 +137,33 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             backends=_backend_descriptors(context.runtime.registry),
             assistant=context.runtime.assistant_summary(),
         )
+
+    @app.post("/api/assistant/reset", response_model=AssistantSummary)
+    async def assistant_reset(
+        body: AssistantResetRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> AssistantSummary:
+        # Rebuild the assistant on a fresh thread — clear context (same backend)
+        # or switch backends. The old thread is demoted to a normal stopped
+        # session, never deleted.
+        return await context.runtime.reset_assistant(
+            backend=body.backend,
+            model=body.model,
+            effort=body.effort,
+            permission_mode=body.permission_mode,
+        )
+
+    @app.post("/api/assistant/terminate", response_model=AssistantSummary)
+    async def assistant_terminate(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> AssistantSummary:
+        return await context.runtime.terminate_assistant()
+
+    @app.post("/api/assistant/reattach", response_model=AssistantSummary)
+    async def assistant_reattach(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> AssistantSummary:
+        return await context.runtime.reattach_assistant()
 
     @app.get("/api/backends")
     async def list_backends(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -543,7 +543,14 @@ class SessionRuntime:
             permission_mode = (
                 permission_mode if permission_mode is not None else old.permission_mode
             )
-        if old is not None:
+        # Spawn the replacement before touching the current thread so a failed
+        # launch (e.g. a misconfigured backend) leaves the live, pinned
+        # assistant intact rather than orphaning the pointer at a stopped row.
+        created = await self._create_assistant_session(
+            chosen, model=model, effort=effort, permission_mode=permission_mode
+        )
+        self.assistant_session_id = created.id
+        if old is not None and old.id != created.id:
             # Release the protection guard, then best-effort stop the old thread.
             # The demoted row lingers as a normal stopped session so its
             # transcript is preserved.
@@ -552,10 +559,6 @@ class SessionRuntime:
             )
             with suppress(Exception):
                 await self.terminate(old.id)
-        created = await self._create_assistant_session(
-            chosen, model=model, effort=effort, permission_mode=permission_mode
-        )
-        self.assistant_session_id = created.id
         return self._require_assistant_summary()
 
     async def terminate_assistant(self) -> AssistantSummary:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -384,17 +384,20 @@ class SessionRuntime:
         # even when the live thread is reused below. The running agent only
         # re-reads AGENTS.md / CLAUDE.md when its thread is next recreated.
         self._prepare_assistant_workspace()
-        # Reuse only a thread that matches the configured backend, is alive,
-        # and already lives in the managed workspace — the last clause
-        # migrates assistants created by older builds (different cwd, charter
-        # sent as a visible message) to a fresh, silently-chartered thread.
+        # Reuse any live assistant that already lives in the managed workspace,
+        # regardless of its backend: the live thread is the source of truth, so
+        # a backend switched from the UI survives a redeploy. ``assistant_backend()``
+        # only seeds the first-ever creation below; later YAML edits to
+        # ``assistant.backend`` are ignored while a thread exists (clear context
+        # to re-seed). The cwd clause migrates assistants created by older builds
+        # (different cwd, charter sent as a visible message) to a fresh,
+        # silently-chartered thread.
         workspace = str(self._assistant_workspace_dir())
         live = next(
             (
                 session
                 for session in existing
-                if session.backend == target_backend
-                and session.status not in {SessionStatus.EXITED, SessionStatus.ERROR}
+                if session.status not in {SessionStatus.EXITED, SessionStatus.ERROR}
                 and session.cwd == workspace
             ),
             None,
@@ -411,16 +414,28 @@ class SessionRuntime:
             self.storage.update_session(
                 session.id, source=SessionSource.MANAGED, pinned_at=None
             )
-        created = await self._create_assistant_session(target_backend)
+        assistant = self.settings.assistant
+        assert assistant is not None  # guarded by target_backend is not None
+        created = await self._create_assistant_session(
+            target_backend,
+            model=assistant.model,
+            effort=assistant.effort,
+            permission_mode=assistant.permission_mode,
+        )
         self.assistant_session_id = created.id
 
-    async def _create_assistant_session(self, backend: str) -> SessionRecord:
-        assistant = self.settings.assistant
-        assert assistant is not None  # guarded by assistant_backend()
+    async def _create_assistant_session(
+        self,
+        backend: str,
+        *,
+        model: str | None,
+        effort: str | None,
+        permission_mode: str | None,
+    ) -> SessionRecord:
         plugin = self.registry.get(backend)
-        permission_mode = (
-            plugin.validate_permission_mode(assistant.permission_mode)
-            if assistant.permission_mode
+        validated_mode = (
+            plugin.validate_permission_mode(permission_mode)
+            if permission_mode
             else None
         )
         workspace = self._prepare_assistant_workspace()
@@ -428,9 +443,9 @@ class SessionRuntime:
             backend=backend,
             cwd=workspace,
             title="Personal Assistant",
-            model=assistant.model,
-            effort=assistant.effort,
-            permission_mode=permission_mode,
+            model=model,
+            effort=effort,
+            permission_mode=validated_mode,
         )
         session = await self.create_session(request)
         return self.storage.update_session(
@@ -472,7 +487,92 @@ class SessionRuntime:
             backend=session.backend,
             native_thread_id=plugin.native_thread_id(session),
             status=session.status,
+            supports_reattach=plugin.capabilities.supports_reattach_after_exit,
         )
+
+    def _require_assistant_summary(self) -> AssistantSummary:
+        summary = self.assistant_summary()
+        if summary is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="the assistant is disabled",
+            )
+        return summary
+
+    async def reset_assistant(
+        self,
+        *,
+        backend: str | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        permission_mode: str | None = None,
+    ) -> AssistantSummary:
+        """Rebuild the assistant on a fresh thread (clear context / switch backend).
+
+        The previous thread is demoted to an ordinary stopped session so its
+        transcript survives in the normal session list — it is never deleted.
+        Because boot reuses whatever thread is live, the chosen backend persists
+        across redeploys.
+        """
+        target_backend = self.settings.assistant_backend()
+        if target_backend is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="the assistant is disabled",
+            )
+        chosen = backend or target_backend
+        if not self.registry.has_backend(chosen):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown backend: {chosen}",
+            )
+        old_id = self.assistant_session_id
+        if old_id is not None and self.storage.get_session(old_id) is not None:
+            # Release the protection guard, then best-effort stop the old thread.
+            # The demoted row lingers as a normal stopped session so its
+            # transcript is preserved.
+            self.storage.update_session(
+                old_id, source=SessionSource.MANAGED, pinned_at=None
+            )
+            with suppress(Exception):
+                await self.terminate(old_id)
+        created = await self._create_assistant_session(
+            chosen, model=model, effort=effort, permission_mode=permission_mode
+        )
+        self.assistant_session_id = created.id
+        return self._require_assistant_summary()
+
+    async def terminate_assistant(self) -> AssistantSummary:
+        """Stop the assistant thread while keeping it the pinned singleton.
+
+        Unlike clearing context, the native thread and transcript are kept so
+        ``reattach_assistant`` can resume the same conversation.
+        """
+        session_id = self.assistant_session_id
+        if session_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="the assistant is disabled",
+            )
+        session = self.get_session(session_id)
+        if session.status != SessionStatus.EXITED:
+            plugin = self.registry.plugin_for(session)
+            await plugin.terminate_session(self, session)
+            await self._record_system_event(
+                session.id, "Assistant terminated", status=SessionStatus.EXITED
+            )
+            self.storage.update_session(session.id, status=SessionStatus.EXITED)
+        return self._require_assistant_summary()
+
+    async def reattach_assistant(self) -> AssistantSummary:
+        session_id = self.assistant_session_id
+        if session_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="the assistant is disabled",
+            )
+        await self.reattach(session_id)
+        return self._require_assistant_summary()
 
     async def fork_session(self, session_id: str) -> SessionRecord:
         session = self.get_session(session_id)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -380,6 +380,10 @@ class SessionRuntime:
                 )
             self.assistant_session_id = None
             return
+        # Refresh the charter files on every boot so a redeploy updates them
+        # even when the live thread is reused below. The running agent only
+        # re-reads AGENTS.md / CLAUDE.md when its thread is next recreated.
+        self._prepare_assistant_workspace()
         # Reuse only a thread that matches the configured backend, is alive,
         # and already lives in the managed workspace — the last clause
         # migrates assistants created by older builds (different cwd, charter

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -509,6 +509,12 @@ class SessionRuntime:
     ) -> AssistantSummary:
         """Rebuild the assistant on a fresh thread (clear context / switch backend).
 
+        Clearing context keeps the *current* thread's backend and live config
+        (model / effort / permission mode), so a context wipe doesn't silently
+        revert tuning done from the UI; only an explicit ``backend`` switch
+        overrides them, since model/effort are backend-specific. waypoint.yaml
+        only seeds the first creation, when no live thread exists.
+
         The previous thread is demoted to an ordinary stopped session so its
         transcript survives in the normal session list — it is never deleted.
         Because boot reuses whatever thread is live, the chosen backend persists
@@ -520,22 +526,32 @@ class SessionRuntime:
                 status_code=status.HTTP_409_CONFLICT,
                 detail="the assistant is disabled",
             )
-        chosen = backend or target_backend
+        old_id = self.assistant_session_id
+        old = self.storage.get_session(old_id) if old_id is not None else None
+        chosen = backend or (old.backend if old is not None else target_backend)
         if not self.registry.has_backend(chosen):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"unknown backend: {chosen}",
             )
-        old_id = self.assistant_session_id
-        if old_id is not None and self.storage.get_session(old_id) is not None:
+        # Inherit the live thread's config when staying on the same backend;
+        # an explicit request value always wins. A backend switch starts from
+        # that backend's defaults because model/effort don't transfer.
+        if old is not None and chosen == old.backend:
+            model = model if model is not None else old.model
+            effort = effort if effort is not None else old.effort
+            permission_mode = (
+                permission_mode if permission_mode is not None else old.permission_mode
+            )
+        if old is not None:
             # Release the protection guard, then best-effort stop the old thread.
             # The demoted row lingers as a normal stopped session so its
             # transcript is preserved.
             self.storage.update_session(
-                old_id, source=SessionSource.MANAGED, pinned_at=None
+                old.id, source=SessionSource.MANAGED, pinned_at=None
             )
             with suppress(Exception):
-                await self.terminate(old_id)
+                await self.terminate(old.id)
         created = await self._create_assistant_session(
             chosen, model=model, effort=effort, permission_mode=permission_mode
         )

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -227,6 +227,19 @@ class AssistantSummary(BaseModel):
     # outside the app. ``None`` when the backend has no resumable id.
     native_thread_id: str | None = None
     status: SessionStatus
+    # Whether the backend can revive this thread after it exits. Drives the
+    # assistant UI's choice between offering Reattach and only Clear context.
+    supports_reattach: bool = False
+
+
+class AssistantResetRequest(BaseModel):
+    # Rebuild the assistant on a fresh thread. ``backend`` switches the coding
+    # agent (``None`` keeps the current one); the rest seed the new thread,
+    # where ``None`` means the backend's default.
+    backend: BackendId | None = None
+    model: str | None = None
+    effort: str | None = None
+    permission_mode: str | None = None
 
 
 class MeResponse(BaseModel):

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3583,6 +3583,40 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
 
 
 @pytest.mark.asyncio
+async def test_reset_assistant_keeps_current_thread_when_create_fails(tmp_path) -> None:
+    # A failed launch (e.g. switching to a misconfigured backend) must leave the
+    # live assistant intact rather than orphaning the pointer at a stopped row.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-live",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    runtime.assistant_session_id = "codex-live"
+
+    async def _boom(
+        backend: str, *, model: Any, effort: Any, permission_mode: Any
+    ) -> SessionRecord:
+        raise RuntimeError("spawn failed")
+
+    runtime._create_assistant_session = _boom  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        await runtime.reset_assistant(backend="claude_code")
+
+    assert runtime.assistant_session_id == "codex-live"
+    row = storage.get_session("codex-live")
+    assert row is not None
+    assert row.source == SessionSource.ASSISTANT
+    assert row.status == SessionStatus.IDLE
+
+
+@pytest.mark.asyncio
 async def test_reset_assistant_unknown_backend_404(tmp_path) -> None:
     runtime, _, settings = make_runtime(tmp_path)
     settings.assistant = AssistantConfig(backend="codex")

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -15,7 +15,7 @@ from waypoint.backends.codex.permission_modes import (
 )
 from waypoint.backends.codex.schemas import CodexThreadImportRequest
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.runtime import SessionRuntime
+from waypoint.runtime import ASSISTANT_CHARTER, SessionRuntime
 from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
@@ -3418,3 +3418,35 @@ async def test_assistant_recreates_when_cwd_is_not_workspace(tmp_path) -> None:
     legacy = storage.get_session("codex-legacy")
     assert legacy is not None
     assert legacy.source == SessionSource.MANAGED
+
+
+@pytest.mark.asyncio
+async def test_assistant_refreshes_charter_files_on_reuse(tmp_path) -> None:
+    # A reused live thread still gets its workspace charter files rewritten to
+    # the current charter on boot, without recreating the thread.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    workspace = runtime._assistant_workspace_dir()
+    workspace.mkdir(parents=True, exist_ok=True)
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        (workspace / name).write_text("stale charter", encoding="utf-8")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(workspace),
+    )
+
+    async def _fail_create(backend: str) -> Any:  # pragma: no cover - must reuse
+        raise AssertionError("should reuse the live thread, not recreate")
+
+    runtime._create_assistant_session = _fail_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "codex-assistant"
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        assert (workspace / name).read_text(encoding="utf-8") == ASSISTANT_CHARTER

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3240,7 +3240,9 @@ async def test_assistant_reuses_live_matching_session(tmp_path) -> None:
         cwd=str(runtime._assistant_workspace_dir()),
     )
 
-    async def _fail_create(backend: str) -> Any:  # pragma: no cover - must not run
+    async def _fail_create(
+        backend: str, **_kwargs: Any
+    ) -> Any:  # pragma: no cover - must not run
         raise AssertionError("should not recreate a live assistant")
 
     runtime._create_assistant_session = _fail_create  # type: ignore[method-assign]
@@ -3254,7 +3256,10 @@ async def test_assistant_reuses_live_matching_session(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_assistant_recreates_when_backend_changes(tmp_path) -> None:
+async def test_assistant_reuses_live_session_across_backend_mismatch(tmp_path) -> None:
+    # Durable reuse: the live thread is the source of truth, so a backend
+    # switched from the UI survives a redeploy even when waypoint.yaml still
+    # names a different backend. YAML only seeds the first-ever creation.
     runtime, storage, settings = make_runtime(tmp_path)
     settings.assistant = AssistantConfig(backend="claude_code")
     _make_assistant_row(
@@ -3264,27 +3269,21 @@ async def test_assistant_recreates_when_backend_changes(tmp_path) -> None:
         backend="codex",
         status=SessionStatus.IDLE,
         transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
     )
 
-    async def _fake_create(backend: str) -> SessionRecord:
-        assert backend == "claude_code"
-        return _make_assistant_row(
-            storage,
-            settings,
-            session_id="claude-assistant",
-            backend="claude_code",
-            status=SessionStatus.STARTING,
-            transport="claude_cli",
-        )
+    async def _fail_create(backend: str, **_kwargs: Any) -> Any:
+        raise AssertionError("should reuse the live assistant, not recreate")
 
-    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+    runtime._create_assistant_session = _fail_create  # type: ignore[method-assign]
 
     await runtime._ensure_assistant_session()
 
-    assert runtime.assistant_session_id == "claude-assistant"
-    old = storage.get_session("codex-assistant")
-    assert old is not None
-    assert old.source == SessionSource.MANAGED
+    assert runtime.assistant_session_id == "codex-assistant"
+    kept = storage.get_session("codex-assistant")
+    assert kept is not None
+    assert kept.source == SessionSource.ASSISTANT
+    assert kept.backend == "codex"
 
 
 @pytest.mark.asyncio
@@ -3300,7 +3299,7 @@ async def test_assistant_recreates_when_prior_thread_exited(tmp_path) -> None:
         transport="codex_app_server",
     )
 
-    async def _fake_create(backend: str) -> SessionRecord:
+    async def _fake_create(backend: str, **_kwargs: Any) -> SessionRecord:
         return _make_assistant_row(
             storage,
             settings,
@@ -3363,6 +3362,10 @@ async def test_assistant_summary_reports_native_thread_id(tmp_path) -> None:
     assert summary.backend == "codex"
     assert summary.native_thread_id == "thread-1"
     assert summary.status == SessionStatus.IDLE
+    assert (
+        summary.supports_reattach
+        == runtime.registry.get("codex").capabilities.supports_reattach_after_exit
+    )
 
 
 def test_assistant_summary_is_none_when_untracked(tmp_path) -> None:
@@ -3399,7 +3402,7 @@ async def test_assistant_recreates_when_cwd_is_not_workspace(tmp_path) -> None:
         cwd="/home/someone",
     )
 
-    async def _fake_create(backend: str) -> SessionRecord:
+    async def _fake_create(backend: str, **_kwargs: Any) -> SessionRecord:
         return _make_assistant_row(
             storage,
             settings,
@@ -3440,7 +3443,9 @@ async def test_assistant_refreshes_charter_files_on_reuse(tmp_path) -> None:
         cwd=str(workspace),
     )
 
-    async def _fail_create(backend: str) -> Any:  # pragma: no cover - must reuse
+    async def _fail_create(
+        backend: str, **_kwargs: Any
+    ) -> Any:  # pragma: no cover - must reuse
         raise AssertionError("should reuse the live thread, not recreate")
 
     runtime._create_assistant_session = _fail_create  # type: ignore[method-assign]
@@ -3450,3 +3455,145 @@ async def test_assistant_refreshes_charter_files_on_reuse(tmp_path) -> None:
     assert runtime.assistant_session_id == "codex-assistant"
     for name in ("AGENTS.md", "CLAUDE.md"):
         assert (workspace / name).read_text(encoding="utf-8") == ASSISTANT_CHARTER
+
+
+@pytest.mark.asyncio
+async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
+    # Switch backends: the old thread is demoted to a normal stopped session
+    # (transcript preserved, never deleted) and a fresh thread becomes the
+    # singleton.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-old",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    runtime.assistant_session_id = "codex-old"
+
+    terminated: list[str] = []
+
+    async def _fake_terminate(session_id: str) -> SessionRecord:
+        terminated.append(session_id)
+        return storage.update_session(session_id, status=SessionStatus.EXITED)
+
+    runtime.terminate = _fake_terminate  # type: ignore[method-assign]
+
+    async def _fake_create(
+        backend: str, *, model: Any, effort: Any, permission_mode: Any
+    ) -> SessionRecord:
+        assert backend == "claude_code"
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="claude-new",
+            backend="claude_code",
+            status=SessionStatus.STARTING,
+            transport="claude_cli",
+            cwd=str(runtime._assistant_workspace_dir()),
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    summary = await runtime.reset_assistant(backend="claude_code")
+
+    assert summary.session_id == "claude-new"
+    assert runtime.assistant_session_id == "claude-new"
+    assert terminated == ["codex-old"]
+    old = storage.get_session("codex-old")
+    assert old is not None
+    assert old.source == SessionSource.MANAGED
+    assert old.pinned_at is None
+
+
+@pytest.mark.asyncio
+async def test_reset_assistant_unknown_backend_404(tmp_path) -> None:
+    runtime, _, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.reset_assistant(backend="nope")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_reset_assistant_disabled_409(tmp_path) -> None:
+    runtime, _, settings = make_runtime(tmp_path)
+    settings.assistant = None
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.reset_assistant()
+    assert exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_terminate_assistant_keeps_singleton(tmp_path, monkeypatch) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+    )
+    runtime.assistant_session_id = "codex-assistant"
+
+    async def _noop(rt: Any, sess: Any) -> None:
+        return None
+
+    monkeypatch.setattr(runtime.registry.get("codex"), "terminate_session", _noop)
+
+    summary = await runtime.terminate_assistant()
+
+    assert summary.status == SessionStatus.EXITED
+    row = storage.get_session("codex-assistant")
+    assert row is not None
+    # Still the protected singleton, so reattach can revive the same thread.
+    assert row.source == SessionSource.ASSISTANT
+    assert row.status == SessionStatus.EXITED
+
+
+@pytest.mark.asyncio
+async def test_reattach_assistant_revives_thread(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.EXITED,
+        transport="codex_app_server",
+    )
+    runtime.assistant_session_id = "codex-assistant"
+
+    reattached: list[str] = []
+
+    async def _fake_reattach(session_id: str) -> SessionRecord:
+        reattached.append(session_id)
+        return storage.update_session(session_id, status=SessionStatus.RUNNING)
+
+    runtime.reattach = _fake_reattach  # type: ignore[method-assign]
+
+    summary = await runtime.reattach_assistant()
+
+    assert reattached == ["codex-assistant"]
+    assert summary.status == SessionStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_assistant_lifecycle_409_when_untracked(tmp_path) -> None:
+    runtime, _, _ = make_runtime(tmp_path)
+    assert runtime.assistant_session_id is None
+
+    with pytest.raises(HTTPException) as terminate_exc:
+        await runtime.terminate_assistant()
+    assert terminate_exc.value.status_code == 409
+
+    with pytest.raises(HTTPException) as reattach_exc:
+        await runtime.reattach_assistant()
+    assert reattach_exc.value.status_code == 409

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3461,7 +3461,7 @@ async def test_assistant_refreshes_charter_files_on_reuse(tmp_path) -> None:
 async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
     # Switch backends: the old thread is demoted to a normal stopped session
     # (transcript preserved, never deleted) and a fresh thread becomes the
-    # singleton.
+    # singleton. Backend-specific config does NOT carry to the new backend.
     runtime, storage, settings = make_runtime(tmp_path)
     settings.assistant = AssistantConfig(backend="codex")
     _make_assistant_row(
@@ -3473,6 +3473,9 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
         transport="codex_app_server",
         cwd=str(runtime._assistant_workspace_dir()),
     )
+    storage.update_session(
+        "codex-old", model="gpt-5", effort="high", permission_mode="full-access"
+    )
     runtime.assistant_session_id = "codex-old"
 
     terminated: list[str] = []
@@ -3483,10 +3486,14 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
 
     runtime.terminate = _fake_terminate  # type: ignore[method-assign]
 
+    captured: dict[str, Any] = {}
+
     async def _fake_create(
         backend: str, *, model: Any, effort: Any, permission_mode: Any
     ) -> SessionRecord:
-        assert backend == "claude_code"
+        captured.update(
+            backend=backend, model=model, effort=effort, permission_mode=permission_mode
+        )
         return _make_assistant_row(
             storage,
             settings,
@@ -3504,10 +3511,75 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
     assert summary.session_id == "claude-new"
     assert runtime.assistant_session_id == "claude-new"
     assert terminated == ["codex-old"]
+    # New backend starts from its own defaults — codex's model/effort/mode do
+    # not transfer to claude_code.
+    assert captured == {
+        "backend": "claude_code",
+        "model": None,
+        "effort": None,
+        "permission_mode": None,
+    }
     old = storage.get_session("codex-old")
     assert old is not None
     assert old.source == SessionSource.MANAGED
     assert old.pinned_at is None
+
+
+@pytest.mark.asyncio
+async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> None:
+    # Clearing context (no backend arg) keeps the live thread's backend and its
+    # tuned config rather than reverting to waypoint.yaml / backend defaults.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(
+        backend="claude_code", model="opus", effort="low"
+    )
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-live",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    storage.update_session(
+        "codex-live", model="gpt-5", effort="high", permission_mode="full-access"
+    )
+    runtime.assistant_session_id = "codex-live"
+
+    async def _fake_terminate(session_id: str) -> SessionRecord:
+        return storage.update_session(session_id, status=SessionStatus.EXITED)
+
+    runtime.terminate = _fake_terminate  # type: ignore[method-assign]
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(
+        backend: str, *, model: Any, effort: Any, permission_mode: Any
+    ) -> SessionRecord:
+        captured.update(
+            backend=backend, model=model, effort=effort, permission_mode=permission_mode
+        )
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="codex-fresh",
+            backend=backend,
+            status=SessionStatus.STARTING,
+            transport="codex_app_server",
+            cwd=str(runtime._assistant_workspace_dir()),
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime.reset_assistant()
+
+    assert captured == {
+        "backend": "codex",
+        "model": "gpt-5",
+        "effort": "high",
+        "permission_mode": "full-access",
+    }
 
 
 @pytest.mark.asyncio

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -39,13 +39,38 @@ unaffected.
 
 ## Lifecycle
 
-- On startup the runtime reuses a still-alive assistant whose backend matches
-  the configured one.
-- If the configured backend changed, or the previous thread exited and cannot
-  be reattached, a fresh thread is created. The previous thread is **demoted to
-  an ordinary session** (its transcript is preserved and it becomes deletable),
-  never destroyed.
-- The assistant cannot be deleted or terminated through the API.
+- On startup the runtime reuses any still-alive assistant thread that lives in
+  the managed workspace, **regardless of its backend**. The live thread is the
+  source of truth, so a backend chosen from the UI survives a redeploy. The
+  `assistant` block in `waypoint.yaml` only seeds the *first* creation; editing
+  `assistant.backend` later has no effect while a thread exists — clear the
+  context to re-seed.
+- If no live thread exists (first boot, or the previous one exited), a fresh
+  thread is created from the `waypoint.yaml` defaults.
+- The assistant cannot be **deleted**, and the generic session terminate/delete
+  endpoints reject it (it is a protected singleton).
+
+### Controls (assistant page)
+
+The settings popover next to the composer exposes the assistant's lifecycle:
+
+- **Switch backend** — rebuild the assistant on a different coding agent. The
+  conversation cannot migrate between backends, so this starts a fresh thread
+  at the new backend's default model/effort/permission mode.
+- **Clear context** — start a fresh thread on the same backend.
+- **Terminate / Reattach** — stop the thread (keeping it the pinned singleton)
+  and later revive the same conversation. Reattach is offered only when the
+  backend can resume after exit.
+- **Model / effort / permission mode** — applied live to the running thread; no
+  context is lost.
+
+Switching backend and clearing context discard the conversation: the previous
+thread is **demoted to an ordinary stopped session** (its transcript is
+preserved and it becomes deletable), never destroyed.
+
+A terminated assistant survives reattach only within the running deployment; a
+redeploy cannot reattach an exited thread, so it demotes that thread to a normal
+stopped session and creates a fresh assistant.
 
 Both the Waypoint session id and the backend-native thread id (e.g. the value
 for `claude --resume`) are surfaced on the assistant page and via `/api/me`, so

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -5,14 +5,20 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
 
-import { SessionDetail } from "@/components/SessionDetail";
+import { AssistantControls, SessionDetail } from "@/components/SessionDetail";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import { fetchMe, isAuthError } from "@/lib/api";
+import {
+  fetchMe,
+  isAuthError,
+  reattachAssistant,
+  resetAssistant,
+  terminateAssistant,
+} from "@/lib/api";
 import { humaniseBackend } from "@/lib/backends";
 import { copyText } from "@/lib/clipboard";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
-import { AssistantSummary, SessionStatus } from "@/lib/types";
+import { AssistantSummary, Backend, BackendDescriptor, SessionStatus } from "@/lib/types";
 
 type LoadState = "loading" | "ready" | "disabled" | "error";
 
@@ -63,6 +69,7 @@ export default function AssistantPage() {
   const [host, setHost] = useState("");
   const [token, setToken] = useState("");
   const [assistant, setAssistant] = useState<AssistantSummary | null>(null);
+  const [backends, setBackends] = useState<BackendDescriptor[]>([]);
   const [state, setState] = useState<LoadState>("loading");
 
   const handleAuthFailure = useCallback(() => {
@@ -85,6 +92,7 @@ export default function AssistantPage() {
     fetchMe(currentHost, currentToken)
       .then((me) => {
         if (!active) return;
+        setBackends(me.backends ?? []);
         if (me.assistant) {
           setAssistant(me.assistant);
           setState("ready");
@@ -106,6 +114,21 @@ export default function AssistantPage() {
   }, [router, handleAuthFailure]);
 
   useEffect(() => load(), [load]);
+
+  // Run a lifecycle action and adopt the returned summary. Switching backend /
+  // clearing context changes the session id, which remounts SessionDetail via
+  // its key; terminate / reattach keep the id and just refresh the banner.
+  const applyControl = useCallback(
+    async (run: () => Promise<AssistantSummary>) => {
+      try {
+        setAssistant(await run());
+      } catch (err) {
+        if (isAuthError(err)) handleAuthFailure();
+        else console.error(err);
+      }
+    },
+    [handleAuthFailure],
+  );
 
   return (
     <main className="page-shell has-composer">
@@ -167,11 +190,26 @@ export default function AssistantPage() {
           </section>
           {host && token ? (
             <SessionDetail
+              key={assistant.session_id}
               host={host}
               token={token}
               sessionId={assistant.session_id}
               onAuthFailure={handleAuthFailure}
               assistant
+              assistantControls={
+                {
+                  backends,
+                  supportsReattach: assistant.supports_reattach,
+                  onSwitchBackend: (backend: Backend) =>
+                    applyControl(() => resetAssistant(host, token, { backend })),
+                  onClearContext: () =>
+                    applyControl(() => resetAssistant(host, token, {})),
+                  onTerminate: () =>
+                    applyControl(() => terminateAssistant(host, token)),
+                  onReattach: () =>
+                    applyControl(() => reattachAssistant(host, token)),
+                } satisfies AssistantControls
+              }
             />
           ) : null}
         </>

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -123,8 +123,13 @@ export default function AssistantPage() {
       try {
         setAssistant(await run());
       } catch (err) {
-        if (isAuthError(err)) handleAuthFailure();
-        else console.error(err);
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return;
+        }
+        // Surface to the composer's lifecycle footer so a failed switch /
+        // terminate / reattach isn't silently dropped.
+        throw err;
       }
     },
     [handleAuthFailure],

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5708,6 +5708,138 @@ html[data-theme="light"] .composer-tune-restart-apply {
   cursor: progress;
 }
 
+/* Assistant lifecycle footer (backend switch / clear context / terminate). */
+.composer-tune-lifecycle {
+  display: grid;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+}
+
+.composer-tune-lifecycle-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.composer-tune-lifecycle-btn {
+  flex: 1 1 auto;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  padding: 7px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line-strong);
+  background: rgba(8, 11, 16, 0.5);
+  color: var(--text);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+html[data-theme="light"] .composer-tune-lifecycle-btn {
+  background: rgba(235, 230, 218, 0.7);
+}
+
+.composer-tune-lifecycle-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent-strong);
+}
+
+.composer-tune-lifecycle-btn:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.composer-tune-lifecycle-btn.is-danger {
+  border-color: rgba(214, 92, 92, 0.5);
+  color: var(--danger);
+}
+
+.composer-tune-lifecycle-btn.is-danger:hover:not(:disabled) {
+  background: rgba(214, 92, 92, 0.14);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.composer-tune-confirm {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  border: 1px solid var(--line-strong);
+  border-radius: 6px;
+  background: rgba(8, 11, 16, 0.4);
+}
+
+html[data-theme="light"] .composer-tune-confirm {
+  background: rgba(235, 230, 218, 0.6);
+}
+
+.composer-tune-confirm p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--text);
+  line-height: 1.45;
+}
+
+.composer-tune-confirm strong {
+  color: var(--accent-strong);
+  font-weight: 600;
+}
+
+.composer-tune-confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.composer-tune-confirm-cancel,
+.composer-tune-confirm-apply {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  padding: 7px 12px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.composer-tune-confirm-cancel {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+}
+
+.composer-tune-confirm-cancel:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.composer-tune-confirm-apply {
+  border: 1px solid var(--accent);
+  background: rgba(200, 169, 106, 0.2);
+  color: var(--accent-strong);
+}
+
+.composer-tune-confirm-apply:hover:not(:disabled) {
+  background: rgba(200, 169, 106, 0.3);
+}
+
+.composer-tune-confirm-apply.is-danger {
+  border-color: rgba(214, 92, 92, 0.55);
+  background: rgba(214, 92, 92, 0.18);
+  color: var(--danger);
+}
+
+.composer-tune-confirm-apply.is-danger:hover:not(:disabled) {
+  background: rgba(214, 92, 92, 0.28);
+}
+
+.composer-tune-confirm-cancel:disabled,
+.composer-tune-confirm-apply:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
 .composer-shortcut {
   font-family: var(--font-mono);
   font-size: 0.7rem;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5716,6 +5716,13 @@ html[data-theme="light"] .composer-tune-restart-apply {
   border-top: 1px solid var(--line);
 }
 
+.composer-tune-error {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.4;
+  color: var(--danger);
+}
+
 .composer-tune-lifecycle-actions {
   display: flex;
   flex-wrap: wrap;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -77,6 +77,8 @@ import {
 } from "@/components/TranscriptCard";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
+  Backend,
+  BackendDescriptor,
   BackendModelOption,
   BackendPermissionMode,
   EventRecord,
@@ -177,6 +179,19 @@ const EFFORT_LABEL: Record<string, string> = {
 };
 
 
+// Assistant-only lifecycle actions surfaced inside the composer settings
+// popover (backend switch + clear context + terminate/reattach). The owning
+// page wires these to /api/assistant/* and refreshes itself afterwards; when
+// absent, the composer renders no assistant controls.
+export interface AssistantControls {
+  backends: BackendDescriptor[];
+  supportsReattach: boolean;
+  onSwitchBackend: (backend: Backend) => Promise<void> | void;
+  onClearContext: () => Promise<void> | void;
+  onTerminate: () => Promise<void> | void;
+  onReattach: () => Promise<void> | void;
+}
+
 interface SessionDetailProps {
   host: string;
   token: string;
@@ -187,6 +202,8 @@ interface SessionDetailProps {
   // actions (terminate, delete, /new, /fork), and shows a capability-led empty
   // state instead of "Waiting for the agent…".
   assistant?: boolean;
+  // Assistant lifecycle handlers; only meaningful when `assistant` is set.
+  assistantControls?: AssistantControls | null;
 }
 
 type ViewMode = "chat" | "terminal";
@@ -202,7 +219,7 @@ const COMPOSER_HEIGHT_STORAGE_KEY = "waypoint-composer-height";
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
-export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant = false }: SessionDetailProps) {
+export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant = false, assistantControls = null }: SessionDetailProps) {
   const router = useRouter();
   const catalog = useBackendCatalog(host || null, token || null, null);
   const [session, setSession] = useState<SessionRecord | null>(null);
@@ -1852,6 +1869,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onSend={onSendWithOptimistic}
           onTerminate={terminate}
           assistant={assistant}
+          assistantControls={assistantControls}
         />
       ) : null}
     </section>
@@ -1906,6 +1924,7 @@ interface ReplyComposerProps {
   onSend: (text: string, command?: SessionCommandInvocation) => Promise<boolean>;
   onTerminate: () => void | Promise<void>;
   assistant: boolean;
+  assistantControls: AssistantControls | null;
 }
 
 const ReplyComposer = memo(function ReplyComposer({
@@ -1952,12 +1971,20 @@ const ReplyComposer = memo(function ReplyComposer({
   onSend,
   onTerminate,
   assistant,
+  assistantControls,
 }: ReplyComposerProps) {
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
   const [reattaching, setReattaching] = useState(false);
+  // Assistant lifecycle UI: an in-flight action and which context-discarding
+  // action (backend switch / clear) is awaiting an inline confirm.
+  const [assistantBusy, setAssistantBusy] = useState(false);
+  const [assistantConfirm, setAssistantConfirm] = useState<
+    "switch" | "clear" | null
+  >(null);
+  const [pendingBackend, setPendingBackend] = useState<Backend | null>(null);
   // Pending effort for backends that need a session restart to apply (Claude)
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
@@ -2225,7 +2252,26 @@ const ReplyComposer = memo(function ReplyComposer({
     await onEffortChange(value);
   };
 
-  const tuneVisible = modeOptions.length > 0 || hasModelPicker || hasEffortPicker;
+  const assistantOps = assistant ? assistantControls : null;
+  const tuneVisible =
+    modeOptions.length > 0 ||
+    hasModelPicker ||
+    hasEffortPicker ||
+    assistantOps !== null;
+  const runAssistantAction = async (action: () => Promise<void> | void) => {
+    if (assistantBusy) return;
+    setAssistantBusy(true);
+    try {
+      await action();
+    } finally {
+      setAssistantBusy(false);
+      setAssistantConfirm(null);
+      setPendingBackend(null);
+    }
+  };
+  const assistantExited = Boolean(
+    session && (session.status === "exited" || session.status === "error"),
+  );
   const tuneSummary = (() => {
     const parts: string[] = [];
     if (modeOptions.length > 0) {
@@ -2280,6 +2326,33 @@ const ReplyComposer = memo(function ReplyComposer({
                 role="dialog"
                 aria-label="Session settings"
               >
+                {assistantOps && session ? (
+                  <label className="composer-tune-field">
+                    <span>Backend</span>
+                    <select
+                      value={pendingBackend ?? session.backend}
+                      onChange={(event) => {
+                        const next = event.target.value;
+                        if (next === session.backend) {
+                          setPendingBackend(null);
+                          setAssistantConfirm((mode) =>
+                            mode === "switch" ? null : mode,
+                          );
+                          return;
+                        }
+                        setPendingBackend(next);
+                        setAssistantConfirm("switch");
+                      }}
+                      disabled={assistantBusy}
+                    >
+                      {assistantOps.backends.map((backend) => (
+                        <option key={backend.id} value={backend.id}>
+                          {backend.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
                 {modeOptions.length > 0 ? (
                   <label className="composer-tune-field">
                     <span>Permission mode</span>
@@ -2353,6 +2426,108 @@ const ReplyComposer = memo(function ReplyComposer({
                     >
                       {effortBusy ? "Restarting…" : "Apply restart"}
                     </button>
+                  </div>
+                ) : null}
+                {assistantOps ? (
+                  <div className="composer-tune-lifecycle">
+                    {assistantConfirm === "switch" && pendingBackend ? (
+                      <div className="composer-tune-confirm">
+                        <p>
+                          Switch to{" "}
+                          <strong>{humaniseBackend(pendingBackend)}</strong>? This
+                          starts a new conversation; the current one is kept as a
+                          stopped session.
+                        </p>
+                        <div className="composer-tune-confirm-actions">
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-cancel"
+                            onClick={() => {
+                              setPendingBackend(null);
+                              setAssistantConfirm(null);
+                            }}
+                            disabled={assistantBusy}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-apply"
+                            onClick={() =>
+                              void runAssistantAction(() =>
+                                assistantOps.onSwitchBackend(pendingBackend),
+                              )
+                            }
+                            disabled={assistantBusy}
+                          >
+                            {assistantBusy ? "Switching…" : "Switch backend"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : assistantConfirm === "clear" ? (
+                      <div className="composer-tune-confirm">
+                        <p>
+                          Clear the conversation? The current thread is kept as a
+                          stopped session you can revisit.
+                        </p>
+                        <div className="composer-tune-confirm-actions">
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-cancel"
+                            onClick={() => setAssistantConfirm(null)}
+                            disabled={assistantBusy}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-apply is-danger"
+                            onClick={() =>
+                              void runAssistantAction(assistantOps.onClearContext)
+                            }
+                            disabled={assistantBusy}
+                          >
+                            {assistantBusy ? "Clearing…" : "Clear context"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="composer-tune-lifecycle-actions">
+                        <button
+                          type="button"
+                          className="composer-tune-lifecycle-btn"
+                          onClick={() => setAssistantConfirm("clear")}
+                          disabled={assistantBusy}
+                        >
+                          Clear context
+                        </button>
+                        {assistantExited ? (
+                          assistantOps.supportsReattach ? (
+                            <button
+                              type="button"
+                              className="composer-tune-lifecycle-btn"
+                              onClick={() =>
+                                void runAssistantAction(assistantOps.onReattach)
+                              }
+                              disabled={assistantBusy}
+                            >
+                              {assistantBusy ? "Reconnecting…" : "Reattach"}
+                            </button>
+                          ) : null
+                        ) : (
+                          <button
+                            type="button"
+                            className="composer-tune-lifecycle-btn is-danger"
+                            onClick={() =>
+                              void runAssistantAction(assistantOps.onTerminate)
+                            }
+                            disabled={assistantBusy}
+                          >
+                            {assistantBusy ? "Stopping…" : "Terminate"}
+                          </button>
+                        )}
+                      </div>
+                    )}
                   </div>
                 ) : null}
               </div>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1985,6 +1985,7 @@ const ReplyComposer = memo(function ReplyComposer({
     "switch" | "clear" | null
   >(null);
   const [pendingBackend, setPendingBackend] = useState<Backend | null>(null);
+  const [assistantError, setAssistantError] = useState<string | null>(null);
   // Pending effort for backends that need a session restart to apply (Claude)
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
@@ -2261,12 +2262,17 @@ const ReplyComposer = memo(function ReplyComposer({
   const runAssistantAction = async (action: () => Promise<void> | void) => {
     if (assistantBusy) return;
     setAssistantBusy(true);
+    setAssistantError(null);
     try {
       await action();
-    } finally {
-      setAssistantBusy(false);
+      // Only dismiss the confirm on success; on failure keep the selection and
+      // the error visible so the user can retry or cancel.
       setAssistantConfirm(null);
       setPendingBackend(null);
+    } catch (err) {
+      setAssistantError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setAssistantBusy(false);
     }
   };
   const assistantExited = Boolean(
@@ -2333,6 +2339,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       value={pendingBackend ?? session.backend}
                       onChange={(event) => {
                         const next = event.target.value;
+                        setAssistantError(null);
                         if (next === session.backend) {
                           setPendingBackend(null);
                           setAssistantConfirm((mode) =>
@@ -2430,6 +2437,11 @@ const ReplyComposer = memo(function ReplyComposer({
                 ) : null}
                 {assistantOps ? (
                   <div className="composer-tune-lifecycle">
+                    {assistantError ? (
+                      <p className="composer-tune-error" role="alert">
+                        {assistantError}
+                      </p>
+                    ) : null}
                     {assistantConfirm === "switch" && pendingBackend ? (
                       <div className="composer-tune-confirm">
                         <p>
@@ -2445,6 +2457,7 @@ const ReplyComposer = memo(function ReplyComposer({
                             onClick={() => {
                               setPendingBackend(null);
                               setAssistantConfirm(null);
+                              setAssistantError(null);
                             }}
                             disabled={assistantBusy}
                           >
@@ -2474,7 +2487,10 @@ const ReplyComposer = memo(function ReplyComposer({
                           <button
                             type="button"
                             className="composer-tune-confirm-cancel"
-                            onClick={() => setAssistantConfirm(null)}
+                            onClick={() => {
+                              setAssistantConfirm(null);
+                              setAssistantError(null);
+                            }}
                             disabled={assistantBusy}
                           >
                             Cancel

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import {
+  AssistantResetRequest,
+  AssistantSummary,
   Backend,
   BackendDescriptor,
   BackendModelListResponse,
@@ -85,6 +87,47 @@ export async function fetchMe(host: string, token: string): Promise<MeResponse> 
   });
   await ensureOk(response, "failed to fetch backend settings");
   return (await response.json()) as MeResponse;
+}
+
+export async function resetAssistant(
+  host: string,
+  token: string,
+  body: AssistantResetRequest = {},
+): Promise<AssistantSummary> {
+  const response = await fetch(`${host}/api/assistant/reset`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  await ensureOk(response, "failed to reset assistant");
+  return (await response.json()) as AssistantSummary;
+}
+
+export async function terminateAssistant(
+  host: string,
+  token: string,
+): Promise<AssistantSummary> {
+  const response = await fetch(`${host}/api/assistant/terminate`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to terminate assistant");
+  return (await response.json()) as AssistantSummary;
+}
+
+export async function reattachAssistant(
+  host: string,
+  token: string,
+): Promise<AssistantSummary> {
+  const response = await fetch(`${host}/api/assistant/reattach`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to reattach assistant");
+  return (await response.json()) as AssistantSummary;
 }
 
 export async function fetchBackends(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -190,6 +190,16 @@ export interface AssistantSummary {
   backend: Backend;
   native_thread_id: string | null;
   status: SessionStatus;
+  // Whether the backend can revive the thread after it exits — drives the
+  // choice between offering Reattach and only Clear context.
+  supports_reattach: boolean;
+}
+
+export interface AssistantResetRequest {
+  backend?: Backend;
+  model?: string | null;
+  effort?: string | null;
+  permission_mode?: string | null;
 }
 
 export interface MeResponse {


### PR DESCRIPTION
## Summary

The personal assistant was a fixed singleton: its backend, model, and permission mode were pinned by `waypoint.yaml` at creation, and it could not be stopped or its context cleared from the UI. This makes the assistant's lifecycle controllable at runtime — switch coding backend, clear context (start a fresh thread), and terminate / reattach — all from the settings popover on the assistant page, while keeping it a protected singleton. Boot now treats the live thread as the source of truth, so a backend chosen from the UI survives a redeploy; `waypoint.yaml` only seeds the first creation. The previous thread is always demoted to an ordinary stopped session (transcript preserved), never deleted.

This branch also folds in a fix so a redeploy refreshes the assistant's silent charter files even when the live thread is reused.

## Changes

### Backend

- `runtime.py`: `_ensure_assistant_session` now reuses any live in-workspace assistant thread **regardless of backend** — the live thread is authoritative, so a UI backend switch persists across redeploys and `assistant.backend` in `waypoint.yaml` only seeds the first creation. Adds `reset_assistant` (rebuild on a fresh thread for clear-context / backend-switch; demotes the old thread to a normal stopped session and best-effort stops it), `terminate_assistant` (stop the thread but keep it the pinned singleton so it can be revived), and `reattach_assistant`. Clearing context keeps the current thread's backend and inherits its live `model` / `effort` / `permission_mode`; only an explicit backend switch starts from the new backend's defaults, since those are backend-specific. `_create_assistant_session` is generalized to take config overrides. Also rewrites the charter files on every boot so a redeploy updates `AGENTS.md` / `CLAUDE.md` even when the thread is reused.
- `schemas.py`: `AssistantSummary` gains `supports_reattach` (from the backend's `supports_reattach_after_exit` capability) to drive the UI's Reattach-vs-Clear-context choice; new `AssistantResetRequest`.
- `api.py`: `POST /api/assistant/{reset,terminate,reattach}`, returning the updated `AssistantSummary`. The generic session `terminate` / `DELETE` endpoints still reject the assistant (403) — the deliberate path is `/api/assistant/*`, and delete stays fully blocked.

### Frontend

- `components/SessionDetail.tsx`: the composer's ⚙ settings popover gains, in assistant mode, a **Backend** selector plus a lifecycle footer — **Clear context** and a status-driven **Terminate** / **Reattach**. Context-discarding actions (switch backend, clear context) go through an inline confirm styled like the existing effort-restart block. Exposed via a new `AssistantControls` prop bundle; model / effort / permission-mode keep applying live through the existing per-session setters.
- `app/assistant/page.tsx`: wires the controls to `/api/assistant/*` and adopts the returned summary. Switching backend / clearing context change the session id, which remounts `SessionDetail` via its `key`; terminate / reattach keep the id and refresh the banner. Auth failures route through the existing handler.
- `lib/api.ts`, `lib/types.ts`: `resetAssistant` / `terminateAssistant` / `reattachAssistant` helpers, `AssistantResetRequest`, and `supports_reattach` on `AssistantSummary`.
- `app/globals.css`: lifecycle footer + inline-confirm styles, with `html[data-theme="light"]` overrides for the hardcoded dark surfaces.

### Docs

- `docs/personal_assistant.md`: rewrites the lifecycle section to cover durable reuse (live thread wins; `waypoint.yaml` only seeds the first creation), the assistant-page controls, and the caveat that a terminated assistant can only be reattached within the running deployment — a redeploy demotes an exited thread and creates a fresh assistant.
- `README.md`: note that the assistant's backend / model / permission mode are switchable on the fly and the thread can be terminated / reattached / context-cleared.

## Test Plan

- [x] `cd backend && uv run pytest tests/` — 545 pass; the 4 `tests/test_rate_limits.py` failures are pre-existing on `main` (keychain / messages-API header parsing), unrelated to this branch.
- [x] `cd backend && uv run pytest tests/test_runtime.py -k assistant` — 17 pass, covering durable cross-backend reuse, `reset_assistant` (config inherited on clear, reset to defaults on switch, old thread demoted), `terminate_assistant` (keeps the singleton), `reattach_assistant`, and the disabled (409) / unknown-backend (404) gates.
- [x] `cd backend && uv run mypy src/waypoint/runtime.py src/waypoint/api.py src/waypoint/schemas.py` — clean.
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on each commit — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — production build succeeds.