### PR TITLE
feat: paste images and upload files to chat and terminal sessions

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
   "openai-codex",
   "pydantic>=2.11.0",
   "pyte>=0.8.2",
+  "python-multipart>=0.0.9",
   "PyYAML>=6.0.0",
   "typer>=0.12.0",
   "uvicorn>=0.35.0",

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -9,14 +9,17 @@ from typing import Annotated, Any
 from fastapi import (
     Depends,
     FastAPI,
+    File,
     Header,
     HTTPException,
     Query,
+    UploadFile,
     WebSocket,
     WebSocketDisconnect,
     status,
 )
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 
 from waypoint.auth import TokenStore, require_token
 from waypoint.backends import BackendRegistry
@@ -307,6 +310,54 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         session = await context.runtime.handle_input(session_id, request)
         return {"session": session.model_dump(mode="json")}
+
+    @app.post("/api/sessions/{session_id}/attachments")
+    async def upload_attachment(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        file: Annotated[UploadFile, File()],
+    ) -> Any:
+        # 404 on an unknown session before persisting anything.
+        context.runtime.get_session(session_id)
+        max_bytes = context.settings.max_upload_bytes
+        data = await file.read(max_bytes + 1)
+        if len(data) > max_bytes:
+            raise HTTPException(
+                status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+                detail=f"attachment exceeds {max_bytes} byte limit",
+            )
+        spec = context.runtime.attachments.save(
+            session_id,
+            data=data,
+            filename=file.filename or "file",
+            content_type=file.content_type,
+        )
+        return spec.model_dump(mode="json")
+
+    @app.get("/api/sessions/{session_id}/attachments/{attachment_id}")
+    async def serve_attachment(
+        session_id: str,
+        attachment_id: str,
+        token: Annotated[str, Query()] = "",
+    ) -> FileResponse:
+        # ``<img>`` tags can't send an Authorization header, so this mirrors
+        # the WebSocket endpoints and takes the token as a query parameter.
+        if not context.tokens.validate(token):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token"
+            )
+        resolved = context.runtime.attachments.resolve(session_id, attachment_id)
+        if resolved is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="attachment not found"
+            )
+        spec, path = resolved
+        return FileResponse(
+            path,
+            media_type=spec.mime,
+            filename=spec.filename,
+            content_disposition_type="inline",
+        )
 
     @app.post("/api/sessions/{session_id}/interrupt")
     async def session_interrupt(

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -13,6 +13,7 @@ from fastapi import (
     Header,
     HTTPException,
     Query,
+    Response,
     UploadFile,
     WebSocket,
     WebSocketDisconnect,
@@ -334,6 +335,26 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         return spec.model_dump(mode="json")
 
+    @app.get("/api/sessions/{session_id}/attachments")
+    async def list_attachments(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> list[dict[str, Any]]:
+        context.runtime.get_session(session_id)
+        return [
+            {**spec.model_dump(mode="json"), "uploaded_at": uploaded_at}
+            for spec, uploaded_at in context.runtime.attachments.list(session_id)
+        ]
+
+    @app.delete("/api/sessions/{session_id}/attachments")
+    async def delete_all_attachments(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        context.runtime.get_session(session_id)
+        context.runtime.attachments.discard(session_id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
     @app.get("/api/sessions/{session_id}/attachments/{attachment_id}")
     async def serve_attachment(
         session_id: str,
@@ -358,6 +379,23 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             filename=spec.filename,
             content_disposition_type="inline",
         )
+
+    @app.delete("/api/sessions/{session_id}/attachments/{attachment_id}")
+    async def delete_attachment(
+        session_id: str,
+        attachment_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        # Frees a single blob. Called both by the composer (removing a pending
+        # upload) and by the session files manager, which can delete a file a
+        # sent message still references — that message's transcript card then
+        # 404s on its thumbnail, which the client renders as a file fallback.
+        context.runtime.get_session(session_id)
+        if not context.runtime.attachments.delete(session_id, attachment_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="attachment not found"
+            )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @app.post("/api/sessions/{session_id}/interrupt")
     async def session_interrupt(

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -341,9 +341,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> list[dict[str, Any]]:
         context.runtime.get_session(session_id)
+        context.runtime.attachments.sweep(
+            session_id, context.settings.attachment_orphan_ttl_seconds
+        )
         return [
             {**spec.model_dump(mode="json"), "uploaded_at": uploaded_at}
-            for spec, uploaded_at in context.runtime.attachments.list(session_id)
+            for spec, uploaded_at in context.runtime.attachments.entries(session_id)
         ]
 
     @app.delete("/api/sessions/{session_id}/attachments")

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -3,6 +3,7 @@ import json
 import mimetypes
 import re
 import shutil
+import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -15,6 +16,9 @@ _UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
 _ATTACHMENT_ID = re.compile(r"[0-9a-f]{32}")
 _DEFAULT_MIME = "application/octet-stream"
 _IMAGE_MIME_PREFIX = "image/"
+# Index of ids referenced by a sent message; its stem isn't a uuid so it's
+# transparent to entries()/sweep, which only consider sidecars.
+_SENT_INDEX = "_sent.json"
 
 
 def _sanitize_component(value: str, *, fallback: str) -> str:
@@ -145,7 +149,7 @@ class AttachmentStore:
             return None
         return AttachmentSpec.model_validate(raw), blob
 
-    def list(self, session_id: str) -> list[tuple[AttachmentSpec, float]]:
+    def entries(self, session_id: str) -> list[tuple[AttachmentSpec, float]]:
         """Every attachment in the session, each paired with its upload time
         (sidecar mtime), newest first. Skips anything that isn't a valid
         sidecar so a user-uploaded ``*.json`` blob is never mistaken for one."""
@@ -186,6 +190,51 @@ class AttachmentStore:
             (session_dir / stored_name).unlink(missing_ok=True)
         sidecar.unlink(missing_ok=True)
         return True
+
+    def mark_sent(self, session_id: str, attachment_ids: list[str]) -> None:
+        """Record ids carried by a sent message so the sweep never reaps them
+        (a sent file is referenced by the transcript and must survive)."""
+        ids = [aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)]
+        if not ids:
+            return
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return
+        current = self._sent_ids(session_dir)
+        current.update(ids)
+        (session_dir / _SENT_INDEX).write_text(
+            json.dumps(sorted(current)), encoding="utf-8"
+        )
+
+    def sweep(self, session_id: str, ttl_seconds: float) -> int:
+        """Reap eager uploads that were never sent — blobs older than
+        ``ttl_seconds`` that no sent message references. Returns the count
+        removed. Best-effort; never raises."""
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return 0
+        sent = self._sent_ids(session_dir)
+        cutoff = time.time() - ttl_seconds
+        removed = 0
+        for sidecar in session_dir.glob("*.json"):
+            attachment_id = sidecar.stem
+            if not _ATTACHMENT_ID.fullmatch(attachment_id) or attachment_id in sent:
+                continue
+            try:
+                if sidecar.stat().st_mtime >= cutoff:
+                    continue
+            except OSError:
+                continue
+            if self.delete(session_id, attachment_id):
+                removed += 1
+        return removed
+
+    def _sent_ids(self, session_dir: Path) -> set[str]:
+        try:
+            data = json.loads((session_dir / _SENT_INDEX).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return set()
+        return set(data) if isinstance(data, list) else set()
 
     def discard(self, session_id: str) -> None:
         """Remove a session's attachment dir. Best-effort; never raises."""

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -1,0 +1,125 @@
+import base64
+import json
+import mimetypes
+import re
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+from waypoint.schemas import AttachmentKind, AttachmentSpec
+
+_UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
+_ATTACHMENT_ID = re.compile(r"[0-9a-f]{32}")
+_DEFAULT_MIME = "application/octet-stream"
+_IMAGE_MIME_PREFIX = "image/"
+
+
+def _sanitize_component(value: str, *, fallback: str) -> str:
+    cleaned = _UNSAFE_CHARS.sub("_", Path(value).name).strip("._")
+    return (cleaned or fallback)[:128]
+
+
+def _kind_for(mime: str) -> AttachmentKind:
+    if mime.startswith(_IMAGE_MIME_PREFIX):
+        return AttachmentKind.IMAGE
+    return AttachmentKind.FILE
+
+
+@dataclass(frozen=True)
+class ResolvedAttachment:
+    """An uploaded attachment paired with its on-disk host path.
+
+    Backends consume this when delivering input: image-capable backends read
+    the bytes (or reference the path) natively, while text-only transports
+    fall back to :func:`append_attachment_paths`.
+    """
+
+    spec: AttachmentSpec
+    path: Path
+
+    @property
+    def is_image(self) -> bool:
+        return self.spec.kind == AttachmentKind.IMAGE
+
+    def read_base64(self) -> str:
+        return base64.b64encode(self.path.read_bytes()).decode("ascii")
+
+    def to_data_url(self) -> str:
+        return f"data:{self.spec.mime};base64,{self.read_base64()}"
+
+
+def append_attachment_paths(text: str, attachments: list[ResolvedAttachment]) -> str:
+    """Append absolute attachment paths to ``text`` for text-only transports.
+
+    The underlying CLI agent reads the referenced files itself, so this is the
+    universal fallback for backends without native attachment support (tmux)
+    and for non-image files on backends that only embed images inline.
+    """
+    if not attachments:
+        return text
+    listing = "\n".join(f"- {attachment.path}" for attachment in attachments)
+    block = f"Attached files:\n{listing}"
+    return f"{text}\n\n{block}" if text else block
+
+
+class AttachmentStore:
+    """Persists uploaded blobs under a per-session directory and resolves
+    server-issued ids back to their host path.
+
+    Layout: ``<root>/<session_id>/<id><ext>`` for the blob plus a
+    ``<id>.json`` sidecar holding the :class:`AttachmentSpec` and the blob's
+    stored name. The id is a server-generated uuid and the only key the
+    client ever sends back, so a hostile client cannot point resolution at an
+    arbitrary path.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def _session_dir(self, session_id: str) -> Path:
+        return self._root / _sanitize_component(session_id, fallback="session")
+
+    def save(
+        self,
+        session_id: str,
+        *,
+        data: bytes,
+        filename: str,
+        content_type: str | None,
+    ) -> AttachmentSpec:
+        attachment_id = uuid.uuid4().hex
+        clean_name = _sanitize_component(filename, fallback="file")
+        mime = content_type or mimetypes.guess_type(clean_name)[0] or _DEFAULT_MIME
+        stored_name = f"{attachment_id}{Path(clean_name).suffix}"
+        session_dir = self._session_dir(session_id)
+        session_dir.mkdir(parents=True, exist_ok=True)
+        (session_dir / stored_name).write_bytes(data)
+        spec = AttachmentSpec(
+            id=attachment_id,
+            filename=clean_name,
+            mime=mime,
+            size=len(data),
+            kind=_kind_for(mime),
+        )
+        sidecar = {**spec.model_dump(mode="json"), "stored_name": stored_name}
+        (session_dir / f"{attachment_id}.json").write_text(
+            json.dumps(sidecar), encoding="utf-8"
+        )
+        return spec
+
+    def resolve(
+        self, session_id: str, attachment_id: str
+    ) -> tuple[AttachmentSpec, Path] | None:
+        if not _ATTACHMENT_ID.fullmatch(attachment_id):
+            return None
+        sidecar = self._session_dir(session_id) / f"{attachment_id}.json"
+        if not sidecar.is_file():
+            return None
+        raw = json.loads(sidecar.read_text(encoding="utf-8"))
+        stored_name = raw.pop("stored_name", None)
+        if not isinstance(stored_name, str):
+            return None
+        blob = sidecar.parent / stored_name
+        if not blob.is_file():
+            return None
+        return AttachmentSpec.model_validate(raw), blob

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -2,6 +2,7 @@ import base64
 import json
 import mimetypes
 import re
+import shutil
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -123,3 +124,7 @@ class AttachmentStore:
         if not blob.is_file():
             return None
         return AttachmentSpec.model_validate(raw), blob
+
+    def discard(self, session_id: str) -> None:
+        """Remove a session's attachment dir. Best-effort; never raises."""
+        shutil.rmtree(self._session_dir(session_id), ignore_errors=True)

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -7,6 +7,8 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from waypoint.schemas import AttachmentKind, AttachmentSpec
 
 _UNSAFE_CHARS = re.compile(r"[^A-Za-z0-9._-]+")
@@ -63,15 +65,34 @@ def append_attachment_paths(text: str, attachments: list[ResolvedAttachment]) ->
     return f"{text}\n\n{block}" if text else block
 
 
+def _write_unique(session_dir: Path, name: str, data: bytes) -> str:
+    """Write ``data`` under ``name`` in ``session_dir``, suffixing `` (1)``,
+    `` (2)`` … on collision, and return the stored filename. Uses exclusive
+    create so two concurrent uploads of the same name never clobber each other.
+    """
+    stem, suffix = Path(name).stem, Path(name).suffix
+    candidate = name
+    counter = 1
+    while True:
+        try:
+            with (session_dir / candidate).open("xb") as handle:
+                handle.write(data)
+            return candidate
+        except FileExistsError:
+            candidate = f"{stem} ({counter}){suffix}"
+            counter += 1
+
+
 class AttachmentStore:
     """Persists uploaded blobs under a per-session directory and resolves
     server-issued ids back to their host path.
 
-    Layout: ``<root>/<session_id>/<id><ext>`` for the blob plus a
-    ``<id>.json`` sidecar holding the :class:`AttachmentSpec` and the blob's
-    stored name. The id is a server-generated uuid and the only key the
-    client ever sends back, so a hostile client cannot point resolution at an
-    arbitrary path.
+    Layout: ``<root>/<session_id>/<name>`` for the blob — the sanitized
+    original filename, de-duplicated with `` (1)``, `` (2)`` … so the path
+    handed to path-based agents stays legible — plus a ``<id>.json`` sidecar
+    holding the :class:`AttachmentSpec` and that stored name. The id is a
+    server-generated uuid and the only key the client ever sends back, so a
+    hostile client cannot point resolution at an arbitrary path.
     """
 
     def __init__(self, root: Path) -> None:
@@ -91,10 +112,9 @@ class AttachmentStore:
         attachment_id = uuid.uuid4().hex
         clean_name = _sanitize_component(filename, fallback="file")
         mime = content_type or mimetypes.guess_type(clean_name)[0] or _DEFAULT_MIME
-        stored_name = f"{attachment_id}{Path(clean_name).suffix}"
         session_dir = self._session_dir(session_id)
         session_dir.mkdir(parents=True, exist_ok=True)
-        (session_dir / stored_name).write_bytes(data)
+        stored_name = _write_unique(session_dir, clean_name, data)
         spec = AttachmentSpec(
             id=attachment_id,
             filename=clean_name,
@@ -124,6 +144,48 @@ class AttachmentStore:
         if not blob.is_file():
             return None
         return AttachmentSpec.model_validate(raw), blob
+
+    def list(self, session_id: str) -> list[tuple[AttachmentSpec, float]]:
+        """Every attachment in the session, each paired with its upload time
+        (sidecar mtime), newest first. Skips anything that isn't a valid
+        sidecar so a user-uploaded ``*.json`` blob is never mistaken for one."""
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return []
+        out: list[tuple[AttachmentSpec, float]] = []
+        for sidecar in session_dir.glob("*.json"):
+            if not _ATTACHMENT_ID.fullmatch(sidecar.stem):
+                continue
+            try:
+                raw = json.loads(sidecar.read_text(encoding="utf-8"))
+                raw.pop("stored_name", None)
+                spec = AttachmentSpec.model_validate(raw)
+                mtime = sidecar.stat().st_mtime
+            except (OSError, json.JSONDecodeError, ValidationError):
+                continue
+            out.append((spec, mtime))
+        out.sort(key=lambda item: item[1], reverse=True)
+        return out
+
+    def delete(self, session_id: str, attachment_id: str) -> bool:
+        """Remove a single attachment's blob and sidecar. Returns whether it
+        existed; best-effort on the file removals, so it never raises."""
+        if not _ATTACHMENT_ID.fullmatch(attachment_id):
+            return False
+        session_dir = self._session_dir(session_id)
+        sidecar = session_dir / f"{attachment_id}.json"
+        if not sidecar.is_file():
+            return False
+        try:
+            stored_name = json.loads(sidecar.read_text(encoding="utf-8")).get(
+                "stored_name"
+            )
+        except (OSError, json.JSONDecodeError):
+            stored_name = None
+        if isinstance(stored_name, str):
+            (session_dir / stored_name).unlink(missing_ok=True)
+        sidecar.unlink(missing_ok=True)
+        return True
 
     def discard(self, session_id: str) -> None:
         """Remove a session's attachment dir. Best-effort; never raises."""

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -51,6 +51,13 @@ class BackendCapabilities(_FrozenModel):
     supports_plan_approval: bool = False
     supports_slash_compact: bool = False
     supports_approval_note: bool = False
+    # The plugin's transport accepts uploaded attachments alongside text
+    # input. Every backend that sets this delivers images natively where it
+    # can (inline content blocks / local image items / file parts) and falls
+    # back to appending the host file path for other files; the universal
+    # fallback is plain path-insertion (tmux). Drives whether the frontend
+    # composer shows the upload affordance.
+    supports_attachments: bool = False
     permission_modes: tuple[PermissionModeSpec, ...] = ()
     effort_levels: tuple[str, ...] = ()
     model_source: ModelSource = ModelSource.NONE

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -112,6 +112,34 @@ async def _drain_until_newline(reader: asyncio.StreamReader) -> None:
             return
 
 
+async def _read_stream_line(
+    reader: asyncio.StreamReader, session_id: str, stream: str
+) -> bytes | None:
+    """Read one newline-terminated line, surviving an over-limit line.
+
+    Returns the line (with trailing newline), ``b""`` at EOF, or ``None`` when an
+    oversized line was drained and skipped so the caller can continue. We read
+    via ``readuntil`` rather than ``readline`` because ``readline`` masks
+    ``LimitOverrunError`` as a plain ``ValueError`` that loses ``consumed`` and
+    can't be drained — so a single giant stream-json line (e.g. a base64 tool
+    result echoing a large attachment) would otherwise tear down the reader."""
+    try:
+        return await reader.readuntil(b"\n")
+    except asyncio.LimitOverrunError as exc:
+        await reader.readexactly(exc.consumed)
+        await _drain_until_newline(reader)
+        log.warning(
+            "claude %s line exceeded buffer limit; dropped",
+            stream,
+            extra={"session_id": session_id, "consumed_bytes": exc.consumed},
+        )
+        return None
+    except asyncio.IncompleteReadError as exc:
+        # EOF before a newline: hand back the trailing partial (empty once the
+        # stream is fully drained, which the caller treats as EOF).
+        return exc.partial
+
+
 def _auto_approve_for_mode(
     mode: str,
     tool_name: object,
@@ -1339,21 +1367,12 @@ class ClaudeCliAdapter:
         assert state.process.stdout is not None
         try:
             while True:
-                try:
-                    line = await state.process.stdout.readline()
-                except asyncio.LimitOverrunError as exc:
-                    # Line exceeded the StreamReader buffer. Drain and skip it
-                    # so the reader survives; the lost line is almost always a
-                    # giant tool-result blob we couldn't have parsed anyway.
-                    await state.process.stdout.readexactly(exc.consumed)
-                    await _drain_until_newline(state.process.stdout)
-                    log.warning(
-                        "claude stdout line exceeded buffer limit; dropped",
-                        extra={
-                            "session_id": state.session_id,
-                            "consumed_bytes": exc.consumed,
-                        },
-                    )
+                # A dropped line is almost always a giant tool-result blob we
+                # couldn't have parsed anyway; the session survives it.
+                line = await _read_stream_line(
+                    state.process.stdout, state.session_id, "stdout"
+                )
+                if line is None:
                     continue
                 if not line:
                     break
@@ -1391,18 +1410,10 @@ class ClaudeCliAdapter:
         assert state.process.stderr is not None
         try:
             while True:
-                try:
-                    line = await state.process.stderr.readline()
-                except asyncio.LimitOverrunError as exc:
-                    await state.process.stderr.readexactly(exc.consumed)
-                    await _drain_until_newline(state.process.stderr)
-                    log.warning(
-                        "claude stderr line exceeded buffer limit; dropped",
-                        extra={
-                            "session_id": state.session_id,
-                            "consumed_bytes": exc.consumed,
-                        },
-                    )
+                line = await _read_stream_line(
+                    state.process.stderr, state.session_id, "stderr"
+                )
+                if line is None:
                     continue
                 if not line:
                     break

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from waypoint.attachments import ResolvedAttachment, append_attachment_paths
 from waypoint.backends.claude_code.models import (
     claude_context_window_for_model,
     claude_model_family,
@@ -53,6 +54,40 @@ from waypoint.schemas import (
 )
 
 log = logging.getLogger("waypoint.claude_cli")
+
+
+def _user_content(
+    text: str, attachments: list[ResolvedAttachment] | None
+) -> str | list[dict[str, Any]]:
+    """Build the ``message.content`` for a user turn.
+
+    Returns the plain string when there are no attachments (preserving the
+    historical envelope shape). Otherwise returns Anthropic content blocks:
+    images embed inline as base64 ``image`` blocks; non-image files degrade
+    to their host paths appended to the text block, which Claude reads via
+    its file tools.
+    """
+    if not attachments:
+        return text
+    images = [item for item in attachments if item.is_image]
+    files = [item for item in attachments if not item.is_image]
+    body = append_attachment_paths(text, files)
+    blocks: list[dict[str, Any]] = []
+    if body:
+        blocks.append({"type": "text", "text": body})
+    for image in images:
+        blocks.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": image.spec.mime,
+                    "data": image.read_base64(),
+                },
+            }
+        )
+    return blocks or text
+
 
 CONTROL_REQUEST_TIMEOUT_SECONDS = 10.0
 # Claude's stream-json output can emit a single line larger than asyncio's
@@ -527,7 +562,12 @@ class ClaudeCliAdapter:
             return
         future.set_result(response)
 
-    async def send_input(self, session_id: str, text: str) -> None:
+    async def send_input(
+        self,
+        session_id: str,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None:
         state = self._require_session(session_id)
         if state.process.returncode is not None:
             raise ClaudeCliError(
@@ -539,7 +579,7 @@ class ClaudeCliAdapter:
             )
         envelope = {
             "type": "user",
-            "message": {"role": "user", "content": text},
+            "message": {"role": "user", "content": _user_content(text, attachments)},
         }
         line = (json.dumps(envelope) + "\n").encode("utf-8")
         state.process.stdin.write(line)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -131,6 +131,7 @@ class ClaudeCodePlugin:
         supports_fork=True,
         supports_slash_compact=False,
         supports_approval_note=True,
+        supports_attachments=True,
         supports_custom_cli_args=True,
         # One-shot approve/decline only. The binary ignores the can_use_tool
         # response's permission_updates in -p mode (verified against v2.1.157:

--- a/backend/src/waypoint/backends/claude_code/transport.py
+++ b/backend/src/waypoint/backends/claude_code/transport.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 
+from waypoint.attachments import ResolvedAttachment
 from waypoint.backends.claude_code.adapter import ClaudeCliError
 from waypoint.schemas import SessionRecord
 from waypoint.transports.base import TransportAdapter
@@ -35,10 +36,15 @@ class ClaudeTransport(TransportAdapter):
             )
         return adapter
 
-    async def send_input(self, session: SessionRecord, text: str) -> None:
+    async def send_input(
+        self,
+        session: SessionRecord,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None:
         adapter = self._require_adapter()
         try:
-            await adapter.send_input(session.id, text)
+            await adapter.send_input(session.id, text, attachments)
         except ClaudeCliError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -115,6 +115,7 @@ class CodexPlugin:
         supports_plan_approval=True,
         supports_slash_compact=True,
         supports_approval_note=False,
+        supports_attachments=True,
         supports_custom_cli_args=True,
         supports_config_overrides=True,
         # Codex honours "approve for session" on tool approvals

--- a/backend/src/waypoint/backends/codex/transport.py
+++ b/backend/src/waypoint/backends/codex/transport.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 
+from waypoint.attachments import ResolvedAttachment, append_attachment_paths
 from waypoint.schemas import SessionRecord
 from waypoint.transports.base import TransportAdapter
 
@@ -34,13 +35,22 @@ class CodexTransport(TransportAdapter):
             )
         return adapter
 
-    async def send_input(self, session: SessionRecord, text: str) -> None:
+    async def send_input(
+        self,
+        session: SessionRecord,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None:
+        turn_params = self._plugin.turn_params_for(session)
         try:
-            await self.adapter.send_input(
-                session.id,
-                text,
-                turn_params=self._plugin.turn_params_for(session),
-            )
+            if attachments:
+                await self.adapter.send_input_items(
+                    session.id,
+                    _input_items(text, attachments),
+                    turn_params=turn_params,
+                )
+            else:
+                await self.adapter.send_input(session.id, text, turn_params=turn_params)
         except Exception as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
@@ -67,3 +77,17 @@ class CodexTransport(TransportAdapter):
 
     def terminal_snapshot(self, session: SessionRecord) -> str:
         return self.adapter.terminal_snapshot(session.id)
+
+
+def _input_items(
+    text: str, attachments: list[ResolvedAttachment]
+) -> list[dict[str, Any]]:
+    # Codex natively accepts local images via ``localImage`` items; other
+    # files have no item type, so their host paths are appended to the text.
+    images = [item for item in attachments if item.is_image]
+    files = [item for item in attachments if not item.is_image]
+    items: list[dict[str, Any]] = [
+        {"type": "text", "text": append_attachment_paths(text, files)}
+    ]
+    items.extend({"type": "localImage", "path": str(image.path)} for image in images)
+    return items

--- a/backend/src/waypoint/backends/codex/transport.py
+++ b/backend/src/waypoint/backends/codex/transport.py
@@ -86,8 +86,11 @@ def _input_items(
     # files have no item type, so their host paths are appended to the text.
     images = [item for item in attachments if item.is_image]
     files = [item for item in attachments if not item.is_image]
-    items: list[dict[str, Any]] = [
-        {"type": "text", "text": append_attachment_paths(text, files)}
-    ]
+    body = append_attachment_paths(text, files)
+    items: list[dict[str, Any]] = []
+    # Omit the text item entirely on an image-only turn so the app server
+    # doesn't see a blank turn (an empty string is not a valid input item).
+    if body:
+        items.append({"type": "text", "text": body})
     items.extend({"type": "localImage", "path": str(image.path)} for image in images)
     return items

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from waypoint.attachments import ResolvedAttachment
 from waypoint.backends.opencode.client import (
     LocalOpenCodeClient,
     OpenCodeHttpClient,
@@ -977,20 +978,31 @@ class OpenCodeAdapter:
         # The plugin records the user-facing restore/import note; the adapter
         # stays silent here so the transcript only shows one entry.
 
-    async def send_input(self, session_id: str, text: str) -> None:
+    async def send_input(
+        self,
+        session_id: str,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None:
         state = self._sessions.get(session_id)
         if state is None:
             raise OpenCodeError(f"session not found: {session_id}")
         model = self._split_model_ref(state.model)
         client = self._require_client()
-        payload: dict[str, Any] = {
-            "parts": [
+        parts: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        # Embed every attachment as a data-url file part rather than a host
+        # path: the OpenCode server may run on a remote host (SSH launch
+        # target) that can't see the local attachments directory.
+        for attachment in attachments or []:
+            parts.append(
                 {
-                    "type": "text",
-                    "text": text,
+                    "type": "file",
+                    "mime": attachment.spec.mime,
+                    "filename": attachment.spec.filename,
+                    "url": attachment.to_data_url(),
                 }
-            ]
-        }
+            )
+        payload: dict[str, Any] = {"parts": parts}
         if model is not None:
             payload["model"] = model
         if state.effort:

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -989,7 +989,9 @@ class OpenCodeAdapter:
             raise OpenCodeError(f"session not found: {session_id}")
         model = self._split_model_ref(state.model)
         client = self._require_client()
-        parts: list[dict[str, Any]] = [{"type": "text", "text": text}]
+        # Omit the text part on an attachment-only turn so the server doesn't
+        # receive a blank prompt part.
+        parts: list[dict[str, Any]] = [{"type": "text", "text": text}] if text else []
         # Embed every attachment as a data-url file part rather than a host
         # path: the OpenCode server may run on a remote host (SSH launch
         # target) that can't see the local attachments directory.

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -145,6 +145,7 @@ class OpenCodePlugin:
         supports_fork=True,
         supports_slash_compact=True,
         supports_approval_note=True,
+        supports_attachments=True,
         supports_custom_cli_args=True,
         # OpenCode's "always" reply is surfaced as "approve for session"; it
         # has no decision distinct from that, so no acceptAlways.

--- a/backend/src/waypoint/backends/opencode/transport.py
+++ b/backend/src/waypoint/backends/opencode/transport.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING
 
+from waypoint.attachments import ResolvedAttachment
 from waypoint.schemas import SessionRecord
 from waypoint.transports.base import TransportAdapter
 
@@ -23,14 +24,19 @@ class OpenCodeTransport(TransportAdapter):
             )
         )
 
-    async def send_input(self, session: SessionRecord, text: str) -> None:
+    async def send_input(
+        self,
+        session: SessionRecord,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None:
         adapter = await self._plugin._get_or_create_adapter(
             self._runtime,
             session.launch_target_id,
             session.cwd,
             self._effective_args(session),
         )
-        await adapter.send_input(session.id, text)
+        await adapter.send_input(session.id, text, attachments)
 
     async def interrupt(self, session: SessionRecord) -> None:
         adapter = await self._plugin._get_or_create_adapter(

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -80,6 +80,7 @@ class TmuxPlugin:
         supports_thread_discovery=False,
         supports_thread_import=False,
         supports_slash_compact=False,
+        supports_attachments=True,
         model_source=ModelSource.NONE,
         badges={"glyph": "T", "color": "#94a3b8"},
         is_fallback_for_managed_launch=True,

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 
+from waypoint.attachments import ResolvedAttachment, append_attachment_paths
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import (
     SessionInputRequest,
@@ -35,9 +36,17 @@ class TmuxTransport(TransportAdapter):
         state = session.transport_state
         return state.get("tmux_pane") or state.get("tmux_session") or session.id
 
-    async def send_input(self, session: SessionRecord, text: str) -> None:
+    async def send_input(
+        self,
+        session: SessionRecord,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None:
+        # A raw terminal can't carry binary, so attachments degrade to their
+        # host paths appended to the message; the inner CLI reads them itself.
+        payload = append_attachment_paths(text, attachments or [])
         try:
-            await self.adapter.send_input(self._target(session), text, True)
+            await self.adapter.send_input(self._target(session), payload, True)
         except TmuxError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -335,11 +335,27 @@ def sessions_send(
     ctx: typer.Context,
     session_id: Annotated[str, typer.Argument()],
     text: Annotated[str, typer.Argument()],
+    attach: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--attach",
+            "-a",
+            exists=True,
+            dir_okay=False,
+            readable=True,
+            help="Attach a file to the message (repeatable). Images ride "
+            "natively where the backend supports it; other files are delivered "
+            "by host path or inline depending on the backend.",
+        ),
+    ] = None,
 ) -> None:
     """Send a message to a session."""
-    _emit(
-        _settings_from_ctx(ctx), lambda c: {"session": c.send_input(session_id, text)}
-    )
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        ids = [c.upload_attachment(session_id, path)["id"] for path in attach or []]
+        return {"session": c.send_input(session_id, text, attachments=ids or None)}
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @sessions_app.command("interrupt")

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -187,13 +187,30 @@ class WaypointClient:
         ]
         return data
 
+    def upload_attachment(self, session_id: str, path: Path) -> dict[str, Any]:
+        with path.open("rb") as handle:
+            spec: dict[str, Any] = self._request(
+                "POST",
+                f"/api/sessions/{session_id}/attachments",
+                files={"file": (path.name, handle)},
+            ).json()
+        return spec
+
     def send_input(
-        self, session_id: str, text: str, *, submit: bool = True
+        self,
+        session_id: str,
+        text: str,
+        *,
+        submit: bool = True,
+        attachments: list[str] | None = None,
     ) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, "submit": submit}
+        if attachments:
+            body["attachments"] = attachments
         data: dict[str, Any] = self._request(
             "POST",
             f"/api/sessions/{session_id}/input",
-            json={"text": text, "submit": submit},
+            json=body,
         ).json()["session"]
         return data
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -16,6 +16,7 @@ from typing import Any, TextIO
 from fastapi import HTTPException, status
 
 from waypoint.assistant_assets import AssistantAssetError, ensure_assistant_assets
+from waypoint.attachments import AttachmentStore, ResolvedAttachment
 from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
@@ -26,6 +27,7 @@ from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.scheduler import Scheduler
 from waypoint.schemas import (
     AssistantSummary,
+    AttachmentSpec,
     BoardChannel,
     BoardEntry,
     BoardEntryUpdateRequest,
@@ -140,6 +142,7 @@ class SessionRuntime:
     ) -> None:
         self.settings = settings
         self.storage = storage
+        self.attachments = AttachmentStore(settings.attachments_dir)
         self.tmux = TmuxAdapter()
         self.normalizer = TerminalNormalizer()
         self.broadcast = BroadcastHub()
@@ -794,15 +797,38 @@ class SessionRuntime:
         # SSE events; recording the user event afterward would land it last
         # in the transcript. Revert on send failure so the UI doesn't show
         # a stuck "running" state for an unsent message.
+        attachments = self._resolve_attachments(session.id, request.attachments)
         previous_status = session.status
         updated = self.storage.update_session(session.id, status=SessionStatus.RUNNING)
-        await self._record_user_event(session.id, request.text, submit=request.submit)
+        await self._record_user_event(
+            session.id,
+            request.text,
+            submit=request.submit,
+            attachments=[item.spec for item in attachments],
+        )
         try:
-            await transport.send_input(session, request.text)
+            await transport.send_input(session, request.text, attachments or None)
         except Exception:
             self.storage.update_session(session.id, status=previous_status)
             raise
         return updated
+
+    def _resolve_attachments(
+        self, session_id: str, attachment_ids: list[str] | None
+    ) -> list[ResolvedAttachment]:
+        if not attachment_ids:
+            return []
+        resolved: list[ResolvedAttachment] = []
+        for attachment_id in attachment_ids:
+            match = self.attachments.resolve(session_id, attachment_id)
+            if match is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"attachment not found: {attachment_id}",
+                )
+            spec, path = match
+            resolved.append(ResolvedAttachment(spec=spec, path=path))
+        return resolved
 
     async def list_command_completions(
         self,
@@ -1485,8 +1511,13 @@ class SessionRuntime:
         submit: bool,
         status: SessionStatus = SessionStatus.RUNNING,
         extra_metadata: dict[str, Any] | None = None,
+        attachments: list[AttachmentSpec] | None = None,
     ) -> None:
         metadata: dict[str, Any] = {"submit": submit, "status": status}
+        if attachments:
+            metadata["attachments"] = [
+                spec.model_dump(mode="json") for spec in attachments
+            ]
         if extra_metadata:
             metadata.update(extra_metadata)
         event = EventRecord(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -806,6 +806,14 @@ class SessionRuntime:
             submit=request.submit,
             attachments=[item.spec for item in attachments],
         )
+        # The recorded user event now references these blobs, so exempt them
+        # from the orphan sweep; then reap any earlier eager uploads this
+        # session never sent.
+        if attachments:
+            self.attachments.mark_sent(
+                session.id, [item.spec.id for item in attachments]
+            )
+        self.attachments.sweep(session.id, self.settings.attachment_orphan_ttl_seconds)
         try:
             await transport.send_input(session, request.text, attachments or None)
         except Exception:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1182,6 +1182,8 @@ class SessionRuntime:
                 await self.terminate(session_id)
         self._close_structured_log(session_id)
         self.storage.delete_session(session_id)
+        # Reclaim the session's uploaded blobs, which can be large.
+        self.attachments.discard(session_id)
         # Drop this session's blackboard posts along with its record.
         pruned = self.storage.prune_board_for_session(session_id)
         self.registry.plugin_for(session).on_session_deleted(self, session)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -109,6 +109,23 @@ class SessionInputItem(BaseModel):
     path: str | None = None
 
 
+class AttachmentKind(StrEnum):
+    IMAGE = "image"
+    FILE = "file"
+
+
+class AttachmentSpec(BaseModel):
+    # Server-issued handle for an uploaded blob. The frontend receives this
+    # from the upload endpoint and later references the attachment by ``id``
+    # when sending input; the runtime resolves the id back to a host path
+    # server-side, so the absolute path is never trusted from the client.
+    id: str
+    filename: str
+    mime: str
+    size: int
+    kind: AttachmentKind
+
+
 class SessionCompletionsResponse(BaseModel):
     completions: list[CommandCompletion] = Field(default_factory=list)
     refreshing: bool = False
@@ -341,6 +358,9 @@ class SessionInputRequest(BaseModel):
     submit: bool = True
     command: SessionCommandInvocation | None = None
     items: list[SessionInputItem] | None = None
+    # Ids of previously uploaded attachments to deliver alongside the text.
+    # Resolved to host paths server-side; see ``AttachmentSpec``.
+    attachments: list[str] | None = None
 
 
 class SessionApprovalRequest(BaseModel):

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -99,6 +99,10 @@ class Settings(BaseModel):
     default_cwd: str = "~/"
     data_dir: Path = Field(default_factory=default_data_dir)
     sessions_dir_name: str = "sessions"
+    attachments_dir_name: str = "attachments"
+    # Hard ceiling on a single uploaded attachment. Defaults to 25 MiB;
+    # override with ``WAYPOINT_MAX_UPLOAD_BYTES``.
+    max_upload_bytes: int = 25 * 1024 * 1024
     database_name: str = "waypoint.db"
     token_ttl_seconds: int = 60 * 60 * 24 * 30
     stream_poll_interval: float = 1.0
@@ -155,6 +159,10 @@ class Settings(BaseModel):
     def sessions_dir(self) -> Path:
         return self.data_dir / self.sessions_dir_name
 
+    @property
+    def attachments_dir(self) -> Path:
+        return self.data_dir / self.attachments_dir_name
+
     def plugin_config(self, plugin_id: str) -> PluginConfig:
         """Return the validated config for ``plugin_id``.
 
@@ -180,6 +188,7 @@ class Settings(BaseModel):
     def ensure_dirs(self) -> None:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.sessions_dir.mkdir(parents=True, exist_ok=True)
+        self.attachments_dir.mkdir(parents=True, exist_ok=True)
 
 
 def load_settings(config_path_override: Path | None = None) -> Settings:
@@ -230,6 +239,8 @@ def _env_overrides() -> dict[str, Any]:
         overrides["data_dir"] = Path(
             os.path.expandvars(os.environ["WAYPOINT_DATA_DIR"])
         ).expanduser()
+    if "WAYPOINT_MAX_UPLOAD_BYTES" in os.environ:
+        overrides["max_upload_bytes"] = int(os.environ["WAYPOINT_MAX_UPLOAD_BYTES"])
     if "WAYPOINT_CORS_ORIGINS" in os.environ:
         overrides["cors_origins"] = parse_cors_origins(
             os.environ["WAYPOINT_CORS_ORIGINS"]

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -103,6 +103,11 @@ class Settings(BaseModel):
     # Hard ceiling on a single uploaded attachment. Defaults to 25 MiB;
     # override with ``WAYPOINT_MAX_UPLOAD_BYTES``.
     max_upload_bytes: int = 25 * 1024 * 1024
+    # Eager uploads that are never sent (e.g. attached then the page closed
+    # before send) are reaped once their blob is older than this, unless a sent
+    # message references them. Defaults to 24h; override with
+    # ``WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS``.
+    attachment_orphan_ttl_seconds: int = 60 * 60 * 24
     database_name: str = "waypoint.db"
     token_ttl_seconds: int = 60 * 60 * 24 * 30
     stream_poll_interval: float = 1.0
@@ -241,6 +246,10 @@ def _env_overrides() -> dict[str, Any]:
         ).expanduser()
     if "WAYPOINT_MAX_UPLOAD_BYTES" in os.environ:
         overrides["max_upload_bytes"] = int(os.environ["WAYPOINT_MAX_UPLOAD_BYTES"])
+    if "WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS" in os.environ:
+        overrides["attachment_orphan_ttl_seconds"] = int(
+            os.environ["WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS"]
+        )
     if "WAYPOINT_CORS_ORIGINS" in os.environ:
         overrides["cors_origins"] = parse_cors_origins(
             os.environ["WAYPOINT_CORS_ORIGINS"]

--- a/backend/src/waypoint/transports/base.py
+++ b/backend/src/waypoint/transports/base.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 
 from fastapi import HTTPException, status
 
+from waypoint.attachments import ResolvedAttachment
 from waypoint.schemas import SessionRecord
 
 
@@ -19,7 +20,12 @@ class TransportAdapter(ABC):
     supports_resume: bool = False
 
     @abstractmethod
-    async def send_input(self, session: SessionRecord, text: str) -> None: ...
+    async def send_input(
+        self,
+        session: SessionRecord,
+        text: str,
+        attachments: list[ResolvedAttachment] | None = None,
+    ) -> None: ...
 
     @abstractmethod
     async def interrupt(self, session: SessionRecord) -> None: ...

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -1,4 +1,5 @@
 import base64
+import os
 from pathlib import Path
 
 from waypoint.attachments import (
@@ -40,6 +41,73 @@ def test_mime_inferred_from_extension_when_missing(tmp_path: Path) -> None:
     spec = store.save("s", data=b"%PDF-1.4", filename="doc.pdf", content_type=None)
     assert spec.mime == "application/pdf"
     assert spec.kind == AttachmentKind.FILE
+
+
+def test_save_dedupes_colliding_filenames(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    first = store.save(
+        "s", data=b"one", filename="report.pdf", content_type="application/pdf"
+    )
+    second = store.save(
+        "s", data=b"two", filename="report.pdf", content_type="application/pdf"
+    )
+
+    resolved_first = store.resolve("s", first.id)
+    resolved_second = store.resolve("s", second.id)
+    assert resolved_first is not None and resolved_second is not None
+    path_first = resolved_first[1]
+    path_second = resolved_second[1]
+
+    # Blobs are stored under the legible name; the collision gets a `(1)` suffix.
+    assert path_first.name == "report.pdf"
+    assert path_second.name == "report (1).pdf"
+    assert path_first.read_bytes() == b"one"
+    assert path_second.read_bytes() == b"two"
+    # The display filename is unchanged for both.
+    assert first.filename == second.filename == "report.pdf"
+
+
+def test_list_orders_newest_first_and_skips_non_sidecars(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    old = store.save("s", data=b"old", filename="old.txt", content_type="text/plain")
+    new = store.save("s", data=b"new", filename="new.txt", content_type="text/plain")
+    resolved = store.resolve("s", old.id)
+    assert resolved is not None
+    session_dir = resolved[1].parent
+    os.utime(session_dir / f"{old.id}.json", (1000, 1000))
+    os.utime(session_dir / f"{new.id}.json", (2000, 2000))
+    # A stray user-uploaded JSON blob must not be mistaken for a sidecar.
+    (session_dir / "notes.json").write_text('{"hello": 1}', encoding="utf-8")
+
+    listed = store.list("s")
+    assert [spec.id for spec, _ in listed] == [new.id, old.id]
+    assert all(mtime > 0 for _, mtime in listed)
+
+
+def test_list_empty_for_unknown_session(tmp_path: Path) -> None:
+    assert _store(tmp_path).list("never-existed") == []
+
+
+def test_list_empty_after_discard(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    store.discard("s")
+    assert store.list("s") == []
+
+
+def test_delete_removes_blob_and_sidecar(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    resolved = store.resolve("s", spec.id)
+    assert resolved is not None
+    path = resolved[1]
+
+    assert store.delete("s", spec.id) is True
+    assert not path.exists()
+    assert store.resolve("s", spec.id) is None
+    # Deleting again, an unknown id, or a traversal-style id is a no-op.
+    assert store.delete("s", spec.id) is False
+    assert store.delete("s", "../../etc/passwd") is False
 
 
 def test_resolve_rejects_non_uuid_id(tmp_path: Path) -> None:

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -117,3 +117,20 @@ def test_codex_input_items_image_and_file(tmp_path: Path) -> None:
     # ...while the image rides as a native localImage item.
     local_images = [i for i in items if i["type"] == "localImage"]
     assert local_images[0]["path"] == str(image.path)
+
+
+def test_codex_input_items_omits_empty_text(tmp_path: Path) -> None:
+    image = _resolved(tmp_path, "p.png", "image/png", PNG_BYTES)
+    items = _input_items("", [image])
+    # An image-only turn must not emit a blank text item.
+    assert all(item["type"] != "text" for item in items)
+    assert items == [{"type": "localImage", "path": str(image.path)}]
+
+
+def test_discard_removes_session_dir(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    store.discard("s")
+    assert store.resolve("s", spec.id) is None
+    # Discarding a session with no attachments is a no-op, never raises.
+    store.discard("never-existed")

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -1,0 +1,119 @@
+import base64
+from pathlib import Path
+
+from waypoint.attachments import (
+    AttachmentStore,
+    ResolvedAttachment,
+    append_attachment_paths,
+)
+from waypoint.backends.claude_code.adapter import _user_content
+from waypoint.backends.codex.transport import _input_items
+from waypoint.schemas import AttachmentKind, AttachmentSpec
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n fake image bytes"
+
+
+def _store(tmp_path: Path) -> AttachmentStore:
+    return AttachmentStore(tmp_path / "attachments")
+
+
+def test_save_and_resolve_roundtrip(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save(
+        "sess-1", data=PNG_BYTES, filename="shot.png", content_type="image/png"
+    )
+    assert spec.kind == AttachmentKind.IMAGE
+    assert spec.mime == "image/png"
+    assert spec.size == len(PNG_BYTES)
+
+    resolved = store.resolve("sess-1", spec.id)
+    assert resolved is not None
+    resolved_spec, path = resolved
+    assert resolved_spec.id == spec.id
+    assert path.read_bytes() == PNG_BYTES
+    # The blob keeps the original extension so path-based agents can sniff it.
+    assert path.suffix == ".png"
+
+
+def test_mime_inferred_from_extension_when_missing(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=b"%PDF-1.4", filename="doc.pdf", content_type=None)
+    assert spec.mime == "application/pdf"
+    assert spec.kind == AttachmentKind.FILE
+
+
+def test_resolve_rejects_non_uuid_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    # Path-traversal-style ids never match the uuid-hex guard.
+    assert store.resolve("s", "../../etc/passwd") is None
+    assert store.resolve("s", "deadbeef") is None
+
+
+def test_resolve_unknown_returns_none(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    assert store.resolve("s", "0" * 32) is None
+
+
+def test_attachments_are_session_scoped(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save(
+        "owner", data=PNG_BYTES, filename="a.png", content_type="image/png"
+    )
+    assert store.resolve("owner", spec.id) is not None
+    # A different session can't resolve another session's attachment id.
+    assert store.resolve("intruder", spec.id) is None
+
+
+def _resolved(tmp_path: Path, name: str, mime: str, data: bytes) -> ResolvedAttachment:
+    path = tmp_path / name
+    path.write_bytes(data)
+    kind = AttachmentKind.IMAGE if mime.startswith("image/") else AttachmentKind.FILE
+    spec = AttachmentSpec(id="x", filename=name, mime=mime, size=len(data), kind=kind)
+    return ResolvedAttachment(spec=spec, path=path)
+
+
+def test_append_attachment_paths(tmp_path: Path) -> None:
+    att = _resolved(tmp_path, "notes.txt", "text/plain", b"hi")
+    out = append_attachment_paths("look at this", [att])
+    assert "look at this" in out
+    assert str(att.path) in out
+    assert append_attachment_paths("solo", []) == "solo"
+
+
+def test_claude_user_content_plain_without_attachments() -> None:
+    assert _user_content("hello", None) == "hello"
+
+
+def test_claude_user_content_embeds_image_block(tmp_path: Path) -> None:
+    image = _resolved(tmp_path, "p.png", "image/png", PNG_BYTES)
+    content = _user_content("describe", [image])
+    assert isinstance(content, list)
+    text_blocks = [b for b in content if b["type"] == "text"]
+    image_blocks = [b for b in content if b["type"] == "image"]
+    assert text_blocks[0]["text"] == "describe"
+    assert image_blocks[0]["source"]["media_type"] == "image/png"
+    assert image_blocks[0]["source"]["data"] == base64.b64encode(PNG_BYTES).decode()
+
+
+def test_claude_user_content_appends_file_path(tmp_path: Path) -> None:
+    doc = _resolved(tmp_path, "d.pdf", "application/pdf", b"%PDF")
+    content = _user_content("read it", [doc])
+    assert isinstance(content, list)
+    text = next(b["text"] for b in content if b["type"] == "text")
+    assert str(doc.path) in text
+    # A non-image file produces no image block.
+    assert all(b["type"] != "image" for b in content)
+
+
+def test_codex_input_items_image_and_file(tmp_path: Path) -> None:
+    image = _resolved(tmp_path, "p.png", "image/png", PNG_BYTES)
+    doc = _resolved(tmp_path, "d.pdf", "application/pdf", b"%PDF")
+    items = _input_items("hello", [image, doc])
+    text_item = items[0]
+    assert text_item["type"] == "text"
+    assert "hello" in text_item["text"]
+    # The non-image path is appended to the text item...
+    assert str(doc.path) in text_item["text"]
+    # ...while the image rides as a native localImage item.
+    local_images = [i for i in items if i["type"] == "localImage"]
+    assert local_images[0]["path"] == str(image.path)

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -67,7 +67,7 @@ def test_save_dedupes_colliding_filenames(tmp_path: Path) -> None:
     assert first.filename == second.filename == "report.pdf"
 
 
-def test_list_orders_newest_first_and_skips_non_sidecars(tmp_path: Path) -> None:
+def test_entries_orders_newest_first_and_skips_non_sidecars(tmp_path: Path) -> None:
     store = _store(tmp_path)
     old = store.save("s", data=b"old", filename="old.txt", content_type="text/plain")
     new = store.save("s", data=b"new", filename="new.txt", content_type="text/plain")
@@ -79,20 +79,51 @@ def test_list_orders_newest_first_and_skips_non_sidecars(tmp_path: Path) -> None
     # A stray user-uploaded JSON blob must not be mistaken for a sidecar.
     (session_dir / "notes.json").write_text('{"hello": 1}', encoding="utf-8")
 
-    listed = store.list("s")
+    listed = store.entries("s")
     assert [spec.id for spec, _ in listed] == [new.id, old.id]
     assert all(mtime > 0 for _, mtime in listed)
 
 
-def test_list_empty_for_unknown_session(tmp_path: Path) -> None:
-    assert _store(tmp_path).list("never-existed") == []
+def test_entries_empty_for_unknown_session(tmp_path: Path) -> None:
+    assert _store(tmp_path).entries("never-existed") == []
 
 
-def test_list_empty_after_discard(tmp_path: Path) -> None:
+def test_entries_empty_after_discard(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
     store.discard("s")
-    assert store.list("s") == []
+    assert store.entries("s") == []
+
+
+def test_sweep_reaps_unsent_orphan(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    resolved = store.resolve("s", spec.id)
+    assert resolved is not None
+    # Age the blob past the TTL (epoch 1000 is well before now - 60s).
+    os.utime(resolved[1].parent / f"{spec.id}.json", (1000, 1000))
+
+    assert store.sweep("s", ttl_seconds=60) == 1
+    assert store.resolve("s", spec.id) is None
+
+
+def test_sweep_keeps_recent_and_sent(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    recent = store.save("s", data=PNG_BYTES, filename="r.png", content_type="image/png")
+    sent = store.save("s", data=PNG_BYTES, filename="s.png", content_type="image/png")
+    resolved = store.resolve("s", sent.id)
+    assert resolved is not None
+    # The sent blob is old but referenced; the recent blob is young.
+    os.utime(resolved[1].parent / f"{sent.id}.json", (1000, 1000))
+    store.mark_sent("s", [sent.id])
+
+    assert store.sweep("s", ttl_seconds=60) == 0
+    assert store.resolve("s", recent.id) is not None
+    assert store.resolve("s", sent.id) is not None
+
+
+def test_sweep_missing_session_is_noop(tmp_path: Path) -> None:
+    assert _store(tmp_path).sweep("never-existed", ttl_seconds=60) == 0
 
 
 def test_delete_removes_blob_and_sidecar(tmp_path: Path) -> None:

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -8,6 +8,7 @@ import pytest
 from waypoint.backends.claude_code.adapter import (
     ClaudeCliAdapter,
     ClaudeSessionState,
+    _read_stream_line,
     claude_cli_mode_for,
 )
 from waypoint.backends.claude_code.models import (
@@ -1485,3 +1486,19 @@ async def test_replays_real_task_stream_from_production_fixture() -> None:
     assert all(todo["status"] == "completed" for todo in final)
     assert final[0]["content"] == "Write waypoint-subagents skill"
     assert final[-1]["content"] == "Commit 7: hydration fix"
+
+
+@pytest.mark.asyncio
+async def test_read_stream_line_skips_oversized_line() -> None:
+    """A stream-json line longer than the buffer limit (e.g. a base64 tool
+    result echoing a large attachment) must be dropped, not tear down the
+    reader: readline() masks the overrun as a ValueError, so the reader reads
+    via readuntil() and drains the giant line so the next one still parses."""
+    reader = asyncio.StreamReader(limit=64)
+    reader.feed_data(b"x" * 500 + b"\n")
+    reader.feed_data(b'{"type":"result"}\n')
+    reader.feed_eof()
+
+    assert await _read_stream_line(reader, "s", "stdout") is None
+    assert await _read_stream_line(reader, "s", "stdout") == b'{"type":"result"}\n'
+    assert await _read_stream_line(reader, "s", "stdout") == b""

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -98,7 +98,23 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
         if request.url.path == "/api/sessions" and request.method == "POST":
             payload = json.loads(request.content)
             return httpx.Response(200, json={"session": {"id": "new", **payload}})
+        if (
+            request.url.path == "/api/sessions/s1/attachments"
+            and request.method == "POST"
+        ):
+            state["uploads"] = state.get("uploads", 0) + 1
+            return httpx.Response(
+                200,
+                json={
+                    "id": f"att{state['uploads']:032x}",
+                    "filename": "f",
+                    "mime": "text/plain",
+                    "size": 1,
+                    "kind": "file",
+                },
+            )
         if request.url.path == "/api/sessions/s1/input":
+            state["input_body"] = json.loads(request.content)
             return httpx.Response(200, json={"session": {"id": "s1"}})
         if request.url.path.startswith("/api/sessions/") and request.method == "DELETE":
             state["delete_force"] = request.url.params.get("force")
@@ -194,6 +210,32 @@ def test_create_session_posts_payload(
         session = client.create_session(backend="codex", cwd="/tmp", model="gpt-5")
     assert session["backend"] == "codex"
     assert session["model"] == "gpt-5"
+
+
+def test_send_input_uploads_attachments_and_sends_ids(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    one = tmp_path / "a.txt"
+    two = tmp_path / "b.png"
+    one.write_text("x")
+    two.write_bytes(b"y")
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        ids = [client.upload_attachment("s1", p)["id"] for p in (one, two)]
+        client.send_input("s1", "hi", attachments=ids)
+    assert state["uploads"] == 2
+    assert state["input_body"]["attachments"] == ids
+
+
+def test_send_input_omits_attachments_when_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.send_input("s1", "hi")
+    assert "attachments" not in state["input_body"]
 
 
 def test_create_session_passes_spawner_session_id(

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -462,7 +462,9 @@ class _FakeAdapter:
     def __init__(self) -> None:
         self.calls: list[tuple[str, str, tuple[object, ...]]] = []
 
-    async def send_input(self, session_id: str, text: str) -> None:
+    async def send_input(
+        self, session_id: str, text: str, attachments: object = None
+    ) -> None:
         self.calls.append(("send_input", session_id, (text,)))
 
     async def interrupt(self, session_id: str) -> None:

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -945,6 +945,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1133,6 +1142,7 @@ dependencies = [
     { name = "openai-codex" },
     { name = "pydantic" },
     { name = "pyte" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "typer" },
     { name = "uvicorn" },
@@ -1157,6 +1167,7 @@ requires-dist = [
     { name = "openai-codex", directory = "../3rdparty/codex/sdk/python" },
     { name = "pydantic", specifier = ">=2.11.0" },
     { name = "pyte", specifier = ">=0.8.2" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -120,6 +120,20 @@ Returns the `TransportAdapter` (from
 transport class lazily inside the method body — the obvious top-level
 import path triggers a circular import via the package's `__init__`.
 
+`send_input(session, text, attachments=None)` takes an optional
+`list[ResolvedAttachment]` (a `waypoint.attachments.AttachmentSpec` paired
+with its on-disk host path). A backend that sets
+`capabilities.supports_attachments` maps these to its native input form:
+Claude embeds images as base64 content blocks, Codex sends `localImage`
+items, OpenCode adds data-url file parts, and tmux (the universal fallback)
+appends the host paths to the text via
+`waypoint.attachments.append_attachment_paths` so the wrapped CLI reads them.
+Non-image files on image-only protocols degrade to the same path append.
+Uploads are persisted server-side by `AttachmentStore` under
+`settings.attachments_dir`; the runtime resolves the client-supplied ids to
+paths before calling the transport, so a backend never trusts a path from the
+client.
+
 ### Lifecycle
 
 ```python

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -132,7 +132,10 @@ Non-image files on image-only protocols degrade to the same path append.
 Uploads are persisted server-side by `AttachmentStore` under
 `settings.attachments_dir`; the runtime resolves the client-supplied ids to
 paths before calling the transport, so a backend never trusts a path from the
-client.
+client. Blobs are stored under their sanitized original filename,
+de-duplicated with ` (1)`, ` (2)` … on collision, so the paths appended for
+path-based agents stay legible; the server-issued uuid remains the resolution
+key and the only token the client ever sends back.
 
 ### Lifecycle
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7085,6 +7085,16 @@ html[data-theme="light"] .ask-question-note-input {
   background: color-mix(in srgb, var(--danger) 10%, var(--bg-card-soft));
 }
 
+/* A referenced (linked) file reads with a brass edge so it's distinct from a
+   fresh upload. */
+.attachment-chip.is-referenced {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+}
+
+.attachment-chip.is-referenced .attachment-meta {
+  color: var(--accent-strong);
+}
+
 @keyframes attachment-chip-in {
   from {
     opacity: 0;
@@ -7502,6 +7512,7 @@ html[data-theme="light"] .session-files-modal {
   color: var(--muted);
 }
 
+.session-files-add,
 .session-files-open,
 .session-files-delete {
   display: inline-flex;
@@ -7523,9 +7534,19 @@ html[data-theme="light"] .session-files-modal {
     color 120ms ease;
 }
 
+.session-files-add {
+  font-size: 1.15rem;
+}
+
+.session-files-add:hover:not(:disabled),
 .session-files-open:hover {
   background: color-mix(in srgb, var(--accent) 16%, transparent);
   color: var(--accent-strong);
+}
+
+.session-files-add:disabled {
+  color: var(--success);
+  cursor: default;
 }
 
 .session-files-delete:hover {
@@ -7615,6 +7636,40 @@ html[data-theme="light"] .slash-suggestion.active {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* The @-mention popover reuses the slash list, but each row is a file —
+   thumbnail/glyph on the left, name over size on the right. */
+.slash-suggestion.file-mention {
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+}
+
+.file-mention-thumb,
+.file-mention .attachment-tile {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  flex: 0 0 auto;
+}
+
+.file-mention-thumb {
+  object-fit: cover;
+  box-shadow: inset 0 0 0 1px var(--line-strong);
+}
+
+.file-mention-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.file-mention .slash-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text);
 }
 
 .list-actions {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2346,7 +2346,9 @@ html[data-theme="light"] .transcript.codex.agent_output {
  * space via padding so the meta clears the block. */
 .transcript.codex.user_input:has(.markdown-message > *:last-child:not(p)),
 .transcript.codex.agent_output:has(.markdown-message > *:last-child:not(p)),
-.transcript.codex.user_input.ask-answer-summary {
+.transcript.codex.user_input.ask-answer-summary,
+.transcript.codex.user_input:has(.message-attachments),
+.transcript.codex.agent_output:has(.message-attachments) {
   padding-bottom: 30px;
 }
 
@@ -3433,9 +3435,18 @@ html[data-theme="light"] .inline-code {
 .task-dock {
   position: sticky;
   bottom: calc(var(--composer-height, 220px) + 12px);
-  z-index: 7;
+  /* Below the composer (z-index 6) so the composer's upward-opening popovers
+     (model/effort/permission picker, ⋯ menu) — trapped in the composer's
+     stacking context — render above this floating progress strip. */
+  z-index: 5;
   margin-top: -8px;
   pointer-events: none;
+}
+
+/* Expanded, the dock is a modal (full-screen scrim + task list) and must sit
+   above the composer and its popovers. */
+.task-dock.expanded {
+  z-index: 50;
 }
 
 .task-dock-strip {
@@ -6927,15 +6938,29 @@ html[data-theme="light"] .ask-question-note-input {
   display: none;
 }
 
-.composer-attach .glyph {
-  font-size: 0.95rem;
-  line-height: 1;
+.composer-attach {
+  width: 36px;
+  padding: 0;
 }
 
+.composer-attach .glyph {
+  display: inline-flex;
+  line-height: 0;
+}
+
+.composer-attach svg {
+  transition: transform 200ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.composer-attach:hover:not(:disabled) svg {
+  transform: rotate(-14deg) scale(1.06);
+}
+
+/* Drag target: a brass dashed frame that reads as "this surface accepts a drop". */
 .reply-textarea-wrap.is-drag-active,
 .term-compose-field.is-drag-active {
-  outline: 2px dashed var(--accent);
-  outline-offset: 2px;
+  outline: 1.5px dashed color-mix(in srgb, var(--accent) 68%, transparent);
+  outline-offset: 3px;
   border-radius: var(--radius-sm);
 }
 
@@ -6943,64 +6968,189 @@ html[data-theme="light"] .ask-question-note-input {
   position: absolute;
   inset: 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 7px;
   pointer-events: none;
   border-radius: var(--radius-sm);
-  background: color-mix(in srgb, var(--accent) 14%, transparent);
-  color: var(--text-strong);
-  font-size: 0.82rem;
+  background: color-mix(in srgb, var(--accent) 9%, var(--bg-input));
+  backdrop-filter: blur(3px);
+  color: var(--accent-strong);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  animation: drop-hint-in 180ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.composer-drop-glyph {
+  font-size: 1.55rem;
+  line-height: 1;
+  animation: drop-glyph-bob 1.2s ease-in-out infinite;
+}
+
+@keyframes drop-hint-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes drop-glyph-bob {
+  0%,
+  100% {
+    transform: translateY(-2px);
+  }
+  50% {
+    transform: translateY(2px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-drop-glyph,
+  .attachment-chip {
+    animation: none;
+  }
+}
+
+.attachment-tray-wrap {
+  margin-bottom: 8px;
+}
+
+.attachment-tray-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 6px;
+  padding: 0 2px;
+}
+
+.attachment-tray-count {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
   letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.attachment-clear {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 2px 4px;
+  border-radius: var(--radius-sm);
+  transition: color 120ms ease;
+}
+
+.attachment-clear:hover {
+  color: var(--accent-strong);
 }
 
 .attachment-tray {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
-  margin-bottom: 8px;
 }
 
 .attachment-chip {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  max-width: 220px;
-  padding: 4px 6px 4px 4px;
+  gap: 8px;
+  max-width: 240px;
+  padding: 5px 8px 5px 5px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-card-soft);
-  font-size: 0.76rem;
   color: var(--text);
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease;
+  animation: attachment-chip-in 220ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+.attachment-chip:hover {
+  border-color: var(--line-strong);
 }
 
 .attachment-chip.is-error {
   border-color: color-mix(in srgb, var(--danger) 55%, transparent);
-  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 10%, var(--bg-card-soft));
 }
 
-.attachment-thumb {
-  width: 28px;
-  height: 28px;
-  object-fit: cover;
-  border-radius: 4px;
+@keyframes attachment-chip-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+/* A 26px leading square gives image thumbs and file glyphs visual parity. */
+.attachment-thumb,
+.attachment-tile {
+  width: 26px;
+  height: 26px;
+  border-radius: 7px;
   flex: 0 0 auto;
 }
 
-.attachment-glyph {
-  font-size: 0.95rem;
-  opacity: 0.8;
+.attachment-thumb {
+  object-fit: cover;
+  box-shadow: inset 0 0 0 1px var(--line-strong);
+}
+
+.attachment-tile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent-strong);
+}
+
+.attachment-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
 }
 
 .attachment-name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 0.76rem;
+  line-height: 1.25;
+}
+
+.attachment-meta {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.attachment-chip.is-error .attachment-meta {
+  color: var(--danger);
 }
 
 .attachment-spinner {
-  width: 11px;
-  height: 11px;
-  border: 2px solid var(--line-strong);
+  width: 12px;
+  height: 12px;
+  border: 2px solid color-mix(in srgb, var(--accent) 24%, transparent);
   border-top-color: var(--accent);
   border-radius: 50%;
   animation: attachment-spin 0.7s linear infinite;
@@ -7013,63 +7163,385 @@ html[data-theme="light"] .ask-question-note-input {
   }
 }
 
-.attachment-error {
-  color: var(--danger);
-  font-weight: 700;
-}
-
+.attachment-retry,
 .attachment-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  flex: 0 0 auto;
   border: none;
+  border-radius: var(--radius-pill);
   background: transparent;
   color: var(--muted);
   cursor: pointer;
-  font-size: 1rem;
   line-height: 1;
-  padding: 0 2px;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.attachment-remove {
+  font-size: 0.95rem;
+}
+
+.attachment-retry {
+  font-size: 0.85rem;
 }
 
 .attachment-remove:hover {
-  color: var(--text-strong);
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
+  color: var(--danger);
+}
+
+.attachment-retry:hover {
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  color: var(--accent-strong);
+}
+
+/* Phone: a single horizontally-scrollable strip so the tray never balloons
+   vertically on a small screen; the right edge fades to hint overflow. */
+@media (max-width: 720px) {
+  .attachment-tray {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    padding-bottom: 2px;
+    -webkit-overflow-scrolling: touch;
+    -webkit-mask-image: linear-gradient(90deg, #000 calc(100% - 20px), transparent);
+    mask-image: linear-gradient(90deg, #000 calc(100% - 20px), transparent);
+  }
+
+  .attachment-chip {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+    max-width: 76vw;
+  }
+
+  /* Touch has no hover, so keep remove/retry comfortably tappable. */
+  .attachment-retry,
+  .attachment-remove {
+    width: 28px;
+    height: 28px;
+  }
 }
 
 .message-attachments {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
-}
-
-.message-attachment-image {
-  display: inline-flex;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  overflow: hidden;
-}
-
-.message-attachment-image img {
-  max-width: 240px;
-  max-height: 240px;
-  object-fit: contain;
-  display: block;
+  gap: 10px;
+  margin-top: 10px;
 }
 
 .message-attachment-file {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  max-width: 240px;
-  padding: 6px 10px;
+  gap: 10px;
+  max-width: 260px;
+  padding: 8px 12px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-card-soft);
   color: var(--text);
   text-decoration: none;
   font-size: 0.8rem;
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease,
+    transform 140ms ease;
 }
 
 .message-attachment-file:hover {
-  border-color: var(--line-strong);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line-strong));
+  background: var(--bg-card);
   color: var(--text-strong);
+  transform: translateY(-1px);
+}
+
+.message-attachment-file .attachment-tile,
+.message-attachment-thumb {
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+}
+
+.message-attachment-thumb {
+  border-radius: 7px;
+  object-fit: cover;
+  box-shadow: inset 0 0 0 1px var(--line-strong);
+}
+
+.message-attachment-file .attachment-name {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+}
+
+/* ─── Session files manager ─── */
+.term-compose-files .glyph {
+  display: inline-flex;
+  line-height: 0;
+}
+
+.session-files-backdrop {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  padding: 16px;
+}
+
+.session-files-modal {
+  width: 100%;
+  max-width: min(560px, calc(100vw - 32px));
+  max-height: calc(100dvh - 64px);
+  min-height: 0;
+  background: rgba(14, 17, 24, 0.96);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: session-files-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+html[data-theme="light"] .session-files-modal {
+  background: rgba(252, 249, 242, 0.98);
+  box-shadow: 0 16px 48px rgba(60, 45, 20, 0.2);
+}
+
+@keyframes session-files-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.session-files-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.session-files-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.session-files-title > span:first-child {
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+  color: var(--text-strong);
+}
+
+.session-files-count {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.session-files-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.session-files-clear,
+.session-files-cancel,
+.session-files-confirm {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-pill);
+  transition:
+    border-color 120ms ease,
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.session-files-clear:hover,
+.session-files-cancel:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.session-files-confirm {
+  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
+  color: var(--danger);
+}
+
+.session-files-confirm:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--danger) 14%, transparent);
+}
+
+.session-files-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.session-files-close:hover {
+  background: color-mix(in srgb, var(--text) 12%, transparent);
+  color: var(--text-strong);
+}
+
+.session-files-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.session-files-empty {
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.session-files-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.session-files-row:hover {
+  background: var(--bg-card-soft);
+  border-color: var(--line);
+}
+
+.session-files-thumb,
+.session-files-tile {
+  width: 38px;
+  height: 38px;
+  border-radius: 8px;
+  flex: 0 0 auto;
+}
+
+.session-files-thumb {
+  object-fit: cover;
+  box-shadow: inset 0 0 0 1px var(--line-strong);
+}
+
+.session-files-tile {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent-strong);
+}
+
+.session-files-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  flex: 1;
+}
+
+.session-files-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.84rem;
+  color: var(--text);
+}
+
+.session-files-meta {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.session-files-open,
+.session-files-delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  text-decoration: none;
+  font-size: 1rem;
+  line-height: 1;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.session-files-open:hover {
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+  color: var(--accent-strong);
+}
+
+.session-files-delete:hover {
+  background: color-mix(in srgb, var(--danger) 18%, transparent);
+  color: var(--danger);
+}
+
+@media (max-width: 720px) {
+  /* Stay centered like the session switcher — a bottom sheet felt awkward.
+     Only enlarge the touch targets. */
+  .session-files-open,
+  .session-files-delete,
+  .session-files-close {
+    width: 38px;
+    height: 38px;
+  }
 }
 
 .slash-suggestions {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6922,6 +6922,156 @@ html[data-theme="light"] .ask-question-note-input {
   position: relative;
 }
 
+/* ─── Attachments ─── */
+.composer-file-input {
+  display: none;
+}
+
+.composer-attach .glyph {
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.reply-textarea-wrap.is-drag-active,
+.term-compose-field.is-drag-active {
+  outline: 2px dashed var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.composer-drop-hint {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--text-strong);
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+}
+
+.attachment-tray {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+
+.attachment-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  padding: 4px 6px 4px 4px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-soft);
+  font-size: 0.76rem;
+  color: var(--text);
+}
+
+.attachment-chip.is-error {
+  border-color: color-mix(in srgb, var(--danger) 55%, transparent);
+  color: var(--danger);
+}
+
+.attachment-thumb {
+  width: 28px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex: 0 0 auto;
+}
+
+.attachment-glyph {
+  font-size: 0.95rem;
+  opacity: 0.8;
+}
+
+.attachment-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-spinner {
+  width: 11px;
+  height: 11px;
+  border: 2px solid var(--line-strong);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: attachment-spin 0.7s linear infinite;
+  flex: 0 0 auto;
+}
+
+@keyframes attachment-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.attachment-error {
+  color: var(--danger);
+  font-weight: 700;
+}
+
+.attachment-remove {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.attachment-remove:hover {
+  color: var(--text-strong);
+}
+
+.message-attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.message-attachment-image {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.message-attachment-image img {
+  max-width: 240px;
+  max-height: 240px;
+  object-fit: contain;
+  display: block;
+}
+
+.message-attachment-file {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 240px;
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-soft);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 0.8rem;
+}
+
+.message-attachment-file:hover {
+  border-color: var(--line-strong);
+  color: var(--text-strong);
+}
+
 .slash-suggestions {
   position: absolute;
   left: 0;

--- a/frontend/src/components/AttachmentTray.tsx
+++ b/frontend/src/components/AttachmentTray.tsx
@@ -9,17 +9,40 @@ import {
   useState,
 } from "react";
 
-import { attachmentUrl, uploadAttachment } from "@/lib/api";
+import { attachmentUrl, deleteAttachment, uploadAttachment } from "@/lib/api";
 import type { AttachmentSpec, EventRecord } from "@/lib/types";
 
 export interface PendingAttachment {
   localId: string;
   name: string;
+  size: number;
   isImage: boolean;
   status: "uploading" | "done" | "error";
   previewUrl?: string;
   spec?: AttachmentSpec;
   error?: string;
+}
+
+// Human-readable byte size, e.g. "812 B", "2.4 MB".
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value < 10 ? value.toFixed(1) : Math.round(value)} ${units[unit]}`;
+}
+
+// A short type tag for a chip — the uppercased extension, else IMAGE/FILE.
+export function typeTag(filename: string, isImage: boolean): string {
+  const dot = filename.lastIndexOf(".");
+  const ext =
+    dot > 0 && dot < filename.length - 1 ? filename.slice(dot + 1) : "";
+  if (ext && ext.length <= 5) return ext.toUpperCase();
+  return isImage ? "IMAGE" : "FILE";
 }
 
 interface UseAttachmentsArgs {
@@ -59,6 +82,8 @@ export function useAttachments({
   const [items, setItems] = useState<PendingAttachment[]>([]);
   // Object URLs created for image previews, revoked on removal/unmount.
   const urlsRef = useRef<Set<string>>(new Set());
+  // Source File kept per localId so a failed upload can be retried.
+  const filesRef = useRef<Map<string, File>>(new Map());
 
   const revoke = useCallback((url?: string) => {
     if (url && urlsRef.current.has(url)) {
@@ -75,6 +100,36 @@ export function useAttachments({
     };
   }, []);
 
+  const startUpload = useCallback(
+    (localId: string) => {
+      const file = filesRef.current.get(localId);
+      if (!file) return;
+      uploadAttachment(host, token, sessionId, file)
+        .then((spec) => {
+          setItems((prev) =>
+            prev.map((item) =>
+              item.localId === localId
+                ? { ...item, status: "done", spec, error: undefined }
+                : item,
+            ),
+          );
+        })
+        .catch((error) => {
+          const message =
+            error instanceof Error ? error.message : "upload failed";
+          setItems((prev) =>
+            prev.map((item) =>
+              item.localId === localId
+                ? { ...item, status: "error", error: message }
+                : item,
+            ),
+          );
+          onError?.(message);
+        });
+    },
+    [host, token, sessionId, onError],
+  );
+
   const addFiles = useCallback(
     (files: File[]) => {
       const accepted = files.filter((file) => file.size > 0);
@@ -86,60 +141,86 @@ export function useAttachments({
           previewUrl = URL.createObjectURL(file);
           urlsRef.current.add(previewUrl);
         }
+        const localId = `att-${attachmentSeq++}`;
+        filesRef.current.set(localId, file);
         return {
-          localId: `att-${attachmentSeq++}`,
+          localId,
           name: file.name || "file",
+          size: file.size,
           isImage,
           status: "uploading",
           previewUrl,
         };
       });
       setItems((prev) => [...prev, ...pending]);
-      accepted.forEach((file, index) => {
-        const { localId } = pending[index];
-        uploadAttachment(host, token, sessionId, file)
-          .then((spec) => {
-            setItems((prev) =>
-              prev.map((item) =>
-                item.localId === localId
-                  ? { ...item, status: "done", spec }
-                  : item,
-              ),
-            );
-          })
-          .catch((error) => {
-            const message =
-              error instanceof Error ? error.message : "upload failed";
-            setItems((prev) =>
-              prev.map((item) =>
-                item.localId === localId
-                  ? { ...item, status: "error", error: message }
-                  : item,
-              ),
-            );
-            onError?.(message);
-          });
-      });
+      for (const item of pending) startUpload(item.localId);
     },
-    [host, token, sessionId, onError],
+    [startUpload],
+  );
+
+  const retry = useCallback(
+    (localId: string) => {
+      setItems((prev) =>
+        prev.map((item) =>
+          item.localId === localId
+            ? { ...item, status: "uploading", error: undefined }
+            : item,
+        ),
+      );
+      startUpload(localId);
+    },
+    [startUpload],
+  );
+
+  // Free the server blob for any uploaded item so removed eager uploads don't
+  // orphan; best-effort, so a failed cleanup never blocks removal.
+  const discardServerSide = useCallback(
+    (item: PendingAttachment) => {
+      if (item.spec) {
+        void deleteAttachment(host, token, sessionId, item.spec.id).catch(
+          () => {},
+        );
+      }
+      filesRef.current.delete(item.localId);
+    },
+    [host, token, sessionId],
   );
 
   const remove = useCallback(
     (localId: string) => {
       setItems((prev) => {
-        revoke(prev.find((item) => item.localId === localId)?.previewUrl);
+        const target = prev.find((item) => item.localId === localId);
+        if (target) {
+          revoke(target.previewUrl);
+          discardServerSide(target);
+        }
         return prev.filter((item) => item.localId !== localId);
       });
     },
-    [revoke],
+    [revoke, discardServerSide],
   );
 
+  // Reset the tray WITHOUT touching the server — used after a successful send,
+  // where the blobs now belong to the sent message and must survive.
   const clear = useCallback(() => {
     setItems((prev) => {
       for (const item of prev) revoke(item.previewUrl);
+      filesRef.current.clear();
       return [];
     });
   }, [revoke]);
+
+  // Discard every pending attachment AND free its server blob — the explicit
+  // "Clear all" control, only ever used before the message is sent.
+  const discardAll = useCallback(() => {
+    setItems((prev) => {
+      for (const item of prev) {
+        revoke(item.previewUrl);
+        discardServerSide(item);
+      }
+      return [];
+    });
+  }, [revoke, discardServerSide]);
 
   const uploading = items.some((item) => item.status === "uploading");
   const readyIds = items
@@ -150,11 +231,71 @@ export function useAttachments({
     items,
     addFiles,
     remove,
+    retry,
     clear,
+    discardAll,
     uploading,
     readyIds,
     hasItems: items.length > 0,
   };
+}
+
+// Crisp monochrome glyphs that inherit `currentColor`, so they sit alongside
+// the composer's brass action buttons instead of an off-palette emoji.
+export function PaperclipIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 11.5 12 20.5a5 5 0 0 1-7-7l8.5-8.5a3.3 3.3 0 0 1 4.7 4.7l-8.6 8.6a1.7 1.7 0 0 1-2.4-2.4l7.8-7.8" />
+    </svg>
+  );
+}
+
+export function FileIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="15"
+      height="15"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M13 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V9z" />
+      <path d="M13 3v6h6" />
+    </svg>
+  );
+}
+
+// Folder glyph for the "session files" manager entry point.
+export function FilesIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    </svg>
+  );
 }
 
 interface AttachmentContextValue {
@@ -173,49 +314,63 @@ function attachmentSpecsFor(event: EventRecord): AttachmentSpec[] {
   return Array.isArray(raw) ? (raw as AttachmentSpec[]) : [];
 }
 
-// Renders the attachments carried by a user message: images as thumbnails
-// that open full size, other files as labelled links. Both hit the
-// token-scoped serve endpoint.
+// One compact card for a sent message's attachment — a small thumbnail
+// (images) or file glyph plus name and size. A thumbnail whose blob was since
+// deleted via the files manager 404s, so it falls back to the file glyph
+// instead of a broken image. Tapping opens the full file in a new tab.
+function MessageAttachmentCard({
+  spec,
+  url,
+}: {
+  spec: AttachmentSpec;
+  url: string;
+}) {
+  const [imageBroken, setImageBroken] = useState(false);
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
+      className="message-attachment-file"
+      title={spec.filename}
+    >
+      {spec.kind === "image" && !imageBroken ? (
+        // Token-query serve URL — next/image can't optimize it.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          className="message-attachment-thumb"
+          src={url}
+          alt={spec.filename}
+          loading="lazy"
+          onError={() => setImageBroken(true)}
+        />
+      ) : (
+        <span className="attachment-tile" aria-hidden="true">
+          <FileIcon />
+        </span>
+      )}
+      <span className="attachment-body">
+        <span className="attachment-name">{spec.filename}</span>
+        <span className="attachment-meta">{formatBytes(spec.size)}</span>
+      </span>
+    </a>
+  );
+}
+
+// Renders the attachments carried by a user message as compact cards.
 export function MessageAttachments({ event }: { event: EventRecord }) {
   const ctx = useContext(AttachmentContext);
   const specs = attachmentSpecsFor(event);
   if (!ctx || specs.length === 0) return null;
   return (
     <div className="message-attachments">
-      {specs.map((spec) => {
-        const url = attachmentUrl(ctx.host, ctx.token, ctx.sessionId, spec.id);
-        if (spec.kind === "image") {
-          return (
-            <a
-              key={spec.id}
-              href={url}
-              target="_blank"
-              rel="noreferrer"
-              className="message-attachment-image"
-              title={spec.filename}
-            >
-              {/* Token-query serve URL — next/image can't optimize it. */}
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={url} alt={spec.filename} loading="lazy" />
-            </a>
-          );
-        }
-        return (
-          <a
-            key={spec.id}
-            href={url}
-            target="_blank"
-            rel="noreferrer"
-            className="message-attachment-file"
-            title={spec.filename}
-          >
-            <span className="attachment-glyph" aria-hidden="true">
-              ▤
-            </span>
-            <span className="attachment-name">{spec.filename}</span>
-          </a>
-        );
-      })}
+      {specs.map((spec) => (
+        <MessageAttachmentCard
+          key={spec.id}
+          spec={spec}
+          url={attachmentUrl(ctx.host, ctx.token, ctx.sessionId, spec.id)}
+        />
+      ))}
     </div>
   );
 }
@@ -223,52 +378,79 @@ export function MessageAttachments({ event }: { event: EventRecord }) {
 export function AttachmentTray({
   items,
   onRemove,
+  onRetry,
+  onClear,
 }: {
   items: PendingAttachment[];
   onRemove: (localId: string) => void;
+  onRetry: (localId: string) => void;
+  onClear: () => void;
 }) {
   if (items.length === 0) return null;
+  const total = items.reduce((sum, item) => sum + item.size, 0);
+  const summary = `${items.length} file${items.length === 1 ? "" : "s"} · ${formatBytes(total)}`;
   return (
-    <div className="attachment-tray" role="list">
-      {items.map((item) => (
-        <div
-          key={item.localId}
-          className={`attachment-chip is-${item.status}`}
-          role="listitem"
-          title={item.error ?? item.name}
-        >
-          {item.isImage && item.previewUrl ? (
-            // Local object URL preview — next/image can't optimize blob URLs.
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              className="attachment-thumb"
-              src={item.previewUrl}
-              alt={item.name}
-            />
-          ) : (
-            <span className="attachment-glyph" aria-hidden="true">
-              ▤
-            </span>
-          )}
-          <span className="attachment-name">{item.name}</span>
-          {item.status === "uploading" ? (
-            <span className="attachment-spinner" aria-label="Uploading" />
-          ) : null}
-          {item.status === "error" ? (
-            <span className="attachment-error" aria-hidden="true">
-              !
-            </span>
-          ) : null}
-          <button
-            type="button"
-            className="attachment-remove"
-            aria-label={`Remove ${item.name}`}
-            onClick={() => onRemove(item.localId)}
+    <div className="attachment-tray-wrap">
+      <div className="attachment-tray-header">
+        <span className="attachment-tray-count">{summary}</span>
+        <button type="button" className="attachment-clear" onClick={onClear}>
+          Clear all
+        </button>
+      </div>
+      <div className="attachment-tray" role="list">
+        {items.map((item) => (
+          <div
+            key={item.localId}
+            className={`attachment-chip is-${item.status}`}
+            role="listitem"
+            title={item.error ?? item.name}
           >
-            ×
-          </button>
-        </div>
-      ))}
+            {item.isImage && item.previewUrl ? (
+              // Local object URL preview — next/image can't optimize blob URLs.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                className="attachment-thumb"
+                src={item.previewUrl}
+                alt={item.name}
+              />
+            ) : (
+              <span className="attachment-tile" aria-hidden="true">
+                <FileIcon />
+              </span>
+            )}
+            <span className="attachment-body">
+              <span className="attachment-name">{item.name}</span>
+              <span className="attachment-meta">
+                {item.status === "error"
+                  ? "Upload failed"
+                  : `${typeTag(item.name, item.isImage)} · ${formatBytes(item.size)}`}
+              </span>
+            </span>
+            {item.status === "uploading" ? (
+              <span className="attachment-spinner" aria-label="Uploading" />
+            ) : null}
+            {item.status === "error" ? (
+              <button
+                type="button"
+                className="attachment-retry"
+                aria-label={`Retry ${item.name}`}
+                title="Retry upload"
+                onClick={() => onRetry(item.localId)}
+              >
+                ↻
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="attachment-remove"
+              aria-label={`Remove ${item.name}`}
+              onClick={() => onRemove(item.localId)}
+            >
+              ×
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/AttachmentTray.tsx
+++ b/frontend/src/components/AttachmentTray.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+import { attachmentUrl, uploadAttachment } from "@/lib/api";
+import type { AttachmentSpec, EventRecord } from "@/lib/types";
+
+export interface PendingAttachment {
+  localId: string;
+  name: string;
+  isImage: boolean;
+  status: "uploading" | "done" | "error";
+  previewUrl?: string;
+  spec?: AttachmentSpec;
+  error?: string;
+}
+
+interface UseAttachmentsArgs {
+  host: string;
+  token: string;
+  sessionId: string;
+  onError?: (message: string) => void;
+}
+
+let attachmentSeq = 0;
+
+// Extract files from a paste/drop event's DataTransfer, preferring the
+// richer `items` API (which carries pasted screenshots) and falling back to
+// `files` for plain drops.
+export function filesFromDataTransfer(data: DataTransfer | null): File[] {
+  if (!data) return [];
+  const out: File[] = [];
+  if (data.items && data.items.length > 0) {
+    for (const item of Array.from(data.items)) {
+      if (item.kind === "file") {
+        const file = item.getAsFile();
+        if (file) out.push(file);
+      }
+    }
+  } else if (data.files && data.files.length > 0) {
+    out.push(...Array.from(data.files));
+  }
+  return out;
+}
+
+export function useAttachments({
+  host,
+  token,
+  sessionId,
+  onError,
+}: UseAttachmentsArgs) {
+  const [items, setItems] = useState<PendingAttachment[]>([]);
+  // Object URLs created for image previews, revoked on removal/unmount.
+  const urlsRef = useRef<Set<string>>(new Set());
+
+  const revoke = useCallback((url?: string) => {
+    if (url && urlsRef.current.has(url)) {
+      URL.revokeObjectURL(url);
+      urlsRef.current.delete(url);
+    }
+  }, []);
+
+  useEffect(() => {
+    const urls = urlsRef.current;
+    return () => {
+      for (const url of urls) URL.revokeObjectURL(url);
+      urls.clear();
+    };
+  }, []);
+
+  const addFiles = useCallback(
+    (files: File[]) => {
+      const accepted = files.filter((file) => file.size > 0);
+      if (accepted.length === 0) return;
+      const pending = accepted.map<PendingAttachment>((file) => {
+        const isImage = file.type.startsWith("image/");
+        let previewUrl: string | undefined;
+        if (isImage) {
+          previewUrl = URL.createObjectURL(file);
+          urlsRef.current.add(previewUrl);
+        }
+        return {
+          localId: `att-${attachmentSeq++}`,
+          name: file.name || "file",
+          isImage,
+          status: "uploading",
+          previewUrl,
+        };
+      });
+      setItems((prev) => [...prev, ...pending]);
+      accepted.forEach((file, index) => {
+        const { localId } = pending[index];
+        uploadAttachment(host, token, sessionId, file)
+          .then((spec) => {
+            setItems((prev) =>
+              prev.map((item) =>
+                item.localId === localId
+                  ? { ...item, status: "done", spec }
+                  : item,
+              ),
+            );
+          })
+          .catch((error) => {
+            const message =
+              error instanceof Error ? error.message : "upload failed";
+            setItems((prev) =>
+              prev.map((item) =>
+                item.localId === localId
+                  ? { ...item, status: "error", error: message }
+                  : item,
+              ),
+            );
+            onError?.(message);
+          });
+      });
+    },
+    [host, token, sessionId, onError],
+  );
+
+  const remove = useCallback(
+    (localId: string) => {
+      setItems((prev) => {
+        revoke(prev.find((item) => item.localId === localId)?.previewUrl);
+        return prev.filter((item) => item.localId !== localId);
+      });
+    },
+    [revoke],
+  );
+
+  const clear = useCallback(() => {
+    setItems((prev) => {
+      for (const item of prev) revoke(item.previewUrl);
+      return [];
+    });
+  }, [revoke]);
+
+  const uploading = items.some((item) => item.status === "uploading");
+  const readyIds = items
+    .filter((item) => item.status === "done" && item.spec)
+    .map((item) => (item.spec as AttachmentSpec).id);
+
+  return {
+    items,
+    addFiles,
+    remove,
+    clear,
+    uploading,
+    readyIds,
+    hasItems: items.length > 0,
+  };
+}
+
+interface AttachmentContextValue {
+  host: string;
+  token: string;
+  sessionId: string;
+}
+
+// Supplies the credentials needed to build authenticated attachment URLs to
+// the transcript subtree, so individual cards don't have to prop-drill them.
+const AttachmentContext = createContext<AttachmentContextValue | null>(null);
+export const AttachmentContextProvider = AttachmentContext.Provider;
+
+function attachmentSpecsFor(event: EventRecord): AttachmentSpec[] {
+  const raw = event.metadata?.attachments;
+  return Array.isArray(raw) ? (raw as AttachmentSpec[]) : [];
+}
+
+// Renders the attachments carried by a user message: images as thumbnails
+// that open full size, other files as labelled links. Both hit the
+// token-scoped serve endpoint.
+export function MessageAttachments({ event }: { event: EventRecord }) {
+  const ctx = useContext(AttachmentContext);
+  const specs = attachmentSpecsFor(event);
+  if (!ctx || specs.length === 0) return null;
+  return (
+    <div className="message-attachments">
+      {specs.map((spec) => {
+        const url = attachmentUrl(ctx.host, ctx.token, ctx.sessionId, spec.id);
+        if (spec.kind === "image") {
+          return (
+            <a
+              key={spec.id}
+              href={url}
+              target="_blank"
+              rel="noreferrer"
+              className="message-attachment-image"
+              title={spec.filename}
+            >
+              {/* Token-query serve URL — next/image can't optimize it. */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={url} alt={spec.filename} loading="lazy" />
+            </a>
+          );
+        }
+        return (
+          <a
+            key={spec.id}
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="message-attachment-file"
+            title={spec.filename}
+          >
+            <span className="attachment-glyph" aria-hidden="true">
+              ▤
+            </span>
+            <span className="attachment-name">{spec.filename}</span>
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+export function AttachmentTray({
+  items,
+  onRemove,
+}: {
+  items: PendingAttachment[];
+  onRemove: (localId: string) => void;
+}) {
+  if (items.length === 0) return null;
+  return (
+    <div className="attachment-tray" role="list">
+      {items.map((item) => (
+        <div
+          key={item.localId}
+          className={`attachment-chip is-${item.status}`}
+          role="listitem"
+          title={item.error ?? item.name}
+        >
+          {item.isImage && item.previewUrl ? (
+            // Local object URL preview — next/image can't optimize blob URLs.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              className="attachment-thumb"
+              src={item.previewUrl}
+              alt={item.name}
+            />
+          ) : (
+            <span className="attachment-glyph" aria-hidden="true">
+              ▤
+            </span>
+          )}
+          <span className="attachment-name">{item.name}</span>
+          {item.status === "uploading" ? (
+            <span className="attachment-spinner" aria-label="Uploading" />
+          ) : null}
+          {item.status === "error" ? (
+            <span className="attachment-error" aria-hidden="true">
+              !
+            </span>
+          ) : null}
+          <button
+            type="button"
+            className="attachment-remove"
+            aria-label={`Remove ${item.name}`}
+            onClick={() => onRemove(item.localId)}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/AttachmentTray.tsx
+++ b/frontend/src/components/AttachmentTray.tsx
@@ -21,6 +21,10 @@ export interface PendingAttachment {
   previewUrl?: string;
   spec?: AttachmentSpec;
   error?: string;
+  // True when this is a reference to a file the session already stores (added
+  // via the picker or @-mention) rather than a fresh upload — removing it must
+  // not delete the shared blob.
+  referenced?: boolean;
 }
 
 // Human-readable byte size, e.g. "812 B", "2.4 MB".
@@ -172,11 +176,40 @@ export function useAttachments({
     [startUpload],
   );
 
-  // Free the server blob for any uploaded item so removed eager uploads don't
-  // orphan; best-effort, so a failed cleanup never blocks removal.
+  // Add a file the session already stores as a referenced attachment — no
+  // upload. Its id rides on send like any other; the image preview points at
+  // the server's serve endpoint (a plain URL, never an object URL to revoke).
+  const referenceExisting = useCallback(
+    (spec: AttachmentSpec) => {
+      setItems((prev) => {
+        if (prev.some((item) => item.spec?.id === spec.id)) return prev;
+        const isImage = spec.kind === "image";
+        return [
+          ...prev,
+          {
+            localId: `att-${attachmentSeq++}`,
+            name: spec.filename,
+            size: spec.size,
+            isImage,
+            status: "done",
+            spec,
+            referenced: true,
+            previewUrl: isImage
+              ? attachmentUrl(host, token, sessionId, spec.id)
+              : undefined,
+          },
+        ];
+      });
+    },
+    [host, token, sessionId],
+  );
+
+  // Free the server blob for a removed eager upload so it doesn't orphan;
+  // best-effort. A *referenced* item is just a pointer to a file the session
+  // already owns, so removing it must never delete that shared blob.
   const discardServerSide = useCallback(
     (item: PendingAttachment) => {
-      if (item.spec) {
+      if (item.spec && !item.referenced) {
         void deleteAttachment(host, token, sessionId, item.spec.id).catch(
           () => {},
         );
@@ -226,12 +259,19 @@ export function useAttachments({
   const readyIds = items
     .filter((item) => item.status === "done" && item.spec)
     .map((item) => (item.spec as AttachmentSpec).id);
+  // Every session-file id currently in the tray, so a picker can mark files
+  // that are already added.
+  const attachedIds = new Set(
+    items.flatMap((item) => (item.spec ? [item.spec.id] : [])),
+  );
 
   return {
     items,
     addFiles,
     remove,
     retry,
+    referenceExisting,
+    attachedIds,
     clear,
     discardAll,
     uploading,
@@ -401,9 +441,12 @@ export function AttachmentTray({
         {items.map((item) => (
           <div
             key={item.localId}
-            className={`attachment-chip is-${item.status}`}
+            className={`attachment-chip is-${item.status}${item.referenced ? " is-referenced" : ""}`}
             role="listitem"
-            title={item.error ?? item.name}
+            title={
+              item.error ??
+              (item.referenced ? `${item.name} (linked)` : item.name)
+            }
           >
             {item.isImage && item.previewUrl ? (
               // Local object URL preview — next/image can't optimize blob URLs.
@@ -423,7 +466,7 @@ export function AttachmentTray({
               <span className="attachment-meta">
                 {item.status === "error"
                   ? "Upload failed"
-                  : `${typeTag(item.name, item.isImage)} · ${formatBytes(item.size)}`}
+                  : `${item.referenced ? "↪ " : ""}${typeTag(item.name, item.isImage)} · ${formatBytes(item.size)}`}
               </span>
             </span>
             {item.status === "uploading" ? (

--- a/frontend/src/components/AttachmentTray.tsx
+++ b/frontend/src/components/AttachmentTray.tsx
@@ -88,6 +88,11 @@ export function useAttachments({
   const urlsRef = useRef<Set<string>>(new Set());
   // Source File kept per localId so a failed upload can be retried.
   const filesRef = useRef<Map<string, File>>(new Map());
+  // Unsent, non-referenced uploaded blob ids — the orphans to free if the user
+  // leaves before sending. Kept in a ref so the unmount/pagehide handler sees
+  // the latest set without re-subscribing.
+  const orphanRef = useRef<string[]>([]);
+  const credsRef = useRef({ host, token, sessionId });
 
   const revoke = useCallback((url?: string) => {
     if (url && urlsRef.current.has(url)) {
@@ -101,6 +106,37 @@ export function useAttachments({
     return () => {
       for (const url of urls) URL.revokeObjectURL(url);
       urls.clear();
+    };
+  }, []);
+
+  useEffect(() => {
+    credsRef.current = { host, token, sessionId };
+    orphanRef.current = items
+      .filter((item) => item.spec && !item.referenced)
+      .map((item) => (item.spec as AttachmentSpec).id);
+  }, [items, host, token, sessionId]);
+
+  // Eager uploads leak a server blob if the page closes before send. Free the
+  // unsent ones on unmount (SPA navigation / view switch) and on page hide
+  // (hard close) with keepalive so the request survives teardown; a sent turn
+  // clears the tray first, so its blobs are never in `orphanRef`. The server's
+  // TTL sweep is the backstop for crashes / offline.
+  useEffect(() => {
+    const flush = () => {
+      const { host: h, token: t, sessionId: s } = credsRef.current;
+      for (const id of orphanRef.current) {
+        void fetch(`${h}/api/sessions/${s}/attachments/${id}`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${t}` },
+          keepalive: true,
+        }).catch(() => {});
+      }
+      orphanRef.current = [];
+    };
+    window.addEventListener("pagehide", flush);
+    return () => {
+      window.removeEventListener("pagehide", flush);
+      flush();
     };
   }, []);
 

--- a/frontend/src/components/FileMentions.tsx
+++ b/frontend/src/components/FileMentions.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { forwardRef, MutableRefObject } from "react";
+
+import { FileIcon, formatBytes, typeTag } from "@/components/AttachmentTray";
+import { attachmentUrl } from "@/lib/api";
+import type { SessionAttachment } from "@/lib/types";
+
+interface FileMentionsProps {
+  host: string;
+  token: string;
+  sessionId: string;
+  mentions: ReadonlyArray<SessionAttachment>;
+  activeIndex: number;
+  itemRefs: MutableRefObject<Array<HTMLButtonElement | null>>;
+  onApply: (index: number) => void;
+  onHover: (index: number) => void;
+}
+
+// The `@`-mention popover: session files matching the typed query, each shown
+// with a thumbnail/glyph, name, and size. Reuses the slash-suggestion styling.
+export const FileMentions = forwardRef<HTMLUListElement, FileMentionsProps>(
+  function FileMentions(
+    { host, token, sessionId, mentions, activeIndex, itemRefs, onApply, onHover },
+    ref,
+  ) {
+    return (
+      <ul className="slash-suggestions file-mentions" role="listbox" ref={ref}>
+        {mentions.map((file, index) => {
+          const url = attachmentUrl(host, token, sessionId, file.id);
+          return (
+            <li key={file.id}>
+              <button
+                ref={(node) => {
+                  itemRefs.current[index] = node;
+                }}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                className={`slash-suggestion file-mention ${index === activeIndex ? "active" : ""}`}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  onApply(index);
+                }}
+                onMouseEnter={() => onHover(index)}
+              >
+                {file.kind === "image" ? (
+                  // Token-query serve URL — next/image can't optimize it.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    className="file-mention-thumb"
+                    src={url}
+                    alt={file.filename}
+                    loading="lazy"
+                  />
+                ) : (
+                  <span className="attachment-tile" aria-hidden="true">
+                    <FileIcon />
+                  </span>
+                )}
+                <span className="file-mention-body">
+                  <span className="slash-name">{file.filename}</span>
+                  <span className="slash-desc">
+                    {typeTag(file.filename, file.kind === "image")} ·{" "}
+                    {formatBytes(file.size)}
+                  </span>
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  },
+);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1748,6 +1748,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onTerminate={terminate}
           onRemoveFromList={removeFromList}
           onSwitchSession={openSwitcher}
+          onError={setError}
         />
       ) : null}
       {!terminalOnly && pendingApproval ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -59,6 +59,7 @@ import {
   type TerminalSubmitResult,
 } from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
+import { useFileMentions } from "@/lib/use-file-mentions";
 import {
   isPlanEvent,
   itemIdForEvent,
@@ -79,6 +80,7 @@ import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
+import { FileMentions } from "@/components/FileMentions";
 import { type XTerminalHandle } from "@/components/XTerminal";
 import { ApprovalRequestCard, PlanApprovalCard } from "@/components/ApprovalCard";
 import {
@@ -293,7 +295,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => ({ host, token, sessionId }),
     [host, token, sessionId],
   );
-  const [filesOpen, setFilesOpen] = useState(false);
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
   // The todo-event sequence the user last dismissed from the progress dock.
@@ -1751,7 +1752,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onTerminate={terminate}
           onRemoveFromList={removeFromList}
           onSwitchSession={openSwitcher}
-          onOpenFiles={() => setFilesOpen(true)}
           onError={setError}
         />
       ) : null}
@@ -2036,20 +2036,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           attachmentsEnabled={
             session ? supportsAttachments(session.backend, catalog) : false
           }
-          onOpenFiles={() => setFilesOpen(true)}
           onTerminate={terminate}
           onError={setError}
           assistant={assistant}
           assistantControls={assistantControls}
         />
       ) : null}
-      <SessionFilesPanel
-        host={host}
-        token={token}
-        sessionId={sessionId}
-        open={filesOpen}
-        onClose={() => setFilesOpen(false)}
-      />
     </section>
   );
 }
@@ -2105,7 +2097,6 @@ interface ReplyComposerProps {
     attachments?: string[],
   ) => Promise<boolean>;
   attachmentsEnabled: boolean;
-  onOpenFiles: () => void;
   onTerminate: () => void | Promise<void>;
   onError: (message: string) => void;
   assistant: boolean;
@@ -2155,7 +2146,6 @@ const ReplyComposer = memo(function ReplyComposer({
   onSwitchSession,
   onSend,
   attachmentsEnabled,
-  onOpenFiles,
   onTerminate,
   onError,
   assistant,
@@ -2165,6 +2155,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const attachments = useAttachments({ host, token, sessionId, onError });
+  const [filesOpen, setFilesOpen] = useState(false);
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
@@ -2229,6 +2220,17 @@ const ReplyComposer = memo(function ReplyComposer({
     draft,
     setDraft,
     enabled: supportsSlash,
+    textareaRef,
+  });
+
+  const mentions = useFileMentions({
+    host,
+    token,
+    sessionId,
+    draft,
+    setDraft,
+    enabled: attachmentsEnabled,
+    onReference: attachments.referenceExisting,
     textareaRef,
   });
 
@@ -2420,6 +2422,9 @@ const ReplyComposer = memo(function ReplyComposer({
         const nextIndex = (currentIndex + 1) % permissionModeOptions.length;
         void onModeChange(permissionModeOptions[nextIndex].id);
       }
+      return;
+    }
+    if (mentions.handleKey(event)) {
       return;
     }
     if (handleSuggestionKey(event)) {
@@ -2904,6 +2909,18 @@ const ReplyComposer = memo(function ReplyComposer({
             onHover={setActiveIndex}
           />
         ) : null}
+        {mentions.open ? (
+          <FileMentions
+            host={host}
+            token={token}
+            sessionId={sessionId}
+            mentions={mentions.mentions}
+            activeIndex={mentions.activeIndex}
+            itemRefs={mentions.itemRefs}
+            onApply={mentions.apply}
+            onHover={mentions.setActiveIndex}
+          />
+        ) : null}
       </div>
       <div className="composer-actions">
         <button
@@ -3036,7 +3053,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       className="composer-overflow-item"
                       onClick={() => {
                         setOverflowOpen(false);
-                        onOpenFiles();
+                        setFilesOpen(true);
                       }}
                     >
                       <span className="glyph">▤</span>
@@ -3157,6 +3174,17 @@ const ReplyComposer = memo(function ReplyComposer({
           ) : null}
         </div>
       </div>
+      {attachmentsEnabled ? (
+        <SessionFilesPanel
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          open={filesOpen}
+          onClose={() => setFilesOpen(false)}
+          onReference={attachments.referenceExisting}
+          referencedIds={attachments.attachedIds}
+        />
+      ) : null}
     </section>
   );
 });

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -72,8 +72,10 @@ import {
   AttachmentContextProvider,
   AttachmentTray,
   filesFromDataTransfer,
+  PaperclipIcon,
   useAttachments,
 } from "@/components/AttachmentTray";
+import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -291,6 +293,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => ({ host, token, sessionId }),
     [host, token, sessionId],
   );
+  const [filesOpen, setFilesOpen] = useState(false);
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
   // The todo-event sequence the user last dismissed from the progress dock.
@@ -1748,6 +1751,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onTerminate={terminate}
           onRemoveFromList={removeFromList}
           onSwitchSession={openSwitcher}
+          onOpenFiles={() => setFilesOpen(true)}
           onError={setError}
         />
       ) : null}
@@ -2032,12 +2036,20 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           attachmentsEnabled={
             session ? supportsAttachments(session.backend, catalog) : false
           }
+          onOpenFiles={() => setFilesOpen(true)}
           onTerminate={terminate}
           onError={setError}
           assistant={assistant}
           assistantControls={assistantControls}
         />
       ) : null}
+      <SessionFilesPanel
+        host={host}
+        token={token}
+        sessionId={sessionId}
+        open={filesOpen}
+        onClose={() => setFilesOpen(false)}
+      />
     </section>
   );
 }
@@ -2093,6 +2105,7 @@ interface ReplyComposerProps {
     attachments?: string[],
   ) => Promise<boolean>;
   attachmentsEnabled: boolean;
+  onOpenFiles: () => void;
   onTerminate: () => void | Promise<void>;
   onError: (message: string) => void;
   assistant: boolean;
@@ -2142,6 +2155,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onSwitchSession,
   onSend,
   attachmentsEnabled,
+  onOpenFiles,
   onTerminate,
   onError,
   assistant,
@@ -2854,7 +2868,12 @@ const ReplyComposer = memo(function ReplyComposer({
         onDrop={handleDrop}
       >
         {attachmentsEnabled ? (
-          <AttachmentTray items={attachments.items} onRemove={attachments.remove} />
+          <AttachmentTray
+            items={attachments.items}
+            onRemove={attachments.remove}
+            onRetry={attachments.retry}
+            onClear={attachments.discardAll}
+          />
         ) : null}
         <textarea
           ref={textareaRef}
@@ -2871,7 +2890,8 @@ const ReplyComposer = memo(function ReplyComposer({
         />
         {dragActive ? (
           <div className="composer-drop-hint" aria-hidden="true">
-            Drop files to attach
+            <span className="composer-drop-glyph">⤓</span>
+            <span>Drop to attach</span>
           </div>
         ) : null}
         {suggestionsOpen ? (
@@ -2886,31 +2906,6 @@ const ReplyComposer = memo(function ReplyComposer({
         ) : null}
       </div>
       <div className="composer-actions">
-        {attachmentsEnabled ? (
-          <>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              className="composer-file-input"
-              onChange={addFilesFromInput}
-              aria-hidden="true"
-              tabIndex={-1}
-            />
-            <button
-              className="ghost composer-attach"
-              onClick={() => fileInputRef.current?.click()}
-              type="button"
-              disabled={disabled}
-              title="Attach files"
-              aria-label="Attach files"
-            >
-              <span className="glyph" aria-hidden>
-                ⎙
-              </span>
-            </button>
-          </>
-        ) : null}
         <button
           className="primary send"
           onClick={() => void handleSend()}
@@ -2933,6 +2928,31 @@ const ReplyComposer = memo(function ReplyComposer({
         >
           Interrupt
         </button>
+        {attachmentsEnabled ? (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="composer-file-input"
+              onChange={addFilesFromInput}
+              aria-hidden="true"
+              tabIndex={-1}
+            />
+            <button
+              className="ghost composer-attach"
+              onClick={() => fileInputRef.current?.click()}
+              type="button"
+              disabled={disabled}
+              title="Attach files"
+              aria-label="Attach files"
+            >
+              <span className="glyph" aria-hidden>
+                <PaperclipIcon />
+              </span>
+            </button>
+          </>
+        ) : null}
         {canResume ? (
           <button
             className="ghost"
@@ -3009,6 +3029,20 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">⇄</span>
                     Switch session…
                   </button>
+                  {attachmentsEnabled ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="composer-overflow-item"
+                      onClick={() => {
+                        setOverflowOpen(false);
+                        onOpenFiles();
+                      }}
+                    >
+                      <span className="glyph">▤</span>
+                      Files…
+                    </button>
+                  ) : null}
                   {hasToolRuns ? (
                     <button
                       type="button"

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2,6 +2,9 @@
 
 import { useRouter } from "next/navigation";
 import {
+  ChangeEvent,
+  ClipboardEvent,
+  DragEvent,
   KeyboardEvent,
   memo,
   startTransition,
@@ -41,6 +44,7 @@ import {
   humaniseBackend,
   permissionModesFor,
   supportsApprovalNote,
+  supportsAttachments,
   supportsPlanApproval,
   supportsReattachAfterExit,
   supportsResume,
@@ -64,6 +68,12 @@ import {
 } from "@/lib/events";
 import { useTheme } from "@/lib/theme";
 import { formatRelativeTime } from "@/lib/usage";
+import {
+  AttachmentContextProvider,
+  AttachmentTray,
+  filesFromDataTransfer,
+  useAttachments,
+} from "@/components/AttachmentTray";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -277,6 +287,10 @@ const RECONNECT_MAX_MS = 15000;
 export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant = false, assistantControls = null }: SessionDetailProps) {
   const router = useRouter();
   const catalog = useBackendCatalog(host || null, token || null, null);
+  const attachmentContext = useMemo(
+    () => ({ host, token, sessionId }),
+    [host, token, sessionId],
+  );
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
   // The todo-event sequence the user last dismissed from the progress dock.
@@ -938,23 +952,27 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const submitInput = useCallback(async (
     text: string,
     command?: SessionCommandInvocation,
+    attachments?: string[],
   ) => {
-    if (!text.trim()) {
+    if (!text.trim() && !attachments?.length) {
       return false;
     }
 
     // The persistent assistant isn't a launchpad — `/new` and `/fork` would
     // spawn stray managed sessions, so let them flow to the agent as text.
-    const handled = await runFrontendControlCommand(text, {
-      allowFork: !assistant,
-      allowNew: !assistant,
-    });
-    if (handled !== null) {
-      return handled === "handled";
+    // Attachment-bearing turns are never control commands, so skip the check.
+    if (!attachments?.length) {
+      const handled = await runFrontendControlCommand(text, {
+        allowFork: !assistant,
+        allowNew: !assistant,
+      });
+      if (handled !== null) {
+        return handled === "handled";
+      }
     }
 
     try {
-      await sendInput(host, token, sessionId, text, command);
+      await sendInput(host, token, sessionId, text, command, attachments);
       return true;
     } catch (sendError) {
       if (isAuthError(sendError)) {
@@ -967,7 +985,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   }, [runFrontendControlCommand, handleAuthFailure, host, token, sessionId, assistant]);
 
   const onSendWithOptimistic = useCallback(
-    async (text: string, command?: SessionCommandInvocation) => {
+    async (
+      text: string,
+      command?: SessionCommandInvocation,
+      attachments?: string[],
+    ) => {
       const tempId = Math.random().toString(36).slice(2);
       const ts = new Date().toISOString();
       setOptimisticMessages((prev) => [...prev, { tempId, text, ts, confirmed: false }]);
@@ -996,7 +1018,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
             return false;
           }
         }
-        return await submitInput(text, command);
+        return await submitInput(text, command, attachments);
       } finally {
         setOptimisticMessages((prev) => prev.filter((m) => m.tempId !== tempId));
       }
@@ -1374,6 +1396,17 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     return "ok";
   }, [runFrontendControlCommand]);
 
+  // Attachment-bearing terminal submits go over HTTP, not the terminal WS:
+  // handle_input routes them through the tmux transport, which appends the
+  // host file paths to the message so the wrapped CLI can read them.
+  const handleTerminalSubmitWithAttachments = useCallback(
+    async (text: string, attachmentIds: string[]): Promise<TerminalSubmitResult> => {
+      const sent = await submitInput(text, undefined, attachmentIds);
+      return sent ? "ok" : "command-error";
+    },
+    [submitInput],
+  );
+
   const requestPaste = useCallback(async () => {
     setError("");
     if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
@@ -1571,6 +1604,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         </div>
       ) : null}
       {session && !terminalOnly && activeView === "chat" ? (
+        <AttachmentContextProvider value={attachmentContext}>
         <section className="stack transcript-stack">
           {hasOlderEvents ? (
             <div className="transcript-load-older">
@@ -1675,6 +1709,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
               ))
             : null}
         </section>
+        </AttachmentContextProvider>
       ) : null}
       {session && activeView === "terminal" ? (
         <SessionTerminalView
@@ -1699,6 +1734,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onRateLimitRefresh={handleRateLimitRefresh}
           onTerminalInput={handleTerminalInput}
           onTerminalSubmit={handleTerminalSubmit}
+          onTerminalSubmitWithAttachments={handleTerminalSubmitWithAttachments}
+          attachmentsEnabled={
+            session ? supportsAttachments(session.backend, catalog) : false
+          }
           onRequestPaste={requestPaste}
           onTerminalResize={handleTerminalResize}
           onTerminalScrollChip={handleTerminalScrollChip}
@@ -1989,6 +2028,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onResume={resumeSession}
           onSwitchSession={openSwitcher}
           onSend={onSendWithOptimistic}
+          attachmentsEnabled={
+            session ? supportsAttachments(session.backend, catalog) : false
+          }
           onTerminate={terminate}
           onError={setError}
           assistant={assistant}
@@ -2044,7 +2086,12 @@ interface ReplyComposerProps {
   onReattach: () => void | Promise<void>;
   onResume: () => void | Promise<void>;
   onSwitchSession: () => void;
-  onSend: (text: string, command?: SessionCommandInvocation) => Promise<boolean>;
+  onSend: (
+    text: string,
+    command?: SessionCommandInvocation,
+    attachments?: string[],
+  ) => Promise<boolean>;
+  attachmentsEnabled: boolean;
   onTerminate: () => void | Promise<void>;
   onError: (message: string) => void;
   assistant: boolean;
@@ -2093,12 +2140,16 @@ const ReplyComposer = memo(function ReplyComposer({
   onResume,
   onSwitchSession,
   onSend,
+  attachmentsEnabled,
   onTerminate,
   onError,
   assistant,
   assistantControls,
 }: ReplyComposerProps) {
   const [draft, setDraft] = useState("");
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const attachments = useAttachments({ host, token, sessionId, onError });
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
@@ -2279,7 +2330,10 @@ const ReplyComposer = memo(function ReplyComposer({
 
   async function handleSend() {
     const text = draft.trim();
-    if (!text) {
+    const attachmentIds = attachments.readyIds;
+    // Allow an attachment-only turn, but never send while an upload is
+    // still in flight (its id wouldn't be in readyIds yet).
+    if ((!text && attachmentIds.length === 0) || attachments.uploading) {
       return;
     }
     setSending(true);
@@ -2287,14 +2341,56 @@ const ReplyComposer = memo(function ReplyComposer({
     const invocation = selectedCommandInvocation(text);
     resetCompletions();
     try {
-      const sent = await onSend(text, invocation);
-      if (!sent) {
+      const sent = await onSend(
+        text,
+        invocation,
+        attachmentIds.length ? attachmentIds : undefined,
+      );
+      if (sent) {
+        attachments.clear();
+      } else {
         setDraft(text);
       }
     } finally {
       setSending(false);
     }
   }
+
+  const addFilesFromInput = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files ? Array.from(event.target.files) : [];
+    if (files.length) attachments.addFiles(files);
+    event.target.value = "";
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!attachmentsEnabled) return;
+    const files = filesFromDataTransfer(event.clipboardData);
+    if (files.length === 0) return;
+    // Pasted files (e.g. a screenshot) become attachments; let plain-text
+    // pastes fall through to the textarea.
+    event.preventDefault();
+    attachments.addFiles(files);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    if (!attachmentsEnabled) return;
+    event.preventDefault();
+    setDragActive(false);
+    const files = filesFromDataTransfer(event.dataTransfer);
+    if (files.length) attachments.addFiles(files);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!attachmentsEnabled) return;
+    if (!Array.from(event.dataTransfer.types).includes("Files")) return;
+    event.preventDefault();
+    setDragActive(true);
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+    setDragActive(false);
+  };
 
   function handleDraftKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
     if (event.nativeEvent.isComposing) {
@@ -2750,7 +2846,15 @@ const ReplyComposer = memo(function ReplyComposer({
           />
         </div>
       </div>
-      <div className="reply-textarea-wrap">
+      <div
+        className={`reply-textarea-wrap${dragActive ? " is-drag-active" : ""}`}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {attachmentsEnabled ? (
+          <AttachmentTray items={attachments.items} onRemove={attachments.remove} />
+        ) : null}
         <textarea
           ref={textareaRef}
           className="composer-textarea"
@@ -2759,10 +2863,16 @@ const ReplyComposer = memo(function ReplyComposer({
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
           onKeyDown={handleDraftKeyDown}
+          onPaste={handlePaste}
           disabled={disabled}
           placeholder={placeholder}
           aria-label="Reply"
         />
+        {dragActive ? (
+          <div className="composer-drop-hint" aria-hidden="true">
+            Drop files to attach
+          </div>
+        ) : null}
         {suggestionsOpen ? (
           <CommandSuggestions
             ref={suggestionsRef}
@@ -2775,11 +2885,41 @@ const ReplyComposer = memo(function ReplyComposer({
         ) : null}
       </div>
       <div className="composer-actions">
+        {attachmentsEnabled ? (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              className="composer-file-input"
+              onChange={addFilesFromInput}
+              aria-hidden="true"
+              tabIndex={-1}
+            />
+            <button
+              className="ghost composer-attach"
+              onClick={() => fileInputRef.current?.click()}
+              type="button"
+              disabled={disabled}
+              title="Attach files"
+              aria-label="Attach files"
+            >
+              <span className="glyph" aria-hidden>
+                ⎙
+              </span>
+            </button>
+          </>
+        ) : null}
         <button
           className="primary send"
           onClick={() => void handleSend()}
           type="button"
-          disabled={disabled || sending || !draft.trim()}
+          disabled={
+            disabled ||
+            sending ||
+            attachments.uploading ||
+            (!draft.trim() && attachments.readyIds.length === 0)
+          }
         >
           {sending ? "Sending…" : "Send"}
         </button>

--- a/frontend/src/components/SessionFilesPanel.tsx
+++ b/frontend/src/components/SessionFilesPanel.tsx
@@ -19,6 +19,11 @@ interface SessionFilesPanelProps {
   sessionId: string;
   open: boolean;
   onClose: () => void;
+  // When set, each row offers an "add to message" action that references the
+  // file in the composer (no re-upload). `referencedIds` are files already in
+  // the tray, shown as added.
+  onReference?: (spec: SessionAttachment) => void;
+  referencedIds?: ReadonlySet<string>;
 }
 
 // Session-wide files manager: lists every attachment a session has stored and
@@ -30,6 +35,8 @@ export function SessionFilesPanel({
   sessionId,
   open,
   onClose,
+  onReference,
+  referencedIds,
 }: SessionFilesPanelProps) {
   const [items, setItems] = useState<SessionAttachment[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -194,6 +201,22 @@ export function SessionFilesPanel({
                     )}
                   </span>
                 </div>
+                {onReference ? (
+                  <button
+                    type="button"
+                    className="session-files-add"
+                    disabled={referencedIds?.has(it.id)}
+                    aria-label={`Add ${it.filename} to message`}
+                    title={
+                      referencedIds?.has(it.id)
+                        ? "Added to message"
+                        : "Add to message"
+                    }
+                    onClick={() => onReference(it)}
+                  >
+                    {referencedIds?.has(it.id) ? "✓" : "+"}
+                  </button>
+                ) : null}
                 <a
                   className="session-files-open"
                   href={url}

--- a/frontend/src/components/SessionFilesPanel.tsx
+++ b/frontend/src/components/SessionFilesPanel.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { FileIcon, formatBytes, typeTag } from "@/components/AttachmentTray";
+import {
+  attachmentUrl,
+  deleteAllAttachments,
+  deleteAttachment,
+  fetchSessionAttachments,
+} from "@/lib/api";
+import type { SessionAttachment } from "@/lib/types";
+import { formatRelativeTime } from "@/lib/usage";
+
+interface SessionFilesPanelProps {
+  host: string;
+  token: string;
+  sessionId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+// Session-wide files manager: lists every attachment a session has stored and
+// lets the user open, delete, or clear them. Mirrors SessionSwitcher's portal
+// overlay (backdrop dismiss + Escape).
+export function SessionFilesPanel({
+  host,
+  token,
+  sessionId,
+  open,
+  onClose,
+}: SessionFilesPanelProps) {
+  const [items, setItems] = useState<SessionAttachment[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      setItems(await fetchSessionAttachments(host, token, sessionId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load files");
+      setItems([]);
+    }
+  }, [host, token, sessionId]);
+
+  useEffect(() => {
+    if (!open) return;
+    setItems(null);
+    setConfirmingClear(false);
+    void load();
+  }, [open, load]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const removeOne = useCallback(
+    async (id: string) => {
+      setItems((prev) => (prev ? prev.filter((it) => it.id !== id) : prev));
+      try {
+        await deleteAttachment(host, token, sessionId, id);
+      } catch {
+        void load(); // Resync on failure rather than lie about the state.
+      }
+    },
+    [host, token, sessionId, load],
+  );
+
+  const clearAll = useCallback(async () => {
+    setBusy(true);
+    try {
+      await deleteAllAttachments(host, token, sessionId);
+      setItems([]);
+      setConfirmingClear(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete files");
+    } finally {
+      setBusy(false);
+    }
+  }, [host, token, sessionId]);
+
+  if (!open || typeof document === "undefined") return null;
+
+  const total = (items ?? []).reduce((sum, it) => sum + it.size, 0);
+  const summary =
+    items === null
+      ? "Loading…"
+      : `${items.length} file${items.length === 1 ? "" : "s"} · ${formatBytes(total)}`;
+
+  return createPortal(
+    <div
+      className="session-files-backdrop"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="session-files-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Session files"
+      >
+        <div className="session-files-header">
+          <div className="session-files-title">
+            <span>Session files</span>
+            <span className="session-files-count">{summary}</span>
+          </div>
+          <div className="session-files-header-actions">
+            {items && items.length > 0 ? (
+              confirmingClear ? (
+                <>
+                  <button
+                    type="button"
+                    className="session-files-confirm"
+                    disabled={busy}
+                    onClick={() => void clearAll()}
+                  >
+                    {busy ? "Deleting…" : "Delete all?"}
+                  </button>
+                  <button
+                    type="button"
+                    className="session-files-cancel"
+                    onClick={() => setConfirmingClear(false)}
+                  >
+                    Cancel
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  className="session-files-clear"
+                  onClick={() => setConfirmingClear(true)}
+                >
+                  Delete all
+                </button>
+              )
+            ) : null}
+            <button
+              type="button"
+              className="session-files-close"
+              aria-label="Close"
+              onClick={onClose}
+            >
+              ×
+            </button>
+          </div>
+        </div>
+
+        <div className="session-files-list">
+          {error ? <div className="session-files-empty">{error}</div> : null}
+          {items === null && !error ? (
+            <div className="session-files-empty">Loading files…</div>
+          ) : null}
+          {items !== null && items.length === 0 && !error ? (
+            <div className="session-files-empty">
+              No files uploaded to this session yet.
+            </div>
+          ) : null}
+          {(items ?? []).map((it) => {
+            const url = attachmentUrl(host, token, sessionId, it.id);
+            return (
+              <div className="session-files-row" key={it.id}>
+                {it.kind === "image" ? (
+                  // Token-query serve URL — next/image can't optimize it.
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    className="session-files-thumb"
+                    src={url}
+                    alt={it.filename}
+                    loading="lazy"
+                  />
+                ) : (
+                  <span className="session-files-tile" aria-hidden="true">
+                    <FileIcon />
+                  </span>
+                )}
+                <div className="session-files-body">
+                  <span className="session-files-name" title={it.filename}>
+                    {it.filename}
+                  </span>
+                  <span className="session-files-meta">
+                    {typeTag(it.filename, it.kind === "image")} ·{" "}
+                    {formatBytes(it.size)} ·{" "}
+                    {formatRelativeTime(
+                      new Date(it.uploaded_at * 1000).toISOString(),
+                    )}
+                  </span>
+                </div>
+                <a
+                  className="session-files-open"
+                  href={url}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={`Open ${it.filename}`}
+                  title="Open in new tab"
+                >
+                  ↗
+                </a>
+                <button
+                  type="button"
+                  className="session-files-delete"
+                  aria-label={`Delete ${it.filename}`}
+                  title="Delete"
+                  onClick={() => void removeOne(it.id)}
+                >
+                  ×
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -61,6 +61,7 @@ interface SessionTerminalViewProps {
   onTerminate: () => void | Promise<void>;
   onRemoveFromList: () => void | Promise<void>;
   onSwitchSession: () => void;
+  onError: (message: string) => void;
 }
 
 export function SessionTerminalView({
@@ -97,6 +98,7 @@ export function SessionTerminalView({
   onTerminate,
   onRemoveFromList,
   onSwitchSession,
+  onError,
 }: SessionTerminalViewProps) {
   // Primary action shown as a pill button next to the overflow trigger.
   // Only states the user can't trivially reach inside the pane — Reconnect
@@ -298,6 +300,7 @@ export function SessionTerminalView({
           onSubmit={onTerminalSubmit}
           onSubmitWithAttachments={onTerminalSubmitWithAttachments}
           attachmentsEnabled={attachmentsEnabled}
+          onError={onError}
           expanded={composeOpen}
           onExpandedChange={setComposeOpen}
           connection={connection}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -41,6 +41,13 @@ interface SessionTerminalViewProps {
   // control command reported its own error, or clear it on success. Async
   // because Waypoint control commands (e.g. ``/new``) are handled here.
   onTerminalSubmit: (text: string) => Promise<TerminalSubmitResult>;
+  // Attachment-bearing submits route through the HTTP input endpoint (which
+  // appends the host file path for tmux) rather than the terminal WS.
+  onTerminalSubmitWithAttachments: (
+    text: string,
+    attachmentIds: string[],
+  ) => Promise<TerminalSubmitResult>;
+  attachmentsEnabled: boolean;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;
@@ -78,6 +85,8 @@ export function SessionTerminalView({
   locked,
   onTerminalInput,
   onTerminalSubmit,
+  onTerminalSubmitWithAttachments,
+  attachmentsEnabled,
   onRequestPaste,
   onTerminalResize,
   onTerminalScrollChip,
@@ -287,6 +296,8 @@ export function SessionTerminalView({
           sessionId={sessionId}
           session={session}
           onSubmit={onTerminalSubmit}
+          onSubmitWithAttachments={onTerminalSubmitWithAttachments}
+          attachmentsEnabled={attachmentsEnabled}
           expanded={composeOpen}
           onExpandedChange={setComposeOpen}
           connection={connection}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -48,6 +48,7 @@ interface SessionTerminalViewProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
+  onOpenFiles: () => void;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;
@@ -88,6 +89,7 @@ export function SessionTerminalView({
   onTerminalSubmit,
   onTerminalSubmitWithAttachments,
   attachmentsEnabled,
+  onOpenFiles,
   onRequestPaste,
   onTerminalResize,
   onTerminalScrollChip,
@@ -300,6 +302,7 @@ export function SessionTerminalView({
           onSubmit={onTerminalSubmit}
           onSubmitWithAttachments={onTerminalSubmitWithAttachments}
           attachmentsEnabled={attachmentsEnabled}
+          onOpenFiles={onOpenFiles}
           onError={onError}
           expanded={composeOpen}
           onExpandedChange={setComposeOpen}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -48,7 +48,6 @@ interface SessionTerminalViewProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
-  onOpenFiles: () => void;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;
@@ -89,7 +88,6 @@ export function SessionTerminalView({
   onTerminalSubmit,
   onTerminalSubmitWithAttachments,
   attachmentsEnabled,
-  onOpenFiles,
   onRequestPaste,
   onTerminalResize,
   onTerminalScrollChip,
@@ -302,7 +300,6 @@ export function SessionTerminalView({
           onSubmit={onTerminalSubmit}
           onSubmitWithAttachments={onTerminalSubmitWithAttachments}
           attachmentsEnabled={attachmentsEnabled}
-          onOpenFiles={onOpenFiles}
           onError={onError}
           expanded={composeOpen}
           onExpandedChange={setComposeOpen}

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -16,6 +16,8 @@ import {
 import {
   AttachmentTray,
   filesFromDataTransfer,
+  FilesIcon,
+  PaperclipIcon,
   useAttachments,
 } from "@/components/AttachmentTray";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -48,6 +50,7 @@ interface TerminalComposeProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
+  onOpenFiles: () => void;
   onError: (message: string) => void;
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
@@ -71,6 +74,7 @@ export function TerminalCompose({
   onSubmit,
   onSubmitWithAttachments,
   attachmentsEnabled,
+  onOpenFiles,
   onError,
   expanded,
   onExpandedChange,
@@ -324,6 +328,8 @@ export function TerminalCompose({
               <AttachmentTray
                 items={attachments.items}
                 onRemove={attachments.remove}
+                onRetry={attachments.retry}
+                onClear={attachments.discardAll}
               />
             ) : null}
             <textarea
@@ -344,7 +350,8 @@ export function TerminalCompose({
             />
             {dragActive ? (
               <div className="composer-drop-hint" aria-hidden="true">
-                Drop files to attach
+                <span className="composer-drop-glyph">⤓</span>
+                <span>Drop to attach</span>
               </div>
             ) : null}
           </div>
@@ -379,6 +386,18 @@ export function TerminalCompose({
                 />
                 <button
                   type="button"
+                  className="ghost composer-attach term-compose-files"
+                  onClick={onOpenFiles}
+                  title="Session files"
+                  aria-label="Session files"
+                  tabIndex={expanded ? 0 : -1}
+                >
+                  <span className="glyph" aria-hidden>
+                    <FilesIcon />
+                  </span>
+                </button>
+                <button
+                  type="button"
                   className="ghost composer-attach term-compose-attach"
                   onClick={() => fileInputRef.current?.click()}
                   title="Attach files"
@@ -386,7 +405,7 @@ export function TerminalCompose({
                   tabIndex={expanded ? 0 : -1}
                 >
                   <span className="glyph" aria-hidden>
-                    ⎙
+                    <PaperclipIcon />
                   </span>
                 </button>
               </>

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -21,6 +21,8 @@ import {
   useAttachments,
 } from "@/components/AttachmentTray";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
+import { FileMentions } from "@/components/FileMentions";
+import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import {
   COMPOSER_MIN_HEIGHT,
@@ -28,6 +30,7 @@ import {
   type TerminalSubmitResult,
 } from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
+import { useFileMentions } from "@/lib/use-file-mentions";
 import type { SessionRecord } from "@/lib/types";
 
 type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
@@ -50,7 +53,6 @@ interface TerminalComposeProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
-  onOpenFiles: () => void;
   onError: (message: string) => void;
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
@@ -74,7 +76,6 @@ export function TerminalCompose({
   onSubmit,
   onSubmitWithAttachments,
   attachmentsEnabled,
-  onOpenFiles,
   onError,
   expanded,
   onExpandedChange,
@@ -90,6 +91,7 @@ export function TerminalCompose({
   const [textareaHeight, setTextareaHeight] = useState<number | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [filesOpen, setFilesOpen] = useState(false);
   const attachments = useAttachments({ host, token, sessionId, onError });
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -130,6 +132,17 @@ export function TerminalCompose({
     draft,
     setDraft,
     enabled: expanded,
+    textareaRef,
+  });
+
+  const mentions = useFileMentions({
+    host,
+    token,
+    sessionId,
+    draft,
+    setDraft,
+    enabled: expanded && attachmentsEnabled,
+    onReference: attachments.referenceExisting,
     textareaRef,
   });
 
@@ -227,8 +240,11 @@ export function TerminalCompose({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
-      // The suggestions menu owns Tab/Enter/Arrows/Esc when open, so
+      // The suggestion/mention menus own Tab/Enter/Arrows/Esc when open, so
       // Esc-to-dismiss takes precedence over Esc-to-collapse-drawer.
+      if (mentions.handleKey(event)) {
+        return;
+      }
       if (handleSuggestionKey(event)) {
         return;
       }
@@ -244,7 +260,7 @@ export function TerminalCompose({
       event.preventDefault();
       send();
     },
-    [handleSuggestionKey, send, onExpandedChange, refocusTerminal],
+    [mentions, handleSuggestionKey, send, onExpandedChange, refocusTerminal],
   );
 
   const toggle = useCallback(() => {
@@ -387,7 +403,7 @@ export function TerminalCompose({
                 <button
                   type="button"
                   className="ghost composer-attach term-compose-files"
-                  onClick={onOpenFiles}
+                  onClick={() => setFilesOpen(true)}
                   title="Session files"
                   aria-label="Session files"
                   tabIndex={expanded ? 0 : -1}
@@ -430,6 +446,29 @@ export function TerminalCompose({
           itemRefs={suggestionItemRefs}
           onApply={applySuggestion}
           onHover={setActiveIndex}
+        />
+      ) : null}
+      {mentions.open ? (
+        <FileMentions
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          mentions={mentions.mentions}
+          activeIndex={mentions.activeIndex}
+          itemRefs={mentions.itemRefs}
+          onApply={mentions.apply}
+          onHover={mentions.setActiveIndex}
+        />
+      ) : null}
+      {attachmentsEnabled ? (
+        <SessionFilesPanel
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          open={filesOpen}
+          onClose={() => setFilesOpen(false)}
+          onReference={attachments.referenceExisting}
+          referencedIds={attachments.attachedIds}
         />
       ) : null}
     </section>

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import {
+  ChangeEvent,
+  ClipboardEvent,
+  DragEvent,
   KeyboardEvent,
   PointerEvent as ReactPointerEvent,
   useCallback,
@@ -10,6 +13,11 @@ import {
   useState,
 } from "react";
 
+import {
+  AttachmentTray,
+  filesFromDataTransfer,
+  useAttachments,
+} from "@/components/AttachmentTray";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import {
@@ -33,6 +41,13 @@ interface TerminalComposeProps {
   // control commands (``/new``) are handled by the host rather than the
   // socket, so a submit can succeed even while the WS is reconnecting.
   onSubmit: (text: string) => Promise<TerminalSubmitResult>;
+  // Used instead of ``onSubmit`` when the draft carries attachments — routes
+  // through the HTTP input endpoint so the server appends the file paths.
+  onSubmitWithAttachments: (
+    text: string,
+    attachmentIds: string[],
+  ) => Promise<TerminalSubmitResult>;
+  attachmentsEnabled: boolean;
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
   connection: ConnectionState;
@@ -53,6 +68,8 @@ export function TerminalCompose({
   sessionId,
   session,
   onSubmit,
+  onSubmitWithAttachments,
+  attachmentsEnabled,
   expanded,
   onExpandedChange,
   connection,
@@ -65,6 +82,9 @@ export function TerminalCompose({
   const [sending, setSending] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
   const [textareaHeight, setTextareaHeight] = useState<number | null>(null);
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const attachments = useAttachments({ host, token, sessionId });
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
@@ -125,23 +145,31 @@ export function TerminalCompose({
 
   const dirty = draft.trim().length > 0;
   const connected = connection === "open";
+  const hasAttachments = attachments.readyIds.length > 0;
   // Not gated on ``connected``: control commands like ``/new`` work without
   // the socket, and ``send`` surfaces a retry hint for plain text when the WS
   // is closed — so the button mirrors the ⌘↵ path rather than greying out.
-  const canSend = expanded && dirty && !sending;
+  const canSend =
+    expanded && (dirty || hasAttachments) && !sending && !attachments.uploading;
 
   const send = useCallback(async () => {
     const text = draft;
-    if (!text.trim()) return;
+    const attachmentIds = attachments.readyIds;
+    if ((!text.trim() && attachmentIds.length === 0) || attachments.uploading) {
+      return;
+    }
     // No connection gate here: control commands like ``/new`` are handled by
     // the host and don't need the socket, so ``onSubmit`` decides whether the
     // WS was actually required.
     setSending(true);
     try {
-      const result = await onSubmit(text);
+      const result = attachmentIds.length
+        ? await onSubmitWithAttachments(text, attachmentIds)
+        : await onSubmit(text);
       if (result === "ok") {
         setDraft("");
         setHint(null);
+        attachments.clear();
         resetCompletions();
       } else if (result === "socket-closed") {
         setHint(
@@ -155,7 +183,41 @@ export function TerminalCompose({
       // Briefly hold the disabled state so the user gets feedback.
       window.setTimeout(() => setSending(false), 120);
     }
-  }, [draft, connected, onSubmit, resetCompletions]);
+  }, [draft, connected, onSubmit, onSubmitWithAttachments, attachments, resetCompletions]);
+
+  const addFilesFromInput = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files ? Array.from(event.target.files) : [];
+    if (files.length) attachments.addFiles(files);
+    event.target.value = "";
+  };
+
+  const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!attachmentsEnabled) return;
+    const files = filesFromDataTransfer(event.clipboardData);
+    if (files.length === 0) return;
+    event.preventDefault();
+    attachments.addFiles(files);
+  };
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    if (!attachmentsEnabled) return;
+    event.preventDefault();
+    setDragActive(false);
+    const files = filesFromDataTransfer(event.dataTransfer);
+    if (files.length) attachments.addFiles(files);
+  };
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!attachmentsEnabled) return;
+    if (!Array.from(event.dataTransfer.types).includes("Files")) return;
+    event.preventDefault();
+    setDragActive(true);
+  };
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
+    setDragActive(false);
+  };
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -245,12 +307,23 @@ export function TerminalCompose({
       </button>
       <div className="term-compose-shell" id={regionId} aria-hidden={!expanded}>
         <div className="term-compose-inner">
-          <div className="term-compose-field">
+          <div
+            className={`term-compose-field${dragActive ? " is-drag-active" : ""}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
             <div
               className="composer-resize-handle term-compose-resize"
               onPointerDown={handlePointerDown}
               aria-hidden="true"
             />
+            {attachmentsEnabled ? (
+              <AttachmentTray
+                items={attachments.items}
+                onRemove={attachments.remove}
+              />
+            ) : null}
             <textarea
               ref={textareaRef}
               className="composer-textarea term-compose-textarea"
@@ -262,10 +335,16 @@ export function TerminalCompose({
                 if (hint) setHint(null);
               }}
               onKeyDown={handleKeyDown}
+              onPaste={handlePaste}
               placeholder="Type a message"
               aria-label="Message to send to terminal"
               tabIndex={expanded ? 0 : -1}
             />
+            {dragActive ? (
+              <div className="composer-drop-hint" aria-hidden="true">
+                Drop files to attach
+              </div>
+            ) : null}
           </div>
           <div className="term-compose-meta">
             <SessionUsagePill
@@ -285,6 +364,31 @@ export function TerminalCompose({
               <kbd>{shortcutLabel}</kbd>
               <span>send</span>
             </span>
+            {attachmentsEnabled ? (
+              <>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  className="composer-file-input"
+                  onChange={addFilesFromInput}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                />
+                <button
+                  type="button"
+                  className="ghost composer-attach term-compose-attach"
+                  onClick={() => fileInputRef.current?.click()}
+                  title="Attach files"
+                  aria-label="Attach files"
+                  tabIndex={expanded ? 0 : -1}
+                >
+                  <span className="glyph" aria-hidden>
+                    ⎙
+                  </span>
+                </button>
+              </>
+            ) : null}
             <button
               type="button"
               className="primary send term-compose-send"

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -48,6 +48,7 @@ interface TerminalComposeProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
+  onError: (message: string) => void;
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
   connection: ConnectionState;
@@ -70,6 +71,7 @@ export function TerminalCompose({
   onSubmit,
   onSubmitWithAttachments,
   attachmentsEnabled,
+  onError,
   expanded,
   onExpandedChange,
   connection,
@@ -84,7 +86,7 @@ export function TerminalCompose({
   const [textareaHeight, setTextareaHeight] = useState<number | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const attachments = useAttachments({ host, token, sessionId });
+  const attachments = useAttachments({ host, token, sessionId, onError });
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -20,6 +20,7 @@ import {
   summarizeTodos,
   type TodoEntry,
 } from "@/lib/todos";
+import { MessageAttachments } from "@/components/AttachmentTray";
 import { PlanApprovalCard } from "@/components/ApprovalCard";
 import { CopyMessageButton } from "@/components/CopyMessageButton";
 import { DiffPreview } from "@/components/DiffPreview";
@@ -255,6 +256,7 @@ function UserMessageBubble({ event }: { event: EventRecord }) {
       style={style}
     >
       <MarkdownMessage text={event.text} />
+      <MessageAttachments event={event} />
       <div ref={metaRef} className="transcript-meta">
         <span className="badge user">you</span>
         <span className="role-time">{formatTime(event.ts)}</span>
@@ -1208,6 +1210,7 @@ function HeuristicCard({ event }: { event: EventRecord }) {
         <CopyMessageButton text={event.text} />
       </div>
       <pre>{event.text}</pre>
+      <MessageAttachments event={event} />
     </article>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,6 +17,7 @@ import {
   ScheduledSession,
   SessionCompletionsResponse,
   SessionCommandInvocation,
+  SessionAttachment,
   SessionEnvelope,
   SessionRecord,
   UsageDashboardResponse,
@@ -808,6 +809,60 @@ export async function uploadAttachment(
   );
   await ensureOk(response, "failed to upload attachment");
   return (await response.json()) as AttachmentSpec;
+}
+
+// Every attachment stored for a session, newest first — backs the files
+// manager.
+export async function fetchSessionAttachments(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionAttachment[]> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/attachments`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to list attachments");
+  return (await response.json()) as SessionAttachment[];
+}
+
+// Delete every attachment stored for a session ("Delete all").
+export async function deleteAllAttachments(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<void> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/attachments`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to delete attachments");
+}
+
+// Free a server-side attachment blob. Used when a pending attachment is
+// removed from the composer before it is sent, so eager uploads don't orphan.
+export async function deleteAttachment(
+  host: string,
+  token: string,
+  sessionId: string,
+  attachmentId: string,
+): Promise<void> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/attachments/${attachmentId}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  // A 404 means it's already gone — fine for a best-effort cleanup.
+  if (!response.ok && response.status !== 404) {
+    await ensureOk(response, "failed to delete attachment");
+  }
 }
 
 // Authenticated URL for an uploaded attachment. The token rides as a query

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,6 +4,7 @@ import {
   AssistantAttachRequest,
   AssistantResetRequest,
   AssistantSummary,
+  AttachmentSpec,
   Backend,
   BackendDescriptor,
   BackendModelListResponse,
@@ -771,6 +772,7 @@ export async function sendInput(
   sessionId: string,
   text: string,
   command?: SessionCommandInvocation,
+  attachments?: string[],
 ): Promise<void> {
   const response = await fetch(`${host}/api/sessions/${sessionId}/input`, {
     method: "POST",
@@ -778,9 +780,46 @@ export async function sendInput(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ text, submit: true, command }),
+    body: JSON.stringify({
+      text,
+      submit: true,
+      command,
+      attachments: attachments?.length ? attachments : undefined,
+    }),
   });
   await ensureOk(response, "failed to send input");
+}
+
+export async function uploadAttachment(
+  host: string,
+  token: string,
+  sessionId: string,
+  file: File,
+): Promise<AttachmentSpec> {
+  const body = new FormData();
+  body.append("file", file, file.name);
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/attachments`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+      body,
+    },
+  );
+  await ensureOk(response, "failed to upload attachment");
+  return (await response.json()) as AttachmentSpec;
+}
+
+// Authenticated URL for an uploaded attachment. The token rides as a query
+// param because <img>/<a> can't send an Authorization header (mirrors the
+// WebSocket endpoints).
+export function attachmentUrl(
+  host: string,
+  token: string,
+  sessionId: string,
+  attachmentId: string,
+): string {
+  return `${host}/api/sessions/${sessionId}/attachments/${attachmentId}?token=${encodeURIComponent(token)}`;
 }
 
 interface SocketHandlers {

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -159,6 +159,13 @@ export function supportsApprovalNote(
   return caps ? caps.supports_approval_note : FALLBACK_APPROVAL_NOTE.has(backend);
 }
 
+export function supportsAttachments(
+  backend: Backend,
+  catalog?: BackendCatalog,
+): boolean {
+  return Boolean(catalog?.byId(backend)?.capabilities.supports_attachments);
+}
+
 // Which approval decisions a backend honours (e.g. codex/opencode add
 // `acceptForSession`). Drives which escalation buttons the approval card
 // renders so it can't offer a decision the backend would map to a plain

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -329,7 +329,7 @@ export function useCommandCompletions({
 
 // The [start, end) bounds of the non-whitespace word that ``pos`` sits in (or
 // at the edge of). Empty run when ``pos`` is on whitespace.
-function wordRangeAt(text: string, pos: number): [number, number] {
+export function wordRangeAt(text: string, pos: number): [number, number] {
   let start = pos;
   while (start > 0 && !/\s/.test(text[start - 1])) start--;
   let end = pos;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -107,6 +107,12 @@ export interface AttachmentSpec {
   kind: AttachmentKind;
 }
 
+// A session-stored attachment as returned by the list endpoint: the spec plus
+// the upload time (epoch seconds), so the files manager can sort newest-first.
+export interface SessionAttachment extends AttachmentSpec {
+  uploaded_at: number;
+}
+
 export interface EventRecord {
   id?: number;
   session_id: string;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -97,6 +97,16 @@ export interface SessionRecord {
   config_overrides: string[];
 }
 
+export type AttachmentKind = "image" | "file";
+
+export interface AttachmentSpec {
+  id: string;
+  filename: string;
+  mime: string;
+  size: number;
+  kind: AttachmentKind;
+}
+
 export interface EventRecord {
   id?: number;
   session_id: string;
@@ -164,6 +174,7 @@ export interface BackendCapabilities {
   supports_plan_approval: boolean;
   supports_slash_compact: boolean;
   supports_approval_note: boolean;
+  supports_attachments: boolean;
   supports_custom_cli_args: boolean;
   supports_config_overrides: boolean;
   supports_reattach_after_exit: boolean;

--- a/frontend/src/lib/use-file-mentions.ts
+++ b/frontend/src/lib/use-file-mentions.ts
@@ -1,0 +1,173 @@
+"use client";
+
+import type { KeyboardEvent, RefObject } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { wordRangeAt } from "@/lib/composer-completions";
+import { fetchSessionAttachments } from "@/lib/api";
+import type { SessionAttachment } from "@/lib/types";
+
+interface UseFileMentionsOptions {
+  host: string;
+  token: string;
+  sessionId: string;
+  draft: string;
+  setDraft: (next: string) => void;
+  enabled: boolean;
+  onReference: (spec: SessionAttachment) => void;
+  textareaRef?: RefObject<HTMLTextAreaElement | null>;
+}
+
+export interface FileMentionsState {
+  mentions: ReadonlyArray<SessionAttachment>;
+  open: boolean;
+  activeIndex: number;
+  setActiveIndex: (index: number) => void;
+  itemRefs: RefObject<Array<HTMLButtonElement | null>>;
+  apply: (index: number) => void;
+  handleKey: (event: KeyboardEvent<HTMLTextAreaElement>) => boolean;
+}
+
+const MAX_MENTIONS = 8;
+
+// Inline `@name` file referencing: type `@` in the composer to search the
+// session's stored files and pick one. Selecting strips the `@query` token and
+// adds the file to the attachment tray (no re-upload) via `onReference`. Models
+// the caret/word + key handling of `useCommandCompletions`, but the source is
+// the local session-files list and the apply is an attachment, not text.
+export function useFileMentions({
+  host,
+  token,
+  sessionId,
+  draft,
+  setDraft,
+  enabled,
+  onReference,
+  textareaRef,
+}: UseFileMentionsOptions): FileMentionsState {
+  const [index, setIndex] = useState(0);
+  const [files, setFiles] = useState<SessionAttachment[] | null>(null);
+  const [dismissedQuery, setDismissedQuery] = useState<string | null>(null);
+  const [caret, setCaret] = useState(0);
+  const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    const el = textareaRef?.current;
+    if (!el) return;
+    let frame = 0;
+    const sync = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() =>
+        setCaret(el.selectionStart ?? el.value.length),
+      );
+    };
+    const events = ["input", "keyup", "mouseup", "focus", "select"] as const;
+    events.forEach((name) => el.addEventListener(name, sync));
+    return () => {
+      cancelAnimationFrame(frame);
+      events.forEach((name) => el.removeEventListener(name, sync));
+    };
+  }, [textareaRef]);
+
+  const caretPos = textareaRef ? Math.min(caret, draft.length) : draft.length;
+  const [wordStart] = wordRangeAt(draft, caretPos);
+  const word = draft.slice(wordStart, caretPos);
+  const query = word.startsWith("@") ? word.slice(1) : null;
+  const active = enabled && query !== null && dismissedQuery !== word;
+
+  // Load the session's files when a mention opens; clear when it closes so the
+  // next `@` refetches a fresh list.
+  useEffect(() => {
+    if (!active) {
+      setFiles(null);
+      return;
+    }
+    if (files !== null) return;
+    const controller = new AbortController();
+    fetchSessionAttachments(host, token, sessionId)
+      .then((list) => {
+        if (!controller.signal.aborted) setFiles(list);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setFiles([]);
+      });
+    return () => controller.abort();
+  }, [active, files, host, token, sessionId]);
+
+  const mentions = useMemo<ReadonlyArray<SessionAttachment>>(() => {
+    if (!active || files === null) return [];
+    const needle = (query ?? "").toLowerCase();
+    return files
+      .filter((file) => file.filename.toLowerCase().includes(needle))
+      .slice(0, MAX_MENTIONS);
+  }, [active, files, query]);
+
+  const open = mentions.length > 0;
+  const activeIndex = Math.min(index, Math.max(0, mentions.length - 1));
+
+  function apply(target: number) {
+    const chosen = mentions[target];
+    if (!chosen) return;
+    const pos = textareaRef ? Math.min(caret, draft.length) : draft.length;
+    const [start, end] = wordRangeAt(draft, pos);
+    const before = draft.slice(0, start);
+    const tail = draft.slice(end);
+    // Drop the `@query` token; collapse a doubled space the removal would leave.
+    const next =
+      before.endsWith(" ") && tail.startsWith(" ")
+        ? before + tail.slice(1)
+        : before + tail;
+    setDraft(next);
+    setCaret(before.length);
+    setIndex(0);
+    onReference(chosen);
+    if (textareaRef) {
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.focus();
+        el.setSelectionRange(before.length, before.length);
+      });
+    }
+  }
+
+  function handleKey(event: KeyboardEvent<HTMLTextAreaElement>): boolean {
+    if (!open) return false;
+    if (
+      event.key === "Tab" ||
+      (event.key === "Enter" &&
+        !(event.metaKey || event.ctrlKey) &&
+        !event.shiftKey)
+    ) {
+      event.preventDefault();
+      apply(activeIndex);
+      return true;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setIndex((i) => Math.min(mentions.length - 1, i + 1));
+      return true;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setIndex((i) => Math.max(0, i - 1));
+      return true;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      setDismissedQuery(word);
+      return true;
+    }
+    return false;
+  }
+
+  return {
+    mentions,
+    open,
+    activeIndex,
+    setActiveIndex: setIndex,
+    itemRefs,
+    apply,
+    handleKey,
+  };
+}


### PR DESCRIPTION
## Summary

Sessions could only receive plain text — there was no way to hand an agent a screenshot or a file. This adds attachment support across the stack: paste, drag-drop, or pick files in the chat reply composer and the terminal quick-compose drawer, and they reach the agent in whatever form that backend speaks natively. It also adds the management around that: deduplicated, human-readable on-disk names, a composer tray with progress / retry / clear-all, and a session-wide files manager to browse and delete everything a session has uploaded.

Upload is decoupled from send. A new endpoint persists each blob under a per-session attachments dir and returns a server-issued id; the input request then references attachments by id, so the runtime resolves ids to host paths server-side and a path is never trusted from the client. Because Waypoint runs natively on the host, absolute paths under `~/.waypoint/backend-data` are readable by the agents and tmux without polluting the user's working tree. The transport contract gains an optional `attachments` argument (no per-backend branching in the runtime), and a `supports_attachments` capability tells the frontend when to offer the affordance.

A file a session already stores can be pulled into a new message without re-uploading — via a `+` action on each row of the files manager or inline `@name` search in either composer — and lands as a referenced chip that sends by id exactly like an upload. Eager uploads that are attached but never sent are reclaimed so they don't accumulate on disk: the composer frees them on page-leave, and a server-side TTL sweep backstops crashes and offline clients.

## Changes

### Backend

- `attachments.py` (new): `AttachmentStore` persists each blob under its sanitized original filename, de-duplicated with ` (1)`, ` (2)` … on collision via a race-safe exclusive create, so the path handed to path-based agents stays legible; a `<id>.json` sidecar holds the `AttachmentSpec` and the stored name. `resolve` is uuid-guarded and session-scoped, so a hostile or traversal-style id can't escape the session's dir. `entries`/`delete`/`discard` back the files manager. `mark_sent` records the ids a sent message carries in a per-session `_sent.json` index, and `sweep` reaps any sidecar older than a TTL that no sent message references, so eager uploads that were never sent don't pile up. `ResolvedAttachment` pairs a spec with its host path and exposes `read_base64`/`to_data_url`; `append_attachment_paths` is the text-only fallback.
- `api.py`: `POST /api/sessions/{id}/attachments` (multipart `UploadFile`, size-capped → `413`); `GET …/attachments/{aid}`, which takes the token as a query param because `<img>`/`<a>` can't send an Authorization header (mirrors the WS endpoints), serving inline for previews; `GET …/attachments` (list, with upload time; sweeps stale unsent uploads first); and `DELETE …/attachments/{aid}` (per-file) and `DELETE …/attachments` (delete-all). Deleting a file a sent message still references is allowed — the files manager exposes it — and that message's transcript thumbnail then 404s, which the client renders as a file fallback.
- `runtime.py`: `handle_input` resolves `request.attachments` ids to `ResolvedAttachment`s, passes them to `transport.send_input`, records the specs in the `user_input` event metadata, marks the carried ids sent, and sweeps stale unsent uploads for the session.
- `transports/base.py` + the four backends: `send_input` takes an optional `list[ResolvedAttachment]`. Claude embeds images as base64 `image` content blocks (`_user_content`), Codex sends `localImage` items (`_input_items`), OpenCode adds data-url file parts (robust when the server runs over SSH), and tmux — plus non-image files on image-only protocols — appends the host paths to the text.
- `backends/claude_code/adapter.py`: the stdout reader now reads via `readuntil` so an over-limit stream-json line (e.g. a base64 tool result echoing a large attachment) is drained and skipped instead of tearing down the session — `readline()` had masked the `LimitOverrunError` as a `ValueError`, leaving the existing drain handler dead.
- `capabilities.py` + plugins: a `supports_attachments` flag, set on all four backends.
- `settings.py`: `attachments_dir`, a `max_upload_bytes` cap (env `WAYPOINT_MAX_UPLOAD_BYTES`, default 25 MiB), and `attachment_orphan_ttl_seconds` (env `WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS`, default 24h) governing the orphan sweep. `pyproject.toml`/`uv.lock`: add `python-multipart` for `UploadFile`.
- `cli.py` + `client.py`: `waypoint sessions send` gains a repeatable `--attach`/`-a PATH` that uploads each file and references it by id on the input request, so a CLI-spawned session (e.g. a subagent on another backend) can be handed an image or document the same way the composer does.

### Frontend

- `components/AttachmentTray.tsx` (new): a `useAttachments` hook (eager upload with object-URL thumbnail previews, per-item progress/error, retry of a failed upload, server-side delete of a removed pending blob, `referenceExisting` to add a stored file as a chip without re-upload, and a delete-on-leave flush that frees unsent, non-referenced uploads on unmount and on `pagehide` via a keepalive DELETE so a closed page doesn't orphan a blob), the tray UI (file size + type, a `N files · total` header with clear-all, a linked-edge style for referenced chips), and `MessageAttachments` + a context provider so transcript cards render attachments — as compact thumbnail cards that fall back to a file glyph when a blob was since deleted — without prop-drilling credentials.
- `components/SessionFilesPanel.tsx` (new): a session-wide files manager (portal modal mirroring the session switcher) listing every stored file with thumbnail, name, type/size, upload time, open-in-new-tab, per-file delete, and delete-all. When given an `onReference`, each row also offers a `+` "add to message" action that references the file into the composer (marked added once in the tray). Reached from the chat composer's overflow menu and a terminal-composer button.
- `lib/use-file-mentions.ts` + `components/FileMentions.tsx` (new): inline `@name` referencing — typing `@` in either composer searches the session's stored files (lazy fetch, filename substring match), mirroring the slash-command completion's caret/word and key handling; picking strips the `@query` token and adds the file as a referenced chip. `wordRangeAt` is exported from `composer-completions.ts` for reuse.
- `components/SessionDetail.tsx`, `components/TerminalCompose.tsx`, `components/SessionTerminalView.tsx`: paste / drag-drop / file-pick wired into the reply composer and the terminal quick-compose drawer, gated on `supports_attachments`; the attach button sits beside the primary action in both. Each composer now owns its `SessionFilesPanel` so the panel's add-to-message action binds to that composer's tray, retiring the lifted `onOpenFiles` threading. Attachment-bearing terminal submits route through the HTTP input endpoint (not the raw terminal WS) so tmux gets the host paths appended server-side; sends are blocked while an upload is in flight and an attachment-only turn (no text) is allowed.
- `lib/api.ts`, `lib/types.ts`, `lib/backends.ts`: `uploadAttachment` / `attachmentUrl` / `fetchSessionAttachments` / `deleteAttachment` / `deleteAllAttachments`, the `attachments` arg on `sendInput`, the `AttachmentSpec` / `SessionAttachment` types and `supports_attachments` capability, and a `supportsAttachments` helper.
- `app/globals.css`: tray, chip, drop-hint, message-attachment, files-panel, referenced-chip, and `@`-mention popover styles using theme variables, so dark/light parity holds with no extra overrides; the floating task dock now sits below the composer so its upward-opening popovers (model / permission picker, overflow menu) are no longer covered.

### Docs

- `docs/coding_agent_plugins.md`: document the optional `attachments` argument on `send_input`, the per-backend native mapping and path-append fallback, the `supports_attachments` capability, and the de-duplicated on-disk naming.

## Test Plan

- [x] `cd backend && uv run pytest` — passes except the 5 pre-existing `tests/test_rate_limits.py` / `test_runtime.py` failures (keychain / messages-API / `FakeClaudeAdapter`, host-dependent), confirmed present on a clean tree and unrelated to this branch. Includes `tests/test_attachments.py` (store round-trip, traversal/uuid guard, session scoping, dedup naming, `delete`/`entries`, the orphan `sweep` keeping recent-and-sent blobs while reaping aged unsent ones, and the Claude/Codex native-mapping helpers) and the `_read_stream_line` reader test in `tests/test_claude_cli.py`.
- [x] `cd backend && uv run pre-commit run --files <changed>` — isort / black / ruff / codespell / mypy clean.
- [x] `cd frontend && npx tsc --noEmit`, `npm run lint`, and `npm run build` — clean.
- [x] Exercised live against a running stack on the Claude Code backend: uploaded YAML / PNG / PDF (path reference, inline image, and document); confirmed deduplicated names on disk (`image.png` / `image (1).png`); verified the files manager lists, opens (200), per-file deletes and delete-alls (204, blob + sidecar removed) correctly; referenced a stored file back into a new message via both the `+` action and `@name` and confirmed it sends without re-upload; reproduced and fixed the oversized-line reader crash with a large PDF.
- [x] Exercised the Codex and OpenCode native paths live (driven through the new `waypoint sessions send --attach`, spawning each backend as a subagent): sent a solid-red PNG plus a text file carrying a sentinel codeword. Codex named the image red (image → `localImage`) and quoted the codeword after reading the appended host path (non-image → path append); OpenCode answered `Red` and quoted the codeword with no path appended, confirming it accepts a `file` part with a text MIME + data URL and surfaces it to the model — the previously documented-but-unverified `FilePart` shape.
- [ ] tmux native path (host-path append) was not re-exercised live this round; SSH-launch-target delivery (the motivation for OpenCode's data-url embedding over a host path) remains verified only against a local server.

