### PR TITLE
feat: command-bar composer redesign and frontend catalog threading

### DIFF
--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -16,7 +16,7 @@ import {
   resetAssistant,
   terminateAssistant,
 } from "@/lib/api";
-import { humaniseBackend } from "@/lib/backends";
+import { buildCatalog, humaniseBackend } from "@/lib/backends";
 import { copyText } from "@/lib/clipboard";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
@@ -84,6 +84,7 @@ export default function AssistantPage() {
   const [assistant, setAssistant] = useState<AssistantSummary | null>(null);
   const [backends, setBackends] = useState<BackendDescriptor[]>([]);
   const [state, setState] = useState<LoadState>("loading");
+  const catalog = useMemo(() => buildCatalog(backends), [backends]);
 
   const handleAuthFailure = useCallback(() => {
     clearToken();
@@ -228,7 +229,7 @@ export default function AssistantPage() {
               </span>
               <div className="assistant-banner-text">
                 <p className="assistant-banner-eyebrow">
-                  {humaniseBackend(assistant.backend)}
+                  {humaniseBackend(assistant.backend, catalog)}
                 </p>
                 <p className="assistant-banner-note">
                   Your persistent assistant — ask about this host or your running

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6643,18 +6643,6 @@ html[data-theme="light"] .reply-textarea-wrap {
   }
 }
 
-/* Keyboard hint — desktop only, tucked in the capsule before Send. */
-.composer-bar .composer-shortcut {
-  align-self: center;
-  flex: 0 0 auto;
-  padding-right: 2px;
-}
-@media (pointer: coarse), (max-width: 640px) {
-  .composer-bar .composer-shortcut {
-    display: none;
-  }
-}
-
 /* On phones the ⊕ menu and the control popover become full-width sheets that
  * rise from just above the composer. They must anchor to `.composer` (not the
  * trigger), so the trigger wrappers go `position: static` and the sheet is
@@ -7190,24 +7178,6 @@ html[data-theme="light"] .ask-question-note-input {
 /* ─── Attachments ─── */
 .composer-file-input {
   display: none;
-}
-
-.composer-attach {
-  width: 36px;
-  padding: 0;
-}
-
-.composer-attach .glyph {
-  display: inline-flex;
-  line-height: 0;
-}
-
-.composer-attach svg {
-  transition: transform 200ms cubic-bezier(0.2, 0.7, 0.2, 1);
-}
-
-.composer-attach:hover:not(:disabled) svg {
-  transform: rotate(-14deg) scale(1.06);
 }
 
 /* Drag target: a brass dashed frame that reads as "this surface accepts a drop". */
@@ -9328,21 +9298,6 @@ html[data-theme="light"] .term-compose-input {
   .composer-textarea {
     min-height: 0;
     padding: 0;
-  }
-
-  .composer-actions {
-    gap: 6px;
-  }
-
-  .composer-actions .send {
-    min-width: 0;
-    flex: 1 1 auto;
-  }
-
-  .composer-actions .ghost {
-    min-height: 32px;
-    padding: 0 10px;
-    font-size: 0.7rem;
   }
 
   .composer-overflow-trigger {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3722,8 +3722,8 @@ html[data-theme="light"] .task-dock-panel {
   bottom: 0;
   z-index: 6;
   display: grid;
-  gap: 10px;
-  padding: 14px 16px calc(14px + env(safe-area-inset-bottom));
+  gap: 7px;
+  padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
   border: 1px solid var(--line-strong);
   border-radius: var(--radius);
   background: linear-gradient(
@@ -3748,21 +3748,6 @@ html[data-theme="light"] .composer {
     0 0 0 1px rgba(166, 122, 34, 0.06) inset;
 }
 
-.composer-resize-handle {
-  position: absolute;
-  top: -4px;
-  left: 0;
-  right: 0;
-  height: 8px;
-  cursor: ns-resize;
-  z-index: 10;
-}
-
-@media (pointer: coarse) {
-  .composer-resize-handle {
-    display: none;
-  }
-}
 
 .composer::before {
   content: "";
@@ -3787,13 +3772,17 @@ html[data-theme="light"] .composer::before {
   );
 }
 
+/* The toprow is now a thin "context rail": a single muted line carrying the
+ * model/effort/permission summary (tappable → control sheet) on the left and
+ * the usage/connection chip on the right. No wrapping — it stays one line. */
 .composer-toprow {
   display: flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 10px;
-  flex-wrap: wrap;
+  gap: 8px;
+  flex-wrap: nowrap;
   min-width: 0;
+  padding: 0 4px;
 }
 
 /* Right-anchored trailing group: the keyboard-shortcut hint then the
@@ -6206,29 +6195,26 @@ html[data-theme="light"] .composer-shortcut kbd {
   background: rgba(235, 230, 218, 0.85);
 }
 
+/* The textarea is now the bare input inside the .composer-bar capsule — the
+ * capsule owns the border / background / focus ring, so the field itself is
+ * transparent and chromeless. Default ~2 lines; grows to a cap then scrolls. */
 .composer-textarea {
   width: 100%;
-  min-height: 88px;
+  min-height: 0;
+  max-height: 38vh;
   resize: none;
-  padding: 12px 14px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: rgba(6, 8, 13, 0.65);
+  overflow-y: auto;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--text);
-  line-height: 1.55;
-  transition:
-    border-color 120ms ease,
-    box-shadow 120ms ease;
-}
-
-html[data-theme="light"] .composer-textarea {
-  background: rgba(248, 245, 238, 0.92);
+  font-size: 16px;
+  line-height: 1.4;
 }
 
 .composer-textarea:focus {
   outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(200, 169, 106, 0.16);
 }
 
 .composer-textarea:disabled {
@@ -6236,59 +6222,6 @@ html[data-theme="light"] .composer-textarea {
   cursor: not-allowed;
 }
 
-.composer-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  min-width: 0;
-}
-
-.composer-actions-trail {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin-left: auto;
-}
-
-.composer-actions .send {
-  flex: 0 1 auto;
-  min-width: 120px;
-}
-
-.composer-actions .ghost {
-  background: transparent;
-  border: 1px solid var(--line);
-  color: var(--muted);
-  min-height: 36px;
-  padding: 0 12px;
-  font-family: var(--font-mono);
-  font-size: 0.76rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  border-radius: var(--radius-pill);
-}
-
-.composer-actions .ghost:hover:not(:disabled) {
-  border-color: var(--line-strong);
-  color: var(--text);
-}
-
-.composer-actions .ghost:disabled {
-  opacity: 0.5;
-  cursor: default;
-}
-
-.composer-actions .interrupt {
-  color: var(--warn);
-  border-color: rgba(217, 154, 74, 0.32);
-}
-
-.composer-actions .interrupt:hover:not(:disabled) {
-  border-color: rgba(217, 154, 74, 0.6);
-  color: var(--accent-strong);
-  background: rgba(217, 154, 74, 0.08);
-}
 
 .composer-overflow {
   position: relative;
@@ -6352,6 +6285,17 @@ html[data-theme="light"] .composer-overflow-trigger.open {
 html[data-theme="light"] .composer-overflow-menu {
   background: rgba(252, 249, 242, 0.98);
   box-shadow: 0 12px 32px rgba(60, 45, 20, 0.15);
+}
+
+/* Desktop: the chat ⊕ trigger lives at the LEFT of the bar, so its menu opens
+ * rightward (left edge aligned) instead of the default right-aligned drop that
+ * would shoot off the left edge. Scoped to ≥641px so the ≤640 bottom-sheet
+ * (full-width) rule still wins on phones. */
+@media (min-width: 641px) {
+  .composer-plus .composer-overflow-menu {
+    left: 0;
+    right: auto;
+  }
 }
 
 .composer-overflow-item {
@@ -6450,6 +6394,316 @@ html[data-theme="light"] .composer-overflow-item.warn:hover:not(:disabled) {
   height: 1px;
   margin: 4px 0;
   background: var(--line);
+}
+
+/* ─── Composer command bar (capsule) ─────────────────────────────────────
+ * The reply input as a single native command capsule: a thin context rail
+ * (model/effort summary + usage) above, then [⊕ actions · field · morph send].
+ * The morph button is the one primary control — ↑ Send, ■ Stop while the
+ * agent runs, … while sending.
+ * ────────────────────────────────────────────────────────────────────────── */
+
+/* Rail: the tune summary reads as a quiet, tappable text line, not a pill. */
+.composer-toprow .composer-tune {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+.composer-tune-trigger {
+  border: 0;
+  background: transparent;
+  padding: 2px 4px;
+  min-height: 0;
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+}
+.composer-tune-trigger .composer-tune-summary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.composer-tune-trigger:hover:not(:disabled) {
+  background: rgba(200, 169, 106, 0.1);
+}
+
+/* The bar is a transparent row: leading action buttons (or the ›-chevron) and
+ * the send button sit on the composer deck, flanking the input pill. */
+.composer-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 0;
+}
+
+/* The input pill — the rounded text field the buttons flank. It owns the
+ * border, fill, gold top-hairline, and focus ring (iMessage-style). Its single
+ * line height (38px) matches the flanking buttons; `justify-content: center`
+ * vertically centres the auto-grown textarea, and it grows past 38px only when
+ * the draft wraps to multiple lines. */
+.reply-textarea-wrap {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 20px;
+  background: rgba(6, 8, 13, 0.66);
+  /* Right padding reserves room for the send button, which is pinned inside
+   * the pill so the text field reads wider. */
+  padding: 5px 46px 5px 16px;
+  box-shadow: inset 0 1px 0 rgba(200, 169, 106, 0.1);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+html[data-theme="light"] .reply-textarea-wrap {
+  background: rgba(255, 252, 245, 0.9);
+}
+.reply-textarea-wrap:focus-within {
+  border-color: var(--accent);
+  box-shadow:
+    inset 0 1px 0 rgba(200, 169, 106, 0.16),
+    0 0 0 3px rgba(200, 169, 106, 0.16);
+}
+
+/* The ›-chevron stand-in for the leading cluster. It is always in the DOM but
+ * only shown (and the ⊕/📎 collapsed) while the field is focused — driven by
+ * CSS :focus-within, so focusing never re-renders and can't drop focus.
+ * `lead-forced` (set when the chevron is tapped) reverses it back to ⊕/📎. */
+.composer-lead-expand {
+  display: none;
+  order: -3;
+  flex: 0 0 auto;
+  align-self: flex-end;
+  width: 32px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font-size: 1.5rem;
+  line-height: 1;
+  transition:
+    color 140ms ease,
+    transform 160ms ease;
+}
+.composer-lead-expand:hover {
+  color: var(--accent-strong);
+  transform: translateX(1px);
+}
+.composer-lead-expand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+/* Focused (and not force-opened): show the chevron, collapse ⊕ + 📎. */
+.composer-bar:focus-within:not(.lead-forced) .composer-lead-expand {
+  display: inline-flex;
+}
+.composer-bar:focus-within:not(.lead-forced) .composer-plus,
+.composer-bar:focus-within:not(.lead-forced) .composer-attach-btn {
+  display: none;
+}
+
+/* ⊕ actions + 📎 attach — left cluster (via order), circular and quiet */
+.composer-bar .composer-plus {
+  order: -2;
+  margin: 0;
+  flex: 0 0 auto;
+  align-self: flex-end;
+}
+.composer-attach-btn {
+  order: -1;
+  flex: 0 0 auto;
+  align-self: flex-end;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  color: var(--muted);
+  background: transparent;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease;
+}
+.composer-attach-btn:hover:not(:disabled) {
+  color: var(--text);
+  background: rgba(200, 169, 106, 0.12);
+}
+.composer-attach-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.composer-attach-btn .glyph {
+  display: inline-flex;
+  width: 17px;
+  height: 17px;
+}
+.composer-plus-trigger {
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  color: var(--muted);
+  background: transparent;
+  font-size: 1.3rem;
+  line-height: 1;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease,
+    transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+.composer-plus-trigger:hover {
+  color: var(--text);
+  background: rgba(200, 169, 106, 0.12);
+}
+.composer-plus-trigger.open {
+  color: var(--accent-strong);
+  transform: rotate(45deg);
+}
+
+/* The morph primary — circular, accent for Send, danger for Stop. Pinned to
+ * the bottom-right inside the input pill. */
+.composer-send-morph {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  color: #0c0f15;
+  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 4px 14px rgba(200, 169, 106, 0.3);
+  font-size: 0.98rem;
+  transition:
+    transform 140ms ease,
+    background 200ms ease,
+    box-shadow 200ms ease,
+    opacity 140ms ease;
+}
+.composer-send-glyph {
+  display: inline-flex;
+  line-height: 1;
+  transform: translateY(-1px);
+}
+.composer-send-morph:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(200, 169, 106, 0.42);
+}
+.composer-send-morph:disabled {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
+}
+.composer-send-morph.is-stop {
+  color: #fff;
+  background: linear-gradient(180deg, #e8807f, var(--danger));
+  box-shadow: 0 4px 14px rgba(226, 108, 112, 0.34);
+}
+.composer-send-morph.is-stop .composer-send-glyph {
+  font-size: 0.78rem;
+  transform: none;
+}
+.composer-send-morph.is-stop::after {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  border: 1px solid rgba(226, 108, 112, 0.45);
+  animation: morph-pulse 1.8s ease-out infinite;
+  pointer-events: none;
+}
+@keyframes morph-pulse {
+  0% {
+    opacity: 0.7;
+    transform: scale(0.82);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.3);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-send-morph.is-stop::after {
+    animation: none;
+  }
+}
+
+/* Keyboard hint — desktop only, tucked in the capsule before Send. */
+.composer-bar .composer-shortcut {
+  align-self: center;
+  flex: 0 0 auto;
+  padding-right: 2px;
+}
+@media (pointer: coarse), (max-width: 640px) {
+  .composer-bar .composer-shortcut {
+    display: none;
+  }
+}
+
+/* On phones the ⊕ menu and the control popover become full-width sheets that
+ * rise from just above the composer. They must anchor to `.composer` (not the
+ * trigger), so the trigger wrappers go `position: static` and the sheet is
+ * absolutely positioned against the composer — `position: fixed` can't be used
+ * because `.composer`'s backdrop-filter makes it the containing block for
+ * fixed descendants, which would pin the sheet to the composer's own box. */
+@media (max-width: 640px) {
+  .composer-tune,
+  .composer-overflow {
+    position: static;
+  }
+  .composer-overflow-menu,
+  .composer-tune-popover {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: calc(100% + 8px);
+    top: auto;
+    width: auto;
+    min-width: 0;
+    max-width: 100%;
+    max-height: 58vh;
+    overflow-y: auto;
+    border-radius: 16px;
+    padding: 10px 12px;
+    box-shadow: 0 16px 44px rgba(0, 0, 0, 0.5);
+    animation: sheet-rise 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    z-index: 60;
+  }
+  .composer-overflow-item {
+    padding: 12px 10px;
+    font-size: 0.95rem;
+  }
+  .composer {
+    gap: 6px;
+  }
+  .composer-toprow {
+    font-size: 0.72rem;
+  }
+}
+@keyframes sheet-rise {
+  from {
+    transform: translateY(20px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 /* "Back to top" mirror of the latest-pill — same floating-pill language but
@@ -6958,10 +7212,10 @@ html[data-theme="light"] .ask-question-note-input {
 
 /* Drag target: a brass dashed frame that reads as "this surface accepts a drop". */
 .reply-textarea-wrap.is-drag-active,
-.term-compose-field.is-drag-active {
+.term-compose-field.is-drag-active .term-compose-input {
   outline: 1.5px dashed color-mix(in srgb, var(--accent) 68%, transparent);
   outline-offset: 3px;
-  border-radius: var(--radius-sm);
+  border-radius: 20px;
 }
 
 .composer-drop-hint {
@@ -8089,16 +8343,20 @@ html[data-theme="light"] .term-keys {
   flex: 0 0 auto;
   min-width: 44px;
   min-height: 36px;
-  padding: 4px 10px;
-  border-radius: var(--radius-sm);
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
   border: 1px solid var(--line);
   background: rgba(255, 255, 255, 0.05);
   color: var(--text);
   font-family: var(--font-mono);
   font-size: 0.78rem;
   cursor: pointer;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
   -webkit-tap-highlight-color: transparent;
-  transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+  transition:
+    background 120ms ease,
+    border-color 120ms ease,
+    transform 80ms ease;
 }
 
 html[data-theme="light"] .term-keys button {
@@ -8269,21 +8527,143 @@ html[data-theme="light"] .term-compose-handle:hover {
   transition-delay: 80ms;
 }
 
+/* Capsule field — the same command capsule as chat: [📁 📎 · input · ↑].
+ * `align-items: center` keeps a single-line draft vertically centred against
+ * the flanking buttons so their heights read as matched. */
+/* Transparent bar: the text pill plus the flanking buttons (whatsapp-style),
+ * matching the chat composer. */
 .term-compose-field {
   position: relative;
+  display: flex;
+  align-items: flex-end;
+  gap: 4px;
+  padding: 0;
 }
 
-/* The reused .composer-resize-handle sits on the top edge of the
-   textarea on desktop; the existing @media (pointer: coarse) rule on
-   the base class hides it on touch. We override the absolute offset
-   to align with the textarea's own top edge instead of the parent
-   .composer's top edge. */
-.term-compose-resize {
-  top: -6px;
+.term-compose-rail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 6px;
+  min-width: 0;
+}
+
+/* The text pill — owns the border, fill, gold hairline, focus ring, and the
+ * send button pinned inside its bottom-right. */
+.term-compose-input {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 40px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 20px;
+  background: rgba(6, 8, 13, 0.66);
+  padding: 5px 46px 5px 16px;
+  box-shadow: inset 0 1px 0 rgba(200, 169, 106, 0.1);
+  transition:
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+html[data-theme="light"] .term-compose-input {
+  background: rgba(255, 252, 245, 0.9);
+}
+.term-compose-input:focus-within {
+  border-color: var(--accent);
+  box-shadow:
+    inset 0 1px 0 rgba(200, 169, 106, 0.16),
+    0 0 0 3px rgba(200, 169, 106, 0.16);
+}
+
+/* ›-chevron: shown (and 📁/📎 collapsed) only while focused, via CSS
+ * :focus-within — no re-render on focus. `lead-forced` reverses it. */
+.term-compose-lead-expand {
+  display: none;
+  flex: 0 0 auto;
+  width: 32px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  font-size: 1.5rem;
+  line-height: 1;
+}
+.term-compose-lead-expand:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+.term-compose-field:focus-within:not(.lead-forced) .term-compose-lead-expand {
+  display: inline-flex;
+}
+.term-compose-field:focus-within:not(.lead-forced) .term-compose-act {
+  display: none;
+}
+
+/* 📁 files + 📎 attach — quiet circular buttons on the left of the capsule */
+.term-compose-act {
+  flex: 0 0 auto;
+  align-self: flex-end;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  color: var(--muted);
+  background: transparent;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease;
+}
+.term-compose-act:hover:not(:disabled) {
+  color: var(--text);
+  background: rgba(200, 169, 106, 0.12);
+}
+.term-compose-act .glyph {
+  display: inline-flex;
+  width: 17px;
+  height: 17px;
+}
+
+/* ↑ send — circular accent, pinned inside the pill's bottom-right. */
+.term-compose-send {
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  color: #0c0f15;
+  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 4px 14px rgba(200, 169, 106, 0.3);
+  font-size: 0.98rem;
+  transition:
+    transform 140ms ease,
+    box-shadow 200ms ease,
+    opacity 140ms ease;
+}
+.term-compose-send:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(200, 169, 106, 0.42);
+}
+.term-compose-send:disabled {
+  opacity: 0.4;
+  cursor: default;
+  box-shadow: none;
 }
 
 .term-compose-textarea {
-  min-height: 72px;
+  min-height: 0;
   max-height: min(36dvh, 320px);
   /* 16px suppresses iOS Safari's auto-zoom on focus. */
   font-size: 16px;
@@ -8299,14 +8679,6 @@ html[data-theme="light"] .term-compose-handle:hover {
   .term-compose-textarea {
     max-height: min(28dvh, 220px);
   }
-}
-
-.term-compose-meta {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  min-width: 0;
 }
 
 .term-compose-meta-spacer {
@@ -8366,13 +8738,6 @@ html[data-theme="light"] .term-compose-handle:hover {
   .term-compose-shortcut {
     display: none;
   }
-}
-
-.term-compose-send {
-  /* The .primary.send base lives in the chat composer's rules; we just
-     tighten the padding for the smaller drawer footprint. */
-  padding: 6px 14px;
-  font-size: 0.82rem;
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -8960,14 +9325,9 @@ html[data-theme="light"] .term-compose-handle:hover {
     display: none;
   }
 
-  .composer-resize-handle {
-    display: none;
-  }
-
   .composer-textarea {
-    min-height: 56px;
-    padding: 10px 12px;
-    line-height: 1.45;
+    min-height: 0;
+    padding: 0;
   }
 
   .composer-actions {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -786,6 +786,7 @@ export default function HomePage() {
       {token ? (
         <SessionList
           sessions={sessions.filter((session) => session.source !== "assistant")}
+          catalog={catalog}
           onDelete={handleDelete}
           onDeleteExited={handleDeleteExited}
           onTerminate={handleTerminate}

--- a/frontend/src/components/ResumeThreadPanel.tsx
+++ b/frontend/src/components/ResumeThreadPanel.tsx
@@ -225,7 +225,7 @@ export function ResumeThreadPanel({
         <p className="muted resume-panel-empty">
           {query.trim().length > 0
             ? "No threads match your search."
-            : emptyHintFor(filter, dualBackend, targetLabel)}
+            : emptyHintFor(filter, dualBackend, targetLabel, catalog)}
         </p>
       ) : null}
 
@@ -344,12 +344,13 @@ function emptyHintFor(
   filter: Filter,
   dualBackend: boolean,
   targetLabel: string | null,
+  catalog?: BackendCatalog,
 ): string {
   const where = targetLabel ? ` on ${targetLabel}` : "";
   if (filter === "all" || !dualBackend) {
     return `No importable threads found${where}.`;
   }
-  return `No ${humaniseBackend(filter)} sessions${where}.`;
+  return `No ${humaniseBackend(filter, catalog)} sessions${where}.`;
 }
 
 function formatRelativeTime(value: string): string {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -54,11 +54,7 @@ import {
   useBackendCatalog,
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
-import {
-  COMPOSER_MIN_HEIGHT,
-  SHORTCUT_IS_MAC,
-  type TerminalSubmitResult,
-} from "@/lib/composer";
+import { type TerminalSubmitResult } from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import { useFileMentions } from "@/lib/use-file-mentions";
 import {
@@ -277,7 +273,6 @@ type ConnectionState = "connecting" | "open" | "reconnecting";
 // read `--composer-height` to sit just above it. The fallback keeps things
 // sensible for the very first paint before the observer fires.
 const COMPOSER_HEIGHT_FALLBACK = 220;
-const COMPOSER_HEIGHT_STORAGE_KEY = "waypoint-composer-height";
 
 // Per-session dismissal of the task progress dock, persisted so a refresh
 // keeps it dismissed. We store the dismissed todo-event sequence: any later
@@ -2186,23 +2181,29 @@ const ReplyComposer = memo(function ReplyComposer({
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
   const [pendingEffort, setPendingEffort] = useState<string | null>(null);
-  const [textareaHeight, setTextareaHeight] = useState<number | undefined>(undefined);
+  // iMessage-style leading actions: ⊕ + 📎 collapse to a single ›-chevron via
+  // CSS (:focus-within) so focusing the field never triggers a React re-render
+  // that could drop focus mid-gesture. The chevron re-opens them by forcing
+  // `lead-forced`, which overrides the focus-within collapse; typing or
+  // blurring clears it.
+  const [leadForced, setLeadForced] = useState(false);
 
-  // Rehydrate from localStorage post-mount so SSR and client first-render
-  // produce identical markup (no inline height) and React doesn't warn
-  // about a hydration mismatch.
-  useEffect(() => {
-    const stored = window.localStorage.getItem(COMPOSER_HEIGHT_STORAGE_KEY);
-    if (!stored) return;
-    const parsed = Number.parseInt(stored, 10);
-    if (Number.isFinite(parsed) && parsed >= COMPOSER_MIN_HEIGHT) {
-      setTextareaHeight(parsed);
-    }
-  }, []);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const composerRef = useRef<HTMLElement | null>(null);
   const overflowRef = useRef<HTMLDivElement | null>(null);
   const tuneRef = useRef<HTMLDivElement | null>(null);
+
+  // Auto-grow the field to fit its content: a single line by default (so the
+  // pill matches the flanking buttons), growing as the draft wraps up to the
+  // CSS max-height, then it scrolls.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) {
+      return;
+    }
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [draft]);
 
   // Built-in slash commands are intercepted on the backend only for
   // structured transports (see plugin.maybe_handle_input); skip
@@ -2314,46 +2315,6 @@ const ReplyComposer = memo(function ReplyComposer({
     };
   }, [tuneOpen]);
 
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const handle = e.currentTarget;
-    const pointerId = e.pointerId;
-    handle.setPointerCapture(pointerId);
-    const startY = e.clientY;
-    const startHeight = textareaRef.current?.getBoundingClientRect().height ?? 88;
-    let latestHeight = startHeight;
-
-    const onPointerMove = (moveEvent: PointerEvent) => {
-      const deltaY = startY - moveEvent.clientY;
-      const newHeight = Math.max(COMPOSER_MIN_HEIGHT, startHeight + deltaY);
-      latestHeight = newHeight;
-      setTextareaHeight(newHeight);
-    };
-
-    const finishDrag = () => {
-      try {
-        handle.releasePointerCapture(pointerId);
-      } catch {
-        // Capture may already be released (e.g. on pointercancel).
-      }
-      handle.removeEventListener("pointermove", onPointerMove);
-      handle.removeEventListener("pointerup", finishDrag);
-      handle.removeEventListener("pointercancel", finishDrag);
-      try {
-        window.localStorage.setItem(
-          COMPOSER_HEIGHT_STORAGE_KEY,
-          String(Math.round(latestHeight)),
-        );
-      } catch {
-        // localStorage unavailable (private mode, quota); skip persistence.
-      }
-    };
-
-    handle.addEventListener("pointermove", onPointerMove);
-    handle.addEventListener("pointerup", finishDrag);
-    handle.addEventListener("pointercancel", finishDrag);
-  };
-
   async function handleSend() {
     const text = draft.trim();
     const attachmentIds = attachments.readyIds;
@@ -2454,7 +2415,6 @@ const ReplyComposer = memo(function ReplyComposer({
   const modeOptions = permissionModeOptions;
   // Refresh is always available, so the overflow menu is always present.
   const hasOverflow = true;
-  const shortcutKey = SHORTCUT_IS_MAC ? "⌘" : "Ctrl";
   const hasModelPicker = modelOptions.length > 0 || currentModel !== null;
   // Surface a custom-named model the user already has even if it's not in the
   // curated list, so the dropdown reflects the truth instead of silently
@@ -2584,12 +2544,6 @@ const ReplyComposer = memo(function ReplyComposer({
 
   return (
     <section className="composer" ref={composerRef}>
-      <div
-        className="composer-resize-handle"
-        onPointerDown={handlePointerDown}
-        title="Drag to resize composer"
-        aria-hidden="true"
-      />
       <div className="composer-toprow">
         {tuneVisible ? (
           <div className="composer-tune" ref={tuneRef}>
@@ -2876,6 +2830,19 @@ const ReplyComposer = memo(function ReplyComposer({
           />
         </div>
       </div>
+      <div className={`composer-bar${leadForced ? " lead-forced" : ""}`}>
+      <button
+        type="button"
+        className="composer-lead-expand"
+        onClick={() => {
+          setLeadForced(true);
+          textareaRef.current?.focus();
+        }}
+        aria-label="Show actions"
+        title="Show actions"
+      >
+        ›
+      </button>
       <div
         className={`reply-textarea-wrap${dragActive ? " is-drag-active" : ""}`}
         onDragOver={handleDragOver}
@@ -2893,10 +2860,13 @@ const ReplyComposer = memo(function ReplyComposer({
         <textarea
           ref={textareaRef}
           className="composer-textarea"
-          style={textareaHeight ? { height: textareaHeight } : undefined}
-          rows={3}
+          rows={1}
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setLeadForced(false);
+          }}
+          onBlur={() => setLeadForced(false)}
           onKeyDown={handleDraftKeyDown}
           onPaste={handlePaste}
           disabled={disabled}
@@ -2909,6 +2879,27 @@ const ReplyComposer = memo(function ReplyComposer({
             <span>Drop to attach</span>
           </div>
         ) : null}
+        <button
+          type="button"
+          className={`composer-send-morph ${agentBusy ? "is-stop" : "is-send"}`}
+          onClick={() => (agentBusy ? void onInterrupt() : void handleSend())}
+          disabled={
+            agentBusy
+              ? disabled || dormant
+              : disabled ||
+                sending ||
+                attachments.uploading ||
+                (!draft.trim() && attachments.readyIds.length === 0)
+          }
+          aria-label={agentBusy ? "Stop the agent" : "Send"}
+          title={
+            agentBusy ? "Interrupt the agent's current turn" : "Send (⌘/Ctrl + ↵)"
+          }
+        >
+          <span className="composer-send-glyph" aria-hidden>
+            {sending ? "…" : agentBusy ? "■" : "↑"}
+          </span>
+        </button>
         {suggestionsOpen ? (
           <CommandSuggestions
             ref={suggestionsRef}
@@ -2932,86 +2923,59 @@ const ReplyComposer = memo(function ReplyComposer({
           />
         ) : null}
       </div>
-      <div className="composer-actions">
-        <button
-          className="primary send"
-          onClick={() => void handleSend()}
-          type="button"
-          disabled={
-            disabled ||
-            sending ||
-            attachments.uploading ||
-            (!draft.trim() && attachments.readyIds.length === 0)
-          }
-        >
-          {sending ? "Sending…" : "Send"}
-        </button>
-        <button
-          className="ghost interrupt"
-          onClick={() => void onInterrupt()}
-          type="button"
-          disabled={disabled || dormant}
-          title="Interrupt the agent's current turn"
-        >
-          Interrupt
-        </button>
         {attachmentsEnabled ? (
-          <>
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              className="composer-file-input"
-              onChange={addFilesFromInput}
-              aria-hidden="true"
-              tabIndex={-1}
-            />
-            <button
-              className="ghost composer-attach"
-              onClick={() => fileInputRef.current?.click()}
-              type="button"
-              disabled={disabled}
-              title="Attach files"
-              aria-label="Attach files"
-            >
-              <span className="glyph" aria-hidden>
-                <PaperclipIcon />
-              </span>
-            </button>
-          </>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="composer-file-input"
+            onChange={addFilesFromInput}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
         ) : null}
-        {canResume ? (
+        {attachmentsEnabled ? (
           <button
-            className="ghost"
-            onClick={() => void onResume()}
             type="button"
+            className="composer-attach-btn"
+            onClick={() => fileInputRef.current?.click()}
             disabled={disabled}
-            title="Resume the underlying tmux session"
+            aria-label="Attach files"
+            title="Attach files"
           >
-            Resume
+            <span className="glyph" aria-hidden>
+              <PaperclipIcon />
+            </span>
           </button>
         ) : null}
-        <div className="composer-actions-trail">
-          <span className="composer-shortcut" aria-hidden>
-            <kbd>{shortcutKey}</kbd>
-            <span>+</span>
-            <kbd>↵</kbd>
-            <span>to send</span>
-          </span>
-          {hasOverflow ? (
-            <div className="composer-overflow" ref={overflowRef}>
-              <button
-                type="button"
-                className={`composer-overflow-trigger ${overflowOpen ? "open" : ""}`}
-                aria-haspopup="menu"
-                aria-expanded={overflowOpen}
-                aria-label="More actions"
-                onClick={() => setOverflowOpen((open) => !open)}
-              >
-                ⋯
-              </button>
-              {overflowOpen ? (
-                <div className="composer-overflow-menu" role="menu">
+        {hasOverflow ? (
+          <div className="composer-overflow composer-plus" ref={overflowRef}>
+            <button
+              type="button"
+              className={`composer-plus-trigger ${overflowOpen ? "open" : ""}`}
+              aria-haspopup="menu"
+              aria-expanded={overflowOpen}
+              aria-label="Actions"
+              onClick={() => setOverflowOpen((open) => !open)}
+            >
+              ＋
+            </button>
+            {overflowOpen ? (
+              <div className="composer-overflow-menu" role="menu">
+                {canResume ? (
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="composer-overflow-item"
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      void onResume();
+                    }}
+                  >
+                    <span className="glyph">⟳</span>
+                    Resume session
+                  </button>
+                ) : null}
                   <button
                     type="button"
                     role="menuitem"
@@ -3183,7 +3147,6 @@ const ReplyComposer = memo(function ReplyComposer({
             </div>
           ) : null}
         </div>
-      </div>
       {attachmentsEnabled ? (
         <SessionFilesPanel
           host={host}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/api";
 import {
   approvalDecisionsFor,
+  type BackendCatalog,
   fidelityFor,
   humaniseBackend,
   permissionModesFor,
@@ -825,9 +826,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   useEffect(() => {
     if (!session) return;
     const prev = document.title;
-    document.title = `${humaniseBackend(session.backend)} · ${session.title}`;
+    document.title = `${humaniseBackend(session.backend, catalog)} · ${session.title}`;
     return () => { document.title = prev; };
-  }, [session]);
+  }, [session, catalog]);
 
   useEffect(() => {
     if (view !== "chat") {
@@ -1207,7 +1208,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   }
 
   const pendingApprovals =
-    session && supportsStructuredApproval(session.transport)
+    session && supportsStructuredApproval(session.transport, catalog)
       ? findPendingApprovals(events)
       : [];
   const approvalCount = pendingApprovals.length;
@@ -1269,7 +1270,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // Tmux's Resume control only makes sense while the pane is alive; once the
   // session has exited there is nothing to resume into.
   const canResume = Boolean(
-    session && supportsResume(session.transport) && !sessionExited,
+    session && supportsResume(session.transport, catalog) && !sessionExited,
   );
   const activeView: ViewMode = terminalOnly ? "terminal" : view;
   const showTaskDock =
@@ -1547,6 +1548,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           session={session}
           connection={connection}
           modelOptions={modelOptions}
+          catalog={catalog}
           onSetTitle={handleSetTitle}
           assistant={assistant}
         />
@@ -1658,6 +1660,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                             event={child.pair.call ?? child.pair.result ?? child.event}
                             pair={child.pair}
                             transport={session.transport}
+                            catalog={catalog}
                             onAnswerAskQuestion={submitAskAnswer}
                             key={`pair-${child.pair.itemId}`}
                           />
@@ -1665,6 +1668,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                           <TranscriptCard
                             event={child.event}
                             transport={session.transport}
+                            catalog={catalog}
                             onAnswerAskQuestion={submitAskAnswer}
                             key={`${child.event.sequence}-${child.event.id ?? "local"}`}
                           />
@@ -1678,6 +1682,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                     event={item.pair.call ?? item.pair.result ?? item.event}
                     pair={item.pair}
                     transport={session.transport}
+                    catalog={catalog}
                     onAnswerAskQuestion={submitAskAnswer}
                     key={`pair-${item.pair.itemId}`}
                   />
@@ -1685,6 +1690,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                   <TranscriptCard
                     event={item.event}
                     transport={session.transport}
+                    catalog={catalog}
                     onAnswerAskQuestion={submitAskAnswer}
                     key={`${item.event.sequence}-${item.event.id ?? "local"}`}
                   />
@@ -1792,7 +1798,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       ) : null}
       {!terminalOnly && !pendingApproval && pendingPlanApprovalView ? (
         <PlanApprovalCard
-          agentLabel={session ? humaniseBackend(session.backend) : "Codex"}
+          agentLabel={session ? humaniseBackend(session.backend, catalog) : "Codex"}
           canApprove
           decisions={pendingPlanApprovalView.decisions}
           onDecide={(decision, note) =>
@@ -2003,6 +2009,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           effortBusy={effortBusy}
           permissionMode={session?.permission_mode ?? null}
           transport={session?.transport ?? null}
+          catalog={catalog}
           effortRequiresConfirm={
             // The plugin advertises "effort swap requires a restart"
             // (Claude does, Codex doesn't) and we surface the confirm
@@ -2076,6 +2083,7 @@ interface ReplyComposerProps {
   effortBusy: boolean;
   permissionMode: string | null;
   transport: SessionTransport | null;
+  catalog: BackendCatalog;
   // True when the backend's effort swap requires a session restart
   // (Claude respawns the CLI). Drives the "confirm before applying"
   // UX so the user knows the session will restart, vs. Codex which
@@ -2130,6 +2138,7 @@ const ReplyComposer = memo(function ReplyComposer({
   effortBusy,
   permissionMode,
   transport,
+  catalog,
   effortRequiresConfirm,
   hasToolRuns,
   toolRunsExpanded,
@@ -2200,7 +2209,7 @@ const ReplyComposer = memo(function ReplyComposer({
   // suggestions on tmux. While the session is still loading
   // (transport=null), default to off.
   const supportsSlash =
-    transport !== null && fidelityFor(transport) === "structured";
+    transport !== null && fidelityFor(transport, catalog) === "structured";
 
   const {
     suggestions,
@@ -2760,7 +2769,7 @@ const ReplyComposer = memo(function ReplyComposer({
                     <div className="composer-tune-confirm">
                       <p>
                         Switch to{" "}
-                        <strong>{humaniseBackend(pendingBackend)}</strong>? This
+                        <strong>{humaniseBackend(pendingBackend, catalog)}</strong>? This
                         starts a new conversation; the current one is kept as a
                         stopped session.
                       </p>
@@ -2861,6 +2870,7 @@ const ReplyComposer = memo(function ReplyComposer({
           <SessionUsagePill
             session={session}
             connection={connection}
+            catalog={catalog}
             onRateLimitRefresh={onRateLimitRefresh}
             rateLimitRefreshBusy={rateLimitRefreshBusy}
           />
@@ -3606,12 +3616,14 @@ function SessionHeader({
   session,
   connection,
   modelOptions,
+  catalog,
   onSetTitle,
   assistant = false,
 }: {
   session: SessionRecord;
   connection: ConnectionState;
   modelOptions: BackendModelOption[];
+  catalog: BackendCatalog;
   onSetTitle?: (title: string) => void | Promise<void>;
   assistant?: boolean;
 }) {
@@ -3702,15 +3714,15 @@ function SessionHeader({
       ) : null}
       <div className="session-header-tags">
         <span className={`badge ${session.backend}`}>
-          {humaniseBackend(session.backend)}
+          {humaniseBackend(session.backend, catalog)}
         </span>
         {!assistant ? (
           <>
             <span className={`badge transport ${session.transport}`}>
-              {transportLabel(session.transport)}
+              {transportLabel(session.transport, catalog)}
             </span>
-            <span className={`badge fidelity ${fidelityFor(session.transport)}`}>
-              {fidelityFor(session.transport)}
+            <span className={`badge fidelity ${fidelityFor(session.transport, catalog)}`}>
+              {fidelityFor(session.transport, catalog)}
             </span>
           </>
         ) : null}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { MouseEvent, ReactNode, useEffect, useMemo, useState } from "react";
 
-import { humaniseBackend, transportLabel } from "@/lib/backends";
+import { humaniseBackend, transportLabel, type BackendCatalog } from "@/lib/backends";
 import { matchesQuery, parseQuery } from "@/lib/search";
 import { SessionRecord } from "@/lib/types";
 
@@ -11,6 +11,7 @@ import { SearchInput } from "./SearchInput";
 
 interface SessionListProps {
   sessions: SessionRecord[];
+  catalog?: BackendCatalog;
   onDelete?: (sessionId: string) => void | Promise<void>;
   onDeleteExited?: () => void | Promise<void>;
   onTerminate?: (sessionId: string) => void | Promise<void>;
@@ -22,6 +23,7 @@ const PAGE_SIZE = 10;
 
 export function SessionList({
   sessions,
+  catalog,
   onDelete,
   onDeleteExited,
   onTerminate,
@@ -182,11 +184,11 @@ export function SessionList({
       <Link className="panel session-card" href={`/session/${session.id}`} key={session.id}>
         <div className="session-row">
           <span className={`badge ${session.backend}`}>
-            {humaniseBackend(session.backend)}
+            {humaniseBackend(session.backend, catalog)}
           </span>
           {process.env.NEXT_PUBLIC_SHOW_TRANSPORT_BADGE === "1" ? (
             <span className={`badge transport ${session.transport}`}>
-              {transportLabel(session.transport)}
+              {transportLabel(session.transport, catalog)}
             </span>
           ) : null}
           {session.launch_target_id ? (

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -8,7 +8,7 @@ import { connectSessionsSocket, fetchSessions } from "@/lib/api";
 import { matchesQuery, parseQuery } from "@/lib/search";
 import { SessionEnvelope, SessionRecord } from "@/lib/types";
 import { SearchInput } from "@/components/SearchInput";
-import { humaniseBackend } from "@/lib/backends";
+import { humaniseBackend, useBackendCatalog } from "@/lib/backends";
 
 interface SessionSwitcherProps {
   host: string;
@@ -51,6 +51,7 @@ function formatCwdSegments(cwd: string): string[] {
 
 export function SessionSwitcher({ host, token, currentSession, onAuthFailure, onClose }: SessionSwitcherProps) {
   const router = useRouter();
+  const catalog = useBackendCatalog(host || null, token || null, null);
   const toggleHint = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform) ? "⌘K" : "Ctrl+K";
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
   const [query, setQuery] = useState("");
@@ -311,7 +312,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     const cwdSegments = formatCwdSegments(s.cwd);
     const workspace = s.repo_name || cwdSegments[cwdSegments.length - 1];
     const target = s.launch_target_id || "Local";
-    const breadcrumb = [humaniseBackend(s.backend), target, workspace].filter(Boolean).join(" ▸ ");
+    const breadcrumb = [humaniseBackend(s.backend, catalog), target, workspace].filter(Boolean).join(" ▸ ");
     
     return (
       <button 

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -6,6 +6,7 @@ import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { TerminalCompose } from "@/components/TerminalCompose";
 import { TerminalScrollChips } from "@/components/TerminalScrollChips";
 import { XTerminal, type XTerminalHandle } from "@/components/XTerminal";
+import { useBackendCatalog } from "@/lib/backends";
 import type { TerminalSubmitResult } from "@/lib/composer";
 import { SessionRecord } from "@/lib/types";
 
@@ -100,6 +101,7 @@ export function SessionTerminalView({
   onSwitchSession,
   onError,
 }: SessionTerminalViewProps) {
+  const catalog = useBackendCatalog(host || null, token || null, null);
   // Primary action shown as a pill button next to the overflow trigger.
   // Only states the user can't trivially reach inside the pane — Reconnect
   // when exited (the pane is gone) and Refresh for read-only snapshots.
@@ -154,6 +156,7 @@ export function SessionTerminalView({
         <SessionUsagePill
           session={session}
           connection={connection}
+          catalog={catalog}
           onRateLimitRefresh={onRateLimitRefresh}
           rateLimitRefreshBusy={rateLimitRefreshBusy}
         />

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { UsageBar, UsageReadout } from "@/components/UsageReadout";
-import { humaniseBackend } from "@/lib/backends";
+import { humaniseBackend, type BackendCatalog } from "@/lib/backends";
 import type { SessionContextUsage, SessionRecord } from "@/lib/types";
 import {
   clampPercent,
@@ -18,6 +18,7 @@ type Connection = "idle" | "connecting" | "open" | "reconnecting";
 interface SessionUsagePillProps {
   session: SessionRecord | null;
   connection: Connection;
+  catalog?: BackendCatalog;
   onRateLimitRefresh: () => void | Promise<void>;
   rateLimitRefreshBusy: boolean;
   // When provided, the popover panel is portaled into this element
@@ -31,6 +32,7 @@ interface SessionUsagePillProps {
 export function SessionUsagePill({
   session,
   connection,
+  catalog,
   onRateLimitRefresh,
   rateLimitRefreshBusy,
   popoverContainer,
@@ -93,7 +95,7 @@ export function SessionUsagePill({
   const rateLimitSourceLabel = rateLimitUsage
     ? rateLimitUsage.notes?.length
       ? rateLimitUsage.notes.join(" · ")
-      : humaniseBackend(rateLimitUsage.source)
+      : humaniseBackend(rateLimitUsage.source, catalog)
     : "Unavailable";
   const usageToneValue = (() => {
     if (contextUsage === null) return rateLimitUsageToneValue;
@@ -178,7 +180,7 @@ export function SessionUsagePill({
                   Context
                 </h3>
                 <span className="usage-block-tag">
-                  {humaniseBackend(contextUsage.source)}
+                  {humaniseBackend(contextUsage.source, catalog)}
                 </span>
               </header>
               <div className="usage-block-body">

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -5,7 +5,6 @@ import {
   ClipboardEvent,
   DragEvent,
   KeyboardEvent,
-  PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useId,
@@ -26,7 +25,6 @@ import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { useBackendCatalog } from "@/lib/backends";
 import {
-  COMPOSER_MIN_HEIGHT,
   SHORTCUT_IS_MAC,
   type TerminalSubmitResult,
 } from "@/lib/composer";
@@ -65,9 +63,6 @@ interface TerminalComposeProps {
   refocusTerminal: () => void;
 }
 
-const HEIGHT_STORAGE_KEY = "waypoint-term-compose-height";
-const HEIGHT_FALLBACK = 132;
-const HEIGHT_MAX = 320;
 
 export function TerminalCompose({
   host,
@@ -90,8 +85,10 @@ export function TerminalCompose({
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
-  const [textareaHeight, setTextareaHeight] = useState<number | null>(null);
   const [dragActive, setDragActive] = useState(false);
+  // Mirrors the chat composer: 📁/📎 collapse to a ›-chevron on focus (CSS),
+  // and the chevron forces them back open via `lead-forced`.
+  const [leadForced, setLeadForced] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [filesOpen, setFilesOpen] = useState(false);
   const attachments = useAttachments({ host, token, sessionId, onError });
@@ -148,21 +145,14 @@ export function TerminalCompose({
     textareaRef,
   });
 
-  // Restore the desktop height preference on mount; mobile media query
-  // hides the resize handle so the persisted value is harmless there.
+  // Auto-grow the field: a single line by default (matching the flanking
+  // buttons), growing as the draft wraps up to the CSS max-height.
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    try {
-      const stored = window.localStorage.getItem(HEIGHT_STORAGE_KEY);
-      if (!stored) return;
-      const parsed = Number.parseInt(stored, 10);
-      if (Number.isFinite(parsed) && parsed >= COMPOSER_MIN_HEIGHT) {
-        setTextareaHeight(Math.min(parsed, HEIGHT_MAX));
-      }
-    } catch {
-      // localStorage can throw in private windows — fall back to default.
-    }
-  }, []);
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${el.scrollHeight}px`;
+  }, [draft]);
 
   const dirty = draft.trim().length > 0;
   const connected = connection === "open";
@@ -272,43 +262,6 @@ export function TerminalCompose({
     }
   }, [expanded, onExpandedChange, refocusTerminal]);
 
-  // Desktop resize handle on the top edge of the textarea. Drag-up
-  // grows; drag-down shrinks. Mirrors the chat composer's behaviour so
-  // the gesture feels identical between the two surfaces.
-  const handlePointerDown = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.pointerType === "touch") return;
-    const startY = event.clientY;
-    const startHeight =
-      textareaRef.current?.getBoundingClientRect().height ?? HEIGHT_FALLBACK;
-    event.currentTarget.setPointerCapture(event.pointerId);
-    const onMove = (e: PointerEvent) => {
-      const delta = startY - e.clientY;
-      const next = Math.min(
-        HEIGHT_MAX,
-        Math.max(COMPOSER_MIN_HEIGHT, Math.round(startHeight + delta)),
-      );
-      setTextareaHeight(next);
-    };
-    const onUp = () => {
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
-      window.removeEventListener("pointercancel", onUp);
-      try {
-        if (textareaRef.current) {
-          window.localStorage.setItem(
-            HEIGHT_STORAGE_KEY,
-            String(textareaRef.current.getBoundingClientRect().height),
-          );
-        }
-      } catch {
-        // Ignore storage failures — height resets to default next load.
-      }
-    };
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
-    window.addEventListener("pointercancel", onUp);
-  }, []);
-
   const shortcutLabel = SHORTCUT_IS_MAC ? "⌘↵" : "Ctrl+↵";
 
   return (
@@ -331,49 +284,7 @@ export function TerminalCompose({
       </button>
       <div className="term-compose-shell" id={regionId} aria-hidden={!expanded}>
         <div className="term-compose-inner">
-          <div
-            className={`term-compose-field${dragActive ? " is-drag-active" : ""}`}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
-          >
-            <div
-              className="composer-resize-handle term-compose-resize"
-              onPointerDown={handlePointerDown}
-              aria-hidden="true"
-            />
-            {attachmentsEnabled ? (
-              <AttachmentTray
-                items={attachments.items}
-                onRemove={attachments.remove}
-                onRetry={attachments.retry}
-                onClear={attachments.discardAll}
-              />
-            ) : null}
-            <textarea
-              ref={textareaRef}
-              className="composer-textarea term-compose-textarea"
-              style={textareaHeight ? { height: textareaHeight } : undefined}
-              rows={3}
-              value={draft}
-              onChange={(event) => {
-                setDraft(event.target.value);
-                if (hint) setHint(null);
-              }}
-              onKeyDown={handleKeyDown}
-              onPaste={handlePaste}
-              placeholder="Type a message"
-              aria-label="Message to send to terminal"
-              tabIndex={expanded ? 0 : -1}
-            />
-            {dragActive ? (
-              <div className="composer-drop-hint" aria-hidden="true">
-                <span className="composer-drop-glyph">⤓</span>
-                <span>Drop to attach</span>
-              </div>
-            ) : null}
-          </div>
-          <div className="term-compose-meta">
+          <div className="term-compose-rail">
             <SessionUsagePill
               session={session}
               connection={connection}
@@ -392,6 +303,26 @@ export function TerminalCompose({
               <kbd>{shortcutLabel}</kbd>
               <span>send</span>
             </span>
+          </div>
+          <div
+            className={`term-compose-field${dragActive ? " is-drag-active" : ""}${leadForced ? " lead-forced" : ""}`}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            <button
+              type="button"
+              className="term-compose-lead-expand"
+              onClick={() => {
+                setLeadForced(true);
+                textareaRef.current?.focus();
+              }}
+              aria-label="Show actions"
+              title="Show actions"
+              tabIndex={expanded ? 0 : -1}
+            >
+              ›
+            </button>
             {attachmentsEnabled ? (
               <>
                 <input
@@ -405,7 +336,7 @@ export function TerminalCompose({
                 />
                 <button
                   type="button"
-                  className="ghost composer-attach term-compose-files"
+                  className="term-compose-act term-compose-files"
                   onClick={() => setFilesOpen(true)}
                   title="Session files"
                   aria-label="Session files"
@@ -417,7 +348,7 @@ export function TerminalCompose({
                 </button>
                 <button
                   type="button"
-                  className="ghost composer-attach term-compose-attach"
+                  className="term-compose-act term-compose-attach"
                   onClick={() => fileInputRef.current?.click()}
                   title="Attach files"
                   aria-label="Attach files"
@@ -429,15 +360,52 @@ export function TerminalCompose({
                 </button>
               </>
             ) : null}
-            <button
-              type="button"
-              className="primary send term-compose-send"
-              onClick={send}
-              disabled={!canSend}
-              tabIndex={expanded ? 0 : -1}
-            >
-              {sending ? "Sending…" : "Send"}
-            </button>
+            <div className="term-compose-input">
+              {attachmentsEnabled ? (
+                <AttachmentTray
+                  items={attachments.items}
+                  onRemove={attachments.remove}
+                  onRetry={attachments.retry}
+                  onClear={attachments.discardAll}
+                />
+              ) : null}
+              <textarea
+                ref={textareaRef}
+                className="composer-textarea term-compose-textarea"
+                rows={1}
+                value={draft}
+                onChange={(event) => {
+                  setDraft(event.target.value);
+                  setLeadForced(false);
+                  if (hint) setHint(null);
+                }}
+                onBlur={() => setLeadForced(false)}
+                onKeyDown={handleKeyDown}
+                onPaste={handlePaste}
+                placeholder="Type a message"
+                aria-label="Message to send to terminal"
+                tabIndex={expanded ? 0 : -1}
+              />
+              {dragActive ? (
+                <div className="composer-drop-hint" aria-hidden="true">
+                  <span className="composer-drop-glyph">⤓</span>
+                  <span>Drop to attach</span>
+                </div>
+              ) : null}
+              <button
+                type="button"
+                className="term-compose-send"
+                onClick={send}
+                disabled={!canSend}
+                aria-label="Send"
+                title="Send"
+                tabIndex={expanded ? 0 : -1}
+              >
+                <span className="composer-send-glyph" aria-hidden>
+                  {sending ? "…" : "↑"}
+                </span>
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -24,6 +24,7 @@ import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { FileMentions } from "@/components/FileMentions";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
+import { useBackendCatalog } from "@/lib/backends";
 import {
   COMPOSER_MIN_HEIGHT,
   SHORTCUT_IS_MAC,
@@ -85,6 +86,7 @@ export function TerminalCompose({
   refocusTerminal,
 }: TerminalComposeProps) {
   const regionId = useId();
+  const catalog = useBackendCatalog(host || null, token || null, null);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
@@ -375,6 +377,7 @@ export function TerminalCompose({
             <SessionUsagePill
               session={session}
               connection={connection}
+              catalog={catalog}
               onRateLimitRefresh={onRateLimitRefresh}
               rateLimitRefreshBusy={rateLimitRefreshBusy}
               popoverContainer={popoverHost}

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -6,7 +6,7 @@ import {
   type CSSProperties,
 } from "react";
 
-import { fidelityFor, transportLabel } from "@/lib/backends";
+import { fidelityFor, transportLabel, type BackendCatalog } from "@/lib/backends";
 import { EventRecord, SessionTransport } from "@/lib/types";
 import {
   normalizeToolName,
@@ -107,6 +107,7 @@ export function PendingUserInputCard({
 interface TranscriptCardProps {
   event: EventRecord;
   transport: SessionTransport;
+  catalog?: BackendCatalog;
   pair?: ToolPair;
   onAnswerAskQuestion?: (
     text: string,
@@ -118,10 +119,11 @@ interface TranscriptCardProps {
 export const TranscriptCard = memo(function TranscriptCard({
   event,
   transport,
+  catalog,
   pair,
   onAnswerAskQuestion,
 }: TranscriptCardProps) {
-  if (fidelityFor(transport) === "structured") {
+  if (fidelityFor(transport, catalog) === "structured") {
     if (pair) {
       return (
         <ToolPairCard pair={pair} onAnswerAskQuestion={onAnswerAskQuestion} />
@@ -131,6 +133,7 @@ export const TranscriptCard = memo(function TranscriptCard({
       <StructuredCard
         event={event}
         transport={transport}
+        catalog={catalog}
         onAnswerAskQuestion={onAnswerAskQuestion}
       />
     );
@@ -141,10 +144,12 @@ export const TranscriptCard = memo(function TranscriptCard({
 function StructuredCard({
   event,
   transport,
+  catalog,
   onAnswerAskQuestion,
 }: {
   event: EventRecord;
   transport: SessionTransport;
+  catalog?: BackendCatalog;
   onAnswerAskQuestion?: (
     text: string,
     toolUseId?: string,
@@ -154,7 +159,7 @@ function StructuredCard({
   // transport label, lowercased ("Claude Cli" → "claude", "Codex App
   // Server" → "codex"). New backends inherit it for free as long as
   // their transport label leads with a single-word agent name.
-  const agentLabel = transportLabel(transport).split(" ")[0] || transport;
+  const agentLabel = transportLabel(transport, catalog).split(" ")[0] || transport;
   return (
     <CodexCard
       event={event}

--- a/frontend/src/components/UsageDashboardSection.tsx
+++ b/frontend/src/components/UsageDashboardSection.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { UsageInstrumentPanel } from "@/components/UsageInstrumentPanel";
-import { humaniseBackend } from "@/lib/backends";
+import { humaniseBackend, useBackendCatalog, type BackendCatalog } from "@/lib/backends";
 import {
   fetchUsageDashboard,
   isAuthError,
@@ -31,6 +31,7 @@ interface UsageDashboardSectionProps {
 
 function deriveBucketsFromSessions(
   sessions: SessionRecord[],
+  catalog?: BackendCatalog,
 ): UsageDashboardBucket[] {
   const buckets = new Map<string, UsageDashboardBucket>();
   for (const session of sessions) {
@@ -40,6 +41,7 @@ function deriveBucketsFromSessions(
       session.id,
       snapshot.source,
       snapshot.notes ?? [],
+      catalog,
     );
     const existing = buckets.get(key);
     if (!existing) {
@@ -65,6 +67,7 @@ function accountBucketKey(
   sessionId: string,
   source: Backend,
   notes: string[],
+  catalog?: BackendCatalog,
 ): { key: string; label: string } {
   if (source === "claude_code") {
     const org = findPrefixed(notes, "org: ");
@@ -84,7 +87,7 @@ function accountBucketKey(
   }
   return {
     key: `${source}:session:${sessionId}`,
-    label: humaniseBackend(source),
+    label: humaniseBackend(source, catalog),
   };
 }
 
@@ -187,14 +190,15 @@ export function UsageDashboardSection({
   const [refreshing, setRefreshing] = useState(false);
   const [refreshingBucketId, setRefreshingBucketId] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const catalog = useBackendCatalog(host || null, token || null, null);
 
   useEffect(() => {
     setOpen(readUsageDashboardOpen());
   }, []);
 
   useEffect(() => {
-    setBuckets(deriveBucketsFromSessions(sessions));
-  }, [sessions]);
+    setBuckets(deriveBucketsFromSessions(sessions, catalog));
+  }, [sessions, catalog]);
 
   useEffect(() => {
     if (!host || !token) return;
@@ -383,6 +387,7 @@ export function UsageDashboardSection({
                 <UsageInstrumentPanel
                   key={bucket.account_key}
                   bucket={bucket}
+                  catalog={catalog}
                   emphasis={i === 0 && buckets.length > 1 ? "primary" : "secondary"}
                   index={i}
                   onRefresh={() => handleRefreshBucket(bucket)}

--- a/frontend/src/components/UsageInstrumentPanel.tsx
+++ b/frontend/src/components/UsageInstrumentPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { UsageDial } from "@/components/UsageDial";
-import { humaniseBackend } from "@/lib/backends";
+import { humaniseBackend, type BackendCatalog } from "@/lib/backends";
 import { UsageDashboardBucket } from "@/lib/types";
 import {
   formatRateLimitWindowReset,
@@ -13,6 +13,7 @@ import {
 
 interface UsageInstrumentPanelProps {
   bucket: UsageDashboardBucket;
+  catalog?: BackendCatalog;
   emphasis?: "primary" | "secondary";
   onRefresh?: () => void | Promise<void>;
   refreshing?: boolean;
@@ -28,6 +29,7 @@ function bucketDetailNotes(bucket: UsageDashboardBucket): string[] {
 
 export function UsageInstrumentPanel({
   bucket,
+  catalog,
   emphasis = "secondary",
   onRefresh,
   refreshing = false,
@@ -58,7 +60,7 @@ export function UsageInstrumentPanel({
       <header className="usage-instrument-head">
         <div className="usage-instrument-plaque">
           <span className="usage-instrument-eyebrow">
-            {humaniseBackend(bucket.backend)}
+            {humaniseBackend(bucket.backend, catalog)}
           </span>
           <h3 className="usage-instrument-title">{bucket.account_label}</h3>
         </div>


### PR DESCRIPTION
## Summary

Two frontend changes that accumulated on this branch.

First, the backend-catalog threading fix (carried over from the `claude_tty` work): capability and label helpers were being called without the live `/api/backends` catalog at many call sites, so they fell back to a hardcoded transport set that predates `claude_tty`. That made `claude_tty` sessions render with the generic heuristic cards instead of structured chat bubbles, suppressed their tool-permission approvals entirely, and showed raw plugin ids as labels.

Second, a redesign of the message composer — both the chat reply box and the terminal quick-compose drawer — into a single native-style "command bar": a rounded input pill with the send button inside it, leading actions that collapse out of the way once you start typing, and a textarea that grows from one line instead of a fixed multi-line box. This came out of the composer eating too much vertical space and not feeling native on mobile.

## Changes

### Frontend — backend catalog threading

- Thread the already-in-scope `BackendCatalog` into every capability/label helper call (`fidelityFor`, `transportLabel`, `humaniseBackend`, `supportsStructuredApproval`, `supportsResume`): `TranscriptCard` and the approval/resume gates in `SessionDetail`, plus the session list, session switcher, usage panels, resume-thread panel, and the assistant page.
- New backends stay reachable purely through the live catalog — no per-backend branch in the frontend.

### Frontend — command-bar composer redesign

- The chat composer (`ReplyComposer` in `SessionDetail.tsx`) and the terminal quick-compose drawer (`TerminalCompose.tsx`) are now a rounded input **pill** with the send button pinned inside its bottom-right, flanked by leading action buttons (overflow `+` menu and attach for chat; files and attach for terminal).
- The leading actions **collapse to a single `›` chevron** once the field is engaged, expanding the pill. The collapse is driven purely by CSS `:focus-within` (with a JS `lead-forced` override for the chevron) so focusing the field never triggers a React re-render — that was dropping focus / dismissing the keyboard mid-gesture on iOS.
- The textarea **auto-grows** from a single line up to a cap, then scrolls; the old drag-to-resize handle and its persisted-height state are removed.
- The chat send button **morphs to a stop control** while the agent is working; terminal send stays a plain send (no agent turn to interrupt).
- Accessibility: the chevron is keyboard-focusable with a `:focus-visible` ring, and the stop-button pulse respects `prefers-reduced-motion`.
- Removed the now-dead `.composer-actions` / resize-handle / `.term-compose-meta` CSS left over from the previous composer.

## Test Plan

- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run lint` — clean.
- [x] `waypointctl restart frontend` — production build succeeds, frontend reports healthy.
- [x] Manual, iOS PWA + desktop (verified across iterations this session): composer pill sizing and button alignment, focus-collapse without focus loss, send-inside-pill, the `+` menu opening side on desktop vs the full-width bottom sheet on mobile, and the terminal quick-compose drawer.
- [x] Manual: `claude_tty` chat renders structured bubbles and its tool-permission approval dialog now surfaces (the catalog fix).
- [ ] No automated frontend test harness exists in this repo, so there is no unit coverage for these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)