### PR TITLE
fix: stop replaying the tmux raw log on restore to unblock startup

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 import re
 import secrets
 import shutil
@@ -18,7 +19,7 @@ from waypoint.assistant_assets import AssistantAssetError, ensure_assistant_asse
 from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
-from waypoint.backends.tmux.normalize import TerminalNormalizer
+from waypoint.backends.tmux.normalize import NormalizedChunk, TerminalNormalizer
 from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -53,6 +54,33 @@ log = logging.getLogger("waypoint.runtime")
 
 SAFE_NAME = re.compile(r"[^a-zA-Z0-9_-]+")
 CompletionCacheKey = tuple[str, str]
+
+
+def _raw_log_end_offset(path: Path) -> int:
+    # Returns a text-mode tell() cookie at EOF, matching the offsets
+    # _ingest_raw_output records so a later seek() round-trips cleanly.
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            handle.seek(0, os.SEEK_END)
+            return handle.tell()
+    except OSError:
+        return 0
+
+
+def _read_and_normalize(
+    normalizer: TerminalNormalizer,
+    session_id: str,
+    path: Path,
+    offset: int,
+    start_sequence: int,
+) -> tuple[int, NormalizedChunk | None]:
+    with path.open("r", encoding="utf-8", errors="ignore") as handle:
+        handle.seek(offset)
+        chunk = handle.read()
+        new_offset = handle.tell()
+    if not chunk.strip():
+        return new_offset, None
+    return new_offset, normalizer.normalize(session_id, chunk, start_sequence)
 
 
 class BroadcastHub:
@@ -1566,6 +1594,15 @@ class SessionRuntime:
         session = self.get_session(session_id)
         if session.transport != TMUX_TRANSPORT_ID:
             return
+        if session_id not in self.file_offsets:
+            # A missing offset means this process has never ingested this raw
+            # log — typically a boot-time restore. The prior run already
+            # persisted its events, so resume from the current end instead of
+            # replaying (and synchronously re-normalizing) the whole backlog,
+            # which blocks the event loop and stalls startup.
+            self.file_offsets[session_id] = _raw_log_end_offset(
+                Path(session.raw_log_path)
+            )
         self.monitor_tasks[session_id] = asyncio.create_task(
             self._monitor_session(session_id)
         )
@@ -1635,15 +1672,20 @@ class SessionRuntime:
         if not raw_log_path.exists():
             return
         offset = self.file_offsets.get(session_id, 0)
-        with raw_log_path.open("r", encoding="utf-8", errors="ignore") as handle:
-            handle.seek(offset)
-            chunk = handle.read()
-            self.file_offsets[session_id] = handle.tell()
-        if not chunk.strip():
-            return
-        normalized = self.normalizer.normalize(
-            session_id, chunk, self.storage.next_sequence(session_id)
+        # Read + normalize off the event loop: a large chunk (or slow
+        # storage) would otherwise block every other task, including
+        # uvicorn's bind during boot restore.
+        new_offset, normalized = await asyncio.to_thread(
+            _read_and_normalize,
+            self.normalizer,
+            session_id,
+            raw_log_path,
+            offset,
+            self.storage.next_sequence(session_id),
         )
+        self.file_offsets[session_id] = new_offset
+        if normalized is None:
+            return
         for event in normalized.events:
             persisted = self.storage.append_event(event)
             self._append_structured_log(session_id, persisted)


### PR DESCRIPTION
## Summary

On a host with persisted tmux-transport sessions, `waypointctl start backend` intermittently failed with "backend failed to become healthy" even though the server logged `Application startup complete`. The backend reached lifespan startup in milliseconds but did not log `Uvicorn running on …` until ~30s later — the supervisor's health probe timed out against a port that was not yet listening and killed the process. `getaddrinfo` and the socket bind were both instant in isolation, so the stall was the event loop being occupied: each restored tmux session starts a monitor whose first `_ingest_raw_output` reads the raw log from offset 0, because `file_offsets` is an in-memory dict that is never seeded on restore. That read, the terminal normalization, and the per-event SQLite writes all ran synchronously on the loop, so a long-lived session's accumulated log froze the loop long enough to starve uvicorn's `create_server` and delay the bind (`asyncio` debug attributed a 25.6s and a 5.1s synchronous step to `_monitor_session`). Replaying from offset 0 also re-appended already-persisted output as duplicate events on every restart.

The fix seeds the read offset to the current end of the log when a monitor first starts without a tracked offset, so restore resumes from new output instead of replaying the backlog, and moves the file read and normalization off the event loop so a large incremental chunk can no longer stall it.

## Changes

### Backend

- `runtime.py`: in `_ensure_monitor`, seed `file_offsets[session_id]` to the current end of the raw log (new `_raw_log_end_offset` helper) when no offset is tracked yet — the boot-restore case — so already-persisted history is not re-ingested. Guarded by `session_id not in self.file_offsets`, so the initial-attach, MANAGED-reconnect (which pops the offset after truncating), and live-reattach paths keep their existing behavior. `_ingest_raw_output` now offloads the file read plus the stateless `TerminalNormalizer.normalize` to a worker thread via `asyncio.to_thread` (new `_read_and_normalize` helper); `next_sequence`, `append_event`, and event publishing stay on the loop since the SQLite connection is loop-bound.

## Test Plan

- [x] `cd backend && uv run pre-commit run --files src/waypoint/runtime.py` — isort / black / ruff / codespell / mypy all pass.
- [x] `cd backend && uv run pytest tests/test_runtime.py` — 112 passed.
- [x] `cd backend && uv run pytest tests/test_runtime.py tests/test_tmux_plugin.py tests/test_tmux.py` — stress-run 20× green (one earlier one-off flake in `test_handle_input_tmux_reattach_failure_surfaces_400`, which spawns real `tmux` when installed; not reproducible in 40+ subsequent runs and absent from `main` behavior).
- [x] `cd backend && uv run pytest` — 559 passed; the 2 failures in `test_rate_limits.py` are pre-existing on `main` (claude usage-header parsing) and unrelated to this change.
- [ ] Not yet re-verified on the affected host: `waypointctl start backend` reaching `Uvicorn running on …` immediately. Diagnosis was confirmed there via `PYTHONASYNCIODEBUG=1` (named `_monitor_session` as the blocking step) and an empty-`WAYPOINT_DATA_DIR` run (instant bind); the fix itself still needs a live run on that host.