### PR TITLE
feat: spawn and manage child Waypoint sessions as subagents

### DIFF
--- a/.agents/skills/waypoint-subagents/SKILL.md
+++ b/.agents/skills/waypoint-subagents/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: waypoint-subagents
+description: Use when a coding agent inside a Waypoint session needs to spawn and manage child Waypoint sessions as subagents — fanning work out to other backends/models, running user-visible parallel sessions, or delegating a durable task that outlives the current turn. Distinct from your own harness's in-process subagents.
+---
+
+# Waypoint Subagents
+
+Spawn and drive **child Waypoint sessions** through the `waypoint sessions`
+CLI, treating them as subagents. Each child is a full, independent Waypoint
+session: it shows up in the UI, the user can steer it, it has its own
+transcript, and it survives your own turn ending.
+
+## When to use this vs. your harness's own subagents
+
+Prefer your harness's built-in subagents (Claude Code's Task tool, Codex's
+equivalent) for ordinary in-context fan-out — they are cheaper, in-process, and
+need no preflight.
+
+Reach for Waypoint sub-sessions only when you need something they cannot give:
+
+- A **different backend or model** than your own (e.g. a Claude session
+  delegating a task to a Codex session).
+- Work the **user can watch and steer** in the Waypoint UI while it runs.
+- A **durable** session that must outlive your current turn.
+
+If none of those apply, do not spawn a Waypoint session.
+
+## Before anything: preflight
+
+The `waypoint` CLI is not guaranteed to be reachable from inside every session.
+Confirm it before relying on it — see `references/preflight.md`. If it is
+unavailable, stop and report; do not guess.
+
+## Ownership convention
+
+Waypoint has no parent/owner field on sessions, so a child you spawn is
+otherwise indistinguishable from a user's own session. Establish ownership by
+convention:
+
+- Title every child you create with `--title "subagent:<short-purpose>"`.
+- Keep the returned session ids in your working state for the rest of the turn.
+- **You own the sessions you spawn, and only those.** You may steer, read, and
+  terminate them freely. Never terminate, interrupt, or send to a session you
+  did not create without explicit user confirmation, and never the personal
+  assistant (the server rejects that anyway).
+
+## Routing
+
+- Verify the CLI is reachable and authenticated: `references/preflight.md`.
+- Spawn children and wait for them to finish: `references/spawn-and-poll.md`.
+- Read their output, continue them, or answer their approvals:
+  `references/collect-and-steer.md`.
+- Tear down the children you spawned: `references/cleanup.md`.
+
+## Guardrails
+
+- Preflight first; degrade gracefully (report, don't fabricate) if the CLI is
+  missing or unauthenticated.
+- Keep fan-out small and deliberate — there is no server-side concurrency
+  limit, so a runaway loop will exhaust host resources.
+- Reap what you spawn. Leaving orphaned `subagent:*` sessions behind is a bug.
+- Ground every status claim in `waypoint sessions show`/`events` output, not
+  assumption.

--- a/.agents/skills/waypoint-subagents/references/cleanup.md
+++ b/.agents/skills/waypoint-subagents/references/cleanup.md
@@ -1,0 +1,22 @@
+# Cleanup
+
+Reap the children you spawned once their work is collected. Orphaned
+`subagent:*` sessions left running are a bug.
+
+```bash
+waypoint sessions terminate <session-id>
+```
+
+Rules:
+
+- Terminate **only** the session ids you spawned this turn and tracked. Do not
+  terminate a session you cannot positively account for as your own.
+- The personal-assistant session cannot be terminated — the server rejects it
+  with `403`. Never target it.
+- If a child has already `exited`, no termination is needed; just confirm its
+  final state with `sessions show`.
+- When in doubt about ownership, leave the session alone and ask the user.
+
+A child that exited on its own still leaves a session record behind. Terminating
+is about stopping a running child; it does not delete history. Leave history for
+the user unless they ask otherwise.

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -1,0 +1,53 @@
+# Collect and Steer
+
+Once a child reaches `idle` / `waiting_input` / `exited`, read its work and
+decide whether it is done or needs another turn.
+
+## Read output
+
+```bash
+waypoint sessions events <session-id> --messages 40
+waypoint sessions events <session-id> --before-sequence <sequence>   # page back
+```
+
+`events` returns JSON. Filter for `kind == "agent_output"` to read the agent's
+replies; skip the verbose `system_note` init payload and the `tool_call` /
+`tool_result` chatter. For the `tmux` backend, event kinds are inferred
+heuristically — also check `raw_terminal_chunk` if a reply seems missing.
+
+Quote only the minimum transcript text needed to justify your conclusion;
+summarize the rest. Distinguish the reported `status` from your interpretation of
+whether the task actually succeeded.
+
+## Continue a child
+
+```bash
+waypoint sessions send <session-id> "<follow-up instructions>"
+```
+
+After sending, poll again (see `spawn-and-poll.md`) — `send` returns
+immediately; it does not wait for the child to finish the new turn.
+
+## Answer an approval
+
+A child sitting in `waiting_input` may be blocked on an approval rather than
+asking you for more work. Read the pending request from its events first, then:
+
+```bash
+waypoint sessions approve <session-id> <decision>
+waypoint sessions approve <session-id> <decision> --approval-id <id>
+waypoint sessions approve <session-id> <decision> --text <message>
+```
+
+Pass `--approval-id` when multiple approvals are pending. Do not auto-approve
+destructive, privileged, or unclear requests on a child's behalf — surface them
+to the user, exactly as you would for your own session.
+
+## Interrupt a stuck child
+
+```bash
+waypoint sessions interrupt <session-id>
+```
+
+Only for a child you spawned that is clearly stuck. After interrupting, re-check
+its status and events before deciding the next step.

--- a/.agents/skills/waypoint-subagents/references/preflight.md
+++ b/.agents/skills/waypoint-subagents/references/preflight.md
@@ -1,0 +1,44 @@
+# Preflight
+
+Run this once before treating Waypoint sub-sessions as available. It is cheap
+and prevents acting on a CLI that cannot reach the server.
+
+## 1. Is the CLI on PATH?
+
+```bash
+waypoint --help
+```
+
+If `waypoint` is not found, the server was likely started without its virtualenv
+on `PATH`. Try the backend venv directly before giving up:
+
+```bash
+"$WAYPOINT_HOME/backend/.venv/bin/waypoint" --help   # if WAYPOINT_HOME is set
+```
+
+If neither resolves, stop: report that the `waypoint` CLI is unavailable in this
+session and that subagent sessions cannot be managed from here.
+
+## 2. Is it authenticated and pointed at the running server?
+
+```bash
+waypoint doctor
+waypoint sessions list
+```
+
+`sessions list` returning the current session set confirms both connectivity and
+auth. Authentication resolves automatically in this order, so no setup is
+normally needed when you run as the same user as the server:
+
+1. `WAYPOINT_TOKEN` environment variable.
+2. The token file at `~/.waypoint/backend-data/cli-token`.
+3. Password login via `WAYPOINT_PASSWORD` or the server config.
+
+If `sessions list` fails with an auth error, report it — do not attempt to
+discover or write credentials yourself.
+
+## Notes
+
+- The CLI computes the server URL from local settings and connects over
+  loopback; you are talking to the same server you run under.
+- Prefer JSON output and concrete session ids over inferring state from memory.

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -1,0 +1,67 @@
+# Spawn and Poll
+
+## Spawn a child
+
+```bash
+waypoint sessions start \
+  --backend <id> \
+  --cwd <path> \
+  --title "subagent:<short-purpose>" \
+  [--model <model>] [--effort <effort>] [--permission-mode <mode>]
+```
+
+- Pick `--backend` deliberately — this is the main reason to use a Waypoint
+  sub-session over a harness subagent. Use `waypoint doctor` to see which
+  backend ids are available locally.
+- Pick `--cwd` deliberately. For repo work, pass the repo root; for scratch or
+  host inspection, pass an explicit safe directory. Do not assume the child
+  should inherit your own working directory.
+- Always set the `subagent:` title prefix so the session is recognizable as one
+  you own.
+- Capture the returned session id. Keep it for the rest of the turn.
+
+Then send the task as the first input:
+
+```bash
+waypoint sessions send <session-id> "<task instructions>"
+```
+
+## Poll to completion
+
+There is no blocking `wait` command, so poll `sessions show` until the child
+reaches a terminal state. Terminal/idle statuses to stop on:
+
+- `idle` / `waiting_input` — the child has finished its turn (possibly awaiting
+  more input or an approval).
+- `exited` — the child process ended.
+- `error` — the child failed; read its events to find out why.
+
+Statuses that mean keep waiting: `starting`, `running`, `interrupted`.
+
+The CLI always prints JSON; `sessions show <id>` emits `{"session": {...}}`, so
+the status lives at `.session.status`. A reasonable poll loop with an interval
+and a hard timeout:
+
+```bash
+sid=<session-id>
+deadline=$((SECONDS + 600))   # cap the wait; tune per task
+while :; do
+  status=$(waypoint sessions show "$sid" | jq -r .session.status)
+  case "$status" in
+    idle|waiting_input|exited|error) break ;;
+  esac
+  [ "$SECONDS" -ge "$deadline" ] && { echo "timed out waiting on $sid"; break; }
+  sleep 5
+done
+```
+
+Parse the JSON `status` field rather than scraping human output. The status
+values are lowercase: `starting`, `idle`, `waiting_input`, `running`,
+`interrupted`, `exited`, `error`.
+
+## Fan-out
+
+To run several children in parallel, start them all, collect their ids, then
+poll each (or loop over the set each tick). Keep the count small and
+intentional — there is no server-side cap, so an unbounded loop will exhaust the
+host.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,9 @@ Override ports or paths inline with `WAYPOINT_STACK_BACKEND_PORT`, `WAYPOINT_STA
 
 `scripts/waypoint.sh` is the legacy supervisor and is slated for deprecation; prefer `waypointctl` for new work and only fall back to the script if the user explicitly asks for it.
 
+## Distributing Coding-Agent Skills
+The repo's `.agents/skills/` are auto-installed only into the personal assistant's workspace. To let *any* coding session spawn and manage child Waypoint sessions, install the `waypoint-subagents` skill into the cross-agent global skills directory (`~/.agents/skills` by default) with `scripts/install_skills.sh install` (or `waypointctl skills install`). The installer symlinks by default so the skill tracks the repo; pass `--skill-dir` / `WAYPOINT_SKILLS_DIR` to target an agent-specific directory (e.g. `~/.claude/skills`, `~/.codex/skills`), `--skill`/`--all` to widen the selection, and `--copy` for a detached snapshot. `status` and `uninstall` round-trip it; `uninstall` only removes symlinks the installer created, never a real or copied directory.
+
 ## Coding Style & Naming Conventions
 Follow the existing style in each half of the repo. Python uses 4-space indentation, type hints, top-level imports, and `snake_case` for functions/modules; keep FastAPI handlers and Pydantic models explicit. TypeScript uses 2-space indentation, strict typing, `PascalCase` for components, and `camelCase` for helpers and state. Keep comments sparse and only explain non-obvious reasoning.
 

--- a/scripts/install_skills.sh
+++ b/scripts/install_skills.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_DIR="${ROOT_DIR}/.agents/skills"
+
+# Default skill installed for use by arbitrary coding sessions. The other repo
+# skills (waypoint, waypointctl) target the personal assistant and are mirrored
+# into its workspace already, so they are not installed globally by default.
+DEFAULT_SKILLS=("waypoint-subagents")
+
+# Default destination skill root: the cross-agent global skills directory.
+# Override with --skill-dir or WAYPOINT_SKILLS_DIR to target an agent-specific
+# directory (e.g. ~/.claude/skills, ~/.codex/skills).
+DEFAULT_DEST="${HOME}/.agents/skills"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/install_skills.sh <install|uninstall|status> [options]
+
+Install Waypoint coding-agent skills into per-agent global skill directories so
+that any coding session — not just the personal assistant — can discover them.
+
+Commands:
+  install      Link (or copy) the selected skills into each destination.
+  uninstall    Remove entries this installer created (symlinks into this repo).
+  status       Report what is installed in each destination.
+
+Options:
+  --skill-dir <path>   Destination skill root. Repeatable. Overrides defaults.
+  --skill <name>       Skill to act on (from .agents/skills). Repeatable.
+  --all                Act on every skill under .agents/skills.
+  --copy               Copy skills instead of symlinking (install only).
+  -h, --help           Show this help.
+
+Environment:
+  WAYPOINT_SKILLS_DIR  Colon-separated destination roots, used when no
+                       --skill-dir is given.
+
+Defaults:
+  skills        waypoint-subagents
+  destination   ~/.agents/skills
+
+Symlink installs track this repo's copy of the skill. Copied installs are
+detached snapshots; uninstall will not remove a copied or pre-existing
+directory, only symlinks that point back into this repo.
+EOF
+}
+
+die() {
+  echo "error: $1" >&2
+  exit 1
+}
+
+command="${1:-}"
+case "${command}" in
+  install | uninstall | status) shift ;;
+  -h | --help | "")
+    usage
+    exit 0
+    ;;
+  *) die "unknown command: ${command} (expected install|uninstall|status)" ;;
+esac
+
+dests=()
+skills=()
+copy=0
+all=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skill-dir)
+      [[ $# -ge 2 ]] || die "--skill-dir needs a path"
+      dests+=("$2")
+      shift 2
+      ;;
+    --skill)
+      [[ $# -ge 2 ]] || die "--skill needs a name"
+      skills+=("$2")
+      shift 2
+      ;;
+    --all)
+      all=1
+      shift
+      ;;
+    --copy)
+      copy=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) die "unknown option: $1" ;;
+  esac
+done
+
+[[ -d "${SOURCE_DIR}" ]] || die "missing skills source: ${SOURCE_DIR}"
+
+# Resolve destinations: explicit --skill-dir wins, then WAYPOINT_SKILLS_DIR,
+# then the built-in defaults.
+if [[ ${#dests[@]} -eq 0 ]]; then
+  if [[ -n "${WAYPOINT_SKILLS_DIR:-}" ]]; then
+    IFS=':' read -r -a dests <<<"${WAYPOINT_SKILLS_DIR}"
+  else
+    dests=("${DEFAULT_DEST}")
+  fi
+fi
+
+# Resolve skills: --all wins, then explicit --skill, then the default.
+if [[ ${all} -eq 1 ]]; then
+  skills=()
+  for path in "${SOURCE_DIR}"/*/; do
+    [[ -f "${path}SKILL.md" ]] && skills+=("$(basename "${path}")")
+  done
+  [[ ${#skills[@]} -gt 0 ]] || die "no skills found under ${SOURCE_DIR}"
+elif [[ ${#skills[@]} -eq 0 ]]; then
+  skills=("${DEFAULT_SKILLS[@]}")
+fi
+
+for skill in "${skills[@]}"; do
+  [[ -f "${SOURCE_DIR}/${skill}/SKILL.md" ]] ||
+    die "unknown skill: ${skill} (no ${SOURCE_DIR}/${skill}/SKILL.md)"
+done
+
+# True when ${1} is a symlink resolving into our source skills directory.
+is_managed_link() {
+  local entry="$1"
+  [[ -L "${entry}" ]] || return 1
+  local target
+  target="$(readlink -f "${entry}" 2>/dev/null || true)"
+  [[ -n "${target}" && "${target}" == "$(readlink -f "${SOURCE_DIR}")"/* ]]
+}
+
+do_install() {
+  local dest skill src entry
+  for dest in "${dests[@]}"; do
+    mkdir -p "${dest}"
+    for skill in "${skills[@]}"; do
+      src="${SOURCE_DIR}/${skill}"
+      entry="${dest}/${skill}"
+      if [[ -e "${entry}" || -L "${entry}" ]]; then
+        if is_managed_link "${entry}"; then
+          rm -f "${entry}"
+        elif [[ -L "${entry}" ]]; then
+          die "${entry} is a symlink we do not own; remove it manually first"
+        else
+          die "${entry} already exists and was not created by this installer; refusing to overwrite"
+        fi
+      fi
+      if [[ ${copy} -eq 1 ]]; then
+        cp -R "${src}" "${entry}"
+        echo "copied  ${skill} -> ${entry}"
+      else
+        ln -s "$(readlink -f "${src}")" "${entry}"
+        echo "linked  ${skill} -> ${entry}"
+      fi
+    done
+  done
+}
+
+do_uninstall() {
+  local dest skill entry
+  for dest in "${dests[@]}"; do
+    for skill in "${skills[@]}"; do
+      entry="${dest}/${skill}"
+      if is_managed_link "${entry}"; then
+        rm -f "${entry}"
+        echo "removed ${entry}"
+      elif [[ -e "${entry}" || -L "${entry}" ]]; then
+        echo "skip    ${entry} (not a managed symlink; remove manually if intended)" >&2
+      else
+        echo "absent  ${entry}"
+      fi
+    done
+  done
+}
+
+do_status() {
+  local dest skill entry
+  for dest in "${dests[@]}"; do
+    for skill in "${skills[@]}"; do
+      entry="${dest}/${skill}"
+      if is_managed_link "${entry}"; then
+        echo "linked  ${entry} -> $(readlink "${entry}")"
+      elif [[ -L "${entry}" ]]; then
+        echo "foreign ${entry} -> $(readlink "${entry}")"
+      elif [[ -d "${entry}" ]]; then
+        echo "copied  ${entry} (plain directory)"
+      else
+        echo "absent  ${entry}"
+      fi
+    done
+  done
+}
+
+case "${command}" in
+  install) do_install ;;
+  uninstall) do_uninstall ;;
+  status) do_status ;;
+esac

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -2,6 +2,7 @@ import os
 import signal
 import subprocess
 from pathlib import Path
+from typing import Annotated
 
 import typer
 
@@ -22,6 +23,7 @@ from waypointctl.paths import (
 )
 from waypointctl.process import is_pid_running, read_pid_file, running_pid
 from waypointctl.protocol import DaemonResult
+from waypointctl.skills import run_skills_helper
 from waypointctl.stack import WaypointStack
 from waypointctl.tailscale import preflight_tailscale_command, run_tailscale_helper
 
@@ -40,6 +42,13 @@ tailscale_app = typer.Typer(
     help="Manage Docker-backed tailnet sidecars",
 )
 app.add_typer(tailscale_app, name="tailscale")
+
+skills_app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    help="Install coding-agent skills into global skill directories",
+)
+app.add_typer(skills_app, name="skills")
 
 
 def _ctx_home(ctx: typer.Context) -> Path:
@@ -288,6 +297,83 @@ def _run_tailscale_command(ctx: typer.Context, command: str, profile: str) -> No
     home = _ctx_home(ctx)
     preflight_tailscale_command(command)
     run_tailscale_helper(home, command, profile)
+
+
+def _skills_extra_args(
+    skill_dir: list[str] | None,
+    skill: list[str] | None,
+    *,
+    all_skills: bool = False,
+    copy: bool = False,
+) -> list[str]:
+    extra: list[str] = []
+    for path in skill_dir or []:
+        extra += ["--skill-dir", path]
+    for name in skill or []:
+        extra += ["--skill", name]
+    if all_skills:
+        extra.append("--all")
+    if copy:
+        extra.append("--copy")
+    return extra
+
+
+SkillDirOption = Annotated[
+    list[str] | None,
+    typer.Option("--skill-dir", help="Destination skill root. Repeatable."),
+]
+SkillOption = Annotated[
+    list[str] | None,
+    typer.Option("--skill", help="Skill to act on. Repeatable."),
+]
+AllSkillsOption = Annotated[
+    bool, typer.Option("--all", help="Act on every skill under .agents/skills.")
+]
+
+
+@skills_app.command("install")
+def skills_install(
+    ctx: typer.Context,
+    skill_dir: SkillDirOption = None,
+    skill: SkillOption = None,
+    all_skills: AllSkillsOption = False,
+    copy: Annotated[
+        bool, typer.Option("--copy", help="Copy skills instead of symlinking.")
+    ] = False,
+) -> None:
+    run_skills_helper(
+        _ctx_home(ctx),
+        "install",
+        _skills_extra_args(skill_dir, skill, all_skills=all_skills, copy=copy),
+    )
+
+
+@skills_app.command("uninstall")
+def skills_uninstall(
+    ctx: typer.Context,
+    skill_dir: SkillDirOption = None,
+    skill: SkillOption = None,
+    all_skills: AllSkillsOption = False,
+) -> None:
+    run_skills_helper(
+        _ctx_home(ctx),
+        "uninstall",
+        _skills_extra_args(skill_dir, skill, all_skills=all_skills),
+    )
+
+
+@skills_app.command("status")
+def skills_status(
+    ctx: typer.Context,
+    skill_dir: SkillDirOption = None,
+    skill: SkillOption = None,
+    all_skills: AllSkillsOption = False,
+) -> None:
+    run_skills_helper(
+        _ctx_home(ctx),
+        "status",
+        _skills_extra_args(skill_dir, skill, all_skills=all_skills),
+    )
 
 
 def _should_use_daemon(home: Path) -> bool:

--- a/waypointctl/src/waypointctl/skills.py
+++ b/waypointctl/src/waypointctl/skills.py
@@ -1,0 +1,18 @@
+import subprocess
+from pathlib import Path
+
+import typer
+
+
+def skills_helper_script(home: Path) -> Path:
+    return home / "scripts" / "install_skills.sh"
+
+
+def run_skills_helper(home: Path, command: str, extra: list[str]) -> None:
+    script = skills_helper_script(home)
+    if not script.is_file():
+        typer.echo(f"skills helper not found: {script}", err=True)
+        raise typer.Exit(code=1)
+    argv = ["bash", str(script), command, *extra]
+    completed = subprocess.run(argv, cwd=home, check=False)
+    raise typer.Exit(code=completed.returncode)

--- a/waypointctl/tests/test_skills.py
+++ b/waypointctl/tests/test_skills.py
@@ -1,0 +1,206 @@
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import waypointctl.cli as cli_module
+from waypointctl.cli import app
+
+
+def _make_repo(
+    home: Path, *, skills: tuple[str, ...] = ("waypoint-subagents",)
+) -> Path:
+    (home / "backend").mkdir(parents=True)
+    (home / "frontend").mkdir()
+    (home / "scripts").mkdir()
+    for skill in skills:
+        skill_dir = home / ".agents" / "skills" / skill
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {skill}\ndescription: test\n---\n", encoding="utf-8"
+        )
+    return home
+
+
+def _copy_skills_script(repo: Path) -> Path:
+    source = Path(__file__).resolve().parents[2] / "scripts" / "install_skills.sh"
+    target = repo / "scripts" / "install_skills.sh"
+    target.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    target.chmod(target.stat().st_mode | stat.S_IEXEC)
+    return target
+
+
+def _run_script(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    bash = shutil.which("bash") or "/bin/bash"
+    return subprocess.run(
+        [bash, str(repo / "scripts" / "install_skills.sh"), *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("command", ["install", "uninstall", "status"])
+def test_skills_commands_route_to_helper(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, command: str
+) -> None:
+    home = _make_repo(tmp_path / "repo")
+
+    captured: dict[str, object] = {}
+
+    def fake_run_skills_helper(
+        resolved_home: Path, helper_command: str, extra: list[str]
+    ) -> None:
+        captured["home"] = resolved_home
+        captured["command"] = helper_command
+        captured["extra"] = extra
+
+    monkeypatch.setattr(cli_module, "run_skills_helper", fake_run_skills_helper)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "--home",
+            str(home),
+            "skills",
+            command,
+            "--skill-dir",
+            "/tmp/a",
+            "--skill",
+            "waypoint-subagents",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["home"] == home
+    assert captured["command"] == command
+    assert captured["extra"] == [
+        "--skill-dir",
+        "/tmp/a",
+        "--skill",
+        "waypoint-subagents",
+    ]
+
+
+def test_skills_install_forwards_all_and_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    home = _make_repo(tmp_path / "repo")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        cli_module,
+        "run_skills_helper",
+        lambda h, c, extra: captured.update(extra=extra),
+    )
+
+    result = CliRunner().invoke(
+        app, ["--home", str(home), "skills", "install", "--all", "--copy"]
+    )
+
+    assert result.exit_code == 0
+    assert captured["extra"] == ["--all", "--copy"]
+
+
+def test_helper_install_status_uninstall_roundtrip(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+
+    installed = _run_script(repo, "install", "--skill-dir", str(dest))
+    assert installed.returncode == 0
+    link = dest / "waypoint-subagents"
+    assert link.is_symlink()
+    assert link.resolve() == (repo / ".agents" / "skills" / "waypoint-subagents")
+    assert (link / "SKILL.md").is_file()
+
+    status = _run_script(repo, "status", "--skill-dir", str(dest))
+    assert status.returncode == 0
+    assert "linked" in status.stdout
+
+    removed = _run_script(repo, "uninstall", "--skill-dir", str(dest))
+    assert removed.returncode == 0
+    assert not link.exists()
+
+
+def test_helper_install_is_idempotent(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+
+    first = _run_script(repo, "install", "--skill-dir", str(dest))
+    second = _run_script(repo, "install", "--skill-dir", str(dest))
+
+    assert first.returncode == 0
+    assert second.returncode == 0
+    assert (dest / "waypoint-subagents").is_symlink()
+
+
+def test_helper_refuses_to_overwrite_foreign_directory(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+    (dest / "waypoint-subagents").mkdir(parents=True)
+
+    result = _run_script(repo, "install", "--skill-dir", str(dest))
+
+    assert result.returncode != 0
+    assert "refusing to overwrite" in result.stderr
+    assert (dest / "waypoint-subagents").is_dir()
+
+
+def test_helper_uninstall_skips_unmanaged_entry(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+    foreign = dest / "waypoint-subagents"
+    foreign.mkdir(parents=True)
+
+    result = _run_script(repo, "uninstall", "--skill-dir", str(dest))
+
+    assert result.returncode == 0
+    assert "not a managed symlink" in result.stderr
+    assert foreign.is_dir()
+
+
+def test_helper_copy_mode_detaches_from_repo(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+
+    result = _run_script(repo, "install", "--copy", "--skill-dir", str(dest))
+
+    assert result.returncode == 0
+    entry = dest / "waypoint-subagents"
+    assert entry.is_dir() and not entry.is_symlink()
+    assert (entry / "SKILL.md").is_file()
+
+    status = _run_script(repo, "status", "--skill-dir", str(dest))
+    assert "copied" in status.stdout
+
+
+def test_helper_all_selects_every_skill(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo", skills=("waypoint-subagents", "other"))
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+
+    result = _run_script(repo, "install", "--all", "--skill-dir", str(dest))
+
+    assert result.returncode == 0
+    assert (dest / "waypoint-subagents").is_symlink()
+    assert (dest / "other").is_symlink()
+
+
+def test_helper_rejects_unknown_skill(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path / "repo")
+    _copy_skills_script(repo)
+    dest = tmp_path / "dest"
+
+    result = _run_script(repo, "install", "--skill", "nope", "--skill-dir", str(dest))
+
+    assert result.returncode != 0
+    assert "unknown skill: nope" in result.stderr


### PR DESCRIPTION
## Summary

Waypoint sessions can already be created and steered through the `waypoint sessions` CLI, but only the personal assistant ships the skills that document that workflow, and nothing frames child sessions as *subagents*. This adds a `waypoint-subagents` skill that lets a coding agent inside any Waypoint session spawn and drive child sessions — for the cases the harness's own in-process subagents cannot cover: a different backend or model, user-steerable parallel work, or a session that must outlive the current turn. It also adds an installer that distributes the skill into the global skill directories ordinary sessions discover, since repo skills are otherwise materialized only into the assistant's workspace.

## Changes

### Skills

- `.agents/skills/waypoint-subagents/`: a self-contained skill (`SKILL.md` plus `references/{preflight,spawn-and-poll,collect-and-steer,cleanup}.md`). It frames when to prefer a Waypoint sub-session over an in-process subagent, then walks the lifecycle: preflight that the `waypoint` CLI is on `PATH` and authenticated; spawn with a `subagent:<purpose>` title to establish ownership (sessions carry no parent/owner field); poll `sessions show` to a terminal status because there is no blocking wait command; read replies by filtering events for `kind == "agent_output"` (with a `raw_terminal_chunk` fallback for the heuristically-classified `tmux` backend); and reap only the children you spawned, never the protected assistant.

### Distribution tooling

- `scripts/install_skills.sh`: `install` / `uninstall` / `status` that link (default) or copy selected skills into a global skill root — defaulting to the cross-agent `~/.agents/skills` and the `waypoint-subagents` skill, overridable via `--skill-dir` / `WAYPOINT_SKILLS_DIR`, `--skill` / `--all`, and `--copy`. It is idempotent, only ever removes symlinks it created, and refuses to overwrite a real or foreign directory.
- `waypointctl/src/waypointctl/skills.py`, `waypointctl/src/waypointctl/cli.py`: a `waypointctl skills {install,uninstall,status}` sub-app that forwards to the script, resolving the repo root from `--home` / `WAYPOINT_HOME` — mirroring the existing `tailscale` helper pattern.

### Tests

- `waypointctl/tests/test_skills.py`: covers the CLI arg-forwarding layer plus the script's install/status/uninstall roundtrip, idempotency, foreign-directory guard, copy mode, `--all` selection, and unknown-skill rejection.

### Docs

- `AGENTS.md`: a "Distributing Coding-Agent Skills" note explaining that repo skills auto-install only into the assistant workspace, and pointing at `scripts/install_skills.sh` / `waypointctl skills` for global distribution.

## Test Plan

- [x] `cd waypointctl && uv run pytest tests/test_skills.py` — 11 pass.
- [x] `cd waypointctl && uv run pytest` — 114 pass; the 2 `tests/test_tailscale.py` failures are pre-existing and Docker-presence-dependent (this host has Docker, so the "docker missing" assertions don't hold), confirmed still failing with this branch's changes stashed.
- [x] `cd waypointctl && uv run ruff check` + `uv run ruff format --check` on the changed files — clean.
- [x] `cd waypointctl && uv run mypy src/waypointctl/skills.py src/waypointctl/cli.py` — only a pre-existing missing-stub error for `dotenv` in `config.py`, unrelated to this branch.
- [x] Validated the real assistant asset source with the new skill present — passes (skills: `waypoint`, `waypoint-subagents`, `waypointctl`).
- [x] pre-commit hooks (isort / black / ruff / codespell / mypy) ran on each commit — clean (isort is scoped to backend, so skipped here).
- [x] Manual end-to-end via the skill: spawned a `claude_code` child in the repo root, sent a read-only task, polled to `idle`, read its `agent_output` reply (returned the `SUBAGENT_OK` sentinel), then terminated it to `exited`.