### PR TITLE
fix: clarify waypoint CLI skills and permission inheritance

### DIFF
--- a/.agents/skills/waypoint-comms/SKILL.md
+++ b/.agents/skills/waypoint-comms/SKILL.md
@@ -11,7 +11,7 @@ two mechanisms, and picking the right one matters:
 - **Direct send** (`waypoint sessions send`) — a message lands in the **target's
   input** and starts a turn for that agent, exactly as if a user had typed it;
   its reply comes back on the target's event stream. **Point-to-point and
-  interrupt-driven.** The right tool for a direct hand-off or question to a
+  input-injecting.** The right tool for a direct hand-off or question to a
   specific session — a parent delegating to a child it spawned, or one peer
   asking another for something.
 
@@ -50,9 +50,10 @@ without a prompt each time.
 
 ## Guardrails
 
-- A **send interrupts** the target's turn. Check `waypoint sessions show <id>`
-  first and prefer `idle` / `waiting_input` targets. A **board post interrupts
-  no one** — prefer it when the message can wait.
+- A **send injects input** into the target and may disrupt or interleave with an
+  active turn. Check `waypoint sessions show <id>` first and prefer `idle` /
+  `waiting_input` targets. A **board post interrupts no one** — prefer it when
+  the message can wait.
 - Message freely the sessions you spawned; message a session you did not create
   only with explicit user confirmation, and never the personal assistant. Any
   session may read and post to any board channel.

--- a/.agents/skills/waypoint-comms/references/blackboard.md
+++ b/.agents/skills/waypoint-comms/references/blackboard.md
@@ -35,7 +35,7 @@ waypoint board post team:$PARENT "blocked on migration review" --key status
 # Attach structured metadata (repeatable key=value):
 waypoint board post topic:bench "throughput 1240 rps" --meta run=3 --meta host=gpu1
 
-# Read a whole channel, or just new entries since an id, or one cell:
+# Read a whole channel, append-log entries since an id, or one cell:
 waypoint board read topic:auth-refactor
 waypoint board read topic:auth-refactor --since 42
 waypoint board read team:$PARENT --key status
@@ -89,8 +89,11 @@ path). Colons and dashes are fine.
 The board is pull-based: nothing tells you an entry arrived. An agent that never
 looks never sees it. So build the habit explicitly —
 
-- **Start of a turn** on shared work: `board read <channel> --since <last-id>` to
-  pick up what landed since you last looked. Track the highest id you've seen.
+- **Start of a turn** on shared work: use
+  `board read <channel> --since <last-id>` to pick up new append-log entries.
+  Track the highest id you've seen. Because keyed cells overwrite in place and
+  keep their original id, also read the whole channel or the specific `--key`
+  cells you depend on when cell updates matter.
 - **End of a turn**: post what a peer or parent would need (a result, a status
   cell update) before you go idle.
 
@@ -103,4 +106,4 @@ looks never sees it. So build the habit explicitly —
 - **Both**, occasionally: post the detail to a channel, then fire a one-line
   `waypoint sessions send <id> "check board <channel>"` to wake an idle peer.
   Pull store plus a light push — use it sparingly, and mind that the send still
-  interrupts (see `etiquette.md`).
+  injects input (see `etiquette.md`).

--- a/.agents/skills/waypoint-comms/references/etiquette.md
+++ b/.agents/skills/waypoint-comms/references/etiquette.md
@@ -3,7 +3,7 @@
 Direct messaging injects input into the target session, which **starts a turn**
 for that agent. Treat it accordingly.
 
-## A send interrupts
+## A send injects input
 
 `waypoint sessions send` flips the target to `running` and hands the text to its
 backend. There is no "deliver when free" queue you can rely on — sending to a
@@ -38,6 +38,6 @@ Reach for the **blackboard** (`references/blackboard.md`) instead when:
 - **Broadcasting** to many sessions, or posting a finding others may or may not
   consume → post to a channel, not N direct sends.
 - **The target is busy** and the message is informational, not urgent → post it
-  where the target reads when ready, rather than interrupting its turn.
+  where the target reads when ready, rather than injecting input into its turn.
 - **No specific recipient** ("whoever picks this up") → direct addressing does
   not apply; a `topic:` channel does.

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -11,15 +11,17 @@ waypoint sessions start \
 ```
 
 - Pick `--backend` deliberately — this is the main reason to use a Waypoint
-  sub-session over a harness subagent. Use `waypoint doctor` to see which
-  backend ids are available locally.
+  sub-session over a harness subagent. Use `waypoint backends` to see which
+  backend ids are registered, and `waypoint doctor` to check local CLI
+  availability when launch fails.
 - Pick `--cwd` deliberately. For repo work, pass the repo root; for scratch or
   host inspection, pass an explicit safe directory. Do not assume the child
   should inherit your own working directory.
 - Always set the `subagent:` title prefix so the session is recognizable as one
   you own.
-- The child **inherits your permission mode** automatically; pass
-  `--permission-mode` only to override it. See `references/permissions.md`.
+- A child on the **same backend** inherits your permission mode automatically;
+  cross-backend children fall back to that backend's default. Pass
+  `--permission-mode` only to override this. See `references/permissions.md`.
 - Capture the returned session id. Keep it for the rest of the turn.
 
 Then send the task as the first input:

--- a/.agents/skills/waypoint/references/sessions-launch.md
+++ b/.agents/skills/waypoint/references/sessions-launch.md
@@ -10,8 +10,9 @@ waypoint sessions start --backend <id> --cwd <path> --effort <effort>
 waypoint sessions start --backend <id> --cwd <path> --permission-mode <mode>
 ```
 
-Use `waypoint doctor` or `waypoint sessions start --help` to discover available
-backend ids and local CLI availability when launch fails.
+Use `waypoint backends` to discover registered backend ids and capabilities.
+Use `waypoint doctor` for local CLI availability when launch fails, and
+`waypoint sessions start --help` for the installed flag surface.
 
 Choose `cwd` deliberately. For repository work, use the repo root. For host
 inspection or scratch work, use an explicit safe directory rather than assuming


### PR DESCRIPTION
## Summary

Clarifies several details in the Waypoint CLI skills and reference documentation to ensure agents and users receive accurate usage instructions.

## Changes

### Docs / Skills

- `.agents/skills/waypoint/references/sessions-launch.md`, `.agents/skills/waypoint-subagents/references/spawn-and-poll.md`: Update to use `waypoint backends` rather than `waypoint doctor` for backend discovery. Clarify that permission inheritance in subagents only applies within the same backend; cross-backend children fall back to the backend default.
- `.agents/skills/waypoint-comms/references/blackboard.md`: Clarify that blackboard `--since` only picks up new append-log entries, because keyed cells overwrite in place.
- `.agents/skills/waypoint-comms/SKILL.md`, `.agents/skills/waypoint-comms/references/etiquette.md`: Replace direct-send "interrupts" wording with "injects input" to more accurately describe how it may disrupt or interleave with an active turn.

## Test Plan

- [x] Read docs to ensure they're coherent.