### PR TITLE
feat: claude_tty live settings, composer send/interrupt, and Claude slash autocomplete

### DIFF
--- a/backend/src/waypoint/backends/approvals.py
+++ b/backend/src/waypoint/backends/approvals.py
@@ -1,0 +1,27 @@
+"""Shared approval-decision vocabulary.
+
+The frontend and CLI send a decision string for a tool approval; several
+distinct strings ("accept", "approve", "acceptForSession", …) all mean "let the
+tool run". Each backend maps that to its own mechanism (claude_code → an "allow"
+control response, claude_tty/tmux → the dialog's Yes keystroke). Centralising
+the vocabulary keeps those backends from drifting apart — a backend that
+recognises a narrower set silently turns an unrecognised approval into a
+decline.
+"""
+
+APPROVE_DECISIONS = frozenset(
+    {
+        "approve",
+        "accept",
+        "yes",
+        "y",
+        "allow",
+        "acceptforsession",
+        "acceptalways",
+    }
+)
+
+
+def is_approve_decision(decision: str) -> bool:
+    """Return True when ``decision`` means the tool should be allowed to run."""
+    return decision.strip().lower() in APPROVE_DECISIONS

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -45,6 +45,12 @@ class BackendCapabilities(_FrozenModel):
     # path don't have to also claim ``supports_set_effort_inline``.
     supports_set_effort_with_restart: bool = False
     supports_set_permission_mode_inline: bool = False
+    # Applying a model/permission-mode/effort change relaunches the session
+    # process, so doing it mid-turn interrupts the running turn. claude_tty
+    # is the only backend like this today — its TUI has no in-process knob,
+    # so every swap kills the pane and respawns ``--resume``. The frontend
+    # reads this to warn before changing settings on a running session.
+    settings_change_interrupts_turn: bool = False
     supports_thread_discovery: bool = False
     supports_thread_import: bool = False
     supports_fork: bool = False

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from waypoint.attachments import ResolvedAttachment, append_attachment_paths
+from waypoint.backends.approvals import is_approve_decision
 from waypoint.backends.claude_code.models import (
     claude_context_window_for_model,
     claude_model_family,
@@ -1919,18 +1920,7 @@ class ClaudeCliAdapter:
         await self._publish_context_usage(state, refreshed)
 
     def _map_decision(self, decision: str) -> str:
-        lowered = decision.strip().lower()
-        if lowered in {
-            "approve",
-            "accept",
-            "yes",
-            "y",
-            "allow",
-            "acceptforsession",
-            "acceptalways",
-        }:
-            return "allow"
-        return "deny"
+        return "allow" if is_approve_decision(decision) else "deny"
 
     def _require_session(self, session_id: str) -> ClaudeSessionState:
         try:

--- a/backend/src/waypoint/backends/claude_code/commands.py
+++ b/backend/src/waypoint/backends/claude_code/commands.py
@@ -6,10 +6,29 @@ from typing import Any
 
 import yaml
 
+from waypoint.backends.capabilities import SlashCommandSpec
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import CommandCompletion, CompletionDispatch
 
 log = logging.getLogger("waypoint.backends.claude_code.commands")
+
+# A static baseline of Claude's built-in slash commands. The structured backend
+# normally learns these from the SDK's ``system.init`` stream, but a
+# tmux-transport Claude session never emits it — without this list such a session
+# would surface no built-ins at all. Plain-text dispatch: typed into the CLI/pane.
+CLAUDE_BUILTIN_SLASH_COMMANDS = (
+    SlashCommandSpec(
+        name="compact", description="Compact the conversation to free up context"
+    ),
+    SlashCommandSpec(name="clear", description="Clear the conversation history"),
+    SlashCommandSpec(name="context", description="Show context window usage"),
+    SlashCommandSpec(name="cost", description="Show token usage and cost"),
+    SlashCommandSpec(name="export", description="Export the conversation"),
+    SlashCommandSpec(name="memory", description="Edit Claude memory files"),
+    SlashCommandSpec(name="init", description="Generate a CLAUDE.md for the project"),
+    SlashCommandSpec(name="config", description="Open the settings panel"),
+    SlashCommandSpec(name="help", description="List available commands"),
+)
 
 _REMOTE_SCRIPT = r"""
 import glob

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -23,7 +23,10 @@ from waypoint.backends.capabilities import (
     ModelSource,
 )
 from waypoint.backends.claude_code.adapter import ClaudeCliAdapter, ClaudeCliError
-from waypoint.backends.claude_code.commands import list_claude_command_completions
+from waypoint.backends.claude_code.commands import (
+    CLAUDE_BUILTIN_SLASH_COMMANDS,
+    list_claude_command_completions,
+)
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
@@ -53,6 +56,7 @@ from waypoint.backends.claude_code.threads import (
     list_local_claude_threads,
 )
 from waypoint.backends.claude_code.threads_remote import RemoteClaudeThreadEnumerator
+from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.backends.tmux.plugin import TmuxPlugin
 from waypoint.git_meta import GitMeta
@@ -142,6 +146,7 @@ class ClaudeCodePlugin:
         permission_modes=CLAUDE_PERMISSION_MODE_SPECS,
         effort_levels=CLAUDE_EFFORT_LEVELS,
         model_source=ModelSource.STATIC,
+        slash_commands=CLAUDE_BUILTIN_SLASH_COMMANDS,
         badges={"glyph": "C", "color": "#a78bfa"},
         cli_binary="claude",
         target_aliases=("claude",),
@@ -491,6 +496,16 @@ class ClaudeCodePlugin:
             else _claude_waypoint_completions(prefix)
         )
         completions.extend(_claude_runtime_slash_completions(runtime_commands, prefix))
+        # Curated built-ins as a baseline for sessions with no live slash-command
+        # stream (tmux transport), deduped against anything the runtime reported.
+        present = {f"{item.trigger}{item.name}" for item in completions}
+        for builtin in static_slash_completions(
+            self.id, self.capabilities, prefix=prefix
+        ):
+            key = f"{builtin.trigger}{builtin.name}"
+            if key not in present:
+                completions.append(builtin)
+                present.add(key)
         launch_target = (
             runtime._find_launch_target(session.launch_target_id)
             if session.launch_target_id

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -193,6 +193,8 @@ class TranscriptNormalizer:
         if _is_injected_turn(content):
             return []
 
+        turn_aborted = _is_user_rejection(record)
+
         # Only tool_result blocks are surfaced from user records. A user/peer
         # turn's own text is already recorded at the input boundary
         # (runtime.handle_input → _record_user_event); re-emitting the
@@ -237,6 +239,22 @@ class TranscriptNormalizer:
                 )
             )
 
+        # A declined tool ends the turn with no terminal-stop_reason record to
+        # follow, so resolve the session to idle here or it stays stuck running.
+        if turn_aborted:
+            events.append(
+                NormalizedEvent(
+                    kind=EventKind.SYSTEM_NOTE,
+                    text="Turn ended — tool use declined",
+                    metadata={
+                        "method": "result",
+                        "stop_reason": "tool_rejected",
+                        "status": SessionStatus.IDLE,
+                    },
+                    status=SessionStatus.IDLE,
+                )
+            )
+
         return events
 
     def _emit_task_snapshot(self) -> list[NormalizedEvent]:
@@ -268,3 +286,17 @@ def _is_injected_turn(content: Any) -> bool:
             "This session is being continued"
         )
     return False
+
+
+def _is_user_rejection(record: dict[str, Any]) -> bool:
+    """Return True when the user declined the tool this record reports on.
+
+    A declined tool aborts the TUI turn back to the ready prompt with no
+    following assistant record, so the terminal-``stop_reason`` path never
+    fires. The CLI tags the record with ``toolUseResult: "User rejected tool
+    use"``, which we use to resolve the session to idle off the rejection.
+    """
+    result = record.get("toolUseResult")
+    return isinstance(result, str) and result.strip().lower().startswith(
+        "user rejected"
+    )

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -29,12 +29,11 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
-from waypoint.backends.capabilities import (
-    BackendCapabilities,
-    ModelSource,
-    SlashCommandSpec,
+from waypoint.backends.capabilities import BackendCapabilities, ModelSource
+from waypoint.backends.claude_code.commands import (
+    CLAUDE_BUILTIN_SLASH_COMMANDS,
+    list_claude_command_completions,
 )
-from waypoint.backends.claude_code.commands import list_claude_command_completions
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
@@ -86,24 +85,6 @@ log = logging.getLogger("waypoint.backends.claude_tty")
 # in the control-swap helper, so a caller can clear a flag (effort=None) while
 # the unspecified flags keep the session's current value.
 _UNSET: Any = object()
-
-# Built-in Claude TUI slash commands worth surfacing in the composer. claude_code
-# learns these from the SDK's ``system.init`` stream, which the TUI path never
-# emits, so claude_tty carries a curated static list instead. They dispatch as
-# plain text — typed straight into the pane, where the TUI interprets them.
-_CLAUDE_TTY_SLASH_COMMANDS = (
-    SlashCommandSpec(
-        name="compact", description="Compact the conversation to free up context"
-    ),
-    SlashCommandSpec(name="clear", description="Clear the conversation history"),
-    SlashCommandSpec(name="context", description="Show context window usage"),
-    SlashCommandSpec(name="cost", description="Show token usage and cost"),
-    SlashCommandSpec(name="export", description="Export the conversation"),
-    SlashCommandSpec(name="memory", description="Edit Claude memory files"),
-    SlashCommandSpec(name="init", description="Generate a CLAUDE.md for the project"),
-    SlashCommandSpec(name="config", description="Open the settings panel"),
-    SlashCommandSpec(name="help", description="List available commands"),
-)
 
 # CLI flags Waypoint owns; users may not smuggle them in through custom args.
 _RESERVED_CLI_FLAGS = frozenset(
@@ -161,7 +142,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
         effort_levels=CLAUDE_EFFORT_LEVELS,
         model_source=ModelSource.STATIC,
         permission_modes=CLAUDE_PERMISSION_MODE_SPECS,
-        slash_commands=_CLAUDE_TTY_SLASH_COMMANDS,
+        slash_commands=CLAUDE_BUILTIN_SLASH_COMMANDS,
         badges={"glyph": "C", "color": "#a78bfa"},
         cli_binary="claude",
         target_aliases=("claude_tty",),

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -121,11 +121,15 @@ class ClaudeTtyPlugin(TmuxPlugin):
         supports_fork=True,
         supports_attachments=True,
         # All control swaps restart the pane with `--resume <thread>` and a
-        # rebuilt flag set; none of them mutate a live process inline.
+        # rebuilt flag set; none of them mutate a live process inline. The
+        # ``*_inline`` flags here gate whether the change is *allowed* at all
+        # (the runtime's only knob), not whether it skips a restart, so they
+        # read True; ``settings_change_interrupts_turn`` records the real cost.
         supports_set_model_inline=True,
         supports_set_effort_inline=False,
         supports_set_effort_with_restart=True,
         supports_set_permission_mode_inline=True,
+        settings_change_interrupts_turn=True,
         supports_custom_cli_args=True,
         supports_thread_discovery=True,
         supports_thread_import=True,
@@ -599,11 +603,19 @@ class ClaudeTtyPlugin(TmuxPlugin):
             if model is not _UNSET
             else "effort" if effort is not _UNSET else "permission mode"
         )
-        if session.status is not SessionStatus.IDLE:
+        # The swap kills the pane and respawns ``--resume``, which interrupts
+        # any in-flight turn — acceptable (the frontend warns first) and the
+        # only way to apply the change. A STARTING pane has nothing to resume
+        # yet, so reject that one state.
+        if session.status is SessionStatus.STARTING:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"cannot change {field} while the session is running",
+                detail=f"cannot change {field} while the session is starting",
             )
+        interrupting = session.status in {
+            SessionStatus.RUNNING,
+            SessionStatus.WAITING_INPUT,
+        }
 
         new_model = session.model if model is _UNSET else model
         new_effort = session.effort if effort is _UNSET else effort
@@ -687,9 +699,15 @@ class ClaudeTtyPlugin(TmuxPlugin):
         runtime.storage.update_session(
             session.id, transport_state=new_state, status=SessionStatus.STARTING
         )
+        note = (
+            f"Interrupted the running turn and restarted Claude TUI session to "
+            f"apply {field} change (thread {thread_id})"
+            if interrupting
+            else f"Restarted Claude TUI session to apply {field} change (thread {thread_id})"
+        )
         await runtime._record_system_event(
             session.id,
-            f"Restarted Claude TUI session to apply {field} change (thread {thread_id})",
+            note,
             status=SessionStatus.IDLE,
         )
         # The resumed thread reopens its already-populated transcript, whose

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -29,7 +29,12 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
-from waypoint.backends.capabilities import BackendCapabilities, ModelSource
+from waypoint.backends.capabilities import (
+    BackendCapabilities,
+    ModelSource,
+    SlashCommandSpec,
+)
+from waypoint.backends.claude_code.commands import list_claude_command_completions
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
@@ -55,6 +60,7 @@ from waypoint.backends.claude_code.threads import (
 )
 from waypoint.backends.claude_tty._state import PendingTtyApproval
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
+from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.backends.tmux.plugin import TmuxPlugin
@@ -62,6 +68,7 @@ from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
     BackendModelOption,
+    CommandCompletion,
     SessionCreateRequest,
     SessionRateLimitUsage,
     SessionRecord,
@@ -79,6 +86,24 @@ log = logging.getLogger("waypoint.backends.claude_tty")
 # in the control-swap helper, so a caller can clear a flag (effort=None) while
 # the unspecified flags keep the session's current value.
 _UNSET: Any = object()
+
+# Built-in Claude TUI slash commands worth surfacing in the composer. claude_code
+# learns these from the SDK's ``system.init`` stream, which the TUI path never
+# emits, so claude_tty carries a curated static list instead. They dispatch as
+# plain text — typed straight into the pane, where the TUI interprets them.
+_CLAUDE_TTY_SLASH_COMMANDS = (
+    SlashCommandSpec(
+        name="compact", description="Compact the conversation to free up context"
+    ),
+    SlashCommandSpec(name="clear", description="Clear the conversation history"),
+    SlashCommandSpec(name="context", description="Show context window usage"),
+    SlashCommandSpec(name="cost", description="Show token usage and cost"),
+    SlashCommandSpec(name="export", description="Export the conversation"),
+    SlashCommandSpec(name="memory", description="Edit Claude memory files"),
+    SlashCommandSpec(name="init", description="Generate a CLAUDE.md for the project"),
+    SlashCommandSpec(name="config", description="Open the settings panel"),
+    SlashCommandSpec(name="help", description="List available commands"),
+)
 
 # CLI flags Waypoint owns; users may not smuggle them in through custom args.
 _RESERVED_CLI_FLAGS = frozenset(
@@ -136,6 +161,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
         effort_levels=CLAUDE_EFFORT_LEVELS,
         model_source=ModelSource.STATIC,
         permission_modes=CLAUDE_PERMISSION_MODE_SPECS,
+        slash_commands=_CLAUDE_TTY_SLASH_COMMANDS,
         badges={"glyph": "C", "color": "#a78bfa"},
         cli_binary="claude",
         target_aliases=("claude_tty",),
@@ -212,6 +238,51 @@ class ClaudeTtyPlugin(TmuxPlugin):
         if launch_target is None:
             return await probe_claude_usage()
         return await probe_claude_usage_remote(launch_target)
+
+    async def list_command_completions(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        *,
+        trigger: str = "/",
+        prefix: str = "",
+        force_refresh: bool = False,
+    ) -> list[CommandCompletion]:
+        if trigger != "/":
+            return []
+        completions = static_slash_completions(
+            self.id, self.capabilities, prefix=prefix
+        )
+        # Custom commands and skills come from the same on-disk discovery
+        # claude_code uses; both wrap the ``claude`` binary in the same cwd.
+        launch_target = (
+            runtime._find_launch_target(session.launch_target_id)
+            if session.launch_target_id
+            else None
+        )
+        claude_bin = (
+            self.remote_executable(launch_target)
+            if launch_target is not None
+            else self.capabilities.cli_binary
+        )
+        if not claude_bin:
+            return completions
+        try:
+            dynamic = await list_claude_command_completions(
+                cwd=session.cwd,
+                claude_bin=claude_bin,
+                prefix=prefix,
+                launch_target=launch_target,
+            )
+        except Exception:
+            return completions
+        seen = {f"{item.trigger}{item.name}" for item in completions}
+        for item in dynamic:
+            key = f"{item.trigger}{item.name}"
+            if key not in seen:
+                completions.append(item)
+                seen.add(key)
+        return completions
 
     # ── Session lifecycle ────────────────────────────────────────────────────
 

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -135,12 +135,12 @@ class TranscriptTailer:
     async def _poll_dialog(self) -> None:
         """Capture the live pane and surface any stable tool-permission dialog.
 
-        Detection is intentionally mode-agnostic: ``claude_tty`` cannot change
-        permission mode inline (``supports_set_permission_mode_inline=False``),
-        so the session's stored ``permission_mode`` is fixed at launch, while
-        the TUI's real posture can drift independently (a human pressing
-        shift+tab in the pane, or choosing "allow all this session"). Gating on
-        the stored mode would miss a dialog that appears after an auto→prompting
+        Detection is intentionally mode-agnostic: ``claude_tty`` only changes
+        permission mode by relaunching the pane, so the stored
+        ``permission_mode`` holds whatever the last launch passed, while the
+        TUI's real posture can drift independently (a human pressing shift+tab
+        in the pane, or choosing "allow all this session"). Gating on the
+        stored mode would miss a dialog that appears after an auto→prompting
         drift and hang the session, so we always trust the on-screen dialog
         rather than the recorded mode. (The run loop throttles how often this
         runs to keep the capture cost low on sessions that never prompt.)

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -13,6 +13,7 @@ Thin subclass of ``TmuxTransport`` that overrides:
 
 from typing import TYPE_CHECKING
 
+from waypoint.backends.approvals import is_approve_decision
 from waypoint.backends.tmux.transport import TmuxTransport
 from waypoint.schemas import SessionRecord
 
@@ -30,6 +31,12 @@ class ClaudeTtyTransport(TmuxTransport):
         self._plugin = plugin
 
     async def interrupt(self, session: SessionRecord) -> None:
+        # Esc cancels whatever the pane is showing — including an open
+        # permission dialog, which it declines. Drop any pending approval now
+        # so ``has_pending_approval`` goes false immediately instead of lingering
+        # until the next dialog poll, where a racing ``respond_to_approval``
+        # would fire a stray digit at the ready prompt.
+        self._plugin._pending_approvals.pop(session.id, None)
         await self.adapter.send_bytes(self._target(session), b"\x1b")
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
@@ -54,9 +61,8 @@ class ClaudeTtyTransport(TmuxTransport):
         self._plugin._pending_approvals.pop(session.id, None)
 
         target = self._target(session)
-        normalized = decision.strip().lower()
 
-        if normalized in {"approve", "yes", "y"}:
+        if is_approve_decision(decision):
             await self.adapter.send_input(
                 target, str(pending.approve_number), submit=True
             )

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from fastapi import HTTPException, status
 
 from waypoint.attachments import ResolvedAttachment, append_attachment_paths
+from waypoint.backends.approvals import is_approve_decision
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import (
     SessionInputRequest,
@@ -79,8 +80,7 @@ class TmuxTransport(TransportAdapter):
         text: str | None,
         approval_id: str | None = None,
     ) -> bool:
-        normalized = decision.strip().lower()
-        mapped = "y" if normalized in {"approve", "yes", "y"} else "n"
+        mapped = "y" if is_approve_decision(decision) else "n"
         reply = text or mapped
         await self._runtime.handle_input(
             session.id, SessionInputRequest(text=reply, submit=True)

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -375,6 +375,21 @@ async def test_respond_approve_sends_digit_1_enter() -> None:
     assert "sess-1" not in plugin._pending_approvals
 
 
+async def test_respond_accept_sends_approve_digit_not_decline() -> None:
+    # The frontend ApprovalCard sends decision="accept" for the primary approve;
+    # it must drive the Yes digit, not fall through to the decline branch.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending(approve_number=1, decline_number=3)
+
+    transport, tmux = _make_transport(plugin)
+    result = await transport.respond_to_approval(session, "accept", None)
+
+    assert result is True
+    tmux.send_input.assert_called_once_with("%0", "1", submit=True)
+    assert "sess-1" not in plugin._pending_approvals
+
+
 async def test_respond_decline_sends_no_digit_enter() -> None:
     plugin = ClaudeTtyPlugin()
     session = _make_session()
@@ -425,6 +440,21 @@ async def test_respond_wrong_approval_id_returns_false() -> None:
 
     assert result is False
     assert "sess-1" in plugin._pending_approvals  # not cleared
+
+
+async def test_interrupt_clears_pending_approval_and_sends_esc() -> None:
+    # Esc declines an open dialog; dropping the pending entry up front closes
+    # the window where a racing approve would fire a digit at the ready prompt.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_approvals["sess-1"] = _pending()
+
+    transport, tmux = _make_transport(plugin)
+    await transport.interrupt(session)
+
+    assert "sess-1" not in plugin._pending_approvals
+    tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
+    assert not transport.has_pending_approval(session)
 
 
 async def test_respond_correct_approval_id_resolves() -> None:

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -25,6 +25,7 @@ from waypoint.backends.claude_tty.plugin import (
 )
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import (
+    CommandCompletion,
     SessionCreateRequest,
     SessionRecord,
     SessionSource,
@@ -335,6 +336,58 @@ async def test_list_threads_dedups_imported(monkeypatch: pytest.MonkeyPatch) -> 
     summaries = await plugin.list_threads(runtime)
 
     assert [s.id for s in summaries] == ["t-b"]
+
+
+# ── command completions ───────────────────────────────────────────────────────
+
+
+async def test_list_command_completions_surfaces_compact(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Isolate the static built-ins from on-disk skill/command discovery.
+    monkeypatch.setattr(
+        plugin_mod, "list_claude_command_completions", AsyncMock(return_value=[])
+    )
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+    runtime._find_launch_target.return_value = None
+    session = _make_session()
+
+    completions = await plugin.list_command_completions(
+        runtime, session, prefix="/comp"
+    )
+
+    compact = next(c for c in completions if c.name == "compact")
+    assert compact.replacement == "/compact "
+    assert compact.dispatch == "plain_text"
+
+
+async def test_list_command_completions_merges_dynamic_skills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = CommandCompletion(
+        id="claude:skill:deep-research",
+        trigger="/",
+        replacement="/deep-research ",
+        name="deep-research",
+        description="Run deep research",
+        kind="skill",
+        source="user_skill",
+        dispatch="plain_text",
+    )
+    monkeypatch.setattr(
+        plugin_mod,
+        "list_claude_command_completions",
+        AsyncMock(return_value=[skill]),
+    )
+    plugin = ClaudeTtyPlugin()
+    runtime = MagicMock()
+    runtime._find_launch_target.return_value = None
+    session = _make_session()
+
+    names = {c.name for c in await plugin.list_command_completions(runtime, session)}
+
+    assert {"compact", "deep-research"} <= names
 
 
 async def test_list_threads_remote_returns_empty() -> None:

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -2,10 +2,10 @@
 
 claude_tty has no in-process knobs: model/effort/permission-mode swaps all
 relaunch the pane with ``--resume <thread>`` and a rebuilt flag set. These
-tests cover the arg scrubber, the restart helper (idle guard, no-op
-short-circuit, flag rebuild), the effort return contract, custom-arg
-validation, thread-discovery dedup, and the resume-import path — all against
-fakes so no live TUI/tmux is needed.
+tests cover the arg scrubber, the restart helper (running-restart with an
+interruption note, starting guard, no-op short-circuit, flag rebuild), the
+effort return contract, custom-arg validation, thread-discovery dedup, and the
+resume-import path — all against fakes so no live TUI/tmux is needed.
 """
 
 from datetime import UTC, datetime
@@ -23,6 +23,7 @@ from waypoint.backends.claude_tty.plugin import (
     _scrub_session_args,
     _validate_custom_args,
 )
+from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import (
     SessionCreateRequest,
     SessionRecord,
@@ -133,18 +134,50 @@ def test_scrub_strips_resume() -> None:
 # ── _restart_with_args ────────────────────────────────────────────────────────
 
 
-async def test_restart_idle_guard_raises_when_running() -> None:
+async def test_restart_while_running_relaunches_and_notes_interruption() -> None:
     plugin = ClaudeTtyPlugin()
     _stub_lifecycle(plugin)
     session = _make_session(status=SessionStatus.RUNNING, model="opus")
+    runtime, _ = _restart_runtime()
+
+    result = await plugin._restart_with_args(runtime, session, model="sonnet")
+
+    assert result is True
+    runtime.tmux.start_managed_session.assert_awaited_once()
+    note = runtime._record_system_event.call_args.args[1]
+    assert "Interrupted the running turn" in note
+
+
+async def test_restart_guard_raises_when_starting() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(status=SessionStatus.STARTING, model="opus")
     runtime, _ = _restart_runtime()
 
     with pytest.raises(HTTPException) as exc:
         await plugin._restart_with_args(runtime, session, model="sonnet")
 
     assert exc.value.status_code == 400
-    assert "model" in exc.value.detail
+    assert "starting" in exc.value.detail
     runtime.tmux.start_managed_session.assert_not_called()
+
+
+async def test_restart_when_exited_tolerates_dead_pane_and_relaunches() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(status=SessionStatus.EXITED, model="opus")
+    runtime, _ = _restart_runtime()
+    # The old pane is already gone, so killing it raises — which must be
+    # swallowed so the resume relaunch still happens.
+    runtime.tmux.kill_session = AsyncMock(side_effect=TmuxError("no such session"))
+
+    result = await plugin._restart_with_args(runtime, session, model="sonnet")
+
+    assert result is True
+    runtime.tmux.start_managed_session.assert_awaited_once()
+    # EXITED is not a running turn, so the note must not claim an interruption.
+    note = runtime._record_system_event.call_args.args[1]
+    assert "Interrupted the running turn" not in note
 
 
 async def test_restart_unchanged_value_returns_false_without_relaunch() -> None:

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -221,6 +221,32 @@ def test_error_tool_result_sets_is_error() -> None:
     assert events[0].metadata["is_error"] is True
 
 
+def test_generic_error_tool_result_stays_running() -> None:
+    # A failing tool (not a user decline) does not end the turn — the agent
+    # gets the error and continues — so status must stay RUNNING.
+    norm = TranscriptNormalizer()
+    record = _user_record([_tool_result_block("tu2", "ENOENT", is_error=True)])
+    events = norm.process_record(record)
+    assert all(e.status == SessionStatus.RUNNING for e in events)
+    assert not any(e.kind == EventKind.SYSTEM_NOTE for e in events)
+
+
+def test_user_rejected_tool_resolves_session_to_idle() -> None:
+    # A declined tool aborts the turn back to the prompt with no terminal
+    # stop_reason record, so the normalizer must synthesize an idle result or
+    # the session stays stuck running.
+    norm = TranscriptNormalizer()
+    record = _user_record(
+        [_tool_result_block("tu3", "The tool use was rejected", is_error=True)]
+    )
+    record["toolUseResult"] = "User rejected tool use"
+    events = norm.process_record(record)
+
+    note = next(e for e in events if e.kind == EventKind.SYSTEM_NOTE)
+    assert note.status == SessionStatus.IDLE
+    assert note.metadata["stop_reason"] == "tool_rejected"
+
+
 def test_injected_task_notification_produces_no_events() -> None:
     norm = TranscriptNormalizer()
     record = _user_record("<task-notification>some harness turn</task-notification>")

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -615,7 +615,7 @@ async def test_list_command_completions_uses_claude_runtime_commands(
 
 
 @pytest.mark.asyncio
-async def test_list_command_completions_claude_omits_unreported_tui_commands(
+async def test_list_command_completions_claude_surfaces_reported_and_curated(
     monkeypatch, tmp_path
 ) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
@@ -644,10 +644,14 @@ async def test_list_command_completions_claude_omits_unreported_tui_commands(
     )
 
     names = {item.name for item in completions}
-    assert "status" in names
-    assert "usage" in names
+    assert "status" in names  # waypoint builtin
+    assert "usage" in names  # SDK-reported
+    # Curated built-ins are surfaced as a baseline even when the session never
+    # reported them (e.g. tmux-transport Claude has no system.init stream).
+    assert "help" in names
+    assert "compact" in names
+    # …but a real TUI command that is neither reported nor curated stays absent.
     assert "permissions" not in names
-    assert "help" not in names
 
 
 @pytest.mark.asyncio

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -101,6 +101,7 @@ plugin without calling into it:
 | `supports_set_effort_inline` | `bool` | Gates the effort picker. Set `False` if effort changes require a session restart (Claude); the runtime still routes through your `apply_effort`, which decides whether to short-circuit. |
 | `supports_set_effort_with_restart` | `bool` | Gates effort changes that restart and resume the backend between turns instead of applying the value mid-stream. |
 | `supports_set_permission_mode_inline` | `bool` | Gates the permission-mode picker + the `/api/sessions/{id}/mode` endpoint. |
+| `settings_change_interrupts_turn` | `bool` | Frontend hint that applying a model/permission-mode/effort change relaunches the session and interrupts any running turn (claude_tty), so the composer confirms before changing settings on a running session. |
 | `supports_thread_discovery` | `bool` | Enables `GET /api/backends/{id}/threads`. |
 | `supports_thread_import` | `bool` | Enables `POST /api/backends/{id}/sessions/import`. |
 | `supports_fork` | `bool` | Enables creating a new session from an existing backend thread. |
@@ -125,17 +126,19 @@ mechanisms behind it:
 | Backend | Transport | Models | Effort | Permission mode | Threads | Custom CLI args | Approval notes |
 |---------|-----------|--------|--------|-----------------|---------|-----------------|----------------|
 | `claude_code` | Claude stream-json subprocess | Static Claude model catalogue; swaps through the CLI control protocol | `low` / `medium` / `high` / `xhigh`; restart-with-resume while idle | Claude permission-mode catalogue; swaps through the CLI control protocol | Discovers and imports Claude transcripts | Yes | Yes, on decline |
-| `claude_tty` | Claude fullscreen TUI in tmux, tailed from transcript JSONL | Static Claude model catalogue; restart-with-resume while idle | `low` / `medium` / `high` / `xhigh`; restart-with-resume while idle | Claude permission-mode catalogue; restart-with-resume while idle | Discovers and imports Claude transcripts | Yes | No |
+| `claude_tty` | Claude fullscreen TUI in tmux, tailed from transcript JSONL | Static Claude model catalogue; restart-with-resume, interrupting any running turn | `low` / `medium` / `high` / `xhigh`; restart-with-resume, interrupting any running turn | Claude permission-mode catalogue; restart-with-resume, interrupting any running turn | Discovers and imports Claude transcripts | Yes | No |
 | `codex` | App Server SDK | Live `model/list` RPC | Per-turn flag from live model metadata | Codex permission-mode catalogue; applied inline | Discovers and imports Codex threads | Yes | No |
 | `opencode` | OpenCode REST + SSE | Live OpenCode metadata | Backend-native setting | OpenCode permission-mode catalogue; applied inline | Discovers and imports OpenCode sessions | Yes | Yes, on decline |
 | `tmux` | Generic tmux pane | None | None | None | None | No | No |
 
 `claude_tty` applies model, effort, and permission-mode swaps by
 relaunching the pane with `claude --resume <thread>` plus the selected
-`--model`, `--effort`, and `--permission-mode` flags while the session
-is idle. That is deliberately different from `claude_code`, which can
-send model and permission changes over Claude's stdio control protocol
-and uses restart-with-resume only for effort changes.
+`--model`, `--effort`, and `--permission-mode` flags. The TUI has no
+in-process knob, so a swap on a running session interrupts the live turn
+before resuming; the plugin sets `settings_change_interrupts_turn` so the
+composer warns first. That is deliberately different from `claude_code`,
+which sends model and permission changes over Claude's stdio control
+protocol mid-turn and uses restart-with-resume only for effort changes.
 
 Thread discovery/import for `claude_tty` reads the same
 `~/.claude/projects` transcript store as `claude_code`, so the same

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6466,6 +6466,11 @@ html[data-theme="light"] .reply-textarea-wrap {
     inset 0 1px 0 rgba(200, 169, 106, 0.16),
     0 0 0 3px rgba(200, 169, 106, 0.16);
 }
+/* While busy the Interrupt button joins Send in the corner; widen the reserve
+ * so neither button overlaps the text. */
+.reply-textarea-wrap.is-busy {
+  padding-right: 84px;
+}
 
 /* The ›-chevron stand-in for the leading cluster. It is always in the DOM but
  * only shown (and the ⊕/📎 collapsed) while the field is focused — driven by
@@ -6571,11 +6576,12 @@ html[data-theme="light"] .reply-textarea-wrap {
   transform: rotate(45deg);
 }
 
-/* The morph primary — circular, accent for Send, danger for Stop. Pinned to
- * the bottom-right inside the input pill. */
-.composer-send-morph {
+/* Composer actions — a gold circular Send pinned bottom-right, with a danger
+ * Interrupt that appears to its left while the agent is busy so a follow-up
+ * can still be sent. Send keeps its slot so it never jumps between states. */
+.composer-send,
+.composer-interrupt {
   position: absolute;
-  right: 3px;
   bottom: 3px;
   width: 32px;
   height: 32px;
@@ -6584,40 +6590,49 @@ html[data-theme="light"] .reply-textarea-wrap {
   justify-content: center;
   border: 0;
   border-radius: 50%;
-  color: #0c0f15;
-  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
-  box-shadow: 0 4px 14px rgba(200, 169, 106, 0.3);
-  font-size: 0.98rem;
   transition:
     transform 140ms ease,
     background 200ms ease,
     box-shadow 200ms ease,
     opacity 140ms ease;
 }
+.composer-send {
+  right: 3px;
+  color: #0c0f15;
+  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 4px 14px rgba(200, 169, 106, 0.3);
+  font-size: 0.98rem;
+}
 .composer-send-glyph {
   display: inline-flex;
   line-height: 1;
   transform: translateY(-1px);
 }
-.composer-send-morph:hover:not(:disabled) {
+.composer-send:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 6px 18px rgba(200, 169, 106, 0.42);
 }
-.composer-send-morph:disabled {
+.composer-send:disabled,
+.composer-interrupt:disabled {
   opacity: 0.4;
   cursor: default;
   box-shadow: none;
 }
-.composer-send-morph.is-stop {
+.composer-interrupt {
+  right: 39px;
   color: #fff;
   background: linear-gradient(180deg, #e8807f, var(--danger));
   box-shadow: 0 4px 14px rgba(226, 108, 112, 0.34);
 }
-.composer-send-morph.is-stop .composer-send-glyph {
+.composer-interrupt:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(226, 108, 112, 0.46);
+}
+.composer-interrupt .composer-send-glyph {
   font-size: 0.78rem;
   transform: none;
 }
-.composer-send-morph.is-stop::after {
+.composer-interrupt::after {
   content: "";
   position: absolute;
   inset: -4px;
@@ -6638,7 +6653,7 @@ html[data-theme="light"] .reply-textarea-wrap {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .composer-send-morph.is-stop::after {
+  .composer-interrupt::after {
     animation: none;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6466,11 +6466,6 @@ html[data-theme="light"] .reply-textarea-wrap {
     inset 0 1px 0 rgba(200, 169, 106, 0.16),
     0 0 0 3px rgba(200, 169, 106, 0.16);
 }
-/* While busy the Interrupt button joins Send in the corner; widen the reserve
- * so neither button overlaps the text. */
-.reply-textarea-wrap.is-busy {
-  padding-right: 84px;
-}
 
 /* The ›-chevron stand-in for the leading cluster. It is always in the DOM but
  * only shown (and the ⊕/📎 collapsed) while the field is focused — driven by
@@ -6478,7 +6473,7 @@ html[data-theme="light"] .reply-textarea-wrap {
  * `lead-forced` (set when the chevron is tapped) reverses it back to ⊕/📎. */
 .composer-lead-expand {
   display: none;
-  order: -3;
+  order: -4;
   flex: 0 0 auto;
   align-self: flex-end;
   width: 32px;
@@ -6509,19 +6504,56 @@ html[data-theme="light"] .reply-textarea-wrap {
   display: inline-flex;
 }
 .composer-bar:focus-within:not(.lead-forced) .composer-plus,
+.composer-bar:focus-within:not(.lead-forced) .composer-interrupt-btn,
 .composer-bar:focus-within:not(.lead-forced) .composer-attach-btn {
   display: none;
 }
 
 /* ⊕ actions + 📎 attach — left cluster (via order), circular and quiet */
 .composer-bar .composer-plus {
-  order: -2;
+  order: -3;
   margin: 0;
   flex: 0 0 auto;
   align-self: flex-end;
 }
-.composer-attach-btn {
+
+/* ■ interrupt — last of the lead cluster, right after 📎 attach. Static (always
+ * present, never toggled by agent state) so it never flickers; sending an
+ * interrupt is safe in any state, the backend ignores it when there's nothing
+ * to stop. Quiet by default, danger only on hover so an idle composer doesn't
+ * read as alarming. */
+.composer-bar .composer-interrupt-btn {
   order: -1;
+  flex: 0 0 auto;
+  align-self: flex-end;
+  width: 40px;
+  height: 40px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 50%;
+  color: var(--muted);
+  background: transparent;
+  transition:
+    color 140ms ease,
+    background-color 140ms ease;
+}
+.composer-interrupt-btn:hover:not(:disabled) {
+  color: var(--danger);
+  background: rgba(226, 108, 112, 0.14);
+}
+.composer-interrupt-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.composer-interrupt-btn .glyph {
+  display: inline-flex;
+  font-size: 0.7rem;
+  line-height: 1;
+}
+.composer-attach-btn {
+  order: -2;
   flex: 0 0 auto;
   align-self: flex-end;
   width: 40px;
@@ -6576,12 +6608,13 @@ html[data-theme="light"] .reply-textarea-wrap {
   transform: rotate(45deg);
 }
 
-/* Composer actions — a gold circular Send pinned bottom-right, with a danger
- * Interrupt that appears to its left while the agent is busy so a follow-up
- * can still be sent. Send keeps its slot so it never jumps between states. */
-.composer-send,
-.composer-interrupt {
+/* The send button — a gold circular primary pinned bottom-right inside the
+ * input pill. Always present; it sends a follow-up even while the agent is
+ * busy. Interrupting lives in the lead cluster (`.composer-interrupt-btn`), so
+ * it costs no width here. */
+.composer-send {
   position: absolute;
+  right: 3px;
   bottom: 3px;
   width: 32px;
   height: 32px;
@@ -6590,18 +6623,15 @@ html[data-theme="light"] .reply-textarea-wrap {
   justify-content: center;
   border: 0;
   border-radius: 50%;
+  color: #0c0f15;
+  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 4px 14px rgba(200, 169, 106, 0.3);
+  font-size: 0.98rem;
   transition:
     transform 140ms ease,
     background 200ms ease,
     box-shadow 200ms ease,
     opacity 140ms ease;
-}
-.composer-send {
-  right: 3px;
-  color: #0c0f15;
-  background: linear-gradient(180deg, var(--accent-strong), var(--accent));
-  box-shadow: 0 4px 14px rgba(200, 169, 106, 0.3);
-  font-size: 0.98rem;
 }
 .composer-send-glyph {
   display: inline-flex;
@@ -6612,50 +6642,10 @@ html[data-theme="light"] .reply-textarea-wrap {
   transform: translateY(-1px);
   box-shadow: 0 6px 18px rgba(200, 169, 106, 0.42);
 }
-.composer-send:disabled,
-.composer-interrupt:disabled {
+.composer-send:disabled {
   opacity: 0.4;
   cursor: default;
   box-shadow: none;
-}
-.composer-interrupt {
-  right: 39px;
-  color: #fff;
-  background: linear-gradient(180deg, #e8807f, var(--danger));
-  box-shadow: 0 4px 14px rgba(226, 108, 112, 0.34);
-}
-.composer-interrupt:hover:not(:disabled) {
-  transform: translateY(-1px);
-  box-shadow: 0 6px 18px rgba(226, 108, 112, 0.46);
-}
-.composer-interrupt .composer-send-glyph {
-  font-size: 0.78rem;
-  transform: none;
-}
-.composer-interrupt::after {
-  content: "";
-  position: absolute;
-  inset: -4px;
-  border-radius: 50%;
-  border: 1px solid rgba(226, 108, 112, 0.45);
-  animation: morph-pulse 1.8s ease-out infinite;
-  pointer-events: none;
-}
-@keyframes morph-pulse {
-  0% {
-    opacity: 0.7;
-    transform: scale(0.82);
-  }
-  100% {
-    opacity: 0;
-    transform: scale(1.3);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .composer-interrupt::after {
-    animation: none;
-  }
 }
 
 /* On phones the ⊕ menu and the control popover become full-width sheets that

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2875,7 +2875,9 @@ const ReplyComposer = memo(function ReplyComposer({
         ›
       </button>
       <div
-        className={`reply-textarea-wrap${dragActive ? " is-drag-active" : ""}`}
+        className={`reply-textarea-wrap${dragActive ? " is-drag-active" : ""}${
+          agentBusy ? " is-busy" : ""
+        }`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -2910,25 +2912,35 @@ const ReplyComposer = memo(function ReplyComposer({
             <span>Drop to attach</span>
           </div>
         ) : null}
+        {agentBusy ? (
+          <button
+            type="button"
+            className="composer-interrupt"
+            onClick={() => void onInterrupt()}
+            disabled={disabled || dormant}
+            aria-label="Interrupt the agent"
+            title="Interrupt the agent's current turn"
+          >
+            <span className="composer-send-glyph" aria-hidden>
+              ■
+            </span>
+          </button>
+        ) : null}
         <button
           type="button"
-          className={`composer-send-morph ${agentBusy ? "is-stop" : "is-send"}`}
-          onClick={() => (agentBusy ? void onInterrupt() : void handleSend())}
+          className="composer-send"
+          onClick={() => void handleSend()}
           disabled={
-            agentBusy
-              ? disabled || dormant
-              : disabled ||
-                sending ||
-                attachments.uploading ||
-                (!draft.trim() && attachments.readyIds.length === 0)
+            disabled ||
+            sending ||
+            attachments.uploading ||
+            (!draft.trim() && attachments.readyIds.length === 0)
           }
-          aria-label={agentBusy ? "Stop the agent" : "Send"}
-          title={
-            agentBusy ? "Interrupt the agent's current turn" : "Send (⌘/Ctrl + ↵)"
-          }
+          aria-label="Send"
+          title="Send (⌘/Ctrl + ↵)"
         >
           <span className="composer-send-glyph" aria-hidden>
-            {sending ? "…" : agentBusy ? "■" : "↑"}
+            {sending ? "…" : "↑"}
           </span>
         </button>
         {suggestionsOpen ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2021,7 +2021,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           connection={connection}
           disabled={composerDisabled}
           rateLimitRefreshBusy={rateLimitRefreshBusy}
-          dormant={dormantReattach}
           placeholder={composerPlaceholder}
           agentBusy={agentBusy}
           modeBusy={modeBusy}
@@ -2096,7 +2095,6 @@ interface ReplyComposerProps {
   connection: ConnectionState;
   disabled: boolean;
   rateLimitRefreshBusy: boolean;
-  dormant: boolean;
   placeholder: string;
   modeBusy: boolean;
   modelBusy: boolean;
@@ -2151,7 +2149,6 @@ const ReplyComposer = memo(function ReplyComposer({
   connection,
   disabled,
   rateLimitRefreshBusy,
-  dormant,
   placeholder,
   modeBusy,
   modelBusy,
@@ -2874,10 +2871,20 @@ const ReplyComposer = memo(function ReplyComposer({
       >
         ›
       </button>
+      <button
+        type="button"
+        className="composer-interrupt-btn"
+        onClick={() => void onInterrupt()}
+        disabled={disabled}
+        aria-label="Interrupt the agent"
+        title="Interrupt the agent"
+      >
+        <span className="glyph" aria-hidden>
+          ■
+        </span>
+      </button>
       <div
-        className={`reply-textarea-wrap${dragActive ? " is-drag-active" : ""}${
-          agentBusy ? " is-busy" : ""
-        }`}
+        className={`reply-textarea-wrap${dragActive ? " is-drag-active" : ""}`}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
@@ -2911,20 +2918,6 @@ const ReplyComposer = memo(function ReplyComposer({
             <span className="composer-drop-glyph">⤓</span>
             <span>Drop to attach</span>
           </div>
-        ) : null}
-        {agentBusy ? (
-          <button
-            type="button"
-            className="composer-interrupt"
-            onClick={() => void onInterrupt()}
-            disabled={disabled || dormant}
-            aria-label="Interrupt the agent"
-            title="Interrupt the agent's current turn"
-          >
-            <span className="composer-send-glyph" aria-hidden>
-              ■
-            </span>
-          </button>
         ) : null}
         <button
           type="button"

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -442,9 +442,29 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     window.scrollTo({ top: 0, behavior });
   }, []);
 
+  // Backends that apply settings by relaunching the process (claude_tty)
+  // interrupt the live turn, so confirm before changing one mid-turn.
+  const confirmTurnInterrupt = useCallback(
+    (field: string): boolean => {
+      if (!session) return false;
+      const interrupts = catalog.byId(session.backend)?.capabilities
+        .settings_change_interrupts_turn;
+      const running =
+        session.status === "running" || session.status === "waiting_input";
+      if (!interrupts || !running) return true;
+      return window.confirm(
+        `Changing the ${field} restarts this session and interrupts the current turn. Continue?`,
+      );
+    },
+    [session, catalog],
+  );
+
   const handlePermissionModeChange = useCallback(
     async (nextMode: string) => {
       if (!session || nextMode === (session.permission_mode ?? "default")) {
+        return;
+      }
+      if (!confirmTurnInterrupt("permission mode")) {
         return;
       }
       setModeBusy(true);
@@ -464,7 +484,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         setModeBusy(false);
       }
     },
-    [host, token, session, handleAuthFailure],
+    [host, token, session, handleAuthFailure, confirmTurnInterrupt],
   );
 
   // Refresh the model picker whenever the active backend or launch target
@@ -518,6 +538,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       if (cleaned === current) {
         return;
       }
+      if (!confirmTurnInterrupt("model")) {
+        return;
+      }
       setModelBusy(true);
       setError("");
       try {
@@ -535,7 +558,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         setModelBusy(false);
       }
     },
-    [host, token, session, handleAuthFailure],
+    [host, token, session, handleAuthFailure, confirmTurnInterrupt],
   );
 
   const handleEffortChange = useCallback(
@@ -546,6 +569,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       const cleaned = nextEffort.trim() || null;
       const current = session.effort ?? null;
       if (cleaned === current) {
+        return;
+      }
+      if (!confirmTurnInterrupt("effort")) {
         return;
       }
       setEffortBusy(true);
@@ -565,7 +591,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         setEffortBusy(false);
       }
     },
-    [host, token, session, handleAuthFailure],
+    [host, token, session, handleAuthFailure, confirmTurnInterrupt],
   );
 
   const flushPendingEvents = useCallback(() => {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -175,6 +175,7 @@ export interface BackendCapabilities {
   supports_set_effort_inline: boolean;
   supports_set_effort_with_restart: boolean;
   supports_set_permission_mode_inline: boolean;
+  settings_change_interrupts_turn: boolean;
   supports_thread_discovery: boolean;
   supports_thread_import: boolean;
   supports_plan_approval: boolean;


### PR DESCRIPTION
## Summary

A cluster of `claude_tty` (#104) and composer improvements — several surfaced while debugging a session that hung after a tool approval.

1. **Live settings on a running `claude_tty` session.** `claude_tty` applies model/permission-mode/effort changes by relaunching the pane with `--resume` (it has no inline control channel), and previously refused any swap unless the session was idle — a gap versus `claude_code`, which swaps inline mid-turn. The restart necessarily interrupts the live turn, so rather than block it, we now allow it and warn first. The guard rejects only a `STARTING` pane (nothing to resume yet); every other state proceeds, interrupts the turn, and records a system note. A new `settings_change_interrupts_turn` capability lets the composer confirm before changing a setting on a running session, with no per-backend branch in the frontend.

2. **Send a follow-up while the agent is busy, with an always-available interrupt.** The send button used to morph into an interrupt-only button while the agent was running, blocking a follow-up — even though every backend already accepts input mid-turn and queues it natively (`claude_code` stdin, Codex `turn_steer`, OpenCode concurrent posts, tmux/`claude_tty` keystrokes). Send is now always a send; interrupt is a separate, static control in the composer's lead cluster (next to the actions/attach buttons, collapsing into the same chevron on focus) that is available in any state. No Waypoint-side queue is needed; the change is purely frontend.

3. **Claude built-in slash commands (`/compact`, …) autocomplete for both Claude backends.** Neither backend surfaced them reliably: `claude_code` learns them from the SDK's `system.init` stream, which a tmux-transport Claude session never emits, and `claude_tty` had no source at all. Both backends now carry a shared curated baseline, merged (and deduped) with whatever the runtime reports, so `/compact` autocompletes in the chat and terminal composers regardless of transport.

4. **Approval / interrupt / turn-resolution correctness.** Debugging a stuck session turned up three related bugs: the composer sends the decision string `accept` for the primary approve, but `claude_tty` and the `tmux` transport only honoured `{approve, yes, y}`, so every UI approval silently declined; a declined tool left the session wedged in `running`; and interrupting left a stale pending-approval entry behind.

## Changes

### Backend

- **`backends/capabilities.py`** — adds `settings_change_interrupts_turn` (default `False`): a frontend hint that applying a settings change relaunches the session and interrupts any running turn.
- **`backends/approvals.py`** (new) — a shared `is_approve_decision` / `APPROVE_DECISIONS`, used by `claude_code`, `claude_tty`, and `tmux` so the approve vocabulary (`approve`/`accept`/`yes`/`y`/`allow`/`acceptForSession`/`acceptAlways`) can't drift between backends. Fixes the `accept`-silently-declines bug; `claude_code`'s mapping is unchanged (same set, now shared).
- **`backends/claude_tty/plugin.py`** — `_restart_with_args` rejects only `STARTING`; running/waiting/exited sessions proceed (mid-turn note reads "Interrupted the running turn and restarted…"). `list_command_completions` now merges the shared curated built-in list with on-disk command/skill discovery.
- **`backends/claude_tty/transport.py`** — `respond_to_approval` uses the shared vocab; `interrupt` now drops any pending approval before sending Esc, closing the window where a racing approve would fire a stray digit at the ready prompt.
- **`backends/claude_tty/normalize.py`** — detects a user-rejected tool (record-level `toolUseResult: "User rejected tool use"`) and synthesizes an idle result, so a declined tool resolves the session instead of hanging on `running`. Generic tool errors still keep the turn running.
- **`backends/claude_tty/tailer.py`** — corrects a stale comment that referenced `supports_set_permission_mode_inline=False`.
- **`backends/claude_code/commands.py`** — `CLAUDE_BUILTIN_SLASH_COMMANDS`, the shared curated baseline of Claude's built-in slash commands.
- **`backends/claude_code/plugin.py`** — sets `slash_commands` and merges the static baseline into `list_command_completions` (deduped against SDK-reported commands), so `/compact` autocompletes even for tmux-transport `claude_code` sessions that never emit `system.init`.
- **`backends/tmux/transport.py`** — approval decision now uses the shared vocab.

### Frontend

- **`components/SessionDetail.tsx`** — adds a `confirmTurnInterrupt` helper that, for a backend with `settings_change_interrupts_turn` on a running/waiting session, confirms before a model/permission-mode/effort change. The interrupt is now a static lead-cluster button — always available (gated only on disconnect), never toggled by agent state — and the top-row spinner is the working indicator.
- **`app/globals.css`** — `.composer-interrupt-btn` lives in the lead cluster (ordered after the attach button, collapsing on focus like the other lead controls), quiet by default and danger only on hover. Removes the superseded `.composer-send-morph` / `.composer-stop` / `morph-pulse` / `.is-busy` rules; no new theme-parity gap.
- **`lib/types.ts`** — mirrors the new capability field.

### Tests

- **`test_claude_tty_controls.py`** — running → relaunch + interruption note, starting → 400 guard, exited → tolerates a dead pane; plus completion surfacing.
- **`test_claude_tty_approval.py`** — `accept` drives the approve keystroke (not decline); interrupt clears pending and sends Esc.
- **`test_claude_tty_normalize.py`** — a user-rejected tool resolves to idle; a generic tool error stays running.
- **`test_runtime.py`** — `claude_code` completions surface curated built-ins (`compact`/`help`) alongside reported ones, while an unreported non-curated command stays absent.

### Docs

- **`docs/coding_agent_plugins.md`** — documents `settings_change_interrupts_turn` and updates the `claude_tty` capability matrix/prose to "restart-with-resume, interrupting any running turn."

## Test Plan

- [x] `cd backend && uv run pytest` — 842 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort / black / ruff / codespell / mypy clean; hooks also ran clean per-commit.
- [x] `cd frontend && npx tsc --noEmit`, `npm run lint`, `npm run build` — clean.
- [x] Live e2e (backend restarted on this branch): `POST /effort` on a *running* `claude_tty` session returned **HTTP 200** (previously 400), recorded "Interrupted the running turn and restarted…", and resumed; `settings_change_interrupts_turn` is served `True` only for `claude_tty`.
- [x] Live e2e: `POST /input` while `running` returned **HTTP 200** and the session stayed `running` (backend accepted/queued the follow-up).
- [x] Live e2e: the completions API for a **`claude_code` + tmux** session returns `/compact` (`plain_text`, `/compact ` replacement) for prefix `/comp`, confirming the curated baseline surfaces where the SDK stream is absent. Confirmed in the terminal composer UI.
- [x] Live e2e: approving a `claude_tty` tool now allows it (the `accept` decision drives the Yes keystroke instead of declining); a declined tool resolves the session to idle.
- [x] In-browser visual pass of the static lead-cluster interrupt button (iterated on directly during review; covered by `tsc`/lint/build, not driven headlessly here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
