### PR TITLE
feat: render Codex plans in the todo dock and refine the dock UI

### DIFF
--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -22,6 +22,7 @@ from waypoint.backends.codex.normalize import (
     map_notification,
     payload_to_dict,
     plan_metadata_for_item,
+    plan_todo_items,
 )
 from waypoint.backends.diff_preview import DiffPreviewPayload, preview_to_metadata
 from waypoint.schemas import (
@@ -611,6 +612,16 @@ class CodexAppServerAdapter:
                     if snapshot is not None:
                         await self._publish_context_usage(state, snapshot)
                     continue
+                if notification.method == "turn/plan/updated":
+                    # Synthesize a todo_list item so the generic metadata path
+                    # below emits a canonical todo event (rendered in the shared
+                    # dock/card). Keying the item by turnId collapses successive
+                    # plan updates within a turn into one evolving card.
+                    payload["item"] = {
+                        "type": "todo_list",
+                        "id": payload.get("turnId"),
+                        "items": plan_todo_items(payload.get("plan")),
+                    }
                 kind, text, status = map_notification(notification.method, payload)
                 if kind is not None and text:
                     if notification.method == "item/commandExecution/outputDelta":

--- a/backend/src/waypoint/backends/codex/normalize.py
+++ b/backend/src/waypoint/backends/codex/normalize.py
@@ -109,11 +109,14 @@ def map_notification(
         item = extract_item(payload)
         return _format_item_completed(item)
     if method == "turn/plan/updated":
-        plan = payload.get("plan", [])
-        text = "\n".join(
-            f"- {entry.get('step', '')} [{entry.get('status', '')}]" for entry in plan
+        # Codex's update_plan tool. Surfaced as a todo_list (TOOL_RESULT) so it
+        # renders in the shared todo dock/card like other backends rather than
+        # as a plain system note; the adapter synthesizes the todo_list item.
+        return (
+            EventKind.TOOL_RESULT,
+            format_plan(payload.get("plan", [])),
+            (SessionStatus.RUNNING),
         )
-        return EventKind.SYSTEM_NOTE, text, SessionStatus.RUNNING
     if method == "error":
         error = payload.get("error", {})
         return (
@@ -347,6 +350,45 @@ def diff_preview_for_approval(
             "proposed", files_from_codex_legacy_file_changes(params.get("fileChanges"))
         )
     return None
+
+
+# Codex update_plan step statuses → the canonical todo statuses the frontend
+# reads (`in_progress`, not Codex's `inProgress`).
+_PLAN_TODO_STATUS = {
+    "completed": "completed",
+    "inProgress": "in_progress",
+    "pending": "pending",
+}
+
+
+def plan_todo_items(plan: Any) -> list[dict[str, Any]]:
+    """Map a Codex ``turn/plan/updated`` plan into todo_list item entries."""
+    if not isinstance(plan, list):
+        return []
+    items: list[dict[str, Any]] = []
+    for entry in plan:
+        if not isinstance(entry, dict):
+            continue
+        items.append(
+            {
+                "text": str(entry.get("step", "")),
+                "status": _PLAN_TODO_STATUS.get(
+                    str(entry.get("status", "")), "pending"
+                ),
+            }
+        )
+    return items
+
+
+def format_plan(plan: Any) -> str:
+    if not isinstance(plan, list):
+        return ""
+    lines = [
+        f"- {entry.get('step', '')} [{entry.get('status', '')}]"
+        for entry in plan
+        if isinstance(entry, dict)
+    ]
+    return "\n".join(lines)
 
 
 def format_todo_list(item: dict[str, Any]) -> str:

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -671,6 +671,87 @@ async def test_streamed_file_change_completed_preserves_diff_preview() -> None:
     assert tool_results[1][3]["diff_preview"]["files"][0]["path"] == "app.py"
 
 
+@pytest.mark.asyncio
+async def test_turn_plan_updated_emits_todo_list_event() -> None:
+    """Codex's update_plan plan is normalised into a canonical todo_list event
+    (TOOL_RESULT + item_type), keyed by turnId, so the shared todo dock/card
+    renders it like any other backend."""
+    emitted: list[tuple[str, EventKind, str, dict[str, Any], SessionStatus]] = []
+    adapter, fake = make_adapter(emitted)
+    await adapter.start_session("sess", "/tmp/work")
+
+    fake.notifications.put_nowait(
+        FakeNotification(
+            "turn/plan/updated",
+            {
+                "turnId": "turn-1",
+                "explanation": "Dummy plan.",
+                "plan": [
+                    {"step": "First task", "status": "completed"},
+                    {"step": "Second task", "status": "inProgress"},
+                    {"step": "Third task", "status": "pending"},
+                ],
+            },
+        )
+    )
+    fake.notifications.put_nowait(
+        FakeNotification(
+            "turn/completed",
+            {"turn": {"id": "turn-1", "status": "completed"}},
+        )
+    )
+
+    await adapter.send_input("sess", "make a plan")
+    state = adapter._sessions["sess"]
+    if state.stream_task is not None:
+        await state.stream_task
+
+    todo_events = [
+        entry for entry in emitted if entry[3].get("item_type") == "todo_list"
+    ]
+    assert len(todo_events) == 1
+    kind, _text, metadata = todo_events[0][1], todo_events[0][2], todo_events[0][3]
+    assert kind == EventKind.TOOL_RESULT
+    assert metadata["item_id"] == "turn-1"
+    assert metadata["payload"]["item"]["items"] == [
+        {"text": "First task", "status": "completed"},
+        {"text": "Second task", "status": "in_progress"},
+        {"text": "Third task", "status": "pending"},
+    ]
+
+
+def test_plan_todo_items_maps_codex_statuses() -> None:
+    from waypoint.backends.codex.normalize import plan_todo_items
+
+    items = plan_todo_items(
+        [
+            {"step": "a", "status": "completed"},
+            {"step": "b", "status": "inProgress"},
+            {"step": "c", "status": "pending"},
+            {"step": "d", "status": "weird"},
+            "not-a-dict",
+        ]
+    )
+    assert items == [
+        {"text": "a", "status": "completed"},
+        {"text": "b", "status": "in_progress"},
+        {"text": "c", "status": "pending"},
+        {"text": "d", "status": "pending"},
+    ]
+
+
+def test_map_notification_turn_plan_updated_is_todo_result() -> None:
+    from waypoint.backends.codex.normalize import map_notification
+
+    kind, text, status = map_notification(
+        "turn/plan/updated",
+        {"plan": [{"step": "a", "status": "completed"}], "turnId": "t1"},
+    )
+    assert kind == EventKind.TOOL_RESULT
+    assert text == "- a [completed]"
+    assert status == SessionStatus.RUNNING
+
+
 def test_map_notification_agent_message_delta() -> None:
     from waypoint.backends.codex.normalize import map_notification
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2628,7 +2628,7 @@ html[data-theme="light"] .transcript.codex.tool_pair {
 /* Chronological todo marker: a slim, collapsed-by-default record of the task
  * list at a point in the transcript. The live view is the docked
  * TaskProgressDock, so this stays out of the way until expanded. */
-.todo-marker {
+.todo-marker-card {
   padding: 8px 12px;
 }
 
@@ -2674,34 +2674,36 @@ html[data-theme="light"] .transcript.codex.tool_pair {
   padding: 0;
 }
 
+/* Flat rows — status is carried by the marker glyph and text colour, not a
+ * per-item box, so the list stays clean inside the dock panel and the
+ * transcript marker (both already bordered surfaces). The in-progress row
+ * gets a faint accent wash so the current task still stands out. */
 .todo-item {
   display: grid;
-  grid-template-columns: 18px minmax(0, 1fr);
+  grid-template-columns: 16px minmax(0, 1fr);
   align-items: start;
   gap: 10px;
-  padding: 8px 10px;
-  border: 1px solid rgba(180, 150, 220, 0.18);
-  border-radius: var(--radius-sm);
-  background: rgba(180, 150, 220, 0.08);
+  padding: 3px 0;
   color: var(--text);
 }
 
 .todo-item.in-progress {
-  border-color: rgba(200, 169, 106, 0.32);
-  background: rgba(200, 169, 106, 0.1);
   color: var(--text-strong);
 }
 
 .todo-item.completed {
-  border-color: rgba(94, 210, 156, 0.2);
-  background: rgba(94, 210, 156, 0.08);
   color: var(--muted);
 }
 
+.todo-item.completed .todo-text {
+  text-decoration: line-through;
+  text-decoration-color: var(--muted-soft);
+}
+
 .todo-marker {
-  color: var(--todo-glyph);
+  color: var(--muted-soft);
   font-weight: 700;
-  line-height: 1.4;
+  line-height: 1.5;
 }
 
 .todo-item.in-progress .todo-marker {
@@ -3587,6 +3589,23 @@ html[data-theme="light"] .task-dock-panel {
   box-shadow: 0 -10px 30px rgba(60, 50, 30, 0.16);
 }
 
+/* Mobile bottom sheet: join the panel to the strip into one surface — the
+ * panel's bottom edge meets the strip's top border (a single seam divider),
+ * with the strip carrying the shadow. (Desktop overrides this below to float
+ * the panel as a detached popover.) */
+.task-dock.expanded .task-dock-panel {
+  margin-bottom: 0;
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  box-shadow: none;
+}
+
+.task-dock.expanded .task-dock-strip {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
 .task-dock-panel-head {
   display: flex;
   align-items: center;
@@ -3626,6 +3645,24 @@ html[data-theme="light"] .task-dock-panel {
     bottom: calc(100% + 8px);
     width: min(420px, 92vw);
     margin-bottom: 0;
+  }
+
+  /* The panel floats as a detached popover, so undo the mobile sheet join:
+   * restore its own border, rounding, and a downward shadow, and give the
+   * strip its full rounding back. */
+  .task-dock.expanded .task-dock-panel {
+    border-bottom: 1px solid var(--line-strong);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  }
+
+  html[data-theme="light"] .task-dock.expanded .task-dock-panel {
+    box-shadow: 0 12px 30px rgba(60, 50, 30, 0.16);
+  }
+
+  .task-dock.expanded .task-dock-strip {
+    border-top-left-radius: var(--radius);
+    border-top-right-radius: var(--radius);
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3130,6 +3130,17 @@ html[data-theme="light"] .tool-run-chip.read {
   border-color: rgba(47, 111, 158, 0.3);
 }
 
+.tool-run-chip.todo {
+  background: rgba(180, 150, 220, 0.1);
+  border-color: rgba(180, 150, 220, 0.22);
+  color: var(--todo-glyph);
+}
+
+html[data-theme="light"] .tool-run-chip.todo {
+  background: rgba(120, 90, 160, 0.1);
+  border-color: rgba(120, 90, 160, 0.3);
+}
+
 .tool-run-chip.other {
   background: rgba(151, 162, 179, 0.06);
   border-color: rgba(151, 162, 179, 0.14);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1602,7 +1602,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                   const toolNames = item.items
                     .map((child) => {
                       const event = child.kind === "pair" ? child.pair.call ?? child.pair.result : child.event;
-                      return event ? readToolName(event) : null;
+                      if (!event) return null;
+                      // Codex's todo event carries no tool_name; tag every todo
+                      // as "TodoWrite" so the run summary can show a todos chip.
+                      return isTodoListEvent(event) ? "TodoWrite" : readToolName(event);
                     })
                     .filter((name): name is string => name !== null);
                   return (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3221,9 +3221,12 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
   }
 
   // Classify each item so the grouping loop is easy to reason about.
-  // "content"  → user messages, agent text, approvals, todos, ask-questions:
+  // "content"  → user messages, agent text, approvals, ask-questions:
   //              always breaks (and terminates) the current tool run.
-  // "tool"     → ordinary tool call/result pairs/singles: join the run.
+  // "tool"     → ordinary tool call/result pairs/singles, including todos:
+  //              join the run. The live task list lives in the dock now, so
+  //              the transcript todo marker is just a historical tool record
+  //              and folds into the run instead of standing alone.
   // "absorbed" → system_note / status_update lifecycle noise: silently join
   //              the active run (rendered as quiet separators when expanded),
   //              or fall through as standalone if no run is active yet.
@@ -3231,7 +3234,7 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     if (item.kind === "pair") {
       const { call, result } = item.pair;
       const isSpecial = (e: EventRecord | null) =>
-        e !== null && (isTodoListEvent(e) || readToolName(e) === "AskUserQuestion");
+        e !== null && readToolName(e) === "AskUserQuestion";
       return isSpecial(call) || isSpecial(result) ? "content" : "tool";
     }
     const { event } = item;
@@ -3242,9 +3245,7 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
         return "content";
       case "tool_call":
       case "tool_result":
-        return isTodoListEvent(event) || readToolName(event) === "AskUserQuestion"
-          ? "content"
-          : "tool";
+        return readToolName(event) === "AskUserQuestion" ? "content" : "tool";
       default:
         return isPlanEvent(event) ? "content" : "absorbed";
     }

--- a/frontend/src/components/TaskProgressDock.tsx
+++ b/frontend/src/components/TaskProgressDock.tsx
@@ -61,7 +61,9 @@ export function TaskProgressDock({
       : "Tasks";
 
   return (
-    <div className={`task-dock ${allComplete ? "complete" : "active"}`}>
+    <div
+      className={`task-dock ${allComplete ? "complete" : "active"}${expanded ? " expanded" : ""}`}
+    >
       {expanded ? (
         <>
           <button

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -674,7 +674,7 @@ function TodoMarkerCard({ todos, ts }: { todos: TodoEntry[] | null; ts: string }
     ? `${progress.total} item${progress.total === 1 ? "" : "s"} · ${progress.completed}/${progress.total} done`
     : "no items";
   return (
-    <details className="panel transcript codex todo-marker">
+    <details className="panel transcript codex todo-marker-card">
       <summary className="transcript-summary todo-marker-summary">
         <span className={`tool-glyph ${TODO_BADGE.variant}`} aria-hidden>
           {TODO_BADGE.glyph}

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -493,11 +493,13 @@ export function ToolCallRunGroup({
   let bashCount = 0;
   let editCount = 0;
   let readCount = 0;
+  let todoCount = 0;
   let otherCount = 0;
   for (const name of toolNames) {
     if (name === "Bash") bashCount++;
     else if (isFileEditToolName(name)) editCount++;
     else if (name === "Read" || name === "Grep" || name === "Glob") readCount++;
+    else if (name === "TodoWrite") todoCount++;
     else otherCount++;
   }
 
@@ -524,6 +526,13 @@ export function ToolCallRunGroup({
               <span className="tool-run-glyph">▤</span>
               <span className="tool-run-label">read</span>
               <span className="tool-run-count">×{readCount}</span>
+            </span>
+          )}
+          {todoCount > 0 && (
+            <span className="tool-run-chip todo">
+              <span className="tool-run-glyph">☑</span>
+              <span className="tool-run-label">todos</span>
+              <span className="tool-run-count">×{todoCount}</span>
             </span>
           )}
           {otherCount > 0 && (


### PR DESCRIPTION
## Summary

Follows up #94 (Claude Code Task tools in the shared todo dock) on two fronts: it brings Codex's `update_plan` into that same dock, and it fixes the dock/marker layout that shipped with #94.

Codex emits its plan through `turn/plan/updated`, which was rendered as a plain system note and never reached the cross-backend todo dock/card. And the dock itself had a few layout problems: the transcript marker inherited a stray purple/bold tint from a CSS class collision, each todo row was a heavy box nested inside an already-bordered surface, and the expanded panel floated as a detached second card. With the dock now carrying the live task list, the standalone transcript marker was also redundant, so it folds into the surrounding tool run.

## Changes

### Backend

- `backends/codex/normalize.py`: add `plan_todo_items` (mapping Codex's `inProgress` → the canonical `in_progress`) and `format_plan`, and make `map_notification` emit `turn/plan/updated` as a `TOOL_RESULT`.
- `backends/codex/adapter.py`: synthesize a `todo_list` item for `turn/plan/updated`, keyed by `turnId` so successive plan updates collapse into one evolving card. The existing generic metadata path then emits a canonical todo event — no frontend backend-specific code.

### Frontend

- `components/TranscriptCard.tsx`, `app/globals.css`: rename the transcript marker container to `.todo-marker-card` (it collided with the per-item `.todo-marker` glyph rule, tinting the whole card purple/bold), and flatten `.todo-item` rows so status reads from the marker glyph + text colour (completed struck through) instead of nested boxes.
- `components/TaskProgressDock.tsx`, `app/globals.css`: on mobile the expanded panel joins the strip into one sheet; desktop keeps a floating bottom-right popover.
- `components/SessionDetail.tsx`, `components/TranscriptCard.tsx`, `app/globals.css`: fold the todo marker into normal tool runs (todo events classify as `tool`, not `content`) since the dock owns the live view, and give folded runs a recognizable `☑ todos` chip — todo events are tagged as todos in the run summary even when they carry no `tool_name` (Codex).

### Tests

- `tests/test_codex_app_server.py`: end-to-end `turn/plan/updated` → todo_list assertion, `plan_todo_items` status mapping, and `map_notification` kind.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_codex_app_server.py` — 45 passed (incl. the new plan→todo tests).
- [x] `cd backend && uv run pre-commit run --files <changed>` — isort / black / ruff / codespell / mypy all clean.
- [x] `cd frontend && npm run lint` + `npm run build` — clean.
- [x] Live on the running stack: drove a Codex (Gemini 3.1 Pro Preview via OpenCode for comparison) and Codex `update_plan` session and confirmed the plan renders in the dock as a `todo_list`; verified the marker layout fix, the flattened rows, the mobile-sheet/desktop-popover expansion, and the folded `☑ todos` chip in both dark and light themes.

Addresses the dock follow-ups from #94.