### PR TITLE
fix: stop the homepage poll storm and move streaming work off the event loop

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -11,7 +11,7 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
-from typing import Any
+from typing import Any, TextIO
 
 from fastapi import HTTPException, status
 
@@ -52,6 +52,12 @@ from waypoint.transports import TransportAdapter
 
 TMUX_TRANSPORT_ID = "tmux"
 COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
+# Debounce window for streaming-driven session_state / session_list
+# broadcasts. A burst of streamed events collapses into one broadcast per
+# window instead of one per token; lifecycle changes still broadcast
+# immediately, so this only adds at most this much latency to the live
+# list/status updates a fast stream produces.
+SESSION_BROADCAST_DEBOUNCE_SECONDS = 0.25
 
 
 log = logging.getLogger("waypoint.runtime")
@@ -159,6 +165,19 @@ class SessionRuntime:
             CompletionCacheKey, asyncio.Task[list[CommandCompletion]]
         ] = {}
         self.file_offsets: dict[str, int] = {}
+        # Open append handles for per-session structured logs, kept around
+        # so the streaming path doesn't reopen (and re-stat via get_session)
+        # the file on every event. Closed on terminate/delete and at stop().
+        self._structured_log_handles: dict[str, TextIO] = {}
+        # Coalesced session_state / session_list broadcasting. The
+        # streaming event path marks sessions dirty and wakes the flusher
+        # instead of re-serializing every session per event; the flusher
+        # debounces and emits one broadcast per window. See
+        # ``_session_broadcast_loop``.
+        self._dirty_session_states: set[str] = set()
+        self._session_list_dirty = False
+        self._broadcast_wake = asyncio.Event()
+        self._broadcast_flusher: asyncio.Task[None] | None = None
         # Id of the personal-assistant singleton, populated by
         # ``_ensure_assistant_session`` during ``start``. ``None`` when the
         # assistant is disabled or its bootstrap failed.
@@ -176,6 +195,9 @@ class SessionRuntime:
         return self._transports[session.transport]
 
     async def start(self) -> None:
+        self._broadcast_flusher = asyncio.create_task(
+            self._session_broadcast_loop(), name="session-broadcast-flusher"
+        )
         for session in self.storage.list_sessions():
             # ERROR sessions get one passive restore attempt at boot — the
             # plugin's restore_session is responsible for tagging them
@@ -222,6 +244,15 @@ class SessionRuntime:
         for completion_task in completion_tasks:
             with suppress(asyncio.CancelledError):
                 await completion_task
+        if self._broadcast_flusher is not None:
+            self._broadcast_flusher.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._broadcast_flusher
+            self._broadcast_flusher = None
+        for handle in self._structured_log_handles.values():
+            with suppress(Exception):
+                handle.close()
+        self._structured_log_handles.clear()
         for plugin in self.registry.all():
             await plugin.shutdown(self)
         self.storage.close()
@@ -689,16 +720,7 @@ class SessionRuntime:
             structured_log,
         )
         self._warm_command_completions(new_session)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         return new_session
 
     async def attach_tmux(self, request: SessionAttachRequest) -> SessionRecord:
@@ -1061,6 +1083,7 @@ class SessionRuntime:
         await self._record_system_event(
             session.id, "Session terminated", status=SessionStatus.EXITED
         )
+        self._close_structured_log(session.id)
         return self.storage.update_session(session.id, status=SessionStatus.EXITED)
 
     async def reattach(self, session_id: str) -> SessionRecord:
@@ -1131,20 +1154,12 @@ class SessionRuntime:
                     await self.terminate(session_id)
             else:
                 await self.terminate(session_id)
+        self._close_structured_log(session_id)
         self.storage.delete_session(session_id)
         # Drop this session's blackboard posts along with its record.
         pruned = self.storage.prune_board_for_session(session_id)
         self.registry.plugin_for(session).on_session_deleted(self, session)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         if pruned:
             await self._publish_board_update(None)
 
@@ -1225,16 +1240,7 @@ class SessionRuntime:
             )
         await plugin.apply_permission_mode(self, session, validated)
         updated = self.storage.update_session(session_id, permission_mode=validated)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         return updated
 
     async def set_model(self, session_id: str, model: str | None) -> SessionRecord:
@@ -1248,16 +1254,7 @@ class SessionRuntime:
             )
         await plugin.apply_model(self, session, cleaned)
         updated = self.storage.update_session(session_id, model=cleaned)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         return updated
 
     async def set_effort(self, session_id: str, effort: str | None) -> SessionRecord:
@@ -1290,16 +1287,7 @@ class SessionRuntime:
                 status=SessionStatus.IDLE,
             )
         updated = self.storage.update_session(session_id, effort=cleaned)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         return updated
 
     async def list_backend_models(
@@ -1325,16 +1313,7 @@ class SessionRuntime:
         if session.title == title:
             return session
         updated = self.storage.update_session(session_id, title=title)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         return updated
 
     async def set_pinned(self, session_id: str, pinned: bool) -> SessionRecord:
@@ -1343,16 +1322,7 @@ class SessionRuntime:
         if (session.pinned_at is None) == (pinned_at is None):
             return session
         updated = self.storage.update_session(session_id, pinned_at=pinned_at)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
-            )
-        )
+        await self._broadcast_session_list()
         return updated
 
     async def answer_question(
@@ -1558,7 +1528,7 @@ class SessionRuntime:
     ) -> SessionRecord:
         session = self.storage.update_session(session_id, **updates)
         if publish:
-            await self._publish_session_state(session_id)
+            self._publish_session_state(session_id)
         return session
 
     def session_update_callback(
@@ -1581,17 +1551,19 @@ class SessionRuntime:
             ),
             session_id=event.session_id,
         )
-        await self._publish_session_state(event.session_id)
+        self._publish_session_state(event.session_id)
 
-    async def _publish_session_state(self, session_id: str) -> None:
-        session = self.get_session(session_id)
-        await self.broadcast.publish(
-            SessionEnvelope(
-                type="session_state",
-                payload={"session": session.model_dump(mode="json")},
-            ),
-            session_id=session_id,
-        )
+    def _publish_session_state(self, session_id: str) -> None:
+        # Streaming hot path: mark the session dirty and let the debounced
+        # flusher emit the session_state / session_list broadcasts. A fast
+        # token stream would otherwise re-serialize every session on every
+        # event. Lifecycle changes call ``_broadcast_session_list``
+        # directly when they need an immediate update.
+        self._dirty_session_states.add(session_id)
+        self._session_list_dirty = True
+        self._broadcast_wake.set()
+
+    async def _broadcast_session_list(self) -> None:
         await self.broadcast.publish(
             SessionEnvelope(
                 type="session_list_update",
@@ -1603,11 +1575,51 @@ class SessionRuntime:
             )
         )
 
+    async def _broadcast_session_state(self, session_id: str) -> None:
+        session = self.storage.get_session(session_id)
+        if session is None:
+            # Deleted between being marked dirty and this flush; the
+            # delete already broadcast a fresh list, so there's nothing to
+            # publish for it.
+            return
+        await self.broadcast.publish(
+            SessionEnvelope(
+                type="session_state",
+                payload={"session": session.model_dump(mode="json")},
+            ),
+            session_id=session_id,
+        )
+
+    async def _session_broadcast_loop(self) -> None:
+        while True:
+            await self._broadcast_wake.wait()
+            await asyncio.sleep(SESSION_BROADCAST_DEBOUNCE_SECONDS)
+            # Clear before draining so any event arriving during the
+            # broadcast below re-arms the flusher rather than being lost.
+            self._broadcast_wake.clear()
+            dirty_ids = self._dirty_session_states
+            self._dirty_session_states = set()
+            list_dirty = self._session_list_dirty
+            self._session_list_dirty = False
+            for session_id in dirty_ids:
+                await self._broadcast_session_state(session_id)
+            if list_dirty:
+                await self._broadcast_session_list()
+
     def _append_structured_log(self, session_id: str, event: EventRecord) -> None:
-        session = self.get_session(session_id)
-        path = Path(session.structured_log_path)
-        with path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(event.model_dump(mode="json")) + "\n")
+        handle = self._structured_log_handles.get(session_id)
+        if handle is None:
+            session = self.get_session(session_id)
+            handle = Path(session.structured_log_path).open("a", encoding="utf-8")
+            self._structured_log_handles[session_id] = handle
+        handle.write(json.dumps(event.model_dump(mode="json")) + "\n")
+        handle.flush()
+
+    def _close_structured_log(self, session_id: str) -> None:
+        handle = self._structured_log_handles.pop(session_id, None)
+        if handle is not None:
+            with suppress(Exception):
+                handle.close()
 
     def _generate_session_id(self, backend: str) -> str:
         token = secrets.token_hex(4)
@@ -1698,11 +1710,22 @@ class SessionRuntime:
         )
 
     async def _monitor_session(self, session_id: str) -> None:
+        ingest_interval = self.settings.stream_poll_interval
+        ticks_per_refresh = max(
+            1, round(self.settings.state_poll_interval / ingest_interval)
+        )
         try:
+            tick = 0
             while True:
                 await self._ingest_raw_output(session_id)
-                await self._refresh_state(session_id)
-                await asyncio.sleep(self.settings.stream_poll_interval)
+                # Ingest the cheap (threaded) output read every tick, but
+                # only run the subprocess-spawning liveness refresh every
+                # Nth tick. tick 0 refreshes immediately so a pane that's
+                # already dead is caught on the first pass.
+                if tick % ticks_per_refresh == 0:
+                    await self._refresh_state(session_id)
+                tick += 1
+                await asyncio.sleep(ingest_interval)
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -102,6 +102,12 @@ class Settings(BaseModel):
     database_name: str = "waypoint.db"
     token_ttl_seconds: int = 60 * 60 * 24 * 30
     stream_poll_interval: float = 1.0
+    # tmux pane liveness/pid refresh runs on this slower cadence than the
+    # raw-output ingest above: describe_target spawns a tmux subprocess per
+    # poll per session, so refreshing every ingest tick is wasteful. The
+    # cost is up to this much latency detecting a pane that died on its own
+    # (explicit terminate/delete are unaffected).
+    state_poll_interval: float = 3.0
     tail_snapshot_lines: int = 200
     cors_origins: list[str] = Field(default_factory=lambda: list(DEFAULT_CORS_ORIGINS))
     cors_allow_origin_regex: str | None = DEFAULT_CORS_ORIGIN_REGEX

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -96,6 +96,17 @@ class Storage:
         self._lock = threading.RLock()
         self.connection = sqlite3.connect(self.database_path, check_same_thread=False)
         self.connection.row_factory = sqlite3.Row
+        # WAL lets reads run concurrently with the writer and drops the
+        # full fsync that the default rollback journal does on every
+        # commit — the streaming event path commits per event, so that
+        # fsync otherwise serializes the whole asyncio loop. synchronous
+        # NORMAL is safe under WAL (a crash can lose only the last
+        # un-checkpointed commits, never corrupt the db), and busy_timeout
+        # lets the threadpooled readers wait out a checkpoint instead of
+        # raising "database is locked".
+        self.connection.execute("PRAGMA journal_mode=WAL")
+        self.connection.execute("PRAGMA synchronous=NORMAL")
+        self.connection.execute("PRAGMA busy_timeout=5000")
         self._init_db()
 
     def _init_db(self) -> None:
@@ -138,6 +149,12 @@ class Storage:
                 sequence INTEGER NOT NULL,
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
+
+            -- Serves both the per-event next_sequence MAX(sequence) lookup
+            -- and the per-session paginated event reads, which would
+            -- otherwise scan the whole events table.
+            CREATE INDEX IF NOT EXISTS idx_events_session_seq
+                ON events(session_id, sequence);
 
             CREATE TABLE IF NOT EXISTS auth_tokens (
                 token TEXT PRIMARY KEY,

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -96,14 +96,14 @@ class Storage:
         self._lock = threading.RLock()
         self.connection = sqlite3.connect(self.database_path, check_same_thread=False)
         self.connection.row_factory = sqlite3.Row
-        # WAL lets reads run concurrently with the writer and drops the
-        # full fsync that the default rollback journal does on every
-        # commit — the streaming event path commits per event, so that
-        # fsync otherwise serializes the whole asyncio loop. synchronous
-        # NORMAL is safe under WAL (a crash can lose only the last
-        # un-checkpointed commits, never corrupt the db), and busy_timeout
-        # lets the threadpooled readers wait out a checkpoint instead of
-        # raising "database is locked".
+        # WAL drops the full fsync that the default rollback journal does
+        # on every commit — the streaming event path commits per event, so
+        # that fsync otherwise serializes the whole asyncio loop.
+        # synchronous NORMAL is safe under WAL (a crash can lose only the
+        # last un-checkpointed commits, never corrupt the db). This single
+        # connection is serialized by ``_synchronized``, so WAL's
+        # concurrent-reader benefit doesn't apply today; busy_timeout is
+        # defensive in case that ever changes.
         self.connection.execute("PRAGMA journal_mode=WAL")
         self.connection.execute("PRAGMA synchronous=NORMAL")
         self.connection.execute("PRAGMA busy_timeout=5000")

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { BackendSwitcher } from "@/components/BackendSwitcher";
 import { BoardPanel } from "@/components/BoardPanel";
@@ -163,6 +163,24 @@ export default function HomePage() {
     : launchableBackends[0] ?? supportedBackends[0];
   const effectiveDefaultCwd = activeLaunchTarget?.default_cwd ?? defaultCwd;
 
+  const resetAuthState = useCallback((message: string) => {
+    clearToken();
+    setToken("");
+    setSessions([]);
+    setDefaultBackend("codex");
+    setDefaultCwd("~/");
+    setLaunchTargets([]);
+    setActiveLaunchTargetId("");
+    setSchedules([]);
+    setThreadsByBackend({});
+    setLoadingByBackend({});
+    setError(message);
+  }, []);
+
+  const handleAuthFailure = useCallback(() => {
+    resetAuthState("Session expired. Log in again.");
+  }, [resetAuthState]);
+
   useEffect(() => {
     const currentHost = readHost();
     const currentToken = readToken();
@@ -280,7 +298,7 @@ export default function HomePage() {
       }
       socket?.close();
     };
-  }, [host, token]);
+  }, [host, resetAuthState, token]);
 
   // The set of backends we should fetch threads for: those that
   // advertise `supports_thread_discovery=True` AND are listed by the
@@ -368,6 +386,7 @@ export default function HomePage() {
     host,
     launchTargets,
     discoveryBackendsKey,
+    resetAuthState,
     token,
   ]);
 
@@ -488,24 +507,6 @@ export default function HomePage() {
           : `failed to import ${backend} thread`,
       );
     }
-  }
-
-  function resetAuthState(message: string) {
-    clearToken();
-    setToken("");
-    setSessions([]);
-    setDefaultBackend("codex");
-    setDefaultCwd("~/");
-    setLaunchTargets([]);
-    setActiveLaunchTargetId("");
-    setSchedules([]);
-    setThreadsByBackend({});
-    setLoadingByBackend({});
-    setError(message);
-  }
-
-  function handleAuthFailure() {
-    resetAuthState("Session expired. Log in again.");
   }
 
   async function handleCreateSchedule(payload: ScheduleCreateRequest) {


### PR DESCRIPTION
## Summary

Staying on the homepage produced a steady stream of backend requests — `GET /api/backends/<id>/models` and `GET /api/usage` every 2–3s — and, separately, an active session's streaming did a surprising amount of synchronous per-event work on the backend's single asyncio loop. Both came down to work scaling with something it shouldn't: render count on the frontend, and event × session count on the backend, all funneled through one process.

The homepage churn was a stale-closure feedback loop: `resetAuthState` / `handleAuthFailure` were recreated on every `HomePage` render and passed as `onAuthFailure` into `ModelPicker` and `UsageDashboardSection`, whose effects list it as a dependency — so each render (e.g. every WebSocket `session_list_update`) re-ran those effects and re-fetched `/models` and `/usage`.

On the backend, every streamed event (chat token chunk or tmux output chunk) ran a full SQLite `commit()` (an fsync, under the default rollback journal) on the loop, re-serialized the *entire* session list and broadcast it to every subscriber, reopened the structured-log file plus re-read the session row, and — for tmux — spawned a `tmux` subprocess for a liveness refresh on every output tick. A single chatty session could saturate the loop and starve every other session's streaming.

## Changes

### Frontend

- `app/page.tsx`: wrap `resetAuthState` and `handleAuthFailure` in `useCallback` so their identities are stable across renders. The `onAuthFailure`-dependent effects in `ModelPicker` / `UsageDashboardSection` now have all-stable deps and fetch once per real change instead of once per render. Adds `resetAuthState` to the two effect dependency arrays for correctness (now safe, since it's stable).

### Backend

- `storage.py`: open the SQLite connection in **WAL** mode with `synchronous=NORMAL` and a `busy_timeout`. WAL drops the per-commit fsync that serialized the loop under a fast stream (a crash can lose only the last un-checkpointed commits, never corrupt the DB) and lets reads run concurrently with the writer; `busy_timeout` lets the threadpooled readers wait out a checkpoint. Adds `idx_events_session_seq` on `events(session_id, sequence)` (via `CREATE INDEX IF NOT EXISTS`, so existing DBs migrate cleanly), which serves both the per-event `next_sequence` `MAX(sequence)` lookup and the per-session paginated reads that previously scanned the whole table.
- `runtime.py`: coalesce streaming-driven broadcasts. `_publish_session_state` no longer re-serializes and broadcasts the full session list per event; it marks the session dirty and a debounced flusher task (`_session_broadcast_loop`, started in `start()` / cancelled in `stop()`) emits one `session_state` and one `session_list_update` per window. Lifecycle changes (create/delete/terminate/pin/title/model/effort/permission) still broadcast immediately through a new `_broadcast_session_list` helper, which also de-duplicates seven copies of the same inline block.
- `runtime.py`: cache structured-log file handles per session (`_append_structured_log` no longer reopens the file and re-reads the session row on every event); handles close on terminate/delete and at `stop()`.
- `runtime.py` + `settings.py`: decouple the tmux pane monitor's liveness refresh from output ingestion. Output still ingests every `stream_poll_interval` (1s), but the subprocess-spawning `_refresh_state` now runs every `state_poll_interval` (new, default 3s), cutting tmux subprocess spawns ~3× across all open panes.

## Test Plan

- [x] `cd backend && uv run pre-commit run --all-files` — isort / black / ruff / codespell / mypy all clean.
- [x] `cd backend && uv run pytest` — 598 passed; the 4 `tests/test_rate_limits.py` failures are pre-existing on the base commit (keychain / Messages-API header parsing, host-dependent) and unrelated to this branch. One tmux-reattach test flaked once under full-suite ordering but passes consistently on re-run and in isolation; it spawns real `tmux` when installed and is timing-sensitive (same caveat as #89).
- [x] `cd frontend && npm run lint` — clean.
- [x] Live against a restarted backend (561 MB DB): confirmed `journal_mode=wal` with `-wal`/`-shm` sidecars, `idx_events_session_seq` present, clean lifespan startup with the broadcast flusher running and no errors, and an events page returning `200` in ~5ms (exercises the new index).