### PR TITLE
feat: orchestration-focused CLI ergonomics and durable board history

### DIFF
--- a/.agents/skills/waypoint-comms/references/blackboard.md
+++ b/.agents/skills/waypoint-comms/references/blackboard.md
@@ -67,9 +67,11 @@ stamps an `edited_at` the UI shows as "edited" while preserving `created_at`, so
 the log keeps its order.
 
 `post` stamps the author from `WAYPOINT_SESSION_ID` automatically (the same id as
-`addressing.md`); you don't pass it. When that session is deleted, its posts are
-pruned — so durable shared state should live on a long-lived session's channel,
-not a short subagent's.
+`addressing.md`); you don't pass it. When a session is deleted, only its **keyed
+cells** are pruned — keyless log posts are durable history and survive the session
+row being removed. Read the log with `board log <channel>`. Durable shared state
+(keyed cells) should live on a long-lived session; append-log posts are safe to
+make from short subagents.
 
 ## Channel naming
 

--- a/.agents/skills/waypoint-subagents/SKILL.md
+++ b/.agents/skills/waypoint-subagents/SKILL.md
@@ -33,11 +33,21 @@ unavailable, stop and report; do not guess.
 
 ## Ownership convention
 
-Waypoint has no parent/owner field on sessions, so a child you spawn is
-otherwise indistinguishable from a user's own session. Establish ownership by
-convention:
+Every session you spawn carries a `spawner_session_id` set at creation — this is
+the structural ownership link. It drives permission inheritance and lets you list
+or reap only your children:
 
-- Title every child you create with `--title "subagent:<short-purpose>"`.
+```bash
+waypoint sessions list --spawned-by <your-sid>   # list children you own
+waypoint sessions list --mine                     # shorthand: children of the current session
+waypoint sessions reap --spawned-by <your-sid>    # reap only your children
+waypoint sessions reap --mine                     # shorthand
+```
+
+Reinforce ownership with the title convention — title every child you create with
+`--title "subagent:<short-purpose>"` — because `spawner_session_id` may not be
+visible to a downstream lead reading the board.
+
 - Keep the returned session ids in your working state for the rest of the turn.
 - **You own the sessions you spawn, and only those.** You may steer, read, and
   terminate them freely. Never terminate, interrupt, or send to a session you

--- a/.agents/skills/waypoint-subagents/SKILL.md
+++ b/.agents/skills/waypoint-subagents/SKILL.md
@@ -25,6 +25,20 @@ Reach for Waypoint sub-sessions only when you need something they cannot give:
 
 If none of those apply, do not spawn a Waypoint session.
 
+## Two shapes: parallel crew vs. delegate-and-review
+
+Spawning children comes in two shapes, good for opposite kinds of work:
+
+- **Parallel crew** — many children, each an independent task, merged by a lead.
+  For batch work too big for one context: migrations, codemods, per-file sweeps.
+  See `waypoint-workqueue`.
+- **Delegate-and-review** — *one* child takes a whole coherent chunk and you
+  review its diff before integrating. For work too large to do inline but too
+  tightly coupled to parallelize (a multi-file change to one module, where
+  splitting it would only create merge conflicts). You stay the reviewer: read
+  the diff, run the checks yourself, own the merge. This is the right move for
+  exactly the coupled work the crew is wrong for.
+
 ## Before anything: preflight
 
 The `waypoint` CLI is not guaranteed to be reachable from inside every session.

--- a/.agents/skills/waypoint-workqueue/SKILL.md
+++ b/.agents/skills/waypoint-workqueue/SKILL.md
@@ -58,8 +58,10 @@ harness and model with `references/backends.md`.
 - Size the crew to the work and scale it deliberately — fan-out has no
   server-side limit, so an unbounded pool exhausts the host. Reap what you finish
   with.
-- The lead owns the board cells; workers only report. A worker-authored cell is
-  pruned when the worker is reaped, so durable state must stay with the lead.
+- The lead owns the board cells; workers only append to the log. A worker-authored
+  keyed cell is pruned when the worker is reaped; keyless log posts are durable
+  history — they survive reap and are readable with `board log job:<id>`. Durable
+  state (cells) must stay with the lead.
 - Give each worker a task it can do with no other context, and its own worktree —
   never let two workers share a tree.
 - Check the **final merged** result, not just per-task success.

--- a/.agents/skills/waypoint-workqueue/references/org-template.md
+++ b/.agents/skills/waypoint-workqueue/references/org-template.md
@@ -26,11 +26,14 @@ One channel for the whole job: `job:<job-id>` (a short slug, no slashes — e.g.
 `job:drop-py38`). Everything lives here, so `/board` shows the job's progress at
 a glance.
 
-Two kinds of cell, **both written only by the lead**:
+Three kinds of cell, **all written only by the lead**:
 
 - `plan` — the job in one cell: goal, integration branch, and the task list.
-- `task:<n>` — one per task. The text is the instruction plus how to check it;
-  `--meta` carries the live status.
+- `task:<n>` — one per task. **Immutable contract**: the text is the instruction
+  plus how to check it. Set once; never rewritten.
+- `status:<n>` — paired with each `task:<n>`. **Mutable status**: `--meta`
+  carries `state=todo|doing|done|blocked` and `assignee=<sid>`. Text is a brief
+  label. Update with `waypoint board set-meta` to flip state without touching text.
 
 ```bash
 # plan — once
@@ -38,25 +41,31 @@ waypoint board post job:drop-py38 \
   "Drop Python 3.8 support. Integration branch wq/drop-py38. 12 tasks, one per package." \
   --key plan
 
-# a task — text is the contract, meta is the status
+# task cell — immutable contract, written once
 waypoint board post job:drop-py38 \
   "pkg/auth: remove the 3.8 shims and set requires-python >=3.9. Check: uv run pytest pkg/auth." \
-  --key task:3 --meta state=todo
+  --key task:3
+
+# status cell — created alongside the task, updated as work progresses
+waypoint board post job:drop-py38 "task 3 status" --key status:3 --meta state=todo
+
+# flip state without resupplying text
+waypoint board set-meta job:drop-py38 --key status:3 --meta state=doing --meta assignee=<sid>
 ```
 
 `state` is `todo | doing | done | blocked`. Workers report progress to the **log**
 (a plain `waypoint board post job:<id> "..."`) or by a direct send; the lead
-updates the `task:<n>` cell. Workers never write cells — a worker's own posts
+updates `status:<n>` cells. Workers never write cells — a worker's own posts
 vanish when it is reaped, so durable state stays with the long-lived lead.
 
-> **Pitfall — `--key` is an upsert that REPLACES the cell's text.** There is no
-> text-preserving metadata patch (`board edit-entry` also requires the text). So
-> to flip a task's status, **re-post the cell with its full contract text** plus
-> the new `--meta`; keep that text in a shell variable so you can repost it
-> verbatim. Never post a keyed cell with throwaway text (`"task 3 -> <sid>"`) just
-> to change `state` — that silently destroys the contract the worker reads, and
-> the worker will (correctly) report blocked for want of scope. Track the
-> assignee in `--meta`, not in the text.
+> **Why two cells? — `--key` is an upsert that REPLACES the cell's text.** There
+> is no text-preserving metadata patch (`board edit-entry` also requires the text).
+> With a single cell, flipping state forces you to re-post the full contract text or
+> silently clobber it — posting a stub like `"task 3 -> <sid>"` destroys the scope
+> the worker reads, and the worker will (correctly) report blocked. The two-cell
+> shape avoids this by design: `task:<n>` is the immutable contract (never touched
+> after creation), and `status:<n>` is the mutable status cell updated with
+> `set-meta`. Track the assignee in `status:<n>`'s `--meta`, not in text.
 
 ## Handing a task to a worker
 
@@ -70,12 +79,13 @@ waypoint sessions send <worker-sid> \
 
 ## Lifecycle (five steps)
 
-1. Lead writes `plan` and one `task:<n>` per task.
+1. Lead writes `plan`, one `task:<n>` per task, and one `status:<n>` per task
+   (state=todo).
 2. Lead gives each free worker a task — a worktree plus the message above — and
-   sets that task `doing`.
+   sets `status:<n>` to state=doing with assignee=\<sid\>.
 3. Worker does it, self-checks, reports `done` (or `blocked`).
-4. Lead checks the result against the task, merges the worker's branch, sets the
-   task `done` (or hands it back as `todo`).
+4. Lead checks the result against the task, merges the worker's branch, sets
+   `status:<n>` to done (or todo to hand it back).
 5. Repeat until every task is `done` or `blocked`; then run the full check on the
    integration branch and report.
 

--- a/.agents/skills/waypoint-workqueue/references/org-template.md
+++ b/.agents/skills/waypoint-workqueue/references/org-template.md
@@ -55,8 +55,11 @@ waypoint board set-meta job:drop-py38 --key status:3 --meta state=doing --meta a
 
 `state` is `todo | doing | done | blocked`. Workers report progress to the **log**
 (a plain `waypoint board post job:<id> "..."`) or by a direct send; the lead
-updates `status:<n>` cells. Workers never write cells — a worker's own posts
-vanish when it is reaped, so durable state stays with the long-lived lead.
+updates `status:<n>` cells. Workers never write cells — a worker-authored keyed
+cell is pruned when the worker is reaped. Keyless log posts are durable history:
+they survive reap and persist as long as the channel does. Read the job's history
+with `board log job:<id>`; confirm what landed from git (ground truth for code),
+the log is the narrative. Durable state (cells) stays with the long-lived lead.
 
 > **Why two cells? — `--key` is an upsert that REPLACES the cell's text.** There
 > is no text-preserving metadata patch (`board edit-entry` also requires the text).

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -79,6 +79,9 @@ The board is the checkpoint — no separate state file. A lead (re)starting read
 `todo` tasks get assigned; a `doing` task whose worker is gone
 (`waypoint sessions show <sid>` → `exited`/`error`) is handed back to `todo`.
 
+Read the job's history with `board log job:<job-id>`; confirm what landed from
+git (ground truth for code), the log is the narrative.
+
 ### Resume after the lead dies
 
 1. Read the board: `waypoint board read job:<job-id>`.

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -19,22 +19,28 @@ its code lives:
 
 ```bash
 n=3
-# Task branch is `wq/$job-t$n`, NOT `wq/$job/task-$n`: a slash makes it a child
-# of the integration ref `wq/$job`, and git cannot hold both a branch and a
-# directory at that path ("cannot lock ref ... exists").
-git -C "$repo" worktree add "$repo/../.wq/$job/task-$n" -b "wq/$job-t$n" "wq/$job"
+lead=$WAYPOINT_SESSION_ID   # the lead's own session id; set --spawner-session-id explicitly if unset
+# `--worktree` creates branch `wq/$job-t$n` off the integration branch in a
+# sibling worktree, records the path on the session for cleanup, and launches
+# the worker there — no manual `git worktree add`. `--cwd` is the repo root the
+# worktree is cut from.
 sid=$(waypoint sessions start \
   --backend codex --model gpt-5-codex \
-  --cwd "$repo/../.wq/$job/task-$n" \
-  --title "subagent:wq-$job-$n" | jq -r .session.id)
+  --cwd "$repo" --worktree "wq/$job-t$n" --worktree-base "wq/$job" \
+  --title "subagent:wq-$job-$n" --spawner-session-id "$lead" \
+  | jq -r .session.id)
 # task:<n> is the immutable contract — never rewritten. Update status:<n> only.
 waypoint board set-meta job:$job --key status:$n --meta state=doing --meta assignee=$sid
 # then send the worker the fixed message from org-template.md
 ```
 
-Put the worktree root **outside** the repo (as above, `"$repo/../.wq/..."`)
-or add `.wq/` to `.gitignore`. Git does not auto-ignore a nested worktree path,
-so an in-tree `.wq/` shows up as untracked in the integration branch.
+`--worktree` removes the whole class of plumbing this step used to need: it picks
+a sibling path outside the working tree (so nothing shows up as untracked) and
+names the branch for you, so the old `wq/$job/task-$n` slash-collision and the
+in-tree `.wq/` gitignore caveats no longer apply. `--spawner-session-id "$lead"`
+is what makes owner-scoped reap work at the end (`sessions reap --spawned-by
+"$lead"`); it defaults from `WAYPOINT_SESSION_ID` when the lead is a session, but
+set it explicitly so cleanup is reliable.
 
 The per-task `--backend` / `--model` choice is a core reason to use a crew: spend
 a cheap, fast model on mechanical tasks and a stronger one where it matters. See
@@ -42,8 +48,17 @@ a cheap, fast model on mechanical tasks and a stronger one where it matters. See
 it a judgement call, not a routing engine.
 
 **Cross-repo jobs:** `repo` need not be fixed. For a task in another repository,
-create its worktree in that repo and point `--cwd` there — one job can span
-several repos at once. Track which repo a task belongs to in its `task:<n>` cell.
+point `--cwd` at that repo's root (with `--worktree`, the sibling worktree is cut
+there) — one job can span several repos at once. Track which repo a task belongs
+to in its `task:<n>` cell.
+
+**Monitor without polling.** Once workers are assigned, block on them rather than
+looping: `waypoint sessions wait <sid> <sid> …` returns when every worker reaches
+idle/terminal — that is the default; pass `--any` to return on the first. To react
+to a blocked child instantly, follow the fleet:
+`waypoint sessions events --follow --spawned-by "$lead" --filter approval_request`
+surfaces matching events across all your workers as they happen (`--filter` takes a
+single event kind; drop it to see everything).
 
 Check and merge **one task at a time** (sequential merges keep every conflict
 between a single branch and the integration branch):
@@ -54,14 +69,28 @@ git -C "$repo" merge --no-ff "wq/$job-t$n"
 # run the task's check, e.g. uv run pytest pkg/auth
 ```
 
-- Clean merge and green check → `git -C "$repo" worktree remove "$repo/../.wq/$job/task-$n"`
-  and set the task done: `waypoint board set-meta job:$job --key status:$n --meta state=done`.
-- Conflict or red → `git -C "$repo" merge --abort`, hand the task back:
-  `waypoint board set-meta job:$job --key status:$n --meta state=todo`, and reassign it.
+- Clean merge and green check → set the task done: `waypoint board set-meta
+  job:$job --key status:$n --meta state=done`. The worktree is removed for you
+  when the worker is reaped (its path is recorded on the session), so there is no
+  manual `git worktree remove`.
+- Red check → `git -C "$repo" merge --abort`, hand the task back
+  (`--meta state=todo`), and reassign it (often a fresh worktree).
+- Conflict → tell the two kinds apart. An **additive** conflict — two workers
+  appending to the same append-only file (a test suite, a registry, an export
+  list) — is not a real disagreement: keep both. Take the integration side and
+  re-append the worker's block: `git checkout --ours <file>`, then add the
+  worker's additions to the end (or hand-merge both hunks) and commit. A
+  **semantic** conflict — both branches changed the same logic — is the one you
+  `merge --abort` and hand back. If a shared file conflicts on *every* merge, the
+  tasks were not independent enough and should have been one worker.
 
 Finish when no task is `todo` or `doing`: run the **full** suite on `wq/$job`,
-post a summary to the board, reap the workers (`waypoint-subagents` → cleanup),
-and report integrated vs. blocked counts.
+then — for a server/CLI/integration artifact — **exercise the real thing**, not
+just unit tests. Green mocked tests routinely miss wiring bugs (a 422 from an
+unset field, git chatter polluting stdout); start the app and run the new paths
+once. Post a summary to the board, reap the workers with `waypoint sessions reap
+--spawned-by "$lead"` (this also removes their recorded worktrees), and report
+integrated vs. blocked counts.
 
 ## Worker
 

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -27,10 +27,8 @@ sid=$(waypoint sessions start \
   --backend codex --model gpt-5-codex \
   --cwd "$repo/../.wq/$job/task-$n" \
   --title "subagent:wq-$job-$n" | jq -r .session.id)
-# Re-post the cell's FULL contract text (kept in $task_text) — NOT a stub like
-# "task $n -> $sid". `--key` replaces the cell text, so a stub wipes the scope
-# the worker reads. The assignee goes in --meta. See org-template.md.
-waypoint board post job:$job "$task_text" --key task:$n --meta state=doing --meta assignee=$sid
+# task:<n> is the immutable contract — never rewritten. Update status:<n> only.
+waypoint board set-meta job:$job --key status:$n --meta state=doing --meta assignee=$sid
 # then send the worker the fixed message from org-template.md
 ```
 
@@ -57,9 +55,9 @@ git -C "$repo" merge --no-ff "wq/$job-t$n"
 ```
 
 - Clean merge and green check → `git -C "$repo" worktree remove "$repo/../.wq/$job/task-$n"`
-  and set the task done: `waypoint board post job:$job "task $n merged" --key task:$n --meta state=done`.
-- Conflict or red → `git -C "$repo" merge --abort`, hand the task back
-  (`--meta state=todo`), and reassign it (often a fresh worktree).
+  and set the task done: `waypoint board set-meta job:$job --key status:$n --meta state=done`.
+- Conflict or red → `git -C "$repo" merge --abort`, hand the task back:
+  `waypoint board set-meta job:$job --key status:$n --meta state=todo`, and reassign it.
 
 Finish when no task is `todo` or `doing`: run the **full** suite on `wq/$job`,
 post a summary to the board, reap the workers (`waypoint-subagents` → cleanup),
@@ -80,3 +78,17 @@ The board is the checkpoint — no separate state file. A lead (re)starting read
 `waypoint board read job:<job-id>` and continues: `done` tasks are merged (skip);
 `todo` tasks get assigned; a `doing` task whose worker is gone
 (`waypoint sessions show <sid>` → `exited`/`error`) is handed back to `todo`.
+
+### Resume after the lead dies
+
+1. Read the board: `waypoint board read job:<job-id>`.
+2. Find the old lead's workers: `waypoint sessions list --spawned-by <old-lead-sid>`.
+3. For each `doing` task, check its assigned worker (`waypoint sessions show <sid>`).
+   If `exited`/`error`, the worker is orphaned — hand the task back to `todo`:
+   `waypoint board set-meta job:<job-id> --key status:<n> --meta state=todo`.
+4. Workers still running can be adopted: read their events to verify progress, then
+   resume steering them.
+
+> **`waypoint sessions send` may report a transport timeout even when the input
+> landed.** Confirm via `waypoint sessions events <sid>` before resending — a
+> duplicate message can cause a worker to execute a task twice.

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -60,29 +60,41 @@ to a blocked child instantly, follow the fleet:
 surfaces matching events across all your workers as they happen (`--filter` takes a
 single event kind; drop it to see everything).
 
-Check and merge **one task at a time** (sequential merges keep every conflict
-between a single branch and the integration branch):
+Integrate **one task at a time**, and keep the integration branch's history
+**linear** — no merge commits. Rebase each task's branch onto the current
+integration tip, check it there, then fast-forward:
 
 ```bash
+git -C "$repo" switch "wq/$job-t$n"
+git -C "$repo" rebase "wq/$job"        # replay the task's commits onto the integration tip
+# run the task's check on the rebased branch, e.g. uv run pytest pkg/auth
 git -C "$repo" switch "wq/$job"
-git -C "$repo" merge --no-ff "wq/$job-t$n"
-# run the task's check, e.g. uv run pytest pkg/auth
+git -C "$repo" merge --ff-only "wq/$job-t$n"   # green check → fast-forward, never a merge commit
 ```
 
-- Clean merge and green check → set the task done: `waypoint board set-meta
-  job:$job --key status:$n --meta state=done`. The worktree is removed for you
-  when the worker is reaped (its path is recorded on the session), so there is no
-  manual `git worktree remove`.
-- Red check → `git -C "$repo" merge --abort`, hand the task back
-  (`--meta state=todo`), and reassign it (often a fresh worktree).
-- Conflict → tell the two kinds apart. An **additive** conflict — two workers
-  appending to the same append-only file (a test suite, a registry, an export
-  list) — is not a real disagreement: keep both. Take the integration side and
-  re-append the worker's block: `git checkout --ours <file>`, then add the
-  worker's additions to the end (or hand-merge both hunks) and commit. A
-  **semantic** conflict — both branches changed the same logic — is the one you
-  `merge --abort` and hand back. If a shared file conflicts on *every* merge, the
-  tasks were not independent enough and should have been one worker.
+A linear integration branch is the preferred shape. Rebasing one branch at a
+time keeps every conflict between a single task and the integration tip, and the
+branch lands cleanly however the final PR is merged. Merge commits are the thing
+to avoid: a squash- or rebase-style landing flattens them and re-replays the
+underlying commits, so any conflict you resolved *inside* a merge commit
+silently resurfaces at landing time.
+
+- Green check → fast-forward (above) and set the task done: `waypoint board
+  set-meta job:$job --key status:$n --meta state=done`. The worktree is removed
+  for you when the worker is reaped (its path is recorded on the session), so
+  there is no manual `git worktree remove`.
+- Red check → hand the task back (`--meta state=todo`) and reassign it (often a
+  fresh worktree). You checked *before* the fast-forward, so the integration
+  branch is untouched — nothing to undo.
+- Conflict during the rebase → tell the two kinds apart. An **additive**
+  conflict — two workers appending to the same append-only file (a test suite, a
+  registry, an export list) — is not a real disagreement: keep both. Take the
+  integration side and re-append the worker's block (`git checkout --ours
+  <file>`, then add the worker's additions to the end, or hand-merge both
+  hunks), `git add` it, and `git rebase --continue`. A **semantic** conflict —
+  both branches changed the same logic — is the one you `git rebase --abort` and
+  hand back. If a shared file conflicts on *every* task, the tasks were not
+  independent enough and should have been one worker.
 
 Finish when no task is `todo` or `doing`: run the **full** suite on `wq/$job`,
 then — for a server/CLI/integration artifact — **exercise the real thing**, not

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -202,11 +202,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return snapshot.model_dump(mode="json")
 
     @app.get("/api/sessions")
-    async def list_sessions(_: Annotated[str, Depends(token_dependency())]) -> Any:
-        sessions = [
-            session.model_dump(mode="json")
-            for session in context.runtime.list_sessions()
-        ]
+    async def list_sessions(
+        _: Annotated[str, Depends(token_dependency())],
+        spawned_by: Annotated[str | None, Query()] = None,
+    ) -> Any:
+        all_sessions = context.runtime.list_sessions()
+        if spawned_by is not None:
+            all_sessions = [
+                s for s in all_sessions if s.spawner_session_id == spawned_by
+            ]
+        sessions = [session.model_dump(mode="json") for session in all_sessions]
         return {"sessions": sessions}
 
     @app.get("/api/backends/{backend}/threads")

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -578,9 +578,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def board_clear(
         channel: str,
         _: Annotated[str, Depends(token_dependency())],
+        keep_last: Annotated[int | None, Query(ge=1)] = None,
     ) -> Any:
         # Remove the channel's posts but keep the (now empty) channel.
-        removed = await context.runtime.clear_board_channel(channel)
+        # With keep_last, the N most-recent log posts are retained; cells are
+        # always dropped.
+        removed = await context.runtime.clear_board_channel(
+            channel, keep_last=keep_last
+        )
         return {"channel": channel, "cleared": removed}
 
     @app.delete("/api/board/{channel}")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import os
 import shutil
+import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -267,6 +269,28 @@ def reset(
     run_reset(_settings_from_ctx(ctx), confirmed=yes)
 
 
+@app.command()
+def usage(
+    ctx: typer.Context,
+    refresh: Annotated[
+        bool,
+        typer.Option(
+            "--refresh",
+            help="POST /api/usage/refresh to pull fresh rate-limit data before "
+            "returning the dashboard.",
+        ),
+    ] = False,
+) -> None:
+    """Show the usage dashboard (token usage, rate limits, cost per session)."""
+
+    def run(c: WaypointClient) -> Any:
+        if refresh:
+            return c.refresh_usage()
+        return c.get_usage()
+
+    _emit(_settings_from_ctx(ctx), run)
+
+
 @session_app.command("start")
 def session_start(
     ctx: typer.Context,
@@ -504,24 +528,194 @@ async def _wait_for_session(
         return session, None
 
 
-async def _follow_events(settings: Settings, session_id: str) -> None:
-    """Stream event envelopes as NDJSON until a terminal status or SIGINT."""
+async def _follow_events_fleet(
+    settings: Settings,
+    session_ids: list[str],
+    *,
+    spawned_by: str | None,
+    mine: bool,
+    filter_type: str | None,
+) -> None:
+    """Stream event envelopes as NDJSON across one or more sessions.
+
+    Each output line is a compact JSON envelope; multi-session output adds a
+    ``session_id`` key to disambiguate. Stops when all tracked sessions reach
+    a terminal status or SIGINT fires.
+    """
     try:
         with WaypointClient(settings) as client:
-            async for envelope in client.stream_session_envelopes(session_id):
-                if is_event_envelope(envelope):
-                    _emit_ndjson(envelope)
-                if session_status_from_envelope(envelope) in FOLLOW_TERMINAL_STATUSES:
-                    break
+            extra_ids: list[str] = []
+            if spawned_by or mine:
+                sessions = await asyncio.to_thread(client.list_sessions)
+                if spawned_by:
+                    extra_ids += [
+                        s["id"]
+                        for s in sessions
+                        if s.get("spawner_session_id") == spawned_by
+                    ]
+                if mine:
+                    my_id = os.environ.get("WAYPOINT_SESSION_ID")
+                    if my_id:
+                        extra_ids += [
+                            s["id"]
+                            for s in sessions
+                            if s.get("spawner_session_id") == my_id
+                        ]
+
+            # Deduplicate while preserving order.
+            seen: set[str] = set()
+            all_ids: list[str] = []
+            for sid in session_ids + extra_ids:
+                if sid not in seen:
+                    seen.add(sid)
+                    all_ids.append(sid)
+
+            if not all_ids:
+                typer.echo("error: no sessions to follow", err=True)
+                raise typer.Exit(code=1)
+
+            if len(all_ids) == 1:
+                sid = all_ids[0]
+                async for envelope in client.stream_session_envelopes(sid):
+                    if is_event_envelope(envelope):
+                        kind = envelope.get("payload", {}).get("event", {}).get("kind")
+                        if filter_type is None or kind == filter_type:
+                            _emit_ndjson(envelope)
+                    if (
+                        session_status_from_envelope(envelope)
+                        in FOLLOW_TERMINAL_STATUSES
+                    ):
+                        break
+                return
+
+            # Multiple sessions: merge streams, prefix each line with session_id.
+            queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
+
+            async def _stream_one(sid: str) -> None:
+                try:
+                    async for envelope in client.stream_session_envelopes(sid):
+                        if is_event_envelope(envelope):
+                            await queue.put({"session_id": sid, **envelope})
+                        if (
+                            session_status_from_envelope(envelope)
+                            in FOLLOW_TERMINAL_STATUSES
+                        ):
+                            break
+                except (WaypointError, OSError, WebSocketException):
+                    pass
+                finally:
+                    await queue.put(None)
+
+            tasks = [asyncio.create_task(_stream_one(sid)) for sid in all_ids]
+            remaining = len(all_ids)
+            try:
+                while remaining > 0:
+                    item = await queue.get()
+                    if item is None:
+                        remaining -= 1
+                    else:
+                        kind = item.get("payload", {}).get("event", {}).get("kind")
+                        if filter_type is None or kind == filter_type:
+                            _emit_ndjson(item)
+            finally:
+                for task in tasks:
+                    task.cancel()
+
     except (WaypointError, OSError, WebSocketException) as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
 
 
+async def _wait_sessions_concurrent(
+    client: WaypointClient,
+    session_ids: list[str],
+    until: frozenset[str],
+    timeout: float | None,
+    *,
+    first_wins: bool,
+) -> list[tuple[dict[str, Any], str | None]]:
+    """Wait for all sessions (or the first one) to reach ``until`` or timeout.
+
+    Returns a list of ``(session, status)`` pairs.  ``status`` is ``None`` when
+    the session's slot timed out before reaching the target set.
+    """
+    tasks = [
+        asyncio.create_task(_wait_for_session(client, sid, until, None))
+        for sid in session_ids
+    ]
+    try:
+        async with asyncio.timeout(timeout):
+            if first_wins:
+                done, pending = await asyncio.wait(
+                    tasks, return_when=asyncio.FIRST_COMPLETED
+                )
+                for t in pending:
+                    t.cancel()
+                first = next(iter(done))
+                try:
+                    return [first.result()]
+                except Exception:
+                    session = await asyncio.to_thread(
+                        client.get_session, session_ids[0]
+                    )
+                    return [(session, None)]
+            else:
+                pairs = await asyncio.gather(*tasks, return_exceptions=True)
+                results: list[tuple[dict[str, Any], str | None]] = []
+                for i, pair in enumerate(pairs):
+                    if isinstance(pair, BaseException):
+                        try:
+                            session = await asyncio.to_thread(
+                                client.get_session, session_ids[i]
+                            )
+                        except Exception:
+                            session = {"id": session_ids[i]}
+                        results.append((session, None))
+                    else:
+                        results.append(pair)
+                return results
+    except TimeoutError:
+        for t in tasks:
+            t.cancel()
+        results = []
+        for sid in session_ids:
+            try:
+                session = await asyncio.to_thread(client.get_session, sid)
+            except Exception:
+                session = {"id": sid}
+            results.append((session, None))
+        return results
+
+
 @sessions_app.command("list")
-def sessions_list(ctx: typer.Context) -> None:
+def sessions_list(
+    ctx: typer.Context,
+    spawned_by: Annotated[
+        str | None,
+        typer.Option(
+            "--spawned-by", help="Return only sessions spawned by this session id."
+        ),
+    ] = None,
+    mine: Annotated[
+        bool,
+        typer.Option(
+            "--mine",
+            help="Return only sessions spawned by $WAYPOINT_SESSION_ID.",
+        ),
+    ] = False,
+) -> None:
     """List all sessions."""
-    _emit(_settings_from_ctx(ctx), lambda c: {"sessions": c.list_sessions()})
+    if mine:
+        spawned_by = os.environ.get("WAYPOINT_SESSION_ID")
+        if not spawned_by:
+            raise typer.BadParameter(
+                "$WAYPOINT_SESSION_ID is not set; cannot use --mine",
+                param_hint="--mine",
+            )
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {"sessions": c.list_sessions(spawned_by=spawned_by)},
+    )
 
 
 @sessions_app.command("show")
@@ -535,7 +729,7 @@ def sessions_show(
 @sessions_app.command("events")
 def sessions_events(
     ctx: typer.Context,
-    session_id: Annotated[str, typer.Argument()],
+    session_ids: Annotated[list[str] | None, typer.Argument()] = None,
     messages: Annotated[int | None, typer.Option()] = None,
     before_sequence: Annotated[int | None, typer.Option()] = None,
     follow: Annotated[
@@ -547,14 +741,58 @@ def sessions_events(
             "terminal status or Ctrl+C, instead of printing the transcript.",
         ),
     ] = False,
+    spawned_by: Annotated[
+        str | None,
+        typer.Option(
+            "--spawned-by",
+            help="(--follow only) Also follow sessions whose spawner_session_id "
+            "matches this id.",
+        ),
+    ] = None,
+    mine: Annotated[
+        bool,
+        typer.Option(
+            "--mine",
+            help="(--follow only) Also follow sessions spawned by this session "
+            "(WAYPOINT_SESSION_ID env).",
+        ),
+    ] = False,
+    filter_type: Annotated[
+        str | None,
+        typer.Option(
+            "--filter",
+            help="(--follow only) Print only events whose kind matches this value "
+            "(e.g. approval_request, agent_output).",
+        ),
+    ] = None,
 ) -> None:
-    """Show a session's transcript, or stream live events with --follow."""
+    """Show a session's transcript, or stream live events with --follow.
+
+    Pass one or more SESSION_IDs, or use --spawned-by / --mine with --follow
+    to resolve the set dynamically from the running server.
+    """
     if follow:
         try:
-            asyncio.run(_follow_events(_settings_from_ctx(ctx), session_id))
+            asyncio.run(
+                _follow_events_fleet(
+                    _settings_from_ctx(ctx),
+                    list(session_ids or []),
+                    spawned_by=spawned_by,
+                    mine=mine,
+                    filter_type=filter_type,
+                )
+            )
         except KeyboardInterrupt:
             pass
         return
+
+    # Non-follow: exactly one session id required.
+    if not session_ids or len(session_ids) != 1:
+        typer.echo(
+            "error: exactly one SESSION_ID is required without --follow", err=True
+        )
+        raise typer.Exit(code=1)
+    session_id = session_ids[0]
     _emit(
         _settings_from_ctx(ctx),
         lambda c: c.get_events(
@@ -571,7 +809,7 @@ def _conversation_events(events_page: dict[str, Any]) -> list[dict[str, Any]]:
 @sessions_app.command("wait")
 def sessions_wait(
     ctx: typer.Context,
-    session_id: Annotated[str, typer.Argument()],
+    session_ids: Annotated[list[str], typer.Argument()],
     until: Annotated[
         str | None,
         typer.Option(
@@ -584,27 +822,95 @@ def sessions_wait(
         float | None,
         typer.Option("--timeout", help="Give up after this many seconds (exit 124)."),
     ] = None,
+    any_: Annotated[
+        bool,
+        typer.Option(
+            "--any",
+            help="Return as soon as the first session reaches the until-set "
+            "(default: wait for ALL).",
+        ),
+    ] = False,
 ) -> None:
-    """Block (printing nothing) until a session reaches a terminal/idle status.
+    """Block until one or more sessions reach a terminal/idle status.
 
-    Emits the final ``{"session": {...}}`` once, then exits with a status-mapped
-    code (error=1, timeout=124, otherwise 0) so it composes in shell ``&&``
-    chains. Prefers the WS stream, falling back to polling if it cannot connect.
+    With a single id emits ``{"session": {...}}``; with multiple ids emits
+    ``{"sessions": [...]}``.  Exits with a status-mapped code (error=1,
+    timeout=124, otherwise 0) so it composes in shell ``&&`` chains.  Prefers
+    the WS stream, falling back to polling if it cannot connect.
     """
+    if not session_ids:
+        typer.echo("error: provide at least one SESSION_ID", err=True)
+        raise typer.Exit(code=1)
+
     until_set = parse_wait_until(until)
-    outcome: dict[str, str | None] = {}
+    outcome_statuses: list[str | None] = []
 
     def run(c: WaypointClient) -> dict[str, Any]:
-        session, status = asyncio.run(
-            _wait_for_session(c, session_id, until_set, timeout)
+        pairs = asyncio.run(
+            _wait_sessions_concurrent(
+                c, session_ids, until_set, timeout, first_wins=any_
+            )
         )
-        outcome["status"] = status
-        return {"session": session}
+        outcome_statuses.extend(status for _, status in pairs)
+        if len(session_ids) == 1:
+            session, _ = pairs[0]
+            return {"session": session}
+        return {"sessions": [session for session, _ in pairs]}
 
     _emit(_settings_from_ctx(ctx), run)
-    code = exit_code_for_wait(outcome.get("status"))
-    if code:
-        raise typer.Exit(code=code)
+
+    if any(s is None for s in outcome_statuses):
+        raise typer.Exit(code=WAIT_TIMEOUT_EXIT_CODE)
+    if any(s == SessionStatus.ERROR for s in outcome_statuses):
+        raise typer.Exit(code=1)
+
+
+def _create_worktree(branch: str, base: str | None, cwd: str) -> str:
+    """Create a git worktree for ``branch`` and return its path.
+
+    The worktree is placed in a sibling directory of the repo root so it
+    never appears as an untracked file inside the working tree.
+    """
+    try:
+        repo_root = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        typer.echo(f"error: not a git repository: {exc.stderr.strip()}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    if base is None:
+        try:
+            base = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+        except subprocess.CalledProcessError:
+            base = "main"
+
+    # Sanitize branch name for use as a directory component.
+    safe = branch.replace("/", "-").replace("\\", "-")
+    repo_dir = Path(repo_root)
+    worktree_path = str(repo_dir.parent / f"{repo_dir.name}-{safe}")
+
+    try:
+        subprocess.run(
+            ["git", "worktree", "add", worktree_path, "-b", branch, base],
+            cwd=repo_root,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        typer.echo(f"error: git worktree add failed: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+    return worktree_path
 
 
 @sessions_app.command("start")
@@ -625,21 +931,42 @@ def sessions_start(
             "Defaults to this session's id when run inside one.",
         ),
     ] = None,
+    worktree: Annotated[
+        str | None,
+        typer.Option(
+            "--worktree",
+            help="Create a git worktree on this new branch and use it as the session cwd.",
+        ),
+    ] = None,
+    worktree_base: Annotated[
+        str | None,
+        typer.Option(
+            "--worktree-base",
+            help="Base ref for the new worktree branch (default: current HEAD, else main).",
+        ),
+    ] = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Launch a new session on the running server."""
+    effective_cwd = cwd
+    worktree_path: str | None = None
+    if worktree is not None:
+        worktree_path = _create_worktree(worktree, worktree_base, cwd)
+        effective_cwd = worktree_path
+
     _emit(
         _settings_from_ctx(ctx),
         lambda c: {
             "session": c.create_session(
                 backend=backend,
-                cwd=cwd,
+                cwd=effective_cwd,
                 launch_target_id=launch_target_id,
                 title=title,
                 model=model,
                 effort=effort,
                 permission_mode=permission_mode,
                 spawner_session_id=spawner_session_id,
+                worktree_path=worktree_path,
                 args=list(args or []),
             )
         },
@@ -665,13 +992,22 @@ def sessions_send(
         ),
     ] = None,
 ) -> None:
-    """Send a message to a session."""
+    """Send a message to a session.
+
+    Exits 0 on confirmed delivery or when the server accepted the input.
+    On transport timeout, reports ``{"session": {..., "send": "delivered"}}``
+    when the session advanced to running, or ``{"send": "unknown"}`` when
+    delivery cannot be confirmed, and exits 1 in the unknown case.
+    """
 
     def _run(c: WaypointClient) -> dict[str, Any]:
         ids = [c.upload_attachment(session_id, path)["id"] for path in attach or []]
         return {"session": c.send_input(session_id, text, attachments=ids or None)}
 
-    _emit(_settings_from_ctx(ctx), _run)
+    result = _run_client(_settings_from_ctx(ctx), _run)
+    typer.echo(json.dumps(result, indent=2))
+    if result.get("session", {}).get("send") == "unknown":
+        raise typer.Exit(code=1)
 
 
 @sessions_app.command("interrupt")
@@ -704,6 +1040,61 @@ def sessions_delete(
 ) -> None:
     """Terminate (if needed) and remove a session record."""
     _emit(_settings_from_ctx(ctx), lambda c: c.delete(session_id, force=force))
+
+
+@sessions_app.command("reap")
+def sessions_reap(
+    ctx: typer.Context,
+    spawned_by: Annotated[
+        str | None,
+        typer.Option(
+            "--spawned-by", help="Reap only sessions spawned by this session id."
+        ),
+    ] = None,
+    mine: Annotated[
+        bool,
+        typer.Option(
+            "--mine",
+            help="Reap only sessions spawned by $WAYPOINT_SESSION_ID.",
+        ),
+    ] = False,
+    all_sessions: Annotated[
+        bool,
+        typer.Option(
+            "--all",
+            help="Reap all sessions regardless of spawner. Required when no scope is given.",
+        ),
+    ] = False,
+) -> None:
+    """Terminate and delete sessions in bulk."""
+    if mine:
+        spawned_by = os.environ.get("WAYPOINT_SESSION_ID")
+        if not spawned_by:
+            raise typer.BadParameter(
+                "$WAYPOINT_SESSION_ID is not set; cannot use --mine",
+                param_hint="--mine",
+            )
+
+    if spawned_by is None and not all_sessions:
+        raise typer.BadParameter(
+            "pass --spawned-by <id>, --mine, or --all to select a scope",
+            param_hint="--spawned-by/--mine/--all",
+        )
+
+    def _run(client: WaypointClient) -> dict[str, Any]:
+        sessions = client.list_sessions(spawned_by=spawned_by)
+        reaped: list[str] = []
+        failed: list[str] = []
+        for session in sessions:
+            sid = session["id"]
+            try:
+                client.delete(sid)
+                reaped.append(sid)
+            except Exception:
+                failed.append(sid)
+        return {"reaped": reaped, "failed": failed}
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @sessions_app.command("approve")
@@ -931,6 +1322,45 @@ def board_edit_entry(
         _settings_from_ctx(ctx),
         lambda c: {"entry": c.update_board_entry(channel, entry_id, text, metadata)},
     )
+
+
+@board_app.command("set-meta")
+def board_set_meta(
+    ctx: typer.Context,
+    channel: Annotated[str, typer.Argument()],
+    meta: Annotated[
+        list[str] | None,
+        typer.Option("--meta", help="Replace metadata with key=value. Repeatable."),
+    ] = None,
+    key: Annotated[
+        str | None, typer.Option("--key", help="Cell key to target.")
+    ] = None,
+    entry_id: Annotated[
+        int | None, typer.Option("--entry-id", help="Entry id to target.")
+    ] = None,
+) -> None:
+    """Update a keyed cell's metadata without changing its text."""
+    if key is None and entry_id is None:
+        raise typer.BadParameter("Provide --key or --entry-id.")
+    if key is not None and entry_id is not None:
+        raise typer.BadParameter("--key and --entry-id are mutually exclusive.")
+    metadata = _parse_meta(meta)
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        if key is not None:
+            entries = c.read_board(channel, key=key)
+            if not entries:
+                typer.echo(f"error: no entry with key '{key}' in {channel}", err=True)
+                raise typer.Exit(code=1)
+            eid: int = entries[0]["id"]
+        else:
+            assert entry_id is not None
+            eid = entry_id
+        return {
+            "entry": c.update_board_entry(channel, eid, text=None, metadata=metadata)
+        }
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @schedule_app.command("list")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -904,10 +904,12 @@ def _create_worktree(branch: str, base: str | None, cwd: str) -> str:
         subprocess.run(
             ["git", "worktree", "add", worktree_path, "-b", branch, base],
             cwd=repo_root,
+            capture_output=True,
+            text=True,
             check=True,
         )
     except subprocess.CalledProcessError as exc:
-        typer.echo(f"error: git worktree add failed: {exc}", err=True)
+        typer.echo(f"error: git worktree add failed: {exc.stderr.strip()}", err=True)
         raise typer.Exit(code=1) from exc
 
     return worktree_path

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1229,7 +1229,8 @@ def board_post(
         typer.Option(
             envvar="WAYPOINT_SESSION_ID",
             help="Authoring session; defaults to this session's id. "
-            "Posts are pruned when that session is deleted.",
+            "Keyed cells are pruned when that session is deleted; "
+            "keyless log posts survive as durable history.",
         ),
     ] = None,
 ) -> None:
@@ -1260,12 +1261,117 @@ def board_read(
     key: Annotated[
         str | None, typer.Option("--key", help="Only the cell with this key.")
     ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json", help="Emit structured JSON instead of the rendered view."
+        ),
+    ] = False,
 ) -> None:
-    """Read entries from a board channel."""
-    _emit(
-        _settings_from_ctx(ctx),
-        lambda c: {"entries": c.read_board(channel, since=since, key=key)},
+    """Read entries from a board channel.
+
+    Default view: a Cells section followed by a Log section (newest-first).
+    With --json: ``{"channel": ..., "cells": [...], "log": [...]}``.
+    """
+    entries = _run_client(
+        _settings_from_ctx(ctx), lambda c: c.read_board(channel, since=since, key=key)
     )
+    cells = [e for e in entries if e.get("key") is not None]
+    log = [e for e in entries if e.get("key") is None]
+
+    if key is not None and not cells:
+        typer.echo(f"no cell '{key}' matched in {channel}", err=True)
+
+    if json_output:
+        typer.echo(
+            json.dumps({"channel": channel, "cells": cells, "log": log}, indent=2)
+        )
+        return
+
+    typer.echo(f"=== Cells ({channel}) ===")
+    if cells:
+        for cell in cells:
+            meta_str = "  ".join(
+                f"{k}={v}" for k, v in (cell.get("metadata") or {}).items()
+            )
+            line = cell.get("key", "")
+            if meta_str:
+                line += f"  [{meta_str}]"
+            line += f"  {cell.get('text', '')}"
+            typer.echo(line)
+    else:
+        typer.echo("(no cells)")
+
+    typer.echo(f"\n=== Log ({channel}) ===")
+    if log:
+        for post in reversed(log):
+            ts = post.get("created_at", "")
+            author = post.get("author_label") or post.get("author_session_id") or "—"
+            typer.echo(f"{ts}  {author}: {post.get('text', '')}")
+    else:
+        typer.echo("(no posts)")
+
+
+@board_app.command("log")
+def board_log(
+    ctx: typer.Context,
+    channel: Annotated[str, typer.Argument()],
+    since: Annotated[
+        int | None,
+        typer.Option("--since", help="Only posts with an id greater than this."),
+    ] = None,
+    author: Annotated[
+        str | None,
+        typer.Option("--author", help="Filter by author session id."),
+    ] = None,
+    grep: Annotated[
+        str | None,
+        typer.Option("--grep", help="Substring match on post text (case-insensitive)."),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Maximum number of posts to show."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option(
+            "--json", help="Emit structured JSON instead of the rendered view."
+        ),
+    ] = False,
+) -> None:
+    """Show the append-log (keyless posts) for a channel, newest-first."""
+    entries = _run_client(
+        _settings_from_ctx(ctx), lambda c: c.read_board(channel, since=since)
+    )
+    posts = [e for e in entries if e.get("key") is None]
+
+    if author is not None:
+        posts = [p for p in posts if p.get("author_session_id") == author]
+        if not posts:
+            typer.echo(f"no posts by '{author}' matched in {channel}", err=True)
+
+    if grep is not None:
+        posts = [p for p in posts if grep.lower() in (p.get("text") or "").lower()]
+        if not posts:
+            typer.echo(f"no posts matching '{grep}' matched in {channel}", err=True)
+
+    posts = list(reversed(posts))
+    if limit is not None:
+        posts = posts[:limit]
+
+    if json_output:
+        typer.echo(json.dumps(posts, indent=2))
+        return
+
+    if posts:
+        for post in posts:
+            ts = post.get("created_at", "")
+            author_label = (
+                post.get("author_label") or post.get("author_session_id") or "—"
+            )
+            typer.echo(f"{ts}  {author_label}: {post.get('text', '')}")
+    else:
+        typer.echo("(no posts)")
 
 
 @board_app.command("channels")
@@ -1278,9 +1384,23 @@ def board_channels(ctx: typer.Context) -> None:
 def board_clear(
     ctx: typer.Context,
     channel: Annotated[str, typer.Argument()],
+    keep_last: Annotated[
+        int | None,
+        typer.Option(
+            "--keep-last",
+            help="Retain the N most-recent log posts; cells are always dropped.",
+            min=1,
+        ),
+    ] = None,
 ) -> None:
-    """Remove all posts from a channel, keeping the (now empty) channel."""
-    _emit(_settings_from_ctx(ctx), lambda c: c.clear_board(channel))
+    """Remove all posts from a channel, keeping the (now empty) channel.
+
+    With --keep-last N, the N most-recent keyless log posts are kept; cells
+    are always deleted.
+    """
+    _emit(
+        _settings_from_ctx(ctx), lambda c: c.clear_board(channel, keep_last=keep_last)
+    )
 
 
 @board_app.command("delete")

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -411,9 +411,12 @@ class WaypointClient:
         ).json()["entry"]
         return data
 
-    def clear_board(self, channel: str) -> dict[str, Any]:
+    def clear_board(self, channel: str, keep_last: int | None = None) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if keep_last is not None:
+            params["keep_last"] = keep_last
         data: dict[str, Any] = self._request(
-            "POST", f"/api/board/{channel}/clear"
+            "POST", f"/api/board/{channel}/clear", params=params or None
         ).json()
         return data
 

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -155,10 +155,13 @@ class WaypointClient:
 
     # ── sessions ────────────────────────────────────────────────────────
 
-    def list_sessions(self) -> list[dict[str, Any]]:
-        data: list[dict[str, Any]] = self._request("GET", "/api/sessions").json()[
-            "sessions"
-        ]
+    def list_sessions(self, spawned_by: str | None = None) -> list[dict[str, Any]]:
+        params: dict[str, str] = {}
+        if spawned_by is not None:
+            params["spawned_by"] = spawned_by
+        data: list[dict[str, Any]] = self._request(
+            "GET", "/api/sessions", params=params if params else None
+        ).json()["sessions"]
         return data
 
     def get_session(self, session_id: str) -> dict[str, Any]:
@@ -251,6 +254,7 @@ class WaypointClient:
         effort: str | None = None,
         permission_mode: str | None = None,
         spawner_session_id: str | None = None,
+        worktree_path: str | None = None,
         args: list[str] | None = None,
     ) -> dict[str, Any]:
         body = {
@@ -262,6 +266,7 @@ class WaypointClient:
             "effort": effort,
             "permission_mode": permission_mode,
             "spawner_session_id": spawner_session_id,
+            "worktree_path": worktree_path,
             "args": args or [],
         }
         data: dict[str, Any] = self._request("POST", "/api/sessions", json=body).json()[
@@ -295,12 +300,22 @@ class WaypointClient:
         body: dict[str, Any] = {"text": text, "submit": submit}
         if attachments:
             body["attachments"] = attachments
-        data: dict[str, Any] = self._request(
-            "POST",
-            f"/api/sessions/{session_id}/input",
-            json=body,
-        ).json()["session"]
-        return data
+        try:
+            return self._request(
+                "POST",
+                f"/api/sessions/{session_id}/input",
+                json=body,
+            ).json()["session"]
+        except WaypointError as exc:
+            if not isinstance(exc.__cause__, httpx.TimeoutException):
+                raise
+        # Timeout: the server may have already accepted the input. Check session status.
+        try:
+            session = self.get_session(session_id)
+        except WaypointError:
+            return {"id": session_id, "send": "unknown"}
+        send_flag = "delivered" if session.get("status") == "running" else "unknown"
+        return {**session, "send": send_flag}
 
     def answer_question(
         self,
@@ -416,10 +431,12 @@ class WaypointClient:
         self,
         channel: str,
         entry_id: int,
-        text: str,
+        text: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        body = {"text": text, "metadata": metadata or {}}
+        body: dict[str, Any] = {"metadata": metadata or {}}
+        if text is not None:
+            body["text"] = text
         data: dict[str, Any] = self._request(
             "PATCH", f"/api/board/{channel}/entries/{entry_id}", json=body
         ).json()["entry"]
@@ -482,4 +499,14 @@ class WaypointClient:
         data: dict[str, Any] = self._request(
             "POST", "/api/schedules/clear-history"
         ).json()
+        return data
+
+    # ── usage ────────────────────────────────────────────────────────────
+
+    def get_usage(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("GET", "/api/usage").json()
+        return data
+
+    def refresh_usage(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("POST", "/api/usage/refresh").json()
         return data

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -5,6 +5,7 @@ import os
 import re
 import secrets
 import shutil
+import subprocess
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
@@ -366,6 +367,10 @@ class SessionRuntime:
             resolved_model=resolved_model,
             resolved_effort=resolved_effort,
         )
+        if request.worktree_path is not None:
+            session = self.storage.update_session(
+                session.id, worktree_path=request.worktree_path
+            )
         self._warm_command_completions(session)
         return session
 
@@ -1190,6 +1195,12 @@ class SessionRuntime:
                 await self.terminate(session_id)
         self._close_structured_log(session_id)
         self.storage.delete_session(session_id)
+        if session.worktree_path is not None:
+            with suppress(Exception):
+                subprocess.run(
+                    ["git", "worktree", "remove", "--force", session.worktree_path],
+                    check=False,
+                )
         # Reclaim the session's uploaded blobs, which can be large.
         self.attachments.discard(session_id)
         # Drop this session's blackboard posts along with its record.

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1213,11 +1213,17 @@ class SessionRuntime:
     async def post_board_entry(
         self, channel: str, request: BoardPostRequest
     ) -> BoardEntry:
+        author_label: str | None = None
+        if request.author_session_id is not None:
+            session = self.storage.get_session(request.author_session_id)
+            if session is not None:
+                author_label = session.title
         entry = self.storage.add_board_entry(
             channel,
             request.text,
             key=request.key,
             author_session_id=request.author_session_id,
+            author_label=author_label,
             metadata=request.metadata,
         )
         await self._publish_board_update(channel)
@@ -1238,8 +1244,10 @@ class SessionRuntime:
     def list_board_channels(self) -> list[BoardChannel]:
         return self.storage.list_board_channels()
 
-    async def clear_board_channel(self, channel: str) -> int:
-        removed = self.storage.clear_board_channel(channel)
+    async def clear_board_channel(
+        self, channel: str, keep_last: int | None = None
+    ) -> int:
+        removed = self.storage.clear_board_channel(channel, keep_last=keep_last)
         await self._publish_board_update(channel)
         return removed
 

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -232,8 +232,13 @@ class BoardEntry(BaseModel):
     channel: str
     # The session that posted this, stamped by the CLI from
     # ``WAYPOINT_SESSION_ID``. ``None`` when posted outside a session (a user
-    # via the frontend, an ad-hoc CLI call). Pruned with its authoring session.
+    # via the frontend, an ad-hoc CLI call). Keyed cells authored by a session
+    # are pruned on session delete; keyless log posts are durable history and
+    # survive the session row being removed.
     author_session_id: str | None = None
+    # Snapshot of the authoring session's title at post time. Stays readable
+    # after the session row is deleted.
+    author_label: str | None = None
     key: str | None = None
     text: str
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -201,6 +201,7 @@ class SessionRecord(BaseModel):
     # ``WAYPOINT_SESSION_ID``). Used to inherit the spawner's permission mode
     # and to identify subagent sessions. ``None`` for user/top-level sessions.
     spawner_session_id: str | None = None
+    worktree_path: str | None = None
     permission_mode: str | None = None
     model: str | None = None
     effort: str | None = None
@@ -257,7 +258,7 @@ class BoardPostRequest(BaseModel):
 
 
 class BoardEntryUpdateRequest(BaseModel):
-    text: str
+    text: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
 
 
@@ -342,6 +343,7 @@ class SessionCreateRequest(BaseModel):
     # spawns this one. When ``permission_mode`` is unset and the spawner shares
     # this backend, the child inherits the spawner's mode.
     spawner_session_id: str | None = None
+    worktree_path: str | None = None
     permission_mode: str | None = None
     model: str | None = None
     effort: str | None = None

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -184,6 +184,7 @@ class Storage:
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 channel TEXT NOT NULL,
                 author_session_id TEXT,
+                author_label TEXT,
                 key TEXT,
                 text TEXT NOT NULL,
                 metadata TEXT NOT NULL DEFAULT '{}',
@@ -209,6 +210,7 @@ class Storage:
             "SELECT channel, MIN(created_at) FROM board_entries GROUP BY channel"
         )
         self._ensure_column("board_entries", "edited_at", "TEXT")
+        self._ensure_column("board_entries", "author_label", "TEXT")
         self._ensure_column("scheduled_sessions", "permission_mode", "TEXT")
         self._ensure_column("scheduled_sessions", "model", "TEXT")
         self._ensure_column("scheduled_sessions", "effort", "TEXT")
@@ -344,6 +346,7 @@ class Storage:
         *,
         key: str | None = None,
         author_session_id: str | None = None,
+        author_label: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> BoardEntry:
         now = datetime.now(UTC)
@@ -357,10 +360,17 @@ class Storage:
             cursor = self.connection.execute(
                 """
                 INSERT INTO board_entries
-                    (channel, author_session_id, key, text, metadata, created_at)
-                VALUES (?, ?, NULL, ?, ?, ?)
+                    (channel, author_session_id, author_label, key, text, metadata, created_at)
+                VALUES (?, ?, ?, NULL, ?, ?, ?)
                 """,
-                (channel, author_session_id, text, meta_json, now.isoformat()),
+                (
+                    channel,
+                    author_session_id,
+                    author_label,
+                    text,
+                    meta_json,
+                    now.isoformat(),
+                ),
             )
             entry_id = int(cursor.lastrowid or 0)
         else:
@@ -369,15 +379,24 @@ class Storage:
             self.connection.execute(
                 """
                 INSERT INTO board_entries
-                    (channel, author_session_id, key, text, metadata, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (channel, author_session_id, author_label, key, text, metadata, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(channel, key) DO UPDATE SET
                     author_session_id = excluded.author_session_id,
+                    author_label = excluded.author_label,
                     text = excluded.text,
                     metadata = excluded.metadata,
                     created_at = excluded.created_at
                 """,
-                (channel, author_session_id, key, text, meta_json, now.isoformat()),
+                (
+                    channel,
+                    author_session_id,
+                    author_label,
+                    key,
+                    text,
+                    meta_json,
+                    now.isoformat(),
+                ),
             )
             row = self.connection.execute(
                 "SELECT id FROM board_entries WHERE channel = ? AND key = ?",
@@ -389,6 +408,7 @@ class Storage:
             id=entry_id,
             channel=channel,
             author_session_id=author_session_id,
+            author_label=author_label,
             key=key,
             text=text,
             metadata=meta,
@@ -483,12 +503,37 @@ class Storage:
         ]
 
     @_synchronized
-    def clear_board_channel(self, channel: str) -> int:
+    def clear_board_channel(self, channel: str, keep_last: int | None = None) -> int:
         # Remove the posts but keep the channel registered so it survives empty.
-        cursor = self.connection.execute(
-            "DELETE FROM board_entries WHERE channel = ?",
-            (channel,),
-        )
+        # With keep_last, retain the N most-recent keyless log posts; cells are
+        # always deleted regardless.
+        if keep_last is not None and keep_last > 0:
+            cutoff_row = self.connection.execute(
+                """
+                SELECT id FROM board_entries
+                WHERE channel = ? AND key IS NULL
+                ORDER BY id DESC
+                LIMIT 1 OFFSET ?
+                """,
+                (channel, keep_last - 1),
+            ).fetchone()
+            if cutoff_row is not None:
+                cursor = self.connection.execute(
+                    "DELETE FROM board_entries WHERE channel = ? AND "
+                    "(key IS NOT NULL OR id < ?)",
+                    (channel, cutoff_row["id"]),
+                )
+            else:
+                # Fewer than keep_last log posts exist; only drop cells.
+                cursor = self.connection.execute(
+                    "DELETE FROM board_entries WHERE channel = ? AND key IS NOT NULL",
+                    (channel,),
+                )
+        else:
+            cursor = self.connection.execute(
+                "DELETE FROM board_entries WHERE channel = ?",
+                (channel,),
+            )
         self.connection.commit()
         return cursor.rowcount or 0
 
@@ -549,8 +594,10 @@ class Storage:
 
     @_synchronized
     def prune_board_for_session(self, session_id: str) -> int:
+        # Only keyed cells are pruned; keyless log posts are durable history
+        # and survive a session delete (GC by channel via clear/delete).
         cursor = self.connection.execute(
-            "DELETE FROM board_entries WHERE author_session_id = ?",
+            "DELETE FROM board_entries WHERE author_session_id = ? AND key IS NOT NULL",
             (session_id,),
         )
         self.connection.commit()

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -223,6 +223,7 @@ class Storage:
         self._ensure_column("sessions", "context_usage", "TEXT")
         self._ensure_column("sessions", "rate_limit_usage", "TEXT")
         self._ensure_column("sessions", "spawner_session_id", "TEXT")
+        self._ensure_column("sessions", "worktree_path", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -240,9 +241,9 @@ class Storage:
                 id, backend, source, transport, title, cwd, launch_target_id,
                 launch_mode, repo_name, branch, status, created_at, updated_at,
                 last_event_at, raw_log_path, structured_log_path, transport_state,
-                pinned_at, spawner_session_id, permission_mode, model, effort, args,
-                config_overrides, context_usage, rate_limit_usage
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                pinned_at, spawner_session_id, worktree_path, permission_mode, model,
+                effort, args, config_overrides, context_usage, rate_limit_usage
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -264,6 +265,7 @@ class Storage:
                 json.dumps(session.transport_state),
                 session.pinned_at.isoformat() if session.pinned_at else None,
                 session.spawner_session_id,
+                session.worktree_path,
                 session.permission_mode,
                 session.model,
                 session.effort,
@@ -520,17 +522,22 @@ class Storage:
         self,
         channel: str,
         entry_id: int,
-        text: str,
+        text: str | None,
         metadata: dict[str, Any] | None = None,
     ) -> BoardEntry | None:
-        # Edit a post's text/metadata in place, preserving ``created_at`` and
-        # stamping ``edited_at``. The cell key is immutable here.
         now = datetime.now(UTC)
-        cursor = self.connection.execute(
-            "UPDATE board_entries SET text = ?, metadata = ?, edited_at = ? "
-            "WHERE id = ? AND channel = ?",
-            (text, json.dumps(metadata or {}), now.isoformat(), entry_id, channel),
-        )
+        if text is None:
+            cursor = self.connection.execute(
+                "UPDATE board_entries SET metadata = ?, edited_at = ? "
+                "WHERE id = ? AND channel = ?",
+                (json.dumps(metadata or {}), now.isoformat(), entry_id, channel),
+            )
+        else:
+            cursor = self.connection.execute(
+                "UPDATE board_entries SET text = ?, metadata = ?, edited_at = ? "
+                "WHERE id = ? AND channel = ?",
+                (text, json.dumps(metadata or {}), now.isoformat(), entry_id, channel),
+            )
         self.connection.commit()
         if not (cursor.rowcount or 0):
             return None

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1476,3 +1476,255 @@ def test_help_includes_usage_command() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
     assert "usage" in result.stdout
+
+
+# ── board read / board log CLI tests ─────────────────────────────────────────
+
+
+def _board_read_handler(entries: list[dict]) -> "httpx.MockTransport":
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.startswith("/api/board/") and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={"channel": "job:test", "entries": entries},
+            )
+        if request.url.path == "/api/auth/login":
+            return httpx.Response(200, json={"token": "t", "expires_at": "x"})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    return httpx.MockTransport(handler)
+
+
+_MIXED_ENTRIES: list[dict[str, Any]] = [
+    {
+        "id": 1,
+        "channel": "job:test",
+        "key": "plan",
+        "text": "plan text",
+        "metadata": {"state": "done"},
+        "created_at": "2024-01-01T00:00:00+00:00",
+        "author_session_id": "lead",
+        "author_label": "Lead Session",
+    },
+    {
+        "id": 2,
+        "channel": "job:test",
+        "key": None,
+        "text": "task 1 done",
+        "metadata": {},
+        "created_at": "2024-01-02T00:00:00+00:00",
+        "author_session_id": "worker-1",
+        "author_label": "Worker One",
+    },
+    {
+        "id": 3,
+        "channel": "job:test",
+        "key": None,
+        "text": "task 2 done",
+        "metadata": {},
+        "created_at": "2024-01-03T00:00:00+00:00",
+        "author_session_id": "worker-2",
+        "author_label": "Worker Two",
+    },
+]
+
+
+def test_board_read_json_splits_cells_and_log(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=_board_read_handler(_MIXED_ENTRIES),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "board", "read", "job:test", "--json"],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["channel"] == "job:test"
+    assert len(out["cells"]) == 1
+    assert out["cells"][0]["key"] == "plan"
+    assert len(out["log"]) == 2
+    assert all(e["key"] is None for e in out["log"])
+
+
+def test_board_read_default_render_shows_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=_board_read_handler(_MIXED_ENTRIES),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "board", "read", "job:test"],
+    )
+    assert result.exit_code == 0
+    assert "=== Cells" in result.output
+    assert "=== Log" in result.output
+    assert "plan" in result.output
+    assert "task 1 done" in result.output
+    assert "task 2 done" in result.output
+
+
+def test_board_read_key_no_match_writes_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=_board_read_handler([]),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "read",
+            "job:test",
+            "--key",
+            "missing",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "no cell 'missing' matched" in result.output
+
+
+def test_board_log_filters_by_author(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=_board_read_handler(_MIXED_ENTRIES),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "log",
+            "job:test",
+            "--author",
+            "worker-1",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    posts = json.loads(result.stdout)
+    assert len(posts) == 1
+    assert posts[0]["author_session_id"] == "worker-1"
+
+
+def test_board_log_filters_by_grep(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=_board_read_handler(_MIXED_ENTRIES),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "log",
+            "job:test",
+            "--grep",
+            "task 2",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0
+    posts = json.loads(result.stdout)
+    assert len(posts) == 1
+    assert posts[0]["text"] == "task 2 done"
+
+
+def test_board_log_empty_author_filter_writes_stderr(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=_board_read_handler(_MIXED_ENTRIES),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "log",
+            "job:test",
+            "--author",
+            "nobody",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "no posts by 'nobody' matched" in result.output
+
+
+def test_board_clear_keep_last_passes_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            return httpx.Response(200, json={"token": "t", "expires_at": "x"})
+        if request.url.path == "/api/board/job:test/clear" and request.method == "POST":
+            state["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"channel": "job:test", "cleared": 2})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "clear",
+            "job:test",
+            "--keep-last",
+            "5",
+        ],
+    )
+    assert result.exit_code == 0
+    assert state["params"].get("keep_last") == "5"
+
+
+def test_board_help_lists_log_command() -> None:
+    result = runner.invoke(app, ["board", "--help"])
+    assert result.exit_code == 0
+    assert "log" in result.stdout

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -67,6 +67,7 @@ def test_board_help_lists_commands() -> None:
         "delete",
         "delete-entry",
         "edit-entry",
+        "set-meta",
     ):
         assert name in result.stdout
 
@@ -237,6 +238,146 @@ def test_backends_threads_surfaces_server_capability_error(
     )
     assert result.exit_code != 0
     assert "thread discovery is not supported for tmux" in result.output
+
+
+def test_sessions_list_spawned_by_passes_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = dict(request.url.params)
+            return httpx.Response(
+                200, json={"sessions": [{"id": "child-1", "spawner_session_id": "p1"}]}
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "list", "--spawned-by", "p1"],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["sessions"] == [
+        {"id": "child-1", "spawner_session_id": "p1"}
+    ]
+    assert state["params"] == {"spawned_by": "p1"}
+
+
+def test_sessions_list_mine_reads_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_SESSION_ID", "my-session")
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"sessions": []})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "list", "--mine"],
+    )
+    assert result.exit_code == 0
+    assert state["params"] == {"spawned_by": "my-session"}
+
+
+def test_sessions_list_mine_errors_when_env_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WAYPOINT_SESSION_ID", raising=False)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "list", "--mine"],
+    )
+    assert result.exit_code != 0
+    assert "WAYPOINT_SESSION_ID" in result.output
+
+
+def test_sessions_reap_deletes_matched_sessions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    deleted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "sessions": [
+                        {"id": "c1", "spawner_session_id": "p1"},
+                        {"id": "c2", "spawner_session_id": "p1"},
+                    ]
+                },
+            )
+        if request.url.path.startswith("/api/sessions/") and request.method == "DELETE":
+            sid = request.url.path.rsplit("/", 1)[-1]
+            deleted.append(sid)
+            return httpx.Response(200, json={"deleted": sid})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "reap", "--spawned-by", "p1"],
+    )
+    assert result.exit_code == 0
+    summary = json.loads(result.stdout)
+    assert set(summary["reaped"]) == {"c1", "c2"}
+    assert summary["failed"] == []
+    assert set(deleted) == {"c1", "c2"}
+
+
+def test_sessions_reap_reports_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            return httpx.Response(200, json={"sessions": [{"id": "c1"}, {"id": "c2"}]})
+        if request.url.path == "/api/sessions/c1" and request.method == "DELETE":
+            return httpx.Response(200, json={"deleted": "c1"})
+        if request.url.path == "/api/sessions/c2" and request.method == "DELETE":
+            return httpx.Response(500, json={"detail": "internal error"})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "reap", "--all"],
+    )
+    assert result.exit_code == 0
+    summary = json.loads(result.stdout)
+    assert summary["reaped"] == ["c1"]
+    assert summary["failed"] == ["c2"]
+
+
+def test_sessions_reap_requires_scope(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "reap"],
+    )
+    assert result.exit_code != 0
+    assert "--all" in result.output or "scope" in result.output
 
 
 def test_sessions_import_reads_json_file_and_emits_session(
@@ -721,3 +862,617 @@ def test_events_follow_streams_ndjson_until_terminal(
         1,
         2,
     ]
+
+
+def _board_set_meta_handler(
+    request: httpx.Request, state: dict[str, Any]
+) -> httpx.Response:
+    path = request.url.path
+    if path == "/api/board/job:x" and request.method == "GET":
+        key_filter = request.url.params.get("key")
+        entries = [
+            {"id": 42, "channel": "job:x", "key": "task:1", "text": "original text"}
+        ]
+        if key_filter:
+            entries = [e for e in entries if e.get("key") == key_filter]
+        return httpx.Response(200, json={"channel": "job:x", "entries": entries})
+    if path == "/api/board/job:x/entries/42" and request.method == "PATCH":
+        payload = json.loads(request.content)
+        state["patch_body"] = payload
+        return httpx.Response(
+            200,
+            json={
+                "entry": {
+                    "id": 42,
+                    "channel": "job:x",
+                    "text": "original text",
+                    **payload,
+                }
+            },
+        )
+    return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+
+def test_board_set_meta_by_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    state: dict[str, Any] = {}
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(lambda r: _board_set_meta_handler(r, state)),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "set-meta",
+            "job:x",
+            "--key",
+            "task:1",
+            "--meta",
+            "status=done",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    # Text is preserved; only metadata changed.
+    assert out["entry"]["text"] == "original text"
+    assert out["entry"]["metadata"] == {"status": "done"}
+    assert "text" not in state["patch_body"]
+
+
+def test_board_set_meta_by_entry_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(lambda r: _board_set_meta_handler(r, state)),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "board",
+            "set-meta",
+            "job:x",
+            "--entry-id",
+            "42",
+            "--meta",
+            "status=blocked",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["entry"]["text"] == "original text"
+    assert out["entry"]["metadata"] == {"status": "blocked"}
+    assert "text" not in state["patch_body"]
+
+
+def test_sessions_start_worktree_creates_worktree_and_sets_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[list[str]] = []
+    root = str(tmp_path / "myrepo")
+    worktree_dir = str(tmp_path / "myrepo-feat-foo")
+
+    import subprocess
+
+    def fake_run(
+        cmd: list[str], *, check: bool = False, **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cmd)
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=root + "\n", stderr="")
+        if cmd[:3] == ["git", "rev-parse", "--abbrev-ref"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="main\n", stderr="")
+        if cmd[:3] == ["git", "worktree", "add"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    monkeypatch.setattr("waypoint.cli.subprocess.run", fake_run)
+
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "POST":
+            body = json.loads(request.content)
+            state["create_body"] = body
+            return httpx.Response(200, json={"session": {"id": "new", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            root,
+            "--worktree",
+            "feat/foo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    wt_call = next(c for c in calls if c[:3] == ["git", "worktree", "add"])
+    assert wt_call[3] == worktree_dir
+    assert wt_call[4:6] == ["-b", "feat/foo"]
+    body = state["create_body"]
+    assert isinstance(body, dict)
+    assert body["worktree_path"] == worktree_dir
+    assert body["cwd"] == worktree_dir
+
+
+def test_sessions_start_worktree_git_failure_exits_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import subprocess
+
+    def fake_run(
+        cmd: list[str], *, check: bool = False, **kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        if cmd[:3] == ["git", "rev-parse", "--show-toplevel"]:
+            raise subprocess.CalledProcessError(128, cmd, stderr="not a git repo")
+        raise AssertionError(f"unexpected: {cmd}")
+
+    monkeypatch.setattr("waypoint.cli.subprocess.run", fake_run)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp",
+            "--worktree",
+            "feat/bar",
+        ],
+    )
+    assert result.exit_code == 1
+
+
+# ── multi-id sessions wait ────────────────────────────────────────────────────
+
+
+def _session_state_for(session_id: str, status: str) -> dict[str, Any]:
+    """Session-state envelope with the given id (unlike _session_state which hardcodes s1)."""
+    return {
+        "type": "session_state",
+        "payload": {"session": {"id": session_id, "status": status}},
+    }
+
+
+def test_wait_multi_all_emits_sessions_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    streams: dict[str, list[dict[str, Any]]] = {
+        "s1": [_session_state_for("s1", "running"), _session_state_for("s1", "idle")],
+        "s2": [_session_state_for("s2", "idle")],
+    }
+
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        for envelope in streams[session_id]:
+            yield envelope
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "wait", "s1", "s2"],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert "sessions" in out
+    statuses = {s["id"]: s["status"] for s in out["sessions"]}
+    assert statuses["s1"] == "idle"
+    assert statuses["s2"] == "idle"
+
+
+def test_wait_multi_any_returns_first_and_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    # s2 reaches idle immediately; s1 would block indefinitely without cancel.
+    import asyncio
+
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        if session_id == "s2":
+            yield _session_state("idle")
+        else:
+            # Never yields a terminal status — would block without --any.
+            await asyncio.sleep(60)
+            yield _session_state("idle")
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "wait",
+            "s1",
+            "s2",
+            "--any",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    # --any returns a single-element sessions list (the first to finish).
+    assert "sessions" in out
+    assert len(out["sessions"]) == 1
+    assert out["sessions"][0]["status"] == "idle"
+
+
+def test_wait_multi_exits_one_when_any_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    streams: dict[str, list[dict[str, Any]]] = {
+        "s1": [_session_state_for("s1", "idle")],
+        "s2": [_session_state_for("s2", "error")],
+    }
+
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        for envelope in streams[session_id]:
+            yield envelope
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "wait", "s1", "s2"],
+    )
+    assert result.exit_code == 1
+
+
+def test_wait_multi_exits_124_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    _patch_stream(monkeypatch, [_session_state("running")])
+    monkeypatch.setattr(
+        WaypointClient,
+        "get_session",
+        lambda self, session_id: {"id": session_id, "status": "running"},
+    )
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "wait",
+            "s1",
+            "s2",
+            "--timeout",
+            "0.05",
+        ],
+    )
+    assert result.exit_code == 124
+
+
+# ── fleet events --follow ─────────────────────────────────────────────────────
+
+
+def test_events_follow_single_session_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Single-id follow still works without a session_id prefix in output."""
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    _patch_stream(
+        monkeypatch,
+        [
+            {
+                "type": "event",
+                "payload": {"event": {"sequence": 1, "kind": "agent_output"}},
+            },
+            _session_state("exited"),
+        ],
+    )
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "events", "s1", "--follow"],
+    )
+    assert result.exit_code == 0
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    # No session_id prefix for single-session follow.
+    envelope = json.loads(lines[0])
+    assert "session_id" not in envelope
+    assert envelope["type"] == "event"
+
+
+def test_events_follow_multi_prefixes_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    streams: dict[str, list[dict[str, Any]]] = {
+        "s1": [
+            {
+                "type": "event",
+                "payload": {"event": {"sequence": 1, "kind": "agent_output"}},
+            },
+            _session_state_for("s1", "exited"),
+        ],
+        "s2": [
+            {
+                "type": "event",
+                "payload": {"event": {"sequence": 2, "kind": "user_input"}},
+            },
+            _session_state_for("s2", "exited"),
+        ],
+    }
+
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        for envelope in streams[session_id]:
+            yield envelope
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "events",
+            "s1",
+            "s2",
+            "--follow",
+        ],
+    )
+    assert result.exit_code == 0
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 2
+    session_ids_seen = {json.loads(ln)["session_id"] for ln in lines}
+    assert session_ids_seen == {"s1", "s2"}
+
+
+def test_events_follow_filter_type_excludes_non_matching(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    _patch_stream(
+        monkeypatch,
+        [
+            {
+                "type": "event",
+                "payload": {"event": {"sequence": 1, "kind": "agent_output"}},
+            },
+            {
+                "type": "event",
+                "payload": {"event": {"sequence": 2, "kind": "approval_request"}},
+            },
+            _session_state("exited"),
+        ],
+    )
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "events",
+            "s1",
+            "--follow",
+            "--filter",
+            "approval_request",
+        ],
+    )
+    assert result.exit_code == 0
+    lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+    assert len(lines) == 1
+    assert json.loads(lines[0])["payload"]["event"]["kind"] == "approval_request"
+
+
+def test_events_follow_spawned_by_resolves_sessions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    all_sessions = [
+        {"id": "child1", "spawner_session_id": "parent"},
+        {"id": "child2", "spawner_session_id": "parent"},
+        {"id": "other", "spawner_session_id": "other-parent"},
+    ]
+    seen_ids: list[str] = []
+
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        seen_ids.append(session_id)
+        yield _session_state("exited")
+
+    def fake_list_sessions(self: WaypointClient) -> list[dict]:
+        return all_sessions
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+    monkeypatch.setattr(WaypointClient, "list_sessions", fake_list_sessions)
+
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "events",
+            "--follow",
+            "--spawned-by",
+            "parent",
+        ],
+    )
+    assert result.exit_code == 0
+    assert set(seen_ids) == {"child1", "child2"}
+
+
+def test_events_follow_mine_resolves_spawned_sessions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    monkeypatch.setenv("WAYPOINT_SESSION_ID", "me")
+
+    all_sessions = [
+        {"id": "my-child", "spawner_session_id": "me"},
+        {"id": "other", "spawner_session_id": "someone-else"},
+    ]
+    seen_ids: list[str] = []
+
+    async def stream(self: WaypointClient, session_id: str) -> AsyncIterator[dict]:
+        seen_ids.append(session_id)
+        yield _session_state("exited")
+
+    def fake_list_sessions(self: WaypointClient) -> list[dict]:
+        return all_sessions
+
+    monkeypatch.setattr(WaypointClient, "stream_session_envelopes", stream)
+    monkeypatch.setattr(WaypointClient, "list_sessions", fake_list_sessions)
+
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "events",
+            "--follow",
+            "--mine",
+        ],
+    )
+    assert result.exit_code == 0
+    assert seen_ids == ["my-child"]
+
+
+# ── sessions send timeout semantics ──────────────────────────────────────────
+
+
+def test_sessions_send_reports_delivered_on_timeout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            raise httpx.ReadTimeout("timeout", request=request)
+        if request.url.path == "/api/sessions/s1":
+            return httpx.Response(
+                200, json={"session": {"id": "s1", "status": "running"}}
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "send", "s1", "hi"],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["session"]["send"] == "delivered"
+
+
+def test_sessions_send_reports_unknown_on_timeout_idle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            raise httpx.ReadTimeout("timeout", request=request)
+        if request.url.path == "/api/sessions/s1":
+            return httpx.Response(200, json={"session": {"id": "s1", "status": "idle"}})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "send", "s1", "hi"],
+    )
+    # unknown send → exits 1 to signal uncertainty
+    assert result.exit_code == 1
+    out = json.loads(result.stdout)
+    assert out["session"]["send"] == "unknown"
+
+
+# ── usage command ─────────────────────────────────────────────────────────────
+
+
+def test_usage_emits_dashboard(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/usage" and request.method == "GET":
+            return httpx.Response(200, json={"buckets": [], "total_cost_usd": 0.5})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(app, ["--config", str(_config(tmp_path)), "usage"])
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["buckets"] == []
+    assert out["total_cost_usd"] == 0.5
+
+
+def test_usage_refresh_posts_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/usage/refresh" and request.method == "POST":
+            called.append("refresh")
+            return httpx.Response(
+                200, json={"buckets": [{"id": "b1"}], "total_cost_usd": 2.0}
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app, ["--config", str(_config(tmp_path)), "usage", "--refresh"]
+    )
+    assert result.exit_code == 0
+    assert called == ["refresh"]
+    out = json.loads(result.stdout)
+    assert out["total_cost_usd"] == 2.0
+
+
+def test_help_includes_usage_command() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "usage" in result.stdout

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -74,6 +74,7 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             rest = request.url.path[len("/api/board/") :]
             if rest.endswith("/clear") and request.method == "POST":
                 channel = rest[: -len("/clear")]
+                state["clear_params"] = dict(request.url.params)
                 return httpx.Response(200, json={"channel": channel, "cleared": 3})
             if "/entries/" in rest:
                 channel, entry_id = rest.split("/entries/", 1)
@@ -749,3 +750,24 @@ def test_send_input_non_timeout_error_raises(
     with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
         with pytest.raises(WaypointError):
             c.send_input("s1", "hello")
+
+
+def test_clear_board_keep_last_passes_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        result = client.clear_board("topic:x", keep_last=5)
+    assert result == {"channel": "topic:x", "cleared": 3}
+    assert state["clear_params"].get("keep_last") == "5"
+
+
+def test_clear_board_no_keep_last_omits_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.clear_board("topic:x")
+    assert state.get("clear_params", {}).get("keep_last") is None

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -399,6 +399,20 @@ def test_create_session_passes_spawner_session_id(
     assert session["spawner_session_id"] == "parent-1"
 
 
+def test_create_session_passes_worktree_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        session = client.create_session(
+            backend="claude_code",
+            cwd="/repos/myrepo-feat",
+            worktree_path="/repos/myrepo-feat",
+        )
+    assert session["worktree_path"] == "/repos/myrepo-feat"
+
+
 def test_list_board_channels(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
     state: dict = {}
@@ -472,6 +486,20 @@ def test_update_board_entry_sends_body(
     assert entry["text"] == "new"
     assert state["board_update"]["entry_id"] == 7
     assert state["board_update"]["metadata"] == {"a": "b"}
+
+
+def test_update_board_entry_meta_only_omits_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        entry = client.update_board_entry("topic:x", 7, metadata={"x": "y"})
+    assert state["board_update"]["entry_id"] == 7
+    assert state["board_update"]["metadata"] == {"x": "y"}
+    assert "text" not in state["board_update"]
+    # Server echoes back existing text unchanged.
+    assert entry["id"] == 7
 
 
 def test_error_response_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -560,3 +588,164 @@ def test_session_status_from_envelope() -> None:
 def test_is_event_envelope() -> None:
     assert is_event_envelope({"type": "event", "payload": {"event": {}}})
     assert not is_event_envelope({"type": "session_state", "payload": {"session": {}}})
+
+
+def test_list_sessions_passes_spawned_by(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/auth/login":
+            return httpx.Response(200, json={"token": VALID_TOKEN, "expires_at": "x"})
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = dict(request.url.params)
+            spawned_by = request.url.params.get("spawned_by")
+            if spawned_by == "parent-1":
+                return httpx.Response(200, json={"sessions": [{"id": "child-1"}]})
+            return httpx.Response(200, json={"sessions": [{"id": "s1"}, {"id": "s2"}]})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+    settings = _settings(tmp_path)
+    with WaypointClient(settings, token=VALID_TOKEN, client=http) as client:
+        all_sessions = client.list_sessions()
+        filtered = client.list_sessions(spawned_by="parent-1")
+    assert all_sessions == [{"id": "s1"}, {"id": "s2"}]
+    assert (
+        "spawned_by" not in state.get("params", {})
+        or state["params"].get("spawned_by") == "parent-1"
+    )
+    assert filtered == [{"id": "child-1"}]
+    assert state["params"]["spawned_by"] == "parent-1"
+
+
+def test_list_sessions_omits_spawned_by_when_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"sessions": []})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+    settings = _settings(tmp_path)
+    with WaypointClient(settings, token=VALID_TOKEN, client=http) as client:
+        client.list_sessions()
+    assert "spawned_by" not in state["params"]
+
+
+def test_get_usage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/usage" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={"buckets": [], "total_cost_usd": 0.0},
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
+        result = c.get_usage()
+    assert result["buckets"] == []
+    assert result["total_cost_usd"] == 0.0
+
+
+def test_refresh_usage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    called: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/usage/refresh" and request.method == "POST":
+            called.append("refresh")
+            return httpx.Response(
+                200,
+                json={"buckets": [{"id": "b1"}], "total_cost_usd": 1.5},
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
+        result = c.refresh_usage()
+    assert called == ["refresh"]
+    assert result["total_cost_usd"] == 1.5
+
+
+def test_send_input_timeout_session_running_reports_delivered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            raise httpx.ReadTimeout("timed out", request=request)
+        if request.url.path == "/api/sessions/s1" and request.method == "GET":
+            return httpx.Response(
+                200, json={"session": {"id": "s1", "status": "running"}}
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
+        result = c.send_input("s1", "hello")
+    assert result["send"] == "delivered"
+    assert result["status"] == "running"
+
+
+def test_send_input_timeout_session_idle_reports_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            raise httpx.ReadTimeout("timed out", request=request)
+        if request.url.path == "/api/sessions/s1" and request.method == "GET":
+            return httpx.Response(200, json={"session": {"id": "s1", "status": "idle"}})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
+        result = c.send_input("s1", "hello")
+    assert result["send"] == "unknown"
+
+
+def test_send_input_timeout_get_fails_reports_unknown(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            raise httpx.ReadTimeout("timed out", request=request)
+        # GET also fails
+        return httpx.Response(503, json={"detail": "unavailable"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
+        result = c.send_input("s1", "hello")
+    assert result["send"] == "unknown"
+    assert result["id"] == "s1"
+
+
+def test_send_input_non_timeout_error_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            return httpx.Response(400, json={"detail": "bad input"})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as c:
+        with pytest.raises(WaypointError):
+            c.send_input("s1", "hello")

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -402,6 +402,33 @@ async def test_post_board_entry_persists_and_broadcasts(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_post_board_entry_stamps_author_label_from_session_title(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    session = make_session(settings, id="worker-1", status=SessionStatus.IDLE)
+    # Override the title to something recognizable.
+    session = session.model_copy(update={"title": "My Worker"})
+    storage.create_session(session)
+    entry = await runtime.post_board_entry(
+        "job:test", BoardPostRequest(text="task done", author_session_id="worker-1")
+    )
+    assert entry.author_label == "My Worker"
+    loaded = storage.list_board_entries("job:test")
+    assert loaded[0].author_label == "My Worker"
+
+
+@pytest.mark.asyncio
+async def test_post_board_entry_author_label_none_for_unknown_session(tmp_path) -> None:
+    runtime, storage, _ = make_runtime(tmp_path)
+    entry = await runtime.post_board_entry(
+        "job:test",
+        BoardPostRequest(text="anon post", author_session_id="nonexistent"),
+    )
+    assert entry.author_label is None
+
+
+@pytest.mark.asyncio
 async def test_clear_board_channel_broadcasts(tmp_path) -> None:
     runtime, storage, _ = make_runtime(tmp_path)
     await runtime.post_board_entry("topic:x", BoardPostRequest(text="a"))
@@ -418,16 +445,24 @@ async def test_delete_session_prunes_board_entries_and_broadcasts(tmp_path) -> N
     storage.create_session(
         make_session(settings, id="poster", status=SessionStatus.EXITED)
     )
+    # Keyless log post: survives session delete.
+    log_entry = await runtime.post_board_entry(
+        "topic:x", BoardPostRequest(text="mine-log", author_session_id="poster")
+    )
+    # Keyed cell: pruned on session delete.
     await runtime.post_board_entry(
-        "topic:x", BoardPostRequest(text="mine", author_session_id="poster")
+        "topic:x",
+        BoardPostRequest(text="mine-cell", key="k", author_session_id="poster"),
     )
     await runtime.post_board_entry("topic:x", BoardPostRequest(text="anon"))
     queue = runtime.broadcast.subscribe_global()
 
     await runtime.delete("poster")
 
-    # The poster's row is gone; the unauthored one survives.
-    assert [e.text for e in storage.list_board_entries("topic:x")] == ["anon"]
+    # Only the keyed cell is pruned; the log post and anon post survive.
+    remaining = storage.list_board_entries("topic:x")
+    assert {e.text for e in remaining} == {"mine-log", "anon"}
+    assert any(e.id == log_entry.id for e in remaining)
     drained = [queue.get_nowait()["type"] for _ in range(queue.qsize())]
     assert "board_update" in drained
 

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -17,6 +17,25 @@ from waypoint.schemas import (
 from waypoint.storage import Storage
 
 
+def _make_session(storage: Storage, session_id: str, title: str) -> None:
+    now = datetime.now(UTC)
+    storage.create_session(
+        SessionRecord(
+            id=session_id,
+            backend="codex",
+            source=SessionSource.MANAGED,
+            title=title,
+            cwd="/tmp",
+            status=SessionStatus.EXITED,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/tmp/raw.log",
+            structured_log_path="/tmp/events.jsonl",
+        )
+    )
+
+
 def test_storage_round_trip(tmp_path) -> None:
     storage = Storage(tmp_path / "waypoint.db")
     now = datetime.now(UTC)
@@ -853,15 +872,21 @@ def test_board_delete_channel_removes_it_from_the_list(tmp_path) -> None:
     assert storage.list_board_entries("topic:a") == []
 
 
-def test_board_prune_for_session_drops_authored_rows(tmp_path) -> None:
+def test_board_prune_for_session_drops_keyed_cells_keeps_log(tmp_path) -> None:
+    # Keyed cells authored by s1 are pruned; keyless log posts survive.
     storage = Storage(tmp_path / "waypoint.db")
-    storage.add_board_entry("topic:a", "mine", author_session_id="s1")
+    log_post = storage.add_board_entry("topic:a", "log-mine", author_session_id="s1")
+    cell = storage.add_board_entry(
+        "topic:a", "cell-mine", key="k", author_session_id="s1"
+    )
     storage.add_board_entry("topic:a", "theirs", author_session_id="s2")
     storage.add_board_entry("topic:a", "anon")
     removed = storage.prune_board_for_session("s1")
-    assert removed == 1
+    assert removed == 1  # only the keyed cell
     remaining = storage.list_board_entries("topic:a")
-    assert [e.text for e in remaining] == ["theirs", "anon"]
+    ids = [e.id for e in remaining]
+    assert log_post.id in ids
+    assert cell.id not in ids
 
 
 def test_board_delete_entry_removes_one_post(tmp_path) -> None:
@@ -982,3 +1007,82 @@ def test_storage_legacy_db_gets_launch_mode_column(tmp_path) -> None:
         assert row[0] == LaunchMode.AUTO.value
     finally:
         conn.close()
+
+
+# ── board history / author_label / keep_last ────────────────────────────────
+
+
+def test_board_author_label_round_trips(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry(
+        "topic:a", "hello", author_session_id="s1", author_label="My Session"
+    )
+    assert entry.author_label == "My Session"
+    loaded = storage.list_board_entries("topic:a")
+    assert loaded[0].author_label == "My Session"
+
+
+def test_board_author_label_survives_session_delete(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    _make_session(storage, "s1", "Worker One")
+    entry = storage.add_board_entry(
+        "topic:a", "done", author_session_id="s1", author_label="Worker One"
+    )
+    storage.delete_session("s1")
+    # Log post survives; author_label still readable.
+    remaining = storage.list_board_entries("topic:a")
+    assert len(remaining) == 1
+    assert remaining[0].id == entry.id
+    assert remaining[0].author_label == "Worker One"
+
+
+def test_board_clear_keep_last_retains_n_newest_log_posts(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    ids = [storage.add_board_entry("topic:a", f"log-{i}").id for i in range(5)]
+    # Also add a keyed cell (always dropped by clear).
+    storage.add_board_entry("topic:a", "val", key="k1")
+    removed = storage.clear_board_channel("topic:a", keep_last=3)
+    remaining = storage.list_board_entries("topic:a")
+    # Cell is gone; 2 oldest log posts dropped; 3 newest kept.
+    assert all(e.key is None for e in remaining)
+    remaining_ids = [e.id for e in remaining]
+    assert ids[0] not in remaining_ids
+    assert ids[1] not in remaining_ids
+    assert ids[2] in remaining_ids
+    assert ids[3] in remaining_ids
+    assert ids[4] in remaining_ids
+    assert removed == 3  # 2 old log + 1 cell
+
+
+def test_board_clear_keep_last_fewer_posts_than_n_only_drops_cells(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    log_id = storage.add_board_entry("topic:a", "only-post").id
+    storage.add_board_entry("topic:a", "cell", key="k")
+    removed = storage.clear_board_channel("topic:a", keep_last=10)
+    remaining = storage.list_board_entries("topic:a")
+    assert len(remaining) == 1
+    assert remaining[0].id == log_id
+    assert removed == 1  # only the cell
+
+
+def test_board_regression_log_post_survives_session_delete_and_list(tmp_path) -> None:
+    # Regression for the original bug: a keyless "done" log post must survive
+    # session delete, and list_board_entries must surface it.
+    storage = Storage(tmp_path / "waypoint.db")
+    _make_session(storage, "worker", "worker-session")
+    log_post = storage.add_board_entry(
+        "job:test",
+        "task 1 done",
+        author_session_id="worker",
+        author_label="worker-session",
+    )
+    storage.add_board_entry(
+        "job:test", "running", key="status", author_session_id="worker"
+    )
+    storage.prune_board_for_session("worker")
+    storage.delete_session("worker")
+    entries = storage.list_board_entries("job:test")
+    assert any(e.id == log_post.id for e in entries)
+    log_entries = [e for e in entries if e.key is None]
+    assert len(log_entries) == 1
+    assert log_entries[0].text == "task 1 done"

--- a/backend/tests/test_worktree.py
+++ b/backend/tests/test_worktree.py
@@ -1,0 +1,162 @@
+"""Tests for worktree_path field on sessions: storage round-trip and delete cleanup."""
+
+import asyncio
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+from waypoint.storage import Storage
+
+
+def _make_session(settings: Any, tmp_path: Path, **overrides: Any) -> SessionRecord:
+    session_dir = tmp_path / overrides.get("id", "sess")
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=overrides.get("id", "sess"),
+        backend=overrides.get("backend", "codex"),
+        source=SessionSource.MANAGED,
+        title="Test",
+        cwd=overrides.get("cwd", "/tmp/project"),
+        status=overrides.get("status", SessionStatus.EXITED),
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(session_dir / "raw.log"),
+        structured_log_path=str(session_dir / "events.jsonl"),
+        worktree_path=overrides.get("worktree_path"),
+    )
+
+
+def test_worktree_path_round_trips_through_storage(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="wt-1",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title="Worktree session",
+        cwd="/repos/myrepo-feat",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/events.jsonl",
+        worktree_path="/repos/myrepo-feat",
+    )
+    storage.create_session(session)
+    loaded = storage.get_session("wt-1")
+    assert loaded is not None
+    assert loaded.worktree_path == "/repos/myrepo-feat"
+
+    listed = storage.list_sessions()
+    assert any(s.worktree_path == "/repos/myrepo-feat" for s in listed)
+
+
+def test_worktree_path_none_by_default(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="no-wt",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title="Plain session",
+        cwd="/tmp",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/events.jsonl",
+    )
+    storage.create_session(session)
+    loaded = storage.get_session("no-wt")
+    assert loaded is not None
+    assert loaded.worktree_path is None
+
+
+def test_delete_removes_worktree(tmp_path: Path) -> None:
+    from waypoint.runtime import SessionRuntime
+    from waypoint.settings import Settings
+
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+
+    worktree = str(tmp_path / "myrepo-feat")
+    session_dir = settings.sessions_dir / "wt-del"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="wt-del",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title="Worktree del",
+        cwd=worktree,
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(session_dir / "raw.log"),
+        structured_log_path=str(session_dir / "events.jsonl"),
+        worktree_path=worktree,
+    )
+    storage.create_session(session)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch("waypoint.runtime.subprocess.run", side_effect=fake_run):
+        asyncio.run(runtime.delete("wt-del"))
+
+    assert any(
+        c == ["git", "worktree", "remove", "--force", worktree] for c in calls
+    ), f"git worktree remove not called; got: {calls}"
+    assert storage.get_session("wt-del") is None
+
+
+def test_delete_skips_worktree_removal_when_none(tmp_path: Path) -> None:
+    from waypoint.runtime import SessionRuntime
+    from waypoint.settings import Settings
+
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+
+    session_dir = settings.sessions_dir / "plain-del"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="plain-del",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title="Plain del",
+        cwd="/tmp",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(session_dir / "raw.log"),
+        structured_log_path=str(session_dir / "events.jsonl"),
+    )
+    storage.create_session(session)
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        calls.append(list(cmd))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    with patch("waypoint.runtime.subprocess.run", side_effect=fake_run):
+        asyncio.run(runtime.delete("plain-del"))
+
+    assert not any("worktree" in c for c in calls), f"unexpected worktree call: {calls}"


### PR DESCRIPTION
Implements the orchestration improvement plan from the PR #98 follow-on (`tmp/cli-orchestration-improvements.md`) — CLI and skill changes that each closed a real friction or failure hit while running a multi-agent work-queue crew. Built by a 5-worker Waypoint crew (Claude Code / Sonnet) on the `wq/cli-orch` integration branch, merged one task at a time.

## CLI

- **`board set-meta <channel> --key <key> --meta k=v`** (and `--entry-id`) — update a keyed cell's metadata without resupplying its text. `BoardEntryUpdateRequest.text` is now optional end-to-end; a meta-only edit preserves the existing text. This is the fix for the `--key` upsert clobbering task contracts.
- **`sessions start --worktree <branch> [--worktree-base <ref>]`** — the CLI creates the branch + git worktree (in a sibling path, outside the working tree), launches the session there, and records `worktree_path` on the session. `sessions delete` removes the worktree. Callers never touch `git worktree`.
- **`sessions list --spawned-by <id>` / `--mine`** and **`sessions reap --spawned-by <id>` / `--mine` / `--all`** — owner-scoped listing and bulk terminate-delete, keyed on the existing `spawner_session_id`. `GET /api/sessions` gains a `spawned_by` query param. `reap` refuses to run unscoped unless `--all` is given.
- **`sessions wait <id...>`** — now variadic, with `--all` (default) / `--any`; preserves single-id behavior and the 124 timeout exit code.
- **`sessions events --follow`** — follows multiple owned sessions at once (ids and/or `--spawned-by`/`--mine`), with `--filter <type>` for `approval_request` / `AskUserQuestion`; each line is prefixed with its session id.
- **`sessions send`** — reports a queued/accepted send accurately instead of surfacing a false-negative transport timeout.
- **`waypoint usage`** (`--refresh`) — exposes the existing `/api/usage` dashboard.

## Skills

- **`waypoint-workqueue`** — recommends a two-cell-per-task structure (immutable `task:<n>` contract + mutable `status:<n>`), which avoids the text-clobber by design; documents `board set-meta`; adds a "resume after the lead dies" drill and a note on `send`'s timeout-but-landed semantics.
- **`waypoint-subagents`** — corrects the stale "Waypoint has no parent/owner field" claim; the skill now leans on `spawner_session_id` (surfaced via `sessions list --spawned-by`/`reap`).

## Tests / checks

`cd backend && uv run pytest` — 714 passed. `uv run pre-commit run --all-files` — black, isort, ruff, codespell, mypy all pass. New coverage in `test_cli.py`, `test_client.py`, and `test_worktree.py` for every command above.

Not yet exercised against a live server: `set-meta` (optional text) and the `spawned_by` query param need the backend running this branch, which requires a restart. Happy to restart the stack onto this branch and smoke-test the new endpoints if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Board as durable history + readable reads (follow-on)

Two coupled fixes prompted by missing five workers' `task done` posts during the run.

**Reads were a shape-guessing game.** `board read` emitted a flat `{"entries":[...]}` mixing keyed cells and keyless log posts with no `.log` field, so a wrong `jq` failed silently to empty. Now `board read` renders a two-section view (Cells + Log, newest-first) by default, `--json` returns `{"channel", "cells":[...], "log":[...]}`, and a new `board log <channel>` (`--author`/`--grep`/`--since`/`--limit`/`--json`) answers "what did my workers report?" with no jq. Over-filtered reads print a stderr diagnostic (exit stays 0 — empty isn't an error).

**Reaping a worker deleted its posts.** `delete_session` hard-deleted every row a session authored, destroying the append-log audit trail. Now only keyed **cells** (live state) are pruned on reap; keyless **log** posts are durable history, GC'd by channel teardown (`board clear`/`delete`). A new `author_label` column snapshots the author's title at post time so persisted posts stay attributable after the session row is gone. `board clear --keep-last N` caps log retention.

Skill docs (`waypoint-workqueue`, `waypoint-comms`) corrected: the append-log is durable history read via `board log`; only cells vanish on reap, which is why the lead owns the cells.

Backend prune/retention changes are additive (`author_label` via `_ensure_column`) and forward-only; no API response-shape change (the read rendering is CLI-side). Full suite now **731 passed**; `pre-commit --all-files` clean.
