### PR TITLE
feat: add Fable 5 model to Claude Code backend model catalogue

### DIFF
--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -9,8 +9,9 @@ from waypoint.schemas import BackendModelOption
 
 # Effort levels gated by the binary's per-model checks (`vy`/`L4_`/`k4_`):
 # opus-4-6/4-7/4-8 and sonnet-4-6 expose the full set; haiku and older
-# opus/sonnet don't accept --effort at all.
+# opus/sonnet don't accept --effort at all. Fable 5 adds `max`.
 CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
+CLAUDE_FABLE_EFFORT_LEVELS: tuple[str, ...] = CLAUDE_EFFORT_LEVELS + ("max",)
 
 # Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
 # see either the human-facing alias (``opus[1m]``) or a resolved API model id
@@ -22,14 +23,17 @@ CLAUDE_MODEL_ALIASES: dict[str, str] = {
     "claude-sonnet-4-6": "sonnet",
     "claude-sonnet-4-5": "sonnet",
     "claude-haiku-4-5": "haiku",
+    "claude-fable-5": "fable",
 }
 
 CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
     "opus": 200_000,
     "sonnet": 200_000,
     "haiku": 200_000,
+    "fable": 200_000,
     "opus[1m]": 1_000_000,
     "sonnet[1m]": 1_000_000,
+    "fable[1m]": 1_000_000,
 }
 
 DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
@@ -67,6 +71,20 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
     ),
+    BackendModelOption(
+        id="fable",
+        label="Fable 5",
+        description="Most capable for the hardest, longest-running tasks",
+        supported_efforts=list(CLAUDE_FABLE_EFFORT_LEVELS),
+        default_effort="high",
+    ),
+    BackendModelOption(
+        id="fable[1m]",
+        label="Fable 5 (1M context)",
+        description="Longest sessions with very large codebases",
+        supported_efforts=list(CLAUDE_FABLE_EFFORT_LEVELS),
+        default_effort="high",
+    ),
 )
 
 
@@ -87,6 +105,8 @@ def normalize_claude_model_id(model: str | None) -> str | None:
         return "sonnet"
     if candidate.startswith("claude-haiku-"):
         return "haiku"
+    if candidate.startswith("claude-fable-"):
+        return "fable"
     return candidate
 
 

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -28,6 +28,7 @@ _WINDOWS: tuple[tuple[str, str, int], ...] = (
     ("seven_day", "Weekly", 7 * 24 * 60),
     ("seven_day_opus", "Opus", 7 * 24 * 60),
     ("seven_day_sonnet", "Sonnet", 7 * 24 * 60),
+    ("seven_day_fable", "Fable", 7 * 24 * 60),
 )
 _CLAUDE_USER_AGENT: str | None = None
 _CLAUDE_USER_AGENT_RESOLVED = False


### PR DESCRIPTION
## Summary

Adds Fable 5 as a selectable model in Waypoint's Claude Code backend. Fable 5 is Anthropic's newest top-tier model for Claude Code (above Opus 4.8), launched in May 2026. It is selected via `--model fable` — the same mechanism as `opus`/`sonnet`/`haiku` — with no adapter or control protocol changes required.

The model is gated behind CLI v2.1.170; the effort picker shows `low`/`medium`/`high`/`xhigh`/`max` when Fable is active (Fable supports the `max` level that Opus/Sonnet do not), and the 7-day usage dashboard shows Fable's token window.

## Changes

### Backend

- `backends/claude_code/models.py`: add `claude-fable-5` → `fable` alias mapping, `fable` (200K) and `fable[1m]` (1M) context window entries, `BackendModelOption` entries for `fable` and `fable[1m]` using a `CLAUDE_FABLE_EFFORT_LEVELS` tuple that includes `max`, and prefix-based normalization in `normalize_claude_model_id` for `claude-fable-*` resolved model IDs.
- `backends/claude_code/rate_limits.py`: add `seven_day_fable` window tuple so Fable token usage appears in the 7-day usage dashboard.

## Test Plan

- [x] `cd backend && uv run pre-commit run --all-files` — all hooks pass (isort / black / ruff / codespell / mypy).
- [x] `cd backend && uv run mypy src/waypoint/backends/claude_code/models.py src/waypoint/backends/claude_code/rate_limits.py` — clean.
- [x] `cd backend && uv run ruff check src/waypoint/backends/claude_code/models.py src/waypoint/backends/claude_code/rate_limits.py` — clean.