### PR TITLE
feat: add a recursive help command to both CLIs

### DIFF
--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -9,9 +9,12 @@ Use this skill for the `waypoint` backend CLI. Prefer `waypoint sessions ...`
 for a running Waypoint server; avoid the singular `waypoint session ...` flow
 unless the user explicitly wants an in-process one-shot runtime.
 
-Start by running `waypoint sessions --help` or the specific subcommand's
-`--help` when uncertain; the CLI is the source of truth for the installed
-version.
+Run `waypoint help` to dump the entire CLI surface — every nested command, its
+arguments, and its options — in one call (`waypoint help --json` for structured
+output). This is generated directly from the command definitions, so it is
+ground truth for the installed version and never drifts. Prefer it over running
+`--help` at each nested level, and defer to it for exact flags rather than
+trusting any flag list reproduced in this skill.
 
 ## Common Routing
 

--- a/.agents/skills/waypointctl/SKILL.md
+++ b/.agents/skills/waypointctl/SKILL.md
@@ -8,8 +8,12 @@ description: Use when managing the Waypoint stack with `waypointctl`, including 
 Use this skill for `waypointctl`, the local stack supervisor for Waypoint.
 These commands affect the deployment the assistant is running on.
 
-Start with `waypointctl status` for state and `waypointctl --help` or a
-subcommand's `--help` when the installed command surface is uncertain.
+Start with `waypointctl status` for state. To learn the command surface, run
+`waypointctl help` to dump every nested command with its arguments and options
+in one call (`waypointctl help --json` for structured output). It is generated
+from the command definitions, so it is ground truth for the installed version;
+prefer it over per-level `--help`, and defer to it for exact flags rather than
+trusting any list reproduced in this skill.
 
 ## Common Routing
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1622,6 +1622,11 @@ def _walk_commands(group: click.Group, prefix: str) -> list[dict[str, Any]]:
         # Typer vendors its own Click, so a sub-app is not an ``isinstance`` of
         # the top-level ``click.Group``; detect groups by the ``commands`` map.
         if isinstance(getattr(cmd, "commands", None), dict):
+            # A group that runs without a subcommand (e.g. ``backends``) is a
+            # usable command in its own right, so describe it alongside its
+            # children rather than only recursing.
+            if getattr(cmd, "invoke_without_command", False):
+                out.append(_describe_command(cmd, path))
             out.extend(_walk_commands(cast(click.Group, cmd), path))
             continue
         out.append(_describe_command(cmd, path))

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1634,6 +1634,17 @@ def _walk_commands(group: click.Group, prefix: str) -> list[dict[str, Any]]:
     return out
 
 
+def _json_safe(value: Any) -> Any:
+    """Coerce an option default to a JSON-serializable form.
+
+    Defaults are usually primitives, but some (enums, paths, frozensets) are
+    not; fall back to ``str`` so the dump never fails to serialize.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
 def _describe_command(cmd: click.Command, path: str) -> dict[str, Any]:
     arguments: list[dict[str, Any]] = []
     options: list[dict[str, Any]] = []
@@ -1647,7 +1658,7 @@ def _describe_command(cmd: click.Command, path: str) -> dict[str, Any]:
                         "flags": list(param.opts),
                         "type": param.type.name,
                         "required": param.required,
-                        "default": param.default,
+                        "default": _json_safe(param.default),
                         "help": getattr(param, "help", None),
                     }
                 )

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -6,8 +6,9 @@ import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, cast
 
+import click
 import typer
 import uvicorn
 from websockets.exceptions import WebSocketException
@@ -289,6 +290,22 @@ def usage(
         return c.get_usage()
 
     _emit(_settings_from_ctx(ctx), run)
+
+
+@app.command("help")
+def help_(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the command tree as structured JSON."),
+    ] = False,
+) -> None:
+    """Dump the entire CLI surface (all nested commands) in one call."""
+    root = cast(click.Group, typer.main.get_command(app))
+    commands = _walk_commands(root, "waypoint")
+    if json_output:
+        typer.echo(json.dumps(commands, indent=2))
+    else:
+        typer.echo(_render_help_text(commands))
 
 
 @session_app.command("start")
@@ -1588,6 +1605,87 @@ def run_reset(settings: Settings | None = None, *, confirmed: bool) -> None:
         print(f"removed {target}")
     settings.ensure_dirs()
     print(f"recreated {settings.data_dir}")
+
+
+def _walk_commands(group: click.Group, prefix: str) -> list[dict[str, Any]]:
+    """Recursively flatten a Click command tree into serializable descriptors.
+
+    Sub-groups are descended into; non-group commands are leaves. Hidden
+    commands/params and the auto-added ``--help`` option are skipped. Output is
+    sorted by command path for stable text/JSON dumps.
+    """
+    out: list[dict[str, Any]] = []
+    for name, cmd in group.commands.items():
+        if cmd.hidden:
+            continue
+        path = f"{prefix} {name}"
+        # Typer vendors its own Click, so a sub-app is not an ``isinstance`` of
+        # the top-level ``click.Group``; detect groups by the ``commands`` map.
+        if isinstance(getattr(cmd, "commands", None), dict):
+            out.extend(_walk_commands(cast(click.Group, cmd), path))
+            continue
+        out.append(_describe_command(cmd, path))
+    out.sort(key=lambda entry: entry["command"])
+    return out
+
+
+def _describe_command(cmd: click.Command, path: str) -> dict[str, Any]:
+    arguments: list[dict[str, Any]] = []
+    options: list[dict[str, Any]] = []
+    with click.Context(cmd, info_name=path) as ctx:
+        for param in cmd.get_params(ctx):
+            if getattr(param, "hidden", False) or param.name == "help":
+                continue
+            if param.param_type_name == "option":
+                options.append(
+                    {
+                        "flags": list(param.opts),
+                        "type": param.type.name,
+                        "required": param.required,
+                        "default": param.default,
+                        "help": getattr(param, "help", None),
+                    }
+                )
+            else:
+                arguments.append(
+                    {"name": param.name, "required": param.required, "help": None}
+                )
+    # Strip the leading "waypoint " (or other root) from the reported command.
+    command = path.split(" ", 1)[1] if " " in path else path
+    return {
+        "command": command,
+        "help": cmd.get_short_help_str() or None,
+        "arguments": arguments,
+        "options": options,
+    }
+
+
+def _render_help_text(commands: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for entry in commands:
+        lines.append(entry["command"])
+        if entry["help"]:
+            lines.append(f"  {entry['help']}")
+        if entry["arguments"]:
+            lines.append("  ARGUMENTS:")
+            for arg in entry["arguments"]:
+                req = "required" if arg["required"] else "optional"
+                lines.append(f"    {arg['name']} ({req})")
+        if entry["options"]:
+            lines.append("  OPTIONS:")
+            for opt in entry["options"]:
+                flags = ", ".join(opt["flags"])
+                bits = [opt["type"]]
+                bits.append("required" if opt["required"] else "optional")
+                if opt["default"] is not None:
+                    bits.append(f"default={opt['default']}")
+                detail = ", ".join(bits)
+                line = f"    {flags} [{detail}]"
+                if opt["help"]:
+                    line += f" — {opt['help']}"
+                lines.append(line)
+        lines.append("")
+    return "\n".join(lines).rstrip()
 
 
 def run_doctor(settings: Settings | None = None) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -106,6 +106,8 @@ def _walk_leaf_paths(group: click.Group, prefix: str) -> list[str]:
             continue
         path = f"{prefix} {name}".strip()
         if isinstance(getattr(cmd, "commands", None), dict):
+            if getattr(cmd, "invoke_without_command", False):
+                paths.append(path)
             paths.extend(_walk_leaf_paths(cast(click.Group, cmd), path))
         else:
             paths.append(path)
@@ -121,6 +123,16 @@ def test_help_covers_every_leaf_command() -> None:
     root = cast(click.Group, typer.main.get_command(app))
     expected = set(_walk_leaf_paths(root, ""))
     assert expected <= dumped
+
+
+def test_help_surfaces_runnable_groups() -> None:
+    # `backends` runs without a subcommand (lists backend capabilities), so it
+    # must appear as its own command, not only its `threads` child.
+    result = runner.invoke(app, ["help", "--json"])
+    assert result.exit_code == 0
+    by_path = {entry["command"]: entry for entry in json.loads(result.stdout)}
+    assert "backends" in by_path
+    assert by_path["backends"]["help"]
 
 
 def test_board_post_rejects_malformed_meta(tmp_path: Path) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,8 +1,9 @@
 import json
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import click
 import httpx
 import pytest
 import typer
@@ -76,6 +77,50 @@ def test_backends_help_lists_threads() -> None:
     result = runner.invoke(app, ["backends", "--help"])
     assert result.exit_code == 0
     assert "threads" in result.stdout
+
+
+def test_help_command_dumps_full_surface() -> None:
+    # No server or token configured — recursive help is pure introspection.
+    result = runner.invoke(app, ["help"])
+    assert result.exit_code == 0
+    for command in ("sessions start", "board set-meta", "usage"):
+        assert command in result.stdout
+    assert "--backend" in result.stdout
+
+
+def test_help_json_is_structured() -> None:
+    result = runner.invoke(app, ["help", "--json"])
+    assert result.exit_code == 0
+    commands = json.loads(result.stdout)
+    by_path = {entry["command"]: entry for entry in commands}
+    start = by_path["sessions start"]
+    backend = next(o for o in start["options"] if "--backend" in o["flags"])
+    assert backend["required"] is True
+    assert backend["type"] == "text"
+
+
+def _walk_leaf_paths(group: click.Group, prefix: str) -> list[str]:
+    paths: list[str] = []
+    for name, cmd in group.commands.items():
+        if cmd.hidden:
+            continue
+        path = f"{prefix} {name}".strip()
+        if isinstance(getattr(cmd, "commands", None), dict):
+            paths.extend(_walk_leaf_paths(cast(click.Group, cmd), path))
+        else:
+            paths.append(path)
+    return paths
+
+
+def test_help_covers_every_leaf_command() -> None:
+    # Regression guard: every leaf in the tree must appear in the dump so the
+    # surface can't silently drift away from the generated help.
+    result = runner.invoke(app, ["help", "--json"])
+    assert result.exit_code == 0
+    dumped = {entry["command"] for entry in json.loads(result.stdout)}
+    root = cast(click.Group, typer.main.get_command(app))
+    expected = set(_walk_leaf_paths(root, ""))
+    assert expected <= dumped
 
 
 def test_board_post_rejects_malformed_meta(tmp_path: Path) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -9,7 +9,7 @@ import pytest
 import typer
 from typer.testing import CliRunner
 
-from waypoint.cli import app, exit_code_for_wait, parse_wait_until
+from waypoint.cli import _json_safe, app, exit_code_for_wait, parse_wait_until
 from waypoint.client import WaypointClient
 from waypoint.settings import Settings
 
@@ -133,6 +133,16 @@ def test_help_surfaces_runnable_groups() -> None:
     by_path = {entry["command"]: entry for entry in json.loads(result.stdout)}
     assert "backends" in by_path
     assert by_path["backends"]["help"]
+
+
+def test_json_safe_stringifies_non_primitive_defaults() -> None:
+    # Primitives pass through untouched so the JSON dump stays faithful.
+    for value in (None, True, 3, 1.5, "x"):
+        assert _json_safe(value) == value
+    # Non-serializable defaults (enums, paths, frozensets) coerce to str so a
+    # future option can never break `help --json`.
+    assert _json_safe(frozenset({"a"})) == str(frozenset({"a"}))
+    assert _json_safe(Path("/tmp/x")) == "/tmp/x"
 
 
 def test_board_post_rejects_malformed_meta(tmp_path: Path) -> None:

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -118,6 +118,17 @@ def _walk_commands(group: click.Group, prefix: str) -> list[dict[str, Any]]:
     return out
 
 
+def _json_safe(value: Any) -> Any:
+    """Coerce an option default to a JSON-serializable form.
+
+    Defaults are usually primitives, but some (enums, paths, frozensets) are
+    not; fall back to ``str`` so the dump never fails to serialize.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
 def _describe_command(cmd: click.Command, path: str) -> dict[str, Any]:
     arguments: list[dict[str, Any]] = []
     options: list[dict[str, Any]] = []
@@ -131,7 +142,7 @@ def _describe_command(cmd: click.Command, path: str) -> dict[str, Any]:
                         "flags": list(param.opts),
                         "type": param.type.name,
                         "required": param.required,
-                        "default": param.default,
+                        "default": _json_safe(param.default),
                         "help": getattr(param, "help", None),
                     }
                 )

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -106,6 +106,11 @@ def _walk_commands(group: click.Group, prefix: str) -> list[dict[str, Any]]:
         # Typer vendors its own Click, so a sub-app is not an ``isinstance`` of
         # the top-level ``click.Group``; detect groups by the ``commands`` map.
         if isinstance(getattr(cmd, "commands", None), dict):
+            # A group that runs without a subcommand is a usable command in its
+            # own right, so describe it alongside its children rather than only
+            # recursing.
+            if getattr(cmd, "invoke_without_command", False):
+                out.append(_describe_command(cmd, path))
             out.extend(_walk_commands(cast(click.Group, cmd), path))
             continue
         out.append(_describe_command(cmd, path))

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -1,9 +1,11 @@
+import json
 import os
 import signal
 import subprocess
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any, cast
 
+import click
 import typer
 
 from waypointctl.ancestry import is_descendant_of
@@ -71,6 +73,101 @@ def bootstrap(
     home_path = resolve_waypoint_home(home)
     apply_dotenv(home_path)
     ctx.obj = {"home": home_path}
+
+
+@app.command("help")
+def help_(
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the command tree as structured JSON."),
+    ] = False,
+) -> None:
+    """Dump the entire CLI surface (all nested commands) in one call."""
+    root = cast(click.Group, typer.main.get_command(app))
+    commands = _walk_commands(root, "waypointctl")
+    if json_output:
+        typer.echo(json.dumps(commands, indent=2))
+    else:
+        typer.echo(_render_help_text(commands))
+
+
+def _walk_commands(group: click.Group, prefix: str) -> list[dict[str, Any]]:
+    """Recursively flatten a Click command tree into serializable descriptors.
+
+    Sub-groups are descended into; non-group commands are leaves. Hidden
+    commands/params and the auto-added ``--help`` option are skipped. Output is
+    sorted by command path for stable text/JSON dumps.
+    """
+    out: list[dict[str, Any]] = []
+    for name, cmd in group.commands.items():
+        if cmd.hidden:
+            continue
+        path = f"{prefix} {name}"
+        # Typer vendors its own Click, so a sub-app is not an ``isinstance`` of
+        # the top-level ``click.Group``; detect groups by the ``commands`` map.
+        if isinstance(getattr(cmd, "commands", None), dict):
+            out.extend(_walk_commands(cast(click.Group, cmd), path))
+            continue
+        out.append(_describe_command(cmd, path))
+    out.sort(key=lambda entry: entry["command"])
+    return out
+
+
+def _describe_command(cmd: click.Command, path: str) -> dict[str, Any]:
+    arguments: list[dict[str, Any]] = []
+    options: list[dict[str, Any]] = []
+    with click.Context(cmd, info_name=path) as ctx:
+        for param in cmd.get_params(ctx):
+            if getattr(param, "hidden", False) or param.name == "help":
+                continue
+            if param.param_type_name == "option":
+                options.append(
+                    {
+                        "flags": list(param.opts),
+                        "type": param.type.name,
+                        "required": param.required,
+                        "default": param.default,
+                        "help": getattr(param, "help", None),
+                    }
+                )
+            else:
+                arguments.append(
+                    {"name": param.name, "required": param.required, "help": None}
+                )
+    command = path.split(" ", 1)[1] if " " in path else path
+    return {
+        "command": command,
+        "help": cmd.get_short_help_str() or None,
+        "arguments": arguments,
+        "options": options,
+    }
+
+
+def _render_help_text(commands: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+    for entry in commands:
+        lines.append(entry["command"])
+        if entry["help"]:
+            lines.append(f"  {entry['help']}")
+        if entry["arguments"]:
+            lines.append("  ARGUMENTS:")
+            for arg in entry["arguments"]:
+                req = "required" if arg["required"] else "optional"
+                lines.append(f"    {arg['name']} ({req})")
+        if entry["options"]:
+            lines.append("  OPTIONS:")
+            for opt in entry["options"]:
+                flags = ", ".join(opt["flags"])
+                bits = [opt["type"], "required" if opt["required"] else "optional"]
+                if opt["default"] is not None:
+                    bits.append(f"default={opt['default']}")
+                detail = ", ".join(bits)
+                line = f"    {flags} [{detail}]"
+                if opt["help"]:
+                    line += f" — {opt['help']}"
+                lines.append(line)
+        lines.append("")
+    return "\n".join(lines).rstrip()
 
 
 @app.command()

--- a/waypointctl/tests/test_cli.py
+++ b/waypointctl/tests/test_cli.py
@@ -1,0 +1,51 @@
+import json
+from typing import cast
+
+import click
+import typer
+from typer.testing import CliRunner
+
+from waypointctl.cli import app
+
+runner = CliRunner()
+
+
+def test_help_command_dumps_full_surface() -> None:
+    result = runner.invoke(app, ["help"])
+    assert result.exit_code == 0
+    for command in ("daemon start", "skills install", "tailscale up"):
+        assert command in result.stdout
+    assert "--skill-dir" in result.stdout
+
+
+def test_help_json_is_structured() -> None:
+    result = runner.invoke(app, ["help", "--json"])
+    assert result.exit_code == 0
+    commands = json.loads(result.stdout)
+    by_path = {entry["command"]: entry for entry in commands}
+    install = by_path["skills install"]
+    skill_dir = next(o for o in install["options"] if "--skill-dir" in o["flags"])
+    assert skill_dir["required"] is False
+    assert skill_dir["type"] == "text"
+
+
+def _walk_leaf_paths(group: click.Group, prefix: str) -> list[str]:
+    paths: list[str] = []
+    for name, cmd in group.commands.items():
+        if cmd.hidden:
+            continue
+        path = f"{prefix} {name}".strip()
+        if isinstance(getattr(cmd, "commands", None), dict):
+            paths.extend(_walk_leaf_paths(cast(click.Group, cmd), path))
+        else:
+            paths.append(path)
+    return paths
+
+
+def test_help_covers_every_leaf_command() -> None:
+    result = runner.invoke(app, ["help", "--json"])
+    assert result.exit_code == 0
+    dumped = {entry["command"] for entry in json.loads(result.stdout)}
+    root = cast(click.Group, typer.main.get_command(app))
+    expected = set(_walk_leaf_paths(root, ""))
+    assert expected <= dumped


### PR DESCRIPTION
## Summary

Discovering the full CLI surface meant running `--help` at every level of a nested Typer command tree — many round-trips for an orchestrating agent, and a surface that drifts from hand-written skill docs (PR #100 had to fix exactly that class of drift). This adds a top-level `help` command to both `waypoint` and `waypointctl` that dumps the entire nested tree in one offline call, giving the skills a generated, drift-proof ground truth to defer to.

## Changes

### CLI

- **`waypoint help` / `waypointctl help`** — print a compact text dump: one block per command (full path, summary, arguments, and options with flags / type / required / default / help), sorted by path. `--json` emits the same tree as structured JSON for programmatic and test use.
- Pure command-tree introspection — it never builds a client, loads settings, or needs a token, so it runs fully offline with no server.
- A group that runs without a subcommand (e.g. `waypoint backends`, which lists backend capabilities) is described as a command in its own right, not just its children.
- Option defaults are coerced to a JSON-serializable form (enum / `Path` / `frozenset` fall back to `str`), so a future option can never break `help --json`.
- Implementation note: Typer vendors its own copy of Click, so groups are detected via the `commands` mapping and parameters classified by `param_type_name` rather than `isinstance` against the top-level `click` types.

### Skills

- The `waypoint` and `waypointctl` skills now point at `help` / `help --json` as the canonical generated ground truth for the full surface and defer to it for exact flags instead of re-enumerating them.

### Tests

- `backend/tests/test_cli.py` and a new `waypointctl/tests/test_cli.py`: text and `--json` structure, a leaf-coverage regression guard (every command in the tree — including runnable groups — must appear in the dump), the runnable-group case, and the JSON-safe default coercion. All run with no server or token.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_cli.py` — 68 passed.
- [x] `cd waypointctl && uv run pytest tests/test_cli.py` — 3 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort / black / ruff / codespell / mypy clean.
- [x] `cd waypointctl && uv run ruff check src tests` — clean (waypointctl has no mypy hook configured).
- [x] Live: `uv run waypoint help`, `uv run waypoint help --json | jq`, `uv run waypointctl help`, `uv run waypointctl help --json | jq` — clean output, valid JSON, `backends` surfaced, no server needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)