### PR TITLE
chore: scope the isort pre-commit hook to backend

### DIFF
--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: 8.0.1
     hooks:
       - id: isort
+        files: ^backend/
 
   - repo: https://github.com/psf/black
     rev: 26.3.1


### PR DESCRIPTION
## Summary

`waypointctl` failed the backend pre-commit suite even though it passed `ruff` on its own: the `isort` hook ran repo-wide and batched backend and `waypointctl` files into a single `isort` invocation. With no root-level config, that batch resolved one config (backend's, with `known_first_party = ["waypoint"]`) and applied it to `waypointctl`, reordering its imports into a layout that `ruff`'s import sorting — the `I` rule, which already governs `waypointctl` and treats it as first-party — then rejected. The two tools fought: `isort` rewrote the files, `ruff-check` failed on the result, and the hook never converged. Setting `known_first_party` in `waypointctl/pyproject.toml` has no effect because the batched invocation never reads that per-project config.

Scope `isort` to `backend/` so it only sees files whose config it actually resolves, and let `ruff` own `waypointctl` import order (as it already does for the rest of `waypointctl`'s lint).

## Changes

### Backend

- `.pre-commit-config.yaml`: add `files: ^backend/` to the `isort` hook. `black`, `ruff-check`, and `codespell` stay repo-wide (they pass on `waypointctl`); only `isort` carried the cross-project config conflict.

## Test Plan

- [x] `cd backend && uv run pre-commit run --all-files` — all hooks pass (isort / black / ruff / codespell / mypy) with **no files modified**; before the change the same command rewrote 12 `waypointctl` files via `isort` and then failed `ruff-check` on them.
- [x] Confirmed `isort` still runs on `backend/` (the hook reports clean rather than skipped) and that `waypointctl` import order is enforced by `ruff-check`, which passes on the committed code.