### PR TITLE
feat: add the claude_tty backend driving the Claude Code TUI

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -72,7 +72,7 @@ ignore = [
 
 [tool.codespell]
 ignore-words-list = "pres,ratatui"
-skip = "*/package-lock.json,*.lock,*.png,*.jsonl,*.log"
+skip = "*/package-lock.json,*.lock,*.png,*.jsonl,*.log,*/fixtures/claude_tty_pane/*"
 
 [tool.mypy]
 python_version = "3.12"

--- a/backend/src/waypoint/backends/bootstrap.py
+++ b/backend/src/waypoint/backends/bootstrap.py
@@ -20,6 +20,7 @@ from importlib.metadata import entry_points
 
 from waypoint.backends.base import BackendPlugin
 from waypoint.backends.claude_code.plugin import ClaudeCodePlugin
+from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
 from waypoint.backends.codex.plugin import CodexPlugin
 from waypoint.backends.opencode.plugin import OpenCodePlugin
 from waypoint.backends.registry import BackendRegistry
@@ -33,6 +34,7 @@ log = logging.getLogger("waypoint.backends.bootstrap")
 def build_default_registry() -> BackendRegistry:
     registry = BackendRegistry()
     registry.register(ClaudeCodePlugin())
+    registry.register(ClaudeTtyPlugin())
     registry.register(CodexPlugin())
     registry.register(OpenCodePlugin())
     registry.register(TmuxPlugin())

--- a/backend/src/waypoint/backends/claude_tty/_state.py
+++ b/backend/src/waypoint/backends/claude_tty/_state.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class PendingTtyApproval:
+    approval_id: str
+    tool_name: str | None
+    target: str | None
+    approve_number: int
+    decline_number: int | None  # None → send Esc
+    signature: str  # debounce key: "tool_name:target:question"

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -161,6 +161,10 @@ class TranscriptNormalizer:
         if _is_injected_turn(content):
             return []
 
+        # Only tool_result blocks are surfaced from user records. A user/peer
+        # turn's own text is already recorded at the input boundary
+        # (runtime.handle_input → _record_user_event); re-emitting the
+        # transcript's copy would duplicate the message in the event stream.
         events: list[NormalizedEvent] = []
         for block in iter_content_blocks(content):
             if block.get("type") != "tool_result":

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -20,9 +20,14 @@ Key invariants (all verified against real transcripts in Phase 0):
 """
 
 import json
+import uuid
 from typing import Any
 
 from waypoint.backends.claude_code.normalize import (
+    TASK_TOOL_NAMES,
+    TaskListTracker,
+    extract_created_task_id,
+    format_task_snapshot,
     iter_content_blocks,
     stringify_tool_result,
 )
@@ -60,6 +65,10 @@ class TranscriptNormalizer:
 
     def __init__(self) -> None:
         self._seen_message_ids: set[str] = set()
+        self._task_tracker: TaskListTracker = TaskListTracker()
+        self._pending_task_creates: dict[str, dict[str, Any]] = {}
+        self._suppressed_result_tool_use_ids: set[str] = set()
+        self._task_card_item_id: str | None = None
 
     def process_record(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         rec_type = record.get("type")
@@ -105,6 +114,29 @@ class TranscriptNormalizer:
                 has_tool_use = True
                 tool_use_id = str(block.get("id") or "")
                 tool_name = str(block.get("name") or "tool")
+                if tool_name in TASK_TOOL_NAMES:
+                    tool_input: dict[str, Any] = block.get("input") or {}
+                    if tool_name == "TaskCreate":
+                        if tool_use_id:
+                            self._pending_task_creates[tool_use_id] = tool_input
+                    elif tool_name == "TaskUpdate":
+                        task_id = str(tool_input.get("taskId") or "")
+                        if tool_use_id:
+                            self._suppressed_result_tool_use_ids.add(tool_use_id)
+                        if task_id:
+                            self._task_tracker.update(
+                                task_id,
+                                status=tool_input.get("status"),
+                                content=tool_input.get("subject"),
+                                active_form=tool_input.get("activeForm"),
+                                description=tool_input.get("description"),
+                            )
+                            events.extend(self._emit_task_snapshot())
+                    else:
+                        # TaskGet / TaskList: suppress result, emit nothing
+                        if tool_use_id:
+                            self._suppressed_result_tool_use_ids.add(tool_use_id)
+                    continue
                 input_text = json.dumps(block.get("input") or {}, indent=2)
                 events.append(
                     NormalizedEvent(
@@ -170,6 +202,23 @@ class TranscriptNormalizer:
             if block.get("type") != "tool_result":
                 continue
             tool_use_id = str(block.get("tool_use_id") or "")
+            if tool_use_id and tool_use_id in self._pending_task_creates:
+                create_input = self._pending_task_creates.pop(tool_use_id)
+                task_id = extract_created_task_id(block) or tool_use_id
+                if self._task_tracker.is_empty:
+                    self._task_card_item_id = None
+                self._task_tracker.create(
+                    task_id,
+                    content=str(create_input.get("subject") or ""),
+                    active_form=create_input.get("activeForm"),
+                    description=create_input.get("description"),
+                    status=create_input.get("status") or "pending",
+                )
+                events.extend(self._emit_task_snapshot())
+                continue
+            if tool_use_id and tool_use_id in self._suppressed_result_tool_use_ids:
+                self._suppressed_result_tool_use_ids.discard(tool_use_id)
+                continue
             text = stringify_tool_result(block.get("content"))
             is_error = bool(block.get("is_error"))
             events.append(
@@ -189,6 +238,26 @@ class TranscriptNormalizer:
             )
 
         return events
+
+    def _emit_task_snapshot(self) -> list[NormalizedEvent]:
+        if self._task_card_item_id is None:
+            self._task_card_item_id = uuid.uuid4().hex
+        todos = self._task_tracker.snapshot()
+        return [
+            NormalizedEvent(
+                kind=EventKind.TOOL_RESULT,
+                text=format_task_snapshot(todos),
+                metadata={
+                    "method": "assistant.task_update",
+                    "item_id": self._task_card_item_id,
+                    "item_type": "todo_list",
+                    "tool_name": "TodoWrite",
+                    "payload": {"input": {"todos": todos}},
+                    "status": SessionStatus.RUNNING,
+                },
+                status=SessionStatus.RUNNING,
+            )
+        ]
 
 
 def _is_injected_turn(content: Any) -> bool:

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -1,0 +1,197 @@
+"""Transcript-record → canonical-event normalization for the claude_tty backend.
+
+The Claude TUI writes a JSONL transcript to
+``~/.claude/projects/<dashed-cwd>/<session-id>.jsonl``.  Each record wraps the
+same ``message`` object consumed by the claude_code normalizer, so
+``iter_content_blocks`` / ``stringify_tool_result`` are reused directly.
+
+Key invariants (all verified against real transcripts in Phase 0):
+
+- Records are processed in arrival order; same-``message.id`` records are
+  interleaved with ``user`` tool_result records and must NOT be merged.
+- Usage is counted only on the first record for each ``message.id``; subsequent
+  records carry an identical copy that would inflate totals 2–3.6× without the
+  guard.
+- A synthesized result (SYSTEM_NOTE, status=IDLE) is emitted when the last
+  assistant record in a turn has a terminal ``stop_reason`` (anything other than
+  ``tool_use``) and contains no ``tool_use`` blocks.
+- Injected harness user turns (``<task-notification>`` and context-window
+  summaries beginning with "This session is being continued") are dropped.
+"""
+
+import json
+from typing import Any
+
+from waypoint.backends.claude_code.normalize import (
+    iter_content_blocks,
+    stringify_tool_result,
+)
+from waypoint.schemas import EventKind, SessionStatus
+
+# Allowlist of record types we handle; everything else is dropped silently.
+# This is an allowlist rather than a denylist so undocumented TUI record types
+# (e.g. the ``pr-link`` type observed in real transcripts) are dropped rather
+# than mis-rendered.
+HANDLED_RECORD_TYPES: frozenset[str] = frozenset({"assistant", "user"})
+
+
+class NormalizedEvent:
+    __slots__ = ("kind", "text", "metadata", "status")
+
+    def __init__(
+        self,
+        kind: EventKind,
+        text: str,
+        metadata: dict[str, Any],
+        status: SessionStatus,
+    ) -> None:
+        self.kind = kind
+        self.text = text
+        self.metadata = metadata
+        self.status = status
+
+
+class TranscriptNormalizer:
+    """Stateful normalizer for a single session's JSONL transcript stream.
+
+    Instantiate one per session and feed records in arrival order via
+    ``process_record``.  Usage deduplication state is accumulated across calls.
+    """
+
+    def __init__(self) -> None:
+        self._seen_message_ids: set[str] = set()
+
+    def process_record(self, record: dict[str, Any]) -> list[NormalizedEvent]:
+        rec_type = record.get("type")
+        if rec_type == "assistant":
+            return self._process_assistant(record)
+        if rec_type == "user":
+            return self._process_user(record)
+        return []
+
+    def _process_assistant(self, record: dict[str, Any]) -> list[NormalizedEvent]:
+        message: dict[str, Any] = record.get("message") or {}
+        message_id = str(message.get("id") or "")
+        usage: dict[str, Any] = message.get("usage") or {}
+        stop_reason = str(message.get("stop_reason") or "")
+
+        first_seen = message_id not in self._seen_message_ids
+        if message_id:
+            self._seen_message_ids.add(message_id)
+
+        events: list[NormalizedEvent] = []
+        blocks = iter_content_blocks(message.get("content"))
+        has_tool_use = False
+
+        for block in blocks:
+            bt = block.get("type")
+            if bt == "text":
+                text = str(block.get("text") or "")
+                if text:
+                    events.append(
+                        NormalizedEvent(
+                            kind=EventKind.AGENT_OUTPUT,
+                            text=text,
+                            metadata={
+                                "method": "assistant.text",
+                                "item_id": message_id,
+                                "payload": block,
+                                "status": SessionStatus.RUNNING,
+                            },
+                            status=SessionStatus.RUNNING,
+                        )
+                    )
+            elif bt == "tool_use":
+                has_tool_use = True
+                tool_use_id = str(block.get("id") or "")
+                tool_name = str(block.get("name") or "tool")
+                input_text = json.dumps(block.get("input") or {}, indent=2)
+                events.append(
+                    NormalizedEvent(
+                        kind=EventKind.TOOL_CALL,
+                        text=f"{tool_name}\n{input_text}",
+                        metadata={
+                            "method": "assistant.tool_use",
+                            "item_id": tool_use_id,
+                            "tool_name": tool_name,
+                            "tool_use_id": tool_use_id,
+                            "payload": block,
+                            "status": SessionStatus.RUNNING,
+                        },
+                        status=SessionStatus.RUNNING,
+                    )
+                )
+            # thinking blocks: intentionally skipped
+
+        # Synthesize a result event when the turn is complete: stop_reason is
+        # terminal (not "tool_use") and no tool_use blocks were in this record.
+        if stop_reason and stop_reason != "tool_use" and not has_tool_use:
+            usage_payload: dict[str, Any] = usage if first_seen else {}
+            output_tokens = int(usage.get("output_tokens") or 0)
+            if stop_reason == "end_turn":
+                result_text = (
+                    f"Turn complete · {output_tokens} output tokens"
+                    if output_tokens
+                    else "Turn complete"
+                )
+            else:
+                suffix = f" · {output_tokens} output tokens" if output_tokens else ""
+                result_text = f"Turn complete ({stop_reason}){suffix}"
+            events.append(
+                NormalizedEvent(
+                    kind=EventKind.SYSTEM_NOTE,
+                    text=result_text,
+                    metadata={
+                        "method": "result",
+                        "stop_reason": stop_reason,
+                        "usage": usage_payload,
+                        "payload": usage_payload,
+                        "status": SessionStatus.IDLE,
+                    },
+                    status=SessionStatus.IDLE,
+                )
+            )
+
+        return events
+
+    def _process_user(self, record: dict[str, Any]) -> list[NormalizedEvent]:
+        message: dict[str, Any] = record.get("message") or {}
+        content = message.get("content")
+
+        if _is_injected_turn(content):
+            return []
+
+        events: list[NormalizedEvent] = []
+        for block in iter_content_blocks(content):
+            if block.get("type") != "tool_result":
+                continue
+            tool_use_id = str(block.get("tool_use_id") or "")
+            text = stringify_tool_result(block.get("content"))
+            is_error = bool(block.get("is_error"))
+            events.append(
+                NormalizedEvent(
+                    kind=EventKind.TOOL_RESULT,
+                    text=text,
+                    metadata={
+                        "method": "user.tool_result",
+                        "item_id": tool_use_id,
+                        "tool_use_id": tool_use_id,
+                        "is_error": is_error,
+                        "payload": block,
+                        "status": SessionStatus.RUNNING,
+                    },
+                    status=SessionStatus.RUNNING,
+                )
+            )
+
+        return events
+
+
+def _is_injected_turn(content: Any) -> bool:
+    """Return True for harness-injected user turns that must not surface as chat."""
+    if isinstance(content, str):
+        stripped = content.lstrip()
+        return stripped.startswith("<task-notification>") or stripped.startswith(
+            "This session is being continued"
+        )
+    return False

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -45,6 +45,16 @@ _OPTION_RE = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
 _QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
 _WHITESPACE_RE = re.compile(r"\s+")
+# CSI / OSC / two-byte escape sequences. A pane captured with `tmux capture-pane
+# -e` carries colour and cursor codes interleaved with the text, which would
+# shred the substring/regex anchors; strip them before any matching.
+_ANSI_RE = re.compile(
+    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
+)
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 def _compact(text: str) -> str:
@@ -87,6 +97,7 @@ class ApprovalDialog:
 
 
 def classify(screen: str) -> PaneScreen:
+    screen = _strip_ansi(screen)
     compact = _compact(screen)
     if _contains(screen, compact, _APPROVAL_FOOTER) and _contains(
         screen, compact, _APPROVAL_QUESTION_MARKER
@@ -127,6 +138,7 @@ def parse_approval(screen: str) -> ApprovalDialog | None:
     The question, options, and footer form the dialog; the ``● Tool(arg)`` line
     nearest above it carries the tool name and target.
     """
+    screen = _strip_ansi(screen)
     if classify(screen) is not PaneScreen.APPROVAL:
         return None
     lines = screen.splitlines()
@@ -152,13 +164,7 @@ def parse_approval(screen: str) -> ApprovalDialog | None:
         len(lines),
     )
     options = _parse_options(lines[question_idx + 1 : footer_idx])
-
-    tool_name: str | None = None
-    target: str | None = None
-    for line in lines[:question_idx]:
-        header = _TOOL_HEADER_RE.match(line)
-        if header is not None:
-            tool_name, target = header.group(1), header.group(2)
+    tool_name, target = _extract_tool_target(lines[:question_idx], question)
 
     return ApprovalDialog(
         tool_name=tool_name,
@@ -168,8 +174,53 @@ def parse_approval(screen: str) -> ApprovalDialog | None:
     )
 
 
+# Dialog-body labels Claude renders above the question. These are the reliable
+# source of the tool + target: the `● Tool(arg)` header line is often absent
+# (e.g. a Bash dialog shows a "Running…" spinner there instead), so it is only
+# a fallback.
+_BODY_TOOL_LABELS: dict[str, str] = {
+    "Bash command": "Bash",
+    "Create file": "Write",
+    "Write file": "Write",
+    "Edit file": "Edit",
+    "Update file": "Edit",
+}
+
+
+def _extract_tool_target(
+    head_lines: list[str], question: str
+) -> tuple[str | None, str | None]:
+    stripped = [line.strip() for line in head_lines]
+
+    # 1. Body label → tool; the next non-empty line is the command/path.
+    for i, line in enumerate(stripped):
+        tool = _BODY_TOOL_LABELS.get(line)
+        if tool is not None:
+            target = next((s for s in stripped[i + 1 :] if s), None)
+            return tool, target
+
+    # 2. File operations name the path in the question itself.
+    qmatch = re.match(
+        r"Do you want to (create|write to|edit|update) (.+?)\?$", question
+    )
+    if qmatch is not None:
+        verb = qmatch.group(1)
+        tool = "Write" if verb in {"create", "write to"} else "Edit"
+        return tool, qmatch.group(2)
+
+    # 3. Fallback: the `● Tool(arg)` header line, if present.
+    header_tool: str | None = None
+    header_target: str | None = None
+    for line in head_lines:
+        header = _TOOL_HEADER_RE.match(line)
+        if header is not None:
+            header_tool, header_target = header.group(1), header.group(2)
+    return header_tool, header_target
+
+
 def parse_model_selector(screen: str) -> list[DialogOption] | None:
     """Parse the ``/model`` selector's choices, or None if not on that screen."""
+    screen = _strip_ansi(screen)
     if classify(screen) is not PaneScreen.MODEL_SELECTOR:
         return None
     lines = screen.splitlines()

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -192,9 +192,14 @@ def _extract_tool_target(
 ) -> tuple[str | None, str | None]:
     stripped = [line.strip() for line in head_lines]
 
-    # 1. Body label → tool; the next non-empty line is the command/path.
-    for i, line in enumerate(stripped):
-        tool = _BODY_TOOL_LABELS.get(line)
+    # 1. Body label → tool; the next non-empty line is the command/path. Scan
+    # bottom-up: the active dialog is the lowest block on the pane, so an
+    # identical label string sitting earlier in the scrollback can't win. The
+    # target is taken as a single line — at the fixed 120-col launch width with
+    # `capture-pane -J` joining wraps this holds; a label rendered without its
+    # body is the only degenerate case and yields no worse than a None target.
+    for i in range(len(stripped) - 1, -1, -1):
+        tool = _BODY_TOOL_LABELS.get(stripped[i])
         if tool is not None:
             target = next((s for s in stripped[i + 1 :] if s), None)
             return tool, target

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -1,0 +1,154 @@
+"""Pure detection/parsing of Claude TUI dialogs from a captured pane screen.
+
+The TUI resolves tool permissions, model choice, and effort in on-screen popups
+with no stdio control channel, so a `claude_tty` session that wants to surface
+approvals (or drive `/model` / `/effort`) must read them off the rendered pane.
+These functions are deliberately side-effect free: they take the text of a
+`tmux capture-pane` snapshot and return structured descriptions, so the brittle,
+layout-coupled parsing is unit-testable against captured fixtures without a live
+TUI. Keystroke delivery and pane polling live in the (not-yet-wired) caller.
+
+Verified against fixtures captured from Claude Code 2.1.177 in
+``tests/fixtures/claude_tty_pane/``.
+"""
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class PaneScreen(StrEnum):
+    APPROVAL = "approval"
+    TRUST = "trust"
+    MODEL_SELECTOR = "model_selector"
+    EFFORT_POPUP = "effort_popup"
+    OTHER = "other"
+
+
+# Footer signatures uniquely identify each popup. The approval and trust dialogs
+# both end in "Esc to cancel", so the distinguishing token is "Tab to amend"
+# (approval) vs "Enter to confirm" anchored to the trust question.
+_APPROVAL_FOOTER = "Esc to cancel · Tab to amend"
+_MODEL_FOOTER = "Enter to set as default"
+_EFFORT_FOOTER = "←/→ to adjust · Enter to confirm"
+_TRUST_MARKER = "Is this a project you created or one you trust?"
+
+_OPTION_RE = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
+_TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
+_QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
+
+
+@dataclass
+class DialogOption:
+    number: int
+    label: str
+    selected: bool
+
+
+@dataclass
+class ApprovalDialog:
+    tool_name: str | None
+    target: str | None
+    question: str
+    options: list[DialogOption]
+
+    @property
+    def approve_option(self) -> DialogOption | None:
+        """Option 1 ("Yes") — the unconditional approve."""
+        for opt in self.options:
+            if opt.number == 1 and opt.label.lower().startswith("yes"):
+                return opt
+        return None
+
+    @property
+    def decline_option(self) -> DialogOption | None:
+        """The "No" option — the decline that does not widen permissions."""
+        for opt in self.options:
+            if opt.label.lower().startswith("no"):
+                return opt
+        return None
+
+
+def classify(screen: str) -> PaneScreen:
+    if _APPROVAL_FOOTER in screen and _QUESTION_RE.search(screen) is not None:
+        return PaneScreen.APPROVAL
+    if _TRUST_MARKER in screen:
+        return PaneScreen.TRUST
+    if _MODEL_FOOTER in screen and "Select model" in screen:
+        return PaneScreen.MODEL_SELECTOR
+    if _EFFORT_FOOTER in screen and "Effort" in screen:
+        return PaneScreen.EFFORT_POPUP
+    return PaneScreen.OTHER
+
+
+def _parse_options(lines: list[str]) -> list[DialogOption]:
+    options: list[DialogOption] = []
+    for line in lines:
+        match = _OPTION_RE.match(line)
+        if match is None:
+            continue
+        options.append(
+            DialogOption(
+                number=int(match.group(2)),
+                label=match.group(3),
+                selected=match.group(1) is not None,
+            )
+        )
+    return options
+
+
+def parse_approval(screen: str) -> ApprovalDialog | None:
+    """Parse a tool-permission dialog, or None if the screen is not one.
+
+    The question, options, and footer form the dialog; the ``● Tool(arg)`` line
+    nearest above it carries the tool name and target.
+    """
+    if classify(screen) is not PaneScreen.APPROVAL:
+        return None
+    lines = screen.splitlines()
+    question_idx: int | None = None
+    question = ""
+    for i, line in enumerate(lines):
+        match = _QUESTION_RE.match(line)
+        if match is not None:
+            question_idx, question = i, match.group(1)
+            break
+    if question_idx is None:
+        return None
+
+    # Options live between the question and the footer; bounding the slice keeps
+    # diff-preview lines like "  1 waypoint-probe" (no dot) and numbered list
+    # content out of the option set.
+    footer_idx = next(
+        (
+            i
+            for i, line in enumerate(lines[question_idx:], question_idx)
+            if _APPROVAL_FOOTER in line
+        ),
+        len(lines),
+    )
+    options = _parse_options(lines[question_idx + 1 : footer_idx])
+
+    tool_name: str | None = None
+    target: str | None = None
+    for line in lines[:question_idx]:
+        header = _TOOL_HEADER_RE.match(line)
+        if header is not None:
+            tool_name, target = header.group(1), header.group(2)
+
+    return ApprovalDialog(
+        tool_name=tool_name,
+        target=target or None,
+        question=question,
+        options=options,
+    )
+
+
+def parse_model_selector(screen: str) -> list[DialogOption] | None:
+    """Parse the ``/model`` selector's choices, or None if not on that screen."""
+    if classify(screen) is not PaneScreen.MODEL_SELECTOR:
+        return None
+    lines = screen.splitlines()
+    start = next((i for i, line in enumerate(lines) if "Select model" in line), 0)
+    end = next((i for i, line in enumerate(lines) if _MODEL_FOOTER in line), len(lines))
+    return _parse_options(lines[start:end])

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -28,14 +28,31 @@ class PaneScreen(StrEnum):
 # Footer signatures uniquely identify each popup. The approval and trust dialogs
 # both end in "Esc to cancel", so the distinguishing token is "Tab to amend"
 # (approval) vs "Enter to confirm" anchored to the trust question.
+#
+# Anchors are matched in both their literal form and a whitespace-stripped
+# ("compact") form, so a dialog that wraps or pads differently at the rendered
+# width still classifies — box-drawn popups reflow and a raw substring match is
+# brittle to that.
 _APPROVAL_FOOTER = "Esc to cancel · Tab to amend"
+_APPROVAL_QUESTION_MARKER = "Do you want to"
 _MODEL_FOOTER = "Enter to set as default"
+_MODEL_MARKER = "Select model"
 _EFFORT_FOOTER = "←/→ to adjust · Enter to confirm"
+_EFFORT_MARKER = "Effort"
 _TRUST_MARKER = "Is this a project you created or one you trust?"
 
 _OPTION_RE = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
 _QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def _compact(text: str) -> str:
+    return _WHITESPACE_RE.sub("", text)
+
+
+def _contains(screen: str, screen_compact: str, marker: str) -> bool:
+    return marker in screen or _compact(marker) in screen_compact
 
 
 @dataclass
@@ -70,13 +87,20 @@ class ApprovalDialog:
 
 
 def classify(screen: str) -> PaneScreen:
-    if _APPROVAL_FOOTER in screen and _QUESTION_RE.search(screen) is not None:
+    compact = _compact(screen)
+    if _contains(screen, compact, _APPROVAL_FOOTER) and _contains(
+        screen, compact, _APPROVAL_QUESTION_MARKER
+    ):
         return PaneScreen.APPROVAL
-    if _TRUST_MARKER in screen:
+    if _contains(screen, compact, _TRUST_MARKER):
         return PaneScreen.TRUST
-    if _MODEL_FOOTER in screen and "Select model" in screen:
+    if _contains(screen, compact, _MODEL_FOOTER) and _contains(
+        screen, compact, _MODEL_MARKER
+    ):
         return PaneScreen.MODEL_SELECTOR
-    if _EFFORT_FOOTER in screen and "Effort" in screen:
+    if _contains(screen, compact, _EFFORT_FOOTER) and _contains(
+        screen, compact, _EFFORT_MARKER
+    ):
         return PaneScreen.EFFORT_POPUP
     return PaneScreen.OTHER
 

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -313,6 +313,12 @@ class ClaudeTtyPlugin(TmuxPlugin):
                     session.cwd,
                     start_at_end=True,
                 )
+            else:
+                log.warning(
+                    "restored session has no thread_id; "
+                    "transcript tailer not started",
+                    extra={"session_id": session.id},
+                )
             self._spawn_rate_limit_watcher(runtime, session)
             return
 
@@ -397,7 +403,16 @@ class ClaudeTtyPlugin(TmuxPlugin):
         await runtime._record_system_event(
             session.id, message, status=SessionStatus.IDLE
         )
-        self._start_tailer(runtime, session.id, new_thread_id, session.cwd)
+        # Resuming an existing thread reopens its already-populated transcript,
+        # whose records are already in the event DB; tail from the end so they
+        # are not replayed. A new thread starts an empty file, so read from 0.
+        self._start_tailer(
+            runtime,
+            session.id,
+            new_thread_id,
+            session.cwd,
+            start_at_end=effective_thread_id is not None,
+        )
         self._spawn_rate_limit_watcher(runtime, session)
 
     async def fork_session(

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -42,6 +42,7 @@ from waypoint.backends.claude_code.rate_limits import (
     probe_claude_usage,
     probe_claude_usage_remote,
 )
+from waypoint.backends.claude_tty._state import PendingTtyApproval
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.plugin_config import PluginConfig
 from waypoint.backends.tmux.adapter import TmuxError
@@ -102,11 +103,12 @@ class ClaudeTtyPlugin(TmuxPlugin):
 
     def __init__(self) -> None:
         self._tailer_tasks: dict[str, asyncio.Task[None]] = {}
+        self._pending_approvals: dict[str, PendingTtyApproval] = {}
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
         from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
 
-        return ClaudeTtyTransport(runtime)
+        return ClaudeTtyTransport(runtime, self)
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         return shutil.which("claude") is not None
@@ -189,6 +191,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
             session_uuid=thread_id,
             cwd=cwd,
             runtime=runtime,
+            plugin=self,
             start_at_end=start_at_end,
         )
         self._tailer_tasks[session_id] = asyncio.create_task(tailer.run())
@@ -202,6 +205,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
             tailer_task.cancel()
             with suppress(asyncio.CancelledError, Exception):
                 await tailer_task
+        self._pending_approvals.pop(session.id, None)
 
     async def create_session(
         self,
@@ -246,6 +250,8 @@ class ClaudeTtyPlugin(TmuxPlugin):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
+        with suppress(TmuxError):
+            await runtime.tmux.resize_window(target.session, 120, 50)
 
         now = datetime.now(UTC)
         session = SessionRecord(
@@ -369,6 +375,8 @@ class ClaudeTtyPlugin(TmuxPlugin):
                 status=SessionStatus.EXITED,
             )
             return
+        with suppress(TmuxError):
+            await runtime.tmux.resize_window(target.session, 120, 50)
 
         new_state: dict[str, Any] = {
             "tmux_session": target.session,
@@ -447,6 +455,8 @@ class ClaudeTtyPlugin(TmuxPlugin):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
+        with suppress(TmuxError):
+            await runtime.tmux.resize_window(target.session, 120, 50)
 
         now = datetime.now(UTC)
         new_session = SessionRecord(

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1,0 +1,525 @@
+"""Claude TUI backend plugin (claude_tty).
+
+Drives the interactive Claude Code TUI (``claude``) instead of ``claude -p``
+(stream-json mode).  The TUI path is exempt from the API rate limit applied to
+``claude -p``, making it the preferred backend for autonomous Waypoint sessions.
+
+Architecture summary:
+- Input: reuses the ``tmux`` transport (send-keys injection, pipe-pane logging).
+- Output: a transcript tailer reads ``~/.claude/projects/<cwd>/<uuid>.jsonl`` by
+  byte offset and normalizes records into the canonical event stream.
+- ``is_structured=True`` so the frontend renders structured events, not the
+  heuristic raw-terminal view.
+
+Inherits from ``TmuxPlugin`` to reuse shared infrastructure:
+``_conversation_exists``, ``_spawn_rate_limit_watcher``, ``_rate_limit_refresh_loop``,
+``refresh_rate_limit_usage``, ``_ssh_capture``, ``native_thread_id``,
+``on_session_deleted``, ``_resume_args``.
+"""
+
+import asyncio
+import logging
+import shutil
+import uuid
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from fastapi import HTTPException, status
+from pydantic import Field
+
+from waypoint.backends.capabilities import BackendCapabilities, ModelSource
+from waypoint.backends.claude_code.models import (
+    DEFAULT_CLAUDE_MODELS,
+    claude_default_model_id,
+)
+from waypoint.backends.claude_code.permission_modes import (
+    CLAUDE_PERMISSION_MODE_SPECS,
+    CLAUDE_PERMISSION_MODES,
+)
+from waypoint.backends.claude_code.rate_limits import (
+    probe_claude_usage,
+    probe_claude_usage_remote,
+)
+from waypoint.backends.claude_tty.tailer import TranscriptTailer
+from waypoint.backends.plugin_config import PluginConfig
+from waypoint.backends.tmux.adapter import TmuxError
+from waypoint.backends.tmux.plugin import TmuxPlugin
+from waypoint.git_meta import GitMeta
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import (
+    BackendModelOption,
+    SessionCreateRequest,
+    SessionRateLimitUsage,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+from waypoint.transports.base import TransportAdapter
+
+if TYPE_CHECKING:
+    from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.claude_tty")
+
+
+class ClaudeTtyPluginConfig(PluginConfig):
+    """Configuration for the claude_tty plugin.
+
+    Shares the same static model catalogue as claude_code; no runtime
+    model/list RPC is available for Claude.
+    """
+
+    models: list[BackendModelOption] = Field(
+        default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
+    )
+    default_model_id: str | None = Field(default_factory=claude_default_model_id)
+    default_effort: str | None = None
+
+
+class ClaudeTtyPlugin(TmuxPlugin):
+    id = "claude_tty"
+    transport_id = "claude_tty"
+    label = "Claude TUI"
+    config_schema: type[PluginConfig] = ClaudeTtyPluginConfig
+    extra_env = {"CLAUDE_CODE_NO_FLICKER": "1"}
+    capabilities = BackendCapabilities(
+        is_structured=True,
+        supports_resume=True,
+        supports_reattach_after_exit=True,
+        supports_fork=True,
+        supports_attachments=True,
+        supports_set_model_inline=False,
+        supports_set_effort_inline=False,
+        supports_set_permission_mode_inline=False,
+        model_source=ModelSource.STATIC,
+        permission_modes=CLAUDE_PERMISSION_MODE_SPECS,
+        badges={"glyph": "C", "color": "#a78bfa"},
+        cli_binary="claude",
+        target_aliases=("claude_tty",),
+    )
+
+    def __init__(self) -> None:
+        self._tailer_tasks: dict[str, asyncio.Task[None]] = {}
+
+    def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
+        from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
+
+        return ClaudeTtyTransport(runtime)
+
+    def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
+        return shutil.which("claude") is not None
+
+    def remote_executable(self, launch_target: SshLaunchTargetConfig) -> str:
+        return "claude"
+
+    def validate_permission_mode(self, mode: str | None) -> str | None:
+        if mode is None:
+            return None
+        if mode not in CLAUDE_PERMISSION_MODES:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"unknown permission mode for claude_tty: {mode!r}",
+            )
+        return mode
+
+    def _config(self, runtime: "SessionRuntime") -> ClaudeTtyPluginConfig:
+        config = runtime.settings.plugin_config(self.id)
+        if not isinstance(config, ClaudeTtyPluginConfig):
+            return ClaudeTtyPluginConfig()
+        return config
+
+    async def list_models(
+        self,
+        runtime: "SessionRuntime",
+        launch_target_id: str | None = None,
+        include_hidden: bool = False,
+    ) -> dict[str, Any]:
+        config = self._config(runtime)
+        default_model = config.default_model_id
+        options = [opt.model_dump(mode="json") for opt in config.models]
+        default_model_id: str | None = None
+        if default_model is None:
+            for opt in config.models:
+                if opt.is_default:
+                    default_model_id = opt.id
+                    break
+        else:
+            default_model_id = default_model
+        default_model_label: str | None = None
+        if default_model_id:
+            for opt in config.models:
+                if opt.id == default_model_id:
+                    default_model_label = opt.label
+                    break
+        return {
+            "backend": self.id,
+            "models": options,
+            "default_model_id": default_model_id,
+            "default_model_label": default_model_label,
+            "default_effort": config.default_effort,
+            "supports_free_text": True,
+        }
+
+    async def probe_account_rate_limit(
+        self,
+        runtime: "SessionRuntime",
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> SessionRateLimitUsage | None:
+        if launch_target is None:
+            return await probe_claude_usage()
+        return await probe_claude_usage_remote(launch_target)
+
+    # ── Session lifecycle ────────────────────────────────────────────────────
+
+    def _start_tailer(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        thread_id: str,
+        cwd: str,
+        *,
+        start_at_end: bool = False,
+    ) -> None:
+        if session_id in self._tailer_tasks:
+            return
+        tailer = TranscriptTailer(
+            session_id=session_id,
+            session_uuid=thread_id,
+            cwd=cwd,
+            runtime=runtime,
+            start_at_end=start_at_end,
+        )
+        self._tailer_tasks[session_id] = asyncio.create_task(tailer.run())
+
+    async def terminate_session(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        await super().terminate_session(runtime, session)
+        tailer_task = self._tailer_tasks.pop(session.id, None)
+        if tailer_task is not None:
+            tailer_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await tailer_task
+
+    async def create_session(
+        self,
+        runtime: "SessionRuntime",
+        request: SessionCreateRequest,
+        *,
+        session_id: str,
+        launch_target: SshLaunchTargetConfig | None,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+        git_meta: GitMeta,
+        permission_mode: str | None,
+        resolved_model: str | None,
+        resolved_effort: str | None,
+    ) -> SessionRecord:
+        thread_id = str(uuid.uuid4())
+        launch_args = _build_launch_args(
+            thread_id=thread_id,
+            permission_mode=permission_mode,
+            model=resolved_model,
+            effort=resolved_effort,
+            extra_args=request.args,
+        )
+        try:
+            command = runtime._command_for_backend(
+                self.id,
+                launch_args,
+                launch_target,
+                request.cwd,
+                allocate_tty=True,
+                session_id=session_id,
+            )
+        except HTTPException:
+            raise
+        try:
+            target = await runtime.tmux.start_managed_session(
+                session_id, request.cwd, command
+            )
+            await runtime.tmux.pipe_output(target.pane, raw_log)
+        except TmuxError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+
+        now = datetime.now(UTC)
+        session = SessionRecord(
+            id=session_id,
+            backend=self.id,
+            source=SessionSource.MANAGED,
+            transport=self.transport_id,
+            title=title,
+            cwd=request.cwd,
+            launch_target_id=launch_target.id if launch_target else None,
+            launch_mode=request.launch_mode,
+            repo_name=git_meta.repo_name,
+            branch=git_meta.branch,
+            status=SessionStatus.STARTING,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={
+                "tmux_session": target.session,
+                "tmux_window": target.window,
+                "tmux_pane": target.pane,
+                "pid": target.pane_pid,
+                "thread_id": thread_id,
+                "launch_args": launch_args,
+            },
+            spawner_session_id=request.spawner_session_id,
+            permission_mode=permission_mode,
+            model=resolved_model,
+            effort=resolved_effort,
+            args=request.args,
+        )
+        runtime.storage.create_session(session)
+        await runtime._record_system_event(
+            session.id,
+            f"Claude TUI session started (thread {thread_id})",
+            status=SessionStatus.IDLE,
+        )
+        self._start_tailer(runtime, session.id, thread_id, request.cwd)
+        self._spawn_rate_limit_watcher(runtime, session)
+        return runtime.get_session(session.id)
+
+    async def restore_session(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        state = session.transport_state
+        thread_id: str | None = state.get("thread_id")
+
+        if session.status != SessionStatus.EXITED:
+            # Boot-time restore: pane should still be running.  Start the
+            # tailer at the current end of the transcript so we don't replay
+            # records that are already in the event DB.
+            if thread_id:
+                self._start_tailer(
+                    runtime,
+                    session.id,
+                    thread_id,
+                    session.cwd,
+                    start_at_end=True,
+                )
+            self._spawn_rate_limit_watcher(runtime, session)
+            return
+
+        # EXITED reconnect: relaunch a new tmux session.
+        old_tmux_session = state.get("tmux_session")
+        if old_tmux_session:
+            with suppress(TmuxError):
+                await runtime.tmux.kill_session(old_tmux_session)
+
+        launch_target = runtime._find_launch_target(session.launch_target_id)
+        stored_args = state.get("launch_args")
+        base_args = _scrub_session_args(
+            stored_args if isinstance(stored_args, list) else []
+        )
+
+        effective_thread_id: str | None = None
+        if thread_id and await self._conversation_exists(
+            "claude_code", thread_id, session.cwd, launch_target
+        ):
+            effective_thread_id = thread_id
+
+        if effective_thread_id:
+            new_thread_id = effective_thread_id
+            launch_args = ["--resume", effective_thread_id, *base_args]
+        else:
+            new_thread_id = str(uuid.uuid4())
+            launch_args = ["--session-id", new_thread_id, *base_args]
+
+        try:
+            command = runtime._command_for_backend(
+                self.id,
+                launch_args,
+                launch_target,
+                session.cwd,
+                allocate_tty=True,
+                session_id=session.id,
+            )
+        except HTTPException as exc:
+            await runtime._record_system_event(
+                session.id,
+                f"Failed to rebuild launch command for reconnect: {exc.detail}",
+                status=SessionStatus.EXITED,
+            )
+            return
+
+        raw_log = Path(session.raw_log_path)
+        with suppress(OSError):
+            raw_log.parent.mkdir(parents=True, exist_ok=True)
+            raw_log.write_bytes(b"")
+
+        try:
+            target = await runtime.tmux.start_managed_session(
+                session.id, session.cwd, command
+            )
+            await runtime.tmux.pipe_output(target.pane, raw_log)
+        except TmuxError as exc:
+            await runtime._record_system_event(
+                session.id,
+                f"Failed to relaunch tmux session: {exc}",
+                status=SessionStatus.EXITED,
+            )
+            return
+
+        new_state: dict[str, Any] = {
+            "tmux_session": target.session,
+            "tmux_window": target.window,
+            "tmux_pane": target.pane,
+            "pid": target.pane_pid,
+            "thread_id": new_thread_id,
+            "launch_args": launch_args,
+        }
+        runtime.storage.update_session(
+            session.id, transport_state=new_state, status=SessionStatus.STARTING
+        )
+        message = (
+            f"Session reconnected (resumed thread {new_thread_id})"
+            if effective_thread_id
+            else "Session reconnected (new thread)"
+        )
+        await runtime._record_system_event(
+            session.id, message, status=SessionStatus.IDLE
+        )
+        self._start_tailer(runtime, session.id, new_thread_id, session.cwd)
+        self._spawn_rate_limit_watcher(runtime, session)
+
+    async def fork_session(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        src_thread_id: str | None = session.transport_state.get("thread_id")
+        if not src_thread_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="claude_tty session has no thread id to fork from",
+            )
+        launch_target = (
+            runtime._find_launch_target(session.launch_target_id)
+            if session.launch_target_id
+            else None
+        )
+        stored_args = session.transport_state.get("launch_args")
+        base_args = _scrub_session_args(
+            stored_args if isinstance(stored_args, list) else []
+        )
+        new_thread_id = str(uuid.uuid4())
+        launch_args = [
+            "--resume",
+            src_thread_id,
+            "--fork-session",
+            "--session-id",
+            new_thread_id,
+            *base_args,
+        ]
+        try:
+            command = runtime._command_for_backend(
+                self.id,
+                launch_args,
+                launch_target,
+                session.cwd,
+                allocate_tty=True,
+                session_id=new_session_id,
+            )
+        except HTTPException:
+            raise
+        raw_log.parent.mkdir(parents=True, exist_ok=True)
+        raw_log.touch(exist_ok=True)
+        try:
+            target = await runtime.tmux.start_managed_session(
+                new_session_id, session.cwd, command
+            )
+            await runtime.tmux.pipe_output(target.pane, raw_log)
+        except TmuxError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+
+        now = datetime.now(UTC)
+        new_session = SessionRecord(
+            id=new_session_id,
+            backend=self.id,
+            source=SessionSource.MANAGED,
+            transport=self.transport_id,
+            title=title,
+            cwd=session.cwd,
+            launch_target_id=session.launch_target_id,
+            repo_name=session.repo_name,
+            branch=session.branch,
+            status=SessionStatus.STARTING,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={
+                "tmux_session": target.session,
+                "tmux_window": target.window,
+                "tmux_pane": target.pane,
+                "pid": target.pane_pid,
+                "thread_id": new_thread_id,
+                "launch_args": launch_args,
+            },
+            permission_mode=session.permission_mode,
+            model=session.model,
+            effort=session.effort,
+            args=session.args,
+        )
+        runtime.storage.create_session(new_session)
+        await runtime._record_system_event(
+            new_session_id,
+            f"Claude TUI forked from {session.title or session.id} (thread {new_thread_id})",
+            status=SessionStatus.IDLE,
+        )
+        self._start_tailer(runtime, new_session_id, new_thread_id, session.cwd)
+        self._spawn_rate_limit_watcher(runtime, new_session)
+        return runtime.get_session(new_session_id)
+
+
+def _build_launch_args(
+    *,
+    thread_id: str,
+    permission_mode: str | None,
+    model: str | None,
+    effort: str | None,
+    extra_args: list[str],
+) -> list[str]:
+    args = ["--session-id", thread_id]
+    if model:
+        args += ["--model", model]
+    if effort:
+        args += ["--effort", effort]
+    if permission_mode:
+        args += ["--permission-mode", permission_mode]
+    args += extra_args
+    return args
+
+
+def _scrub_session_args(args: list[str]) -> list[str]:
+    """Strip ``--session-id`` and ``--resume`` (plus their value) from args."""
+    result: list[str] = []
+    skip = 0
+    for arg in args:
+        if skip:
+            skip -= 1
+            continue
+        if arg in ("--session-id", "--resume", "--fork-session"):
+            # --fork-session has no value argument; --session-id and --resume do
+            if arg != "--fork-session":
+                skip = 1
+            continue
+        result.append(arg)
+    return result

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -72,6 +72,10 @@ class TranscriptTailer:
         # Dialog debounce state
         self._prev_dialog_sig: str | None = None
         self._dialog_stable_count: int = 0
+        # Signature of the dialog already surfaced as an APPROVAL_REQUEST; held
+        # until the dialog leaves the screen so a response that clears pending
+        # before the pane redraws cannot trigger a duplicate emit.
+        self._surfaced_sig: str | None = None
 
     def _read_new_bytes(self) -> bytes:
         if not self._path.exists():
@@ -143,6 +147,7 @@ class TranscriptTailer:
             self._plugin._pending_approvals.pop(self._session_id, None)
             self._prev_dialog_sig = None
             self._dialog_stable_count = 0
+            self._surfaced_sig = None
             return
 
         dialog = pane_dialog.parse_approval(snapshot)
@@ -162,8 +167,10 @@ class TranscriptTailer:
         if self._dialog_stable_count < _DIALOG_STABLE_TICKS:
             return
 
-        # Already surfaced — avoid re-emitting the same pending dialog.
-        if self._session_id in self._plugin._pending_approvals:
+        # Already surfaced this exact dialog — do not re-emit, even once the
+        # response has cleared the pending entry but the pane has not yet
+        # redrawn the box away.
+        if sig == self._surfaced_sig:
             return
 
         approve_num = dialog.approve_option.number if dialog.approve_option else 1
@@ -192,6 +199,7 @@ class TranscriptTailer:
             decline_number=decline_num,
             signature=sig,
         )
+        self._surfaced_sig = sig
 
         await self._runtime._emit_adapter_event(
             self._session_id,

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -150,6 +150,20 @@ class TranscriptTailer:
 
         screen_type = pane_dialog.classify(snapshot)
 
+        if screen_type is pane_dialog.PaneScreen.TRUST:
+            # A fresh cwd opens with the workspace-trust prompt, which blocks the
+            # session (including autonomously-spawned ones in fresh worktrees)
+            # until answered. Option 1 ("trust") is preselected, so a bare Enter
+            # accepts. Re-sent each tick it persists — idempotent, and self-heals
+            # if a keystroke is dropped; a stray Enter at the ready prompt after
+            # it clears is a harmless empty submit.
+            log.info(
+                "accepting workspace-trust prompt",
+                extra={"session_id": self._session_id},
+            )
+            await self._runtime.tmux.send_input(pane, "", submit=True)
+            return
+
         if screen_type is not pane_dialog.PaneScreen.APPROVAL:
             # Dialog gone — clear any pending approval for this session.
             self._plugin._pending_approvals.pop(self._session_id, None)

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from waypoint.backends.claude_code.normalize import format_approval_text
-from waypoint.backends.claude_code.permission_modes import CLAUDE_AUTO_APPROVE_MODES
 from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval
 from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
@@ -32,6 +31,7 @@ log = logging.getLogger("waypoint.backends.claude_tty")
 
 _POLL_INTERVAL = 0.5  # seconds between transcript polls
 _PANE_CHECK_INTERVAL = 10.0  # seconds between tmux pane liveness checks
+_DIALOG_POLL_INTERVAL = 1.0  # seconds between live-pane dialog captures
 _DIALOG_STABLE_TICKS = 2  # consecutive identical captures before surfacing
 
 
@@ -66,6 +66,7 @@ class TranscriptTailer:
         self._plugin = plugin
         self._normalizer = TranscriptNormalizer()
         self._pane_check_elapsed = 0.0
+        self._dialog_check_elapsed = 0.0
         self._offset = (
             self._path.stat().st_size if start_at_end and self._path.exists() else 0
         )
@@ -123,13 +124,20 @@ class TranscriptTailer:
                 )
 
     async def _poll_dialog(self) -> None:
-        """Capture the live pane and surface any stable tool-permission dialog."""
+        """Capture the live pane and surface any stable tool-permission dialog.
+
+        Detection is intentionally mode-agnostic: ``claude_tty`` cannot change
+        permission mode inline (``supports_set_permission_mode_inline=False``),
+        so the session's stored ``permission_mode`` is fixed at launch, while
+        the TUI's real posture can drift independently (a human pressing
+        shift+tab in the pane, or choosing "allow all this session"). Gating on
+        the stored mode would miss a dialog that appears after an auto→prompting
+        drift and hang the session, so we always trust the on-screen dialog
+        rather than the recorded mode. (The run loop throttles how often this
+        runs to keep the capture cost low on sessions that never prompt.)
+        """
         session = self._runtime.storage.get_session(self._session_id)
         if session is None:
-            return
-
-        # Fully-automatic modes never show permission dialogs.
-        if session.permission_mode in CLAUDE_AUTO_APPROVE_MODES:
             return
 
         state = session.transport_state
@@ -237,7 +245,10 @@ class TranscriptTailer:
                 await self._drain()
 
                 if session.status not in (SessionStatus.EXITED, SessionStatus.ERROR):
-                    await self._poll_dialog()
+                    self._dialog_check_elapsed += _POLL_INTERVAL
+                    if self._dialog_check_elapsed >= _DIALOG_POLL_INTERVAL:
+                        self._dialog_check_elapsed = 0.0
+                        await self._poll_dialog()
 
                 if session.status in (SessionStatus.EXITED, SessionStatus.ERROR):
                     # One final drain in case records landed between the status

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -3,25 +3,36 @@
 Polls the session JSONL transcript by byte offset, normalizes each new record
 into canonical events, and emits them through the runtime.  Periodically checks
 whether the tmux pane is still alive and marks the session EXITED when it dies.
+
+Also polls the live pane for tool-permission dialogs (when the session's
+permission_mode requires them) and emits APPROVAL_REQUEST events so the
+frontend can surface them.
 """
 
 import asyncio
 import json
 import logging
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from waypoint.backends.claude_code.normalize import format_approval_text
+from waypoint.backends.claude_code.permission_modes import CLAUDE_AUTO_APPROVE_MODES
+from waypoint.backends.claude_tty import pane_dialog
+from waypoint.backends.claude_tty._state import PendingTtyApproval
 from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
 from waypoint.backends.tmux.adapter import TmuxError
-from waypoint.schemas import SessionStatus
+from waypoint.schemas import EventKind, SessionStatus
 
 if TYPE_CHECKING:
+    from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
     from waypoint.runtime import SessionRuntime
 
 log = logging.getLogger("waypoint.backends.claude_tty")
 
 _POLL_INTERVAL = 0.5  # seconds between transcript polls
 _PANE_CHECK_INTERVAL = 10.0  # seconds between tmux pane liveness checks
+_DIALOG_STABLE_TICKS = 2  # consecutive identical captures before surfacing
 
 
 def transcript_path(cwd: str, session_uuid: str) -> Path:
@@ -45,17 +56,22 @@ class TranscriptTailer:
         session_uuid: str,
         cwd: str,
         runtime: "SessionRuntime",
+        plugin: "ClaudeTtyPlugin",
         *,
         start_at_end: bool = False,
     ) -> None:
         self._session_id = session_id
         self._path = transcript_path(cwd, session_uuid)
         self._runtime = runtime
+        self._plugin = plugin
         self._normalizer = TranscriptNormalizer()
         self._pane_check_elapsed = 0.0
         self._offset = (
             self._path.stat().st_size if start_at_end and self._path.exists() else 0
         )
+        # Dialog debounce state
+        self._prev_dialog_sig: str | None = None
+        self._dialog_stable_count: int = 0
 
     def _read_new_bytes(self) -> bytes:
         if not self._path.exists():
@@ -102,6 +118,95 @@ class TranscriptTailer:
                     ev.status,
                 )
 
+    async def _poll_dialog(self) -> None:
+        """Capture the live pane and surface any stable tool-permission dialog."""
+        session = self._runtime.storage.get_session(self._session_id)
+        if session is None:
+            return
+
+        # Fully-automatic modes never show permission dialogs.
+        if session.permission_mode in CLAUDE_AUTO_APPROVE_MODES:
+            return
+
+        state = session.transport_state
+        pane = state.get("tmux_pane") or state.get("tmux_session") or self._session_id
+
+        try:
+            snapshot = await self._runtime.tmux.capture_snapshot(pane)
+        except TmuxError:
+            return
+
+        screen_type = pane_dialog.classify(snapshot)
+
+        if screen_type is not pane_dialog.PaneScreen.APPROVAL:
+            # Dialog gone — clear any pending approval for this session.
+            self._plugin._pending_approvals.pop(self._session_id, None)
+            self._prev_dialog_sig = None
+            self._dialog_stable_count = 0
+            return
+
+        dialog = pane_dialog.parse_approval(snapshot)
+        if dialog is None:
+            self._prev_dialog_sig = None
+            self._dialog_stable_count = 0
+            return
+
+        sig = f"{dialog.tool_name}:{dialog.target}:{dialog.question}"
+
+        if sig == self._prev_dialog_sig:
+            self._dialog_stable_count += 1
+        else:
+            self._prev_dialog_sig = sig
+            self._dialog_stable_count = 1
+
+        if self._dialog_stable_count < _DIALOG_STABLE_TICKS:
+            return
+
+        # Already surfaced — avoid re-emitting the same pending dialog.
+        if self._session_id in self._plugin._pending_approvals:
+            return
+
+        approve_num = dialog.approve_option.number if dialog.approve_option else 1
+        decline_opt = dialog.decline_option
+        decline_num = decline_opt.number if decline_opt else None
+
+        approval_id = str(uuid.uuid4())
+        tool_name = dialog.tool_name or "Unknown"
+        target = dialog.target or ""
+
+        if tool_name == "Bash":
+            tool_input: dict[str, str] = {"command": target}
+        elif tool_name in {"Write", "Edit", "MultiEdit"}:
+            tool_input = {"file_path": target}
+        else:
+            tool_input = {"description": target}
+
+        payload: dict[str, Any] = {"tool_name": tool_name, "tool_input": tool_input}
+        text = format_approval_text(payload)
+
+        self._plugin._pending_approvals[self._session_id] = PendingTtyApproval(
+            approval_id=approval_id,
+            tool_name=tool_name,
+            target=target or None,
+            approve_number=approve_num,
+            decline_number=decline_num,
+            signature=sig,
+        )
+
+        await self._runtime._emit_adapter_event(
+            self._session_id,
+            EventKind.APPROVAL_REQUEST,
+            text,
+            {
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+                "approval_id": approval_id,
+                "method": "tty_permission",
+                "status": SessionStatus.WAITING_INPUT,
+            },
+            SessionStatus.WAITING_INPUT,
+        )
+
     async def _pane_alive(self) -> bool:
         session = self._runtime.storage.get_session(self._session_id)
         if session is None:
@@ -122,6 +227,9 @@ class TranscriptTailer:
                     return
 
                 await self._drain()
+
+                if session.status not in (SessionStatus.EXITED, SessionStatus.ERROR):
+                    await self._poll_dialog()
 
                 if session.status in (SessionStatus.EXITED, SessionStatus.ERROR):
                     # One final drain in case records landed between the status

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -1,0 +1,151 @@
+"""Transcript file tailer for the claude_tty backend.
+
+Polls the session JSONL transcript by byte offset, normalizes each new record
+into canonical events, and emits them through the runtime.  Periodically checks
+whether the tmux pane is still alive and marks the session EXITED when it dies.
+"""
+
+import asyncio
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
+from waypoint.backends.tmux.adapter import TmuxError
+from waypoint.schemas import SessionStatus
+
+if TYPE_CHECKING:
+    from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.claude_tty")
+
+_POLL_INTERVAL = 0.5  # seconds between transcript polls
+_PANE_CHECK_INTERVAL = 10.0  # seconds between tmux pane liveness checks
+
+
+def transcript_path(cwd: str, session_uuid: str) -> Path:
+    """Return the Claude TUI's JSONL transcript path for the given session."""
+    dashed = cwd.replace("/", "-")
+    return Path.home() / ".claude" / "projects" / dashed / f"{session_uuid}.jsonl"
+
+
+class TranscriptTailer:
+    """Background task that tails a Claude TUI transcript and emits events.
+
+    ``start_at_end=True`` skips existing content (used on boot-time restore so
+    already-emitted records are not replayed).  The default (``False``) reads
+    from byte 0, which is correct for fresh sessions where the transcript file
+    will be created on first user input.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        session_uuid: str,
+        cwd: str,
+        runtime: "SessionRuntime",
+        *,
+        start_at_end: bool = False,
+    ) -> None:
+        self._session_id = session_id
+        self._path = transcript_path(cwd, session_uuid)
+        self._runtime = runtime
+        self._normalizer = TranscriptNormalizer()
+        self._pane_check_elapsed = 0.0
+        self._offset = (
+            self._path.stat().st_size if start_at_end and self._path.exists() else 0
+        )
+
+    def _read_new_bytes(self) -> bytes:
+        if not self._path.exists():
+            return b""
+        try:
+            with self._path.open("rb") as fh:
+                fh.seek(self._offset)
+                return fh.read()
+        except OSError:
+            return b""
+
+    async def _drain(self) -> None:
+        data = await asyncio.to_thread(self._read_new_bytes)
+        if not data:
+            return
+
+        lines = data.split(b"\n")
+        consumed = len(data)
+        # If the file ends without a trailing newline the last element is a
+        # partial record; rewind so it is re-read on the next poll.
+        if not data.endswith(b"\n"):
+            partial = lines.pop()
+            consumed -= len(partial)
+        self._offset += consumed
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(line)
+            except json.JSONDecodeError:
+                log.warning(
+                    "transcript JSON decode error",
+                    extra={"session_id": self._session_id, "line": raw_line[:200]},
+                )
+                continue
+            for ev in self._normalizer.process_record(record):
+                await self._runtime._emit_adapter_event(
+                    self._session_id,
+                    ev.kind,
+                    ev.text,
+                    ev.metadata,
+                    ev.status,
+                )
+
+    async def _pane_alive(self) -> bool:
+        session = self._runtime.storage.get_session(self._session_id)
+        if session is None:
+            return False
+        state = session.transport_state
+        target = state.get("tmux_pane") or state.get("tmux_session") or self._session_id
+        try:
+            info = await self._runtime.tmux.describe_target(target)
+        except TmuxError:
+            return False
+        return not info.pane_dead
+
+    async def run(self) -> None:
+        try:
+            while True:
+                session = self._runtime.storage.get_session(self._session_id)
+                if session is None:
+                    return
+
+                await self._drain()
+
+                if session.status in (SessionStatus.EXITED, SessionStatus.ERROR):
+                    # One final drain in case records landed between the status
+                    # check and this point.
+                    await self._drain()
+                    return
+
+                self._pane_check_elapsed += _POLL_INTERVAL
+                if self._pane_check_elapsed >= _PANE_CHECK_INTERVAL:
+                    self._pane_check_elapsed = 0.0
+                    if not await self._pane_alive():
+                        await self._drain()
+                        await self._runtime._record_system_event(
+                            self._session_id,
+                            "Claude TUI session exited",
+                            status=SessionStatus.EXITED,
+                        )
+                        return
+
+                await asyncio.sleep(_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception(
+                "transcript tailer crashed",
+                extra={"session_id": self._session_id},
+            )

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -1,11 +1,14 @@
 """Transport adapter for the claude_tty backend.
 
-Thin subclass of ``TmuxTransport`` that overrides two properties:
+Thin subclass of ``TmuxTransport`` that overrides:
 
 - ``is_structured = True`` — the transcript tailer emits canonical events, so
   the frontend must not fall back to the heuristic raw-terminal view.
 - ``interrupt`` sends ``Esc`` instead of ``Ctrl-C``; ``Esc`` is the Claude TUI's
   cancel key and cancels the running generation without terminating the process.
+- ``has_pending_approval`` / ``respond_to_approval`` — drive tool-permission
+  dialogs by sending the appropriate digit + Enter keystroke to the TUI pane.
+  Pending state is owned by the plugin singleton (``ClaudeTtyPlugin``).
 """
 
 from typing import TYPE_CHECKING
@@ -14,12 +17,53 @@ from waypoint.backends.tmux.transport import TmuxTransport
 from waypoint.schemas import SessionRecord
 
 if TYPE_CHECKING:
-    pass
+    from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
+    from waypoint.runtime import SessionRuntime
 
 
 class ClaudeTtyTransport(TmuxTransport):
     is_structured = True
     supports_resume = True
 
+    def __init__(self, runtime: "SessionRuntime", plugin: "ClaudeTtyPlugin") -> None:
+        super().__init__(runtime)
+        self._plugin = plugin
+
     async def interrupt(self, session: SessionRecord) -> None:
         await self.adapter.send_bytes(self._target(session), b"\x1b")
+
+    def has_pending_approval(self, session: SessionRecord) -> bool:
+        return session.id in self._plugin._pending_approvals
+
+    async def respond_to_approval(
+        self,
+        session: SessionRecord,
+        decision: str,
+        text: str | None,
+        approval_id: str | None = None,
+    ) -> bool:
+        pending = self._plugin._pending_approvals.get(session.id)
+        if pending is None:
+            return False
+        if approval_id is not None and pending.approval_id != approval_id:
+            return False
+
+        target = self._target(session)
+        normalized = decision.strip().lower()
+
+        if normalized in {"approve", "yes", "y"}:
+            await self.adapter.send_input(
+                target, str(pending.approve_number), submit=True
+            )
+        else:
+            # Decline: send the No-labelled option's digit, never position 2
+            # ("allow all this session"). Fall back to Esc if no explicit No.
+            if pending.decline_number is not None:
+                await self.adapter.send_input(
+                    target, str(pending.decline_number), submit=True
+                )
+            else:
+                await self.adapter.send_bytes(target, b"\x1b")
+
+        del self._plugin._pending_approvals[session.id]
+        return True

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -48,6 +48,11 @@ class ClaudeTtyTransport(TmuxTransport):
         if approval_id is not None and pending.approval_id != approval_id:
             return False
 
+        # Claim the approval before the await below, so a concurrent call
+        # (double-click, retried POST) short-circuits on the None lookup above
+        # rather than sending a second keystroke and double-deleting the key.
+        self._plugin._pending_approvals.pop(session.id, None)
+
         target = self._target(session)
         normalized = decision.strip().lower()
 
@@ -65,5 +70,4 @@ class ClaudeTtyTransport(TmuxTransport):
             else:
                 await self.adapter.send_bytes(target, b"\x1b")
 
-        del self._plugin._pending_approvals[session.id]
         return True

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -1,0 +1,25 @@
+"""Transport adapter for the claude_tty backend.
+
+Thin subclass of ``TmuxTransport`` that overrides two properties:
+
+- ``is_structured = True`` — the transcript tailer emits canonical events, so
+  the frontend must not fall back to the heuristic raw-terminal view.
+- ``interrupt`` sends ``Esc`` instead of ``Ctrl-C``; ``Esc`` is the Claude TUI's
+  cancel key and cancels the running generation without terminating the process.
+"""
+
+from typing import TYPE_CHECKING
+
+from waypoint.backends.tmux.transport import TmuxTransport
+from waypoint.schemas import SessionRecord
+
+if TYPE_CHECKING:
+    pass
+
+
+class ClaudeTtyTransport(TmuxTransport):
+    is_structured = True
+    supports_resume = True
+
+    async def interrupt(self, session: SessionRecord) -> None:
+        await self.adapter.send_bytes(self._target(session), b"\x1b")

--- a/backend/tests/fixtures/claude_tty_pane/approval_bash.txt
+++ b/backend/tests/fixtures/claude_tty_pane/approval_bash.txt
@@ -1,0 +1,40 @@
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+❯ Run this exact shell command, nothing else: echo waypoint-probe-hello
+
+● Bash(echo waypoint-probe-hello)
+  ⎿  waypoint-probe-hello
+
+● waypoint-probe-hello
+
+✻ Cogitated for 5s
+
+❯ Create a new file named probe_out.txt containing exactly the text: waypoint-probe
+
+● Write(probe_out.txt)
+  ⎿  Wrote 1 lines to probe_out.txt
+      1 waypoint-probe
+
+● Created /tmp/cc-tty-probe/probe_out.txt containing waypoint-probe.
+
+✻ Churned for 5s
+
+❯ Run exactly this shell command, nothing else: mkdir /tmp/cc-tty-probe/probe_subdir
+
+● Bash(mkdir /tmp/cc-tty-probe/probe_subdir)
+  ⎿  Waiting…
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Bash command
+
+   mkdir /tmp/cc-tty-probe/probe_subdir
+   Create probe_subdir directory
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and always allow access to cc-tty-probe/ from this project
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain
+

--- a/backend/tests/fixtures/claude_tty_pane/approval_bash_ansi.txt
+++ b/backend/tests/fixtures/claude_tty_pane/approval_bash_ansi.txt
@@ -1,0 +1,50 @@
+
+[38;5;174m╭───[39m [38;5;174mClaude Code[39m [38;5;246mv2.1.177[39m [38;5;174m─────────────────────────────────────────────────────────────────────────────────────────────╮
+│[39m                                                    [2m[38;5;174m│[0m [1m[38;5;174mTips for getting started[0m                                        [38;5;174m│
+│[39m               [1mWelcome back Noppanat![0m               [2m[38;5;174m│[0m Ask Claude to create a new app or clone a repository            [38;5;174m│
+│[39m                                                    [2m[38;5;174m│[0m [38;5;174m───────────────────────────────────────────────────────────────[39m [38;5;174m│
+│[39m                      [38;5;174m ▐[48;5;16m▛███▜[49m▌[39m                      [2m[38;5;174m│[0m [1m[38;5;174mWhat's new[0m                                                      [38;5;174m│
+│[39m                      [38;5;174m▝▜[48;5;16m█████[49m▛▘[39m                     [2m[38;5;174m│[0m Session titles are now generated in the language of your conve… [38;5;174m│
+│[39m                      [38;5;174m  ▘▘ ▝▝  [39m                     [2m[38;5;174m│[0m Added `footerLinksRegexes` setting for regex-matched link badg… [38;5;174m│
+│[39m   [38;5;246mOpus 4.8 (1M context) with hi… · Claude Team · [39m  [2m[38;5;174m│[0m Improved Bedrock credential caching: credentials from `awsCred… [38;5;174m│
+│[39m   [38;5;246mlumid[39m                                            [2m[38;5;174m│[0m [3m[38;5;246m/release-notes for more[0m                                         [38;5;174m│
+│[39m                   [38;5;246m/tmp/cctty-e2e[39m                   [2m[38;5;174m│[0m                                                                 [38;5;174m│
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+[38;5;239m[48;5;237m❯ [38;5;231mRun exactly this shell command and nothing else: mkdir /tmp/cctty-e2e-made[39m                                            
+
+[38;5;246m[49m●[39m Running [1m1[0m shell command…
+[38;5;246m  ⎿  $ mkdir /tmp/cctty-e2e-made
+
+[38;5;153m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m [1m[38;5;153mBash command
+
+[0m   mkdir /tmp/cctty-e2e-made
+   [38;5;246mCreate directory /tmp/cctty-e2e-made
+
+[39m Do you want to proceed?
+ [38;5;153m❯[39m [38;5;246m1. [38;5;153mYes
+[39m   [38;5;246m2. [39mYes, and always allow access to [1mtmp[0m/ from this project
+   [38;5;246m3. [39mNo
+
+ [38;5;246mEsc to cancel · Tab to amend · ctrl+e to explain
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+[39m                                                                                                                       
+
+
+
+                                

--- a/backend/tests/fixtures/claude_tty_pane/approval_write.txt
+++ b/backend/tests/fixtures/claude_tty_pane/approval_write.txt
@@ -1,0 +1,40 @@
+-4d72-469f-ac29-796d750db24c
+╭─── Claude Code v2.1.177 ─────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                 │ Tips for getting started                                           │
+│              Welcome back Noppanat!             │ Run /init to create a CLAUDE.md file with instructions for Claude  │
+│                                                 │ ────────────────────────────────────────────────────────────────── │
+│                     ▐▛███▜▌                     │ What's new                                                         │
+│                    ▝▜█████▛▘                    │ Session titles are now generated in the language of your conversa… │
+│                      ▘▘ ▝▝                      │ Added `footerLinksRegexes` setting for regex-matched link badges … │
+│                                                 │ Improved Bedrock credential caching: credentials from `awsCredent… │
+│   Opus 4.8 (1M context) · Claude Team · lumid   │ /release-notes for more                                            │
+│                /tmp/cc-tty-probe                │                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+❯ Run this exact shell command, nothing else: echo waypoint-probe-hello
+
+● Bash(echo waypoint-probe-hello)
+  ⎿  waypoint-probe-hello
+
+● waypoint-probe-hello
+
+✻ Cogitated for 5s
+
+❯ Create a new file named probe_out.txt containing exactly the text: waypoint-probe
+
+● Write(probe_out.txt)
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Create file
+ probe_out.txt
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+  1 waypoint-probe
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+ Do you want to create probe_out.txt?
+ ❯ 1. Yes
+   2. Yes, allow all edits during this session (shift+tab)
+   3. No
+
+ Esc to cancel · Tab to amend
+

--- a/backend/tests/fixtures/claude_tty_pane/effort_popup.txt
+++ b/backend/tests/fixtures/claude_tty_pane/effort_popup.txt
@@ -1,0 +1,40 @@
+● Write(probe_out.txt)
+  ⎿  Wrote 1 lines to probe_out.txt
+      1 waypoint-probe
+
+● Created /tmp/cc-tty-probe/probe_out.txt containing waypoint-probe.
+
+✻ Churned for 5s
+
+❯ Run exactly this shell command, nothing else: mkdir /tmp/cc-tty-probe/probe_subdir
+
+● Bash(mkdir /tmp/cc-tty-probe/probe_subdir)
+  ⎿  Interrupted · What should Claude do instead?
+
+❯ /model
+  ⎿  Set model to Opus 4.8 (1M context) (default) and saved as your default for new sessions
+
+❯ /effort
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Effort
+
+                             Faster                                                 Smarter
+                             ────────────────────▲──────────────────────┆──────────────────
+                             low     medium     high     xhigh      max       ultracode
+                                                                          xhigh + workflows
+
+  ←/→ to adjust · Enter to confirm · Esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/backend/tests/fixtures/claude_tty_pane/model_selector.txt
+++ b/backend/tests/fixtures/claude_tty_pane/model_selector.txt
@@ -1,0 +1,40 @@
+cd /tmp/cc-tty-probe && claude --session-id 766eaabc-21d5-40c9-9767-3f11f0412887
+01:23:45 noppanat@luyao-h0 cc-tty-probe → cd /tmp/cc-tty-probe && claude --session-id 766eaabc-21d5-40c9-9767-3f11f04128
+87
+╭─── Claude Code v2.1.177 ─────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                    │ Tips for getting started                                        │
+│               Welcome back Noppanat!               │ Run /init to create a CLAUDE.md file with instructions for Cla… │
+│                                                    │ ─────────────────────────────────────────────────────────────── │
+│                       ▐▛███▜▌                      │ What's new                                                      │
+│                      ▝▜█████▛▘                     │ Session titles are now generated in the language of your conve… │
+│                        ▘▘ ▝▝                       │ Added `footerLinksRegexes` setting for regex-matched link badg… │
+│   Opus 4.8 (1M context) with hi… · Claude Team ·   │ Improved Bedrock credential caching: credentials from `awsCred… │
+│   lumid                                            │ /release-notes for more                                         │
+│                  /tmp/cc-tty-probe                 │                                                                 │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+❯ /model
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Select model
+  Switch between Claude models. Your pick becomes the default for new sessions. For other/previous model names,
+  specify with --model.
+
+  ❯ 1. Default (recommended) ✔  Opus 4.8 with 1M context · Best for everyday, complex tasks
+    2. Opus                     Opus 4.8 with 1M context · Best for everyday, complex tasks
+    3. Sonnet                   Sonnet 4.6 · Efficient for routine tasks
+    4. Haiku                    Haiku 4.5 · Fastest for quick answers
+    5. Fable (disabled)         Claude Fable 5 is currently unavailable. Learn more:
+                                https://www.anthropic.com/news/fable-mythos-access
+
+  ● High effort (default) ←/→ to adjust
+
+  Enter to set as default · s to use this session only · Esc to cancel
+
+
+
+
+
+
+

--- a/backend/tests/fixtures/claude_tty_pane/ready.txt
+++ b/backend/tests/fixtures/claude_tty_pane/ready.txt
@@ -1,0 +1,40 @@
+cd /tmp/cc-tty-probe && claude --permission-mode default --session-id 49f99157-4d72-469f-ac29-796d750db24c
+01:16:05 noppanat@luyao-h0 cc-tty-probe → cd /tmp/cc-tty-probe && claude --permission-mode default --session-id 49f99157
+-4d72-469f-ac29-796d750db24c
+╭─── Claude Code v2.1.177 ─────────────────────────────────────────────────────────────────────────────────────────────╮
+│                                                 │ Tips for getting started                                           │
+│              Welcome back Noppanat!             │ Run /init to create a CLAUDE.md file with instructions for Claude  │
+│                                                 │ ────────────────────────────────────────────────────────────────── │
+│                     ▐▛███▜▌                     │ What's new                                                         │
+│                    ▝▜█████▛▘                    │ Session titles are now generated in the language of your conversa… │
+│                      ▘▘ ▝▝                      │ Added `footerLinksRegexes` setting for regex-matched link badges … │
+│                                                 │ Improved Bedrock credential caching: credentials from `awsCredent… │
+│   Opus 4.8 (1M context) · Claude Team · lumid   │ /release-notes for more                                            │
+│                /tmp/cc-tty-probe                │                                                                    │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ Try "fix typecheck errors"
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  ? for shortcuts · ← for agents
+                  tmux focus-events off · add 'set -g focus-events on' to ~/.tmux.conf and reattach for focus tracking
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/backend/tests/fixtures/claude_tty_pane/slash_menu.txt
+++ b/backend/tests/fixtures/claude_tty_pane/slash_menu.txt
@@ -1,0 +1,40 @@
+
+❯ Create a new file named probe_out.txt containing exactly the text: waypoint-probe
+
+● Write(probe_out.txt)
+  ⎿  Wrote 1 lines to probe_out.txt
+      1 waypoint-probe
+
+● Created /tmp/cc-tty-probe/probe_out.txt containing waypoint-probe.
+
+✻ Churned for 5s
+
+❯ Run exactly this shell command, nothing else: mkdir /tmp/cc-tty-probe/probe_subdir
+
+● Bash(mkdir /tmp/cc-tty-probe/probe_subdir)
+  ⎿  Interrupted · What should Claude do instead?
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+❯ /model
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+/model                        Set the AI model for Claude Code (currently Opus 4.8 (1M context))
+/waypoint-workqueue           Use when a coding agent needs to run a batch of independent software tasks across a
+                              crew of durable Waypoint sessions — possibly different models or backends, in separat…
+/loop                         Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo). Omit the
+                              interval to let the model self-pace.
+/claude-api                   Reference for the Claude API / Anthropic SDK — model ids, pricing, params, streaming,
+                              tool use, MCP, agents, caching, token counting, model migration. TRIGGER — read BEFOR…
+/advisor                      Let Claude consult a stronger model at key moments
+/effort                       Set effort level for model usage
+/status                       Show Claude Code status including version, model, account, API connectivity, and tool
+                              statuses
+/waypoint-subagents           Use when a coding agent inside a Waypoint session needs to spawn and manage child
+                              Waypoint sessions as subagents — fanning work out to other backends/models, running u…
+/update-config                Use this skill to configure the Claude Code harness via settings.json. Automated
+                              behaviors ("from now on when X", "each time X", "whenever X", "before/after X") requi…
+/fast                         Toggle fast mode (Opus 4.8)
+/voice                        Toggle voice mode
+/plan                         Enable plan mode or view the current session plan
+
+
+

--- a/backend/tests/fixtures/claude_tty_pane/trust_dialog.txt
+++ b/backend/tests/fixtures/claude_tty_pane/trust_dialog.txt
@@ -1,0 +1,40 @@
+cd /tmp/cc-tty-probe && claude --permission-mode default --session-id 49f99157-4d72-469f-ac29-796d750db24c
+01:16:05 noppanat@luyao-h0 cc-tty-probe → cd /tmp/cc-tty-probe && claude --permission-mode default --session-id 49f99157
+-4d72-469f-ac29-796d750db24c
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Accessing workspace:
+
+ /tmp/cc-tty-probe
+
+ Quick safety check: Is this a project you created or one you trust? (Like your own code, a well-known open source
+ project, or work from your team). If not, take a moment to review what's in this folder first.
+
+ Claude Code'll be able to read, edit, and execute files here.
+
+ Security guide
+
+ ❯ 1. Yes, I trust this folder
+   2. No, exit
+
+ Enter to confirm · Esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -155,9 +155,16 @@ class _StubPlugin:
 
 def test_default_registry_has_legacy_plugins() -> None:
     registry = get_registry()
-    assert registry.backends() == {"claude_code", "codex", "opencode", "tmux"}
+    assert registry.backends() == {
+        "claude_code",
+        "claude_tty",
+        "codex",
+        "opencode",
+        "tmux",
+    }
     assert registry.transports() == {
         "claude_cli",
+        "claude_tty",
         "codex_app_server",
         "opencode_http",
         "tmux",

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -250,6 +250,22 @@ async def test_auto_mode_dialog_still_surfaced() -> None:
         assert session.id in plugin._pending_approvals
 
 
+async def test_trust_prompt_is_accepted() -> None:
+    # A fresh-cwd session opens at the workspace-trust prompt; the tailer must
+    # accept it (bare Enter) so the session — including autonomous ones — does
+    # not hang, without emitting any approval.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("trust_dialog.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+
+    runtime.tmux.send_input.assert_called_once_with("%0", "", submit=True)
+    runtime._emit_adapter_event.assert_not_called()
+    assert "sess-1" not in plugin._pending_approvals
+
+
 async def test_non_approval_screen_does_not_emit() -> None:
     for fixture in ("ready.txt", "trust_dialog.txt", "model_selector.txt"):
         plugin = ClaudeTtyPlugin()

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -33,6 +33,7 @@ def _make_session(
     session_id: str = "sess-1",
     permission_mode: str | None = None,
     pane: str = "%0",
+    status: SessionStatus = SessionStatus.RUNNING,
 ) -> SessionRecord:
     now = datetime.now(UTC)
     return SessionRecord(
@@ -42,7 +43,7 @@ def _make_session(
         transport="claude_tty",
         title="test",
         cwd="/tmp",
-        status=SessionStatus.RUNNING,
+        status=status,
         created_at=now,
         updated_at=now,
         last_event_at=now,
@@ -277,6 +278,58 @@ async def test_non_approval_screen_does_not_emit() -> None:
         await tailer._poll_dialog()
 
         runtime._emit_adapter_event.assert_not_called()
+
+
+# ── plugin: reconnect resume must not replay the transcript ──────────────────
+
+
+async def _run_exited_reconnect(resumes: bool) -> bool:
+    """Run restore_session on an EXITED session and report the tailer's
+    start_at_end. resumes=True → an existing thread is reattached."""
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(status=SessionStatus.EXITED)
+
+    target = MagicMock(session="s", window="0", pane="%9", pane_pid=123)
+    runtime = MagicMock()
+    runtime.tmux.kill_session = AsyncMock()
+    runtime.tmux.start_managed_session = AsyncMock(return_value=target)
+    runtime.tmux.pipe_output = AsyncMock()
+    runtime.tmux.resize_window = AsyncMock()
+    runtime._find_launch_target.return_value = None
+    runtime._command_for_backend.return_value = ["claude", "--resume", "thread-1"]
+    runtime._record_system_event = AsyncMock()
+    runtime.storage.update_session = MagicMock()
+
+    plugin._conversation_exists = AsyncMock(return_value=resumes)  # type: ignore[method-assign]
+    plugin._spawn_rate_limit_watcher = MagicMock()  # type: ignore[method-assign]
+
+    captured: dict[str, bool] = {}
+
+    def _fake_start_tailer(
+        runtime: object,
+        session_id: str,
+        thread_id: str,
+        cwd: str,
+        *,
+        start_at_end: bool = False,
+    ) -> None:
+        captured["start_at_end"] = start_at_end
+
+    plugin._start_tailer = _fake_start_tailer  # type: ignore[method-assign]
+
+    await plugin.restore_session(runtime, session)
+    return captured["start_at_end"]
+
+
+async def test_reconnect_resume_tails_from_end_not_replay() -> None:
+    # Resuming an existing thread reopens its populated transcript (already in
+    # the event DB); the tailer must start at the end so it is not replayed.
+    assert await _run_exited_reconnect(resumes=True) is True
+
+
+async def test_reconnect_new_thread_tails_from_start() -> None:
+    # A fresh thread starts an empty transcript, so reading from 0 is correct.
+    assert await _run_exited_reconnect(resumes=False) is False
 
 
 # ── transport: respond_to_approval ───────────────────────────────────────────

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -181,6 +181,56 @@ async def test_vanished_dialog_clears_pending() -> None:
     assert "sess-1" not in plugin._pending_approvals
 
 
+async def test_no_reemit_after_response_while_dialog_lingers() -> None:
+    # After respond_to_approval clears pending, the dialog can still be on the
+    # pane for up to one poll before it redraws. The tailer must NOT re-emit a
+    # duplicate approval for that same dialog.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("approval_write.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()  # tick 1: debounce
+    await tailer._poll_dialog()  # tick 2: emit + pending
+    assert runtime._emit_adapter_event.call_count == 1
+
+    # Simulate the transport answering the approval.
+    del plugin._pending_approvals["sess-1"]
+
+    await tailer._poll_dialog()  # tick 3: same dialog still rendered
+    assert runtime._emit_adapter_event.call_count == 1  # no duplicate
+    assert "sess-1" not in plugin._pending_approvals
+
+
+async def test_reemits_distinct_dialog_after_screen_clears() -> None:
+    # Once the pane redraws away (dialog gone) the surfaced-signature guard
+    # resets, so a genuinely new dialog later is surfaced again.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    write_screen = _load("approval_write.txt")
+    ready_screen = _load("ready.txt")
+    screens = [write_screen, write_screen, ready_screen, write_screen, write_screen]
+    idx = [0]
+
+    async def _side_effect(pane: str) -> str:
+        screen = screens[min(idx[0], len(screens) - 1)]
+        idx[0] += 1
+        return screen
+
+    runtime = _make_runtime(session, write_screen)
+    runtime.tmux.capture_snapshot = AsyncMock(side_effect=_side_effect)
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()  # emit (debounce tick 1)
+    await tailer._poll_dialog()  # emit (tick 2) → 1
+    del plugin._pending_approvals["sess-1"]  # responded
+    await tailer._poll_dialog()  # ready: screen cleared, guard resets
+    await tailer._poll_dialog()  # write again, debounce
+    await tailer._poll_dialog()  # write stable → re-emit → 2
+
+    assert runtime._emit_adapter_event.call_count == 2
+
+
 async def test_auto_mode_never_captures_pane() -> None:
     for mode in ("auto", "bypassPermissions", "dontAsk"):
         plugin = ClaudeTtyPlugin()

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -231,17 +231,23 @@ async def test_reemits_distinct_dialog_after_screen_clears() -> None:
     assert runtime._emit_adapter_event.call_count == 2
 
 
-async def test_auto_mode_never_captures_pane() -> None:
+async def test_auto_mode_dialog_still_surfaced() -> None:
+    # claude_tty's stored permission_mode is launch-fixed, but the TUI posture
+    # can drift (shift+tab) into a prompting mode. Detection must not gate on
+    # the stored mode: a dialog present on an "auto" session's pane is still
+    # surfaced rather than silently missed (which would hang the session).
     for mode in ("auto", "bypassPermissions", "dontAsk"):
         plugin = ClaudeTtyPlugin()
         session = _make_session(permission_mode=mode)
         runtime = _make_runtime(session, _load("approval_write.txt"))
         tailer = _make_tailer(plugin, runtime)
 
-        await tailer._poll_dialog()
+        await tailer._poll_dialog()  # tick 1: debounce
+        await tailer._poll_dialog()  # tick 2: stable → emit
 
-        runtime.tmux.capture_snapshot.assert_not_called()
-        runtime._emit_adapter_event.assert_not_called()
+        runtime.tmux.capture_snapshot.assert_called()
+        runtime._emit_adapter_event.assert_called_once()
+        assert session.id in plugin._pending_approvals
 
 
 async def test_non_approval_screen_does_not_emit() -> None:

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -1,0 +1,331 @@
+"""Unit tests for claude_tty live approval wiring.
+
+Uses captured pane fixtures and a fake runtime/tmux so no live TUI is needed.
+Verifies:
+  - stable dialog (>=2 ticks) emits exactly ONE APPROVAL_REQUEST
+  - single-tick dialog emits nothing (debounce)
+  - respond_to_approval('decline') sends the No-option digit + Enter
+  - respond_to_approval('approve') sends '1' + Enter
+  - respond_to_approval with no pending returns False
+  - wrong approval_id returns False without clearing pending
+  - auto-mode session never calls capture_snapshot
+  - vanished dialog clears pending
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from waypoint.backends.claude_tty._state import PendingTtyApproval
+from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
+from waypoint.backends.claude_tty.tailer import TranscriptTailer
+from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
+from waypoint.schemas import EventKind, SessionRecord, SessionSource, SessionStatus
+
+FIXTURES = Path(__file__).parent / "fixtures" / "claude_tty_pane"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+def _make_session(
+    session_id: str = "sess-1",
+    permission_mode: str | None = None,
+    pane: str = "%0",
+) -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=session_id,
+        backend="claude_tty",
+        source=SessionSource.MANAGED,
+        transport="claude_tty",
+        title="test",
+        cwd="/tmp",
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/structured.log",
+        transport_state={
+            "tmux_session": session_id,
+            "tmux_window": "0",
+            "tmux_pane": pane,
+            "thread_id": "thread-1",
+        },
+        permission_mode=permission_mode,
+    )
+
+
+def _make_tailer(
+    plugin: ClaudeTtyPlugin,
+    runtime: MagicMock,
+    session_id: str = "sess-1",
+) -> TranscriptTailer:
+    return TranscriptTailer(
+        session_id=session_id,
+        session_uuid="thread-1",
+        cwd="/nonexistent",
+        runtime=runtime,
+        plugin=plugin,
+    )
+
+
+def _make_runtime(session: SessionRecord, snapshot: str) -> MagicMock:
+    tmux = MagicMock()
+    tmux.capture_snapshot = AsyncMock(return_value=snapshot)
+    tmux.send_input = AsyncMock()
+    tmux.send_bytes = AsyncMock()
+    runtime = MagicMock()
+    runtime.storage.get_session.return_value = session
+    runtime.tmux = tmux
+    runtime._emit_adapter_event = AsyncMock()
+    return runtime
+
+
+# ── tailer: dialog detection ──────────────────────────────────────────────────
+
+
+async def test_single_tick_emits_nothing() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("approval_write.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+
+    runtime._emit_adapter_event.assert_not_called()
+    assert "sess-1" not in plugin._pending_approvals
+
+
+async def test_stable_write_dialog_emits_approval_request() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("approval_write.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()  # tick 1: debounce
+    runtime._emit_adapter_event.assert_not_called()
+
+    await tailer._poll_dialog()  # tick 2: stable → emit
+    runtime._emit_adapter_event.assert_called_once()
+
+    call = runtime._emit_adapter_event.call_args
+    assert call.args[1] is EventKind.APPROVAL_REQUEST
+    meta = call.args[3]
+    assert meta["tool_name"] == "Write"
+    assert meta["tool_input"] == {"file_path": "probe_out.txt"}
+    assert meta["method"] == "tty_permission"
+    assert meta["status"] is SessionStatus.WAITING_INPUT
+    assert "approval_id" in meta
+
+    assert "sess-1" in plugin._pending_approvals
+    pending = plugin._pending_approvals["sess-1"]
+    assert pending.tool_name == "Write"
+    assert pending.approve_number == 1
+    assert pending.decline_number == 3
+
+
+async def test_stable_bash_dialog_emits_approval_request() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("approval_bash.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+    await tailer._poll_dialog()
+
+    runtime._emit_adapter_event.assert_called_once()
+    meta = runtime._emit_adapter_event.call_args.args[3]
+    assert meta["tool_name"] == "Bash"
+    assert meta["tool_input"] == {"command": "mkdir /tmp/cc-tty-probe/probe_subdir"}
+
+
+async def test_stable_dialog_emits_only_once() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("approval_write.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    for _ in range(5):
+        await tailer._poll_dialog()
+
+    assert runtime._emit_adapter_event.call_count == 1
+
+
+async def test_vanished_dialog_clears_pending() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    write_screen = _load("approval_write.txt")
+    ready_screen = _load("ready.txt")
+
+    call_count: list[int] = [0]
+
+    async def _side_effect(pane: str) -> str:
+        call_count[0] += 1
+        return write_screen if call_count[0] <= 3 else ready_screen
+
+    runtime = _make_runtime(session, write_screen)
+    runtime.tmux.capture_snapshot = AsyncMock(side_effect=_side_effect)
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()  # tick 1
+    await tailer._poll_dialog()  # tick 2 → emit + pending
+    assert "sess-1" in plugin._pending_approvals
+
+    await tailer._poll_dialog()  # tick 3: still same screen, already pending
+    assert "sess-1" in plugin._pending_approvals
+
+    await tailer._poll_dialog()  # tick 4: dialog gone → clear
+    assert "sess-1" not in plugin._pending_approvals
+
+
+async def test_auto_mode_never_captures_pane() -> None:
+    for mode in ("auto", "bypassPermissions", "dontAsk"):
+        plugin = ClaudeTtyPlugin()
+        session = _make_session(permission_mode=mode)
+        runtime = _make_runtime(session, _load("approval_write.txt"))
+        tailer = _make_tailer(plugin, runtime)
+
+        await tailer._poll_dialog()
+
+        runtime.tmux.capture_snapshot.assert_not_called()
+        runtime._emit_adapter_event.assert_not_called()
+
+
+async def test_non_approval_screen_does_not_emit() -> None:
+    for fixture in ("ready.txt", "trust_dialog.txt", "model_selector.txt"):
+        plugin = ClaudeTtyPlugin()
+        session = _make_session()
+        runtime = _make_runtime(session, _load(fixture))
+        tailer = _make_tailer(plugin, runtime)
+
+        await tailer._poll_dialog()
+        await tailer._poll_dialog()
+
+        runtime._emit_adapter_event.assert_not_called()
+
+
+# ── transport: respond_to_approval ───────────────────────────────────────────
+
+
+def _pending(
+    approval_id: str = "aid-1",
+    tool_name: str = "Write",
+    target: str = "probe_out.txt",
+    approve_number: int = 1,
+    decline_number: int | None = 3,
+) -> PendingTtyApproval:
+    return PendingTtyApproval(
+        approval_id=approval_id,
+        tool_name=tool_name,
+        target=target,
+        approve_number=approve_number,
+        decline_number=decline_number,
+        signature=f"{tool_name}:{target}:Do you want to create {target}?",
+    )
+
+
+def _make_transport(plugin: ClaudeTtyPlugin) -> tuple[ClaudeTtyTransport, MagicMock]:
+    tmux = MagicMock()
+    tmux.send_input = AsyncMock()
+    tmux.send_bytes = AsyncMock()
+    runtime = MagicMock()
+    runtime.tmux = tmux
+    transport = ClaudeTtyTransport(runtime, plugin)
+    return transport, tmux
+
+
+async def test_respond_approve_sends_digit_1_enter() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending(approve_number=1)
+
+    transport, tmux = _make_transport(plugin)
+    result = await transport.respond_to_approval(session, "approve", None)
+
+    assert result is True
+    tmux.send_input.assert_called_once_with("%0", "1", submit=True)
+    assert "sess-1" not in plugin._pending_approvals
+
+
+async def test_respond_decline_sends_no_digit_enter() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending(decline_number=3)
+
+    transport, tmux = _make_transport(plugin)
+    result = await transport.respond_to_approval(session, "decline", None)
+
+    assert result is True
+    tmux.send_input.assert_called_once_with("%0", "3", submit=True)
+    assert "sess-1" not in plugin._pending_approvals
+
+
+async def test_respond_decline_no_option_sends_esc() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending(decline_number=None)
+
+    transport, tmux = _make_transport(plugin)
+    result = await transport.respond_to_approval(session, "decline", None)
+
+    assert result is True
+    tmux.send_input.assert_not_called()
+    tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
+    assert "sess-1" not in plugin._pending_approvals
+
+
+async def test_respond_no_pending_returns_false() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+
+    transport, tmux = _make_transport(plugin)
+    result = await transport.respond_to_approval(session, "approve", None)
+
+    assert result is False
+    tmux.send_input.assert_not_called()
+
+
+async def test_respond_wrong_approval_id_returns_false() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending(approval_id="correct-id")
+
+    transport, _ = _make_transport(plugin)
+    result = await transport.respond_to_approval(
+        session, "approve", None, approval_id="wrong-id"
+    )
+
+    assert result is False
+    assert "sess-1" in plugin._pending_approvals  # not cleared
+
+
+async def test_respond_correct_approval_id_resolves() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending(approval_id="correct-id")
+
+    transport, tmux = _make_transport(plugin)
+    result = await transport.respond_to_approval(
+        session, "approve", None, approval_id="correct-id"
+    )
+
+    assert result is True
+    tmux.send_input.assert_called_once()
+    assert "sess-1" not in plugin._pending_approvals
+
+
+def test_has_pending_approval_reflects_plugin_state() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    transport, _ = _make_transport(plugin)
+
+    assert not transport.has_pending_approval(session)
+
+    plugin._pending_approvals["sess-1"] = _pending()
+    assert transport.has_pending_approval(session)
+
+    del plugin._pending_approvals["sess-1"]
+    assert not transport.has_pending_approval(session)

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -3,6 +3,7 @@
 import pytest
 
 from waypoint.backends.claude_tty.normalize import (
+    NormalizedEvent,
     TranscriptNormalizer,
     _is_injected_turn,
 )
@@ -338,3 +339,215 @@ def test_result_text_non_end_turn_stop_reason() -> None:
     events = norm.process_record(record)
     result = next(e for e in events if e.metadata.get("method") == "result")
     assert "max_tokens" in result.text
+
+
+# ── Task tool handling ────────────────────────────────────────────────────────
+
+
+def _task_create_block(tool_id: str, subject: str, status: str = "pending") -> dict:
+    return _tool_use_block(
+        tool_id, "TaskCreate", {"subject": subject, "status": status}
+    )
+
+
+def _task_update_block(
+    tool_id: str, task_id: str, status: str, subject: str | None = None
+) -> dict:
+    inp: dict = {"taskId": task_id, "status": status}
+    if subject is not None:
+        inp["subject"] = subject
+    return _tool_use_block(tool_id, "TaskUpdate", inp)
+
+
+def _task_create_result(tool_use_id: str, task_id: str) -> dict:
+    return _tool_result_block(tool_use_id, f"Task #{task_id} created successfully")
+
+
+def _snapshot_event(events: list) -> "NormalizedEvent":
+    return next(
+        e for e in events if e.metadata.get("method") == "assistant.task_update"
+    )
+
+
+def test_task_create_assistant_emits_no_event() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1", [_task_create_block("tc1", "Write tests")], stop_reason="tool_use"
+    )
+    events = norm.process_record(record)
+    assert events == []
+
+
+def test_task_create_result_emits_snapshot() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msg1", [_task_create_block("tc1", "Write tests")], stop_reason="tool_use"
+        )
+    )
+    events = norm.process_record(_user_record([_task_create_result("tc1", "42")]))
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == EventKind.TOOL_RESULT
+    assert ev.metadata["method"] == "assistant.task_update"
+    assert ev.metadata["tool_name"] == "TodoWrite"
+    assert ev.metadata["item_type"] == "todo_list"
+    todos = ev.metadata["payload"]["input"]["todos"]
+    assert len(todos) == 1
+    assert todos[0]["content"] == "Write tests"
+    assert todos[0]["status"] == "pending"
+
+
+def test_task_create_result_not_emitted_as_raw_tool_result() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msg1", [_task_create_block("tc1", "Do work")], stop_reason="tool_use"
+        )
+    )
+    events = norm.process_record(_user_record([_task_create_result("tc1", "1")]))
+    assert not any(e.metadata.get("method") == "user.tool_result" for e in events)
+
+
+def test_task_update_emits_snapshot_with_status_change() -> None:
+    norm = TranscriptNormalizer()
+    # Create a task first
+    norm.process_record(
+        _assistant_record(
+            "msg1", [_task_create_block("tc1", "Fix bug")], stop_reason="tool_use"
+        )
+    )
+    norm.process_record(_user_record([_task_create_result("tc1", "1")]))
+    # Now update it
+    events = norm.process_record(
+        _assistant_record(
+            "msg2",
+            [_task_update_block("tu2", "1", "in_progress", "Fix bug now")],
+            stop_reason="tool_use",
+        )
+    )
+    snapshot_ev = _snapshot_event(events)
+    todos = snapshot_ev.metadata["payload"]["input"]["todos"]
+    assert todos[0]["status"] == "in_progress"
+    assert todos[0]["content"] == "Fix bug now"
+
+
+def test_task_update_result_is_suppressed() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msg1", [_task_create_block("tc1", "Task A")], stop_reason="tool_use"
+        )
+    )
+    norm.process_record(_user_record([_task_create_result("tc1", "1")]))
+    norm.process_record(
+        _assistant_record(
+            "msg2",
+            [_task_update_block("tu2", "1", "completed")],
+            stop_reason="tool_use",
+        )
+    )
+    # The tool_result for the TaskUpdate should be silently dropped
+    events = norm.process_record(
+        _user_record([_tool_result_block("tu2", "Task updated")])
+    )
+    assert events == []
+
+
+def test_task_get_list_suppressed_no_snapshot() -> None:
+    for tool_name in ("TaskGet", "TaskList"):
+        n = TranscriptNormalizer()
+        events = n.process_record(
+            _assistant_record(
+                "msg1",
+                [_tool_use_block("tg1", tool_name, {"taskId": "1"})],
+                stop_reason="tool_use",
+            )
+        )
+        assert events == [], f"{tool_name} should emit no events"
+        # result is also suppressed
+        result_events = n.process_record(
+            _user_record([_tool_result_block("tg1", "some result")])
+        )
+        assert result_events == [], f"{tool_name} result should be suppressed"
+
+
+def test_task_tool_use_not_emitted_as_tool_call() -> None:
+    for tool_name in ("TaskCreate", "TaskUpdate", "TaskGet", "TaskList"):
+        n = TranscriptNormalizer()
+        events = n.process_record(
+            _assistant_record(
+                "msg1",
+                [_tool_use_block("x1", tool_name, {"subject": "t", "taskId": "1"})],
+                stop_reason="tool_use",
+            )
+        )
+        assert not any(
+            e.kind == EventKind.TOOL_CALL for e in events
+        ), f"{tool_name} must not emit TOOL_CALL"
+
+
+def test_task_card_item_id_stable_within_group() -> None:
+    norm = TranscriptNormalizer()
+    # Create two tasks
+    norm.process_record(
+        _assistant_record(
+            "msg1",
+            [
+                _task_create_block("tc1", "Task A"),
+                _task_create_block("tc2", "Task B"),
+            ],
+            stop_reason="tool_use",
+        )
+    )
+    ev1 = norm.process_record(_user_record([_task_create_result("tc1", "1")]))
+    ev2 = norm.process_record(_user_record([_task_create_result("tc2", "2")]))
+    id1 = ev1[0].metadata["item_id"]
+    id2 = ev2[0].metadata["item_id"]
+    assert id1 == id2, "item_id must be stable across snapshots in same group"
+
+
+def test_task_card_item_id_rotates_for_new_group() -> None:
+    norm = TranscriptNormalizer()
+    # First group: one task, completed
+    norm.process_record(
+        _assistant_record(
+            "msg1", [_task_create_block("tc1", "Task A")], stop_reason="tool_use"
+        )
+    )
+    ev1 = norm.process_record(_user_record([_task_create_result("tc1", "1")]))
+    # Mark as deleted (empties tracker)
+    norm.process_record(
+        _assistant_record(
+            "msg2",
+            [_task_update_block("tu2", "1", "deleted")],
+            stop_reason="tool_use",
+        )
+    )
+    norm.process_record(_user_record([_tool_result_block("tu2", "ok")]))
+    # Second group: new task
+    norm.process_record(
+        _assistant_record(
+            "msg3", [_task_create_block("tc3", "Task B")], stop_reason="tool_use"
+        )
+    )
+    ev2 = norm.process_record(_user_record([_task_create_result("tc3", "2")]))
+    id1 = ev1[0].metadata["item_id"]
+    id2 = ev2[0].metadata["item_id"]
+    assert id1 != id2, "item_id must rotate when a new task group starts"
+
+
+def test_non_task_tool_use_in_same_record_still_emits_tool_call() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1",
+        [
+            _task_create_block("tc1", "Task A"),
+            _tool_use_block("bash1", "Bash", {"command": "ls"}),
+        ],
+        stop_reason="tool_use",
+    )
+    events = norm.process_record(record)
+    tool_call_events = [e for e in events if e.kind == EventKind.TOOL_CALL]
+    assert len(tool_call_events) == 1
+    assert tool_call_events[0].metadata["tool_name"] == "Bash"

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -1,0 +1,340 @@
+"""Unit tests for the claude_tty transcript normalizer."""
+
+import pytest
+
+from waypoint.backends.claude_tty.normalize import (
+    TranscriptNormalizer,
+    _is_injected_turn,
+)
+from waypoint.schemas import EventKind, SessionStatus
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _assistant_record(
+    message_id: str,
+    content: list[dict],
+    stop_reason: str = "end_turn",
+    usage: dict | None = None,
+) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "id": message_id,
+            "content": content,
+            "stop_reason": stop_reason,
+            "usage": usage or {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+
+
+def _user_record(content: list[dict] | str) -> dict:
+    return {"type": "user", "message": {"content": content}}
+
+
+def _tool_use_block(tool_id: str, name: str, inp: dict) -> dict:
+    return {"type": "tool_use", "id": tool_id, "name": name, "input": inp}
+
+
+def _tool_result_block(tool_use_id: str, result: str, is_error: bool = False) -> dict:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": result,
+        "is_error": is_error,
+    }
+
+
+def _text_block(text: str) -> dict:
+    return {"type": "text", "text": text}
+
+
+# ── _is_injected_turn ─────────────────────────────────────────────────────────
+
+
+def test_is_injected_task_notification() -> None:
+    assert _is_injected_turn("<task-notification>foo</task-notification>")
+
+
+def test_is_injected_task_notification_leading_whitespace() -> None:
+    assert _is_injected_turn("  \n<task-notification>bar</task-notification>")
+
+
+def test_is_injected_context_summary() -> None:
+    assert _is_injected_turn(
+        "This session is being continued from a previous conversation."
+    )
+
+
+def test_not_injected_plain_text() -> None:
+    assert not _is_injected_turn("Hello, world!")
+
+
+def test_not_injected_list_content() -> None:
+    assert not _is_injected_turn([{"type": "tool_result", "content": "ok"}])
+
+
+def test_not_injected_none() -> None:
+    assert not _is_injected_turn(None)
+
+
+# ── TranscriptNormalizer: assistant records ────────────────────────────────────
+
+
+def test_text_block_emits_agent_output() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record("msg1", [_text_block("Hello")])
+    events = norm.process_record(record)
+    # text block + synthesized result
+    assert len(events) == 2
+    text_ev = events[0]
+    assert text_ev.kind == EventKind.AGENT_OUTPUT
+    assert text_ev.text == "Hello"
+    assert text_ev.status == SessionStatus.RUNNING
+    assert text_ev.metadata["item_id"] == "msg1"
+
+
+def test_tool_use_block_emits_tool_call() -> None:
+    norm = TranscriptNormalizer()
+    block = _tool_use_block("tu1", "Bash", {"command": "ls"})
+    # stop_reason=tool_use → no synthesized result
+    record = _assistant_record("msg1", [block], stop_reason="tool_use")
+    events = norm.process_record(record)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == EventKind.TOOL_CALL
+    assert "Bash" in ev.text
+    assert ev.metadata["tool_use_id"] == "tu1"
+    assert ev.metadata["tool_name"] == "Bash"
+    assert ev.status == SessionStatus.RUNNING
+
+
+def test_thinking_block_is_skipped() -> None:
+    norm = TranscriptNormalizer()
+    blocks = [
+        {"type": "thinking", "thinking": "hmm"},
+        _text_block("Answer"),
+    ]
+    record = _assistant_record("msg1", blocks)
+    events = norm.process_record(record)
+    kinds = [e.kind for e in events]
+    assert EventKind.AGENT_OUTPUT in kinds
+    assert all(e.kind != EventKind.TOOL_CALL for e in events)
+    # no event emitted for thinking
+    assert sum(1 for e in events if e.kind == EventKind.AGENT_OUTPUT) == 1
+
+
+def test_result_synthesized_on_end_turn() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record("msg1", [_text_block("Done")], stop_reason="end_turn")
+    events = norm.process_record(record)
+    result_events = [e for e in events if e.metadata.get("method") == "result"]
+    assert len(result_events) == 1
+    result = result_events[0]
+    assert result.kind == EventKind.SYSTEM_NOTE
+    assert result.status == SessionStatus.IDLE
+    assert result.metadata["stop_reason"] == "end_turn"
+
+
+def test_no_result_when_stop_reason_is_tool_use() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1", [_tool_use_block("tu1", "Read", {})], stop_reason="tool_use"
+    )
+    events = norm.process_record(record)
+    assert not any(e.metadata.get("method") == "result" for e in events)
+
+
+def test_no_result_when_tool_use_block_present_despite_end_turn() -> None:
+    """A record with tool_use blocks must not synthesize a result regardless of stop_reason."""
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1",
+        [_tool_use_block("tu1", "Read", {}), _text_block("ok")],
+        stop_reason="end_turn",
+    )
+    events = norm.process_record(record)
+    assert not any(e.metadata.get("method") == "result" for e in events)
+
+
+# ── Usage deduplication ───────────────────────────────────────────────────────
+
+
+def test_usage_counted_only_on_first_seen_message_id() -> None:
+    norm = TranscriptNormalizer()
+    usage = {"input_tokens": 100, "output_tokens": 50}
+    # First record: usage should appear in result metadata
+    r1 = _assistant_record(
+        "msgX", [_text_block("a")], stop_reason="end_turn", usage=usage
+    )
+    events1 = norm.process_record(r1)
+    result1 = next(e for e in events1 if e.metadata.get("method") == "result")
+    assert result1.metadata["usage"] == usage
+
+    # Second record with same message.id: usage in result should be empty
+    r2 = _assistant_record(
+        "msgX", [_text_block("b")], stop_reason="end_turn", usage=usage
+    )
+    events2 = norm.process_record(r2)
+    result2 = next(e for e in events2 if e.metadata.get("method") == "result")
+    assert result2.metadata["usage"] == {}
+
+
+def test_usage_counted_for_different_message_ids() -> None:
+    norm = TranscriptNormalizer()
+    usage = {"input_tokens": 100, "output_tokens": 50}
+    r1 = _assistant_record(
+        "msgA", [_text_block("a")], stop_reason="end_turn", usage=usage
+    )
+    r2 = _assistant_record(
+        "msgB", [_text_block("b")], stop_reason="end_turn", usage=usage
+    )
+    events1 = norm.process_record(r1)
+    events2 = norm.process_record(r2)
+    result1 = next(e for e in events1 if e.metadata.get("method") == "result")
+    result2 = next(e for e in events2 if e.metadata.get("method") == "result")
+    assert result1.metadata["usage"] == usage
+    assert result2.metadata["usage"] == usage
+
+
+# ── User record handling ──────────────────────────────────────────────────────
+
+
+def test_tool_result_emits_tool_result_event() -> None:
+    norm = TranscriptNormalizer()
+    record = _user_record([_tool_result_block("tu1", "file contents")])
+    events = norm.process_record(record)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == EventKind.TOOL_RESULT
+    assert ev.text == "file contents"
+    assert ev.metadata["tool_use_id"] == "tu1"
+    assert not ev.metadata["is_error"]
+    assert ev.status == SessionStatus.RUNNING
+
+
+def test_error_tool_result_sets_is_error() -> None:
+    norm = TranscriptNormalizer()
+    record = _user_record([_tool_result_block("tu2", "ENOENT", is_error=True)])
+    events = norm.process_record(record)
+    assert events[0].metadata["is_error"] is True
+
+
+def test_injected_task_notification_produces_no_events() -> None:
+    norm = TranscriptNormalizer()
+    record = _user_record("<task-notification>some harness turn</task-notification>")
+    assert norm.process_record(record) == []
+
+
+def test_injected_context_summary_produces_no_events() -> None:
+    norm = TranscriptNormalizer()
+    record = _user_record(
+        "This session is being continued from a previous conversation."
+    )
+    assert norm.process_record(record) == []
+
+
+def test_plain_text_user_turn_produces_no_events() -> None:
+    # Non-tool-result, non-injected user text is already recorded by Waypoint
+    # on input; the normalizer drops it to avoid duplication.
+    norm = TranscriptNormalizer()
+    record = _user_record([{"type": "text", "text": "hello"}])
+    assert norm.process_record(record) == []
+
+
+# ── TUI-only record types are dropped ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "rec_type",
+    [
+        "mode",
+        "permission-mode",
+        "file-history-snapshot",
+        "last-prompt",
+        "queue-operation",
+        "ai-title",
+        "attachment",
+        "pr-link",
+        "system",
+        "unknown-future-type",
+    ],
+)
+def test_tui_only_records_dropped(rec_type: str) -> None:
+    norm = TranscriptNormalizer()
+    assert norm.process_record({"type": rec_type, "data": {}}) == []
+
+
+# ── Interleaved record scenario ───────────────────────────────────────────────
+
+
+def test_interleaved_tool_use_and_tool_result() -> None:
+    """Simulate the real-transcript pattern: same message.id spans multiple
+    assistant records interleaved with user tool_result records."""
+    norm = TranscriptNormalizer()
+    usage = {"input_tokens": 200, "output_tokens": 80}
+
+    # First assistant record: tool_use block
+    r1 = _assistant_record(
+        "msgM",
+        [_tool_use_block("tu1", "Read", {"file_path": "foo.py"})],
+        stop_reason="tool_use",
+        usage=usage,
+    )
+    # User record: tool_result
+    r2 = _user_record([_tool_result_block("tu1", "# contents")])
+    # Second assistant record: same message.id, text + end_turn
+    r3 = _assistant_record(
+        "msgM",
+        [_text_block("I see.")],
+        stop_reason="end_turn",
+        usage=usage,
+    )
+
+    ev1 = norm.process_record(r1)
+    ev2 = norm.process_record(r2)
+    ev3 = norm.process_record(r3)
+
+    # First record: one TOOL_CALL, no result
+    assert len(ev1) == 1
+    assert ev1[0].kind == EventKind.TOOL_CALL
+    # User record: one TOOL_RESULT
+    assert len(ev2) == 1
+    assert ev2[0].kind == EventKind.TOOL_RESULT
+    # Second record: AGENT_OUTPUT + synthesized SYSTEM_NOTE result
+    kinds3 = [e.kind for e in ev3]
+    assert EventKind.AGENT_OUTPUT in kinds3
+    assert EventKind.SYSTEM_NOTE in kinds3
+    # Usage must appear in second record's result (first_seen was True on r1, so
+    # r3 with same id is not first_seen → usage dict should be empty)
+    result3 = next(e for e in ev3 if e.metadata.get("method") == "result")
+    assert result3.metadata["usage"] == {}
+
+
+# ── result text formatting ────────────────────────────────────────────────────
+
+
+def test_result_text_includes_output_tokens() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1",
+        [_text_block("ok")],
+        stop_reason="end_turn",
+        usage={"input_tokens": 10, "output_tokens": 42},
+    )
+    events = norm.process_record(record)
+    result = next(e for e in events if e.metadata.get("method") == "result")
+    assert "42" in result.text
+
+
+def test_result_text_non_end_turn_stop_reason() -> None:
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1",
+        [_text_block("ok")],
+        stop_reason="max_tokens",
+        usage={"input_tokens": 10, "output_tokens": 5},
+    )
+    events = norm.process_record(record)
+    result = next(e for e in events if e.metadata.get("method") == "result")
+    assert "max_tokens" in result.text

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -121,6 +121,19 @@ def test_parse_real_ansi_capture() -> None:
     assert dialog.decline_option is not None and dialog.decline_option.number == 3
 
 
+def test_body_extraction_ignores_earlier_scrollback_label() -> None:
+    # A line equal to a body label ("Bash command") sitting earlier in the
+    # scrollback (e.g. echoed transcript text) must not win over the actual
+    # dialog block at the bottom of the pane.
+    real = _load("approval_bash.txt")
+    decoy = "● I ran a Bash command\n Bash command\n   rm -rf /decoy\n\n"
+    dialog = parse_approval(decoy + real)
+    assert dialog is not None
+    assert dialog.tool_name == "Bash"
+    assert dialog.target == "mkdir /tmp/cc-tty-probe/probe_subdir"
+    assert dialog.target != "rm -rf /decoy"
+
+
 def test_classify_robust_to_wrapped_footer() -> None:
     # The footer wrapping across two lines breaks a raw substring match but not
     # the compact one.

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -1,0 +1,93 @@
+"""Offline validation of claude_tty pane-dialog detection against captured
+fixtures (Claude Code 2.1.177). Proves detection/parsing before any live
+keystroke wiring.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from waypoint.backends.claude_tty.pane_dialog import (
+    PaneScreen,
+    classify,
+    parse_approval,
+    parse_model_selector,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "claude_tty_pane"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text()
+
+
+@pytest.mark.parametrize(
+    "fixture, expected",
+    [
+        ("approval_write.txt", PaneScreen.APPROVAL),
+        ("approval_bash.txt", PaneScreen.APPROVAL),
+        ("trust_dialog.txt", PaneScreen.TRUST),
+        ("model_selector.txt", PaneScreen.MODEL_SELECTOR),
+        ("effort_popup.txt", PaneScreen.EFFORT_POPUP),
+        ("ready.txt", PaneScreen.OTHER),
+        ("slash_menu.txt", PaneScreen.OTHER),
+    ],
+)
+def test_classify(fixture: str, expected: PaneScreen) -> None:
+    assert classify(_load(fixture)) is expected
+
+
+def test_parse_write_approval() -> None:
+    dialog = parse_approval(_load("approval_write.txt"))
+    assert dialog is not None
+    assert dialog.tool_name == "Write"
+    assert dialog.target == "probe_out.txt"
+    assert dialog.question == "Do you want to create probe_out.txt?"
+    assert [(o.number, o.label) for o in dialog.options] == [
+        (1, "Yes"),
+        (2, "Yes, allow all edits during this session (shift+tab)"),
+        (3, "No"),
+    ]
+    assert dialog.approve_option is not None and dialog.approve_option.number == 1
+    assert dialog.approve_option.selected is True
+    assert dialog.decline_option is not None and dialog.decline_option.number == 3
+
+
+def test_parse_bash_approval() -> None:
+    dialog = parse_approval(_load("approval_bash.txt"))
+    assert dialog is not None
+    assert dialog.tool_name == "Bash"
+    assert dialog.target == "mkdir /tmp/cc-tty-probe/probe_subdir"
+    assert dialog.question == "Do you want to proceed?"
+    assert dialog.approve_option is not None and dialog.approve_option.number == 1
+    assert dialog.decline_option is not None and dialog.decline_option.number == 3
+    # The conditional always-allow option must not be mistaken for approve/decline.
+    assert dialog.options[1].label.startswith("Yes, and always allow")
+
+
+def test_diff_preview_numbers_are_not_options() -> None:
+    # The Write dialog renders a numbered diff line ("  1 waypoint-probe") that
+    # must not be parsed as a fourth option.
+    dialog = parse_approval(_load("approval_write.txt"))
+    assert dialog is not None
+    assert [o.number for o in dialog.options] == [1, 2, 3]
+
+
+def test_parse_approval_returns_none_for_non_approval() -> None:
+    assert parse_approval(_load("ready.txt")) is None
+    assert parse_approval(_load("trust_dialog.txt")) is None
+    assert parse_approval(_load("model_selector.txt")) is None
+
+
+def test_parse_model_selector() -> None:
+    options = parse_model_selector(_load("model_selector.txt"))
+    assert options is not None
+    labels = [o.label for o in options]
+    assert any(label.startswith("Default") for label in labels)
+    assert any(label.startswith("Sonnet") for label in labels)
+    selected = [o for o in options if o.selected]
+    assert len(selected) == 1 and selected[0].number == 1
+
+
+def test_parse_model_selector_returns_none_off_screen() -> None:
+    assert parse_model_selector(_load("ready.txt")) is None

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -104,6 +104,23 @@ def test_classify_robust_to_spacing_variation() -> None:
     assert classify(padded) is PaneScreen.APPROVAL
 
 
+def test_parse_real_ansi_capture() -> None:
+    # A pane captured with `tmux capture-pane -e` (as the live tailer does)
+    # carries ANSI colour/cursor codes interleaved with the text. The detector
+    # must strip them. This fixture is a real capture from a running session
+    # whose Bash dialog rendered no "Bash(...)" header — tool/target must come
+    # from the dialog body.
+    screen = _load("approval_bash_ansi.txt")
+    assert "\x1b" in screen  # guard: fixture really contains escapes
+    assert classify(screen) is PaneScreen.APPROVAL
+    dialog = parse_approval(screen)
+    assert dialog is not None
+    assert dialog.tool_name == "Bash"
+    assert dialog.target == "mkdir /tmp/cctty-e2e-made"
+    assert dialog.approve_option is not None and dialog.approve_option.number == 1
+    assert dialog.decline_option is not None and dialog.decline_option.number == 3
+
+
 def test_classify_robust_to_wrapped_footer() -> None:
     # The footer wrapping across two lines breaks a raw substring match but not
     # the compact one.

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -3,6 +3,7 @@ fixtures (Claude Code 2.1.177). Proves detection/parsing before any live
 keystroke wiring.
 """
 
+import re
 from pathlib import Path
 
 import pytest
@@ -91,3 +92,22 @@ def test_parse_model_selector() -> None:
 
 def test_parse_model_selector_returns_none_off_screen() -> None:
     assert parse_model_selector(_load("ready.txt")) is None
+
+
+def test_classify_robust_to_spacing_variation() -> None:
+    # A reflowed dialog with collapsed/expanded inter-word spacing must still
+    # classify via the whitespace-compact anchor match.
+    screen = _load("approval_write.txt")
+    squeezed = re.sub(r" {2,}", " ", screen)
+    padded = screen.replace("Tab to amend", "Tab   to   amend")
+    assert classify(squeezed) is PaneScreen.APPROVAL
+    assert classify(padded) is PaneScreen.APPROVAL
+
+
+def test_classify_robust_to_wrapped_footer() -> None:
+    # The footer wrapping across two lines breaks a raw substring match but not
+    # the compact one.
+    screen = _load("approval_bash.txt").replace(
+        "Esc to cancel · Tab to amend", "Esc to cancel · Tab to\namend"
+    )
+    assert classify(screen) is PaneScreen.APPROVAL

--- a/waypointctl/pyproject.toml
+++ b/waypointctl/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
   "typer>=0.12.0",
+  "click>=8.0",
   "python-dotenv>=1.0.0",
 ]
 

--- a/waypointctl/uv.lock
+++ b/waypointctl/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -156,6 +156,7 @@ name = "waypointctl"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "python-dotenv" },
     { name = "typer" },
 ]
@@ -167,6 +168,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "click", specifier = ">=8.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "typer", specifier = ">=0.12.0" },
 ]


### PR DESCRIPTION
## Summary

The Claude Agent SDK and `claude -p` (print mode) are being moved behind a separate, restrictive rate limit that the interactive Claude Code TUI is exempt from. The existing `claude_code` plugin drives `claude -p`, so it inherits that limit and stops being usable. `claude_tty` is a new backend that drives the *interactive* TUI (the exempt path) while presenting a structured surface as close as practical to `claude_code`: structured assistant/tool events, reliable turn completion, resume/fork, todo cards, and pane-scraped tool approvals. It serves both the chat UI and — the primary goal — autonomous agent-to-agent coordination over the `waypoint` CLI, where sessions spawn and drive each other.

The architecture is a structured plugin (`is_structured=True`) that pairs the `tmux` transport for input with a single transcript-driven output source: Claude persists each turn to a JSONL transcript that is byte-faithful to the screen and flushes at message/block completion — the same granularity `claude_code` already renders on, so transcript-only output is at parity, not a regression. There is no screen scrape in the output path; the pane is read only for the launch trust prompt and for tool-permission dialogs. The full design and rationale live in `tmp/claude_tty_backend.md` (working doc, not committed).

## Changes

### Backend — `claude_tty` backend (new package `backends/claude_tty/`)

- **`plugin.py`** — `ClaudeTtyPlugin(TmuxPlugin)`: pre-generates a `--session-id` UUID, launches `claude` in tmux (resizing the window to 120 cols so dialogs and commands never wrap), starts a transcript tailer instead of the raw-log monitor, and reuses the `tmux` resume/`_conversation_exists`/rate-limit machinery. `restore_session` re-attaches the tailer on boot and relaunches on `EXITED`; `fork_session` uses `--resume <src> --fork-session --session-id <new>`. Reuses the `claude_code` model catalogue, permission-mode specs, and `probe_claude_usage`.
- **`tailer.py`** — `TranscriptTailer`: polls the session JSONL by byte offset (partial-line safe), normalizes records to canonical events, watches tmux pane liveness, auto-accepts the workspace-trust prompt, and polls the live pane for permission dialogs.
- **`normalize.py`** — `TranscriptNormalizer`: processes records in arrival order, dedups `usage` by first-seen `message.id` (same-id records interleave with `tool_result` records, so merging would reorder — verified against real transcripts), synthesizes a `result` on a terminal `stop_reason`, allowlist-filters TUI-only record types, drops injected `<task-notification>`/context-summary turns, and folds the `TaskCreate`/`TaskUpdate`/… stream into TodoWrite snapshots (reusing the `claude_code` helpers) so the existing frontend todo card renders.
- **`pane_dialog.py`** — pure, side-effect-free detection/parsing of TUI dialogs from a captured pane: classifies approval / trust / model-selector / effort screens, strips ANSI, extracts the tool and target from the dialog body (the `● Tool(arg)` header is often absent), and maps approve/decline to option digits. Anchors are matched in both literal and whitespace-compact form to survive reflow.
- **`transport.py`** — `ClaudeTtyTransport(TmuxTransport)`: `is_structured=True`; `interrupt` sends `Esc`; `respond_to_approval`/`has_pending_approval` drive a pending dialog by sending the option digit + Enter (decline targets the "No"-labelled option, never the position-2 "allow all this session"; Esc fallback).
- **`_state.py`** — `PendingTtyApproval`, the per-session approval state owned by the plugin singleton and shared with the tailer/transport.
- **`bootstrap.py`** — registers `ClaudeTtyPlugin()`.

Tool approvals are surfaced out-of-band: the tailer detects a stable dialog (debounced across polls), emits an `APPROVAL_REQUEST` shaped exactly like `claude_code`'s (so the existing approval card renders), and resolves it via `respond_to_approval`. Detection is mode-agnostic — `claude_tty` cannot change permission mode inline, so the stored mode is launch-fixed while the TUI posture can drift (shift+tab), and trusting the on-screen dialog over the recorded mode avoids missing an approval and hanging the session.

### Tooling — `waypointctl`

- Declare `click` as a direct dependency. `cli.py` imports it (the recursive-help command introspects Typer's underlying Click objects) but it was only pulled in transitively via Typer, so a fresh `uv tool install` produced an env where `import click` failed with `ModuleNotFoundError`.

### Tests

- `test_claude_tty_normalize.py` — content-block normalization, first-seen usage dedup, interleaving, result synthesis, record filtering, and the Task→TodoWrite folding.
- `test_claude_tty_pane_dialog.py` + `tests/fixtures/claude_tty_pane/` — classification and parsing validated against pane snapshots captured from a real Claude Code 2.1.177 session (Write/Bash approvals, trust prompt, model selector), including a real `capture-pane -e` snapshot with ANSI escapes and whitespace-reflow cases.
- `test_claude_tty_approval.py` — the tailer's detect/debounce/emit, the post-response re-emit guard, mode-agnostic detection, trust auto-accept, and the transport's digit+Enter approve/decline/Esc paths.

## Test Plan

- [x] `cd backend && uv run pytest` — 811 passed.
- [x] `cd backend && uv run pre-commit run --files <changed>` — isort / black / ruff / codespell / mypy clean (run per-file on the changed set, not `--all-files`).
- [x] `uv tool install ./waypointctl --reinstall` then `waypointctl status` — installs `click==8.4.1` explicitly and runs (previously crashed with `ModuleNotFoundError: click`).
- [x] Live e2e, interactive approvals (running backend on this branch): launched a `claude_tty` session in `default` mode, sent a Bash command via `waypoint sessions send`, confirmed an `APPROVAL_REQUEST` surfaced via the API (`tool_name=Bash`, `tool_input={command}`, `waiting_input`); `waypoint sessions approve <id> decline` → keystroke sent, dir not created; `approve` → dir created; status transitioned correctly each time.
- [x] Live e2e, autonomous (fresh cwd, `auto` mode, no human input): the workspace-trust prompt was auto-accepted, the session reached ready on its own, a sent turn ran (Bash auto-approved) and produced `tool_call` / `tool_result` / `agent_output` / synthesized `result` → `idle`.
- [x] Standalone live keystroke check against a raw TUI: `3`+Enter declined a Write (no file), `1`+Enter approved it (file created) — proves the digit+Enter mechanism the transport relies on.
- [ ] No frontend changes in this branch; `claude_tty` reuses the existing structured-event UI and was not exercised in the browser this round.
- [ ] Not yet covered: the ExitPlanMode/plan-approval dialog and the `bypassPermissions` first-run consent (distinct dialog shapes, not captured), and inline `/model` / `/effort` (out of scope — restart-to-change already works).

Note: the running backend is currently on this branch's code from the live e2e above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
