### PR TITLE
chore: clean up dock review nits

### DIFF
--- a/backend/src/waypoint/backends/codex/normalize.py
+++ b/backend/src/waypoint/backends/codex/normalize.py
@@ -115,7 +115,7 @@ def map_notification(
         return (
             EventKind.TOOL_RESULT,
             format_plan(payload.get("plan", [])),
-            (SessionStatus.RUNNING),
+            SessionStatus.RUNNING,
         )
     if method == "error":
         error = payload.get("error", {})

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2677,7 +2677,8 @@ html[data-theme="light"] .transcript.codex.tool_pair {
 /* Flat rows — status is carried by the marker glyph and text colour, not a
  * per-item box, so the list stays clean inside the dock panel and the
  * transcript marker (both already bordered surfaces). The in-progress row
- * gets a faint accent wash so the current task still stands out. */
+ * carries a stronger text colour and an accent-tinted marker glyph so the
+ * current task still stands out. */
 .todo-item {
   display: grid;
   grid-template-columns: 16px minmax(0, 1fr);

--- a/frontend/src/lib/todos.ts
+++ b/frontend/src/lib/todos.ts
@@ -49,9 +49,10 @@ export function readTodoEntries(event: EventRecord | null | undefined): TodoEntr
   const todos = rawTodos
     .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object")
     .map((entry) => {
-      // Codex todo_list items carry `text`/`completed` (only two states);
-      // Claude's TodoWrite tool uses `content`/`status` with a third
-      // `in_progress` state. Read both shapes so one card renders both.
+      // Cross-backend shapes: Codex's native todo_list items use
+      // `text`/`completed`, its update_plan todos and Claude's TodoWrite use
+      // `text`/`content` with a `status` that includes `in_progress`. Read all
+      // of them so one card renders every backend.
       const content =
         typeof entry.text === "string" && entry.text
           ? entry.text


### PR DESCRIPTION
## Summary

Two cosmetic follow-ups from the post-merge review of #95 — no behaviour change.

## Changes

### Frontend

- `app/globals.css`: the `.todo-item` comment still described a "faint accent wash" background that #95 removed; reword it to match what the rule actually does (the in-progress row stands out via a stronger text colour and the accent-tinted marker glyph).

### Backend

- `backends/codex/normalize.py`: drop the redundant parentheses around `SessionStatus.RUNNING` in the `turn/plan/updated` return tuple.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_codex_app_server.py` — 45 passed.
- [x] `cd frontend && npm run build` — clean.
- [x] Pre-commit (isort / black / ruff / codespell / mypy) clean on the changed files.