### PR TITLE
feat: support Claude Code Task tools for todo tracking

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -1188,8 +1188,23 @@ class ClaudeCliAdapter:
         state.stdout_task = asyncio.create_task(self._read_stdout(state))
         state.stderr_task = asyncio.create_task(self._read_stderr(state))
         state.wait_task = asyncio.create_task(self._watch_process(state))
+        if resume:
+            self._carry_task_state(self._sessions.get(session_id), state)
         self._sessions[session_id] = state
         return state
+
+    @staticmethod
+    def _carry_task_state(
+        prior: ClaudeSessionState | None, state: ClaudeSessionState
+    ) -> None:
+        # A resume/respawn builds a fresh state, but the CLI keeps the same task
+        # ids and will send TaskUpdate deltas for tasks created before the
+        # respawn. Without the prior tracker those deltas hit unknown ids and
+        # materialise blank stubs under a new card, so carry the fold forward.
+        if prior is None:
+            return
+        state.task_tracker = prior.task_tracker
+        state.task_card_item_id = prior.task_card_item_id
 
     def _build_local_launch_spec(
         self,

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -1668,6 +1668,7 @@ class ClaudeCliAdapter:
                 status=tool_input.get("status"),
                 content=tool_input.get("subject"),
                 active_form=tool_input.get("activeForm"),
+                description=tool_input.get("description"),
             )
             await self._emit_task_snapshot(state)
 
@@ -1694,6 +1695,7 @@ class ClaudeCliAdapter:
             task_id,
             content=str(create_input.get("subject") or ""),
             active_form=create_input.get("activeForm"),
+            description=create_input.get("description"),
             status=create_input.get("status") or "pending",
         )
         await self._emit_task_snapshot(state)

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -20,10 +20,14 @@ from waypoint.backends.claude_code.models import (
     normalize_claude_model_id,
 )
 from waypoint.backends.claude_code.normalize import (
+    TASK_TOOL_NAMES,
+    TaskListTracker,
+    extract_created_task_id,
     format_approval_text,
     format_compact_boundary,
     format_rate_limit,
     format_status_event,
+    format_task_snapshot,
     iter_content_blocks,
     stringify_tool_result,
 )
@@ -226,6 +230,15 @@ class ClaudeSessionState:
     # 0-call tool run. Suppress that result's display too.
     suppressed_result_tool_use_ids: set[str] = field(default_factory=set)
     file_edit_preview_metadata: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Folds Claude Code's incremental Task tool stream (CC >= v2.1.142) back
+    # into a single evolving todo card. `pending_task_creates` holds each
+    # TaskCreate's input until its tool_result reveals the assigned task id;
+    # `task_card_item_id` is the stable item_id the snapshots merge under, and
+    # is rotated when a new task group starts so completed groups keep their
+    # own card.
+    task_tracker: TaskListTracker = field(default_factory=TaskListTracker)
+    pending_task_creates: dict[str, dict[str, Any]] = field(default_factory=dict)
+    task_card_item_id: str | None = None
     last_message_text: dict[str, str] = field(default_factory=dict)
     terminal_fragments: list[str] = field(default_factory=list)
     stderr_tail: deque[str] = field(
@@ -1550,6 +1563,11 @@ class ClaudeCliAdapter:
                     if tool_use_id:
                         state.suppressed_result_tool_use_ids.add(tool_use_id)
                     continue
+                if tool_name in TASK_TOOL_NAMES:
+                    await self._handle_task_tool_use(
+                        state, tool_name, tool_use_id, block.get("input") or {}
+                    )
+                    continue
                 input_text = json.dumps(block.get("input") or {}, indent=2)
                 await self._emit_event(
                     state.session_id,
@@ -1584,9 +1602,16 @@ class ClaudeCliAdapter:
             if block.get("type") != "tool_result":
                 continue
             tool_use_id = str(block.get("tool_use_id") or "")
+            if tool_use_id and tool_use_id in state.pending_task_creates:
+                # The TaskCreate result carries the assigned task id; fold it
+                # into the todo snapshot instead of rendering the raw result.
+                await self._handle_task_create_result(state, tool_use_id, block)
+                continue
             if tool_use_id and tool_use_id in state.suppressed_result_tool_use_ids:
-                # Echoed verdict for an ExitPlanMode approval; the plan card and
-                # the agent's next message already convey the outcome.
+                # Echoed verdict for an ExitPlanMode approval, or a suppressed
+                # Task tool result (TaskUpdate/TaskGet/TaskList) whose effect is
+                # already reflected in the todo card. The plan card and the
+                # agent's next message convey ExitPlanMode outcomes.
                 state.suppressed_result_tool_use_ids.discard(tool_use_id)
                 continue
             content = block.get("content")
@@ -1610,6 +1635,87 @@ class ClaudeCliAdapter:
                 if preview_metadata is not None:
                     metadata.update(preview_metadata)
             await self._emit_event(state.session_id, kind, text, metadata, status)
+
+    async def _handle_task_tool_use(
+        self,
+        state: ClaudeSessionState,
+        tool_name: str,
+        tool_use_id: str,
+        tool_input: dict[str, Any],
+    ) -> None:
+        if tool_name == "TaskCreate":
+            # The assigned id only comes back in the matching tool_result, so
+            # stash the input until then; the result handler folds it in.
+            if tool_use_id:
+                state.pending_task_creates[tool_use_id] = tool_input
+            return
+        # Drop the echoed result for the remaining Task tools — their effect is
+        # already reflected in the todo card (TaskUpdate) or read-only
+        # (TaskGet/TaskList). We deliberately do not reseed the tracker from
+        # TaskList results: persisted production data shows TaskGet/TaskList go
+        # effectively unused, so their result schema is unverified and
+        # reconciling against the doc's shape would risk clobbering good state.
+        # Resume is instead covered by stub-materialisation in
+        # TaskListTracker.update for updates that reference an unseen id.
+        if tool_use_id:
+            state.suppressed_result_tool_use_ids.add(tool_use_id)
+        if tool_name == "TaskUpdate":
+            task_id = str(tool_input.get("taskId") or "")
+            if not task_id:
+                return
+            state.task_tracker.update(
+                task_id,
+                status=tool_input.get("status"),
+                content=tool_input.get("subject"),
+                active_form=tool_input.get("activeForm"),
+            )
+            await self._emit_task_snapshot(state)
+
+    async def _handle_task_create_result(
+        self, state: ClaudeSessionState, tool_use_id: str, block: dict[str, Any]
+    ) -> None:
+        create_input = state.pending_task_creates.pop(tool_use_id, None)
+        if create_input is None:
+            return
+        task_id = extract_created_task_id(block)
+        if task_id is None:
+            # Fall back to the tool_use_id so the item still renders; a later
+            # TaskUpdate keyed by the real id will then create a stub instead of
+            # patching this one.
+            log.debug("TaskCreate result missing task id; falling back to tool_use_id")
+            task_id = tool_use_id
+        if state.task_tracker.is_empty:
+            # A fresh task group — rotate to a new card so it doesn't overwrite
+            # a prior, completed group's card. CC numbers task ids monotonically
+            # within a session (and never deletes in the observed data), so the
+            # tracker is genuinely empty here and reused ids can't collide.
+            state.task_card_item_id = None
+        state.task_tracker.create(
+            task_id,
+            content=str(create_input.get("subject") or ""),
+            active_form=create_input.get("activeForm"),
+            status=create_input.get("status") or "pending",
+        )
+        await self._emit_task_snapshot(state)
+
+    async def _emit_task_snapshot(self, state: ClaudeSessionState) -> None:
+        if state.task_card_item_id is None:
+            state.task_card_item_id = uuid.uuid4().hex
+        todos = state.task_tracker.snapshot()
+        await self._emit_event(
+            state.session_id,
+            EventKind.TOOL_RESULT,
+            format_task_snapshot(todos),
+            {
+                "method": "assistant.task_update",
+                "item_id": state.task_card_item_id,
+                "item_type": "todo_list",
+                "tool_name": "TodoWrite",
+                "payload": {"input": {"todos": todos}},
+                "status": SessionStatus.RUNNING,
+            },
+            SessionStatus.RUNNING,
+        )
 
     async def _handle_result(
         self, state: ClaudeSessionState, event: dict[str, Any]

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -1222,6 +1222,13 @@ class ClaudeCliAdapter:
             return
         state.task_tracker, state.task_card_item_id = carried
 
+    def discard_session(self, session_id: str) -> None:
+        # Permanent removal: drop the carried todo tracker so a stash for a
+        # session that's deleted (rather than respawned) doesn't linger. An
+        # exited session keeps its stash — it may still be reattached, which is
+        # exactly when the carry-over is needed.
+        self._carried_task_state.pop(session_id, None)
+
     def _build_local_launch_spec(
         self,
         session_id: str,

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -301,6 +301,11 @@ class ClaudeCliAdapter:
         self._on_session_update = on_session_update
         self._default_model_id = normalize_claude_model_id(default_model_id)
         self._sessions: dict[str, ClaudeSessionState] = {}
+        # Folded todo state stashed by terminate_session and consumed by the
+        # next resume-spawn, so a respawn (set_effort, reattach) restores the
+        # tracker instead of stubbing the CLI's TaskUpdate deltas for tasks
+        # created before the respawn. Keyed by session id.
+        self._carried_task_state: dict[str, tuple[TaskListTracker, str | None]] = {}
         self._approval_lock = asyncio.Lock()
 
     async def start_session(
@@ -1071,6 +1076,13 @@ class ClaudeCliAdapter:
         state = self._sessions.pop(session_id, None)
         if state is None:
             return False
+        if not state.task_tracker.is_empty:
+            # A respawn (set_effort, reattach) terminates before the
+            # resume-spawn; preserve the folded todo state for it to restore.
+            self._carried_task_state[session_id] = (
+                state.task_tracker,
+                state.task_card_item_id,
+            )
         state.closing = True
         if state.rate_limit_refresh_task is not None:
             state.rate_limit_refresh_task.cancel()
@@ -1189,22 +1201,26 @@ class ClaudeCliAdapter:
         state.stderr_task = asyncio.create_task(self._read_stderr(state))
         state.wait_task = asyncio.create_task(self._watch_process(state))
         if resume:
-            self._carry_task_state(self._sessions.get(session_id), state)
+            self._restore_carried_task_state(session_id, state)
+        else:
+            # A fresh (non-resume) start of this id isn't a respawn; drop any
+            # stale carry so it can't leak into an unrelated session.
+            self._carried_task_state.pop(session_id, None)
         self._sessions[session_id] = state
         return state
 
-    @staticmethod
-    def _carry_task_state(
-        prior: ClaudeSessionState | None, state: ClaudeSessionState
+    def _restore_carried_task_state(
+        self, session_id: str, state: ClaudeSessionState
     ) -> None:
         # A resume/respawn builds a fresh state, but the CLI keeps the same task
         # ids and will send TaskUpdate deltas for tasks created before the
         # respawn. Without the prior tracker those deltas hit unknown ids and
-        # materialise blank stubs under a new card, so carry the fold forward.
-        if prior is None:
+        # materialise blank stubs under a new card, so restore the fold that
+        # terminate_session stashed just before this respawn.
+        carried = self._carried_task_state.pop(session_id, None)
+        if carried is None:
             return
-        state.task_tracker = prior.task_tracker
-        state.task_card_item_id = prior.task_card_item_id
+        state.task_tracker, state.task_card_item_id = carried
 
     def _build_local_launch_spec(
         self,

--- a/backend/src/waypoint/backends/claude_code/normalize.py
+++ b/backend/src/waypoint/backends/claude_code/normalize.py
@@ -159,6 +159,7 @@ class TaskItem:
     content: str
     status: str = "pending"
     active_form: str | None = None
+    description: str | None = None
 
 
 @dataclass
@@ -184,12 +185,14 @@ class TaskListTracker:
         *,
         content: str,
         active_form: str | None = None,
+        description: str | None = None,
         status: str = "pending",
     ) -> None:
         self.tasks[task_id] = TaskItem(
             content=content,
             status=normalize_task_status(status),
             active_form=active_form,
+            description=description,
         )
 
     def update(
@@ -199,6 +202,7 @@ class TaskListTracker:
         status: str | None = None,
         content: str | None = None,
         active_form: str | None = None,
+        description: str | None = None,
     ) -> None:
         if status == "deleted":
             self.tasks.pop(task_id, None)
@@ -219,6 +223,8 @@ class TaskListTracker:
             task.content = content
         if active_form is not None:
             task.active_form = active_form
+        if description is not None:
+            task.description = description
 
     def snapshot(self) -> list[dict[str, Any]]:
         return [
@@ -226,6 +232,7 @@ class TaskListTracker:
                 "content": task.content,
                 "status": task.status,
                 "activeForm": task.active_form,
+                "description": task.description,
             }
             for task in self.tasks.values()
         ]

--- a/backend/src/waypoint/backends/claude_code/normalize.py
+++ b/backend/src/waypoint/backends/claude_code/normalize.py
@@ -10,6 +10,8 @@ session bookkeeping.
 """
 
 import json
+import re
+from dataclasses import dataclass, field
 from typing import Any
 
 from waypoint.schemas import SessionStatus
@@ -131,3 +133,168 @@ def stringify_tool_result(content: Any) -> str:
                 parts.append(str(entry))
         return "\n".join(parts)
     return json.dumps(content)
+
+
+# ─── Task tools (Claude Code >= v2.1.142) ───────────────────────────────────
+#
+# Newer Claude Code tracks todos through structured Task tools instead of the
+# single TodoWrite call. Where TodoWrite rewrote the whole `todos` array on
+# every invocation, the Task tools split it up: TaskCreate adds one item,
+# TaskUpdate patches one item by id, and TaskGet/TaskList read the list back.
+# The frontend's todo card still expects a full snapshot per event, so we fold
+# the incremental stream back into one here. See docs/coding_agent_plugins.md
+# and https://code.claude.com/docs/en/agent-sdk/todo-tracking.
+
+TASK_TOOL_NAMES = frozenset({"TaskCreate", "TaskUpdate", "TaskGet", "TaskList"})
+
+_VALID_TASK_STATUSES = frozenset({"pending", "in_progress", "completed"})
+
+
+def normalize_task_status(value: Any) -> str:
+    return value if value in _VALID_TASK_STATUSES else "pending"
+
+
+@dataclass
+class TaskItem:
+    content: str
+    status: str = "pending"
+    active_form: str | None = None
+
+
+@dataclass
+class TaskListTracker:
+    """Reconstructs a TodoWrite-style snapshot from the incremental Task stream.
+
+    ``TaskCreate`` learns its assigned id only from the matching tool_result,
+    so the adapter stitches the create input to that id before calling
+    :meth:`create`. ``TaskUpdate`` carries the id in its input and maps onto
+    :meth:`update`; ``status == "deleted"`` removes the item. Insertion order is
+    preserved so the rendered list stays stable across updates.
+    """
+
+    tasks: dict[str, TaskItem] = field(default_factory=dict)
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.tasks
+
+    def create(
+        self,
+        task_id: str,
+        *,
+        content: str,
+        active_form: str | None = None,
+        status: str = "pending",
+    ) -> None:
+        self.tasks[task_id] = TaskItem(
+            content=content,
+            status=normalize_task_status(status),
+            active_form=active_form,
+        )
+
+    def update(
+        self,
+        task_id: str,
+        *,
+        status: str | None = None,
+        content: str | None = None,
+        active_form: str | None = None,
+    ) -> None:
+        if status == "deleted":
+            self.tasks.pop(task_id, None)
+            return
+        task = self.tasks.get(task_id)
+        if task is None:
+            # An update for a task we never saw created — e.g. a resumed
+            # session whose creates predate this process. Materialise a stub so
+            # the item still appears, but only when the patch carries something
+            # to show.
+            if content is None and status is None:
+                return
+            task = TaskItem(content=content or "")
+            self.tasks[task_id] = task
+        if status is not None:
+            task.status = normalize_task_status(status)
+        if content is not None:
+            task.content = content
+        if active_form is not None:
+            task.active_form = active_form
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "content": task.content,
+                "status": task.status,
+                "activeForm": task.active_form,
+            }
+            for task in self.tasks.values()
+        ]
+
+
+_TASK_CREATED_RE = re.compile(r"[Tt]ask #(\d+)")
+
+
+def extract_created_task_id(block: dict[str, Any]) -> str | None:
+    """Pull the assigned task id out of a ``TaskCreate`` tool_result.
+
+    Real Claude Code returns a plain string ``"Task #N created successfully:
+    <subject>"`` whose ``N`` matches the ``taskId`` later passed to
+    ``TaskUpdate``. The Agent SDK docs instead describe a structured
+    ``{"task": {"id": ...}}`` payload. Try the structured form first (so we
+    track newer shapes if CC adopts them), then fall back to parsing ``#N`` out
+    of the result text.
+    """
+    for payload in _iter_result_payloads(block.get("content")):
+        task = payload.get("task")
+        if isinstance(task, dict) and task.get("id"):
+            return str(task["id"])
+        task_id = payload.get("id") or payload.get("taskId")
+        if task_id:
+            return str(task_id)
+    match = _TASK_CREATED_RE.search(stringify_tool_result(block.get("content")))
+    return match.group(1) if match else None
+
+
+def _iter_result_payloads(content: Any) -> list[dict[str, Any]]:
+    if isinstance(content, dict):
+        return [content]
+    if isinstance(content, str):
+        parsed = _try_json(content)
+        return [parsed] if isinstance(parsed, dict) else []
+    if isinstance(content, list):
+        payloads: list[dict[str, Any]] = []
+        for entry in content:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("type") == "text" and isinstance(entry.get("text"), str):
+                parsed = _try_json(entry["text"])
+                if isinstance(parsed, dict):
+                    payloads.append(parsed)
+            else:
+                payloads.append(entry)
+        return payloads
+    return []
+
+
+def _try_json(text: str) -> Any:
+    try:
+        return json.loads(text)
+    except ValueError:
+        return None
+
+
+def format_task_snapshot(todos: list[dict[str, Any]]) -> str:
+    if not todos:
+        return "Todos cleared"
+    glyphs = {"completed": "[x]", "in_progress": "[~]", "pending": "[ ]"}
+    lines: list[str] = []
+    for todo in todos:
+        status = todo.get("status", "pending")
+        active_form = todo.get("activeForm")
+        text = (
+            active_form
+            if status == "in_progress" and active_form
+            else todo.get("content", "")
+        )
+        lines.append(f"{glyphs.get(status, '[ ]')} {text}")
+    return "\n".join(lines)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -298,6 +298,9 @@ class ClaudeCodePlugin:
         # invalidate so a re-import after delete sees the freed slot.
         if session.launch_target_id and self.thread_enumerator is not None:
             self.thread_enumerator.invalidate(session.launch_target_id)
+        # Drop any todo tracker stashed for a respawn that will never come.
+        if self.adapter is not None:
+            self.adapter.discard_session(session.id)
 
     def register_routes(self, app: FastAPI, context: Any) -> None:
         # Tool approval now rides the `can_use_tool` control protocol over the

--- a/backend/tests/fixtures/claude_task_stream.json
+++ b/backend/tests/fixtures/claude_task_stream.json
@@ -1,0 +1,2404 @@
+[
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01DaV7cBjYoK3msz1TSJLjSV",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Write waypoint-subagents skill",
+            "description": "Create .agents/skills/waypoint-subagents/SKILL.md plus references (preflight, spawn-and-poll, collect-and-steer, cleanup).",
+            "activeForm": "Writing waypoint-subagents skill"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01DaV7cBjYoK3msz1TSJLjSV",
+          "content": "Task #1 created successfully: Write waypoint-subagents skill"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01ATCgSiGSL3ARixhcZ5gRUD",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Write scripts/install_skills.sh",
+            "description": "Bash installer mirroring waypoint_tailscale.sh: install/uninstall/status, --skill-dir/WAYPOINT_SKILLS_DIR, --skill/--all, --copy, idempotent, safe uninstall.",
+            "activeForm": "Writing install_skills.sh"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01ATCgSiGSL3ARixhcZ5gRUD",
+          "content": "Task #2 created successfully: Write scripts/install_skills.sh"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01GiQKKKqV63wu4gLs7eWysw",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Wire waypointctl skills sub-app",
+            "description": "Add waypointctl/src/waypointctl/skills.py helper + skills_app typer group in cli.py (install/uninstall/status), mirroring tailscale pattern.",
+            "activeForm": "Wiring waypointctl skills sub-app"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01GiQKKKqV63wu4gLs7eWysw",
+          "content": "Task #3 created successfully: Wire waypointctl skills sub-app"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01V6sZUPFq74JmtkB6wdyTdg",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Add tests + docs",
+            "description": "waypointctl/tests/test_skills.py mirroring test_tailscale.py; doc note in AGENTS.md / docs on distributing the subagent skill.",
+            "activeForm": "Adding tests and docs"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01V6sZUPFq74JmtkB6wdyTdg",
+          "content": "Task #4 created successfully: Add tests + docs"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01K88toVMtPLgWCzgXDfzyyA",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "1",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01K88toVMtPLgWCzgXDfzyyA",
+          "content": "Updated task #1 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01FyFag92R2AJwtMCRXK5HFk",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "1",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01FyFag92R2AJwtMCRXK5HFk",
+          "content": "Updated task #1 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01LwBd4EudNwYoXKK7zmEgEo",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "2",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01LwBd4EudNwYoXKK7zmEgEo",
+          "content": "Updated task #2 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01N3GEDzQZpqiajCRVwThtda",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "2",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01N3GEDzQZpqiajCRVwThtda",
+          "content": "Updated task #2 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01X72Z2Va4namzjZHgcuvygF",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "3",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01X72Z2Va4namzjZHgcuvygF",
+          "content": "Updated task #3 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01VYrY3swQwzrQ9oYJJyGyXa",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "3",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01VYrY3swQwzrQ9oYJJyGyXa",
+          "content": "Updated task #3 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_013XyEB2jctkPrnLBWZmgrB2",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "4",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_013XyEB2jctkPrnLBWZmgrB2",
+          "content": "Updated task #4 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Ex32PdZp3n2VGPfn8PDprz",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "4",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Ex32PdZp3n2VGPfn8PDprz",
+          "content": "Updated task #4 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01PfJ73pL7bBiUQ5bKsgBchu",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Web-research inter-agent communication patterns",
+            "description": "Search for multi-agent / inter-session communication protocols and patterns (A2A, MCP, message buses, blackboard, mailbox, pub/sub) circa 2025-2026 and how frameworks implement them.",
+            "activeForm": "Researching inter-agent communication patterns"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01PfJ73pL7bBiUQ5bKsgBchu",
+          "content": "Task #5 created successfully: Web-research inter-agent communication patterns"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Pp1aaXGjJ2db9Vq3KfBbeF",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Map Waypoint's existing messaging primitives",
+            "description": "Inventory what Waypoint already exposes that could carry inter-session messages: sessions send/events, WebSocket, event kinds, storage, scheduler. Identify gaps.",
+            "activeForm": "Mapping Waypoint messaging primitives"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Pp1aaXGjJ2db9Vq3KfBbeF",
+          "content": "Task #6 created successfully: Map Waypoint's existing messaging primitives"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Bp8aqsWC53ES54LFWnyahy",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "5",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Bp8aqsWC53ES54LFWnyahy",
+          "content": "Updated task #5 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_017EnaeNfwsDDqQyrLjxB2DQ",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "6",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_017EnaeNfwsDDqQyrLjxB2DQ",
+          "content": "Updated task #6 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01EPXRoNfMofvuLMxNTEmQ97",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Build Phase 1: waypoint-comms skill",
+            "description": "Self-contained skill for direct agent-to-agent messaging via sessions send/events: SKILL.md + references (addressing, send-and-reply, etiquette). Zero backend change. Add to install_skills default selection if appropriate.",
+            "activeForm": "Building waypoint-comms skill"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01EPXRoNfMofvuLMxNTEmQ97",
+          "content": "Task #7 created successfully: Build Phase 1: waypoint-comms skill"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_015F1hyBjQCFgRz85Pnnd6rz",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "7",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_015F1hyBjQCFgRz85Pnnd6rz",
+          "content": "Updated task #7 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01DSgBH68RqYZHZgxivzTA1x",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "7",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01DSgBH68RqYZHZgxivzTA1x",
+          "content": "Updated task #7 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01VTUQgzZxeifivza7CzwXU4",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Schema: spawner_session_id field + storage column",
+            "description": "Add spawner_session_id to SessionRecord and SessionCreateRequest; storage _ensure_column + row read/write.",
+            "activeForm": "Adding spawner_session_id schema + storage"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01VTUQgzZxeifivza7CzwXU4",
+          "content": "Task #8 created successfully: Schema: spawner_session_id field + storage column"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01M4nQ3ULeUVqCcjKwNvKqRH",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Runtime: inheritance resolution + persist spawner",
+            "description": "In create_session: explicit mode wins (may widen) > inherit spawner stored mode if same backend > default. Persist spawner_session_id on record.",
+            "activeForm": "Wiring inheritance resolution in runtime"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01M4nQ3ULeUVqCcjKwNvKqRH",
+          "content": "Task #9 created successfully: Runtime: inheritance resolution + persist spawner"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01QYQkXnnwY9PpNcXm2SKg2d",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Inject WAYPOINT_SESSION_ID (claude_code + tmux)",
+            "description": "Add WAYPOINT_SESSION_ID to spawned env: claude_code launch spec env dict; tmux command env prefix.",
+            "activeForm": "Injecting session id into spawned env"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01QYQkXnnwY9PpNcXm2SKg2d",
+          "content": "Task #10 created successfully: Inject WAYPOINT_SESSION_ID (claude_code + tmux)"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01TqeMVa7nVLCWsauvF9SKdM",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "CLI/client: auto-stamp spawner_session_id from env",
+            "description": "client.create_session gains spawner_session_id; CLI sessions start reads os.environ WAYPOINT_SESSION_ID and passes it.",
+            "activeForm": "Auto-stamping spawner id in CLI/client"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01TqeMVa7nVLCWsauvF9SKdM",
+          "content": "Task #11 created successfully: CLI/client: auto-stamp spawner_session_id from env"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_0199S5aw5ULbaEWjW3riLBhf",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Skills: inheritance guidance (no contradiction) + comms self-id",
+            "description": "Rewrite permissions.md (auto-inherit default, explicit-can-widen, ask-user-if-top-level); comms uses $WAYPOINT_SESSION_ID; subagents spawn note.",
+            "activeForm": "Updating skills for inheritance"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_0199S5aw5ULbaEWjW3riLBhf",
+          "content": "Task #12 created successfully: Skills: inheritance guidance (no contradiction) + comms self-id"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01FDRKgXNtMmmKgQxBkMRdNW",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Tests for inheritance + injection",
+            "description": "storage column round-trip; runtime inheritance cases; CLI auto-stamp; env injection in claude_code/tmux.",
+            "activeForm": "Writing inheritance tests"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01FDRKgXNtMmmKgQxBkMRdNW",
+          "content": "Task #13 created successfully: Tests for inheritance + injection"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01VzFbzSXMrVNF3GG82eke9u",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "8",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01VzFbzSXMrVNF3GG82eke9u",
+          "content": "Updated task #8 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01G8wt6GppK9jnydzZby8jgH",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "9",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01G8wt6GppK9jnydzZby8jgH",
+          "content": "Updated task #9 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_012PYax294Pyiuos9KrLioQB",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "10",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_012PYax294Pyiuos9KrLioQB",
+          "content": "Updated task #10 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01JhHr21rqtexNH9rMFVon5X",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "11",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01JhHr21rqtexNH9rMFVon5X",
+          "content": "Updated task #11 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_014GdZczDCP5UDASdsktWCnS",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "12",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_014GdZczDCP5UDASdsktWCnS",
+          "content": "Updated task #12 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_015a2C2Ty7VNHt1y4Jgx2d65",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "13",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_015a2C2Ty7VNHt1y4Jgx2d65",
+          "content": "Updated task #13 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01MorXSi3a7ZTvdYvq15LPYf",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Board storage + schema layer",
+            "description": "Add BoardEntry/BoardChannel/BoardPostRequest schemas; board_entries table (append-log + KV upsert via UNIQUE(channel,key)); storage CRUD (add/list/channels/clear/prune_for_session); storage tests.",
+            "activeForm": "Building board storage + schema layer"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01MorXSi3a7ZTvdYvq15LPYf",
+          "content": "Task #14 created successfully: Board storage + schema layer"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01R2KTgyEUxatw8c6phSEsR7",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Board runtime + API endpoints",
+            "description": "Runtime board methods (post/read/channels/clear) with board_update broadcast; prune board rows in delete(); /api/board/{channel} GET/POST/DELETE + /api/board channels list; runtime/api tests.",
+            "activeForm": "Building board runtime + API"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01R2KTgyEUxatw8c6phSEsR7",
+          "content": "Task #15 created successfully: Board runtime + API endpoints"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01CXdVtd6SQeVxDmKoeBL2f1",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Board client + CLI",
+            "description": "client.py board methods; cli.py board sub-typer (post/read/channels/clear) with author auto-stamp from WAYPOINT_SESSION_ID; client/cli tests.",
+            "activeForm": "Building board client + CLI"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01CXdVtd6SQeVxDmKoeBL2f1",
+          "content": "Task #16 created successfully: Board client + CLI"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_015Z4jnbe4jvhJ9GhwstxKxE",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Extend waypoint-comms skill with blackboard",
+            "description": "Add a blackboard reference to waypoint-comms: when to use board vs direct send, check-channels-at-turn-boundaries habit, channel conventions.",
+            "activeForm": "Extending waypoint-comms skill"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_015Z4jnbe4jvhJ9GhwstxKxE",
+          "content": "Task #17 created successfully: Extend waypoint-comms skill with blackboard"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_016Fq8N2XK1GdRKCq4ShKt4q",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Frontend board view + management",
+            "description": "Board route/page, BoardPanel component, api.ts fetch/post/clear, types, globals.css (dark/light parity), nav entry, board_update WS handling.",
+            "activeForm": "Building frontend board view"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_016Fq8N2XK1GdRKCq4ShKt4q",
+          "content": "Task #18 created successfully: Frontend board view + management"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01CWM7sK8SyhNFnM3bMBeuwS",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "14",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01CWM7sK8SyhNFnM3bMBeuwS",
+          "content": "Updated task #14 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_0156qXkAfajBFMLFx4jE1sm5",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "14",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_0156qXkAfajBFMLFx4jE1sm5",
+          "content": "Updated task #14 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01A2htUoUdbEZtkdctWHhVqA",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "15",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01A2htUoUdbEZtkdctWHhVqA",
+          "content": "Updated task #15 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_013bqdxz5kv56PGSD3q3ohfx",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "16",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_013bqdxz5kv56PGSD3q3ohfx",
+          "content": "Updated task #16 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01XyxYrvFLsJzgjznuaUVNPD",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "17",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01XyxYrvFLsJzgjznuaUVNPD",
+          "content": "Updated task #17 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_017MRQ9G2Jp3AgioGUjCiQh2",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "17",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_017MRQ9G2Jp3AgioGUjCiQh2",
+          "content": "Updated task #17 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01DckooRsza1aDaLMSTztMZi",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "18",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01DckooRsza1aDaLMSTztMZi",
+          "content": "Updated task #18 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Hk1hWsXjprwyK47SYQigKV",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "18",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Hk1hWsXjprwyK47SYQigKV",
+          "content": "Updated task #18 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01ChPSnqzZarxgiYBeFzVPZw",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Storage + schema: edited_at, delete/update entry",
+            "description": "Add edited_at column + migration, delete_board_entry/update_board_entry methods, edited_at in BoardEntry, BoardEntryUpdateRequest schema.",
+            "activeForm": "Adding storage + schema layer"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01ChPSnqzZarxgiYBeFzVPZw",
+          "content": "Task #19 created successfully: Storage + schema: edited_at, delete/update entry"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01DfoLQDdYA7brN4wAuY7her",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Runtime + API per-entry endpoints",
+            "description": "Runtime delete/update methods with broadcast; DELETE + PATCH /api/board/{channel}/entries/{entry_id}.",
+            "activeForm": "Adding runtime + API endpoints"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01DfoLQDdYA7brN4wAuY7her",
+          "content": "Task #20 created successfully: Runtime + API per-entry endpoints"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_015CkzbYSSC6BhMC3P8Y223R",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Client + CLI per-entry commands",
+            "description": "client delete/update methods; CLI board delete-entry / edit-entry.",
+            "activeForm": "Adding client + CLI commands"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_015CkzbYSSC6BhMC3P8Y223R",
+          "content": "Task #21 created successfully: Client + CLI per-entry commands"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01VKJQRoXxBLDJyR5x5AciCA",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Frontend per-entry edit/delete UI",
+            "description": "types/api fns, board page inline edit + delete + edited indicator, globals.css with theme parity.",
+            "activeForm": "Building frontend edit/delete UI"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01VKJQRoXxBLDJyR5x5AciCA",
+          "content": "Task #22 created successfully: Frontend per-entry edit/delete UI"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01BSHHXtGrPtnh5xnw3qNz45",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Backend tests for delete/edit",
+            "description": "storage/runtime/client/cli tests per plan.",
+            "activeForm": "Writing backend tests"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01BSHHXtGrPtnh5xnw3qNz45",
+          "content": "Task #23 created successfully: Backend tests for delete/edit"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01UFCNYBaihYhCd6nRPUCjhr",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Update skill docs (blackboard.md)",
+            "description": "Document delete-entry/edit-entry + edited_at semantics; remove 'no per-post delete yet'.",
+            "activeForm": "Updating skill docs"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01UFCNYBaihYhCd6nRPUCjhr",
+          "content": "Task #24 created successfully: Update skill docs (blackboard.md)"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01FfVJaPS8ZrUNJwJ9dq9qhV",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "19",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01FfVJaPS8ZrUNJwJ9dq9qhV",
+          "content": "Updated task #19 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01JufzgCqfphA6Kxi8XivSfr",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "19",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01JufzgCqfphA6Kxi8XivSfr",
+          "content": "Updated task #19 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_011bB8SdKhchhC98kQnRF76F",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "20",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_011bB8SdKhchhC98kQnRF76F",
+          "content": "Updated task #20 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_014qkk6hStxG13k7rJAUWDpc",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "20",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_014qkk6hStxG13k7rJAUWDpc",
+          "content": "Updated task #20 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01YME2u29xDmaCsWLxJ3TruQ",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "21",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01YME2u29xDmaCsWLxJ3TruQ",
+          "content": "Updated task #21 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01VmHtf4sjQp3f57FyDnkzGu",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "22",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01VmHtf4sjQp3f57FyDnkzGu",
+          "content": "Updated task #22 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_018uAANCw9b2gYK18bpr9rKc",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "22",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_018uAANCw9b2gYK18bpr9rKc",
+          "content": "Updated task #22 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_011KL6Redcn55823cJj24kNh",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "23",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_011KL6Redcn55823cJj24kNh",
+          "content": "Updated task #23 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_0119vJS1L2aCjLsAp8cUk6PH",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "23",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_0119vJS1L2aCjLsAp8cUk6PH",
+          "content": "Updated task #23 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01CEg1yJXYBKw65HLHwp415h",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "24",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01CEg1yJXYBKw65HLHwp415h",
+          "content": "Updated task #24 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01MsDxxhMhQqauPjgPaGw9Lm",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "24",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01MsDxxhMhQqauPjgPaGw9Lm",
+          "content": "Updated task #24 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01XqqyqZN3aDesHyRW7RQKRD",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 1: storage + schema",
+            "description": "schemas.py, storage.py"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01XqqyqZN3aDesHyRW7RQKRD",
+          "content": "Task #25 created successfully: Commit 1: storage + schema"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_012EjJf1mhuqYAWEzn21tCfy",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 2: runtime + API",
+            "description": "runtime.py, api.py"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_012EjJf1mhuqYAWEzn21tCfy",
+          "content": "Task #26 created successfully: Commit 2: runtime + API"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_017pzkc4SnZxbFCXrCsH914L",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 3: client + CLI",
+            "description": "client.py, cli.py"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_017pzkc4SnZxbFCXrCsH914L",
+          "content": "Task #27 created successfully: Commit 3: client + CLI"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01XLxWJiM3j69tRGAbXb99ot",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 4: frontend edit/delete UI",
+            "description": "board/page.tsx, globals.css, lib/api.ts, lib/types.ts"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01XLxWJiM3j69tRGAbXb99ot",
+          "content": "Task #28 created successfully: Commit 4: frontend edit/delete UI"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01SmhCPfrexk5TPD2Prfxxzi",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 5: backend tests",
+            "description": "test_storage/runtime/client/cli.py"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01SmhCPfrexk5TPD2Prfxxzi",
+          "content": "Task #29 created successfully: Commit 5: backend tests"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01DSFdPtNXDKjwceKGt6M6Ec",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 6: skill docs",
+            "description": "blackboard.md"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01DSFdPtNXDKjwceKGt6M6Ec",
+          "content": "Task #30 created successfully: Commit 6: skill docs"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01JvMsRSrQt4DNYsqJrCxmp1",
+          "name": "TaskCreate",
+          "input": {
+            "subject": "Commit 7: hydration fix",
+            "description": "ThemeToggle.tsx"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01JvMsRSrQt4DNYsqJrCxmp1",
+          "content": "Task #31 created successfully: Commit 7: hydration fix"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Go4FaVtDBwrpL4ZgCoXb9m",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "25",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Go4FaVtDBwrpL4ZgCoXb9m",
+          "content": "Updated task #25 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01L5viM6MfPGFDk8enDJtnVg",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "25",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01L5viM6MfPGFDk8enDJtnVg",
+          "content": "Updated task #25 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_019mafhfHPX8aJB6JMW4FhQY",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "26",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_019mafhfHPX8aJB6JMW4FhQY",
+          "content": "Updated task #26 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Fw98kvVCyyvA5vgW1sNuvV",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "26",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Fw98kvVCyyvA5vgW1sNuvV",
+          "content": "Updated task #26 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01TeoBz789cnsJGCtS1gMz3P",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "27",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01TeoBz789cnsJGCtS1gMz3P",
+          "content": "Updated task #27 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01Q1w7cTwZosptg9zWSeMC8p",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "27",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01Q1w7cTwZosptg9zWSeMC8p",
+          "content": "Updated task #27 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01UXo2GqBWre2VDjmbY4aUjt",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "28",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01UXo2GqBWre2VDjmbY4aUjt",
+          "content": "Updated task #28 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01SUNb2FMVLvCMNoH3bFtbgR",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "28",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01SUNb2FMVLvCMNoH3bFtbgR",
+          "content": "Updated task #28 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01PdqKmCmga949pTpndsBNan",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "29",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01PdqKmCmga949pTpndsBNan",
+          "content": "Updated task #29 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01BBv11KYdbU7Fthy5FgVuow",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "29",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01BBv11KYdbU7Fthy5FgVuow",
+          "content": "Updated task #29 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_015Jbxvq5MTAW5JDdvgHjoq7",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "30",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_015Jbxvq5MTAW5JDdvgHjoq7",
+          "content": "Updated task #30 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_0193bokZGXZf7EH78u5ADznD",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "30",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_0193bokZGXZf7EH78u5ADznD",
+          "content": "Updated task #30 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_014AWUebvJ68f4jqfBYzLubb",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "31",
+            "status": "in_progress"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_014AWUebvJ68f4jqfBYzLubb",
+          "content": "Updated task #31 status"
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "id": "m",
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_01DWWGkGQcGmNCJLuYoqzixe",
+          "name": "TaskUpdate",
+          "input": {
+            "taskId": "31",
+            "status": "completed"
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_01DWWGkGQcGmNCJLuYoqzixe",
+          "content": "Updated task #31 status"
+        }
+      ]
+    }
+  }
+]

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1151,7 +1151,12 @@ def test_build_local_launch_spec_emits_model_flag(monkeypatch) -> None:
 # ─── Task tools (Claude Code >= v2.1.142) ───────────────────────────────────
 
 
-def _task_create_event(tool_use_id: str, subject: str) -> dict[str, Any]:
+def _task_create_event(
+    tool_use_id: str, subject: str, description: str | None = None
+) -> dict[str, Any]:
+    tool_input: dict[str, Any] = {"subject": subject}
+    if description is not None:
+        tool_input["description"] = description
     return {
         "type": "assistant",
         "message": {
@@ -1161,7 +1166,7 @@ def _task_create_event(tool_use_id: str, subject: str) -> dict[str, Any]:
                     "type": "tool_use",
                     "id": tool_use_id,
                     "name": "TaskCreate",
-                    "input": {"subject": subject},
+                    "input": tool_input,
                 }
             ],
         },
@@ -1227,7 +1232,14 @@ async def test_task_create_folds_into_todo_snapshot() -> None:
     await adapter._dispatch(state, _task_create_result_event("toolu_a", "1"))
     snapshots = _todo_snapshots(emitted)
     assert snapshots == [
-        [{"content": "Write the parser", "status": "pending", "activeForm": None}]
+        [
+            {
+                "content": "Write the parser",
+                "status": "pending",
+                "activeForm": None,
+                "description": None,
+            }
+        ]
     ]
     assert emitted[0][1] == EventKind.TOOL_RESULT
     assert state.task_card_item_id is not None
@@ -1247,7 +1259,12 @@ async def test_task_create_reads_id_from_json_text_result() -> None:
     await adapter._dispatch(state, _task_update_event("t1", status="completed"))
     snapshots = _todo_snapshots(emitted)
     assert snapshots[-1] == [
-        {"content": "Task A", "status": "completed", "activeForm": None}
+        {
+            "content": "Task A",
+            "status": "completed",
+            "activeForm": None,
+            "description": None,
+        }
     ]
 
 
@@ -1266,8 +1283,18 @@ async def test_task_updates_patch_one_item_keyed_by_id() -> None:
     )
     snapshots = _todo_snapshots(emitted)
     assert snapshots[-1] == [
-        {"content": "First", "status": "in_progress", "activeForm": "Doing first"},
-        {"content": "Second", "status": "pending", "activeForm": None},
+        {
+            "content": "First",
+            "status": "in_progress",
+            "activeForm": "Doing first",
+            "description": None,
+        },
+        {
+            "content": "Second",
+            "status": "pending",
+            "activeForm": None,
+            "description": None,
+        },
     ]
     # Every snapshot merges under one stable card so the transcript shows a
     # single evolving todo list rather than one card per Task call.
@@ -1301,8 +1328,42 @@ async def test_task_update_for_unknown_id_materialises_stub() -> None:
         state, _task_update_event("task-ghost", status="completed", subject="Recovered")
     )
     assert _todo_snapshots(emitted)[-1] == [
-        {"content": "Recovered", "status": "completed", "activeForm": None}
+        {
+            "content": "Recovered",
+            "status": "completed",
+            "activeForm": None,
+            "description": None,
+        }
     ]
+
+
+@pytest.mark.asyncio
+async def test_task_description_flows_into_snapshot_and_is_patchable() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    await adapter._dispatch(
+        state, _task_create_event("toolu_a", "Write parser", "Create parser.py")
+    )
+    await adapter._dispatch(state, _task_create_result_event("toolu_a", "1"))
+    assert _todo_snapshots(emitted)[-1] == [
+        {
+            "content": "Write parser",
+            "status": "pending",
+            "activeForm": None,
+            "description": "Create parser.py",
+        }
+    ]
+    # TaskUpdate can revise the description in place.
+    await adapter._dispatch(
+        state,
+        _task_update_event(
+            "1", status="in_progress", description="Create parser.py + wire it"
+        ),
+    )
+    final = _todo_snapshots(emitted)[-1][0]
+    assert final["status"] == "in_progress"
+    assert final["description"] == "Create parser.py + wire it"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1146,3 +1146,223 @@ def test_build_local_launch_spec_emits_model_flag(monkeypatch) -> None:
     args = spec.args
     assert "--model" in args
     assert args[args.index("--model") + 1] == "opus"
+
+
+# ─── Task tools (Claude Code >= v2.1.142) ───────────────────────────────────
+
+
+def _task_create_event(tool_use_id: str, subject: str) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "id": "m_create",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": tool_use_id,
+                    "name": "TaskCreate",
+                    "input": {"subject": subject},
+                }
+            ],
+        },
+    }
+
+
+def _task_create_result_event(
+    tool_use_id: str, task_id: str, *, shape: str = "string"
+) -> dict[str, Any]:
+    # "string" mirrors what real Claude Code emits (verified against persisted
+    # production events): a plain "Task #N created successfully: ..." line. The
+    # JSON shapes cover the Agent SDK doc's structured payload for forward-compat.
+    content: Any
+    if shape == "json":
+        content = [{"task": {"id": task_id, "subject": "ignored"}}]
+    elif shape == "json_text":
+        content = json.dumps({"task": {"id": task_id, "subject": "ignored"}})
+    else:
+        content = f"Task #{task_id} created successfully: ignored"
+    return {
+        "type": "user",
+        "message": {
+            "content": [
+                {"type": "tool_result", "tool_use_id": tool_use_id, "content": content}
+            ]
+        },
+    }
+
+
+def _task_update_event(task_id: str, **patch: Any) -> dict[str, Any]:
+    return {
+        "type": "assistant",
+        "message": {
+            "id": "m_update",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": f"toolu_update_{task_id}",
+                    "name": "TaskUpdate",
+                    "input": {"taskId": task_id, **patch},
+                }
+            ],
+        },
+    }
+
+
+def _todo_snapshots(emitted: list) -> list[list[dict[str, Any]]]:
+    return [
+        item[3]["payload"]["input"]["todos"]
+        for item in emitted
+        if item[3].get("item_type") == "todo_list"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_task_create_folds_into_todo_snapshot() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    # The raw TaskCreate tool_call must not render; only the result emits a card.
+    await adapter._dispatch(state, _task_create_event("toolu_a", "Write the parser"))
+    assert emitted == []
+    await adapter._dispatch(state, _task_create_result_event("toolu_a", "1"))
+    snapshots = _todo_snapshots(emitted)
+    assert snapshots == [
+        [{"content": "Write the parser", "status": "pending", "activeForm": None}]
+    ]
+    assert emitted[0][1] == EventKind.TOOL_RESULT
+    assert state.task_card_item_id is not None
+
+
+@pytest.mark.asyncio
+async def test_task_create_reads_id_from_json_text_result() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    await adapter._dispatch(state, _task_create_event("toolu_a", "Task A"))
+    await adapter._dispatch(
+        state, _task_create_result_event("toolu_a", "t1", shape="json_text")
+    )
+    # Updating by the id parsed out of the JSON-text result must patch in place,
+    # not create a duplicate stub.
+    await adapter._dispatch(state, _task_update_event("t1", status="completed"))
+    snapshots = _todo_snapshots(emitted)
+    assert snapshots[-1] == [
+        {"content": "Task A", "status": "completed", "activeForm": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_task_updates_patch_one_item_keyed_by_id() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    await adapter._dispatch(state, _task_create_event("toolu_a", "First"))
+    await adapter._dispatch(state, _task_create_result_event("toolu_a", "1"))
+    await adapter._dispatch(state, _task_create_event("toolu_b", "Second"))
+    await adapter._dispatch(state, _task_create_result_event("toolu_b", "2"))
+    await adapter._dispatch(
+        state,
+        _task_update_event("1", status="in_progress", activeForm="Doing first"),
+    )
+    snapshots = _todo_snapshots(emitted)
+    assert snapshots[-1] == [
+        {"content": "First", "status": "in_progress", "activeForm": "Doing first"},
+        {"content": "Second", "status": "pending", "activeForm": None},
+    ]
+    # Every snapshot merges under one stable card so the transcript shows a
+    # single evolving todo list rather than one card per Task call.
+    item_ids = {
+        item[3]["item_id"]
+        for item in emitted
+        if item[3].get("item_type") == "todo_list"
+    }
+    assert len(item_ids) == 1
+
+
+@pytest.mark.asyncio
+async def test_task_update_deleted_removes_item() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    await adapter._dispatch(state, _task_create_event("toolu_a", "Throwaway"))
+    await adapter._dispatch(state, _task_create_result_event("toolu_a", "1"))
+    await adapter._dispatch(state, _task_update_event("1", status="deleted"))
+    assert _todo_snapshots(emitted)[-1] == []
+    assert state.task_tracker.is_empty
+
+
+@pytest.mark.asyncio
+async def test_task_update_for_unknown_id_materialises_stub() -> None:
+    """A resumed session may patch a task whose create predates this process."""
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    await adapter._dispatch(
+        state, _task_update_event("task-ghost", status="completed", subject="Recovered")
+    )
+    assert _todo_snapshots(emitted)[-1] == [
+        {"content": "Recovered", "status": "completed", "activeForm": None}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_task_get_and_list_results_are_suppressed() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    for tool in ("TaskGet", "TaskList"):
+        tool_use_id = f"toolu_{tool}"
+        await adapter._dispatch(
+            state,
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "m",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": tool_use_id,
+                            "name": tool,
+                            "input": {},
+                        }
+                    ],
+                },
+            },
+        )
+        await adapter._dispatch(
+            state,
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": "[]",
+                        }
+                    ]
+                },
+            },
+        )
+    assert emitted == []
+
+
+@pytest.mark.asyncio
+async def test_replays_real_task_stream_from_production_fixture() -> None:
+    """Replay a real Claude Code session's Task stream (captured from persisted
+    production events) and assert the fold reconstructs the full list. The
+    fixture has 31 creates whose ids come only from the "Task #N created"
+    result strings; if the string-id path failed and fell back to tool_use_id,
+    the TaskUpdates would stub empty duplicates and inflate the count past 31."""
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    fixture = Path(__file__).parent / "fixtures" / "claude_task_stream.json"
+    for event in json.loads(fixture.read_text()):
+        await adapter._dispatch(state, event)
+    final = _todo_snapshots(emitted)[-1]
+    assert len(final) == 31
+    assert all(todo["content"] for todo in final)
+    assert all(todo["status"] == "completed" for todo in final)
+    assert final[0]["content"] == "Write waypoint-subagents skill"
+    assert final[-1]["content"] == "Commit 7: hydration fix"

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1367,6 +1367,39 @@ async def test_task_description_flows_into_snapshot_and_is_patchable() -> None:
 
 
 @pytest.mark.asyncio
+async def test_carry_task_state_preserves_tracker_across_respawn() -> None:
+    """A resume builds a fresh state; the folded todo tracker must carry over
+    so the CLI's post-respawn TaskUpdate deltas keep patching real items."""
+    adapter = _make_adapter([])
+    prior, _ = _attach_state(adapter, "sess")
+    prior.task_tracker.create("1", content="First", status="completed")
+    prior.task_card_item_id = "card-abc"
+    fresh, _ = _attach_state(adapter, "sess2")
+    adapter._carry_task_state(prior, fresh)
+    assert fresh.task_tracker is prior.task_tracker
+    assert fresh.task_card_item_id == "card-abc"
+    # A status-only update for the carried id patches in place rather than
+    # creating a blank stub.
+    fresh.task_tracker.update("1", status="in_progress")
+    assert fresh.task_tracker.snapshot() == [
+        {
+            "content": "First",
+            "status": "in_progress",
+            "activeForm": None,
+            "description": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_carry_task_state_tolerates_no_prior() -> None:
+    adapter = _make_adapter([])
+    fresh, _ = _attach_state(adapter)
+    adapter._carry_task_state(None, fresh)
+    assert fresh.task_tracker.is_empty
+
+
+@pytest.mark.asyncio
 async def test_task_get_and_list_results_are_suppressed() -> None:
     emitted: list = []
     adapter = _make_adapter(emitted)

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1412,6 +1412,19 @@ async def test_restore_carried_task_state_tolerates_missing() -> None:
 
 
 @pytest.mark.asyncio
+async def test_discard_session_clears_carried_task_state() -> None:
+    """A permanent delete drops the stash so it doesn't linger for a respawn
+    that will never come."""
+    adapter = _make_adapter([])
+    state, _ = _attach_state(adapter, "sess")
+    state.task_tracker.create("1", content="First")
+    await adapter.terminate_session("sess")
+    assert "sess" in adapter._carried_task_state
+    adapter.discard_session("sess")
+    assert "sess" not in adapter._carried_task_state
+
+
+@pytest.mark.asyncio
 async def test_task_get_and_list_results_are_suppressed() -> None:
     emitted: list = []
     adapter = _make_adapter(emitted)

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1367,19 +1367,23 @@ async def test_task_description_flows_into_snapshot_and_is_patchable() -> None:
 
 
 @pytest.mark.asyncio
-async def test_carry_task_state_preserves_tracker_across_respawn() -> None:
-    """A resume builds a fresh state; the folded todo tracker must carry over
-    so the CLI's post-respawn TaskUpdate deltas keep patching real items."""
+async def test_respawn_restores_task_tracker_after_terminate() -> None:
+    """The respawn paths (set_effort, reattach) terminate before the
+    resume-spawn, so terminate_session must stash the folded todo state and the
+    resume-spawn must restore it — otherwise post-respawn TaskUpdate deltas stub
+    blank items for tasks created before the respawn."""
     adapter = _make_adapter([])
-    prior, _ = _attach_state(adapter, "sess")
-    prior.task_tracker.create("1", content="First", status="completed")
-    prior.task_card_item_id = "card-abc"
-    fresh, _ = _attach_state(adapter, "sess2")
-    adapter._carry_task_state(prior, fresh)
-    assert fresh.task_tracker is prior.task_tracker
+    state, _ = _attach_state(adapter, "sess")
+    state.task_tracker.create("1", content="First", status="completed")
+    state.task_card_item_id = "card-abc"
+    await adapter.terminate_session("sess")
+    assert "sess" in adapter._carried_task_state
+    # The resume-spawn consumes the stash onto its fresh state.
+    fresh, _ = _attach_state(adapter, "sess")
+    adapter._restore_carried_task_state("sess", fresh)
+    assert "sess" not in adapter._carried_task_state
     assert fresh.task_card_item_id == "card-abc"
-    # A status-only update for the carried id patches in place rather than
-    # creating a blank stub.
+    # A status-only update for the carried id patches in place, not a stub.
     fresh.task_tracker.update("1", status="in_progress")
     assert fresh.task_tracker.snapshot() == [
         {
@@ -1392,10 +1396,18 @@ async def test_carry_task_state_preserves_tracker_across_respawn() -> None:
 
 
 @pytest.mark.asyncio
-async def test_carry_task_state_tolerates_no_prior() -> None:
+async def test_terminate_does_not_stash_empty_tracker() -> None:
+    adapter = _make_adapter([])
+    _attach_state(adapter, "sess")
+    await adapter.terminate_session("sess")
+    assert "sess" not in adapter._carried_task_state
+
+
+@pytest.mark.asyncio
+async def test_restore_carried_task_state_tolerates_missing() -> None:
     adapter = _make_adapter([])
     fresh, _ = _attach_state(adapter)
-    adapter._carry_task_state(None, fresh)
+    adapter._restore_carried_task_state("sess", fresh)
     assert fresh.task_tracker.is_empty
 
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3449,6 +3449,10 @@ html[data-theme="light"] .task-dock-strip {
   background: rgba(180, 150, 220, 0.16);
 }
 
+html[data-theme="light"] .task-dock-meter {
+  background: rgba(120, 90, 160, 0.16);
+}
+
 .task-dock-meter-fill {
   height: 100%;
   background: var(--accent-strong);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3511,7 +3511,13 @@ html[data-theme="light"] .task-dock-strip {
 
 .task-dock-chevron {
   flex: none;
+  display: inline-flex;
   color: var(--muted-soft);
+  transition: transform 160ms ease;
+}
+
+.task-dock-toggle[aria-expanded="true"] .task-dock-chevron {
+  transform: rotate(180deg);
 }
 
 .task-dock-dismiss {
@@ -3579,13 +3585,18 @@ html[data-theme="light"] .task-dock-panel {
 }
 
 .task-dock-collapse {
+  display: inline-flex;
+  align-items: center;
   padding: 4px 6px;
   background: none;
   border: none;
   color: var(--muted-soft);
-  font-size: 16px;
-  line-height: 1;
   cursor: pointer;
+}
+
+/* The collapse control always points down ("close"). */
+.task-dock-collapse svg {
+  transform: rotate(180deg);
 }
 
 @media (min-width: 768px) {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3373,6 +3373,233 @@ html[data-theme="light"] .inline-code {
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
 }
 
+/* ─── Task progress dock ─── */
+/* A persistent readout of the current task group, docked just above the
+ * composer in the same sticky band as the scroll affordances. Collapsed it
+ * shows the active task plus a progress meter; expanded it reveals the full
+ * list — a full-width bottom sheet on mobile, a bottom-right popover on
+ * desktop. The whole thing rides the same `--composer-height` offset the
+ * composer reserves. */
+.task-dock {
+  position: sticky;
+  bottom: calc(var(--composer-height, 220px) + 12px);
+  z-index: 7;
+  margin-top: -8px;
+  pointer-events: none;
+}
+
+.task-dock-strip {
+  pointer-events: auto;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.92), rgba(12, 15, 22, 0.96));
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.36),
+    0 0 0 1px rgba(200, 169, 106, 0.05) inset;
+  backdrop-filter: blur(22px) saturate(1.2);
+}
+
+html[data-theme="light"] .task-dock-strip {
+  background: linear-gradient(180deg, rgba(248, 245, 238, 0.96), rgba(240, 236, 226, 0.98));
+  box-shadow:
+    0 12px 30px rgba(60, 50, 30, 0.14),
+    0 0 0 1px rgba(200, 169, 106, 0.12) inset;
+}
+
+.task-dock-meter {
+  height: 3px;
+  width: 100%;
+  background: rgba(180, 150, 220, 0.16);
+}
+
+.task-dock-meter-fill {
+  height: 100%;
+  background: var(--accent-strong);
+  transition: width 0.4s ease;
+}
+
+.task-dock.complete .task-dock-meter-fill {
+  background: var(--success);
+}
+
+.task-dock-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 12px;
+}
+
+.task-dock-toggle {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.task-dock-glyph {
+  flex: none;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.task-dock.complete .task-dock-glyph {
+  color: var(--success);
+}
+
+.task-dock.active .task-dock-glyph {
+  animation: task-dock-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes task-dock-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
+
+.task-dock-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.task-dock-count {
+  flex: none;
+  color: var(--muted);
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+}
+
+.task-dock-chevron {
+  flex: none;
+  color: var(--muted-soft);
+}
+
+.task-dock-dismiss {
+  flex: none;
+  padding: 4px 6px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--muted-soft);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.task-dock-dismiss:hover {
+  color: var(--text);
+}
+
+.task-dock-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 6;
+  border: none;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: default;
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .task-dock-scrim {
+  background: rgba(20, 16, 8, 0.22);
+}
+
+.task-dock-panel {
+  position: relative;
+  z-index: 7;
+  margin-bottom: 8px;
+  max-height: 50vh;
+  overflow-y: auto;
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.96), rgba(12, 15, 22, 0.98));
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(22px) saturate(1.2);
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .task-dock-panel {
+  background: linear-gradient(180deg, rgba(248, 245, 238, 0.98), rgba(240, 236, 226, 0.99));
+  box-shadow: 0 -10px 30px rgba(60, 50, 30, 0.16);
+}
+
+.task-dock-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.task-dock-panel-title {
+  flex: 1;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.task-dock-collapse {
+  padding: 4px 6px;
+  background: none;
+  border: none;
+  color: var(--muted-soft);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .task-dock-scrim,
+  html[data-theme="light"] .task-dock-scrim {
+    background: transparent;
+  }
+
+  .task-dock-panel {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 8px);
+    width: min(420px, 92vw);
+    margin-bottom: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .task-dock.active .task-dock-glyph {
+    animation: none;
+  }
+
+  .task-dock-meter-fill {
+    transition: none;
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ────────────────────────────────────────────────────────────────────────
  * Composer — sticky reply deck pinned to the viewport bottom so the user
  * never has to scroll to find the input. The transcript section reserves

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2651,6 +2651,17 @@ html[data-theme="light"] .transcript.codex.tool_pair {
   font-variant-numeric: tabular-nums;
 }
 
+/* The timestamp lives in the summary, not a `.transcript-role`, so it misses
+ * the shared `.role-time` rule — restate it here. */
+.todo-marker-summary .role-time {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  color: var(--muted-soft);
+  font-variant-numeric: tabular-nums;
+}
+
 .todo-marker-body {
   margin-top: 10px;
 }
@@ -3481,7 +3492,7 @@ html[data-theme="light"] .task-dock-strip {
 }
 
 .task-dock.active .task-dock-glyph {
-  animation: task-dock-pulse 1.6s ease-in-out infinite;
+  animation: task-dock-pulse 2.8s ease-in-out infinite;
 }
 
 @keyframes task-dock-pulse {
@@ -3490,7 +3501,7 @@ html[data-theme="light"] .task-dock-strip {
     opacity: 1;
   }
   50% {
-    opacity: 0.4;
+    opacity: 0.5;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2625,9 +2625,34 @@ html[data-theme="light"] .transcript.codex.tool_pair {
   min-width: 0;
 }
 
-.todo-card {
-  display: grid;
-  gap: 12px;
+/* Chronological todo marker: a slim, collapsed-by-default record of the task
+ * list at a point in the transcript. The live view is the docked
+ * TaskProgressDock, so this stays out of the way until expanded. */
+.todo-marker {
+  padding: 8px 12px;
+}
+
+.todo-marker-summary {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-right: 26px;
+}
+
+.todo-marker-meta {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 0.85em;
+  font-variant-numeric: tabular-nums;
+}
+
+.todo-marker-body {
+  margin-top: 10px;
 }
 
 .todo-list {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2676,9 +2676,26 @@ html[data-theme="light"] .transcript.codex.tool_pair {
   color: var(--success);
 }
 
+.todo-body {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
 .todo-text {
   min-width: 0;
   overflow-wrap: anywhere;
+}
+
+.todo-detail {
+  min-width: 0;
+  font-size: 0.85em;
+  color: var(--muted);
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
 }
 
 .todo-empty {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -265,11 +265,11 @@ const COMPOSER_HEIGHT_FALLBACK = 220;
 const COMPOSER_HEIGHT_STORAGE_KEY = "waypoint-composer-height";
 
 // Per-session dismissal of the task progress dock, persisted so a refresh
-// keeps it dismissed. sessionStorage (not localStorage) scopes it to the tab
-// session and self-cleans, matching "dismiss this for now".
+// keeps it dismissed. We store the dismissed todo-event sequence: any later
+// task update emits a higher-sequence event and re-shows the dock, while a
+// bare refresh (no new event) keeps the same sequence and stays dismissed.
+// sessionStorage (not localStorage) scopes it to the tab and self-cleans.
 const TASK_DOCK_DISMISSED_STORAGE_PREFIX = "waypoint-task-dock-dismissed:";
-
-type DismissedTask = { itemId: string | null; count: number };
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
@@ -279,15 +279,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const catalog = useBackendCatalog(host || null, token || null, null);
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
-  // The task set the user last dismissed from the progress dock, keyed by the
-  // group's item_id and task count. Dismissal sticks through status-only
-  // updates (count unchanged); a genuinely new task (count grows) or a new
-  // group (item_id changes) re-shows the dock. `undefined` means we haven't
-  // read the persisted value yet — the dock stays hidden until then so a
-  // dismissed dock doesn't flash on load (and to avoid an SSR hydration
-  // mismatch from reading sessionStorage during render).
-  const [dismissedTask, setDismissedTask] = useState<
-    DismissedTask | null | undefined
+  // The todo-event sequence the user last dismissed from the progress dock.
+  // `undefined` means we haven't read the persisted value yet — the dock stays
+  // hidden until then so a dismissed dock doesn't flash on load (and to avoid
+  // an SSR hydration mismatch from reading sessionStorage during render).
+  const [dismissedTaskSequence, setDismissedTaskSequence] = useState<
+    number | null | undefined
   >(undefined);
   // Read the persisted dismissal after mount (never during render) so SSR and
   // the first client render agree. Re-reads when the session changes, since
@@ -300,17 +297,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       const raw = window.sessionStorage.getItem(
         `${TASK_DOCK_DISMISSED_STORAGE_PREFIX}${sessionId}`,
       );
-      const parsed = raw ? JSON.parse(raw) : null;
-      if (parsed && typeof parsed === "object" && typeof parsed.count === "number") {
-        setDismissedTask({
-          itemId: typeof parsed.itemId === "string" ? parsed.itemId : null,
-          count: parsed.count,
-        });
-      } else {
-        setDismissedTask(null);
-      }
+      const parsed = raw !== null ? Number(raw) : NaN;
+      setDismissedTaskSequence(Number.isFinite(parsed) ? parsed : null);
     } catch {
-      setDismissedTask(null);
+      setDismissedTaskSequence(null);
     }
   }, [sessionId]);
   const [snapshot, setSnapshot] = useState("");
@@ -1232,7 +1222,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => summarizeTodos(readTodoEntries(currentTaskEvent)),
     [currentTaskEvent],
   );
-  const currentTaskItemId = currentTaskEvent ? itemIdForEvent(currentTaskEvent) : null;
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
     session && (session.status === "exited" || session.status === "error"),
@@ -1260,10 +1249,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const showTaskDock =
     activeView === "chat" &&
     taskProgress !== null &&
-    dismissedTask !== undefined &&
-    (dismissedTask === null ||
-      currentTaskItemId !== dismissedTask.itemId ||
-      taskProgress.total > dismissedTask.count);
+    currentTaskEvent !== null &&
+    dismissedTaskSequence !== undefined &&
+    currentTaskEvent.sequence !== dismissedTaskSequence;
   const liveTmux = session?.transport === "tmux";
   const { theme } = useTheme();
   const terminalRef = useRef<XTerminalHandle | null>(null);
@@ -1922,16 +1910,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         <TaskProgressDock
           progress={taskProgress}
           onDismiss={() => {
-            const next: DismissedTask = {
-              itemId: currentTaskItemId,
-              count: taskProgress.total,
-            };
-            setDismissedTask(next);
-            if (typeof window !== "undefined") {
+            const sequence = currentTaskEvent?.sequence ?? null;
+            setDismissedTaskSequence(sequence);
+            if (sequence !== null && typeof window !== "undefined") {
               try {
                 window.sessionStorage.setItem(
                   `${TASK_DOCK_DISMISSED_STORAGE_PREFIX}${sessionId}`,
-                  JSON.stringify(next),
+                  String(sequence),
                 );
               } catch {
                 // sessionStorage unavailable (private mode, quota) — the

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -264,6 +264,13 @@ type ConnectionState = "connecting" | "open" | "reconnecting";
 const COMPOSER_HEIGHT_FALLBACK = 220;
 const COMPOSER_HEIGHT_STORAGE_KEY = "waypoint-composer-height";
 
+// Per-session dismissal of the task progress dock, persisted so a refresh
+// keeps it dismissed. sessionStorage (not localStorage) scopes it to the tab
+// session and self-cleans, matching "dismiss this for now".
+const TASK_DOCK_DISMISSED_STORAGE_PREFIX = "waypoint-task-dock-dismissed:";
+
+type DismissedTask = { itemId: string | null; count: number };
+
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
 
@@ -275,11 +282,37 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // The task set the user last dismissed from the progress dock, keyed by the
   // group's item_id and task count. Dismissal sticks through status-only
   // updates (count unchanged); a genuinely new task (count grows) or a new
-  // group (item_id changes) re-shows the dock.
-  const [dismissedTask, setDismissedTask] = useState<{
-    itemId: string | null;
-    count: number;
-  } | null>(null);
+  // group (item_id changes) re-shows the dock. `undefined` means we haven't
+  // read the persisted value yet — the dock stays hidden until then so a
+  // dismissed dock doesn't flash on load (and to avoid an SSR hydration
+  // mismatch from reading sessionStorage during render).
+  const [dismissedTask, setDismissedTask] = useState<
+    DismissedTask | null | undefined
+  >(undefined);
+  // Read the persisted dismissal after mount (never during render) so SSR and
+  // the first client render agree. Re-reads when the session changes, since
+  // the route can reuse this component across `/session/[id]` navigations.
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    try {
+      const raw = window.sessionStorage.getItem(
+        `${TASK_DOCK_DISMISSED_STORAGE_PREFIX}${sessionId}`,
+      );
+      const parsed = raw ? JSON.parse(raw) : null;
+      if (parsed && typeof parsed === "object" && typeof parsed.count === "number") {
+        setDismissedTask({
+          itemId: typeof parsed.itemId === "string" ? parsed.itemId : null,
+          count: parsed.count,
+        });
+      } else {
+        setDismissedTask(null);
+      }
+    } catch {
+      setDismissedTask(null);
+    }
+  }, [sessionId]);
   const [snapshot, setSnapshot] = useState("");
   const [snapshotLoading, setSnapshotLoading] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
@@ -1227,6 +1260,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const showTaskDock =
     activeView === "chat" &&
     taskProgress !== null &&
+    dismissedTask !== undefined &&
     (dismissedTask === null ||
       currentTaskItemId !== dismissedTask.itemId ||
       taskProgress.total > dismissedTask.count);
@@ -1887,12 +1921,24 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       {showTaskDock && taskProgress ? (
         <TaskProgressDock
           progress={taskProgress}
-          onDismiss={() =>
-            setDismissedTask({
+          onDismiss={() => {
+            const next: DismissedTask = {
               itemId: currentTaskItemId,
               count: taskProgress.total,
-            })
-          }
+            };
+            setDismissedTask(next);
+            if (typeof window !== "undefined") {
+              try {
+                window.sessionStorage.setItem(
+                  `${TASK_DOCK_DISMISSED_STORAGE_PREFIX}${sessionId}`,
+                  JSON.stringify(next),
+                );
+              } catch {
+                // sessionStorage unavailable (private mode, quota) — the
+                // in-memory dismissal above still applies for this view.
+              }
+            }
+          }}
         />
       ) : null}
       {session && !terminalOnly ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -8,6 +8,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -76,6 +77,8 @@ import {
   type AskAnswerEntry,
   type ToolPair,
 } from "@/components/TranscriptCard";
+import { TaskProgressDock } from "@/components/TaskProgressDock";
+import { readTodoEntries, summarizeTodos } from "@/lib/todos";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
   Backend,
@@ -269,6 +272,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const catalog = useBackendCatalog(host || null, token || null, null);
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
+  // The task group (by item_id) the user has dismissed from the progress
+  // dock; a newer group re-shows the dock since its id differs.
+  const [dismissedTaskItemId, setDismissedTaskItemId] = useState<string | null>(null);
   const [snapshot, setSnapshot] = useState("");
   const [snapshotLoading, setSnapshotLoading] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
@@ -1174,6 +1180,21 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     : transcriptEvents;
   const transcriptItems = buildTranscriptItems(transcriptEventsForDisplay);
   const hasToolRuns = transcriptItems.some((item) => item.kind === "tool_run");
+  // Latest task group, read off the raw event stream so the dock reflects the
+  // true current state regardless of the transcript's event filter.
+  const currentTaskEvent = useMemo(() => {
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      if (isTodoListEvent(events[i])) {
+        return events[i];
+      }
+    }
+    return null;
+  }, [events]);
+  const taskProgress = useMemo(
+    () => summarizeTodos(readTodoEntries(currentTaskEvent)),
+    [currentTaskEvent],
+  );
+  const currentTaskItemId = currentTaskEvent ? itemIdForEvent(currentTaskEvent) : null;
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
     session && (session.status === "exited" || session.status === "error"),
@@ -1198,6 +1219,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     session && supportsResume(session.transport) && !sessionExited,
   );
   const activeView: ViewMode = terminalOnly ? "terminal" : view;
+  const showTaskDock =
+    activeView === "chat" &&
+    taskProgress !== null &&
+    currentTaskItemId !== dismissedTaskItemId;
   const liveTmux = session?.transport === "tmux";
   const { theme } = useTheme();
   const terminalRef = useRef<XTerminalHandle | null>(null);
@@ -1851,6 +1876,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
             ×
           </button>
         </div>
+      ) : null}
+      {showTaskDock && taskProgress ? (
+        <TaskProgressDock
+          progress={taskProgress}
+          onDismiss={() => setDismissedTaskItemId(currentTaskItemId)}
+        />
       ) : null}
       {session && !terminalOnly ? (
         <ReplyComposer

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -272,9 +272,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const catalog = useBackendCatalog(host || null, token || null, null);
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
-  // The task group (by item_id) the user has dismissed from the progress
-  // dock; a newer group re-shows the dock since its id differs.
-  const [dismissedTaskItemId, setDismissedTaskItemId] = useState<string | null>(null);
+  // The todo-event sequence the user last dismissed from the progress dock.
+  // Keyed on sequence (not item_id) because a session reuses one todo item_id
+  // across task groups — every create/update bumps the sequence, so any new
+  // task activity after a dismissal re-shows the dock.
+  const [dismissedTaskSequence, setDismissedTaskSequence] = useState<number | null>(
+    null,
+  );
   const [snapshot, setSnapshot] = useState("");
   const [snapshotLoading, setSnapshotLoading] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
@@ -1194,7 +1198,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => summarizeTodos(readTodoEntries(currentTaskEvent)),
     [currentTaskEvent],
   );
-  const currentTaskItemId = currentTaskEvent ? itemIdForEvent(currentTaskEvent) : null;
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
     session && (session.status === "exited" || session.status === "error"),
@@ -1222,7 +1225,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const showTaskDock =
     activeView === "chat" &&
     taskProgress !== null &&
-    currentTaskItemId !== dismissedTaskItemId;
+    currentTaskEvent !== null &&
+    currentTaskEvent.sequence !== dismissedTaskSequence;
   const liveTmux = session?.transport === "tmux";
   const { theme } = useTheme();
   const terminalRef = useRef<XTerminalHandle | null>(null);
@@ -1880,7 +1884,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       {showTaskDock && taskProgress ? (
         <TaskProgressDock
           progress={taskProgress}
-          onDismiss={() => setDismissedTaskItemId(currentTaskItemId)}
+          onDismiss={() => setDismissedTaskSequence(currentTaskEvent?.sequence ?? null)}
         />
       ) : null}
       {session && !terminalOnly ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -272,13 +272,14 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const catalog = useBackendCatalog(host || null, token || null, null);
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
-  // The todo-event sequence the user last dismissed from the progress dock.
-  // Keyed on sequence (not item_id) because a session reuses one todo item_id
-  // across task groups — every create/update bumps the sequence, so any new
-  // task activity after a dismissal re-shows the dock.
-  const [dismissedTaskSequence, setDismissedTaskSequence] = useState<number | null>(
-    null,
-  );
+  // The task set the user last dismissed from the progress dock, keyed by the
+  // group's item_id and task count. Dismissal sticks through status-only
+  // updates (count unchanged); a genuinely new task (count grows) or a new
+  // group (item_id changes) re-shows the dock.
+  const [dismissedTask, setDismissedTask] = useState<{
+    itemId: string | null;
+    count: number;
+  } | null>(null);
   const [snapshot, setSnapshot] = useState("");
   const [snapshotLoading, setSnapshotLoading] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
@@ -1198,6 +1199,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => summarizeTodos(readTodoEntries(currentTaskEvent)),
     [currentTaskEvent],
   );
+  const currentTaskItemId = currentTaskEvent ? itemIdForEvent(currentTaskEvent) : null;
   // Session has stopped its backend process (clean shutdown or crash).
   const sessionExited = Boolean(
     session && (session.status === "exited" || session.status === "error"),
@@ -1225,8 +1227,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const showTaskDock =
     activeView === "chat" &&
     taskProgress !== null &&
-    currentTaskEvent !== null &&
-    currentTaskEvent.sequence !== dismissedTaskSequence;
+    (dismissedTask === null ||
+      currentTaskItemId !== dismissedTask.itemId ||
+      taskProgress.total > dismissedTask.count);
   const liveTmux = session?.transport === "tmux";
   const { theme } = useTheme();
   const terminalRef = useRef<XTerminalHandle | null>(null);
@@ -1884,7 +1887,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       {showTaskDock && taskProgress ? (
         <TaskProgressDock
           progress={taskProgress}
-          onDismiss={() => setDismissedTaskSequence(currentTaskEvent?.sequence ?? null)}
+          onDismiss={() =>
+            setDismissedTask({
+              itemId: currentTaskItemId,
+              count: taskProgress.total,
+            })
+          }
         />
       ) : null}
       {session && !terminalOnly ? (

--- a/frontend/src/components/TaskProgressDock.tsx
+++ b/frontend/src/components/TaskProgressDock.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { TodoProgress } from "@/lib/todos";
+import { TodoListBody } from "@/components/TodoList";
+
+// A persistent, glanceable readout of the session's current task group,
+// docked above the composer so live progress stays visible as the transcript
+// scrolls. Collapsed it shows the current task + a progress meter; tapping it
+// expands the full list (a bottom sheet on mobile, a popover on desktop).
+export function TaskProgressDock({
+  progress,
+  onDismiss,
+}: {
+  progress: TodoProgress;
+  onDismiss: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const { todos, total, completed, current, allComplete } = progress;
+  const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  useEffect(() => {
+    if (!expanded) {
+      return;
+    }
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setExpanded(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const glyph = allComplete ? "✓" : current?.status === "in-progress" ? "◐" : "○";
+  const label = allComplete
+    ? "All tasks complete"
+    : current
+      ? current.text
+      : "Tasks";
+
+  return (
+    <div className={`task-dock ${allComplete ? "complete" : "active"}`}>
+      {expanded ? (
+        <>
+          <button
+            type="button"
+            className="task-dock-scrim"
+            aria-label="Close task list"
+            onClick={() => setExpanded(false)}
+          />
+          <div className="task-dock-panel" role="dialog" aria-label="Task list">
+            <div className="task-dock-panel-head">
+              <span className="task-dock-panel-title">Tasks</span>
+              <span className="task-dock-count">
+                {completed}/{total}
+              </span>
+              <button
+                type="button"
+                className="task-dock-collapse"
+                aria-label="Collapse task list"
+                onClick={() => setExpanded(false)}
+              >
+                ⌄
+              </button>
+            </div>
+            <TodoListBody todos={todos} />
+          </div>
+        </>
+      ) : null}
+      <div className="task-dock-strip">
+        <div
+          className="task-dock-meter"
+          role="progressbar"
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-valuenow={completed}
+          aria-label={`${completed} of ${total} tasks complete`}
+        >
+          <div className="task-dock-meter-fill" style={{ width: `${pct}%` }} />
+        </div>
+        <div className="task-dock-row">
+          <button
+            type="button"
+            className="task-dock-toggle"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((value) => !value)}
+          >
+            <span className="task-dock-glyph" aria-hidden>
+              {glyph}
+            </span>
+            <span className="task-dock-label">{label}</span>
+            <span className="task-dock-count">
+              {completed}/{total}
+            </span>
+            <span className="task-dock-chevron" aria-hidden>
+              {expanded ? "⌄" : "⌃"}
+            </span>
+          </button>
+          <button
+            type="button"
+            className="task-dock-dismiss"
+            aria-label="Dismiss task progress"
+            onClick={onDismiss}
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      <span className="sr-only" aria-live="polite">
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskProgressDock.tsx
+++ b/frontend/src/components/TaskProgressDock.tsx
@@ -5,6 +5,26 @@ import { useEffect, useState } from "react";
 import { TodoProgress } from "@/lib/todos";
 import { TodoListBody } from "@/components/TodoList";
 
+// A single chevron glyph (pointing up) so the expand and collapse affordances
+// are always identical in size; orientation is handled with a CSS rotation.
+function ChevronIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M4 10l4-4 4 4" />
+    </svg>
+  );
+}
+
 // A persistent, glanceable readout of the session's current task group,
 // docked above the composer so live progress stays visible as the transcript
 // scrolls. Collapsed it shows the current task + a progress meter; tapping it
@@ -62,7 +82,7 @@ export function TaskProgressDock({
                 aria-label="Collapse task list"
                 onClick={() => setExpanded(false)}
               >
-                ⌄
+                <ChevronIcon />
               </button>
             </div>
             <TodoListBody todos={todos} />
@@ -95,7 +115,7 @@ export function TaskProgressDock({
               {completed}/{total}
             </span>
             <span className="task-dock-chevron" aria-hidden>
-              {expanded ? "⌄" : "⌃"}
+              <ChevronIcon />
             </span>
           </button>
           <button

--- a/frontend/src/components/TodoList.tsx
+++ b/frontend/src/components/TodoList.tsx
@@ -1,0 +1,22 @@
+import { TODO_MARKER, TodoEntry } from "@/lib/todos";
+
+export function TodoListBody({ todos }: { todos: TodoEntry[] | null }) {
+  if (!todos || todos.length === 0) {
+    return <p className="todo-empty">No todo items.</p>;
+  }
+  return (
+    <ul className="todo-list">
+      {todos.map((todo, index) => (
+        <li key={`${todo.text}-${index}`} className={`todo-item ${todo.status}`}>
+          <span className="todo-marker" aria-hidden>
+            {TODO_MARKER[todo.status]}
+          </span>
+          <span className="todo-body">
+            <span className="todo-text">{todo.text}</span>
+            {todo.detail ? <span className="todo-detail">{todo.detail}</span> : null}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -17,7 +17,8 @@ import {
 import {
   isTodoToolEvent,
   readTodoEntries,
-  todoStatusForEvent,
+  summarizeTodos,
+  type TodoEntry,
 } from "@/lib/todos";
 import { PlanApprovalCard } from "@/components/ApprovalCard";
 import { CopyMessageButton } from "@/components/CopyMessageButton";
@@ -663,40 +664,39 @@ function ToolPairCard({
 // "TodoWrite" tool name to look it up — render the same badge for both.
 const TODO_BADGE = { glyph: "☑", variant: "todo", label: "Todos" } as const;
 
-function TodoToolCard({ event }: { event: EventRecord }) {
-  const todos = readTodoEntries(event);
-  const status = todoStatusForEvent(event);
+// The live list lives in the docked TaskProgressDock; in the transcript the
+// todo event is just a chronological marker ("when did this list exist") that
+// expands on demand, so it doesn't duplicate the dock or shove the
+// conversation down.
+function TodoMarkerCard({ todos, ts }: { todos: TodoEntry[] | null; ts: string }) {
+  const progress = summarizeTodos(todos);
+  const summary = progress
+    ? `${progress.total} item${progress.total === 1 ? "" : "s"} · ${progress.completed}/${progress.total} done`
+    : "no items";
   return (
-    <article className="panel transcript codex todo-card">
-      <div className="transcript-role">
+    <details className="panel transcript codex todo-marker">
+      <summary className="transcript-summary todo-marker-summary">
         <span className={`tool-glyph ${TODO_BADGE.variant}`} aria-hidden>
           {TODO_BADGE.glyph}
         </span>
         <span className="tool-name">{TODO_BADGE.label}</span>
-        <span className={`badge tool-status ${status}`}>{status}</span>
-        <span className="role-time">{formatTime(event.ts)}</span>
+        <span className="todo-marker-meta">{summary}</span>
+        <span className="role-time">{formatTime(ts)}</span>
+      </summary>
+      <div className="todo-marker-body">
+        <TodoListBody todos={todos} />
       </div>
-      <TodoListBody todos={todos} />
-    </article>
+    </details>
   );
+}
+
+function TodoToolCard({ event }: { event: EventRecord }) {
+  return <TodoMarkerCard todos={readTodoEntries(event)} ts={event.ts} />;
 }
 
 function TodoToolPairCard({ pair }: { pair: ToolPair }) {
   const todos = readTodoEntries(pair.result) ?? readTodoEntries(pair.call);
-  const status = pair.result ? todoStatusForEvent(pair.result) : "pending";
-  return (
-    <article className="panel transcript codex tool_pair todo-card">
-      <div className="transcript-role">
-        <span className={`tool-glyph ${TODO_BADGE.variant}`} aria-hidden>
-          {TODO_BADGE.glyph}
-        </span>
-        <span className="tool-name">{TODO_BADGE.label}</span>
-        <span className={`badge tool-status ${status}`}>{status}</span>
-        <span className="role-time">{formatTime(pair.ts)}</span>
-      </div>
-      <TodoListBody todos={todos} />
-    </article>
-  );
+  return <TodoMarkerCard todos={todos} ts={pair.ts} />;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -657,6 +657,7 @@ type TodoStatus = "completed" | "in-progress" | "pending";
 interface TodoEntry {
   text: string;
   status: TodoStatus;
+  detail?: string;
 }
 
 const TODO_MARKER: Record<TodoStatus, string> = {
@@ -717,7 +718,10 @@ function TodoListBody({ todos }: { todos: TodoEntry[] | null }) {
           <span className="todo-marker" aria-hidden>
             {TODO_MARKER[todo.status]}
           </span>
-          <span className="todo-text">{todo.text}</span>
+          <span className="todo-body">
+            <span className="todo-text">{todo.text}</span>
+            {todo.detail ? <span className="todo-detail">{todo.detail}</span> : null}
+          </span>
         </li>
       ))}
     </ul>
@@ -759,7 +763,7 @@ function readTodoEntries(event: EventRecord | null | undefined): TodoEntry[] | n
       // Codex todo_list items carry `text`/`completed` (only two states);
       // Claude's TodoWrite tool uses `content`/`status` with a third
       // `in_progress` state. Read both shapes so one card renders both.
-      const text =
+      const content =
         typeof entry.text === "string" && entry.text
           ? entry.text
           : typeof entry.content === "string"
@@ -773,7 +777,13 @@ function readTodoEntries(event: EventRecord | null | undefined): TodoEntry[] | n
       } else {
         status = "pending";
       }
-      return { text, status };
+      // While in progress, prefer the present-tense `activeForm` ("Writing
+      // the parser") over the imperative subject, matching how Claude renders
+      // its own spinner. Carried by both TodoWrite and the Task tools.
+      const activeForm = typeof entry.activeForm === "string" ? entry.activeForm : "";
+      const text = status === "in-progress" && activeForm ? activeForm : content;
+      const detail = typeof entry.description === "string" ? entry.description : undefined;
+      return { text, status, detail };
     })
     .filter((entry) => entry.text);
   return todos.length > 0 ? todos : null;

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -14,10 +14,16 @@ import {
   planTextForEvent,
   type EventDiffPreview,
 } from "@/lib/events";
+import {
+  isTodoToolEvent,
+  readTodoEntries,
+  todoStatusForEvent,
+} from "@/lib/todos";
 import { PlanApprovalCard } from "@/components/ApprovalCard";
 import { CopyMessageButton } from "@/components/CopyMessageButton";
 import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
+import { TodoListBody } from "@/components/TodoList";
 
 export interface ToolPair {
   call: EventRecord | null;
@@ -652,20 +658,6 @@ function ToolPairCard({
   );
 }
 
-type TodoStatus = "completed" | "in-progress" | "pending";
-
-interface TodoEntry {
-  text: string;
-  status: TodoStatus;
-  detail?: string;
-}
-
-const TODO_MARKER: Record<TodoStatus, string> = {
-  completed: "✓",
-  "in-progress": "◐",
-  pending: "○",
-};
-
 // Fixed badge for the cross-backend Todo card. Codex's todo_list is a
 // built-in item (not a tool the agent invokes), so don't borrow Claude's
 // "TodoWrite" tool name to look it up — render the same badge for both.
@@ -705,88 +697,6 @@ function TodoToolPairCard({ pair }: { pair: ToolPair }) {
       <TodoListBody todos={todos} />
     </article>
   );
-}
-
-function TodoListBody({ todos }: { todos: TodoEntry[] | null }) {
-  if (!todos || todos.length === 0) {
-    return <p className="todo-empty">No todo items.</p>;
-  }
-  return (
-    <ul className="todo-list">
-      {todos.map((todo, index) => (
-        <li key={`${todo.text}-${index}`} className={`todo-item ${todo.status}`}>
-          <span className="todo-marker" aria-hidden>
-            {TODO_MARKER[todo.status]}
-          </span>
-          <span className="todo-body">
-            <span className="todo-text">{todo.text}</span>
-            {todo.detail ? <span className="todo-detail">{todo.detail}</span> : null}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
-function isTodoToolEvent(event: EventRecord | null | undefined): boolean {
-  if (!event) {
-    return false;
-  }
-  return readTodoEntries(event)?.length ? true : readToolName(event) === "TodoWrite";
-}
-
-function todoStatusForEvent(event: EventRecord): "complete" | "pending" {
-  const method = typeof event.metadata?.method === "string" ? event.metadata.method : "";
-  if (method === "item/completed" || method === "user.tool_result") {
-    return "complete";
-  }
-  return "pending";
-}
-
-function readTodoEntries(event: EventRecord | null | undefined): TodoEntry[] | null {
-  if (!event) {
-    return null;
-  }
-  const meta = asRecord(event.metadata);
-  const payload = asRecord(meta?.payload);
-  const input = asRecord(payload?.input) ?? asRecord(meta?.tool_input);
-  const item = asRecord(payload?.item);
-  const rawTodos =
-    (Array.isArray(item?.items) ? item.items : null) ??
-    (Array.isArray(input?.todos) ? input.todos : null);
-  if (!rawTodos || rawTodos.length === 0) {
-    return null;
-  }
-  const todos = rawTodos
-    .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object")
-    .map((entry) => {
-      // Codex todo_list items carry `text`/`completed` (only two states);
-      // Claude's TodoWrite tool uses `content`/`status` with a third
-      // `in_progress` state. Read both shapes so one card renders both.
-      const content =
-        typeof entry.text === "string" && entry.text
-          ? entry.text
-          : typeof entry.content === "string"
-            ? entry.content
-            : "";
-      let status: TodoStatus;
-      if (entry.completed === true || entry.status === "completed") {
-        status = "completed";
-      } else if (entry.status === "in_progress") {
-        status = "in-progress";
-      } else {
-        status = "pending";
-      }
-      // While in progress, prefer the present-tense `activeForm` ("Writing
-      // the parser") over the imperative subject, matching how Claude renders
-      // its own spinner. Carried by both TodoWrite and the Task tools.
-      const activeForm = typeof entry.activeForm === "string" ? entry.activeForm : "";
-      const text = status === "in-progress" && activeForm ? activeForm : content;
-      const detail = typeof entry.description === "string" ? entry.description : undefined;
-      return { text, status, detail };
-    })
-    .filter((entry) => entry.text);
-  return todos.length > 0 ? todos : null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/frontend/src/lib/todos.ts
+++ b/frontend/src/lib/todos.ts
@@ -32,14 +32,6 @@ export function isTodoToolEvent(event: EventRecord | null | undefined): boolean 
   return readTodoEntries(event)?.length ? true : toolNameOf(event) === "TodoWrite";
 }
 
-export function todoStatusForEvent(event: EventRecord): "complete" | "pending" {
-  const method = typeof event.metadata?.method === "string" ? event.metadata.method : "";
-  if (method === "item/completed" || method === "user.tool_result") {
-    return "complete";
-  }
-  return "pending";
-}
-
 export function readTodoEntries(event: EventRecord | null | undefined): TodoEntry[] | null {
   if (!event) {
     return null;
@@ -90,7 +82,6 @@ export interface TodoProgress {
   todos: TodoEntry[];
   total: number;
   completed: number;
-  inProgress: number;
   // The task to surface as "current": the in-progress one, else the first
   // pending one, else null (everything done).
   current: TodoEntry | null;
@@ -104,7 +95,6 @@ export function summarizeTodos(
     return null;
   }
   const completed = todos.filter((todo) => todo.status === "completed").length;
-  const inProgress = todos.filter((todo) => todo.status === "in-progress").length;
   const current =
     todos.find((todo) => todo.status === "in-progress") ??
     todos.find((todo) => todo.status === "pending") ??
@@ -113,7 +103,6 @@ export function summarizeTodos(
     todos,
     total: todos.length,
     completed,
-    inProgress,
     current,
     allComplete: completed === todos.length,
   };

--- a/frontend/src/lib/todos.ts
+++ b/frontend/src/lib/todos.ts
@@ -1,0 +1,120 @@
+import { EventRecord } from "@/lib/types";
+import { normalizeToolName } from "@/lib/events";
+
+export type TodoStatus = "completed" | "in-progress" | "pending";
+
+export interface TodoEntry {
+  text: string;
+  status: TodoStatus;
+  detail?: string;
+}
+
+export const TODO_MARKER: Record<TodoStatus, string> = {
+  completed: "✓",
+  "in-progress": "◐",
+  pending: "○",
+};
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : null;
+}
+
+function toolNameOf(event: EventRecord): string | null {
+  const meta = asRecord(event.metadata);
+  const name = meta?.tool_name;
+  return typeof name === "string" && name ? normalizeToolName(name) : null;
+}
+
+export function isTodoToolEvent(event: EventRecord | null | undefined): boolean {
+  if (!event) {
+    return false;
+  }
+  return readTodoEntries(event)?.length ? true : toolNameOf(event) === "TodoWrite";
+}
+
+export function todoStatusForEvent(event: EventRecord): "complete" | "pending" {
+  const method = typeof event.metadata?.method === "string" ? event.metadata.method : "";
+  if (method === "item/completed" || method === "user.tool_result") {
+    return "complete";
+  }
+  return "pending";
+}
+
+export function readTodoEntries(event: EventRecord | null | undefined): TodoEntry[] | null {
+  if (!event) {
+    return null;
+  }
+  const meta = asRecord(event.metadata);
+  const payload = asRecord(meta?.payload);
+  const input = asRecord(payload?.input) ?? asRecord(meta?.tool_input);
+  const item = asRecord(payload?.item);
+  const rawTodos =
+    (Array.isArray(item?.items) ? item.items : null) ??
+    (Array.isArray(input?.todos) ? input.todos : null);
+  if (!rawTodos || rawTodos.length === 0) {
+    return null;
+  }
+  const todos = rawTodos
+    .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object")
+    .map((entry) => {
+      // Codex todo_list items carry `text`/`completed` (only two states);
+      // Claude's TodoWrite tool uses `content`/`status` with a third
+      // `in_progress` state. Read both shapes so one card renders both.
+      const content =
+        typeof entry.text === "string" && entry.text
+          ? entry.text
+          : typeof entry.content === "string"
+            ? entry.content
+            : "";
+      let status: TodoStatus;
+      if (entry.completed === true || entry.status === "completed") {
+        status = "completed";
+      } else if (entry.status === "in_progress") {
+        status = "in-progress";
+      } else {
+        status = "pending";
+      }
+      // While in progress, prefer the present-tense `activeForm` ("Writing
+      // the parser") over the imperative subject, matching how Claude renders
+      // its own spinner. Carried by both TodoWrite and the Task tools.
+      const activeForm = typeof entry.activeForm === "string" ? entry.activeForm : "";
+      const text = status === "in-progress" && activeForm ? activeForm : content;
+      const detail = typeof entry.description === "string" ? entry.description : undefined;
+      return { text, status, detail };
+    })
+    .filter((entry) => entry.text);
+  return todos.length > 0 ? todos : null;
+}
+
+export interface TodoProgress {
+  todos: TodoEntry[];
+  total: number;
+  completed: number;
+  inProgress: number;
+  // The task to surface as "current": the in-progress one, else the first
+  // pending one, else null (everything done).
+  current: TodoEntry | null;
+  allComplete: boolean;
+}
+
+export function summarizeTodos(
+  todos: TodoEntry[] | null | undefined,
+): TodoProgress | null {
+  if (!todos || todos.length === 0) {
+    return null;
+  }
+  const completed = todos.filter((todo) => todo.status === "completed").length;
+  const inProgress = todos.filter((todo) => todo.status === "in-progress").length;
+  const current =
+    todos.find((todo) => todo.status === "in-progress") ??
+    todos.find((todo) => todo.status === "pending") ??
+    null;
+  return {
+    todos,
+    total: todos.length,
+    completed,
+    inProgress,
+    current,
+    allComplete: completed === todos.length,
+  };
+}


### PR DESCRIPTION
## Summary

Claude Code v2.1.142+ (this repo's installs run 2.1.175) tracks todos through structured Task tools — `TaskCreate` / `TaskUpdate` / `TaskGet` / `TaskList` — instead of the single `TodoWrite` call that rewrote the whole list on every invocation. This PR makes the `claude_code` backend fold that incremental stream back into a snapshot, and reworks how todos surface in the UI so live progress stays visible.

The fold is needed because state is now spread across many calls: `TaskCreate` adds one item but its assigned id only comes back in the matching tool_result, and `TaskUpdate` patches one item by that id. On the UI side, a single merged todo card was anchored at its first render position and scrolled out of view as the conversation grew — so the current task list, the thing most worth glancing at, kept disappearing. The fix is a persistent dock for the live list plus a slim chronological marker in the transcript.

## Changes

### Backend

- `backends/claude_code/normalize.py`: `TaskListTracker` folds `TaskCreate`/`TaskUpdate` into an ordered, TodoWrite-shaped snapshot (`status` pending/in_progress/completed; `deleted` removes; an update for an unseen id materialises a stub so resumed sessions still render). Each item carries `content`/`status`/`activeForm`/`description`. `extract_created_task_id` reads the assigned id from the real result string `"Task #N created successfully: ..."` (verified against live CC 2.1.175 and persisted production events), with a structured `{task:{id}}` branch kept for forward compat. Plus `TASK_TOOL_NAMES` and `format_task_snapshot`.
- `backends/claude_code/adapter.py`: route the Task tools out of the generic tool-card path — `TaskCreate` inputs are stashed until their result reveals the id, `TaskUpdate` patches the tracker by `taskId`, and each change re-emits a snapshot under a stable `task_card_item_id` so the existing item-id merge collapses them into one evolving event. Raw per-call Task cards and their echoed results are suppressed. `TaskList` reseed is intentionally omitted (unused in practice, unverified schema). On resume/respawn the tracker and card id are carried to the new session state, so post-respawn `TaskUpdate` deltas patch real items instead of blank stubs.

### Frontend

- `lib/todos.ts`, `components/TodoList.tsx`: shared todo parsing/summary helpers and the list renderer, extracted so the dock and the transcript card reuse them.
- `components/TaskProgressDock.tsx` + `SessionDetail.tsx`: a live task dock pinned above the composer. Collapsed it shows the current task's present-tense `activeForm` and a progress meter; tapping expands the full list as a bottom sheet (mobile) or bottom-right popover (desktop). It is dismissible (×). Dismissal is keyed on the todo-event sequence — any task update re-shows it — and persisted per session in `sessionStorage` (read after mount to avoid an SSR hydration mismatch) so a bare refresh stays dismissed.
- `components/TranscriptCard.tsx`: the in-place todo card collapses to a one-line expandable marker (`Todos · N items · M/N done`), so it no longer duplicates the dock or pushes the conversation down. In-progress items render `activeForm`; each item shows its `description` as a muted, two-line-clamped secondary line.
- `app/globals.css`: dock, meter, marker, and detail styles using theme variables with dark/light parity; reduced-motion-gated animations; a consistent inline SVG chevron (the Unicode arrowheads rendered at mismatched sizes).

### Tests

- `tests/test_claude_cli.py`: create→snapshot, id parsed from both the real string and the JSON shape, patch-by-id under one stable card, `deleted` removal, unseen-id stub, description seeding + patch, `TaskGet`/`TaskList` suppression, and the respawn carry-over helper.
- `tests/fixtures/claude_task_stream.json`: a real session's full Task stream (31 creates, 51 updates) replayed end-to-end; asserting exactly 31 non-empty tasks proves the string-id path fired rather than the tool_use_id fallback.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_claude_cli.py` — 52 passed (incl. the production-fixture replay and carry-over tests).
- [x] `cd backend && uv run pre-commit run --files <changed>` — isort / black / ruff / codespell / mypy all clean.
- [x] `cd frontend && npm run lint` + `npm run build` — clean.
- [x] Live against the running stack on CC **2.1.175**: confirmed the result string / bare-number `taskId` wire shapes; drove real `TaskCreate`/`TaskUpdate`/`deleted` sequences and verified the dock (collapse/expand, meter, active-form, description, dismiss + re-show on update, persistence across refresh) and the collapsed transcript marker, in both themes.