### PR TITLE
feat: move assistant instructions into repo skills

### DIFF
--- a/.agents/assistant/AGENTS.md
+++ b/.agents/assistant/AGENTS.md
@@ -1,0 +1,17 @@
+# Waypoint personal assistant
+
+You are the Waypoint personal assistant, a single long-lived thread the user
+talks to from the Waypoint app.
+
+Use local skills for Waypoint-specific workflows:
+- `waypoint` for inspecting and managing coding sessions through the `waypoint`
+  CLI.
+- `waypointctl` for managing the Waypoint stack and deployment.
+
+Answer questions about this host by inspecting the environment, files,
+processes, and tooling rather than guessing. Your working directory is a
+scratch space; operate across the host as needed.
+
+Be concise and act before narrating. Confirm before destructive or irreversible
+actions, including terminating sessions, deleting files, pulling updates, or
+restarting the stack.

--- a/.agents/assistant/CLAUDE.md
+++ b/.agents/assistant/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: waypoint
+description: Use when managing Waypoint coding sessions through the `waypoint` CLI, including listing sessions, reading transcripts, launching agents, sending messages, approvals, interrupts, termination, doctor output, auth, or runtime reset decisions.
+---
+
+# Waypoint Sessions
+
+Use this skill for the `waypoint` backend CLI. Prefer `waypoint sessions ...`
+for a running Waypoint server; avoid the singular `waypoint session ...` flow
+unless the user explicitly wants an in-process one-shot runtime.
+
+Start by running `waypoint sessions --help` or the specific subcommand's
+`--help` when uncertain; the CLI is the source of truth for the installed
+version.
+
+## Common Routing
+
+- Read session state or transcript: see `references/sessions-read.md`.
+- Launch a new coding agent: see `references/sessions-launch.md`.
+- Send messages, interrupt running work, or terminate sessions: see
+  `references/sessions-steer.md`.
+- Respond to approval requests: see `references/sessions-approvals.md`.
+- Handle destructive operations such as reset or termination: see
+  `references/destructive-ops.md`.
+- Diagnose CLI auth/config issues: see `references/auth-config.md`.
+
+## Guardrails
+
+- Prefer JSON output from the CLI over inferring session state from memory.
+- Confirm before terminating sessions, resetting runtime data, or taking action
+  that can discard work.
+- Never try to delete or terminate the personal assistant through generic
+  session endpoints; it is a protected singleton.
+- When reporting status, include concrete session ids and current statuses.

--- a/.agents/skills/waypoint/references/auth-config.md
+++ b/.agents/skills/waypoint/references/auth-config.md
@@ -1,0 +1,18 @@
+# Auth And Config
+
+The `waypoint sessions` CLI talks to the running server over HTTP. On the same
+host, `waypoint serve` writes a token under the backend data dir so the CLI can
+authenticate without prompting for the password.
+
+Useful diagnostics:
+
+```bash
+waypoint doctor
+waypoint --config <path> doctor
+```
+
+Use `--config <path>` when the user points at a non-default `waypoint.yaml`.
+Environment overrides may affect data dir, host, port, and password.
+
+If the server is unreachable, inspect the stack with the `waypointctl` skill
+rather than guessing.

--- a/.agents/skills/waypoint/references/destructive-ops.md
+++ b/.agents/skills/waypoint/references/destructive-ops.md
@@ -1,0 +1,15 @@
+# Destructive Operations
+
+Destructive or irreversible operations require confirmation:
+
+- `waypoint sessions terminate <session-id>`
+- `waypoint reset --yes`
+- deleting files, overwriting user work, or discarding transcripts
+
+`waypoint reset` wipes runtime data such as sessions, events, tokens,
+schedules, and logs while leaving config untouched. Run without `--yes` first
+for a dry-run list of what would be removed.
+
+The personal assistant is protected from generic session termination/deletion.
+Use the assistant page lifecycle controls for assistant-specific reset,
+terminate, and reattach behavior.

--- a/.agents/skills/waypoint/references/sessions-approvals.md
+++ b/.agents/skills/waypoint/references/sessions-approvals.md
@@ -1,0 +1,16 @@
+# Approvals
+
+Use approvals when a coding backend is waiting for a plan or tool decision.
+
+```bash
+waypoint sessions approve <session-id> <decision>
+waypoint sessions approve <session-id> <decision> --approval-id <id>
+waypoint sessions approve <session-id> <decision> --text <message>
+```
+
+Read the pending request from `waypoint sessions events <session-id>` before
+approving. If multiple approvals are pending, pass `--approval-id` when the
+transcript exposes one.
+
+Do not approve destructive, privileged, or unclear requests without user
+confirmation.

--- a/.agents/skills/waypoint/references/sessions-launch.md
+++ b/.agents/skills/waypoint/references/sessions-launch.md
@@ -1,0 +1,18 @@
+# Launching Sessions
+
+Launch through the running server:
+
+```bash
+waypoint sessions start --backend <id> --cwd <path>
+waypoint sessions start --backend <id> --cwd <path> --title <title>
+waypoint sessions start --backend <id> --cwd <path> --model <model>
+waypoint sessions start --backend <id> --cwd <path> --effort <effort>
+waypoint sessions start --backend <id> --cwd <path> --permission-mode <mode>
+```
+
+Use `waypoint doctor` or `waypoint sessions start --help` to discover available
+backend ids and local CLI availability when launch fails.
+
+Choose `cwd` deliberately. For repository work, use the repo root. For host
+inspection or scratch work, use an explicit safe directory rather than assuming
+the assistant workspace is the user's target project.

--- a/.agents/skills/waypoint/references/sessions-read.md
+++ b/.agents/skills/waypoint/references/sessions-read.md
@@ -1,0 +1,18 @@
+# Reading Sessions
+
+Use these commands to ground answers in live Waypoint state:
+
+```bash
+waypoint sessions list
+waypoint sessions show <session-id>
+waypoint sessions events <session-id>
+waypoint sessions events <session-id> --messages 40
+waypoint sessions events <session-id> --before-sequence <sequence>
+```
+
+`list` is the starting point for broad questions. Use `show` for one session's
+metadata and `events` for transcript details.
+
+When summarizing, distinguish status (`running`, `waiting_input`, `idle`,
+`exited`, `error`) from your interpretation of progress. Quote only the minimum
+transcript text needed to justify the conclusion.

--- a/.agents/skills/waypoint/references/sessions-steer.md
+++ b/.agents/skills/waypoint/references/sessions-steer.md
@@ -1,0 +1,23 @@
+# Steering Sessions
+
+Send input:
+
+```bash
+waypoint sessions send <session-id> <text>
+```
+
+Interrupt only when the user asks, or when a session is clearly stuck and the
+user confirms:
+
+```bash
+waypoint sessions interrupt <session-id>
+```
+
+Terminate only with explicit confirmation:
+
+```bash
+waypoint sessions terminate <session-id>
+```
+
+After sending input or control signals, re-check state with `waypoint sessions
+show <session-id>` or `waypoint sessions events <session-id> --messages N`.

--- a/.agents/skills/waypointctl/SKILL.md
+++ b/.agents/skills/waypointctl/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: waypointctl
+description: Use when managing the Waypoint stack with `waypointctl`, including start, stop, restart, status, logs, daemon mode, deploy/update flow, environment/state paths, frontend/backend service targets, and Docker-backed Tailscale profiles.
+---
+
+# Waypoint Stack
+
+Use this skill for `waypointctl`, the local stack supervisor for Waypoint.
+These commands affect the deployment the assistant is running on.
+
+Start with `waypointctl status` for state and `waypointctl --help` or a
+subcommand's `--help` when the installed command surface is uncertain.
+
+## Common Routing
+
+- Observe status or logs: see `references/observe.md`.
+- Start, stop, or restart services: see `references/lifecycle.md`.
+- Handle backend/full-stack restart safely: see `references/restart-safety.md`.
+- Pull/update/redeploy the app: see `references/update-deploy.md`.
+- Manage `waypointd`: see `references/daemon.md`.
+- Manage Docker-backed tailnet profiles: see `references/tailscale.md`.
+- Understand env vars and state paths: see `references/env-state.md`.
+
+## Guardrails
+
+- Confirm before stopping or restarting backend/all services.
+- A backend restart can interrupt every running session, including this
+  assistant.
+- Check active sessions with `waypoint sessions list` before backend or
+  full-stack restarts.
+- Prefer `waypointctl restart frontend` for frontend-only changes.

--- a/.agents/skills/waypointctl/references/daemon.md
+++ b/.agents/skills/waypointctl/references/daemon.md
@@ -1,0 +1,16 @@
+# Daemon Mode
+
+`waypointd` lets hosted agents ask for stop/restart without being killed before
+the command is accepted.
+
+```bash
+waypointctl daemon start
+waypointctl daemon status
+waypointctl daemon stop
+```
+
+`waypointctl daemon stop` stops only the daemon, not backend/frontend services.
+Use `waypointctl stop` for services.
+
+When daemon mode is active, stop/restart may return before work finishes. Check
+`waypointctl status` and logs afterward.

--- a/.agents/skills/waypointctl/references/env-state.md
+++ b/.agents/skills/waypointctl/references/env-state.md
@@ -1,0 +1,13 @@
+# Environment And State
+
+Common environment variables:
+
+- `WAYPOINT_HOME`: repo root used by `waypointctl --home`.
+- `WAYPOINTCTL_DAEMON=1`: route commands through `waypointd`.
+- `WAYPOINT_STACK_BACKEND_PORT`: backend port override.
+- `WAYPOINT_STACK_FRONTEND_PORT`: frontend port override.
+- `WAYPOINT_STACK_CONFIG`: backend config path override.
+- `WAYPOINT_STACK_BACKEND_DATA_DIR`: backend data dir override.
+
+State and logs normally live under the waypointctl state dir. Use
+`waypointctl doctor` to print resolved paths and daemon socket information.

--- a/.agents/skills/waypointctl/references/lifecycle.md
+++ b/.agents/skills/waypointctl/references/lifecycle.md
@@ -1,0 +1,17 @@
+# Lifecycle Commands
+
+Targets are `backend`, `frontend`, or `all`:
+
+```bash
+waypointctl start [backend|frontend|all]
+waypointctl stop [backend|frontend|all]
+waypointctl restart [backend|frontend|all]
+waypointctl status
+```
+
+Starting is generally safe. Frontend restart is safe for frontend-only changes.
+Backend or full-stack restart requires confirmation because it interrupts live
+sessions.
+
+Use `waypointctl restart frontend` after frontend code changes. For backend
+changes, follow `restart-safety.md`.

--- a/.agents/skills/waypointctl/references/observe.md
+++ b/.agents/skills/waypointctl/references/observe.md
@@ -1,0 +1,17 @@
+# Observing The Stack
+
+Use:
+
+```bash
+waypointctl status
+waypointctl logs backend
+waypointctl logs frontend
+waypointctl logs all
+waypointctl doctor
+```
+
+`status` reports managed, stopped, or unmanaged services. `logs` follows the
+service log files and is useful after start/restart or when a health check
+fails.
+
+For session-level state, use the `waypoint` skill and `waypoint sessions list`.

--- a/.agents/skills/waypointctl/references/restart-safety.md
+++ b/.agents/skills/waypointctl/references/restart-safety.md
@@ -1,0 +1,24 @@
+# Restart Safety
+
+Before backend or full-stack restart:
+
+1. Run `waypoint sessions list`.
+2. Surface sessions that are `running` or `waiting_input`.
+3. Ask the user to confirm interruption.
+4. Prefer daemon-backed restart so the caller is not killed mid-command.
+
+Commands:
+
+```bash
+waypointctl daemon start
+waypointctl restart backend
+waypointctl restart all
+```
+
+Avoid `--wait` from inside a hosted backend process unless the user understands
+the caller may be interrupted. After restart, verify with:
+
+```bash
+waypointctl status
+waypointctl logs backend
+```

--- a/.agents/skills/waypointctl/references/tailscale.md
+++ b/.agents/skills/waypointctl/references/tailscale.md
@@ -1,0 +1,16 @@
+# Tailscale Profiles
+
+Waypoint can manage Docker-backed Tailscale profiles:
+
+```bash
+waypointctl tailscale up <profile>
+waypointctl tailscale down <profile>
+waypointctl tailscale status <profile>
+waypointctl tailscale logs <profile>
+```
+
+`up` needs `TS_AUTHKEY`. The helper performs Docker/Tailscale preflight checks.
+If Docker is missing, `status` degrades gracefully but `up`, `down`, and `logs`
+abort with an explanatory message.
+
+Confirm before changing tailnet connectivity.

--- a/.agents/skills/waypointctl/references/update-deploy.md
+++ b/.agents/skills/waypointctl/references/update-deploy.md
@@ -1,0 +1,31 @@
+# Update And Deploy
+
+The repository is usually at `$WAYPOINT_HOME`.
+
+Before pulling:
+
+```bash
+git -C "$WAYPOINT_HOME" status
+git -C "$WAYPOINT_HOME" rev-parse --abbrev-ref HEAD
+```
+
+If the tree is dirty or not on `main`, stop and tell the user. Otherwise:
+
+```bash
+git -C "$WAYPOINT_HOME" pull --ff-only origin main
+```
+
+If backend dependencies changed:
+
+```bash
+cd "$WAYPOINT_HOME/backend" && uv sync
+```
+
+If `waypointctl/` changed, reinstall from source:
+
+```bash
+uv tool install "$WAYPOINT_HOME/waypointctl" --reinstall
+```
+
+Then restart only what changed, following `restart-safety.md` for backend or
+full-stack restarts.

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/backend/src/waypoint/assistant_assets.py
+++ b/backend/src/waypoint/assistant_assets.py
@@ -1,0 +1,298 @@
+import hashlib
+import json
+import os
+import shutil
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ASSISTANT_ASSET_MANIFEST = ".waypoint-assistant-assets.json"
+ASSISTANT_SYMLINK_TARGET = "../.agents/skills"
+ASSET_SCHEMA_VERSION = 1
+
+
+class AssistantAssetError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class AssistantAssetSource:
+    root: Path
+    assistant_dir: Path
+    skills_dir: Path
+
+
+def ensure_assistant_assets(
+    workspace: Path,
+    *,
+    config_path: Path | None = None,
+    source_root: Path | None = None,
+    prefer_symlinks: bool = True,
+) -> Path:
+    source = resolve_assistant_asset_source(
+        config_path=config_path,
+        source_root=source_root,
+    )
+    validate_assistant_asset_source(source)
+    workspace.mkdir(parents=True, exist_ok=True)
+    if prefer_symlinks:
+        try:
+            _ensure_symlink_assets(workspace, source)
+            _write_manifest_if_changed(
+                workspace,
+                {
+                    "schema_version": ASSET_SCHEMA_VERSION,
+                    "mode": "symlink",
+                    "source_root": str(source.root),
+                },
+            )
+            return workspace
+        except OSError:
+            pass
+    _ensure_copied_assets(workspace, source)
+    return workspace
+
+
+def resolve_assistant_asset_source(
+    *,
+    config_path: Path | None = None,
+    source_root: Path | None = None,
+) -> AssistantAssetSource:
+    candidates: list[Path] = []
+    if source_root is not None:
+        candidates.append(source_root)
+    env_root = os.environ.get("WAYPOINT_ASSISTANT_ASSETS_ROOT")
+    if env_root:
+        candidates.append(Path(env_root))
+    waypoint_home = os.environ.get("WAYPOINT_HOME")
+    if waypoint_home:
+        candidates.append(Path(waypoint_home))
+    candidates.append(Path(__file__).resolve().parents[3])
+    if config_path is not None:
+        expanded = config_path.expanduser().resolve()
+        candidates.extend([expanded.parent, *expanded.parents])
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        root = candidate.expanduser().resolve()
+        if root in seen:
+            continue
+        seen.add(root)
+        source = AssistantAssetSource(
+            root=root,
+            assistant_dir=root / ".agents" / "assistant",
+            skills_dir=root / ".agents" / "skills",
+        )
+        if source.assistant_dir.is_dir() and source.skills_dir.is_dir():
+            return source
+    tried = ", ".join(str(path.expanduser()) for path in candidates)
+    raise AssistantAssetError(f"assistant asset source not found; tried: {tried}")
+
+
+def validate_assistant_asset_source(source: AssistantAssetSource) -> None:
+    for name in ("AGENTS.md", "CLAUDE.md"):
+        path = source.assistant_dir / name
+        if not path.is_file():
+            raise AssistantAssetError(f"missing assistant bootstrap file: {path}")
+    if not source.skills_dir.is_dir():
+        raise AssistantAssetError(
+            f"missing assistant skills directory: {source.skills_dir}"
+        )
+    skill_names: set[str] = set()
+    skill_dirs = [
+        path
+        for path in sorted(source.skills_dir.iterdir())
+        if path.is_dir() and not path.name.startswith(".")
+    ]
+    if not skill_dirs:
+        raise AssistantAssetError(f"no assistant skills found in {source.skills_dir}")
+    for skill_dir in skill_dirs:
+        skill_file = skill_dir / "SKILL.md"
+        if not skill_file.is_file():
+            raise AssistantAssetError(f"missing skill file: {skill_file}")
+        metadata = _skill_frontmatter(skill_file)
+        name = _required_metadata_string(metadata, "name", skill_file)
+        _required_metadata_string(metadata, "description", skill_file)
+        if name in skill_names:
+            raise AssistantAssetError(f"duplicate assistant skill name: {name}")
+        skill_names.add(name)
+    repo_claude_skills = source.root / ".claude" / "skills"
+    if not repo_claude_skills.is_symlink():
+        raise AssistantAssetError(
+            f"repo .claude/skills must be a symlink: {repo_claude_skills}"
+        )
+    if os.readlink(repo_claude_skills) != ASSISTANT_SYMLINK_TARGET:
+        raise AssistantAssetError(
+            f"repo .claude/skills must point to {ASSISTANT_SYMLINK_TARGET!r}"
+        )
+
+
+def _ensure_symlink_assets(workspace: Path, source: AssistantAssetSource) -> None:
+    _ensure_symlink(
+        workspace / "AGENTS.md",
+        source.assistant_dir / "AGENTS.md",
+    )
+    _ensure_symlink(
+        workspace / "CLAUDE.md",
+        source.assistant_dir / "CLAUDE.md",
+    )
+    _ensure_symlink(
+        workspace / ".agents" / "skills",
+        source.skills_dir,
+    )
+    _ensure_symlink(
+        workspace / ".claude" / "skills",
+        Path(ASSISTANT_SYMLINK_TARGET),
+    )
+    _ensure_symlink(
+        workspace / ".codex" / "skills",
+        Path(ASSISTANT_SYMLINK_TARGET),
+    )
+
+
+def _ensure_copied_assets(workspace: Path, source: AssistantAssetSource) -> None:
+    signature = _asset_signature(
+        [
+            source.assistant_dir / "AGENTS.md",
+            source.assistant_dir / "CLAUDE.md",
+            source.skills_dir,
+        ]
+    )
+    manifest = _read_manifest(workspace)
+    if (
+        manifest.get("schema_version") == ASSET_SCHEMA_VERSION
+        and manifest.get("mode") == "copy"
+        and manifest.get("source_root") == str(source.root)
+        and manifest.get("signature") == signature
+        and (workspace / "AGENTS.md").is_file()
+        and (workspace / "CLAUDE.md").is_file()
+        and (workspace / ".agents" / "skills").is_dir()
+        and _skill_entry_exists(workspace / ".claude" / "skills")
+        and _skill_entry_exists(workspace / ".codex" / "skills")
+    ):
+        return
+    _replace_file(workspace / "AGENTS.md", source.assistant_dir / "AGENTS.md")
+    _replace_file(workspace / "CLAUDE.md", source.assistant_dir / "CLAUDE.md")
+    _replace_tree(workspace / ".agents" / "skills", source.skills_dir)
+    _ensure_skill_entry(workspace / ".claude" / "skills", source.skills_dir)
+    _ensure_skill_entry(workspace / ".codex" / "skills", source.skills_dir)
+    _write_manifest_if_changed(
+        workspace,
+        {
+            "schema_version": ASSET_SCHEMA_VERSION,
+            "mode": "copy",
+            "source_root": str(source.root),
+            "signature": signature,
+            "written_at": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+def _skill_entry_exists(path: Path) -> bool:
+    return path.is_symlink() or path.is_dir()
+
+
+def _ensure_skill_entry(path: Path, source: Path) -> None:
+    try:
+        _ensure_symlink(path, Path(ASSISTANT_SYMLINK_TARGET))
+    except OSError:
+        _replace_tree(path, source)
+
+
+def _ensure_symlink(path: Path, target: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink() and Path(os.readlink(path)) == target:
+        return
+    _remove_path(path)
+    path.symlink_to(
+        target,
+        target_is_directory=target.name != "AGENTS.md" and target.name != "CLAUDE.md",
+    )
+
+
+def _replace_file(destination: Path, source: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    _remove_path(destination)
+    shutil.copy2(source, destination)
+
+
+def _replace_tree(destination: Path, source: Path) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp = destination.with_name(f".{destination.name}.tmp-{os.getpid()}")
+    _remove_path(tmp)
+    shutil.copytree(source, tmp, symlinks=True)
+    _remove_path(destination)
+    tmp.replace(destination)
+
+
+def _remove_path(path: Path) -> None:
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def _read_manifest(workspace: Path) -> dict[str, Any]:
+    path = workspace / ASSISTANT_ASSET_MANIFEST
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_manifest_if_changed(workspace: Path, payload: dict[str, Any]) -> None:
+    path = workspace / ASSISTANT_ASSET_MANIFEST
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    try:
+        if path.read_text(encoding="utf-8") == text:
+            return
+    except OSError:
+        pass
+    path.write_text(text, encoding="utf-8")
+
+
+def _asset_signature(paths: Iterable[Path]) -> str:
+    digest = hashlib.sha256()
+    for path in paths:
+        if path.is_dir():
+            files = sorted(item for item in path.rglob("*") if item.is_file())
+        else:
+            files = [path]
+        for file_path in files:
+            digest.update(str(file_path).encode("utf-8"))
+            digest.update(b"\0")
+            digest.update(file_path.read_bytes())
+            digest.update(b"\0")
+    return digest.hexdigest()
+
+
+def _skill_frontmatter(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        raise AssistantAssetError(f"missing skill frontmatter: {path}")
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise AssistantAssetError(f"invalid skill frontmatter: {path}")
+    try:
+        payload = yaml.safe_load(parts[1]) or {}
+    except yaml.YAMLError as exc:
+        raise AssistantAssetError(f"invalid skill frontmatter: {path}") from exc
+    if not isinstance(payload, dict):
+        raise AssistantAssetError(f"invalid skill frontmatter: {path}")
+    return payload
+
+
+def _required_metadata_string(
+    metadata: dict[str, Any],
+    key: str,
+    path: Path,
+) -> str:
+    value = metadata.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise AssistantAssetError(f"skill {path} missing required {key!r}")
+    return value.strip()

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from fastapi import HTTPException, status
 
+from waypoint.assistant_assets import ensure_assistant_assets
 from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
@@ -47,61 +48,6 @@ from waypoint.transports import TransportAdapter
 TMUX_TRANSPORT_ID = "tmux"
 COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
 
-# The assistant's charter. Written into AGENTS.md / CLAUDE.md in the
-# assistant's managed working directory so the backend loads it silently as
-# project context — no visible first message, no wasted startup turn.
-# References the `waypoint` / `waypointctl` CLIs, which the runtime expects on
-# the assistant process's PATH.
-ASSISTANT_CHARTER = """\
-# Waypoint personal assistant
-
-You are the Waypoint personal assistant — a single, long-lived thread the
-user talks to from a dedicated page in the Waypoint app. These are standing
-instructions; act on them whenever the user writes to you.
-
-Your job:
-- Answer questions about this host machine. You have full shell access; run
-  commands to inspect the environment, files, processes, and tooling rather
-  than guessing. Your working directory is a scratch space — operate across
-  the host as needed.
-- Ground answers in the user's Waypoint coding sessions (the agents they
-  run). Inspect and manage them with the `waypoint` CLI, which is on your
-  PATH:
-  - `waypoint sessions list` — all sessions and their status.
-  - `waypoint sessions show <id>` — details of one session.
-  - `waypoint sessions events <id>` — a session's transcript.
-  - `waypoint sessions start --backend <id> --cwd <path>` — launch a new agent.
-  - `waypoint sessions send <id> <text>` — send a message to a session.
-  - `waypoint sessions interrupt|terminate <id>` — control a session.
-  Run `waypoint sessions --help` for the full surface. Prefer the CLI over
-  guessing about session state.
-
-Managing your own deployment — you run on this Waypoint stack and can update
-it with `waypointctl` (the stack supervisor) and `uv`, both on your PATH.
-These commands affect the deployment you are running on, so treat them as
-confirm-first. In particular, restarting the backend interrupts every running
-session, including you — your current turn ends and the user has to reconnect.
-- Update from the remote: the repo is at `$WAYPOINT_HOME`. First check it is
-  safe with `git -C "$WAYPOINT_HOME" status`; if the tree is dirty or not on
-  `main`, stop and tell the user rather than pulling. Otherwise
-  `git -C "$WAYPOINT_HOME" pull --ff-only origin main`.
-- Apply changed dependencies: if the pull touched backend deps,
-  `cd "$WAYPOINT_HOME/backend" && uv sync`. Frontend deps install on
-  `waypointctl start`. If `waypointctl/` itself changed, reinstall it with
-  `uv tool install "$WAYPOINT_HOME/waypointctl" --reinstall` (use --reinstall,
-  not --force: it rebuilds from source even though the version is unchanged).
-- Restart to apply: a frontend-only change is safe via
-  `waypointctl restart frontend`. For a backend (or full-stack) change, first
-  review active work with `waypoint sessions list`, surface anything running
-  or waiting on input, get the user's confirmation, then
-  `waypointctl restart backend` (or `waypointctl restart` for both) — expect
-  your own connection to drop and that you cannot observe completion.
-- Verify with `waypointctl status` and `waypointctl logs backend` (or
-  `frontend`).
-
-Be concise and act before narrating. Do not take destructive or irreversible
-actions (terminating sessions, deleting files, pulling updates, restarting the
-stack) without confirming with the user first."""
 
 log = logging.getLogger("waypoint.runtime")
 
@@ -380,9 +326,9 @@ class SessionRuntime:
                 )
             self.assistant_session_id = None
             return
-        # Refresh the charter files on every boot so a redeploy updates them
-        # even when the live thread is reused below. The running agent only
-        # re-reads AGENTS.md / CLAUDE.md when its thread is next recreated.
+        # Refresh assistant workspace asset links on every boot so repo
+        # updates to AGENTS.md / CLAUDE.md / skills are visible to backends
+        # without recreating the live thread.
         self._prepare_assistant_workspace()
         # Reuse any live assistant that already lives in the managed workspace,
         # regardless of its backend: the live thread is the source of truth, so
@@ -390,7 +336,7 @@ class SessionRuntime:
         # only seeds the first-ever creation below; later YAML edits to
         # ``assistant.backend`` are ignored while a thread exists (clear context
         # to re-seed). The cwd clause migrates assistants created by older builds
-        # (different cwd, charter sent as a visible message) to a fresh,
+        # (different cwd, bootstrap instructions sent as a visible message) to a fresh,
         # silently-chartered thread.
         workspace = str(self._assistant_workspace_dir())
         live = next(
@@ -458,17 +404,14 @@ class SessionRuntime:
         return self.settings.data_dir / "assistant"
 
     def _prepare_assistant_workspace(self) -> str:
-        """Materialise the assistant's working dir and its charter files.
+        """Ensure the assistant's working dir and repo-tracked assets exist.
 
-        The charter ships as ``AGENTS.md`` / ``CLAUDE.md`` (read silently by
-        the backend as project context) rather than a visible first message.
-        The directory is a scratch cwd — shell access reaches the whole host
-        regardless — so host inspection is unaffected.
+        The bootstrap files and skills are linked from the repo by default so
+        updates are cheap and visible to backends that reload project context.
+        The directory is a scratch cwd; shell access reaches the whole host.
         """
         workspace = self._assistant_workspace_dir()
-        workspace.mkdir(parents=True, exist_ok=True)
-        for name in ("AGENTS.md", "CLAUDE.md"):
-            (workspace / name).write_text(ASSISTANT_CHARTER, encoding="utf-8")
+        ensure_assistant_assets(workspace, config_path=self.settings.config_path)
         return str(workspace)
 
     def is_assistant_session(self, session: SessionRecord) -> bool:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from fastapi import HTTPException, status
 
-from waypoint.assistant_assets import ensure_assistant_assets
+from waypoint.assistant_assets import AssistantAssetError, ensure_assistant_assets
 from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
@@ -328,8 +328,15 @@ class SessionRuntime:
             return
         # Refresh assistant workspace asset links on every boot so repo
         # updates to AGENTS.md / CLAUDE.md / skills are visible to backends
-        # without recreating the live thread.
-        self._prepare_assistant_workspace()
+        # without recreating the live thread. If the refresh fails, keep a
+        # healthy live assistant tracked rather than making asset validation a
+        # new availability gate for an existing thread.
+        asset_error: Exception | None = None
+        try:
+            self._prepare_assistant_workspace()
+        except (AssistantAssetError, OSError) as exc:
+            asset_error = exc
+            log.warning("failed to refresh assistant workspace assets", exc_info=True)
         # Reuse any live assistant that already lives in the managed workspace,
         # regardless of its backend: the live thread is the source of truth, so
         # a backend switched from the UI survives a redeploy. ``assistant_backend()``
@@ -356,6 +363,8 @@ class SessionRuntime:
                         session.id, source=SessionSource.MANAGED, pinned_at=None
                     )
             return
+        if asset_error is not None:
+            raise asset_error
         for session in existing:
             self.storage.update_session(
                 session.id, source=SessionSource.MANAGED, pinned_at=None

--- a/backend/tests/test_assistant_assets.py
+++ b/backend/tests/test_assistant_assets.py
@@ -1,0 +1,105 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from waypoint.assistant_assets import (
+    ASSISTANT_ASSET_MANIFEST,
+    AssistantAssetError,
+    ensure_assistant_assets,
+    resolve_assistant_asset_source,
+    validate_assistant_asset_source,
+)
+
+
+def _write_source(root: Path) -> Path:
+    assistant = root / ".agents" / "assistant"
+    skills = root / ".agents" / "skills"
+    assistant.mkdir(parents=True)
+    (assistant / "AGENTS.md").write_text("# Assistant\n", encoding="utf-8")
+    (assistant / "CLAUDE.md").write_text("@AGENTS.md\n", encoding="utf-8")
+    waypoint = skills / "waypoint"
+    waypoint.mkdir(parents=True)
+    (waypoint / "SKILL.md").write_text(
+        "---\nname: waypoint\ndescription: Manage sessions\n---\n",
+        encoding="utf-8",
+    )
+    waypointctl = skills / "waypointctl"
+    waypointctl.mkdir()
+    (waypointctl / "SKILL.md").write_text(
+        "---\nname: waypointctl\ndescription: Manage stack\n---\n",
+        encoding="utf-8",
+    )
+    (root / ".claude").mkdir()
+    (root / ".claude" / "skills").symlink_to("../.agents/skills")
+    return root
+
+
+def test_ensure_assistant_assets_prefers_symlinks(tmp_path) -> None:
+    source_root = _write_source(tmp_path / "repo")
+    workspace = tmp_path / "data" / "assistant"
+
+    ensure_assistant_assets(workspace, source_root=source_root)
+
+    assert (workspace / "AGENTS.md").is_symlink()
+    assert (workspace / "AGENTS.md").resolve() == (
+        source_root / ".agents" / "assistant" / "AGENTS.md"
+    )
+    assert (workspace / ".agents" / "skills").is_symlink()
+    assert (workspace / ".agents" / "skills").resolve() == (
+        source_root / ".agents" / "skills"
+    )
+    assert os.readlink(workspace / ".claude" / "skills") == "../.agents/skills"
+    assert os.readlink(workspace / ".codex" / "skills") == "../.agents/skills"
+
+
+def test_ensure_assistant_assets_repairs_stale_workspace_files(tmp_path) -> None:
+    source_root = _write_source(tmp_path / "repo")
+    workspace = tmp_path / "data" / "assistant"
+    workspace.mkdir(parents=True)
+    (workspace / "AGENTS.md").write_text("stale", encoding="utf-8")
+
+    ensure_assistant_assets(workspace, source_root=source_root)
+
+    assert (workspace / "AGENTS.md").is_symlink()
+    assert (workspace / "AGENTS.md").read_text(encoding="utf-8") == "# Assistant\n"
+
+
+def test_ensure_assistant_assets_copy_fallback_is_idempotent(tmp_path) -> None:
+    source_root = _write_source(tmp_path / "repo")
+    workspace = tmp_path / "data" / "assistant"
+
+    ensure_assistant_assets(workspace, source_root=source_root, prefer_symlinks=False)
+    manifest = workspace / ASSISTANT_ASSET_MANIFEST
+    first_manifest = manifest.read_text(encoding="utf-8")
+
+    ensure_assistant_assets(workspace, source_root=source_root, prefer_symlinks=False)
+
+    assert (workspace / "AGENTS.md").is_file()
+    assert not (workspace / "AGENTS.md").is_symlink()
+    assert (workspace / ".agents" / "skills" / "waypoint" / "SKILL.md").is_file()
+    assert manifest.read_text(encoding="utf-8") == first_manifest
+
+
+def test_validate_assistant_asset_source_requires_skill_frontmatter(tmp_path) -> None:
+    source_root = _write_source(tmp_path / "repo")
+    (source_root / ".agents" / "skills" / "waypoint" / "SKILL.md").write_text(
+        "---\nname: waypoint\n---\n",
+        encoding="utf-8",
+    )
+    source = resolve_assistant_asset_source(source_root=source_root)
+
+    with pytest.raises(AssistantAssetError, match="description"):
+        validate_assistant_asset_source(source)
+
+
+def test_validate_assistant_asset_source_requires_repo_claude_symlink(
+    tmp_path,
+) -> None:
+    source_root = _write_source(tmp_path / "repo")
+    (source_root / ".claude" / "skills").unlink()
+    (source_root / ".claude" / "skills").write_text("not a link", encoding="utf-8")
+    source = resolve_assistant_asset_source(source_root=source_root)
+
+    with pytest.raises(AssistantAssetError, match="must be a symlink"):
+        validate_assistant_asset_source(source)

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -15,7 +16,7 @@ from waypoint.backends.codex.permission_modes import (
 )
 from waypoint.backends.codex.schemas import CodexThreadImportRequest
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.runtime import ASSISTANT_CHARTER, SessionRuntime
+from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
@@ -3374,16 +3375,27 @@ def test_assistant_summary_is_none_when_untracked(tmp_path) -> None:
     assert runtime.assistant_summary() is None
 
 
-def test_prepare_assistant_workspace_writes_charter_files(tmp_path) -> None:
+def test_prepare_assistant_workspace_links_tracked_assets(tmp_path) -> None:
     runtime, _, settings = make_runtime(tmp_path)
     workspace = runtime._prepare_assistant_workspace()
     workspace_path = Path(workspace)
+    repo_root = Path(__file__).resolve().parents[2]
+
     assert workspace_path == settings.data_dir / "assistant"
-    for name in ("AGENTS.md", "CLAUDE.md"):
-        text = (workspace_path / name).read_text(encoding="utf-8")
-        assert "Waypoint personal assistant" in text
-        assert "waypoint sessions list" in text
-        assert "waypointctl restart" in text
+    assert (workspace_path / "AGENTS.md").is_symlink()
+    assert (workspace_path / "AGENTS.md").resolve() == (
+        repo_root / ".agents" / "assistant" / "AGENTS.md"
+    )
+    assert (workspace_path / "CLAUDE.md").is_symlink()
+    assert (workspace_path / "CLAUDE.md").resolve() == (
+        repo_root / ".agents" / "assistant" / "CLAUDE.md"
+    )
+    assert (workspace_path / ".agents" / "skills").is_symlink()
+    assert (workspace_path / ".agents" / "skills").resolve() == (
+        repo_root / ".agents" / "skills"
+    )
+    assert os.readlink(workspace_path / ".claude" / "skills") == "../.agents/skills"
+    assert os.readlink(workspace_path / ".codex" / "skills") == "../.agents/skills"
 
 
 @pytest.mark.asyncio
@@ -3424,15 +3436,15 @@ async def test_assistant_recreates_when_cwd_is_not_workspace(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_assistant_refreshes_charter_files_on_reuse(tmp_path) -> None:
-    # A reused live thread still gets its workspace charter files rewritten to
-    # the current charter on boot, without recreating the thread.
+async def test_assistant_refreshes_asset_links_on_reuse(tmp_path) -> None:
+    # A reused live thread still gets its workspace asset links repaired on
+    # boot, without recreating the thread.
     runtime, storage, settings = make_runtime(tmp_path)
     settings.assistant = AssistantConfig(backend="codex")
     workspace = runtime._assistant_workspace_dir()
     workspace.mkdir(parents=True, exist_ok=True)
     for name in ("AGENTS.md", "CLAUDE.md"):
-        (workspace / name).write_text("stale charter", encoding="utf-8")
+        (workspace / name).write_text("stale bootstrap", encoding="utf-8")
     _make_assistant_row(
         storage,
         settings,
@@ -3453,8 +3465,11 @@ async def test_assistant_refreshes_charter_files_on_reuse(tmp_path) -> None:
     await runtime._ensure_assistant_session()
 
     assert runtime.assistant_session_id == "codex-assistant"
-    for name in ("AGENTS.md", "CLAUDE.md"):
-        assert (workspace / name).read_text(encoding="utf-8") == ASSISTANT_CHARTER
+    assert (workspace / "AGENTS.md").is_symlink()
+    assert (workspace / "CLAUDE.md").is_symlink()
+    assert "Waypoint personal assistant" in (workspace / "AGENTS.md").read_text(
+        encoding="utf-8"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import pytest
 from fastapi import HTTPException
 
+from waypoint.assistant_assets import AssistantAssetError
 from waypoint.backends.claude_code.permission_modes import CLAUDE_AUTO_APPROVE_MODES
 from waypoint.backends.claude_code.schemas import ClaudeThreadImportRequest
 from waypoint.backends.claude_code.threads import ClaudeThreadInfo
@@ -3375,7 +3376,11 @@ def test_assistant_summary_is_none_when_untracked(tmp_path) -> None:
     assert runtime.assistant_summary() is None
 
 
-def test_prepare_assistant_workspace_links_tracked_assets(tmp_path) -> None:
+def test_prepare_assistant_workspace_links_tracked_assets(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.delenv("WAYPOINT_ASSISTANT_ASSETS_ROOT", raising=False)
+    monkeypatch.delenv("WAYPOINT_HOME", raising=False)
     runtime, _, settings = make_runtime(tmp_path)
     workspace = runtime._prepare_assistant_workspace()
     workspace_path = Path(workspace)
@@ -3396,6 +3401,42 @@ def test_prepare_assistant_workspace_links_tracked_assets(tmp_path) -> None:
     )
     assert os.readlink(workspace_path / ".claude" / "skills") == "../.agents/skills"
     assert os.readlink(workspace_path / ".codex" / "skills") == "../.agents/skills"
+
+
+@pytest.mark.asyncio
+async def test_assistant_reuses_live_thread_when_asset_refresh_fails(
+    tmp_path, monkeypatch
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    workspace = runtime._assistant_workspace_dir()
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-assistant",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(workspace),
+    )
+
+    def _fail_prepare() -> str:
+        raise AssistantAssetError("bad assets")
+
+    async def _fail_create(
+        backend: str, **_kwargs: Any
+    ) -> Any:  # pragma: no cover - must reuse
+        raise AssertionError("should reuse the live thread, not recreate")
+
+    monkeypatch.setattr(runtime, "_prepare_assistant_workspace", _fail_prepare)
+    runtime._create_assistant_session = _fail_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "codex-assistant"
+    kept = storage.get_session("codex-assistant")
+    assert kept is not None
+    assert kept.source == SessionSource.ASSISTANT
 
 
 @pytest.mark.asyncio
@@ -3436,7 +3477,9 @@ async def test_assistant_recreates_when_cwd_is_not_workspace(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_assistant_refreshes_asset_links_on_reuse(tmp_path) -> None:
+async def test_assistant_refreshes_asset_links_on_reuse(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("WAYPOINT_ASSISTANT_ASSETS_ROOT", raising=False)
+    monkeypatch.delenv("WAYPOINT_HOME", raising=False)
     # A reused live thread still gets its workspace asset links repaired on
     # boot, without recreating the thread.
     runtime, storage, settings = make_runtime(tmp_path)

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -31,20 +31,22 @@ The block is enabled by default when present — set `enabled: false` to keep th
 config but turn the assistant off.
 
 The assistant always runs in a managed working directory (`<data_dir>/assistant`),
-so it has no `cwd` setting. Its charter is written there as `AGENTS.md` /
-`CLAUDE.md` and loaded silently by the backend as project context — there is no
-visible bootstrap message in the transcript. The working directory is only a
-scratch cwd; shell access reaches the whole host, so host inspection is
-unaffected.
+so it has no `cwd` setting. The runtime links repo-tracked assistant assets into
+that directory: `AGENTS.md`, `CLAUDE.md`, `.agents/skills`, `.claude/skills`,
+and `.codex/skills`. The bootstrap files stay small and point the agent at the
+local `waypoint` and `waypointctl` skills, which hold the detailed operational
+workflows. There is no visible bootstrap message in the transcript. The working
+directory is only a scratch cwd; shell access reaches the whole host, so host
+inspection is unaffected.
 
 ## Lifecycle
 
-- On startup the runtime reuses any still-alive assistant thread that lives in
-  the managed workspace, **regardless of its backend**. The live thread is the
-  source of truth, so a backend chosen from the UI survives a redeploy. The
-  `assistant` block in `waypoint.yaml` only seeds the *first* creation; editing
-  `assistant.backend` later has no effect while a thread exists — clear the
-  context to re-seed.
+- On startup the runtime refreshes the assistant workspace asset links, then
+  reuses any still-alive assistant thread that lives in the managed workspace,
+  **regardless of its backend**. The live thread is the source of truth, so a
+  backend chosen from the UI survives a redeploy. The `assistant` block in
+  `waypoint.yaml` only seeds the *first* creation; editing `assistant.backend`
+  later has no effect while a thread exists — clear the context to re-seed.
 - If no live thread exists (first boot, or the previous one exited), a fresh
   thread is created from the `waypoint.yaml` defaults.
 - The assistant cannot be **deleted**, and the generic session terminate/delete
@@ -90,9 +92,15 @@ Both the Waypoint session id and the backend-native thread id (e.g. the value
 for `claude --resume`) are surfaced on the assistant page and via `/api/me`, so
 the thread can be recovered outside the app if needed.
 
+Asset updates do **not** recreate or demote the live assistant. Backends are
+expected to pick up updated `AGENTS.md`, `CLAUDE.md`, and skill files from the
+workspace themselves.
+
 ## Managing sessions: the `waypoint sessions` CLI
 
-The assistant manages your coding sessions through the `waypoint` CLI, which
+The `waypoint` skill is the authoritative assistant workflow for this CLI.
+At a high level, the assistant manages your coding sessions through the
+`waypoint` CLI, which
 talks to the running server over HTTP (distinct from the in-process `waypoint
 session` commands):
 


### PR DESCRIPTION
## Summary

The personal assistant's operational instructions lived as a large embedded `ASSISTANT_CHARTER` string in `runtime.py`, so changing `waypoint` / `waypointctl` guidance required backend code edits and boot-time file rewrites. This moves those instructions into repo-tracked assistant assets: small bootstrap files plus local `waypoint` and `waypointctl` skills. The runtime now links those assets into the managed assistant workspace, so updates are cheap and do not recreate or demote the live assistant.

## Changes

### Backend

- `assistant_assets.py`: new asset resolver/validator/materializer for the assistant workspace. It validates `.agents/assistant/{AGENTS.md,CLAUDE.md}`, checks each `.agents/skills/*/SKILL.md` has required skill frontmatter, verifies the repo `.claude/skills` symlink, and sets up the assistant workspace with symlinks by default. A copy-on-change fallback writes a manifest when symlinks are disabled or unavailable.
- `runtime.py`: removes the embedded `ASSISTANT_CHARTER` and delegates `_prepare_assistant_workspace` to the asset helper. Boot still refreshes the assistant workspace before reuse, but asset updates do not recreate the live thread.
- `tests/test_assistant_assets.py`, `tests/test_runtime.py`: cover source validation, symlink setup/repair, copy fallback idempotence, and assistant reuse with repaired asset links.

### Skills

- `.agents/assistant/AGENTS.md`, `.agents/assistant/CLAUDE.md`: tracked bootstrap files for the personal assistant.
- `.agents/skills/waypoint`: session-management skill for `waypoint sessions`, approvals, launching, steering, destructive operations, and auth/config diagnostics.
- `.agents/skills/waypointctl`: stack-management skill for `waypointctl` status/logs, lifecycle, restart safety, deployment updates, daemon mode, Tailscale profiles, and env/state paths.
- `.claude/skills`: repo symlink to `../.agents/skills`; the assistant workspace also gets `.codex/skills` for Codex compatibility.

### Docs

- `docs/personal_assistant.md`: documents the linked repo asset model, points detailed CLI behavior at the skills, and clarifies that asset updates do not recreate or demote the assistant.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_assistant_assets.py tests/test_runtime.py -k assistant` — 23 pass.
- [x] `cd backend && uv run ruff check src/waypoint/assistant_assets.py src/waypoint/runtime.py tests/test_assistant_assets.py tests/test_runtime.py` — clean.
- [x] `cd backend && uv run mypy src/waypoint/assistant_assets.py` — clean.
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on the commit — clean.
