### PR TITLE
feat: extend the waypoint CLI to backend parity (models, threads, import, output, schedules, wait/follow)

### DIFF
--- a/.agents/skills/waypoint-subagents/SKILL.md
+++ b/.agents/skills/waypoint-subagents/SKILL.md
@@ -48,8 +48,9 @@ convention:
 
 - Verify the CLI is reachable and authenticated: `references/preflight.md`.
 - Spawn children and wait for them to finish: `references/spawn-and-poll.md`.
-- Decide how a child handles approvals, and service them: `references/permissions.md`.
-- Read their output, continue them, or answer their approvals:
+- Decide how a child handles approvals, and service its approvals and questions:
+  `references/permissions.md`.
+- Read their output, continue them, or service their approvals and questions:
   `references/collect-and-steer.md`.
 - Tear down the children you spawned: `references/cleanup.md`.
 

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -41,6 +41,20 @@ See `references/permissions.md` for reading the pending request, the
 backend-specific `<decision>` values, tool-use vs. plan approvals, and choosing a
 child's permission mode at spawn time so it stalls less often.
 
+## Answer a question
+
+A child can instead be blocked on a question (an `AskUserQuestion`, surfacing as
+a `tool_call` with `tool_name: AskUserQuestion`, not an `approval_request`).
+Answer it with `answer-question`, not `send` or `approve`:
+
+```bash
+waypoint sessions answer-question <session-id> --answer "<your answer>"
+```
+
+`send` injects a message and leaves the question blocking; only `answer-question`
+releases it. See `references/permissions.md` for the structured `--answers-json`
+shape and `--tool-use-id`.
+
 ## Interrupt a stuck child
 
 ```bash

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -85,3 +85,28 @@ pending.
 
 Do not approve destructive, privileged, or unclear requests on a child's behalf
 — surface them to the user, exactly as for your own session.
+
+## Service a child's questions
+
+A child can also block on a **question** (an `AskUserQuestion` prompt), which is
+distinct from an approval and is serviced through a different command. It
+surfaces in the child's events as a `tool_call` whose metadata has
+`tool_name: AskUserQuestion` (carrying the question text and options under
+`payload.input.questions`); on some backends the child also reports
+`waiting_input`. There is no `approval_request` for it, so `sessions approve`
+will not release it.
+
+```bash
+waypoint sessions events <child-id> --messages 10   # find the AskUserQuestion tool_call
+waypoint sessions answer-question <child-id> --answer "<your answer>"
+```
+
+- Answer in plain text with `--answer`. For the structured multi-question shape,
+  pass `--answers-json '[{"question": "...", "answer": "...", "notes": "..."}]'`.
+- Pass `--tool-use-id <id>` to target a specific question when several are
+  pending; omit it to answer the sole pending one.
+- **Do not** use `sessions send` to answer a question — injecting a message does
+  not satisfy the blocking prompt, so the child stays parked. `answer-question`
+  is the only command that releases it.
+- As with approvals, do not answer on the child's behalf when the choice is the
+  user's to make — surface it instead.

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -33,10 +33,18 @@ Then send the task as the first input:
 waypoint sessions send <session-id> "<task instructions>"
 ```
 
-## Poll to completion
+## Wait to completion
 
-There is no blocking `wait` command, so poll `sessions show` until the child
-reaches a terminal state. Terminal/idle statuses to stop on:
+`waypoint sessions wait` blocks until the child reaches a terminal/idle status,
+prints nothing until then, and emits the final `{"session": {...}}` once. Use it
+instead of a hand-rolled poll loop:
+
+```bash
+sid=<session-id>
+waypoint sessions wait "$sid" --timeout 600   # cap the wait; tune per task
+```
+
+By default it stops on these statuses:
 
 - `idle` / `waiting_input` — the child has finished its turn (possibly awaiting
   more input, an approval, or an answer to a question — see
@@ -46,24 +54,24 @@ reaches a terminal state. Terminal/idle statuses to stop on:
 
 Statuses that mean keep waiting: `starting`, `running`, `interrupted`.
 
-The CLI always prints JSON; `sessions show <id>` emits `{"session": {...}}`, so
-the status lives at `.session.status`. A reasonable poll loop with an interval
-and a hard timeout:
+It maps the outcome to a process exit code so it composes in `&&` chains:
+`error` → 1, timeout → 124, everything else → 0. Narrow the set with `--until`
+(comma-separated), e.g. wait only for the process to end, then dump events:
 
 ```bash
-sid=<session-id>
-deadline=$((SECONDS + 600))   # cap the wait; tune per task
-while :; do
-  status=$(waypoint sessions show "$sid" | jq -r .session.status)
-  case "$status" in
-    idle|waiting_input|exited|error) break ;;
-  esac
-  [ "$SECONDS" -ge "$deadline" ] && { echo "timed out waiting on $sid"; break; }
-  sleep 5
-done
+waypoint sessions wait "$sid" --until exited,error --timeout 600 \
+  && waypoint sessions events "$sid"
 ```
 
-Parse the JSON `status` field rather than scraping human output. The status
+To watch a child's transcript live instead of blocking silently, stream events
+as NDJSON (one compact JSON object per line) until a terminal status or Ctrl+C:
+
+```bash
+waypoint sessions events "$sid" --follow
+```
+
+The CLI always prints JSON; `sessions show <id>` emits `{"session": {...}}`, so
+when you do need a one-off status read it lives at `.session.status`. The status
 values are lowercase: `starting`, `idle`, `waiting_input`, `running`,
 `interrupted`, `exited`, `error`.
 

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -14,6 +14,9 @@ waypoint sessions start \
   sub-session over a harness subagent. Use `waypoint backends` to see which
   backend ids are registered, and `waypoint doctor` to check local CLI
   availability when launch fails.
+- Pick `--model` / `--effort` from `waypoint models <backend>`, which reports the
+  ids and efforts that backend actually offers. Pass them verbatim; do not guess
+  model names from memory.
 - Pick `--cwd` deliberately. For repo work, pass the repo root; for scratch or
   host inspection, pass an explicit safe directory. Do not assume the child
   should inherit your own working directory.
@@ -36,7 +39,8 @@ There is no blocking `wait` command, so poll `sessions show` until the child
 reaches a terminal state. Terminal/idle statuses to stop on:
 
 - `idle` / `waiting_input` — the child has finished its turn (possibly awaiting
-  more input or an approval).
+  more input, an approval, or an answer to a question — see
+  `references/permissions.md`).
 - `exited` — the child process ended.
 - `error` — the child failed; read its events to find out why.
 

--- a/.agents/skills/waypoint-workqueue/references/backends.md
+++ b/.agents/skills/waypoint-workqueue/references/backends.md
@@ -12,12 +12,17 @@ Do not assume a backend or model exists — the install varies per deployment.
 ```bash
 waypoint doctor      # which backend CLIs are installed on this host
 waypoint backends    # registered plugins + their capability descriptors
+waypoint models      # the model ids and reasoning efforts each backend offers
 ```
 
 `codex` and `opencode` discover their model lists live; `claude_code` serves a
-static curated list; `tmux` has none. Confirm the menu before assigning, and
-apply your own current knowledge of the models it reports — the names below are
-illustrative (mid-2026) and will age.
+static curated list; `tmux` has none. `waypoint models` reports the exact ids
+and efforts each backend offers right now — run it and pass those ids verbatim
+to `--model` / `--effort`, rather than guessing from memory. With no argument it
+sweeps every selectable backend (a backend whose live discovery is down is
+reported with an `error` entry instead of failing the sweep); pass one
+(`waypoint models codex`) to query a single backend. The names below are
+illustrative (mid-2026) and will age — trust `waypoint models` over them.
 
 If you are unsure whether the harness or model you want is available, or whether
 it is the right fit for the job, **ask the user** (use the ask-question tool if

--- a/.agents/skills/waypoint-workqueue/references/org-template.md
+++ b/.agents/skills/waypoint-workqueue/references/org-template.md
@@ -49,6 +49,15 @@ waypoint board post job:drop-py38 \
 updates the `task:<n>` cell. Workers never write cells — a worker's own posts
 vanish when it is reaped, so durable state stays with the long-lived lead.
 
+> **Pitfall — `--key` is an upsert that REPLACES the cell's text.** There is no
+> text-preserving metadata patch (`board edit-entry` also requires the text). So
+> to flip a task's status, **re-post the cell with its full contract text** plus
+> the new `--meta`; keep that text in a shell variable so you can repost it
+> verbatim. Never post a keyed cell with throwaway text (`"task 3 -> <sid>"`) just
+> to change `state` — that silently destroys the contract the worker reads, and
+> the worker will (correctly) report blocked for want of scope. Track the
+> assignee in `--meta`, not in the text.
+
 ## Handing a task to a worker
 
 Spawn the worker in the task's worktree (see `references/playbook.md`), then send
@@ -73,5 +82,5 @@ waypoint sessions send <worker-sid> \
 ## Variant: add a reviewer
 
 For risky changes, before the step-4 merge the lead asks the reviewer session (a
-different model) "does branch `wq/<job>/task-<n>` do exactly `task:<n>`?" and
+different model) "does branch `wq/<job>-t<n>` do exactly `task:<n>`?" and
 merges only on a yes. One extra session; nothing else changes.

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -19,16 +19,22 @@ its code lives:
 
 ```bash
 n=3
-git -C "$repo" worktree add ".wq/$job/task-$n" -b "wq/$job/task-$n" "wq/$job"
+# Task branch is `wq/$job-t$n`, NOT `wq/$job/task-$n`: a slash makes it a child
+# of the integration ref `wq/$job`, and git cannot hold both a branch and a
+# directory at that path ("cannot lock ref ... exists").
+git -C "$repo" worktree add "$repo/../.wq/$job/task-$n" -b "wq/$job-t$n" "wq/$job"
 sid=$(waypoint sessions start \
   --backend codex --model gpt-5-codex \
-  --cwd "$repo/.wq/$job/task-$n" \
+  --cwd "$repo/../.wq/$job/task-$n" \
   --title "subagent:wq-$job-$n" | jq -r .session.id)
-waypoint board post job:$job "task $n -> $sid" --key task:$n --meta state=doing --meta assignee=$sid
+# Re-post the cell's FULL contract text (kept in $task_text) — NOT a stub like
+# "task $n -> $sid". `--key` replaces the cell text, so a stub wipes the scope
+# the worker reads. The assignee goes in --meta. See org-template.md.
+waypoint board post job:$job "$task_text" --key task:$n --meta state=doing --meta assignee=$sid
 # then send the worker the fixed message from org-template.md
 ```
 
-Put the worktree root **outside** the repo (e.g. `"$repo/../.wq/$job/task-$n"`)
+Put the worktree root **outside** the repo (as above, `"$repo/../.wq/..."`)
 or add `.wq/` to `.gitignore`. Git does not auto-ignore a nested worktree path,
 so an in-tree `.wq/` shows up as untracked in the integration branch.
 
@@ -46,11 +52,11 @@ between a single branch and the integration branch):
 
 ```bash
 git -C "$repo" switch "wq/$job"
-git -C "$repo" merge --no-ff "wq/$job/task-$n"
+git -C "$repo" merge --no-ff "wq/$job-t$n"
 # run the task's check, e.g. uv run pytest pkg/auth
 ```
 
-- Clean merge and green check → `git -C "$repo" worktree remove ".wq/$job/task-$n"`
+- Clean merge and green check → `git -C "$repo" worktree remove "$repo/../.wq/$job/task-$n"`
   and set the task done: `waypoint board post job:$job "task $n merged" --key task:$n --meta state=done`.
 - Conflict or red → `git -C "$repo" merge --abort`, hand the task back
   (`--meta state=todo`), and reassign it (often a fresh worktree).
@@ -64,7 +70,7 @@ and report integrated vs. blocked counts.
 1. Read the task: `waypoint board read job:<job-id> --key task:<n>`.
 2. Do exactly that task in your cwd (an isolated worktree). Commit once the
    task's check passes: `git add -A && git commit -m "task <n>"`.
-3. Report: `waypoint board post job:<job-id> "task <n> done — branch wq/<job-id>/task-<n>"`.
+3. Report: `waypoint board post job:<job-id> "task <n> done — branch wq/<job-id>-t<n>"`.
    If stuck, post `"task <n> blocked — <reason>"` and stop. Never fake success.
 4. Go idle. The lead merges, or hands the task back to you.
 

--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: waypoint
-description: Use when managing Waypoint coding sessions through the `waypoint` CLI, including listing sessions, reading transcripts, launching agents, sending messages, approvals, interrupts, termination, doctor output, auth, or runtime reset decisions.
+description: Use when managing Waypoint coding sessions through the `waypoint` CLI, including listing sessions, reading transcripts, launching agents, discovering available models, sending messages, approvals, answering questions, interrupts, termination, doctor output, auth, or runtime reset decisions.
 ---
 
 # Waypoint Sessions
@@ -17,9 +17,12 @@ version.
 
 - Read session state or transcript: see `references/sessions-read.md`.
 - Launch a new coding agent: see `references/sessions-launch.md`.
+- Discover the backend ids and the models/efforts each offers: `waypoint
+  backends` and `waypoint models [backend]` (see `references/sessions-launch.md`).
 - Send messages, interrupt running work, or terminate sessions: see
   `references/sessions-steer.md`.
-- Respond to approval requests: see `references/sessions-approvals.md`.
+- Respond to approval requests or answer a session's question: see
+  `references/sessions-approvals.md`.
 - Handle destructive operations such as reset or termination: see
   `references/destructive-ops.md`.
 - Diagnose CLI auth/config issues: see `references/auth-config.md`.

--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -15,7 +15,7 @@ version.
 
 ## Common Routing
 
-- Read session state or transcript: see `references/sessions-read.md`.
+- Read session state or transcript: see `references/sessions-read.md`; list importable threads with `waypoint backends threads <backend>`, import one with `waypoint sessions import <backend> --json ...`, or pipe just the assistant text with `waypoint sessions output <session-id> --text`.
 - Launch a new coding agent: see `references/sessions-launch.md`.
 - Discover the backend ids and the models/efforts each offers: `waypoint
   backends` and `waypoint models [backend]` (see `references/sessions-launch.md`).

--- a/.agents/skills/waypoint/references/sessions-approvals.md
+++ b/.agents/skills/waypoint/references/sessions-approvals.md
@@ -14,3 +14,20 @@ transcript exposes one.
 
 Do not approve destructive, privileged, or unclear requests without user
 confirmation.
+
+## Questions
+
+A session can also block on a question (an `AskUserQuestion` prompt), which is
+not an approval. It surfaces as a `tool_call` event with
+`tool_name: AskUserQuestion` rather than an `approval_request`, so `approve`
+does not release it — answer it instead:
+
+```bash
+waypoint sessions answer-question <session-id> --answer "<your answer>"
+waypoint sessions answer-question <session-id> --answer "<text>" --tool-use-id <id>
+waypoint sessions answer-question <session-id> --answers-json '[{"question": "...", "answer": "..."}]'
+```
+
+`sessions send` injects a normal message and will **not** satisfy the blocking
+question; only `answer-question` does. Pass `--tool-use-id` when several
+questions are pending.

--- a/.agents/skills/waypoint/references/sessions-launch.md
+++ b/.agents/skills/waypoint/references/sessions-launch.md
@@ -11,8 +11,11 @@ waypoint sessions start --backend <id> --cwd <path> --permission-mode <mode>
 ```
 
 Use `waypoint backends` to discover registered backend ids and capabilities.
-Use `waypoint doctor` for local CLI availability when launch fails, and
-`waypoint sessions start --help` for the installed flag surface.
+Use `waypoint models [backend]` to confirm the model ids and reasoning efforts a
+backend actually offers before passing `--model` / `--effort` — pass those ids
+verbatim rather than guessing. Use `waypoint doctor` for local CLI availability
+when launch fails, and `waypoint sessions start --help` for the installed flag
+surface.
 
 Choose `cwd` deliberately. For repository work, use the repo root. For host
 inspection or scratch work, use an explicit safe directory rather than assuming

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -468,7 +468,9 @@ async def _await_status_via_poll(
     client: WaypointClient, session_id: str, until: frozenset[str]
 ) -> tuple[dict[str, Any], str]:
     while True:
-        session = client.get_session(session_id)
+        # Off the event loop: get_session is sync httpx, so running it inline
+        # would block asyncio.timeout from firing until the request returned.
+        session = await asyncio.to_thread(client.get_session, session_id)
         status = session.get("status")
         if isinstance(status, str) and status in until:
             return session, status
@@ -494,7 +496,8 @@ async def _wait_for_session(
                 return streamed
             return await _await_status_via_poll(client, session_id, until)
     except TimeoutError:
-        return client.get_session(session_id), None
+        session = await asyncio.to_thread(client.get_session, session_id)
+        return session, None
 
 
 async def _follow_events(settings: Settings, session_id: str) -> None:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -8,12 +8,39 @@ from typing import Annotated, Any
 
 import typer
 import uvicorn
+from websockets.exceptions import WebSocketException
 
 from waypoint.api import AppContext, create_app
 from waypoint.backends.registry import get_registry
-from waypoint.client import WaypointClient, WaypointError, write_cli_token
-from waypoint.schemas import SessionAttachRequest, SessionCreateRequest
+from waypoint.client import (
+    WaypointClient,
+    WaypointError,
+    is_event_envelope,
+    session_status_from_envelope,
+    write_cli_token,
+)
+from waypoint.schemas import SessionAttachRequest, SessionCreateRequest, SessionStatus
 from waypoint.settings import Settings, load_settings
+
+# Statuses that, by default, end a `sessions wait`: the session is idle,
+# blocked on the user, or finished. `starting`/`running`/`interrupted` are
+# transient and keep the wait blocked.
+WAIT_DEFAULT_STATUSES: frozenset[str] = frozenset(
+    {
+        SessionStatus.IDLE,
+        SessionStatus.WAITING_INPUT,
+        SessionStatus.EXITED,
+        SessionStatus.ERROR,
+    }
+)
+# Lifecycle-terminal statuses that stop `sessions events --follow` — the
+# process is gone, so no further events will arrive.
+FOLLOW_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {SessionStatus.EXITED, SessionStatus.ERROR}
+)
+# Conventional "timeout" exit code (matches GNU coreutils `timeout`).
+WAIT_TIMEOUT_EXIT_CODE = 124
+WAIT_POLL_INTERVAL_SECONDS = 2.0
 
 
 def _backend_choices() -> list[str]:
@@ -376,6 +403,114 @@ def _parse_meta(items: list[str] | None) -> dict[str, str]:
     return metadata
 
 
+def parse_wait_until(raw: str | None) -> frozenset[str]:
+    """Parse a comma-separated ``--until`` list into a set of valid statuses.
+
+    ``None`` yields the default terminal/idle set; unknown statuses are an
+    error so a typo never blocks forever.
+    """
+    if raw is None:
+        return WAIT_DEFAULT_STATUSES
+    requested = {item.strip() for item in raw.split(",") if item.strip()}
+    if not requested:
+        raise typer.BadParameter("--until needs at least one status")
+    unknown = sorted(requested - {str(status) for status in SessionStatus})
+    if unknown:
+        raise typer.BadParameter(
+            f"--until has unknown status(es): {', '.join(unknown)}"
+        )
+    return frozenset(requested)
+
+
+def exit_code_for_wait(status: str | None) -> int:
+    """Map a ``sessions wait`` outcome to a process exit code.
+
+    ``None`` means the timeout elapsed (124); ``error`` is a failure (1);
+    every other reached status is success (0), so shell ``&&`` chains compose.
+    """
+    if status is None:
+        return WAIT_TIMEOUT_EXIT_CODE
+    if status == SessionStatus.ERROR:
+        return 1
+    return 0
+
+
+def _emit_ndjson(payload: Any) -> None:
+    """Write one compact JSON object per line and flush.
+
+    The streaming counterpart to ``_emit``'s single pretty-printed blob; used
+    by ``sessions events --follow`` so each event is consumable as it arrives.
+    """
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+async def _await_status_via_ws(
+    client: WaypointClient, session_id: str, until: frozenset[str]
+) -> tuple[dict[str, Any], str] | None:
+    """Block on the WS stream until a status in ``until`` is seen.
+
+    Returns the final session and its status, or ``None`` if the stream cannot
+    connect or closes first, so the caller can fall back to polling.
+    """
+    try:
+        async for envelope in client.stream_session_envelopes(session_id):
+            status = session_status_from_envelope(envelope)
+            if status is None:
+                continue
+            if status in until:
+                return envelope["payload"]["session"], status
+    except (OSError, WebSocketException):
+        return None
+    return None
+
+
+async def _await_status_via_poll(
+    client: WaypointClient, session_id: str, until: frozenset[str]
+) -> tuple[dict[str, Any], str]:
+    while True:
+        session = client.get_session(session_id)
+        status = session.get("status")
+        if isinstance(status, str) and status in until:
+            return session, status
+        await asyncio.sleep(WAIT_POLL_INTERVAL_SECONDS)
+
+
+async def _wait_for_session(
+    client: WaypointClient,
+    session_id: str,
+    until: frozenset[str],
+    timeout: float | None,
+) -> tuple[dict[str, Any], str | None]:
+    """Block until the session reaches ``until`` or ``timeout`` elapses.
+
+    Prefers the WS stream and falls back to polling if it cannot connect.
+    Returns the final session plus the reached status, or a ``None`` status on
+    timeout (the caller maps that to exit code 124).
+    """
+    try:
+        async with asyncio.timeout(timeout):
+            streamed = await _await_status_via_ws(client, session_id, until)
+            if streamed is not None:
+                return streamed
+            return await _await_status_via_poll(client, session_id, until)
+    except TimeoutError:
+        return client.get_session(session_id), None
+
+
+async def _follow_events(settings: Settings, session_id: str) -> None:
+    """Stream event envelopes as NDJSON until a terminal status or SIGINT."""
+    try:
+        with WaypointClient(settings) as client:
+            async for envelope in client.stream_session_envelopes(session_id):
+                if is_event_envelope(envelope):
+                    _emit_ndjson(envelope)
+                if session_status_from_envelope(envelope) in FOLLOW_TERMINAL_STATUSES:
+                    break
+    except (WaypointError, OSError, WebSocketException) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
 @sessions_app.command("list")
 def sessions_list(ctx: typer.Context) -> None:
     """List all sessions."""
@@ -396,8 +531,23 @@ def sessions_events(
     session_id: Annotated[str, typer.Argument()],
     messages: Annotated[int | None, typer.Option()] = None,
     before_sequence: Annotated[int | None, typer.Option()] = None,
+    follow: Annotated[
+        bool,
+        typer.Option(
+            "--follow",
+            "-f",
+            help="Stream new event envelopes as NDJSON (one per line) until a "
+            "terminal status or Ctrl+C, instead of printing the transcript.",
+        ),
+    ] = False,
 ) -> None:
-    """Show a session's transcript."""
+    """Show a session's transcript, or stream live events with --follow."""
+    if follow:
+        try:
+            asyncio.run(_follow_events(_settings_from_ctx(ctx), session_id))
+        except KeyboardInterrupt:
+            pass
+        return
     _emit(
         _settings_from_ctx(ctx),
         lambda c: c.get_events(
@@ -409,6 +559,45 @@ def sessions_events(
 def _conversation_events(events_page: dict[str, Any]) -> list[dict[str, Any]]:
     visible = {"user_input", "agent_output"}
     return [event for event in events_page["events"] if event.get("kind") in visible]
+
+
+@sessions_app.command("wait")
+def sessions_wait(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    until: Annotated[
+        str | None,
+        typer.Option(
+            "--until",
+            help="Comma-separated statuses to wait for. Defaults to "
+            "idle,waiting_input,exited,error.",
+        ),
+    ] = None,
+    timeout: Annotated[
+        float | None,
+        typer.Option("--timeout", help="Give up after this many seconds (exit 124)."),
+    ] = None,
+) -> None:
+    """Block (printing nothing) until a session reaches a terminal/idle status.
+
+    Emits the final ``{"session": {...}}`` once, then exits with a status-mapped
+    code (error=1, timeout=124, otherwise 0) so it composes in shell ``&&``
+    chains. Prefers the WS stream, falling back to polling if it cannot connect.
+    """
+    until_set = parse_wait_until(until)
+    outcome: dict[str, str | None] = {}
+
+    def run(c: WaypointClient) -> dict[str, Any]:
+        session, status = asyncio.run(
+            _wait_for_session(c, session_id, until_set, timeout)
+        )
+        outcome["status"] = status
+        return {"session": session}
+
+    _emit(_settings_from_ctx(ctx), run)
+    code = exit_code_for_wait(outcome.get("status"))
+    if code:
+        raise typer.Exit(code=code)
 
 
 @sessions_app.command("start")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import shutil
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import Annotated, Any
@@ -61,6 +62,10 @@ app = typer.Typer(
     no_args_is_help=True,
     add_completion=True,
 )
+backends_app = typer.Typer(
+    help="Inspect backend capabilities and importable threads on a running server.",
+    invoke_without_command=True,
+)
 session_app = typer.Typer(
     help="Launch sessions via an in-process runtime (one-shot, no running server).",
     no_args_is_help=True,
@@ -73,6 +78,7 @@ board_app = typer.Typer(
     help="Blackboard messaging shared across sessions.",
     no_args_is_help=True,
 )
+app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(board_app, name="board")
@@ -132,10 +138,33 @@ def doctor(ctx: typer.Context) -> None:
     run_doctor(_settings_from_ctx(ctx))
 
 
-@app.command()
+@backends_app.callback()
 def backends(ctx: typer.Context) -> None:
     """List backends and their capabilities (permission modes, approval decisions)."""
+    if ctx.invoked_subcommand is not None:
+        return
     _emit(_settings_from_ctx(ctx), lambda c: {"backends": c.list_backends()})
+
+
+@backends_app.command("threads")
+def backends_threads(
+    ctx: typer.Context,
+    backend: Annotated[str, typer.Argument()],
+    launch_target_id: Annotated[
+        str | None,
+        typer.Option(
+            help="Resolve importable threads for a specific launch target "
+            "(e.g. a remote host or worktree)."
+        ),
+    ] = None,
+) -> None:
+    """List a backend's importable threads."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "threads": c.list_threads(backend, launch_target_id=launch_target_id)
+        },
+    )
 
 
 @app.command()
@@ -318,6 +347,20 @@ def _parse_answers(raw: str | None) -> list[dict[str, Any]] | None:
     return parsed
 
 
+def _parse_json_object(source: str) -> dict[str, Any]:
+    try:
+        raw = sys.stdin.read() if source == "-" else Path(source).read_text("utf-8")
+    except OSError as exc:
+        raise typer.BadParameter(f"--json could not read {source}: {exc}") from exc
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"--json is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise typer.BadParameter("--json must be a JSON object")
+    return parsed
+
+
 def _parse_meta(items: list[str] | None) -> dict[str, str]:
     metadata: dict[str, str] = {}
     for item in items or []:
@@ -356,6 +399,11 @@ def sessions_events(
             session_id, messages=messages, before_sequence=before_sequence
         ),
     )
+
+
+def _conversation_events(events_page: dict[str, Any]) -> list[dict[str, Any]]:
+    visible = {"user_input", "agent_output"}
+    return [event for event in events_page["events"] if event.get("kind") in visible]
 
 
 @sessions_app.command("start")
@@ -510,6 +558,66 @@ def sessions_answer_question(
             "session": c.answer_question(
                 session_id, answer, tool_use_id=tool_use_id, answers=answers
             )
+        },
+    )
+
+
+@sessions_app.command("import")
+def sessions_import(
+    ctx: typer.Context,
+    backend: Annotated[str, typer.Argument()],
+    json_source: Annotated[
+        str,
+        typer.Option(
+            "--json",
+            help="Path to a JSON object body, or - to read it from stdin.",
+            metavar="FILE|-",
+        ),
+    ],
+) -> None:
+    """Import a backend-native thread into Waypoint."""
+    body = _parse_json_object(json_source)
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {"session": c.import_thread(backend, body)},
+    )
+
+
+@sessions_app.command("output")
+def sessions_output(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    messages: Annotated[int | None, typer.Option()] = None,
+    text: Annotated[
+        bool,
+        typer.Option(
+            "--text",
+            help="Print only the concatenated agent output text for shell piping.",
+        ),
+    ] = False,
+) -> None:
+    """Show just the conversational transcript from a session."""
+    if text:
+        settings = _settings_from_ctx(ctx)
+        try:
+            with WaypointClient(settings) as client:
+                events = _conversation_events(
+                    client.get_events(session_id, messages=messages)
+                )
+        except WaypointError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+        typer.echo(
+            "".join(
+                event["text"] for event in events if event.get("kind") == "agent_output"
+            ),
+            nl=False,
+        )
+        return
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "events": _conversation_events(c.get_events(session_id, messages=messages))
         },
     )
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -354,15 +354,19 @@ async def _session_attach(
         await context.runtime.stop()
 
 
-def _emit(settings: Settings, run: Callable[[WaypointClient], Any]) -> None:
-    """Run a client call against the live server and print the JSON result."""
+def _run_client(settings: Settings, run: Callable[[WaypointClient], Any]) -> Any:
+    """Run a call against the live server, mapping transport errors to exit 1."""
     try:
         with WaypointClient(settings) as client:
-            result = run(client)
+            return run(client)
     except WaypointError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
-    typer.echo(json.dumps(result, indent=2))
+
+
+def _emit(settings: Settings, run: Callable[[WaypointClient], Any]) -> None:
+    """Run a client call against the live server and print the JSON result."""
+    typer.echo(json.dumps(_run_client(settings, run), indent=2))
 
 
 def _parse_answers(raw: str | None) -> list[dict[str, Any]] | None:
@@ -795,21 +799,16 @@ def sessions_output(
 ) -> None:
     """Show just the conversational transcript from a session."""
     if text:
-        settings = _settings_from_ctx(ctx)
-        try:
-            with WaypointClient(settings) as client:
-                events = _conversation_events(
-                    client.get_events(session_id, messages=messages)
-                )
-        except WaypointError as exc:
-            typer.echo(f"error: {exc}", err=True)
-            raise typer.Exit(code=1) from exc
-        typer.echo(
-            "".join(
-                event["text"] for event in events if event.get("kind") == "agent_output"
-            ),
-            nl=False,
+        page = _run_client(
+            _settings_from_ctx(ctx),
+            lambda c: c.get_events(session_id, messages=messages),
         )
+        agent_text = "".join(
+            event["text"]
+            for event in _conversation_events(page)
+            if event.get("kind") == "agent_output"
+        )
+        typer.echo(agent_text, nl=False)
         return
     _emit(
         _settings_from_ctx(ctx),

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -145,8 +145,17 @@ def models(
         str | None,
         typer.Argument(callback=_validate_backend, autocompletion=_complete_backend),
     ] = None,
-    launch_target_id: Annotated[str | None, typer.Option()] = None,
-    include_hidden: Annotated[bool, typer.Option("--include-hidden")] = False,
+    launch_target_id: Annotated[
+        str | None,
+        typer.Option(
+            help="Resolve models for a specific launch target (e.g. a remote "
+            "host or worktree) rather than the backend's default context."
+        ),
+    ] = None,
+    include_hidden: Annotated[
+        bool,
+        typer.Option("--include-hidden", help="Include models the backend hides."),
+    ] = False,
 ) -> None:
     """List the models a backend offers (its ids, labels, and reasoning efforts).
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -78,10 +78,15 @@ board_app = typer.Typer(
     help="Blackboard messaging shared across sessions.",
     no_args_is_help=True,
 )
+schedule_app = typer.Typer(
+    help="Manage scheduled session launches on a running Waypoint server.",
+    no_args_is_help=True,
+)
 app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(board_app, name="board")
+app.add_typer(schedule_app, name="schedule")
 
 
 @app.callback()
@@ -735,6 +740,76 @@ def board_edit_entry(
         _settings_from_ctx(ctx),
         lambda c: {"entry": c.update_board_entry(channel, entry_id, text, metadata)},
     )
+
+
+@schedule_app.command("list")
+def schedule_list(ctx: typer.Context) -> None:
+    """List all scheduled sessions."""
+    _emit(_settings_from_ctx(ctx), lambda c: {"schedules": c.list_schedules()})
+
+
+@schedule_app.command("create")
+def schedule_create(
+    ctx: typer.Context,
+    backend: BackendOption,
+    cwd: Annotated[str, typer.Option(help="Working directory for the session.")],
+    launch_target_id: Annotated[str | None, typer.Option()] = None,
+    launch_mode: Annotated[str | None, typer.Option()] = None,
+    title: Annotated[str | None, typer.Option()] = None,
+    model: Annotated[str | None, typer.Option()] = None,
+    effort: Annotated[str | None, typer.Option()] = None,
+    permission_mode: Annotated[str | None, typer.Option()] = None,
+    prompt: Annotated[
+        str | None,
+        typer.Option("--prompt", help="Initial prompt sent to the session on launch."),
+    ] = None,
+    delay_seconds: Annotated[
+        int | None,
+        typer.Option(help="Launch this many seconds from now."),
+    ] = None,
+    scheduled_at: Annotated[
+        str | None,
+        typer.Option(help="ISO 8601 datetime at which to launch the session."),
+    ] = None,
+    args: Annotated[list[str] | None, typer.Argument()] = None,
+) -> None:
+    """Schedule a session launch on the running server."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "schedule": c.create_schedule(
+                backend=backend,
+                cwd=cwd,
+                launch_target_id=launch_target_id,
+                launch_mode=launch_mode,
+                title=title,
+                model=model,
+                effort=effort,
+                permission_mode=permission_mode,
+                initial_prompt=prompt,
+                args=list(args or []),
+                delay_seconds=delay_seconds,
+                scheduled_at=scheduled_at,
+            )
+        },
+    )
+
+
+@schedule_app.command("delete")
+def schedule_delete(
+    ctx: typer.Context, schedule_id: Annotated[str, typer.Argument()]
+) -> None:
+    """Cancel and remove a scheduled session."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {"schedule": c.delete_schedule(schedule_id)},
+    )
+
+
+@schedule_app.command("clear-history")
+def schedule_clear_history(ctx: typer.Context) -> None:
+    """Remove completed/cancelled schedule records."""
+    _emit(_settings_from_ctx(ctx), lambda c: c.clear_schedule_history())
 
 
 def run_reset(settings: Settings | None = None, *, confirmed: bool) -> None:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -139,6 +139,50 @@ def backends(ctx: typer.Context) -> None:
 
 
 @app.command()
+def models(
+    ctx: typer.Context,
+    backend: Annotated[
+        str | None,
+        typer.Argument(callback=_validate_backend, autocompletion=_complete_backend),
+    ] = None,
+    launch_target_id: Annotated[str | None, typer.Option()] = None,
+    include_hidden: Annotated[bool, typer.Option("--include-hidden")] = False,
+) -> None:
+    """List the models a backend offers (its ids, labels, and reasoning efforts).
+
+    With no BACKEND, queries every selectable backend; a backend whose live
+    model discovery is unavailable is reported with an ``error`` entry rather
+    than failing the whole listing.
+    """
+
+    def run(c: WaypointClient) -> Any:
+        if backend is not None:
+            return c.list_models(
+                backend,
+                launch_target_id=launch_target_id,
+                include_hidden=include_hidden,
+            )
+        catalogues: list[dict[str, Any]] = []
+        for descriptor in c.list_backends():
+            if descriptor["capabilities"].get("is_fallback_for_managed_launch"):
+                continue
+            backend_id = descriptor["id"]
+            try:
+                catalogues.append(
+                    c.list_models(
+                        backend_id,
+                        launch_target_id=launch_target_id,
+                        include_hidden=include_hidden,
+                    )
+                )
+            except WaypointError as exc:
+                catalogues.append({"backend": backend_id, "error": str(exc)})
+        return {"backends": catalogues}
+
+    _emit(_settings_from_ctx(ctx), run)
+
+
+@app.command()
 def reset(
     ctx: typer.Context,
     yes: Annotated[
@@ -249,6 +293,20 @@ def _emit(settings: Settings, run: Callable[[WaypointClient], Any]) -> None:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
     typer.echo(json.dumps(result, indent=2))
+
+
+def _parse_answers(raw: str | None) -> list[dict[str, Any]] | None:
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise typer.BadParameter(f"--answers-json is not valid JSON: {exc}") from exc
+    if not isinstance(parsed, list) or not all(
+        isinstance(item, dict) for item in parsed
+    ):
+        raise typer.BadParameter("--answers-json must be a JSON array of objects")
+    return parsed
 
 
 def _parse_meta(items: list[str] | None) -> dict[str, str]:
@@ -404,6 +462,44 @@ def sessions_approve(
         lambda c: {
             "session": c.approve(
                 session_id, decision, text=text, approval_id=approval_id
+            )
+        },
+    )
+
+
+@sessions_app.command("answer-question")
+def sessions_answer_question(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    answer: Annotated[
+        str,
+        typer.Option(
+            "--answer", help="Free-text answer to the session's pending question."
+        ),
+    ],
+    tool_use_id: Annotated[
+        str | None,
+        typer.Option(
+            help="Target a specific question by tool-use id. Omit to answer the "
+            "sole pending question.",
+        ),
+    ] = None,
+    answers_json: Annotated[
+        str | None,
+        typer.Option(
+            "--answers-json",
+            help='Structured per-question answers as JSON, e.g. \'[{"question": '
+            '"...", "answer": "...", "notes": "..."}]\'.',
+        ),
+    ] = None,
+) -> None:
+    """Answer a session's blocking question (not the same as send or approve)."""
+    answers = _parse_answers(answers_json)
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "session": c.answer_question(
+                session_id, answer, tool_use_id=tool_use_id, answers=answers
             )
         },
     )

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -372,3 +372,58 @@ class WaypointClient:
             "PATCH", f"/api/board/{channel}/entries/{entry_id}", json=body
         ).json()["entry"]
         return data
+
+    # ── schedules ───────────────────────────────────────────────────────
+
+    def list_schedules(self) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = self._request("GET", "/api/schedules").json()[
+            "schedules"
+        ]
+        return data
+
+    def create_schedule(
+        self,
+        *,
+        backend: str,
+        cwd: str,
+        launch_target_id: str | None = None,
+        launch_mode: str | None = None,
+        title: str | None = None,
+        model: str | None = None,
+        effort: str | None = None,
+        permission_mode: str | None = None,
+        initial_prompt: str | None = None,
+        args: list[str] | None = None,
+        delay_seconds: int | None = None,
+        scheduled_at: str | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "backend": backend,
+            "cwd": cwd,
+            "launch_target_id": launch_target_id,
+            "launch_mode": launch_mode,
+            "title": title,
+            "model": model,
+            "effort": effort,
+            "permission_mode": permission_mode,
+            "initial_prompt": initial_prompt,
+            "args": args or [],
+            "delay_seconds": delay_seconds,
+            "scheduled_at": scheduled_at,
+        }
+        data: dict[str, Any] = self._request(
+            "POST", "/api/schedules", json=body
+        ).json()["schedule"]
+        return data
+
+    def delete_schedule(self, schedule_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "DELETE", f"/api/schedules/{schedule_id}"
+        ).json()["schedule"]
+        return data
+
+    def clear_schedule_history(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", "/api/schedules/clear-history"
+        ).json()
+        return data

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -141,6 +141,23 @@ class WaypointClient:
         ]
         return data
 
+    def list_models(
+        self,
+        backend: str,
+        *,
+        launch_target_id: str | None = None,
+        include_hidden: bool = False,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if launch_target_id is not None:
+            params["launch_target_id"] = launch_target_id
+        if include_hidden:
+            params["include_hidden"] = include_hidden
+        data: dict[str, Any] = self._request(
+            "GET", f"/api/backends/{backend}/models", params=params or None
+        ).json()
+        return data
+
     def get_events(
         self,
         session_id: str,
@@ -211,6 +228,24 @@ class WaypointClient:
             "POST",
             f"/api/sessions/{session_id}/input",
             json=body,
+        ).json()["session"]
+        return data
+
+    def answer_question(
+        self,
+        session_id: str,
+        answer: str,
+        *,
+        tool_use_id: str | None = None,
+        answers: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        body = {
+            "answer": answer,
+            "tool_use_id": tool_use_id,
+            "answers": answers,
+        }
+        data: dict[str, Any] = self._request(
+            "POST", f"/api/sessions/{session_id}/answer-question", json=body
         ).json()["session"]
         return data
 

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -397,9 +397,11 @@ class WaypointClient:
         delay_seconds: int | None = None,
         scheduled_at: str | None = None,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            "backend": backend,
-            "cwd": cwd,
+        body: dict[str, Any] = {"backend": backend, "cwd": cwd, "args": args or []}
+        # Omit unset optionals so the server's model defaults apply. Sending an
+        # explicit null for a non-optional-with-default field like launch_mode
+        # is a 422 (it is validated against the enum, default or not).
+        optional = {
             "launch_target_id": launch_target_id,
             "launch_mode": launch_mode,
             "title": title,
@@ -407,10 +409,12 @@ class WaypointClient:
             "effort": effort,
             "permission_mode": permission_mode,
             "initial_prompt": initial_prompt,
-            "args": args or [],
             "delay_seconds": delay_seconds,
             "scheduled_at": scheduled_at,
         }
+        body.update(
+            {key: value for key, value in optional.items() if value is not None}
+        )
         data: dict[str, Any] = self._request(
             "POST", "/api/schedules", json=body
         ).json()["schedule"]

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -7,11 +7,15 @@ resolves, in order: ``WAYPOINT_TOKEN`` env, the server-issued local token
 file, then a password login (caching the result to the token file).
 """
 
+import json
 import os
+from collections.abc import AsyncIterator, Mapping
 from pathlib import Path
 from typing import Any, Self
+from urllib.parse import quote
 
 import httpx
+from websockets.asyncio.client import connect as ws_connect
 
 from waypoint.settings import Settings
 
@@ -20,6 +24,34 @@ CLI_TOKEN_FILENAME = "cli-token"
 
 class WaypointError(RuntimeError):
     """Raised for transport failures and non-2xx API responses."""
+
+
+def websocket_url(http_base_url: str, path: str, *, token: str) -> str:
+    """Derive a ``ws(s)://`` URL with the auth token as a query param.
+
+    The CLI authenticates the WebSocket endpoints by token query param rather
+    than an ``Authorization`` header, so the resolved token is appended here.
+    """
+    scheme = "wss" if http_base_url.startswith("https") else "ws"
+    host = http_base_url.split("://", 1)[-1].rstrip("/")
+    return f"{scheme}://{host}{path}?token={quote(token)}"
+
+
+def session_status_from_envelope(envelope: Mapping[str, Any]) -> str | None:
+    """Status from a ``session_state`` envelope, or ``None`` for other types."""
+    if envelope.get("type") != "session_state":
+        return None
+    payload = envelope.get("payload", {})
+    session = payload.get("session") if isinstance(payload, Mapping) else None
+    if not isinstance(session, Mapping):
+        return None
+    status = session.get("status")
+    return status if isinstance(status, str) else None
+
+
+def is_event_envelope(envelope: Mapping[str, Any]) -> bool:
+    """Whether the envelope carries a transcript event (vs. a state update)."""
+    return envelope.get("type") == "event"
 
 
 def cli_token_path(settings: Settings) -> Path:
@@ -134,6 +166,26 @@ class WaypointClient:
             "GET", f"/api/sessions/{session_id}"
         ).json()["session"]
         return data
+
+    async def stream_session_envelopes(
+        self, session_id: str
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield decoded envelopes from the per-session WebSocket.
+
+        The server pushes a ``session_state`` envelope on connect, then
+        ``session_state`` and ``event`` envelopes as the session changes,
+        until it closes the connection. Decoding only — callers decide which
+        envelopes to act on (see ``session_status_from_envelope`` /
+        ``is_event_envelope``).
+        """
+        url = websocket_url(
+            str(self._client.base_url),
+            f"/ws/sessions/{session_id}",
+            token=self.token(),
+        )
+        async with ws_connect(url) as connection:
+            async for message in connection:
+                yield json.loads(message)
 
     def list_backends(self) -> list[dict[str, Any]]:
         data: list[dict[str, Any]] = self._request("GET", "/api/backends").json()[

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -158,6 +158,19 @@ class WaypointClient:
         ).json()
         return data
 
+    def list_threads(
+        self, backend: str, *, launch_target_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        params = (
+            {"launch_target_id": launch_target_id}
+            if launch_target_id is not None
+            else None
+        )
+        data: list[dict[str, Any]] = self._request(
+            "GET", f"/api/backends/{backend}/threads", params=params
+        ).json()["threads"]
+        return data
+
     def get_events(
         self,
         session_id: str,
@@ -202,6 +215,12 @@ class WaypointClient:
         data: dict[str, Any] = self._request("POST", "/api/sessions", json=body).json()[
             "session"
         ]
+        return data
+
+    def import_thread(self, backend: str, body: dict[str, Any]) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", f"/api/backends/{backend}/sessions/import", json=body
+        ).json()["session"]
         return data
 
     def upload_attachment(self, session_id: str, path: Path) -> dict[str, Any]:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -39,6 +39,7 @@ def test_help_lists_command_groups() -> None:
         "serve",
         "doctor",
         "backends",
+        "models",
         "reset",
         "session",
         "sessions",
@@ -97,6 +98,50 @@ def test_board_edit_entry_rejects_malformed_meta(tmp_path: Path) -> None:
     )
     assert result.exit_code != 0
     assert "key=value" in result.output
+
+
+def test_models_rejects_unknown_backend(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["--config", str(_config(tmp_path)), "models", "bogus"])
+    assert result.exit_code != 0
+    assert "unknown backend" in result.output
+
+
+def test_answer_question_rejects_malformed_answers_json(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "answer-question",
+            "s1",
+            "--answer",
+            "ok",
+            "--answers-json",
+            "not json",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not valid JSON" in result.output
+
+
+def test_answer_question_rejects_non_array_answers_json(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "answer-question",
+            "s1",
+            "--answer",
+            "ok",
+            "--answers-json",
+            '{"question": "q"}',
+        ],
+    )
+    assert result.exit_code != 0
+    assert "array of objects" in result.output
 
 
 def test_config_is_a_top_level_option(tmp_path: Path) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,11 +1,14 @@
 import json
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 import httpx
 import pytest
+import typer
 from typer.testing import CliRunner
 
-from waypoint.cli import app
+from waypoint.cli import app, exit_code_for_wait, parse_wait_until
 from waypoint.client import WaypointClient
 from waypoint.settings import Settings
 
@@ -574,3 +577,147 @@ def test_schedule_create_emits_schedule(
     assert out["schedule"]["id"] == "sc1"
     assert out["schedule"]["initial_prompt"] == "hello"
     assert out["schedule"]["delay_seconds"] == 60
+
+
+def test_parse_wait_until_defaults_and_validates() -> None:
+    assert parse_wait_until(None) == frozenset(
+        {"idle", "waiting_input", "exited", "error"}
+    )
+    assert parse_wait_until("exited, error") == frozenset({"exited", "error"})
+    with pytest.raises(typer.BadParameter):
+        parse_wait_until("bogus,idle")
+    with pytest.raises(typer.BadParameter):
+        parse_wait_until(",")
+
+
+def test_exit_code_for_wait_maps_terminal_status() -> None:
+    assert exit_code_for_wait(None) == 124  # timeout
+    assert exit_code_for_wait("error") == 1
+    assert exit_code_for_wait("idle") == 0
+    assert exit_code_for_wait("waiting_input") == 0
+    assert exit_code_for_wait("exited") == 0
+
+
+def _session_state(status: str) -> dict[str, Any]:
+    return {
+        "type": "session_state",
+        "payload": {"session": {"id": "s1", "status": status}},
+    }
+
+
+def _patch_stream(
+    monkeypatch: pytest.MonkeyPatch, envelopes: list[dict[str, Any]]
+) -> None:
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        for envelope in envelopes:
+            yield envelope
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+
+
+def test_wait_emits_final_session_and_exits_zero_on_idle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    _patch_stream(monkeypatch, [_session_state("running"), _session_state("idle")])
+    result = runner.invoke(
+        app, ["--config", str(_config(tmp_path)), "sessions", "wait", "s1"]
+    )
+    assert result.exit_code == 0
+    # Nothing intermediate: a single final session blob.
+    assert json.loads(result.stdout)["session"]["status"] == "idle"
+
+
+def test_wait_exits_one_on_error_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    _patch_stream(monkeypatch, [_session_state("error")])
+    result = runner.invoke(
+        app, ["--config", str(_config(tmp_path)), "sessions", "wait", "s1"]
+    )
+    assert result.exit_code == 1
+    assert json.loads(result.stdout)["session"]["status"] == "error"
+
+
+def test_wait_falls_back_to_polling_when_ws_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    async def failing_stream(
+        self: WaypointClient, session_id: str
+    ) -> AsyncIterator[dict]:
+        raise OSError("connection refused")
+        yield {}  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", failing_stream)
+    monkeypatch.setattr(
+        WaypointClient,
+        "get_session",
+        lambda self, session_id: {"id": session_id, "status": "exited"},
+    )
+    result = runner.invoke(
+        app, ["--config", str(_config(tmp_path)), "sessions", "wait", "s1"]
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["session"]["status"] == "exited"
+
+
+def test_wait_times_out_with_code_124(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    # A stream that never reaches the until-set; the timeout must win.
+    _patch_stream(monkeypatch, [_session_state("running")])
+    monkeypatch.setattr(
+        WaypointClient,
+        "get_session",
+        lambda self, session_id: {"id": session_id, "status": "running"},
+    )
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "wait",
+            "s1",
+            "--timeout",
+            "0.05",
+        ],
+    )
+    assert result.exit_code == 124
+    assert json.loads(result.stdout)["session"]["status"] == "running"
+
+
+def test_events_follow_streams_ndjson_until_terminal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    _patch_stream(
+        monkeypatch,
+        [
+            {"type": "event", "payload": {"event": {"sequence": 1}}},
+            _session_state("running"),
+            {"type": "event", "payload": {"event": {"sequence": 2}}},
+            _session_state("exited"),
+            {"type": "event", "payload": {"event": {"sequence": 3}}},
+        ],
+    )
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "events", "s1", "--follow"],
+    )
+    assert result.exit_code == 0
+    lines = [line for line in result.stdout.splitlines() if line.strip()]
+    # Only event envelopes are emitted, one compact JSON object per line, and
+    # the stream stops at the terminal `exited` state (event 3 never prints).
+    assert len(lines) == 2
+    assert all(
+        line == json.dumps(json.loads(line), separators=(",", ":")) for line in lines
+    )
+    assert [json.loads(line)["payload"]["event"]["sequence"] for line in lines] == [
+        1,
+        2,
+    ]

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -67,6 +67,12 @@ def test_board_help_lists_commands() -> None:
         assert name in result.stdout
 
 
+def test_backends_help_lists_threads() -> None:
+    result = runner.invoke(app, ["backends", "--help"])
+    assert result.exit_code == 0
+    assert "threads" in result.stdout
+
+
 def test_board_post_rejects_malformed_meta(tmp_path: Path) -> None:
     result = runner.invoke(
         app,
@@ -161,6 +167,270 @@ def test_models_sweep_skips_fallback_and_isolates_errors(
     # A live-discovery failure becomes an error entry, not a failed sweep.
     assert by_id["claude_code"]["models"] == [{"id": "x"}]
     assert "error" in by_id["codex"]
+
+
+def test_backends_threads_emits_threads_and_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/claude_code/threads":
+            state["threads_params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "threads": [
+                        {"id": "thread-1", "title": "Alpha", "cwd": "/tmp/repo"}
+                    ]
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "backends",
+            "threads",
+            "claude_code",
+            "--launch-target-id",
+            "ssh-box",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "threads": [{"id": "thread-1", "title": "Alpha", "cwd": "/tmp/repo"}]
+    }
+    assert state["threads_params"] == {"launch_target_id": "ssh-box"}
+
+
+def test_backends_threads_surfaces_server_capability_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/tmux/threads":
+            return httpx.Response(
+                400,
+                json={"detail": "thread discovery is not supported for tmux"},
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "backends", "threads", "tmux"],
+    )
+    assert result.exit_code != 0
+    assert "thread discovery is not supported for tmux" in result.output
+
+
+def test_sessions_import_reads_json_file_and_emits_session(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload_path = tmp_path / "thread.json"
+    payload_path.write_text(
+        '{"thread_id": "thread-1", "cwd": "/tmp/repo"}', encoding="utf-8"
+    )
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/claude_code/sessions/import":
+            state["import_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "imported-1"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "import",
+            "claude_code",
+            "--json",
+            str(payload_path),
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"session": {"id": "imported-1"}}
+    assert state["import_body"] == {"thread_id": "thread-1", "cwd": "/tmp/repo"}
+
+
+def test_sessions_import_reads_stdin_when_dash(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/claude_code/sessions/import":
+            state["import_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "imported-stdin"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "import",
+            "claude_code",
+            "--json",
+            "-",
+        ],
+        input='{"thread_id": "stdin-1"}',
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {"session": {"id": "imported-stdin"}}
+    assert state["import_body"] == {"thread_id": "stdin-1"}
+
+
+def test_sessions_import_rejects_malformed_json(tmp_path: Path) -> None:
+    payload_path = tmp_path / "thread.json"
+    payload_path.write_text("not json", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "import",
+            "claude_code",
+            "--json",
+            str(payload_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not valid JSON" in result.output
+
+
+def test_sessions_import_rejects_non_object_json(tmp_path: Path) -> None:
+    payload_path = tmp_path / "thread.json"
+    payload_path.write_text('["thread-1"]', encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "import",
+            "claude_code",
+            "--json",
+            str(payload_path),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "JSON object" in result.output
+
+
+def test_sessions_output_filters_events_and_passes_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/events":
+            state["events_params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "events": [
+                        {"kind": "status_update", "text": "busy", "sequence": 1},
+                        {"kind": "user_input", "text": "question", "sequence": 2},
+                        {"kind": "tool_call", "text": "ignored", "sequence": 3},
+                        {"kind": "agent_output", "text": "answer", "sequence": 4},
+                        {"kind": "system_note", "text": "ignored", "sequence": 5},
+                    ],
+                    "has_more": True,
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "output",
+            "s1",
+            "--messages",
+            "7",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == {
+        "events": [
+            {"kind": "user_input", "text": "question", "sequence": 2},
+            {"kind": "agent_output", "text": "answer", "sequence": 4},
+        ]
+    }
+    assert state["events_params"] == {"messages": "7"}
+
+
+def test_sessions_output_text_prints_only_agent_output(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/events":
+            return httpx.Response(
+                200,
+                json={
+                    "events": [
+                        {"kind": "user_input", "text": "question", "sequence": 1},
+                        {"kind": "agent_output", "text": "hello", "sequence": 2},
+                        {"kind": "tool_result", "text": "ignored", "sequence": 3},
+                        {"kind": "agent_output", "text": " world", "sequence": 4},
+                    ],
+                    "has_more": False,
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "output",
+            "s1",
+            "--text",
+        ],
+    )
+    assert result.exit_code == 0
+    assert result.stdout == "hello world"
 
 
 def test_answer_question_rejects_malformed_answers_json(tmp_path: Path) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -48,6 +48,7 @@ def test_help_lists_command_groups() -> None:
         "session",
         "sessions",
         "board",
+        "schedule",
     ):
         assert name in result.stdout
 
@@ -510,3 +511,66 @@ def test_doctor_reports_config_path(tmp_path: Path) -> None:
     result = runner.invoke(app, ["--config", str(_config(tmp_path)), "doctor"])
     assert result.exit_code == 0
     assert "config_path" in result.stdout
+
+
+def test_schedule_help_lists_commands() -> None:
+    result = runner.invoke(app, ["schedule", "--help"])
+    assert result.exit_code == 0
+    for name in ("list", "create", "delete", "clear-history"):
+        assert name in result.stdout
+
+
+def test_schedule_create_rejects_unknown_backend(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "create",
+            "--backend",
+            "bogus",
+            "--cwd",
+            "/tmp",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown backend" in result.output
+
+
+def test_schedule_create_emits_schedule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/schedules" and request.method == "POST":
+            payload = json.loads(request.content)
+            return httpx.Response(200, json={"schedule": {"id": "sc1", **payload}})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "create",
+            "--backend",
+            "claude_code",
+            "--cwd",
+            "/tmp",
+            "--prompt",
+            "hello",
+            "--delay-seconds",
+            "60",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["schedule"]["id"] == "sc1"
+    assert out["schedule"]["initial_prompt"] == "hello"
+    assert out["schedule"]["delay_seconds"] == 60

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,9 +1,13 @@
+import json
 from pathlib import Path
 
+import httpx
 import pytest
 from typer.testing import CliRunner
 
 from waypoint.cli import app
+from waypoint.client import WaypointClient
+from waypoint.settings import Settings
 
 runner = CliRunner()
 
@@ -104,6 +108,59 @@ def test_models_rejects_unknown_backend(tmp_path: Path) -> None:
     result = runner.invoke(app, ["--config", str(_config(tmp_path)), "models", "bogus"])
     assert result.exit_code != 0
     assert "unknown backend" in result.output
+
+
+def test_models_sweep_skips_fallback_and_isolates_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    requested: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/backends":
+            return httpx.Response(
+                200,
+                json={
+                    "backends": [
+                        {
+                            "id": "claude_code",
+                            "capabilities": {"is_fallback_for_managed_launch": False},
+                        },
+                        {
+                            "id": "codex",
+                            "capabilities": {"is_fallback_for_managed_launch": False},
+                        },
+                        {
+                            "id": "tmux",
+                            "capabilities": {"is_fallback_for_managed_launch": True},
+                        },
+                    ]
+                },
+            )
+        if path.endswith("/models"):
+            backend = path[len("/api/backends/") : -len("/models")]
+            requested.append(backend)
+            if backend == "codex":
+                return httpx.Response(502, json={"detail": "codex discovery failed"})
+            return httpx.Response(
+                200, json={"backend": backend, "models": [{"id": "x"}]}
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(app, ["--config", str(_config(tmp_path)), "models"])
+    assert result.exit_code == 0
+    by_id = {entry["backend"]: entry for entry in json.loads(result.stdout)["backends"]}
+    # The fallback backend is filtered out before any model request.
+    assert set(by_id) == {"claude_code", "codex"}
+    assert "tmux" not in requested
+    # A live-discovery failure becomes an error entry, not a failed sweep.
+    assert by_id["claude_code"]["models"] == [{"id": "x"}]
+    assert "error" in by_id["codex"]
 
 
 def test_answer_question_rejects_malformed_answers_json(tmp_path: Path) -> None:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -34,6 +34,22 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             return httpx.Response(
                 200, json={"backends": [{"id": "claude_code"}, {"id": "codex"}]}
             )
+        if request.url.path == "/api/backends/claude_code/threads":
+            state["threads_params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "threads": [
+                        {"id": "thread-1", "title": "Alpha", "cwd": "/tmp/repo"}
+                    ]
+                },
+            )
+        if request.url.path == "/api/backends/claude_code/sessions/import":
+            state["import_body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={"session": {"id": "imported", **state["import_body"]}},
+            )
         if request.url.path == "/api/board" and request.method == "GET":
             return httpx.Response(
                 200,
@@ -121,6 +137,18 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             return httpx.Response(
                 200, json={"deleted": request.url.path.rsplit("/", 1)[-1]}
             )
+        if request.url.path == "/api/sessions/s1/events" and request.method == "GET":
+            state["events_params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "events": [
+                        {"kind": "user_input", "text": "hi", "sequence": 1},
+                        {"kind": "agent_output", "text": "hello", "sequence": 2},
+                    ],
+                    "has_more": False,
+                },
+            )
         if request.url.path.startswith("/api/backends/") and request.url.path.endswith(
             "/models"
         ):
@@ -191,6 +219,41 @@ def test_list_models_omits_default_params(
     with _client(_settings(tmp_path), state) as client:
         client.list_models("claude_code")
     assert state["models_params"] == {}
+
+
+def test_list_threads_passes_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        threads = client.list_threads("claude_code", launch_target_id="lt1")
+    assert threads == [{"id": "thread-1", "title": "Alpha", "cwd": "/tmp/repo"}]
+    assert state["threads_params"] == {"launch_target_id": "lt1"}
+
+
+def test_import_thread_sends_raw_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        session = client.import_thread(
+            "claude_code", {"thread_id": "thread-1", "cwd": "/tmp/repo"}
+        )
+    assert session["id"] == "imported"
+    assert state["import_body"] == {"thread_id": "thread-1", "cwd": "/tmp/repo"}
+
+
+def test_get_events_passes_messages_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        page = client.get_events("s1", messages=5)
+    assert page["events"][1]["text"] == "hello"
+    assert state["events_params"] == {"messages": "5"}
 
 
 def test_answer_question_sends_body(

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -165,6 +165,23 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
         if request.url.path.endswith("/answer-question") and request.method == "POST":
             state["answer_body"] = json.loads(request.content)
             return httpx.Response(200, json={"session": {"id": "s1"}})
+        if (
+            request.url.path == "/api/schedules/clear-history"
+            and request.method == "POST"
+        ):
+            return httpx.Response(200, json={"removed": 3})
+        if request.url.path == "/api/schedules" and request.method == "GET":
+            return httpx.Response(200, json={"schedules": [{"id": "sc1"}]})
+        if request.url.path == "/api/schedules" and request.method == "POST":
+            payload = json.loads(request.content)
+            state["schedule_create"] = payload
+            return httpx.Response(200, json={"schedule": {"id": "sc1", **payload}})
+        if (
+            request.url.path.startswith("/api/schedules/")
+            and request.method == "DELETE"
+        ):
+            schedule_id = request.url.path.rsplit("/", 1)[-1]
+            return httpx.Response(200, json={"schedule": {"id": schedule_id}})
         if request.url.path == "/api/sessions/missing":
             return httpx.Response(404, json={"detail": "session not found"})
         return httpx.Response(200, json={"session": {"id": "ok"}})
@@ -456,3 +473,47 @@ def test_error_response_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     with _client(_settings(tmp_path), state) as client:
         with pytest.raises(WaypointError):
             client.get_session("missing")
+
+
+def test_list_schedules(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedules = client.list_schedules()
+    assert schedules == [{"id": "sc1"}]
+
+
+def test_create_schedule_posts_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedule = client.create_schedule(
+            backend="claude_code",
+            cwd="/tmp",
+            initial_prompt="do the thing",
+            delay_seconds=30,
+        )
+    assert schedule["id"] == "sc1"
+    assert state["schedule_create"]["backend"] == "claude_code"
+    assert state["schedule_create"]["initial_prompt"] == "do the thing"
+    assert state["schedule_create"]["delay_seconds"] == 30
+
+
+def test_delete_schedule(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedule = client.delete_schedule("sc1")
+    assert schedule == {"id": "sc1"}
+
+
+def test_clear_schedule_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        result = client.clear_schedule_history()
+    assert result == {"removed": 3}

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -4,7 +4,14 @@ from pathlib import Path
 import httpx
 import pytest
 
-from waypoint.client import WaypointClient, WaypointError, cli_token_path
+from waypoint.client import (
+    WaypointClient,
+    WaypointError,
+    cli_token_path,
+    is_event_envelope,
+    session_status_from_envelope,
+    websocket_url,
+)
 from waypoint.settings import Settings
 
 VALID_TOKEN = "valid-token"
@@ -520,3 +527,36 @@ def test_clear_schedule_history(
     with _client(_settings(tmp_path), state) as client:
         result = client.clear_schedule_history()
     assert result == {"removed": 3}
+
+
+def test_websocket_url_derives_scheme_and_encodes_token() -> None:
+    assert (
+        websocket_url("http://127.0.0.1:8787", "/ws/sessions/s1", token="a b")
+        == "ws://127.0.0.1:8787/ws/sessions/s1?token=a%20b"
+    )
+    assert (
+        websocket_url("https://host:443/", "/ws/sessions/s1", token="t")
+        == "wss://host:443/ws/sessions/s1?token=t"
+    )
+
+
+def test_session_status_from_envelope() -> None:
+    assert (
+        session_status_from_envelope(
+            {"type": "session_state", "payload": {"session": {"status": "idle"}}}
+        )
+        == "idle"
+    )
+    # Non-state envelopes and malformed payloads carry no status.
+    assert (
+        session_status_from_envelope({"type": "event", "payload": {"event": {}}})
+        is None
+    )
+    assert (
+        session_status_from_envelope({"type": "session_state", "payload": {}}) is None
+    )
+
+
+def test_is_event_envelope() -> None:
+    assert is_event_envelope({"type": "event", "payload": {"event": {}}})
+    assert not is_event_envelope({"type": "session_state", "payload": {"session": {}}})

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -121,6 +121,22 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             return httpx.Response(
                 200, json={"deleted": request.url.path.rsplit("/", 1)[-1]}
             )
+        if request.url.path.startswith("/api/backends/") and request.url.path.endswith(
+            "/models"
+        ):
+            backend = request.url.path[len("/api/backends/") : -len("/models")]
+            state["models_params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "backend": backend,
+                    "models": [{"id": "opus", "label": "Opus"}],
+                    "default_model_id": "opus",
+                },
+            )
+        if request.url.path.endswith("/answer-question") and request.method == "POST":
+            state["answer_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "s1"}})
         if request.url.path == "/api/sessions/missing":
             return httpx.Response(404, json={"detail": "session not found"})
         return httpx.Response(200, json={"session": {"id": "ok"}})
@@ -150,6 +166,51 @@ def test_list_backends(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     state: dict = {}
     with _client(_settings(tmp_path), state) as client:
         assert client.list_backends() == [{"id": "claude_code"}, {"id": "codex"}]
+
+
+def test_list_models_passes_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        payload = client.list_models(
+            "claude_code", launch_target_id="lt1", include_hidden=True
+        )
+    assert payload["backend"] == "claude_code"
+    assert payload["default_model_id"] == "opus"
+    assert state["models_params"]["launch_target_id"] == "lt1"
+    assert state["models_params"]["include_hidden"] == "true"
+
+
+def test_list_models_omits_default_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.list_models("claude_code")
+    assert state["models_params"] == {}
+
+
+def test_answer_question_sends_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        session = client.answer_question(
+            "s1",
+            "use opus",
+            tool_use_id="tu1",
+            answers=[{"question": "which model?", "answer": "opus"}],
+        )
+    assert session == {"id": "s1"}
+    assert state["answer_body"]["answer"] == "use opus"
+    assert state["answer_body"]["tool_use_id"] == "tu1"
+    assert state["answer_body"]["answers"] == [
+        {"question": "which model?", "answer": "opus"}
+    ]
 
 
 def test_delete_session(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -499,6 +499,9 @@ def test_create_schedule_posts_payload(
     assert state["schedule_create"]["backend"] == "claude_code"
     assert state["schedule_create"]["initial_prompt"] == "do the thing"
     assert state["schedule_create"]["delay_seconds"] == 30
+    # Unset optionals must be omitted, not sent as null: the server validates
+    # launch_mode against its enum even though it has a default.
+    assert "launch_mode" not in state["schedule_create"]
 
 
 def test_delete_schedule(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -176,6 +176,12 @@ def test_read_cli_credentials_prefers_file_before_keychain(
 def test_read_cli_credentials_falls_back_to_keychain_json_blob(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # Isolate the file-based source: on a host with a real ~/.claude
+    # credentials file it would otherwise win over the keychain fallback.
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._credential_paths",
+        lambda env: (),
+    )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._read_keychain_access_token",
         lambda env: (
@@ -194,6 +200,10 @@ def test_read_cli_credentials_falls_back_to_keychain_json_blob(
 def test_read_cli_credentials_keychain_legacy_bare_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._credential_paths",
+        lambda env: (),
+    )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._read_keychain_access_token",
         lambda env: "bare-token-no-json",
@@ -313,11 +323,11 @@ def test_probe_claude_usage_parses_messages_api_headers(
             headers={
                 "anthropic-ratelimit-unified-5h-utilization": "0.25",
                 "anthropic-ratelimit-unified-5h-reset": str(
-                    datetime(2026, 5, 12, 13, 0, tzinfo=UTC).timestamp()
+                    (datetime.now(UTC) + timedelta(hours=4)).timestamp()
                 ),
                 "anthropic-ratelimit-unified-7d-utilization": "0.812",
                 "anthropic-ratelimit-unified-7d-reset": str(
-                    datetime(2026, 5, 19, 1, 0, tzinfo=UTC).timestamp()
+                    (datetime.now(UTC) + timedelta(days=6)).timestamp()
                 ),
             },
             body=b'{"content":[{"type":"text","text":"hi"}]}',
@@ -442,11 +452,11 @@ def test_probe_claude_usage_remote_parses_messages_headers(
         "headers": {
             "anthropic-ratelimit-unified-5h-utilization": "0.4",
             "anthropic-ratelimit-unified-5h-reset": str(
-                datetime(2026, 5, 12, 13, 0, tzinfo=UTC).timestamp()
+                (datetime.now(UTC) + timedelta(hours=4)).timestamp()
             ),
             "anthropic-ratelimit-unified-7d-utilization": "0.92",
             "anthropic-ratelimit-unified-7d-reset": str(
-                datetime(2026, 5, 19, 1, 0, tzinfo=UTC).timestamp()
+                (datetime.now(UTC) + timedelta(days=6)).timestamp()
             ),
         },
         "body_preview": "{}",

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -109,10 +109,14 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         self.efforts: dict[str, str | None] = {}
         self.slash_commands: dict[str, tuple[str, ...]] = {}
         self.pending_ids: list[str] = []
+        self.discard_calls: list[str] = []
 
     async def terminate_session(self, session_id: str) -> bool:
         self.terminate_calls.append(session_id)
         return True
+
+    def discard_session(self, session_id: str) -> None:
+        self.discard_calls.append(session_id)
 
     async def register_rate_limit_probe(
         self,


### PR DESCRIPTION
## Summary

The backend exposes a number of capabilities the `waypoint` CLI did not surface, forcing an orchestrating agent to guess model ids, hand-write `jq` over event firehoses, and poll sessions with `while/sleep` loops. This PR closes those CLI↔server parity gaps so an agent can drive sub-sessions end to end from the CLI alone: discover models, discover and import backend-native threads, read just the conversational turns, manage scheduled launches, block on a session until it settles, and stream a peer's events live. It also exposes the previously-missing model-discovery and answer-question surfaces (the original scope of this branch).

## Changes

### Backend — `client.py`

- `list_models(backend, *, launch_target_id, include_hidden)` → `GET /api/backends/{backend}/models`.
- `answer_question(session_id, answer, *, tool_use_id, answers)` → `POST /api/sessions/{id}/answer-question`.
- `list_threads(backend, *, launch_target_id)` → `GET /api/backends/{backend}/threads`.
- `import_thread(backend, body)` → `POST /api/backends/{backend}/sessions/import`, passing the plugin-specific body through unmodelled (each plugin declares its own `import_request_schema`).
- `list_schedules` / `create_schedule` / `delete_schedule` / `clear_schedule_history` → the `/api/schedules` endpoints. `create_schedule` omits unset optionals from the body so the server's model defaults apply.
- `stream_session_envelopes(session_id)` — async generator over the per-session WebSocket (`/ws/sessions/{id}`, token via query param), plus pure helpers `websocket_url`, `session_status_from_envelope`, and `is_event_envelope`.

### Backend — `cli.py`

- `waypoint models [BACKEND]` — one backend, or a sweep of every selectable backend (skipping the managed-launch fallback) where a live-discovery failure becomes a `{"backend", "error"}` entry instead of sinking the listing.
- `waypoint sessions answer-question <id> --answer <text>` — with optional `--tool-use-id` and `--answers-json` (validated to a JSON array of objects).
- `waypoint backends threads <backend> [--launch-target-id]` — `backends` becomes a Typer group with an `invoke_without_command` callback so the bare command still lists capabilities.
- `waypoint sessions import <backend> --json FILE|-` — opaque JSON object passed through.
- `waypoint sessions output <id> [--messages N] [--text]` — filters the transcript to `user_input` + `agent_output`; `--text` emits just the concatenated agent text for shell piping.
- `waypoint schedule list|create|delete|clear-history` — a new Typer group mirroring `sessions start`'s launch flags plus `--delay-seconds` / `--scheduled-at`.
- `waypoint sessions wait <id> [--until ...] [--timeout S]` — blocks (no intermediate output) until the session reaches a terminal/idle status, emits the final session once, and maps the outcome to a process exit code (error=1, timeout=124, else 0) so it composes in shell `&&` chains. Prefers the WebSocket stream and falls back to polling; the polling fetches run via `asyncio.to_thread` so `asyncio.timeout` fires precisely.
- `waypoint sessions events <id> --follow` — streams event envelopes as NDJSON until a terminal status or Ctrl+C, via a streaming output path separate from the single-blob `_emit`.

### Skills

- `waypoint`, `waypoint-subagents`, `waypoint-workqueue`: point agents at `waypoint models [backend]` before passing `--model`/`--effort`, document that an `AskUserQuestion` block is released only by `answer-question` (not `send`/`approve`), and rewrite `spawn-and-poll.md` to use `sessions wait` instead of a `while/sleep` loop.
- `waypoint-workqueue/{org-template,playbook}.md`: fix two pitfalls hit while dogfooding the crew to build this — `board post --key` is an upsert that replaces a cell's text (so status flips must re-post the full contract, not a stub), and task branches named `wq/<job>/task-<n>` collide with the integration ref `wq/<job>` (use `wq/<job>-t<n>`).

### Tests

- New coverage for every command/method above in `tests/test_cli.py` and `tests/test_client.py`, including the model sweep's error isolation, the `wait` exit-code mapping and WS/poll fallback, and the `--follow` terminal-status stop.
- Fixed three pre-existing failures unrelated to this change so the suite is green: the two `probe_claude_usage` tests hardcoded 2026-05 reset timestamps that the parser zeroes once past (now relative to `now`); the keychain credential tests didn't isolate the file-based source (now stub `_credential_paths`); and `FakeClaudeAdapter` lacked `discard_session`, which the plugin calls on delete.

## Test Plan

- [x] `cd backend && uv run pytest` — 676 passed (was 618 + 5 pre-existing failures, now fixed).
- [x] `cd backend && uv run pre-commit run --all-files` — isort / black / ruff / codespell / mypy clean.
- [x] Live-smoke-tested against a running stack: `backends threads codex` returns real threads; `schedule create`/`delete` round-trips (caught and fixed a `launch_mode` 422); `sessions wait` on an idle session exits 0 with the final blob; `sessions output --text` returns only conversational text; `sessions events --follow` streams and exits cleanly.
- [x] `--help` for each new command/group renders the expected surface.
