### PR TITLE
feat: bring claude_tty to capability parity with claude_code

### DIFF
--- a/backend/src/waypoint/backends/claude_code/threads.py
+++ b/backend/src/waypoint/backends/claude_code/threads.py
@@ -66,6 +66,16 @@ def claude_projects_root() -> Path:
     return root / "projects"
 
 
+def encode_project_dir(cwd: str) -> str:
+    """Encode a cwd to the project-dir name Claude stores transcripts under.
+
+    Matches the CLI's lossy ``[^a-zA-Z0-9] -> '-'`` mapping (e.g. a leading-dot
+    component collapses ``/.`` to ``--``); the result is not reversible, which is
+    why discovery reads ``cwd`` from the records rather than decoding the name.
+    """
+    return re.sub(r"[^a-zA-Z0-9]", "-", cwd)
+
+
 def list_local_claude_threads() -> list[ClaudeThreadInfo]:
     """Enumerate resumable Claude sessions on the local filesystem.
 

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -27,10 +27,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.claude_code.models import (
+    CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
 )
@@ -38,9 +39,19 @@ from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_PERMISSION_MODE_SPECS,
     CLAUDE_PERMISSION_MODES,
 )
+from waypoint.backends.claude_code.plugin import _claude_effort_swap_message
 from waypoint.backends.claude_code.rate_limits import (
     probe_claude_usage,
     probe_claude_usage_remote,
+)
+from waypoint.backends.claude_code.schemas import (
+    ClaudeThreadImportRequest,
+    ClaudeThreadSummary,
+)
+from waypoint.backends.claude_code.threads import (
+    ClaudeThreadInfo,
+    find_local_claude_thread,
+    list_local_claude_threads,
 )
 from waypoint.backends.claude_tty._state import PendingTtyApproval
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
@@ -64,6 +75,23 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("waypoint.backends.claude_tty")
 
+# Sentinel distinguishing "argument not passed" from "explicitly set to None"
+# in the control-swap helper, so a caller can clear a flag (effort=None) while
+# the unspecified flags keep the session's current value.
+_UNSET: Any = object()
+
+# CLI flags Waypoint owns; users may not smuggle them in through custom args.
+_RESERVED_CLI_FLAGS = frozenset(
+    {
+        "--session-id",
+        "--resume",
+        "--fork-session",
+        "--model",
+        "--effort",
+        "--permission-mode",
+    }
+)
+
 
 class ClaudeTtyPluginConfig(PluginConfig):
     """Configuration for the claude_tty plugin.
@@ -83,6 +111,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
     id = "claude_tty"
     transport_id = "claude_tty"
     label = "Claude TUI"
+    import_request_schema: type[BaseModel] | None = ClaudeThreadImportRequest
     config_schema: type[PluginConfig] = ClaudeTtyPluginConfig
     extra_env = {"CLAUDE_CODE_NO_FLICKER": "1"}
     capabilities = BackendCapabilities(
@@ -91,9 +120,16 @@ class ClaudeTtyPlugin(TmuxPlugin):
         supports_reattach_after_exit=True,
         supports_fork=True,
         supports_attachments=True,
-        supports_set_model_inline=False,
+        # All control swaps restart the pane with `--resume <thread>` and a
+        # rebuilt flag set; none of them mutate a live process inline.
+        supports_set_model_inline=True,
         supports_set_effort_inline=False,
-        supports_set_permission_mode_inline=False,
+        supports_set_effort_with_restart=True,
+        supports_set_permission_mode_inline=True,
+        supports_custom_cli_args=True,
+        supports_thread_discovery=True,
+        supports_thread_import=True,
+        effort_levels=CLAUDE_EFFORT_LEVELS,
         model_source=ModelSource.STATIC,
         permission_modes=CLAUDE_PERMISSION_MODE_SPECS,
         badges={"glyph": "C", "color": "#a78bfa"},
@@ -222,6 +258,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
         resolved_model: str | None,
         resolved_effort: str | None,
     ) -> SessionRecord:
+        _validate_custom_args(request.args)
         thread_id = str(uuid.uuid4())
         launch_args = _build_launch_args(
             thread_id=thread_id,
@@ -513,6 +550,288 @@ class ClaudeTtyPlugin(TmuxPlugin):
         self._spawn_rate_limit_watcher(runtime, new_session)
         return runtime.get_session(new_session_id)
 
+    # ── Control swaps (restart-with-resume) ──────────────────────────────────
+
+    async def apply_model(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        model: str | None,
+    ) -> None:
+        await self._restart_with_args(runtime, session, model=model)
+
+    async def apply_permission_mode(
+        self, runtime: "SessionRuntime", session: SessionRecord, mode: str
+    ) -> None:
+        await self._restart_with_args(runtime, session, permission_mode=mode)
+
+    async def apply_effort(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        effort: str | None,
+    ) -> bool:
+        return await self._restart_with_args(runtime, session, effort=effort)
+
+    def effort_swap_message(self, effort: str | None) -> str:
+        return _claude_effort_swap_message(effort)
+
+    async def _restart_with_args(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        *,
+        model: Any = _UNSET,
+        effort: Any = _UNSET,
+        permission_mode: Any = _UNSET,
+    ) -> bool:
+        """Relaunch the pane with ``--resume <thread>`` and a rebuilt flag set.
+
+        Claude's TUI has no in-process knob for model/effort/permission mode,
+        so every swap kills the pane and respawns ``claude --resume <thread>``
+        with the merged flags. Only the kwargs the caller passes change; the
+        others keep the session's current value. Returns ``True`` when a
+        restart happened, ``False`` when the requested value was already
+        active (so ``set_effort`` knows not to announce a no-op swap).
+        """
+        field = (
+            "model"
+            if model is not _UNSET
+            else "effort" if effort is not _UNSET else "permission mode"
+        )
+        if session.status is not SessionStatus.IDLE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"cannot change {field} while the session is running",
+            )
+
+        new_model = session.model if model is _UNSET else model
+        new_effort = session.effort if effort is _UNSET else effort
+        new_permission_mode = (
+            session.permission_mode if permission_mode is _UNSET else permission_mode
+        )
+        current = (
+            session.model or None,
+            session.effort or None,
+            session.permission_mode or None,
+        )
+        merged = (new_model or None, new_effort or None, new_permission_mode or None)
+        if merged == current:
+            return False
+
+        state = session.transport_state
+        thread_id = state.get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="claude_tty session has no thread id to resume",
+            )
+
+        old_tmux_session = state.get("tmux_session")
+        if old_tmux_session:
+            with suppress(TmuxError):
+                await runtime.tmux.kill_session(old_tmux_session)
+        self._pending_approvals.pop(session.id, None)
+        tailer_task = self._tailer_tasks.pop(session.id, None)
+        if tailer_task is not None:
+            tailer_task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await tailer_task
+
+        stored_args = state.get("launch_args")
+        base_args = _scrub_session_args(
+            stored_args if isinstance(stored_args, list) else []
+        )
+        flag_pairs: list[str] = []
+        if merged[0]:
+            flag_pairs += ["--model", merged[0]]
+        if merged[1]:
+            flag_pairs += ["--effort", merged[1]]
+        if merged[2]:
+            flag_pairs += ["--permission-mode", merged[2]]
+        launch_args = ["--resume", thread_id, *flag_pairs, *base_args]
+
+        launch_target = runtime._find_launch_target(session.launch_target_id)
+        command = runtime._command_for_backend(
+            self.id,
+            launch_args,
+            launch_target,
+            session.cwd,
+            allocate_tty=True,
+            session_id=session.id,
+        )
+        raw_log = Path(session.raw_log_path)
+        with suppress(OSError):
+            raw_log.parent.mkdir(parents=True, exist_ok=True)
+            raw_log.write_bytes(b"")
+        try:
+            target = await runtime.tmux.start_managed_session(
+                session.id, session.cwd, command
+            )
+            await runtime.tmux.pipe_output(target.pane, raw_log)
+        except TmuxError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+        with suppress(TmuxError):
+            await runtime.tmux.resize_window(target.session, 120, 50)
+
+        new_state: dict[str, Any] = {
+            "tmux_session": target.session,
+            "tmux_window": target.window,
+            "tmux_pane": target.pane,
+            "pid": target.pane_pid,
+            "thread_id": thread_id,
+            "launch_args": launch_args,
+        }
+        runtime.storage.update_session(
+            session.id, transport_state=new_state, status=SessionStatus.STARTING
+        )
+        await runtime._record_system_event(
+            session.id,
+            f"Restarted Claude TUI session to apply {field} change (thread {thread_id})",
+            status=SessionStatus.IDLE,
+        )
+        # The resumed thread reopens its already-populated transcript, whose
+        # records are in the event DB; tail from the end so they aren't replayed.
+        self._start_tailer(
+            runtime, session.id, thread_id, session.cwd, start_at_end=True
+        )
+        return True
+
+    # ── Thread discovery + import ────────────────────────────────────────────
+
+    def _thread_summary(self, info: ClaudeThreadInfo) -> ClaudeThreadSummary:
+        return ClaudeThreadSummary(
+            id=info.id,
+            title=info.title,
+            cwd=info.cwd,
+            repo_name=info.repo_name,
+            branch=info.branch,
+            preview=info.preview,
+            created_at=info.created_at,
+            updated_at=info.updated_at,
+        )
+
+    def _imported_thread_ids(self, runtime: "SessionRuntime") -> set[str]:
+        imported: set[str] = set()
+        for session in runtime.storage.list_sessions():
+            if session.backend != self.id:
+                continue
+            thread_id = session.transport_state.get("thread_id")
+            if isinstance(thread_id, str) and thread_id:
+                imported.add(thread_id)
+        return imported
+
+    async def list_threads(
+        self,
+        runtime: "SessionRuntime",
+        launch_target_id: str | None = None,
+    ) -> list[ClaudeThreadSummary]:
+        # Remote enumeration is a follow-up; only the local store is read here.
+        if launch_target_id is not None:
+            return []
+        infos = await asyncio.to_thread(list_local_claude_threads)
+        imported = self._imported_thread_ids(runtime)
+        return [self._thread_summary(info) for info in infos if info.id not in imported]
+
+    async def import_thread(
+        self,
+        runtime: "SessionRuntime",
+        request: ClaudeThreadImportRequest,
+    ) -> SessionRecord:
+        if request.launch_target_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="remote import not yet supported for claude_tty",
+            )
+        info = await asyncio.to_thread(find_local_claude_thread, request.thread_id)
+        if info is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="claude thread not found",
+            )
+        cwd_path = Path(info.cwd).expanduser()
+        if not cwd_path.exists():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"claude thread cwd {info.cwd} no longer exists; cannot resume",
+            )
+        if request.thread_id in self._imported_thread_ids(runtime):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="claude thread already imported",
+            )
+        cwd = str(cwd_path)
+        launch_args = ["--resume", request.thread_id]
+        session_id = runtime._generate_session_id(self.id)
+        session_dir = runtime._session_dir(session_id)
+        raw_log = session_dir / "raw.log"
+        structured_log = session_dir / "events.jsonl"
+        raw_log.parent.mkdir(parents=True, exist_ok=True)
+        raw_log.touch(exist_ok=True)
+        try:
+            command = runtime._command_for_backend(
+                self.id,
+                launch_args,
+                None,
+                cwd,
+                allocate_tty=True,
+                session_id=session_id,
+            )
+        except HTTPException:
+            raise
+        try:
+            target = await runtime.tmux.start_managed_session(session_id, cwd, command)
+            await runtime.tmux.pipe_output(target.pane, raw_log)
+        except TmuxError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+        with suppress(TmuxError):
+            await runtime.tmux.resize_window(target.session, 120, 50)
+
+        now = datetime.now(UTC)
+        session = SessionRecord(
+            id=session_id,
+            backend=self.id,
+            source=SessionSource.MANAGED,
+            transport=self.transport_id,
+            title=info.title,
+            cwd=cwd,
+            launch_target_id=None,
+            repo_name=info.repo_name,
+            branch=info.branch,
+            status=SessionStatus.STARTING,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={
+                "tmux_session": target.session,
+                "tmux_window": target.window,
+                "tmux_pane": target.pane,
+                "pid": target.pane_pid,
+                "thread_id": request.thread_id,
+                "launch_args": launch_args,
+            },
+        )
+        runtime.storage.create_session(session)
+        await runtime._record_system_event(
+            session.id,
+            f"Imported stored Claude thread ({cwd})",
+            status=SessionStatus.IDLE,
+            metadata={"imported_thread_id": request.thread_id},
+        )
+        # The resumed thread reopens an already-populated transcript; tail from
+        # the end so records already on disk are not replayed into the DB.
+        self._start_tailer(
+            runtime, session.id, request.thread_id, cwd, start_at_end=True
+        )
+        self._spawn_rate_limit_watcher(runtime, session)
+        return runtime.get_session(session.id)
+
 
 def _build_launch_args(
     *,
@@ -534,17 +853,50 @@ def _build_launch_args(
 
 
 def _scrub_session_args(args: list[str]) -> list[str]:
-    """Strip ``--session-id`` and ``--resume`` (plus their value) from args."""
+    """Strip Waypoint-managed flags (and their values) from stored args.
+
+    Removes the thread-identity flags (``--session-id``/``--resume``/
+    ``--fork-session``) and the control flags (``--model``/``--effort``/
+    ``--permission-mode``) so a restart can rebuild them from the merged
+    session state. Custom user args pass through untouched.
+    """
+    valued = {
+        "--session-id",
+        "--resume",
+        "--model",
+        "--effort",
+        "--permission-mode",
+    }
     result: list[str] = []
     skip = 0
     for arg in args:
         if skip:
             skip -= 1
             continue
-        if arg in ("--session-id", "--resume", "--fork-session"):
-            # --fork-session has no value argument; --session-id and --resume do
-            if arg != "--fork-session":
-                skip = 1
+        if arg == "--fork-session":
+            # Valueless toggle; drop it on its own.
+            continue
+        if arg in valued:
+            skip = 1
             continue
         result.append(arg)
     return result
+
+
+def _validate_custom_args(args: list[str]) -> None:
+    """Reject Waypoint-managed flags supplied as custom CLI args.
+
+    Thread identity and the model/effort/permission knobs are rebuilt by the
+    plugin on every launch and restart; letting a user pin them through
+    ``args`` would desync the stored session state from the live pane.
+    """
+    for arg in args:
+        flag = arg.split("=", 1)[0]
+        if flag in _RESERVED_CLI_FLAGS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"{flag} is managed by Waypoint and cannot be passed "
+                    "as a custom CLI arg"
+                ),
+            )

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -714,6 +714,10 @@ class ClaudeTtyPlugin(TmuxPlugin):
         )
 
     def _imported_thread_ids(self, runtime: "SessionRuntime") -> set[str]:
+        # Keyed on thread_id alone, which is sufficient only because claude_tty
+        # imports the local store exclusively. If remote enumeration lands, switch
+        # to a (launch_target_id, thread_id) key so a local import cannot mask the
+        # same thread on a remote target (cf. claude_code's dedup).
         imported: set[str] = set()
         for session in runtime.storage.list_sessions():
             if session.backend != self.id:

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -17,6 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from waypoint.backends.claude_code.normalize import format_approval_text
+from waypoint.backends.claude_code.threads import (
+    claude_projects_root,
+    encode_project_dir,
+)
 from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval
 from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
@@ -36,9 +40,14 @@ _DIALOG_STABLE_TICKS = 2  # consecutive identical captures before surfacing
 
 
 def transcript_path(cwd: str, session_uuid: str) -> Path:
-    """Return the Claude TUI's JSONL transcript path for the given session."""
-    dashed = cwd.replace("/", "-")
-    return Path.home() / ".claude" / "projects" / dashed / f"{session_uuid}.jsonl"
+    """Return the Claude TUI's JSONL transcript path for the given session.
+
+    Resolves the store root and the encoded project-dir name through the same
+    helpers thread discovery uses, so the tailed path matches where the CLI
+    actually writes — including for cwds with non-slash special characters
+    (hidden dirs, worktrees) and a non-default ``$CLAUDE_CONFIG_DIR``.
+    """
+    return claude_projects_root() / encode_project_dir(cwd) / f"{session_uuid}.jsonl"
 
 
 class TranscriptTailer:

--- a/backend/tests/test_claude_threads.py
+++ b/backend/tests/test_claude_threads.py
@@ -7,6 +7,7 @@ import pytest
 
 from waypoint.backends.claude_code.threads import (
     claude_projects_root,
+    encode_project_dir,
     find_local_claude_thread,
     list_local_claude_threads,
 )
@@ -48,6 +49,20 @@ def claude_root(tmp_path, monkeypatch) -> Path:
 def test_claude_projects_root_honors_env(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "alt"))
     assert claude_projects_root() == tmp_path / "alt" / "projects"
+
+
+@pytest.mark.parametrize(
+    "cwd, expected",
+    [
+        ("/home/user/waypoint", "-home-user-waypoint"),
+        # Leading-dot (hidden) component collapses `/.` to `--`; a naive
+        # str.replace("/", "-") would leave the dot and miss the real dir.
+        ("/home/user/.wq/task-1", "-home-user--wq-task-1"),
+        ("/tmp/a.b_c:d", "-tmp-a-b-c-d"),
+    ],
+)
+def test_encode_project_dir_matches_cli_encoding(cwd, expected) -> None:
+    assert encode_project_dir(cwd) == expected
 
 
 def test_list_local_claude_threads_extracts_metadata(claude_root) -> None:

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -1,0 +1,402 @@
+"""Unit tests for claude_tty control swaps, custom args, and thread import.
+
+claude_tty has no in-process knobs: model/effort/permission-mode swaps all
+relaunch the pane with ``--resume <thread>`` and a rebuilt flag set. These
+tests cover the arg scrubber, the restart helper (idle guard, no-op
+short-circuit, flag rebuild), the effort return contract, custom-arg
+validation, thread-discovery dedup, and the resume-import path — all against
+fakes so no live TUI/tmux is needed.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from waypoint.backends.claude_code.schemas import ClaudeThreadImportRequest
+from waypoint.backends.claude_code.threads import ClaudeThreadInfo
+from waypoint.backends.claude_tty import plugin as plugin_mod
+from waypoint.backends.claude_tty.plugin import (
+    ClaudeTtyPlugin,
+    _scrub_session_args,
+    _validate_custom_args,
+)
+from waypoint.schemas import (
+    SessionCreateRequest,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+
+
+def _make_session(
+    *,
+    session_id: str = "sess-1",
+    status: SessionStatus = SessionStatus.IDLE,
+    model: str | None = None,
+    effort: str | None = None,
+    permission_mode: str | None = None,
+    launch_args: list[str] | None = None,
+    thread_id: str | None = "thread-1",
+) -> SessionRecord:
+    now = datetime.now(UTC)
+    state: dict[str, object] = {
+        "tmux_session": session_id,
+        "tmux_window": "0",
+        "tmux_pane": "%0",
+        "launch_args": (
+            launch_args if launch_args is not None else ["--session-id", "thread-1"]
+        ),
+    }
+    if thread_id is not None:
+        state["thread_id"] = thread_id
+    return SessionRecord(
+        id=session_id,
+        backend="claude_tty",
+        source=SessionSource.MANAGED,
+        transport="claude_tty",
+        title="test",
+        cwd="/tmp",
+        status=status,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/structured.log",
+        transport_state=state,
+        model=model,
+        effort=effort,
+        permission_mode=permission_mode,
+    )
+
+
+def _restart_runtime() -> tuple[MagicMock, MagicMock]:
+    target = MagicMock(session="s-new", window="0", pane="%9", pane_pid=123)
+    runtime = MagicMock()
+    runtime.tmux.kill_session = AsyncMock()
+    runtime.tmux.start_managed_session = AsyncMock(return_value=target)
+    runtime.tmux.pipe_output = AsyncMock()
+    runtime.tmux.resize_window = AsyncMock()
+    runtime._find_launch_target.return_value = None
+    runtime._command_for_backend.return_value = ["claude", "--resume", "thread-1"]
+    runtime._record_system_event = AsyncMock()
+    runtime.storage.update_session = MagicMock()
+    return runtime, target
+
+
+def _stub_lifecycle(plugin: ClaudeTtyPlugin) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    def _fake_start_tailer(
+        runtime: object,
+        session_id: str,
+        thread_id: str,
+        cwd: str,
+        *,
+        start_at_end: bool = False,
+    ) -> None:
+        captured["tailer_thread_id"] = thread_id
+        captured["start_at_end"] = start_at_end
+
+    plugin._start_tailer = _fake_start_tailer  # type: ignore[method-assign]
+    plugin._spawn_rate_limit_watcher = MagicMock()  # type: ignore[method-assign]
+    return captured
+
+
+# ── _scrub_session_args ───────────────────────────────────────────────────────
+
+
+def test_scrub_strips_managed_flags_keeps_custom() -> None:
+    args = [
+        "--session-id",
+        "uuid-1",
+        "--model",
+        "opus",
+        "--effort",
+        "high",
+        "--permission-mode",
+        "plan",
+        "--fork-session",
+        "--verbose",
+        "--add-dir",
+        "/work",
+    ]
+    assert _scrub_session_args(args) == ["--verbose", "--add-dir", "/work"]
+
+
+def test_scrub_strips_resume() -> None:
+    assert _scrub_session_args(["--resume", "uuid-1", "--keep"]) == ["--keep"]
+
+
+# ── _restart_with_args ────────────────────────────────────────────────────────
+
+
+async def test_restart_idle_guard_raises_when_running() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(status=SessionStatus.RUNNING, model="opus")
+    runtime, _ = _restart_runtime()
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin._restart_with_args(runtime, session, model="sonnet")
+
+    assert exc.value.status_code == 400
+    assert "model" in exc.value.detail
+    runtime.tmux.start_managed_session.assert_not_called()
+
+
+async def test_restart_unchanged_value_returns_false_without_relaunch() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(model="opus")
+    runtime, _ = _restart_runtime()
+
+    result = await plugin._restart_with_args(runtime, session, model="opus")
+
+    assert result is False
+    runtime.tmux.kill_session.assert_not_called()
+    runtime.tmux.start_managed_session.assert_not_called()
+    runtime.storage.update_session.assert_not_called()
+
+
+async def test_restart_rebuilds_resume_flags_preserving_custom_args() -> None:
+    plugin = ClaudeTtyPlugin()
+    captured = _stub_lifecycle(plugin)
+    session = _make_session(
+        model="opus",
+        effort="high",
+        launch_args=["--session-id", "thread-1", "--model", "opus", "--verbose"],
+    )
+    runtime, _ = _restart_runtime()
+
+    result = await plugin._restart_with_args(runtime, session, model="sonnet")
+
+    assert result is True
+    # New value plus the untouched effort, custom arg survives, identity flag dropped.
+    built_args = runtime._command_for_backend.call_args.args[1]
+    assert built_args == [
+        "--resume",
+        "thread-1",
+        "--model",
+        "sonnet",
+        "--effort",
+        "high",
+        "--verbose",
+    ]
+    runtime.tmux.kill_session.assert_awaited_once()
+    # Stored state carries the rebuilt args and the new tmux ids.
+    update_kwargs = runtime.storage.update_session.call_args.kwargs
+    assert update_kwargs["status"] is SessionStatus.STARTING
+    assert update_kwargs["transport_state"]["launch_args"] == built_args
+    assert update_kwargs["transport_state"]["thread_id"] == "thread-1"
+    # Resumed transcript is already populated → tail from the end.
+    assert captured["start_at_end"] is True
+
+
+async def test_restart_clears_pending_approval_and_tailer() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    plugin._pending_approvals["sess-1"] = MagicMock()
+    session = _make_session(model="opus")
+    runtime, _ = _restart_runtime()
+
+    await plugin._restart_with_args(runtime, session, model="sonnet")
+
+    assert "sess-1" not in plugin._pending_approvals
+
+
+# ── apply_effort return contract ──────────────────────────────────────────────
+
+
+async def test_apply_effort_returns_true_on_change() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(effort="low")
+    runtime, _ = _restart_runtime()
+
+    assert await plugin.apply_effort(runtime, session, "high") is True
+
+
+async def test_apply_effort_returns_false_when_unchanged() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(effort="high")
+    runtime, _ = _restart_runtime()
+
+    assert await plugin.apply_effort(runtime, session, "high") is False
+    runtime.tmux.start_managed_session.assert_not_called()
+
+
+# ── custom CLI args validation ────────────────────────────────────────────────
+
+
+def test_validate_custom_args_rejects_reserved() -> None:
+    for arg in ("--model=opus", "--resume", "--session-id", "--permission-mode"):
+        with pytest.raises(HTTPException) as exc:
+            _validate_custom_args([arg])
+        assert exc.value.status_code == 400
+
+
+def test_validate_custom_args_allows_passthrough() -> None:
+    _validate_custom_args(["--verbose", "--add-dir", "/work"])
+
+
+async def test_create_session_rejects_reserved_flags() -> None:
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+    request = SessionCreateRequest(
+        backend="claude_tty", cwd="/tmp", args=["--model", "opus"]
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.create_session(
+            runtime,
+            request,
+            session_id="sess-1",
+            launch_target=None,
+            title="t",
+            raw_log=Path("/tmp/raw.log"),
+            structured_log=Path("/tmp/events.jsonl"),
+            git_meta=MagicMock(repo_name=None, branch=None),
+            permission_mode=None,
+            resolved_model=None,
+            resolved_effort=None,
+        )
+
+    assert exc.value.status_code == 400
+    # Bailed before touching tmux.
+    runtime.tmux.start_managed_session.assert_not_called()
+
+
+# ── list_threads dedup ────────────────────────────────────────────────────────
+
+
+def _thread_info(thread_id: str) -> ClaudeThreadInfo:
+    now = datetime.now(UTC)
+    return ClaudeThreadInfo(
+        id=thread_id,
+        cwd="/work",
+        title=f"thread {thread_id}",
+        branch=None,
+        repo_name="work",
+        preview="hello",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def test_list_threads_dedups_imported(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        plugin_mod,
+        "list_local_claude_threads",
+        lambda: [_thread_info("t-a"), _thread_info("t-b")],
+    )
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+    runtime.storage.list_sessions.return_value = [
+        _make_session(session_id="s1", thread_id="t-a"),
+    ]
+
+    summaries = await plugin.list_threads(runtime)
+
+    assert [s.id for s in summaries] == ["t-b"]
+
+
+async def test_list_threads_remote_returns_empty() -> None:
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+
+    assert await plugin.list_threads(runtime, launch_target_id="remote") == []
+
+
+# ── import_thread ─────────────────────────────────────────────────────────────
+
+
+async def test_import_thread_resumes_and_starts_tailer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    info = _thread_info("imp-1")
+    info.cwd = str(tmp_path)
+    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: info)
+    plugin = ClaudeTtyPlugin()
+    captured = _stub_lifecycle(plugin)
+
+    target = MagicMock(session="s", window="0", pane="%1", pane_pid=7)
+    runtime = MagicMock()
+    runtime._generate_session_id.return_value = "claude_tty-abcd"
+    runtime._session_dir.return_value = tmp_path
+    runtime._command_for_backend.return_value = ["claude", "--resume", "imp-1"]
+    runtime.tmux.start_managed_session = AsyncMock(return_value=target)
+    runtime.tmux.pipe_output = AsyncMock()
+    runtime.tmux.resize_window = AsyncMock()
+    runtime.storage.list_sessions.return_value = []
+    runtime.storage.create_session = MagicMock()
+    runtime._record_system_event = AsyncMock()
+    created_holder: dict[str, SessionRecord] = {}
+
+    def _create(session: SessionRecord) -> None:
+        created_holder["session"] = session
+
+    runtime.storage.create_session.side_effect = _create
+    runtime.get_session.side_effect = lambda sid: created_holder["session"]
+
+    request = ClaudeThreadImportRequest(thread_id="imp-1")
+    result = await plugin.import_thread(runtime, request)
+
+    assert result.transport_state["thread_id"] == "imp-1"
+    assert result.transport_state["launch_args"] == ["--resume", "imp-1"]
+    assert result.backend == "claude_tty"
+    # Resume tails from the end of the already-populated transcript.
+    assert captured["tailer_thread_id"] == "imp-1"
+    assert captured["start_at_end"] is True
+    # Resumed thread import recorded with provenance metadata.
+    meta = runtime._record_system_event.call_args.kwargs["metadata"]
+    assert meta["imported_thread_id"] == "imp-1"
+
+
+async def test_import_thread_missing_raises_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: None)
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.import_thread(runtime, ClaudeThreadImportRequest(thread_id="gone"))
+
+    assert exc.value.status_code == 404
+
+
+async def test_import_thread_already_imported_raises_400(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    info = _thread_info("dup-1")
+    info.cwd = str(tmp_path)
+    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: info)
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+    runtime.storage.list_sessions.return_value = [
+        _make_session(session_id="s1", thread_id="dup-1"),
+    ]
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.import_thread(
+            runtime, ClaudeThreadImportRequest(thread_id="dup-1")
+        )
+
+    assert exc.value.status_code == 400
+
+
+async def test_import_thread_remote_not_supported() -> None:
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.import_thread(
+            runtime,
+            ClaudeThreadImportRequest(thread_id="x", launch_target_id="remote"),
+        )
+
+    assert exc.value.status_code == 400

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -128,7 +128,7 @@ mechanisms behind it:
 | `claude_tty` | Claude fullscreen TUI in tmux, tailed from transcript JSONL | Static Claude model catalogue; restart-with-resume while idle | `low` / `medium` / `high` / `xhigh`; restart-with-resume while idle | Claude permission-mode catalogue; restart-with-resume while idle | Discovers and imports Claude transcripts | Yes | No |
 | `codex` | App Server SDK | Live `model/list` RPC | Per-turn flag from live model metadata | Codex permission-mode catalogue; applied inline | Discovers and imports Codex threads | Yes | No |
 | `opencode` | OpenCode REST + SSE | Live OpenCode metadata | Backend-native setting | OpenCode permission-mode catalogue; applied inline | Discovers and imports OpenCode sessions | Yes | Yes, on decline |
-| `tmux` | Generic tmux pane | None | None | None | None | Yes | No |
+| `tmux` | Generic tmux pane | None | None | None | None | No | No |
 
 `claude_tty` applies model, effort, and permission-mode swaps by
 relaunching the pane with `claude --resume <thread>` plus the selected

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -45,6 +45,11 @@ backend/src/waypoint/
     │   ├── support.py        ← host-side support bundle (thread enumerator)
     │   ├── threads.py        ← local thread enumeration
     │   └── threads_remote.py ← SSH thread enumeration
+    ├── claude_tty/
+    │   ├── plugin.py
+    │   ├── transport.py      ← tmux-pane input + approval driver
+    │   ├── tailer.py         ← Claude transcript tailer
+    │   └── normalize.py      ← transcript JSONL → EventEnvelope helpers
     ├── codex/
     │   ├── plugin.py
     │   ├── adapter.py        ← App Server SDK driver
@@ -94,9 +99,14 @@ plugin without calling into it:
 | `supports_terminate` | `bool` | Reserved; today every plugin returns `True`. |
 | `supports_set_model_inline` | `bool` | Gates the model picker in the composer + the `/api/sessions/{id}/model` endpoint. |
 | `supports_set_effort_inline` | `bool` | Gates the effort picker. Set `False` if effort changes require a session restart (Claude); the runtime still routes through your `apply_effort`, which decides whether to short-circuit. |
+| `supports_set_effort_with_restart` | `bool` | Gates effort changes that restart and resume the backend between turns instead of applying the value mid-stream. |
 | `supports_set_permission_mode_inline` | `bool` | Gates the permission-mode picker + the `/api/sessions/{id}/mode` endpoint. |
 | `supports_thread_discovery` | `bool` | Enables `GET /api/backends/{id}/threads`. |
 | `supports_thread_import` | `bool` | Enables `POST /api/backends/{id}/sessions/import`. |
+| `supports_fork` | `bool` | Enables creating a new session from an existing backend thread. |
+| `supports_approval_note` | `bool` | Allows the approval response form to send a reviewer note back to the backend on decline. |
+| `supports_attachments` | `bool` | Enables uploaded attachments in the composer for transports that can deliver paths or native image/file payloads. |
+| `supports_custom_cli_args` | `bool` | Allows launch requests and configured targets to pass extra raw CLI arguments to the backend binary. |
 | `supports_slash_compact` | `bool` | Frontend hint that `/compact` is meaningful for this backend. |
 | `permission_modes` | `tuple[PermissionModeSpec, ...]` | Drives the picker, scheduler validation, and the catalog payload. |
 | `effort_levels` | `tuple[str, ...]` | Empty tuple means "discovered per-model from the live model list" (Codex). |
@@ -106,6 +116,30 @@ plugin without calling into it:
 | `badges` | `dict[str, str]` | UI palette: `{"glyph": "X", "color": "#34d399"}`. |
 | `cli_binary` | `str \| None` | Default CLI invoked for local launches and for tmux fallback launches; `None` opts out. Override per-deployment via `plugin_configs.<id>.local_bin` (local) or `ssh_targets[*].plugin_configs.<id>.remote_bin` (per SSH target). |
 | `target_aliases` | `tuple[str, ...]` | Substrings used to infer this backend from a tmux pane name. |
+
+### Built-in backend capability profiles
+
+The built-in plugins expose the same contract but use different
+mechanisms behind it:
+
+| Backend | Transport | Models | Effort | Permission mode | Threads | Custom CLI args | Approval notes |
+|---------|-----------|--------|--------|-----------------|---------|-----------------|----------------|
+| `claude_code` | Claude stream-json subprocess | Static Claude model catalogue; swaps through the CLI control protocol | `low` / `medium` / `high` / `xhigh`; restart-with-resume while idle | Claude permission-mode catalogue; swaps through the CLI control protocol | Discovers and imports Claude transcripts | Yes | Yes, on decline |
+| `claude_tty` | Claude fullscreen TUI in tmux, tailed from transcript JSONL | Static Claude model catalogue; restart-with-resume while idle | `low` / `medium` / `high` / `xhigh`; restart-with-resume while idle | Claude permission-mode catalogue; restart-with-resume while idle | Discovers and imports Claude transcripts | Yes | No |
+| `codex` | App Server SDK | Live `model/list` RPC | Per-turn flag from live model metadata | Codex permission-mode catalogue; applied inline | Discovers and imports Codex threads | Yes | No |
+| `opencode` | OpenCode REST + SSE | Live OpenCode metadata | Backend-native setting | OpenCode permission-mode catalogue; applied inline | Discovers and imports OpenCode sessions | Yes | Yes, on decline |
+| `tmux` | Generic tmux pane | None | None | None | None | Yes | No |
+
+`claude_tty` applies model, effort, and permission-mode swaps by
+relaunching the pane with `claude --resume <thread>` plus the selected
+`--model`, `--effort`, and `--permission-mode` flags while the session
+is idle. That is deliberately different from `claude_code`, which can
+send model and permission changes over Claude's stdio control protocol
+and uses restart-with-resume only for effort changes.
+
+Thread discovery/import for `claude_tty` reads the same
+`~/.claude/projects` transcript store as `claude_code`, so the same
+Claude threads appear under both backend ids.
 
 ### Transport view
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7963,11 +7963,10 @@ html[data-theme="light"] .terminal {
 }
 
 .term-bar {
-  /* position+z-index creates a stacking context for the bar so the
-     ``.composer-overflow-menu`` (z-index: 30, position: absolute)
-     inside ``.term-bar-overflow`` paints above .term-stage's content
-     — xterm's canvases sit there at z-index: auto and would otherwise
-     win on document order when the bar isn't a stacking context. */
+  /* Keep the bar above .term-stage's xterm canvases (which sit at
+     z-index: auto) so the triggers and their hover states are never
+     painted under the pane content. The popovers themselves are portaled
+     to the body, so they escape this stacking context entirely. */
   position: relative;
   z-index: 2;
   display: flex;
@@ -8048,47 +8047,15 @@ html[data-theme="light"] .term-bar-action.primary {
   color: var(--danger);
 }
 
-/* The .term-bar-overflow wraps the trigger and popover, mirroring
-   .composer-overflow on the chat composer so the two surfaces share
-   visual + structural vocabulary. We reuse .composer-overflow-trigger
-   and .composer-overflow-menu/-item styles directly; the only override
-   here flips the menu from "floats above" (composer is at the bottom of
-   the page) to "drops below" (term-bar is at the top of the pane). */
+/* The .term-bar-overflow wraps the trigger, mirroring .composer-overflow
+   on the chat composer so the two surfaces share visual + structural
+   vocabulary. The term-bar's usage panel and overflow menu both drop out
+   of the bar, and .session-terminal's overflow: hidden would clip an
+   in-pane absolute popover to the pane — so both are portaled to the body
+   and positioned fixed against their trigger (see usePopoverAnchor). */
 .term-bar-overflow {
   position: relative;
   flex: 0 0 auto;
-}
-
-.term-bar-overflow-menu {
-  top: calc(100% + 8px);
-  bottom: auto;
-}
-
-/* The usage pill in the term-bar lives at the top-left of the terminal
-   pane, so the popover must drop downward (the composer variant floats
-   up because it sits at the bottom of the chat surface). .session-terminal
-   has overflow: hidden, which would clip an upward-floating popover
-   entirely; dropping below renders the panel inside the pane's clipped
-   region instead. Anchor to the pill's left edge so a 440px panel
-   doesn't shoot off-screen leftward on a left-aligned trigger. */
-.term-bar .usage-panel {
-  top: calc(100% + 10px);
-  bottom: auto;
-  left: 0;
-  right: auto;
-  /* Above .term-stage's xterm canvases regardless of how their own
-     internal stacking contexts shake out. */
-  z-index: 50;
-}
-
-/* On narrow screens the 440px panel + left-anchor would clip the right
-   edge. Pin the right side too so the panel flexes within the term-bar's
-   width and the popover stays fully visible. */
-@media (max-width: 720px) {
-  .term-bar .usage-panel {
-    right: 8px;
-    width: auto;
-  }
 }
 
 .term-stage {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8651,33 +8651,6 @@ html[data-theme="light"] .term-compose-input {
   }
 }
 
-.term-compose-meta-spacer {
-  flex: 1 1 auto;
-}
-
-/* SessionUsagePill portals its panel into ``.term-compose`` to escape
-   the ``overflow: hidden`` on ``.term-compose-inner`` (without the
-   portal the panel is clipped at the textarea boundary regardless of
-   z-index). Once portaled, the panel positions against the drawer's
-   outer box: float upward above the drawer, anchor to the left to
-   match the pill's left-aligned home in the meta row, and float over
-   the term-stage above the drawer. */
-.term-compose > .usage-panel {
-  left: 8px;
-  right: auto;
-  bottom: calc(100% + 8px);
-  z-index: 50;
-}
-
-/* On narrow screens the 440px panel would overflow the right edge of
-   the pane; pin the right side so it flexes within the drawer width. */
-@media (max-width: 720px) {
-  .term-compose > .usage-panel {
-    right: 8px;
-    width: auto;
-  }
-}
-
 /* The slash-suggestions list also escapes the clipped subtree by
    rendering as a child of ``.term-compose``. Its default anchoring
    (``left: 0; right: 0; bottom: calc(100% + 6px)``) places it above
@@ -8702,12 +8675,6 @@ html[data-theme="light"] .term-compose-input {
   font-family: var(--font-mono);
   font-size: 0.72rem;
   color: var(--warn, var(--accent));
-}
-
-@media (max-width: 480px) {
-  .term-compose-shortcut {
-    display: none;
-  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1483,7 +1483,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     if (!termMenuOpen) return;
     function onPointerDown(event: PointerEvent) {
       const wrap = termMenuWrapRef.current;
-      if (wrap && !wrap.contains(event.target as Node)) {
+      const target = event.target as Element | null;
+      // The menu is portaled to document.body, so a click on an item is not
+      // inside the trigger wrapper — match the portaled menu separately so it
+      // isn't dismissed before the item's handler runs.
+      if (target?.closest("[data-term-overflow-menu]")) return;
+      if (wrap && !wrap.contains(target)) {
         setTermMenuOpen(false);
       }
     }

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -299,7 +299,6 @@ export function SessionTerminalView({
           host={host}
           token={token}
           sessionId={sessionId}
-          session={session}
           onSubmit={onTerminalSubmit}
           onSubmitWithAttachments={onTerminalSubmitWithAttachments}
           attachmentsEnabled={attachmentsEnabled}
@@ -307,8 +306,6 @@ export function SessionTerminalView({
           expanded={composeOpen}
           onExpandedChange={setComposeOpen}
           connection={connection}
-          rateLimitRefreshBusy={rateLimitRefreshBusy}
-          onRateLimitRefresh={onRateLimitRefresh}
           refocusTerminal={refocusTerminal}
         />
       ) : null}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Dispatch, MutableRefObject, SetStateAction, useCallback, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { TerminalCompose } from "@/components/TerminalCompose";
@@ -9,6 +10,7 @@ import { XTerminal, type XTerminalHandle } from "@/components/XTerminal";
 import { useBackendCatalog } from "@/lib/backends";
 import type { TerminalSubmitResult } from "@/lib/composer";
 import { SessionRecord } from "@/lib/types";
+import { usePopoverAnchor } from "@/lib/use-popover-anchor";
 
 type Connection = "idle" | "connecting" | "open" | "reconnecting";
 
@@ -144,6 +146,11 @@ export function SessionTerminalView({
   const refocusTerminal = useCallback(() => {
     terminalRef.current?.focus();
   }, [terminalRef]);
+  // The menu is portaled to ``document.body`` for the same reason as the
+  // usage panel — it drops out of the term-bar, and ``.session-terminal``'s
+  // ``overflow: hidden`` would clip an in-pane absolute menu. Right-anchored
+  // to match the trigger's top-right home.
+  const overflowMenuStyle = usePopoverAnchor(termMenuWrapRef, termMenuOpen, "right");
 
   return (
     <section
@@ -159,6 +166,7 @@ export function SessionTerminalView({
           catalog={catalog}
           onRateLimitRefresh={onRateLimitRefresh}
           rateLimitRefreshBusy={rateLimitRefreshBusy}
+          anchored
         />
         <span className="term-bar-spacer" />
         {liveTmux && terminalDims ? (
@@ -188,7 +196,13 @@ export function SessionTerminalView({
             ⋯
           </button>
           {termMenuOpen ? (
-            <div className="composer-overflow-menu term-bar-overflow-menu" role="menu">
+            createPortal(
+            <div
+              className="composer-overflow-menu term-bar-overflow-menu"
+              role="menu"
+              data-term-overflow-menu
+              style={overflowMenuStyle ?? undefined}
+            >
               {session && primary?.kind !== "refresh" ? (
                 <button
                   type="button"
@@ -255,7 +269,9 @@ export function SessionTerminalView({
                   </button>
                 </>
               ) : null}
-            </div>
+            </div>,
+            document.body,
+            )
           ) : null}
         </div>
       </div>

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -195,10 +195,10 @@ export function SessionTerminalView({
           >
             ⋯
           </button>
-          {termMenuOpen ? (
+          {termMenuOpen && typeof document !== "undefined" ? (
             createPortal(
             <div
-              className="composer-overflow-menu term-bar-overflow-menu"
+              className="composer-overflow-menu"
               role="menu"
               data-term-overflow-menu
               style={overflowMenuStyle ?? undefined}

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -41,7 +41,11 @@ export function SessionUsagePill({
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
-  const anchorStyle = usePopoverAnchor(wrapRef, anchored && open, "left");
+  // Below 540px the generic ``.usage-panel`` mobile bottom-sheet rule takes
+  // over (deferBelow), so the inline fixed anchor only drives wider viewports.
+  const anchorStyle = usePopoverAnchor(wrapRef, anchored && open, "left", {
+    deferBelow: 540,
+  });
 
   useEffect(() => {
     if (!open) return;
@@ -139,7 +143,9 @@ export function SessionUsagePill({
   }
 
   const renderPanel = (node: React.ReactNode): React.ReactNode =>
-    anchored ? createPortal(node, document.body) : node;
+    anchored && typeof document !== "undefined"
+      ? createPortal(node, document.body)
+      : node;
 
   return (
     <div className="composer-context" ref={wrapRef}>

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -12,6 +12,7 @@ import {
   formatTokens,
   rateLimitUsageTone,
 } from "@/lib/usage";
+import { usePopoverAnchor } from "@/lib/use-popover-anchor";
 
 type Connection = "idle" | "connecting" | "open" | "reconnecting";
 
@@ -21,12 +22,12 @@ interface SessionUsagePillProps {
   catalog?: BackendCatalog;
   onRateLimitRefresh: () => void | Promise<void>;
   rateLimitRefreshBusy: boolean;
-  // When provided, the popover panel is portaled into this element
-  // instead of rendering as a sibling of the trigger button. Used by
-  // the tmux quick-compose drawer where the trigger lives inside an
-  // ``overflow: hidden`` ancestor — portaling escapes the clip so the
-  // panel can float above the drawer.
-  popoverContainer?: HTMLElement | null;
+  // When set, the panel is portaled to ``document.body`` and positioned
+  // ``fixed`` below the trigger instead of rendering as a sibling. The
+  // term-bar trigger lives inside ``.session-terminal``'s ``overflow:
+  // hidden`` box, which would otherwise clip the dropped-down panel to the
+  // pane; portaling escapes the clip.
+  anchored?: boolean;
 }
 
 export function SessionUsagePill({
@@ -35,11 +36,12 @@ export function SessionUsagePill({
   catalog,
   onRateLimitRefresh,
   rateLimitRefreshBusy,
-  popoverContainer,
+  anchored = false,
 }: SessionUsagePillProps) {
   const [open, setOpen] = useState(false);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const anchorStyle = usePopoverAnchor(wrapRef, anchored && open, "left");
 
   useEffect(() => {
     if (!open) return;
@@ -137,7 +139,7 @@ export function SessionUsagePill({
   }
 
   const renderPanel = (node: React.ReactNode): React.ReactNode =>
-    popoverContainer ? createPortal(node, popoverContainer) : node;
+    anchored ? createPortal(node, document.body) : node;
 
   return (
     <div className="composer-context" ref={wrapRef}>
@@ -165,6 +167,7 @@ export function SessionUsagePill({
         <div
           ref={panelRef}
           className={`usage-panel tone-${usageToneValue}`}
+          style={anchored ? anchorStyle ?? undefined : undefined}
           role="dialog"
           aria-label="Usage details"
         >

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -22,15 +22,9 @@ import {
 import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { FileMentions } from "@/components/FileMentions";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
-import { SessionUsagePill } from "@/components/SessionUsagePill";
-import { useBackendCatalog } from "@/lib/backends";
-import {
-  SHORTCUT_IS_MAC,
-  type TerminalSubmitResult,
-} from "@/lib/composer";
+import { type TerminalSubmitResult } from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import { useFileMentions } from "@/lib/use-file-mentions";
-import type { SessionRecord } from "@/lib/types";
 
 type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
 
@@ -38,7 +32,6 @@ interface TerminalComposeProps {
   host: string;
   token: string;
   sessionId: string;
-  session: SessionRecord | null;
   // Resolves a ``TerminalSubmitResult``: ``socket-closed`` keeps the draft
   // and surfaces a retry hint, ``command-error`` keeps it silently (the host
   // already reported the error), ``ok`` clears it. Async because Waypoint
@@ -56,8 +49,6 @@ interface TerminalComposeProps {
   expanded: boolean;
   onExpandedChange: (next: boolean) => void;
   connection: ConnectionState;
-  rateLimitRefreshBusy: boolean;
-  onRateLimitRefresh: () => void | Promise<void>;
   // Focus target when the user dismisses the drawer via Escape — the
   // xterm canvas, so typing resumes inside the pane.
   refocusTerminal: () => void;
@@ -68,7 +59,6 @@ export function TerminalCompose({
   host,
   token,
   sessionId,
-  session,
   onSubmit,
   onSubmitWithAttachments,
   attachmentsEnabled,
@@ -76,12 +66,9 @@ export function TerminalCompose({
   expanded,
   onExpandedChange,
   connection,
-  rateLimitRefreshBusy,
-  onRateLimitRefresh,
   refocusTerminal,
 }: TerminalComposeProps) {
   const regionId = useId();
-  const catalog = useBackendCatalog(host || null, token || null, null);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [hint, setHint] = useState<string | null>(null);
@@ -95,19 +82,6 @@ export function TerminalCompose({
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);
-  // Host for popovers that need to escape ``.term-compose-inner``'s
-  // ``overflow: hidden`` clip (the grid-row open animation requires it).
-  // The slash-suggestions list and the SessionUsagePill panel both
-  // anchor against this element, which is the outer drawer container
-  // and lives outside the clipped subtree.
-  const composeRef = useRef<HTMLElement | null>(null);
-  // ``popoverContainer`` only takes effect once the section ref is
-  // attached, which happens on first commit. Mirror it into state so
-  // SessionUsagePill re-renders with a valid host after mount.
-  const [popoverHost, setPopoverHost] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    setPopoverHost(composeRef.current);
-  }, []);
 
   // ``/new`` is a Waypoint control command the host intercepts (see
   // ``handleTerminalSubmit``) rather than forwarding to the wrapped CLI, so
@@ -262,11 +236,8 @@ export function TerminalCompose({
     }
   }, [expanded, onExpandedChange, refocusTerminal]);
 
-  const shortcutLabel = SHORTCUT_IS_MAC ? "⌘↵" : "Ctrl+↵";
-
   return (
     <section
-      ref={composeRef}
       className={`term-compose ${expanded ? "is-open" : "is-closed"}`}
       aria-label="Quick compose"
     >
@@ -284,26 +255,13 @@ export function TerminalCompose({
       </button>
       <div className="term-compose-shell" id={regionId} aria-hidden={!expanded}>
         <div className="term-compose-inner">
-          <div className="term-compose-rail">
-            <SessionUsagePill
-              session={session}
-              connection={connection}
-              catalog={catalog}
-              onRateLimitRefresh={onRateLimitRefresh}
-              rateLimitRefreshBusy={rateLimitRefreshBusy}
-              popoverContainer={popoverHost}
-            />
-            {hint ? (
+          {hint ? (
+            <div className="term-compose-rail">
               <span className="term-compose-hint" role="status">
                 {hint}
               </span>
-            ) : null}
-            <span className="term-compose-meta-spacer" />
-            <span className="composer-shortcut term-compose-shortcut" aria-hidden="true">
-              <kbd>{shortcutLabel}</kbd>
-              <span>send</span>
-            </span>
-          </div>
+            </div>
+          ) : null}
           <div
             className={`term-compose-field${dragActive ? " is-drag-active" : ""}${leadForced ? " lead-forced" : ""}`}
             onDragOver={handleDragOver}

--- a/frontend/src/lib/use-popover-anchor.ts
+++ b/frontend/src/lib/use-popover-anchor.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { CSSProperties, RefObject, useCallback, useLayoutEffect, useState } from "react";
+
+// Fixed-viewport coordinates for a popover dropped just below a trigger.
+// Popovers that open from the term-bar live inside ``.session-terminal``'s
+// ``overflow: hidden`` box, which clips an absolutely-positioned panel to the
+// pane. Portaling the panel to ``document.body`` and positioning it ``fixed``
+// against the trigger's rect escapes the clip entirely. ``align`` pins the
+// panel to the trigger's left or right edge; the coordinates are re-measured
+// while open so the panel tracks scroll and resize.
+export function usePopoverAnchor(
+  triggerRef: RefObject<HTMLElement | null>,
+  open: boolean,
+  align: "left" | "right",
+  gap = 10,
+): CSSProperties | null {
+  const [style, setStyle] = useState<CSSProperties | null>(null);
+
+  const measure = useCallback(() => {
+    const el = triggerRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setStyle(
+      align === "right"
+        ? {
+            position: "fixed",
+            top: rect.bottom + gap,
+            right: Math.max(8, window.innerWidth - rect.right),
+            left: "auto",
+            bottom: "auto",
+          }
+        : {
+            position: "fixed",
+            top: rect.bottom + gap,
+            left: Math.max(8, rect.left),
+            right: "auto",
+            bottom: "auto",
+          },
+    );
+  }, [triggerRef, align, gap]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setStyle(null);
+      return;
+    }
+    measure();
+    window.addEventListener("scroll", measure, true);
+    window.addEventListener("resize", measure);
+    return () => {
+      window.removeEventListener("scroll", measure, true);
+      window.removeEventListener("resize", measure);
+    };
+  }, [open, measure]);
+
+  return style;
+}

--- a/frontend/src/lib/use-popover-anchor.ts
+++ b/frontend/src/lib/use-popover-anchor.ts
@@ -2,43 +2,53 @@
 
 import { CSSProperties, RefObject, useCallback, useLayoutEffect, useState } from "react";
 
+interface PopoverAnchorOptions {
+  gap?: number;
+  // Below this viewport width, return null so a CSS bottom-sheet media query
+  // (e.g. the generic ``.usage-panel`` mobile rule) takes over instead of the
+  // fixed drop-down. Omit for popovers whose mobile styling is specific to a
+  // different anchor and must not apply once portaled to the body.
+  deferBelow?: number;
+}
+
 // Fixed-viewport coordinates for a popover dropped just below a trigger.
 // Popovers that open from the term-bar live inside ``.session-terminal``'s
 // ``overflow: hidden`` box, which clips an absolutely-positioned panel to the
 // pane. Portaling the panel to ``document.body`` and positioning it ``fixed``
 // against the trigger's rect escapes the clip entirely. ``align`` pins the
-// panel to the trigger's left or right edge; the coordinates are re-measured
-// while open so the panel tracks scroll and resize.
+// panel to the trigger's left or right edge; ``max-height``/``overflow-y`` keep
+// a tall panel scrollable rather than running off the viewport bottom. The
+// coordinates are re-measured while open so the panel tracks scroll and resize.
 export function usePopoverAnchor(
   triggerRef: RefObject<HTMLElement | null>,
   open: boolean,
   align: "left" | "right",
-  gap = 10,
+  { gap = 10, deferBelow }: PopoverAnchorOptions = {},
 ): CSSProperties | null {
   const [style, setStyle] = useState<CSSProperties | null>(null);
 
   const measure = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
+    if (deferBelow !== undefined && window.innerWidth <= deferBelow) {
+      setStyle(null);
+      return;
+    }
     const rect = el.getBoundingClientRect();
+    const top = rect.bottom + gap;
+    const common: CSSProperties = {
+      position: "fixed",
+      top,
+      bottom: "auto",
+      maxHeight: `calc(100vh - ${Math.round(top)}px - 8px)`,
+      overflowY: "auto",
+    };
     setStyle(
       align === "right"
-        ? {
-            position: "fixed",
-            top: rect.bottom + gap,
-            right: Math.max(8, window.innerWidth - rect.right),
-            left: "auto",
-            bottom: "auto",
-          }
-        : {
-            position: "fixed",
-            top: rect.bottom + gap,
-            left: Math.max(8, rect.left),
-            right: "auto",
-            bottom: "auto",
-          },
+        ? { ...common, right: Math.max(8, window.innerWidth - rect.right), left: "auto" }
+        : { ...common, left: Math.max(8, rect.left), right: "auto" },
     );
-  }, [triggerRef, align, gap]);
+  }, [triggerRef, align, gap, deferBelow]);
 
   useLayoutEffect(() => {
     if (!open) {


### PR DESCRIPTION
## Summary

`claude_tty` (added in #102) shipped advertising far fewer capabilities than `claude_code`: it could not switch model, effort, or permission mode mid-session, did not surface thread discovery/import, and did not accept custom CLI args. This brings it to parity for those control surfaces, and folds in the review fixes plus two terminal-page UX fixes surfaced while testing.

The TUI has no inline control channel (it is driven over a tmux pane, not a stdio protocol), so every mid-session control swap is applied by **restart-with-resume**: the pane is relaunched as `claude --resume <thread>` with the new `--model` / `--effort` / `--permission-mode` flag while the session is idle. This is the same pattern `claude_code` already uses for effort changes, and it is what `cctty` does for SDK `set_model` / `set_permission_mode`. The frontend is fully catalog-driven (#103), so flipping the capability flags enables every picker with no frontend change.

Approval notes on decline were attempted but are **not** included: Claude Code 2.1.177's "No, and tell Claude what to do differently" path returns straight to the main prompt with no persistent follow-up form to deliver the note into, and declining also leaves the session wedged in `running` (a separate transcript-status issue). `supports_approval_note` is left `False`; this is filed for a dedicated follow-up.

## Changes

### Backend — `claude_tty` capability parity (`backends/claude_tty/plugin.py`)

- **Capability flags** — enables `supports_set_model_inline`, `supports_set_effort_with_restart` + `effort_levels`, `supports_set_permission_mode_inline`, `supports_custom_cli_args`, `supports_thread_discovery`, and `supports_thread_import`, and sets `import_request_schema = ClaudeThreadImportRequest`.
- **`_restart_with_args`** — the shared primitive behind all three control swaps. Idle-guarded (400 if the session is mid-turn), short-circuits when the value is unchanged, then kills the pane, scrubs the managed flag from the stored launch args (custom args survive), relaunches `claude --resume <thread>` with the new flag, and restarts the transcript tailer at end-of-file so the resumed conversation is not replayed. Mirrors `restore_session`'s relaunch path.
- **`apply_model` / `apply_effort` / `apply_permission_mode`** — delegate to `_restart_with_args`; `apply_effort` returns the announce bool the runtime expects, and `effort_swap_message` reuses `claude_code`'s text.
- **Custom CLI args** — `create_session` already forwarded `request.args`; this adds validation that rejects Waypoint-managed flags (`--session-id`, `--resume`, `--fork-session`, `--model`, `--effort`, `--permission-mode`) with a 400 so a custom arg cannot collide with the resume machinery.
- **`list_threads` / `import_thread`** — discovery enumerates the same `~/.claude/projects` transcript store `claude_code` reads (`list_local_claude_threads`), deduped against already-imported `claude_tty` sessions; import resolves the thread, then launches a `claude_tty` pane resuming it (`--resume <thread>`) with the tailer attached. Local launch targets only for now; SSH/remote enumeration is a follow-up.

### Backend — transcript-path encoding fix (`backends/claude_code/threads.py`, `backends/claude_tty/tailer.py`)

The tailer derived the project-dir name with `cwd.replace("/", "-")`, but the CLI encodes *every* non-alphanumeric character to `-`, so a cwd with a hidden-dir or other special-char component (worktrees, dotted paths) tailed a path that never existed and emitted no events. `transcript_path` now routes through a shared `encode_project_dir` helper that replicates the CLI's `[^a-zA-Z0-9] -> '-'` encoding and through `claude_projects_root`, so fresh and imported sessions match where the CLI actually writes, including under `$CLAUDE_CONFIG_DIR`.

### Frontend — terminal page

- **Composer meta row** (`TerminalCompose.tsx`, `SessionTerminalView.tsx`) — the quick-compose drawer duplicated the usage pill already shown in the term-bar above it and carried a `⌘↵` send hint, costing a full row of height. Both are dropped; the meta row now renders only when a transient send hint is present. The `⌘↵` keybinding itself is unchanged.
- **Popover containment** (`SessionUsagePill.tsx`, `SessionTerminalView.tsx`, `SessionDetail.tsx`, new `lib/use-popover-anchor.ts`) — the term-bar usage pill and overflow menu dropped out of the bar into `.session-terminal`'s `overflow: hidden` box, which clipped them to the pane. Both now portal to the document body and position `fixed` against their trigger via a shared `usePopoverAnchor` hook, so they drop downward anchored to the trigger edge without being trapped by the pane. The overflow menu's outside-click dismissal matches the portaled element so item clicks still register.

### Tests

- `backend/tests/test_claude_tty_controls.py` — launch-arg scrub/rebuild (managed flags stripped, custom args preserved), the `_restart_with_args` idle-guard and unchanged-value short-circuit, `apply_*` gating, `list_threads` dedup, the `import_thread` record shape, and custom-arg rejection.
- `backend/tests/test_claude_threads.py` — `encode_project_dir` matches the CLI encoding for plain, hidden-dir, and mixed-special-char cwds.

### Docs

- `docs/coding_agent_plugins.md` — adds a built-in backend capability-profile matrix, documents that `claude_tty` applies swaps via restart-with-resume (vs `claude_code`'s stdio control protocol), and notes that thread discovery/import reads the shared `~/.claude/projects` store so the same threads appear under both backend ids. Corrects the `tmux` row's custom-CLI-args cell (the plugin leaves the flag at its `False` default) and notes that `claude_tty`'s `thread_id`-only import dedup is sound only while it is local-only.

## Test Plan

- [x] `cd backend && uv run pytest` — 834 passed.
- [x] `cd backend && uv run pre-commit run` on every commit — isort / black / ruff / codespell / mypy passed.
- [x] `cd frontend && npx tsc --noEmit` and `npm run lint` — clean; `waypointctl start frontend` ran the production build (`npm run build && start`) and came up healthy.
- [x] Live e2e (running backend on this branch): custom-arg validation rejects `--session-id` / `--resume` with 400; a session launched with `--add-dir /tmp` kept that arg in `launch_args` across every restart.
- [x] Live e2e — control swaps on a real `claude_tty` session: `set_model` sonnet→opus (pane `%55`→`%56`, relaunched `--resume <thread> --model opus`, custom arg preserved); `set_effort`→low (restart + "Restarted Claude session with --effort low" note); `set_permission_mode`→plan and back, plus an invalid mode → 400. Confirmed in the pane as `Opus 4.8 with low effort`.
- [x] Live e2e — thread discovery returned threads with full summaries; thread import created a new `claude_tty` session resuming the chosen thread (`--resume <thread>`, title carried over).
- [ ] Frontend UX fixes (composer row, popover containment) — built and served on this branch; verify the term-bar usage-pill and overflow popovers drop fully outside the pane and the composer row is gone in the browser.
- [ ] Approval note on decline — attempted and reverted (see Summary); `supports_approval_note=False`. Decline itself works without a note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
