### PR TITLE
feat: let the personal assistant attach to an existing backend thread

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -28,6 +28,7 @@ from waypoint.backends.tmux.renderer import (
 )
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
+    AssistantAttachRequest,
     AssistantResetRequest,
     AssistantSummary,
     LoginRequest,
@@ -151,6 +152,19 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             model=body.model,
             effort=body.effort,
             permission_mode=body.permission_mode,
+        )
+
+    @app.post("/api/assistant/attach", response_model=AssistantSummary)
+    async def assistant_attach(
+        body: AssistantAttachRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> AssistantSummary:
+        # Adopt an existing backend-native thread as the assistant, replacing the
+        # current thread (which is demoted to a normal stopped session).
+        return await context.runtime.attach_assistant(
+            backend=body.backend,
+            thread_id=body.thread_id,
+            launch_target_id=body.launch_target_id,
         )
 
     @app.post("/api/assistant/terminate", response_model=AssistantSummary)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -550,16 +550,73 @@ class SessionRuntime:
             chosen, model=model, effort=effort, permission_mode=permission_mode
         )
         self.assistant_session_id = created.id
-        if old is not None and old.id != created.id:
-            # Release the protection guard, then best-effort stop the old thread.
-            # The demoted row lingers as a normal stopped session so its
-            # transcript is preserved.
-            self.storage.update_session(
-                old.id, source=SessionSource.MANAGED, pinned_at=None
-            )
-            with suppress(Exception):
-                await self.terminate(old.id)
+        await self._retire_previous_assistant(old, created.id)
         return self._require_assistant_summary()
+
+    async def attach_assistant(
+        self,
+        *,
+        backend: str,
+        thread_id: str,
+        launch_target_id: str | None = None,
+    ) -> AssistantSummary:
+        """Adopt an existing backend-native thread as the assistant singleton.
+
+        The thread is imported as-is — it resumes its own conversation and
+        working directory, so the assistant charter (which lives in the managed
+        workspace) does not apply. The previous thread is demoted to an ordinary
+        stopped session, never deleted. Because the imported thread lives outside
+        the managed workspace, a redeploy will not re-adopt it and falls back to
+        a fresh assistant.
+        """
+        if self.settings.assistant_backend() is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="the assistant is disabled",
+            )
+        if not self.registry.has_backend(backend):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown backend: {backend}",
+            )
+        plugin = self.registry.get(backend)
+        schema = plugin.import_request_schema
+        if not plugin.capabilities.supports_thread_import or schema is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"thread import is not supported for {backend}",
+            )
+        old_id = self.assistant_session_id
+        old = self.storage.get_session(old_id) if old_id is not None else None
+        # Import before touching the current thread so a failed import (unknown
+        # thread, already imported) leaves the live assistant intact.
+        request = schema.model_validate(
+            {"thread_id": thread_id, "launch_target_id": launch_target_id}
+        )
+        imported = await plugin.import_thread(self, request)
+        adopted = self.storage.update_session(
+            imported.id, source=SessionSource.ASSISTANT, pinned_at=datetime.now(UTC)
+        )
+        self.assistant_session_id = adopted.id
+        await self._retire_previous_assistant(old, adopted.id)
+        return self._require_assistant_summary()
+
+    async def _retire_previous_assistant(
+        self, old: SessionRecord | None, new_id: str
+    ) -> None:
+        """Demote the prior assistant thread to a normal stopped session.
+
+        Releases the protection guard, then best-effort stops it. The demoted
+        row lingers in the normal session list so its transcript is preserved —
+        it is never deleted.
+        """
+        if old is None or old.id == new_id:
+            return
+        self.storage.update_session(
+            old.id, source=SessionSource.MANAGED, pinned_at=None
+        )
+        with suppress(Exception):
+            await self.terminate(old.id)
 
     async def terminate_assistant(self) -> AssistantSummary:
         """Stop the assistant thread while keeping it the pinned singleton.

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -242,6 +242,14 @@ class AssistantResetRequest(BaseModel):
     permission_mode: str | None = None
 
 
+class AssistantAttachRequest(BaseModel):
+    # Adopt an existing backend-native thread as the assistant. ``thread_id`` is
+    # the value surfaced by GET /api/backends/{backend}/threads.
+    backend: BackendId
+    thread_id: str
+    launch_target_id: str | None = None
+
+
 class MeResponse(BaseModel):
     authenticated: bool = True
     default_backend: BackendId = "codex"

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3703,3 +3703,117 @@ async def test_assistant_lifecycle_409_when_untracked(tmp_path) -> None:
     with pytest.raises(HTTPException) as reattach_exc:
         await runtime.reattach_assistant()
     assert reattach_exc.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_attach_assistant_adopts_imported_thread(tmp_path, monkeypatch) -> None:
+    # Adopting an existing thread imports it, pins it as the assistant, and
+    # demotes the previous thread to a normal stopped session.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-old",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    runtime.assistant_session_id = "codex-old"
+
+    async def _fake_terminate(session_id: str) -> SessionRecord:
+        return storage.update_session(session_id, status=SessionStatus.EXITED)
+
+    runtime.terminate = _fake_terminate  # type: ignore[method-assign]
+
+    async def _fake_import(rt: Any, request: Any) -> SessionRecord:
+        assert request.thread_id == "thread-xyz"
+        # import_thread persists a MANAGED session living in the thread's own cwd.
+        session = make_session(
+            settings,
+            id="codex-imported",
+            backend="codex",
+            transport="codex_app_server",
+            status=SessionStatus.STARTING,
+        )
+        storage.create_session(session)
+        return session
+
+    monkeypatch.setattr(runtime.registry.get("codex"), "import_thread", _fake_import)
+
+    summary = await runtime.attach_assistant(backend="codex", thread_id="thread-xyz")
+
+    assert summary.session_id == "codex-imported"
+    assert runtime.assistant_session_id == "codex-imported"
+    adopted = storage.get_session("codex-imported")
+    assert adopted is not None
+    assert adopted.source == SessionSource.ASSISTANT
+    assert adopted.pinned_at is not None
+    old = storage.get_session("codex-old")
+    assert old is not None
+    assert old.source == SessionSource.MANAGED
+    assert old.pinned_at is None
+
+
+@pytest.mark.asyncio
+async def test_attach_assistant_keeps_current_when_import_fails(
+    tmp_path, monkeypatch
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-live",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    runtime.assistant_session_id = "codex-live"
+
+    async def _boom(rt: Any, request: Any) -> SessionRecord:
+        raise HTTPException(status_code=404, detail="thread not found")
+
+    monkeypatch.setattr(runtime.registry.get("codex"), "import_thread", _boom)
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.attach_assistant(backend="codex", thread_id="missing")
+    assert exc.value.status_code == 404
+    assert runtime.assistant_session_id == "codex-live"
+    row = storage.get_session("codex-live")
+    assert row is not None
+    assert row.source == SessionSource.ASSISTANT
+    assert row.status == SessionStatus.IDLE
+
+
+@pytest.mark.asyncio
+async def test_attach_assistant_unsupported_backend_400(tmp_path) -> None:
+    # tmux is the managed-launch fallback and cannot import threads.
+    runtime, _, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.attach_assistant(backend="tmux", thread_id="x")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_attach_assistant_unknown_backend_404(tmp_path) -> None:
+    runtime, _, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.attach_assistant(backend="nope", thread_id="x")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_attach_assistant_disabled_409(tmp_path) -> None:
+    runtime, _, settings = make_runtime(tmp_path)
+    settings.assistant = None
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.attach_assistant(backend="codex", thread_id="x")
+    assert exc.value.status_code == 409

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -52,7 +52,9 @@ unaffected.
 
 ### Controls (assistant page)
 
-The settings popover next to the composer exposes the assistant's lifecycle:
+The **settings popover** (⚙, next to the composer) holds configuration. Changing
+the backend or picking a thread there stages an inline confirm, since both
+replace the conversation:
 
 - **Switch backend** — rebuild the assistant on a different coding agent. The
   conversation cannot migrate between backends, so this starts a fresh thread
@@ -62,12 +64,16 @@ The settings popover next to the composer exposes the assistant's lifecycle:
   imported as-is: it resumes its own conversation and working directory, so the
   assistant charter — which lives in the managed workspace — does **not** apply.
   Offered only for backends that support thread discovery and import.
+- **Model / effort / permission mode** — applied live to the running thread; no
+  context is lost.
+
+The **overflow menu** (⋯) holds the standalone lifecycle actions, mirroring
+where ordinary sessions keep terminate/delete:
+
 - **Clear context** — start a fresh thread on the same backend.
 - **Terminate / Reattach** — stop the thread (keeping it the pinned singleton)
   and later revive the same conversation. Reattach is offered only when the
   backend can resume after exit.
-- **Model / effort / permission mode** — applied live to the running thread; no
-  context is lost.
 
 Switching backend, attaching a thread, and clearing context all replace the
 current conversation: the previous thread is **demoted to an ordinary stopped

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -57,6 +57,11 @@ The settings popover next to the composer exposes the assistant's lifecycle:
 - **Switch backend** — rebuild the assistant on a different coding agent. The
   conversation cannot migrate between backends, so this starts a fresh thread
   at the new backend's default model/effort/permission mode.
+- **Resume thread** — attach the assistant to an existing backend-native thread
+  (one discovered by the chosen backend's thread enumeration). The thread is
+  imported as-is: it resumes its own conversation and working directory, so the
+  assistant charter — which lives in the managed workspace — does **not** apply.
+  Offered only for backends that support thread discovery and import.
 - **Clear context** — start a fresh thread on the same backend.
 - **Terminate / Reattach** — stop the thread (keeping it the pinned singleton)
   and later revive the same conversation. Reattach is offered only when the
@@ -64,13 +69,16 @@ The settings popover next to the composer exposes the assistant's lifecycle:
 - **Model / effort / permission mode** — applied live to the running thread; no
   context is lost.
 
-Switching backend and clearing context discard the conversation: the previous
-thread is **demoted to an ordinary stopped session** (its transcript is
-preserved and it becomes deletable), never destroyed.
+Switching backend, attaching a thread, and clearing context all replace the
+current conversation: the previous thread is **demoted to an ordinary stopped
+session** (its transcript is preserved and it becomes deletable), never
+destroyed.
 
 A terminated assistant survives reattach only within the running deployment; a
 redeploy cannot reattach an exited thread, so it demotes that thread to a normal
-stopped session and creates a fresh assistant.
+stopped session and creates a fresh assistant. Likewise, an attached thread
+lives outside the managed workspace, so a redeploy will not re-adopt it — it is
+demoted and a fresh assistant is created from the `waypoint.yaml` defaults.
 
 Both the Waypoint session id and the backend-native thread id (e.g. the value
 for `claude --resume`) are surfaced on the assistant page and via `/api/me`, so

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -3,11 +3,13 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { AssistantControls, SessionDetail } from "@/components/SessionDetail";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import {
+  attachAssistant,
+  fetchBackendThreads,
   fetchMe,
   isAuthError,
   reattachAssistant,
@@ -135,6 +137,47 @@ export default function AssistantPage() {
     [handleAuthFailure],
   );
 
+  // Memoised so its identity is stable across renders — the composer keys a
+  // thread-fetch effect on it.
+  const controls = useMemo<AssistantControls>(
+    () => ({
+      backends,
+      supportsReattach: assistant?.supports_reattach ?? false,
+      onSwitchBackend: (backend: Backend) =>
+        applyControl(() => resetAssistant(host, token, { backend })),
+      onAttachThread: (backend: Backend, threadId: string) =>
+        applyControl(() =>
+          attachAssistant(host, token, { backend, thread_id: threadId }),
+        ),
+      onClearContext: () => applyControl(() => resetAssistant(host, token, {})),
+      onTerminate: () => applyControl(() => terminateAssistant(host, token)),
+      onReattach: () => applyControl(() => reattachAssistant(host, token)),
+      listThreads: async (backend: Backend) => {
+        try {
+          const threads = await fetchBackendThreads<{
+            id: string;
+            title: string;
+          }>(host, token, backend);
+          return threads.map((thread) => ({
+            id: thread.id,
+            title: thread.title,
+          }));
+        } catch (err) {
+          if (isAuthError(err)) handleAuthFailure();
+          return [];
+        }
+      },
+    }),
+    [
+      backends,
+      assistant?.supports_reattach,
+      host,
+      token,
+      applyControl,
+      handleAuthFailure,
+    ],
+  );
+
   return (
     <main className="page-shell has-composer">
       <header className="app-bar">
@@ -201,20 +244,7 @@ export default function AssistantPage() {
               sessionId={assistant.session_id}
               onAuthFailure={handleAuthFailure}
               assistant
-              assistantControls={
-                {
-                  backends,
-                  supportsReattach: assistant.supports_reattach,
-                  onSwitchBackend: (backend: Backend) =>
-                    applyControl(() => resetAssistant(host, token, { backend })),
-                  onClearContext: () =>
-                    applyControl(() => resetAssistant(host, token, {})),
-                  onTerminate: () =>
-                    applyControl(() => terminateAssistant(host, token)),
-                  onReattach: () =>
-                    applyControl(() => reattachAssistant(host, token)),
-                } satisfies AssistantControls
-              }
+              assistantControls={controls}
             />
           ) : null}
         </>

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -157,10 +157,14 @@ export default function AssistantPage() {
           const threads = await fetchBackendThreads<{
             id: string;
             title: string;
+            updated_at: string;
+            preview: string | null;
           }>(host, token, backend);
           return threads.map((thread) => ({
             id: thread.id,
             title: thread.title,
+            updatedAt: thread.updated_at,
+            preview: thread.preview ?? null,
           }));
         } catch (err) {
           if (isAuthError(err)) handleAuthFailure();

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -24,6 +24,17 @@ import { AssistantSummary, Backend, BackendDescriptor, SessionStatus } from "@/l
 
 type LoadState = "loading" | "ready" | "disabled" | "error";
 
+// Thread summaries differ per backend: claude/codex send ISO datetimes, while
+// opencode sends epoch milliseconds. Normalise to an ISO string the relative-
+// time formatter can parse; return "" when there's no usable timestamp.
+function toIsoTimestamp(value: string | number | null | undefined): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const ms = value < 1e12 ? value * 1000 : value;
+    return new Date(ms).toISOString();
+  }
+  return typeof value === "string" ? value : "";
+}
+
 const STATUS_LABELS: Record<SessionStatus, string> = {
   starting: "Starting…",
   idle: "Ready",
@@ -156,14 +167,14 @@ export default function AssistantPage() {
         try {
           const threads = await fetchBackendThreads<{
             id: string;
-            title: string;
-            updated_at: string;
-            preview: string | null;
+            title?: string | null;
+            updated_at?: string | number | null;
+            preview?: string | null;
           }>(host, token, backend);
           return threads.map((thread) => ({
             id: thread.id,
-            title: thread.title,
-            updatedAt: thread.updated_at,
+            title: thread.title || thread.id,
+            updatedAt: toIsoTimestamp(thread.updated_at),
             preview: thread.preview ?? null,
           }));
         } catch (err) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5716,58 +5716,6 @@ html[data-theme="light"] .composer-tune-restart-apply {
   border-top: 1px solid var(--line);
 }
 
-.composer-tune-error {
-  margin: 0;
-  font-size: 0.78rem;
-  line-height: 1.4;
-  color: var(--danger);
-}
-
-.composer-tune-lifecycle-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
-
-.composer-tune-lifecycle-btn {
-  flex: 1 1 auto;
-  font-family: var(--font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.04em;
-  padding: 7px 12px;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--line-strong);
-  background: rgba(8, 11, 16, 0.5);
-  color: var(--text);
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-html[data-theme="light"] .composer-tune-lifecycle-btn {
-  background: rgba(235, 230, 218, 0.7);
-}
-
-.composer-tune-lifecycle-btn:hover:not(:disabled) {
-  border-color: var(--accent);
-  color: var(--accent-strong);
-}
-
-.composer-tune-lifecycle-btn:disabled {
-  opacity: 0.7;
-  cursor: progress;
-}
-
-.composer-tune-lifecycle-btn.is-danger {
-  border-color: rgba(214, 92, 92, 0.5);
-  color: var(--danger);
-}
-
-.composer-tune-lifecycle-btn.is-danger:hover:not(:disabled) {
-  background: rgba(214, 92, 92, 0.14);
-  border-color: var(--danger);
-  color: var(--danger);
-}
-
 .composer-tune-confirm {
   display: grid;
   gap: 8px;
@@ -5829,16 +5777,6 @@ html[data-theme="light"] .composer-tune-confirm {
 
 .composer-tune-confirm-apply:hover:not(:disabled) {
   background: rgba(200, 169, 106, 0.3);
-}
-
-.composer-tune-confirm-apply.is-danger {
-  border-color: rgba(214, 92, 92, 0.55);
-  background: rgba(214, 92, 92, 0.18);
-  color: var(--danger);
-}
-
-.composer-tune-confirm-apply.is-danger:hover:not(:disabled) {
-  background: rgba(214, 92, 92, 0.28);
 }
 
 .composer-tune-confirm-cancel:disabled,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6026,6 +6026,29 @@ html[data-theme="light"] .composer-overflow-item.danger:hover:not(:disabled) {
   color: var(--danger);
 }
 
+.composer-overflow-item.warn {
+  color: var(--warn);
+  background: rgba(217, 154, 74, 0.08);
+  border-color: rgba(217, 154, 74, 0.32);
+}
+
+html[data-theme="light"] .composer-overflow-item.warn {
+  background: rgba(170, 102, 24, 0.08);
+}
+
+.composer-overflow-item.warn:hover:not(:disabled) {
+  background: rgba(217, 154, 74, 0.18);
+  border-color: rgba(217, 154, 74, 0.5);
+}
+
+html[data-theme="light"] .composer-overflow-item.warn:hover:not(:disabled) {
+  background: rgba(170, 102, 24, 0.16);
+}
+
+.composer-overflow-item.warn .glyph {
+  color: var(--warn);
+}
+
 .composer-overflow-item:disabled {
   opacity: 0.45;
   cursor: default;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2441,14 +2441,19 @@ const ReplyComposer = memo(function ReplyComposer({
                       disabled={assistantBusy}
                     >
                       <option value="">— Start fresh —</option>
-                      {threadOptions.map((thread) => (
-                        <option key={thread.id} value={thread.id}>
-                          {`${thread.title || thread.id} · ${formatRelativeTime(
-                            thread.updatedAt,
-                          )}`}
-                          {thread.preview ? ` — ${thread.preview}` : ""}
-                        </option>
-                      ))}
+                      {threadOptions.map((thread) => {
+                        const when = thread.updatedAt
+                          ? formatRelativeTime(thread.updatedAt)
+                          : "";
+                        const parts = [thread.title || thread.id];
+                        if (when && when !== "Unknown") parts.push(when);
+                        if (thread.preview) parts.push(thread.preview);
+                        return (
+                          <option key={thread.id} value={thread.id}>
+                            {parts.join(" · ")}
+                          </option>
+                        );
+                      })}
                     </select>
                   </label>
                 ) : null}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1879,6 +1879,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onSwitchSession={openSwitcher}
           onSend={onSendWithOptimistic}
           onTerminate={terminate}
+          onError={setError}
           assistant={assistant}
           assistantControls={assistantControls}
         />
@@ -1934,6 +1935,7 @@ interface ReplyComposerProps {
   onSwitchSession: () => void;
   onSend: (text: string, command?: SessionCommandInvocation) => Promise<boolean>;
   onTerminate: () => void | Promise<void>;
+  onError: (message: string) => void;
   assistant: boolean;
   assistantControls: AssistantControls | null;
 }
@@ -1981,6 +1983,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onSwitchSession,
   onSend,
   onTerminate,
+  onError,
   assistant,
   assistantControls,
 }: ReplyComposerProps) {
@@ -1993,13 +1996,15 @@ const ReplyComposer = memo(function ReplyComposer({
   // action (backend switch / attach thread / clear) is awaiting an inline
   // confirm.
   const [assistantBusy, setAssistantBusy] = useState(false);
+  // Confirm state for the dropdown-driven actions in the settings popover
+  // (switch backend / attach thread). Clear context and terminate / reattach
+  // live in the ⋯ overflow menu and confirm via window.confirm instead.
   const [assistantConfirm, setAssistantConfirm] = useState<
-    "switch" | "attach" | "clear" | null
+    "switch" | "attach" | null
   >(null);
   const [pendingBackend, setPendingBackend] = useState<Backend | null>(null);
   const [selectedThreadId, setSelectedThreadId] = useState("");
   const [threadOptions, setThreadOptions] = useState<AssistantThreadOption[]>([]);
-  const [assistantError, setAssistantError] = useState<string | null>(null);
   // Pending effort for backends that need a session restart to apply (Claude)
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
@@ -2306,16 +2311,16 @@ const ReplyComposer = memo(function ReplyComposer({
   const runAssistantAction = async (action: () => Promise<void> | void) => {
     if (assistantBusy) return;
     setAssistantBusy(true);
-    setAssistantError(null);
+    onError("");
     try {
       await action();
-      // Only dismiss the confirm on success; on failure keep the selection and
-      // the error visible so the user can retry or cancel.
+      // Only dismiss the confirm on success; on failure keep the selection so
+      // the user can retry or cancel.
       setAssistantConfirm(null);
       setPendingBackend(null);
       setSelectedThreadId("");
     } catch (err) {
-      setAssistantError(err instanceof Error ? err.message : "Action failed");
+      onError(err instanceof Error ? err.message : "Action failed");
     } finally {
       setAssistantBusy(false);
     }
@@ -2384,7 +2389,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       value={pendingBackend ?? session.backend}
                       onChange={(event) => {
                         const next = event.target.value;
-                        setAssistantError(null);
+                        onError("");
                         // Threads are per-backend; drop any thread selection.
                         setSelectedThreadId("");
                         if (next === session.backend) {
@@ -2415,7 +2420,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       value={selectedThreadId}
                       onChange={(event) => {
                         const id = event.target.value;
-                        setAssistantError(null);
+                        onError("");
                         setSelectedThreadId(id);
                         if (id) {
                           setAssistantConfirm("attach");
@@ -2513,163 +2518,94 @@ const ReplyComposer = memo(function ReplyComposer({
                     </button>
                   </div>
                 ) : null}
-                {assistantOps ? (
+                {assistantOps &&
+                assistantConfirm === "switch" &&
+                pendingBackend ? (
                   <div className="composer-tune-lifecycle">
-                    {assistantError ? (
-                      <p className="composer-tune-error" role="alert">
-                        {assistantError}
+                    <div className="composer-tune-confirm">
+                      <p>
+                        Switch to{" "}
+                        <strong>{humaniseBackend(pendingBackend)}</strong>? This
+                        starts a new conversation; the current one is kept as a
+                        stopped session.
                       </p>
-                    ) : null}
-                    {assistantConfirm === "switch" && pendingBackend ? (
-                      <div className="composer-tune-confirm">
-                        <p>
-                          Switch to{" "}
-                          <strong>{humaniseBackend(pendingBackend)}</strong>? This
-                          starts a new conversation; the current one is kept as a
-                          stopped session.
-                        </p>
-                        <div className="composer-tune-confirm-actions">
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-cancel"
-                            onClick={() => {
-                              setPendingBackend(null);
-                              setAssistantConfirm(null);
-                              setAssistantError(null);
-                            }}
-                            disabled={assistantBusy}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-apply"
-                            onClick={() =>
-                              void runAssistantAction(() =>
-                                assistantOps.onSwitchBackend(pendingBackend),
-                              )
-                            }
-                            disabled={assistantBusy}
-                          >
-                            {assistantBusy ? "Switching…" : "Switch backend"}
-                          </button>
-                        </div>
-                      </div>
-                    ) : assistantConfirm === "attach" &&
-                      selectedThreadId &&
-                      assistantTargetBackend ? (
-                      <div className="composer-tune-confirm">
-                        <p>
-                          Attach to{" "}
-                          <strong>
-                            {threadOptions.find((t) => t.id === selectedThreadId)
-                              ?.title || selectedThreadId}
-                          </strong>
-                          ? This replaces the current conversation, which is kept
-                          as a stopped session.
-                        </p>
-                        <div className="composer-tune-confirm-actions">
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-cancel"
-                            onClick={() => {
-                              setSelectedThreadId("");
-                              setAssistantConfirm(
-                                pendingBackend &&
-                                  pendingBackend !== session?.backend
-                                  ? "switch"
-                                  : null,
-                              );
-                              setAssistantError(null);
-                            }}
-                            disabled={assistantBusy}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-apply"
-                            onClick={() =>
-                              void runAssistantAction(() =>
-                                assistantOps.onAttachThread(
-                                  assistantTargetBackend,
-                                  selectedThreadId,
-                                ),
-                              )
-                            }
-                            disabled={assistantBusy}
-                          >
-                            {assistantBusy ? "Attaching…" : "Attach thread"}
-                          </button>
-                        </div>
-                      </div>
-                    ) : assistantConfirm === "clear" ? (
-                      <div className="composer-tune-confirm">
-                        <p>
-                          Clear the conversation? The current thread is kept as a
-                          stopped session you can revisit.
-                        </p>
-                        <div className="composer-tune-confirm-actions">
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-cancel"
-                            onClick={() => {
-                              setAssistantConfirm(null);
-                              setAssistantError(null);
-                            }}
-                            disabled={assistantBusy}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-apply is-danger"
-                            onClick={() =>
-                              void runAssistantAction(assistantOps.onClearContext)
-                            }
-                            disabled={assistantBusy}
-                          >
-                            {assistantBusy ? "Clearing…" : "Clear context"}
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <div className="composer-tune-lifecycle-actions">
+                      <div className="composer-tune-confirm-actions">
                         <button
                           type="button"
-                          className="composer-tune-lifecycle-btn"
-                          onClick={() => setAssistantConfirm("clear")}
+                          className="composer-tune-confirm-cancel"
+                          onClick={() => {
+                            setPendingBackend(null);
+                            setAssistantConfirm(null);
+                            onError("");
+                          }}
                           disabled={assistantBusy}
                         >
-                          Clear context
+                          Cancel
                         </button>
-                        {assistantExited ? (
-                          assistantOps.supportsReattach ? (
-                            <button
-                              type="button"
-                              className="composer-tune-lifecycle-btn"
-                              onClick={() =>
-                                void runAssistantAction(assistantOps.onReattach)
-                              }
-                              disabled={assistantBusy}
-                            >
-                              {assistantBusy ? "Reconnecting…" : "Reattach"}
-                            </button>
-                          ) : null
-                        ) : (
-                          <button
-                            type="button"
-                            className="composer-tune-lifecycle-btn is-danger"
-                            onClick={() =>
-                              void runAssistantAction(assistantOps.onTerminate)
-                            }
-                            disabled={assistantBusy}
-                          >
-                            {assistantBusy ? "Stopping…" : "Terminate"}
-                          </button>
-                        )}
+                        <button
+                          type="button"
+                          className="composer-tune-confirm-apply"
+                          onClick={() =>
+                            void runAssistantAction(() =>
+                              assistantOps.onSwitchBackend(pendingBackend),
+                            )
+                          }
+                          disabled={assistantBusy}
+                        >
+                          {assistantBusy ? "Switching…" : "Switch backend"}
+                        </button>
                       </div>
-                    )}
+                    </div>
+                  </div>
+                ) : assistantOps &&
+                  assistantConfirm === "attach" &&
+                  selectedThreadId &&
+                  assistantTargetBackend ? (
+                  <div className="composer-tune-lifecycle">
+                    <div className="composer-tune-confirm">
+                      <p>
+                        Attach to{" "}
+                        <strong>
+                          {threadOptions.find((t) => t.id === selectedThreadId)
+                            ?.title || selectedThreadId}
+                        </strong>
+                        ? This replaces the current conversation, which is kept as
+                        a stopped session.
+                      </p>
+                      <div className="composer-tune-confirm-actions">
+                        <button
+                          type="button"
+                          className="composer-tune-confirm-cancel"
+                          onClick={() => {
+                            setSelectedThreadId("");
+                            setAssistantConfirm(
+                              pendingBackend && pendingBackend !== session?.backend
+                                ? "switch"
+                                : null,
+                            );
+                            onError("");
+                          }}
+                          disabled={assistantBusy}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          className="composer-tune-confirm-apply"
+                          onClick={() =>
+                            void runAssistantAction(() =>
+                              assistantOps.onAttachThread(
+                                assistantTargetBackend,
+                                selectedThreadId,
+                              ),
+                            )
+                          }
+                          disabled={assistantBusy}
+                        >
+                          {assistantBusy ? "Attaching…" : "Attach thread"}
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 ) : null}
               </div>
@@ -2781,7 +2717,7 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">↻</span>
                     Refresh
                   </button>
-                  {canReattach ? (
+                  {!assistant && canReattach ? (
                     <button
                       type="button"
                       role="menuitem"
@@ -2856,6 +2792,70 @@ const ReplyComposer = memo(function ReplyComposer({
                       <span className="glyph">✕</span>
                       Delete transcript
                     </button>
+                  ) : null}
+                  {/* The assistant is a protected singleton, so instead of
+                      terminate/delete it gets its own lifecycle actions here:
+                      clear context (fresh thread) and a stop/revive toggle. */}
+                  {assistant && assistantOps ? (
+                    <>
+                      <div className="composer-overflow-separator" />
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className="composer-overflow-item danger"
+                        disabled={assistantBusy}
+                        onClick={() => {
+                          setOverflowOpen(false);
+                          if (
+                            window.confirm(
+                              "Clear the assistant's context? The current thread is kept as a stopped session.",
+                            )
+                          ) {
+                            void runAssistantAction(assistantOps.onClearContext);
+                          }
+                        }}
+                      >
+                        <span className="glyph">✦</span>
+                        Clear context
+                      </button>
+                      {assistantExited ? (
+                        assistantOps.supportsReattach ? (
+                          <button
+                            type="button"
+                            role="menuitem"
+                            className="composer-overflow-item"
+                            disabled={assistantBusy}
+                            onClick={() => {
+                              setOverflowOpen(false);
+                              void runAssistantAction(assistantOps.onReattach);
+                            }}
+                          >
+                            <span className="glyph">↺</span>
+                            Reattach assistant
+                          </button>
+                        ) : null
+                      ) : (
+                        <button
+                          type="button"
+                          role="menuitem"
+                          className="composer-overflow-item danger"
+                          disabled={assistantBusy}
+                          onClick={() => {
+                            setOverflowOpen(false);
+                            if (
+                              window.confirm(
+                                "Terminate the assistant? You can reattach it later to resume this conversation.",
+                              )
+                            ) {
+                              void runAssistantAction(assistantOps.onTerminate);
+                            }
+                          }}
+                        >
+                          <span className="glyph">⏻</span>
+                          Terminate assistant
+                        </button>
+                      )}
+                    </>
                   ) : null}
                 </div>
               ) : null}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -62,6 +62,7 @@ import {
   type PlanViewModel,
 } from "@/lib/events";
 import { useTheme } from "@/lib/theme";
+import { formatRelativeTime } from "@/lib/usage";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -183,6 +184,11 @@ const EFFORT_LABEL: Record<string, string> = {
 export interface AssistantThreadOption {
   id: string;
   title: string;
+  // ISO timestamp of last activity — the assistant titles every thread
+  // "Personal Assistant", so the picker leans on this to tell them apart.
+  updatedAt: string;
+  // First-message snippet when the backend provides one; another distinguisher.
+  preview: string | null;
 }
 
 // Assistant-only lifecycle actions surfaced inside the composer settings
@@ -2437,7 +2443,10 @@ const ReplyComposer = memo(function ReplyComposer({
                       <option value="">— Start fresh —</option>
                       {threadOptions.map((thread) => (
                         <option key={thread.id} value={thread.id}>
-                          {thread.title || thread.id}
+                          {`${thread.title || thread.id} · ${formatRelativeTime(
+                            thread.updatedAt,
+                          )}`}
+                          {thread.preview ? ` — ${thread.preview}` : ""}
                         </option>
                       ))}
                     </select>
@@ -2802,7 +2811,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       <button
                         type="button"
                         role="menuitem"
-                        className="composer-overflow-item danger"
+                        className="composer-overflow-item warn"
                         disabled={assistantBusy}
                         onClick={() => {
                           setOverflowOpen(false);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -179,17 +179,28 @@ const EFFORT_LABEL: Record<string, string> = {
 };
 
 
+// An existing backend-native thread the assistant can adopt.
+export interface AssistantThreadOption {
+  id: string;
+  title: string;
+}
+
 // Assistant-only lifecycle actions surfaced inside the composer settings
-// popover (backend switch + clear context + terminate/reattach). The owning
-// page wires these to /api/assistant/* and refreshes itself afterwards; when
-// absent, the composer renders no assistant controls.
+// popover (backend switch + attach existing thread + clear context +
+// terminate/reattach). The owning page wires these to /api/assistant/* and
+// refreshes itself afterwards; when absent, the composer renders no assistant
+// controls.
 export interface AssistantControls {
   backends: BackendDescriptor[];
   supportsReattach: boolean;
   onSwitchBackend: (backend: Backend) => Promise<void> | void;
+  onAttachThread: (backend: Backend, threadId: string) => Promise<void> | void;
   onClearContext: () => Promise<void> | void;
   onTerminate: () => Promise<void> | void;
   onReattach: () => Promise<void> | void;
+  // Lists importable threads for a backend (empty when discovery unsupported or
+  // it fails); used to populate the "resume an existing thread" picker.
+  listThreads: (backend: Backend) => Promise<AssistantThreadOption[]>;
 }
 
 interface SessionDetailProps {
@@ -1979,12 +1990,15 @@ const ReplyComposer = memo(function ReplyComposer({
   const [tuneOpen, setTuneOpen] = useState(false);
   const [reattaching, setReattaching] = useState(false);
   // Assistant lifecycle UI: an in-flight action and which context-discarding
-  // action (backend switch / clear) is awaiting an inline confirm.
+  // action (backend switch / attach thread / clear) is awaiting an inline
+  // confirm.
   const [assistantBusy, setAssistantBusy] = useState(false);
   const [assistantConfirm, setAssistantConfirm] = useState<
-    "switch" | "clear" | null
+    "switch" | "attach" | "clear" | null
   >(null);
   const [pendingBackend, setPendingBackend] = useState<Backend | null>(null);
+  const [selectedThreadId, setSelectedThreadId] = useState("");
+  const [threadOptions, setThreadOptions] = useState<AssistantThreadOption[]>([]);
   const [assistantError, setAssistantError] = useState<string | null>(null);
   // Pending effort for backends that need a session restart to apply (Claude)
   // — staged here until the user confirms via the Apply button. `null` means
@@ -2259,6 +2273,36 @@ const ReplyComposer = memo(function ReplyComposer({
     hasModelPicker ||
     hasEffortPicker ||
     assistantOps !== null;
+  // Backend the assistant controls target — the picked one, or the current.
+  const assistantTargetBackend = pendingBackend ?? session?.backend ?? null;
+  const assistantTargetCaps =
+    assistantOps && assistantTargetBackend
+      ? assistantOps.backends.find((b) => b.id === assistantTargetBackend)
+          ?.capabilities
+      : undefined;
+  const assistantCanAttach = Boolean(
+    assistantTargetCaps?.supports_thread_discovery &&
+      assistantTargetCaps?.supports_thread_import,
+  );
+  // Load resumable threads for the target backend when the popover is open.
+  useEffect(() => {
+    if (
+      !tuneOpen ||
+      !assistantOps ||
+      !assistantCanAttach ||
+      !assistantTargetBackend
+    ) {
+      setThreadOptions([]);
+      return;
+    }
+    let cancelled = false;
+    void assistantOps.listThreads(assistantTargetBackend).then((threads) => {
+      if (!cancelled) setThreadOptions(threads);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [tuneOpen, assistantOps, assistantCanAttach, assistantTargetBackend]);
   const runAssistantAction = async (action: () => Promise<void> | void) => {
     if (assistantBusy) return;
     setAssistantBusy(true);
@@ -2269,6 +2313,7 @@ const ReplyComposer = memo(function ReplyComposer({
       // the error visible so the user can retry or cancel.
       setAssistantConfirm(null);
       setPendingBackend(null);
+      setSelectedThreadId("");
     } catch (err) {
       setAssistantError(err instanceof Error ? err.message : "Action failed");
     } finally {
@@ -2340,11 +2385,11 @@ const ReplyComposer = memo(function ReplyComposer({
                       onChange={(event) => {
                         const next = event.target.value;
                         setAssistantError(null);
+                        // Threads are per-backend; drop any thread selection.
+                        setSelectedThreadId("");
                         if (next === session.backend) {
                           setPendingBackend(null);
-                          setAssistantConfirm((mode) =>
-                            mode === "switch" ? null : mode,
-                          );
+                          setAssistantConfirm(null);
                           return;
                         }
                         setPendingBackend(next);
@@ -2355,6 +2400,39 @@ const ReplyComposer = memo(function ReplyComposer({
                       {assistantOps.backends.map((backend) => (
                         <option key={backend.id} value={backend.id}>
                           {backend.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                {assistantOps &&
+                session &&
+                assistantCanAttach &&
+                threadOptions.length > 0 ? (
+                  <label className="composer-tune-field">
+                    <span>Resume thread</span>
+                    <select
+                      value={selectedThreadId}
+                      onChange={(event) => {
+                        const id = event.target.value;
+                        setAssistantError(null);
+                        setSelectedThreadId(id);
+                        if (id) {
+                          setAssistantConfirm("attach");
+                        } else {
+                          setAssistantConfirm(
+                            pendingBackend && pendingBackend !== session.backend
+                              ? "switch"
+                              : null,
+                          );
+                        }
+                      }}
+                      disabled={assistantBusy}
+                    >
+                      <option value="">— Start fresh —</option>
+                      {threadOptions.map((thread) => (
+                        <option key={thread.id} value={thread.id}>
+                          {thread.title || thread.id}
                         </option>
                       ))}
                     </select>
@@ -2474,6 +2552,54 @@ const ReplyComposer = memo(function ReplyComposer({
                             disabled={assistantBusy}
                           >
                             {assistantBusy ? "Switching…" : "Switch backend"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : assistantConfirm === "attach" &&
+                      selectedThreadId &&
+                      assistantTargetBackend ? (
+                      <div className="composer-tune-confirm">
+                        <p>
+                          Attach to{" "}
+                          <strong>
+                            {threadOptions.find((t) => t.id === selectedThreadId)
+                              ?.title || selectedThreadId}
+                          </strong>
+                          ? This replaces the current conversation, which is kept
+                          as a stopped session.
+                        </p>
+                        <div className="composer-tune-confirm-actions">
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-cancel"
+                            onClick={() => {
+                              setSelectedThreadId("");
+                              setAssistantConfirm(
+                                pendingBackend &&
+                                  pendingBackend !== session?.backend
+                                  ? "switch"
+                                  : null,
+                              );
+                              setAssistantError(null);
+                            }}
+                            disabled={assistantBusy}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-apply"
+                            onClick={() =>
+                              void runAssistantAction(() =>
+                                assistantOps.onAttachThread(
+                                  assistantTargetBackend,
+                                  selectedThreadId,
+                                ),
+                              )
+                            }
+                            disabled={assistantBusy}
+                          >
+                            {assistantBusy ? "Attaching…" : "Attach thread"}
                           </button>
                         </div>
                       </div>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -184,8 +184,8 @@ const EFFORT_LABEL: Record<string, string> = {
 export interface AssistantThreadOption {
   id: string;
   title: string;
-  // ISO timestamp of last activity — the assistant titles every thread
-  // "Personal Assistant", so the picker leans on this to tell them apart.
+  // ISO timestamp of last activity — the assistant's own threads share the
+  // "Personal Assistant" title, so the picker leans on this to tell them apart.
   updatedAt: string;
   // First-message snippet when the backend provides one; another distinguisher.
   preview: string | null;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  AssistantAttachRequest,
   AssistantResetRequest,
   AssistantSummary,
   Backend,
@@ -103,6 +104,23 @@ export async function resetAssistant(
     body: JSON.stringify(body),
   });
   await ensureOk(response, "failed to reset assistant");
+  return (await response.json()) as AssistantSummary;
+}
+
+export async function attachAssistant(
+  host: string,
+  token: string,
+  body: AssistantAttachRequest,
+): Promise<AssistantSummary> {
+  const response = await fetch(`${host}/api/assistant/attach`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+  await ensureOk(response, "failed to attach thread");
   return (await response.json()) as AssistantSummary;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -202,6 +202,12 @@ export interface AssistantResetRequest {
   permission_mode?: string | null;
 }
 
+export interface AssistantAttachRequest {
+  backend: Backend;
+  thread_id: string;
+  launch_target_id?: string | null;
+}
+
 export interface MeResponse {
   authenticated: boolean;
   default_backend: Backend;


### PR DESCRIPTION
## Summary

Adds a fourth way to point the personal assistant at a conversation: alongside switching backend, clearing context, and terminate/reattach, it can now **adopt an existing backend-native thread** (one discovered by the backend's own thread enumeration). The thread is imported and pinned as the singleton, replacing the current thread — which is demoted to a normal stopped session, never deleted. This builds on the existing thread discovery/import plumbing rather than adding a parallel path.

The PR also reorganizes the assistant's controls and polishes the thread picker: lifecycle *actions* move to the `⋯` overflow menu (where ordinary sessions keep terminate/delete), while the `⚙` settings popover keeps the dropdown-driven config.

## Changes

### Backend

- `runtime.py`: add `attach_assistant` — validate the backend supports thread import, import the chosen thread via the plugin's `import_thread`, then pin it as the assistant and demote the previous thread. Import runs *before* the swap so a failed import leaves the live assistant intact. The retire-previous-thread step is factored into a shared `_retire_previous_assistant` helper reused by `reset_assistant`.
- `schemas.py`: `AssistantAttachRequest` (backend, thread_id, launch_target_id).
- `api.py`: `POST /api/assistant/attach`, returning the updated `AssistantSummary`, gated on the backend's `supports_thread_import` capability (404 unknown backend, 400 unsupported, 409 disabled).

### Frontend

- `SessionDetail.tsx`: the `⚙` settings popover gains a **Resume thread** picker for discovery/import-capable backends, listing the target backend's importable threads with an inline attach confirm. Lifecycle *actions* — **Clear context** (amber, recoverable) and a status-driven **Terminate**/**Reattach** — move to the `⋯` overflow menu, mirroring ordinary sessions; the normal "Reconnect session" item is suppressed in assistant mode so it doesn't collide. Assistant action errors now surface in the shared session error toast.
- `app/assistant/page.tsx`: wire `attachAssistant` + `listThreads` into a memoised controls bundle (stable identity so the thread-fetch effect doesn't loop). Normalise per-backend thread timestamps — opencode reports epoch milliseconds, claude/codex send ISO datetimes — so the picker shows a real relative time instead of "Unknown", and labels threads as `title · when · preview` to distinguish same-titled assistant threads.
- `lib/api.ts`, `lib/types.ts`: `attachAssistant` helper and `AssistantAttachRequest`.
- `app/globals.css`: amber `.composer-overflow-item.warn` variant (with light-theme override); removed the now-unused in-popover lifecycle-button styles.

### Docs

- `docs/personal_assistant.md`: document the **Resume thread** control and its caveats (imported as-is — its own cwd/context, no charter; not re-adopted on redeploy), and the split between the `⚙` settings popover (config) and the `⋯` overflow menu (actions).

## Test Plan

- [x] `cd backend && uv run pytest tests/` — 551 pass; the 4 `tests/test_rate_limits.py` failures are pre-existing on `main` (keychain / messages-API header parsing), unrelated to this branch.
- [x] `cd backend && uv run pytest tests/test_runtime.py -k assistant` — 23 pass, covering attach (adopt + demote old, capability/unknown/disabled gates, import-failure leaves the live assistant intact) alongside the existing reset/terminate/reattach cases.
- [x] `cd backend && uv run mypy src/waypoint/runtime.py src/waypoint/api.py src/waypoint/schemas.py` — clean.
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on each commit — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — production build succeeds.
- [x] Manual: attached the opencode assistant to an existing thread; confirmed the picker lists threads with relative times (no "Unknown"), Clear context renders amber, and lifecycle actions live in the overflow menu.