### PR TITLE
feat: surface AskUserQuestion prompts in claude_tty sessions

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/_state.py
+++ b/backend/src/waypoint/backends/claude_tty/_state.py
@@ -9,3 +9,17 @@ class PendingTtyApproval:
     approve_number: int
     decline_number: int | None  # None → send Esc
     signature: str  # debounce key: "tool_name:target:question"
+
+
+@dataclass
+class PendingTtyQuestion:
+    """An AskUserQuestion surfaced from the transcript and awaiting an answer.
+
+    The popup is dismissed (Esc) the moment it is detected, which flushes the
+    structured ``questions`` to the JSONL; the answer is delivered later as a
+    normal user turn, so all this needs to carry is the tool_use id that pairs
+    the answer back to the surfaced card.
+    """
+
+    approval_id: str
+    tool_use_id: str

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -69,6 +69,16 @@ class TranscriptNormalizer:
         self._pending_task_creates: dict[str, dict[str, Any]] = {}
         self._suppressed_result_tool_use_ids: set[str] = set()
         self._task_card_item_id: str | None = None
+        # Set by the tailer right after it Esc-dismisses an AskUserQuestion
+        # popup. The Esc forces the TUI to flush the tool_use record (and a
+        # "user rejected" result) to the transcript; the latch tells the next
+        # AskUserQuestion record to surface as an answerable card rather than a
+        # plain tool_call, and to swallow the synthetic rejection.
+        self._expect_dismissed_question: bool = False
+        self._dismissed_question_ids: set[str] = set()
+
+    def arm_question_dismissal(self) -> None:
+        self._expect_dismissed_question = True
 
     def process_record(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         rec_type = record.get("type")
@@ -114,6 +124,27 @@ class TranscriptNormalizer:
                 has_tool_use = True
                 tool_use_id = str(block.get("id") or "")
                 tool_name = str(block.get("name") or "tool")
+                if tool_name == "AskUserQuestion" and self._expect_dismissed_question:
+                    self._expect_dismissed_question = False
+                    if tool_use_id:
+                        self._dismissed_question_ids.add(tool_use_id)
+                    events.append(
+                        NormalizedEvent(
+                            kind=EventKind.TOOL_CALL,
+                            text=f"{tool_name}\n"
+                            f"{json.dumps(block.get('input') or {}, indent=2)}",
+                            metadata={
+                                "method": "assistant.tool_use",
+                                "item_id": tool_use_id,
+                                "tool_name": tool_name,
+                                "tool_use_id": tool_use_id,
+                                "payload": block,
+                                "status": SessionStatus.WAITING_INPUT,
+                            },
+                            status=SessionStatus.WAITING_INPUT,
+                        )
+                    )
+                    continue
                 if tool_name in TASK_TOOL_NAMES:
                     tool_input: dict[str, Any] = block.get("input") or {}
                     if tool_name == "TaskCreate":
@@ -194,6 +225,7 @@ class TranscriptNormalizer:
             return []
 
         turn_aborted = _is_user_rejection(record)
+        dismissed_question = False
 
         # Only tool_result blocks are surfaced from user records. A user/peer
         # turn's own text is already recorded at the input boundary
@@ -204,6 +236,14 @@ class TranscriptNormalizer:
             if block.get("type") != "tool_result":
                 continue
             tool_use_id = str(block.get("tool_use_id") or "")
+            if tool_use_id and tool_use_id in self._dismissed_question_ids:
+                # The "user rejected" result the TUI writes when we Esc the
+                # popup to surface it. Drop it so the question card stays
+                # answerable, and skip the abort note below — the session
+                # waits on the user, it has not ended the turn.
+                self._dismissed_question_ids.discard(tool_use_id)
+                dismissed_question = True
+                continue
             if tool_use_id and tool_use_id in self._pending_task_creates:
                 create_input = self._pending_task_creates.pop(tool_use_id)
                 task_id = extract_created_task_id(block) or tool_use_id
@@ -241,7 +281,7 @@ class TranscriptNormalizer:
 
         # A declined tool ends the turn with no terminal-stop_reason record to
         # follow, so resolve the session to idle here or it stays stuck running.
-        if turn_aborted:
+        if turn_aborted and not dismissed_question:
             events.append(
                 NormalizedEvent(
                     kind=EventKind.SYSTEM_NOTE,

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -69,6 +69,11 @@ class TranscriptNormalizer:
         self._pending_task_creates: dict[str, dict[str, Any]] = {}
         self._suppressed_result_tool_use_ids: set[str] = set()
         self._task_card_item_id: str | None = None
+        # Message ids that have already emitted a synthesized "turn complete"
+        # note. A turn's content can arrive as several same-id records (e.g. a
+        # thinking record then a text record, both stamped end_turn); the note
+        # must fire once, not once per record.
+        self._result_emitted_ids: set[str] = set()
         # Set by the tailer right after it Esc-dismisses an AskUserQuestion
         # popup. The Esc forces the TUI to flush the tool_use record (and a
         # "user rejected" result) to the transcript; the latch tells the next
@@ -101,12 +106,15 @@ class TranscriptNormalizer:
         events: list[NormalizedEvent] = []
         blocks = iter_content_blocks(message.get("content"))
         has_tool_use = False
+        had_text = False
+        had_thinking = False
 
         for block in blocks:
             bt = block.get("type")
             if bt == "text":
                 text = str(block.get("text") or "")
                 if text:
+                    had_text = True
                     events.append(
                         NormalizedEvent(
                             kind=EventKind.AGENT_OUTPUT,
@@ -184,11 +192,27 @@ class TranscriptNormalizer:
                         status=SessionStatus.RUNNING,
                     )
                 )
-            # thinking blocks: intentionally skipped
+            elif bt == "thinking":
+                had_thinking = True
+            # thinking blocks emit nothing; tracked only to defer the note below
 
         # Synthesize a result event when the turn is complete: stop_reason is
         # terminal (not "tool_use") and no tool_use blocks were in this record.
-        if stop_reason and stop_reason != "tool_use" and not has_tool_use:
+        # A turn's final message can split into a thinking record then a text
+        # record, both stamped end_turn; defer off the thinking-only record so
+        # the note lands after the visible text, and emit it at most once per
+        # message id so the split does not double the note.
+        already_noted = bool(message_id) and message_id in self._result_emitted_ids
+        thinking_only = had_thinking and not had_text
+        if (
+            stop_reason
+            and stop_reason != "tool_use"
+            and not has_tool_use
+            and not already_noted
+            and not thinking_only
+        ):
+            if message_id:
+                self._result_emitted_ids.add(message_id)
             usage_payload: dict[str, Any] = usage if first_seen else {}
             output_tokens = int(usage.get("output_tokens") or 0)
             if stop_reason == "end_turn":

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -203,7 +203,11 @@ class TranscriptNormalizer:
         # the note lands after the visible text, and emit it at most once per
         # message id so the split does not double the note.
         already_noted = bool(message_id) and message_id in self._result_emitted_ids
-        thinking_only = had_thinking and not had_text
+        # Only an end_turn message splits its thinking and text across sibling
+        # records, so the note can wait for the text. An abnormal termination
+        # (e.g. max_tokens hit mid-thinking) has no text sibling coming, so its
+        # note must fire on the thinking record or the turn never resolves.
+        thinking_only = had_thinking and not had_text and stop_reason == "end_turn"
         if (
             stop_reason
             and stop_reason != "tool_use"

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -19,6 +19,7 @@ from enum import StrEnum
 
 class PaneScreen(StrEnum):
     APPROVAL = "approval"
+    QUESTION = "question"
     TRUST = "trust"
     MODEL_SELECTOR = "model_selector"
     EFFORT_POPUP = "effort_popup"
@@ -35,6 +36,11 @@ class PaneScreen(StrEnum):
 # brittle to that.
 _APPROVAL_FOOTER = "Esc to cancel · Tab to amend"
 _APPROVAL_QUESTION_MARKER = "Do you want to"
+# The AskUserQuestion popup carries its own navigation footer, distinct from the
+# permission dialog's "Tab to amend". We only need to recognize it: the dialog
+# is dismissed with Esc so the TUI flushes the structured questions to the
+# transcript, which is surfaced from there rather than parsed off the pane.
+_QUESTION_FOOTER = "Tab/Arrow keys to navigate"
 _MODEL_FOOTER = "Enter to set as default"
 _MODEL_MARKER = "Select model"
 _EFFORT_FOOTER = "←/→ to adjust · Enter to confirm"
@@ -103,6 +109,8 @@ def classify(screen: str) -> PaneScreen:
         screen, compact, _APPROVAL_QUESTION_MARKER
     ):
         return PaneScreen.APPROVAL
+    if _contains(screen, compact, _QUESTION_FOOTER):
+        return PaneScreen.QUESTION
     if _contains(screen, compact, _TRUST_MARKER):
         return PaneScreen.TRUST
     if _contains(screen, compact, _MODEL_FOOTER) and _contains(

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -57,7 +57,7 @@ from waypoint.backends.claude_code.threads import (
     find_local_claude_thread,
     list_local_claude_threads,
 )
-from waypoint.backends.claude_tty._state import PendingTtyApproval
+from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig
@@ -68,6 +68,7 @@ from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
     BackendModelOption,
     CommandCompletion,
+    EventKind,
     SessionCreateRequest,
     SessionRateLimitUsage,
     SessionRecord,
@@ -151,6 +152,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
     def __init__(self) -> None:
         self._tailer_tasks: dict[str, asyncio.Task[None]] = {}
         self._pending_approvals: dict[str, PendingTtyApproval] = {}
+        self._pending_questions: dict[str, PendingTtyQuestion] = {}
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
         from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
@@ -298,6 +300,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
             with suppress(asyncio.CancelledError, Exception):
                 await tailer_task
         self._pending_approvals.pop(session.id, None)
+        self._pending_questions.pop(session.id, None)
 
     async def create_session(
         self,
@@ -696,6 +699,7 @@ class ClaudeTtyPlugin(TmuxPlugin):
             with suppress(TmuxError):
                 await runtime.tmux.kill_session(old_tmux_session)
         self._pending_approvals.pop(session.id, None)
+        self._pending_questions.pop(session.id, None)
         tailer_task = self._tailer_tasks.pop(session.id, None)
         if tailer_task is not None:
             tailer_task.cancel()
@@ -768,6 +772,78 @@ class ClaudeTtyPlugin(TmuxPlugin):
             runtime, session.id, thread_id, session.cwd, start_at_end=True
         )
         return True
+
+    # ── AskUserQuestion ──────────────────────────────────────────────────────
+
+    async def answer_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        answer: str,
+        tool_use_id: str | None,
+        answers: list[dict[str, Any]] | None,
+    ) -> SessionRecord:
+        """Deliver an answer to a surfaced AskUserQuestion as a new user turn.
+
+        The popup was already Esc-dismissed when the tailer surfaced it, so the
+        pane sits at the ready prompt; the answer is sent as an ordinary message
+        the way claude_code carries it on a denied tool. A synthetic tool_result
+        flips the surfaced card to answered so it stops accepting input, and a
+        styled answers card records the choices.
+        """
+        pending = self._pending_questions.get(session.id)
+        if pending is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="no pending question for this session",
+            )
+        if (
+            tool_use_id is not None
+            and pending.tool_use_id
+            and pending.tool_use_id != tool_use_id
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="question answer does not match the pending question",
+            )
+        self._pending_questions.pop(session.id, None)
+        resolved_tool_use_id = pending.tool_use_id or tool_use_id
+
+        transport = runtime.transport_for(session)
+        await transport.send_input(
+            session,
+            f"User has answered your questions: {answer}. "
+            "You can now continue with the user's answers in mind.",
+        )
+
+        if resolved_tool_use_id:
+            await runtime._emit_adapter_event(
+                session.id,
+                EventKind.TOOL_RESULT,
+                "User answered the question.",
+                {
+                    "method": "user.tool_result",
+                    "item_id": resolved_tool_use_id,
+                    "tool_use_id": resolved_tool_use_id,
+                    "is_error": False,
+                },
+                SessionStatus.RUNNING,
+            )
+
+        extra: dict[str, Any] = {"kind": "ask_user_question_answer"}
+        if answers:
+            extra["answers"] = answers
+        if resolved_tool_use_id:
+            extra["tool_use_id"] = resolved_tool_use_id
+        # Flip status to RUNNING before recording the answer so the broadcast
+        # snapshot shows the spinner immediately, matching handle_input.
+        updated = runtime.storage.update_session(
+            session.id, status=SessionStatus.RUNNING
+        )
+        await runtime._record_user_event(
+            session.id, answer, submit=True, extra_metadata=extra
+        )
+        return updated
 
     # ── Thread discovery + import ────────────────────────────────────────────
 

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -22,7 +22,7 @@ from waypoint.backends.claude_code.threads import (
     encode_project_dir,
 )
 from waypoint.backends.claude_tty import pane_dialog
-from waypoint.backends.claude_tty._state import PendingTtyApproval
+from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
 from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import EventKind, SessionStatus
@@ -86,6 +86,10 @@ class TranscriptTailer:
         # until the dialog leaves the screen so a response that clears pending
         # before the pane redraws cannot trigger a duplicate emit.
         self._surfaced_sig: str | None = None
+        # True once we have Esc-dismissed the current AskUserQuestion popup, so
+        # the dismissal fires once per appearance; reset when the pane leaves
+        # the question screen.
+        self._question_dismissed: bool = False
 
     def _read_new_bytes(self) -> bytes:
         if not self._path.exists():
@@ -124,6 +128,18 @@ class TranscriptTailer:
                 )
                 continue
             for ev in self._normalizer.process_record(record):
+                if (
+                    ev.kind == EventKind.TOOL_CALL
+                    and ev.metadata.get("tool_name") == "AskUserQuestion"
+                    and ev.status == SessionStatus.WAITING_INPUT
+                ):
+                    tool_use_id = str(ev.metadata.get("tool_use_id") or "")
+                    self._plugin._pending_questions[self._session_id] = (
+                        PendingTtyQuestion(
+                            approval_id=uuid.uuid4().hex,
+                            tool_use_id=tool_use_id,
+                        )
+                    )
                 await self._runtime._emit_adapter_event(
                     self._session_id,
                     ev.kind,
@@ -173,12 +189,39 @@ class TranscriptTailer:
             await self._runtime.tmux.send_input(pane, "", submit=True)
             return
 
+        if screen_type is pane_dialog.PaneScreen.QUESTION:
+            # The AskUserQuestion popup withholds its structured questions from
+            # the transcript until it is resolved, so it is invisible to the
+            # tailer while it blocks the turn. Esc dismisses it, which flushes
+            # the full tool_use record to the JSONL; the armed normalizer then
+            # surfaces it as an answerable card (and swallows the resulting
+            # "user rejected" result). The answer is delivered later as a normal
+            # user turn via the plugin's answer_question.
+            if self._prev_dialog_sig == "question":
+                self._dialog_stable_count += 1
+            else:
+                self._prev_dialog_sig = "question"
+                self._dialog_stable_count = 1
+            if (
+                self._dialog_stable_count >= _DIALOG_STABLE_TICKS
+                and not self._question_dismissed
+            ):
+                log.info(
+                    "dismissing AskUserQuestion popup to surface it",
+                    extra={"session_id": self._session_id},
+                )
+                await self._runtime.tmux.send_bytes(pane, b"\x1b")
+                self._normalizer.arm_question_dismissal()
+                self._question_dismissed = True
+            return
+
         if screen_type is not pane_dialog.PaneScreen.APPROVAL:
             # Dialog gone — clear any pending approval for this session.
             self._plugin._pending_approvals.pop(self._session_id, None)
             self._prev_dialog_sig = None
             self._dialog_stable_count = 0
             self._surfaced_sig = None
+            self._question_dismissed = False
             return
 
         dialog = pane_dialog.parse_approval(snapshot)

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -35,8 +35,11 @@ class ClaudeTtyTransport(TmuxTransport):
         # permission dialog, which it declines. Drop any pending approval now
         # so ``has_pending_approval`` goes false immediately instead of lingering
         # until the next dialog poll, where a racing ``respond_to_approval``
-        # would fire a stray digit at the ready prompt.
+        # would fire a stray digit at the ready prompt. A pending question is
+        # already dismissed on the pane (we Esc it when surfacing), so just drop
+        # the entry so a later answer is rejected rather than misrouted.
         self._plugin._pending_approvals.pop(session.id, None)
+        self._plugin._pending_questions.pop(session.id, None)
         await self.adapter.send_bytes(self._target(session), b"\x1b")
 
     def has_pending_approval(self, session: SessionRecord) -> bool:

--- a/backend/tests/fixtures/claude_tty_pane/question_dialog.txt
+++ b/backend/tests/fixtures/claude_tty_pane/question_dialog.txt
@@ -1,0 +1,13 @@
+❯ Use the AskUserQuestion tool to ask me TWO questions at once: (1) tabs or spaces, (2) light or dark theme. Each with
+  two options. Do not do anything else first.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+←  ☐ Indentation  ☐ Theme  ✔ Submit  →
+Tabs or spaces?
+❯ 1. Tabs
+     Use tab characters for indentation
+  2. Spaces
+     Use spaces for indentation
+  3. Type something.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  4. Chat about this
+Enter to select · Tab/Arrow keys to navigate · Esc to cancel

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -12,11 +12,15 @@ Verifies:
   - vanished dialog clears pending
 """
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
-from waypoint.backends.claude_tty._state import PendingTtyApproval
+import pytest
+from fastapi import HTTPException
+
+from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
 from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
@@ -278,6 +282,161 @@ async def test_non_approval_screen_does_not_emit() -> None:
         await tailer._poll_dialog()
 
         runtime._emit_adapter_event.assert_not_called()
+
+
+# ── tailer: AskUserQuestion dialog ───────────────────────────────────────────
+
+
+async def test_question_dialog_dismissed_when_stable() -> None:
+    # The popup withholds its questions from the transcript until resolved, so
+    # the tailer Escs it (which flushes the record) and arms the normalizer to
+    # surface it. No approval is emitted for it.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("question_dialog.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()  # tick 1: debounce
+    runtime.tmux.send_bytes.assert_not_called()
+
+    await tailer._poll_dialog()  # tick 2: stable → Esc + arm
+    runtime.tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
+    assert tailer._normalizer._expect_dismissed_question is True
+    assert tailer._question_dismissed is True
+    runtime._emit_adapter_event.assert_not_called()
+
+
+async def test_question_dialog_dismissed_only_once() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("question_dialog.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    for _ in range(5):
+        await tailer._poll_dialog()
+
+    runtime.tmux.send_bytes.assert_called_once()
+
+
+async def test_question_drain_registers_pending() -> None:
+    # Once the armed normalizer surfaces the flushed tool_use as a WAITING_INPUT
+    # card, the tailer registers the pending question so an answer can route.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("ready.txt"))
+    tailer = _make_tailer(plugin, runtime)
+    tailer._normalizer.arm_question_dismissal()
+
+    record = {
+        "type": "assistant",
+        "message": {
+            "id": "m1",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "auq1",
+                    "name": "AskUserQuestion",
+                    "input": {"questions": [{"question": "Q", "options": []}]},
+                }
+            ],
+        },
+    }
+    data = (json.dumps(record) + "\n").encode()
+    tailer._read_new_bytes = lambda: data  # type: ignore[method-assign]
+
+    await tailer._drain()
+
+    assert "sess-1" in plugin._pending_questions
+    assert plugin._pending_questions["sess-1"].tool_use_id == "auq1"
+
+
+# ── plugin: answer_question ───────────────────────────────────────────────────
+
+
+def _make_answer_runtime(session: SessionRecord, transport: MagicMock) -> MagicMock:
+    runtime = MagicMock()
+    runtime.transport_for.return_value = transport
+    runtime._emit_adapter_event = AsyncMock()
+    runtime._record_user_event = AsyncMock()
+    runtime.storage.update_session = MagicMock(return_value=session)
+    return runtime
+
+
+async def test_answer_question_delivers_message_and_resolves_card() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_questions["sess-1"] = PendingTtyQuestion(
+        approval_id="aid", tool_use_id="auq1"
+    )
+    transport = MagicMock()
+    transport.send_input = AsyncMock()
+    runtime = _make_answer_runtime(session, transport)
+    answers = [{"question": "Tabs or spaces?", "answer": "Spaces"}]
+
+    await plugin.answer_question(
+        runtime, session, '"Tabs or spaces?"="Spaces"', "auq1", answers
+    )
+
+    # Answer is delivered to the pane as a normal user turn.
+    transport.send_input.assert_awaited_once()
+    sent = transport.send_input.call_args.args
+    assert sent[0] is session
+    assert "User has answered your questions" in sent[1]
+    # A synthetic tool_result flips the surfaced card to answered.
+    runtime._emit_adapter_event.assert_awaited_once()
+    res = runtime._emit_adapter_event.call_args.args
+    assert res[1] is EventKind.TOOL_RESULT
+    assert res[3]["tool_use_id"] == "auq1"
+    # The styled answers card carries the structured answers.
+    extra = runtime._record_user_event.call_args.kwargs["extra_metadata"]
+    assert extra["kind"] == "ask_user_question_answer"
+    assert extra["answers"] == answers
+    assert extra["tool_use_id"] == "auq1"
+    assert "sess-1" not in plugin._pending_questions
+
+
+async def test_answer_question_no_pending_raises() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    transport = MagicMock()
+    transport.send_input = AsyncMock()
+    runtime = _make_answer_runtime(session, transport)
+
+    with pytest.raises(HTTPException) as exc:
+        await plugin.answer_question(runtime, session, "x", None, None)
+    assert exc.value.status_code == 400
+    transport.send_input.assert_not_called()
+
+
+async def test_answer_question_mismatched_tool_use_id_keeps_pending() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_questions["sess-1"] = PendingTtyQuestion(
+        approval_id="aid", tool_use_id="auq1"
+    )
+    transport = MagicMock()
+    transport.send_input = AsyncMock()
+    runtime = _make_answer_runtime(session, transport)
+
+    with pytest.raises(HTTPException):
+        await plugin.answer_question(runtime, session, "x", "stale-id", None)
+    transport.send_input.assert_not_called()
+    assert "sess-1" in plugin._pending_questions
+
+
+async def test_interrupt_clears_pending_question() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_questions["sess-1"] = PendingTtyQuestion(
+        approval_id="aid", tool_use_id="auq1"
+    )
+
+    transport, tmux = _make_transport(plugin)
+    await transport.interrupt(session)
+
+    assert "sess-1" not in plugin._pending_questions
+    tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
 
 
 # ── plugin: reconnect resume must not replay the transcript ──────────────────

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -161,10 +161,12 @@ def test_no_result_when_tool_use_block_present_despite_end_turn() -> None:
 # ── Usage deduplication ───────────────────────────────────────────────────────
 
 
-def test_usage_counted_only_on_first_seen_message_id() -> None:
+def test_result_note_emitted_once_per_message_id() -> None:
+    # A turn's content can arrive as several same-id end_turn records; the
+    # synthesized note (and the usage it carries) must fire exactly once, not
+    # once per record, or it duplicates and inflates token totals.
     norm = TranscriptNormalizer()
     usage = {"input_tokens": 100, "output_tokens": 50}
-    # First record: usage should appear in result metadata
     r1 = _assistant_record(
         "msgX", [_text_block("a")], stop_reason="end_turn", usage=usage
     )
@@ -172,13 +174,35 @@ def test_usage_counted_only_on_first_seen_message_id() -> None:
     result1 = next(e for e in events1 if e.metadata.get("method") == "result")
     assert result1.metadata["usage"] == usage
 
-    # Second record with same message.id: usage in result should be empty
+    # Second record, same message.id, also end_turn → no second note.
     r2 = _assistant_record(
         "msgX", [_text_block("b")], stop_reason="end_turn", usage=usage
     )
     events2 = norm.process_record(r2)
-    result2 = next(e for e in events2 if e.metadata.get("method") == "result")
-    assert result2.metadata["usage"] == {}
+    assert not any(e.metadata.get("method") == "result" for e in events2)
+
+
+def test_split_thinking_then_text_emits_single_result_after_text() -> None:
+    # The real-world duplicate: a turn's final message arrives as a thinking
+    # record then a text record, both stamped end_turn. Exactly one note must
+    # fire, and after the visible text — not prematurely off the thinking record
+    # (which also flickered the status idle→running→idle).
+    norm = TranscriptNormalizer()
+    r_think = _assistant_record(
+        "msgT", [{"type": "thinking", "thinking": "hmm"}], stop_reason="end_turn"
+    )
+    r_text = _assistant_record("msgT", [_text_block("Got it")], stop_reason="end_turn")
+
+    assert norm.process_record(r_think) == []
+
+    ev_text = norm.process_record(r_text)
+    assert [e.kind for e in ev_text] == [
+        EventKind.AGENT_OUTPUT,
+        EventKind.SYSTEM_NOTE,
+    ]
+    note = ev_text[1]
+    assert note.metadata["method"] == "result"
+    assert note.status == SessionStatus.IDLE
 
 
 def test_usage_counted_for_different_message_ids() -> None:

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -247,6 +247,78 @@ def test_user_rejected_tool_resolves_session_to_idle() -> None:
     assert note.metadata["stop_reason"] == "tool_rejected"
 
 
+# ── AskUserQuestion surfacing ───────────────────────────────────────────────
+
+
+def _ask_question_block(tool_id: str) -> dict:
+    return _tool_use_block(
+        tool_id,
+        "AskUserQuestion",
+        {
+            "questions": [
+                {
+                    "question": "Tabs or spaces?",
+                    "header": "Indent",
+                    "multiSelect": False,
+                    "options": [{"label": "Tabs"}, {"label": "Spaces"}],
+                }
+            ]
+        },
+    )
+
+
+def test_armed_ask_question_surfaces_as_waiting_input() -> None:
+    norm = TranscriptNormalizer()
+    norm.arm_question_dismissal()
+    record = _assistant_record(
+        "msg1", [_ask_question_block("auq1")], stop_reason="tool_use"
+    )
+    events = norm.process_record(record)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == EventKind.TOOL_CALL
+    assert ev.metadata["tool_name"] == "AskUserQuestion"
+    assert ev.status == SessionStatus.WAITING_INPUT
+    # Full questions payload is carried so the frontend renders the card.
+    assert ev.metadata["payload"]["input"]["questions"][0]["question"] == (
+        "Tabs or spaces?"
+    )
+
+
+def test_armed_ask_question_swallows_rejection_and_stays_waiting() -> None:
+    # Esc-ing the popup to surface it makes the TUI write a "user rejected"
+    # result; it must be dropped so the card stays answerable and the session
+    # does not flip to idle.
+    norm = TranscriptNormalizer()
+    norm.arm_question_dismissal()
+    norm.process_record(
+        _assistant_record("msg1", [_ask_question_block("auq1")], stop_reason="tool_use")
+    )
+    rejection = _user_record(
+        [_tool_result_block("auq1", "The tool use was rejected", is_error=True)]
+    )
+    rejection["toolUseResult"] = "User rejected tool use"
+    events = norm.process_record(rejection)
+    assert events == []
+
+
+def test_unarmed_ask_question_is_a_plain_tool_call() -> None:
+    # Without the dismissal latch (e.g. a historical record), AskUserQuestion
+    # is just a normal tool_call and a genuine rejection still resolves to idle.
+    norm = TranscriptNormalizer()
+    events = norm.process_record(
+        _assistant_record("msg1", [_ask_question_block("auq1")], stop_reason="tool_use")
+    )
+    assert len(events) == 1
+    assert events[0].status == SessionStatus.RUNNING
+    rejection = _user_record([_tool_result_block("auq1", "rejected")])
+    rejection["toolUseResult"] = "User rejected tool use"
+    note = next(
+        e for e in norm.process_record(rejection) if e.kind == EventKind.SYSTEM_NOTE
+    )
+    assert note.status == SessionStatus.IDLE
+
+
 def test_injected_task_notification_produces_no_events() -> None:
     norm = TranscriptNormalizer()
     record = _user_record("<task-notification>some harness turn</task-notification>")

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -205,6 +205,23 @@ def test_split_thinking_then_text_emits_single_result_after_text() -> None:
     assert note.status == SessionStatus.IDLE
 
 
+def test_thinking_only_abnormal_stop_emits_note_immediately() -> None:
+    # Only an end_turn message splits thinking/text across records. An abnormal
+    # termination (max_tokens hit mid-thinking) has no text sibling coming, so
+    # the note must fire on the thinking record rather than be deferred forever.
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msgK",
+        [{"type": "thinking", "thinking": "long thought"}],
+        stop_reason="max_tokens",
+    )
+    note = next(
+        e for e in norm.process_record(record) if e.metadata.get("method") == "result"
+    )
+    assert note.status == SessionStatus.IDLE
+    assert note.metadata["stop_reason"] == "max_tokens"
+
+
 def test_usage_counted_for_different_message_ids() -> None:
     norm = TranscriptNormalizer()
     usage = {"input_tokens": 100, "output_tokens": 50}

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -27,6 +27,7 @@ def _load(name: str) -> str:
     [
         ("approval_write.txt", PaneScreen.APPROVAL),
         ("approval_bash.txt", PaneScreen.APPROVAL),
+        ("question_dialog.txt", PaneScreen.QUESTION),
         ("trust_dialog.txt", PaneScreen.TRUST),
         ("model_selector.txt", PaneScreen.MODEL_SELECTOR),
         ("effort_popup.txt", PaneScreen.EFFORT_POPUP),
@@ -36,6 +37,13 @@ def _load(name: str) -> str:
 )
 def test_classify(fixture: str, expected: PaneScreen) -> None:
     assert classify(_load(fixture)) is expected
+
+
+def test_question_dialog_not_mistaken_for_approval() -> None:
+    # The AskUserQuestion popup carries options and a navigation footer but is
+    # not a permission prompt; parse_approval must reject it so the tailer Escs
+    # it rather than firing an approve/decline digit at it.
+    assert parse_approval(_load("question_dialog.txt")) is None
 
 
 def test_parse_write_approval() -> None:

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -144,6 +144,19 @@ Thread discovery/import for `claude_tty` reads the same
 `~/.claude/projects` transcript store as `claude_code`, so the same
 Claude threads appear under both backend ids.
 
+`AskUserQuestion` needs special handling because the TUI withholds the
+tool_use record from the transcript until the popup is resolved, so the
+question is invisible to the tailer while it blocks the turn. The dialog
+poller detects the question screen and sends `Esc`, which makes the TUI
+flush the full structured `questions` record (and a "user rejected"
+result) to the JSONL. The normalizer, armed by the poller, surfaces that
+record as a `WAITING_INPUT` `AskUserQuestion` tool_call — the same card
+the frontend renders for `claude_code` — and swallows the rejection so the
+card stays answerable. `answer_question` then delivers the answer as an
+ordinary user turn (the pane is back at the ready prompt), the way
+`claude_code` carries it on a denied tool, and emits a synthetic
+tool_result so the card resolves to answered.
+
 ### Transport view
 
 ```python


### PR DESCRIPTION
## Summary

Two `claude_tty` fixes around `AskUserQuestion`, found while debugging a session that appeared stuck after the agent asked a question.

1. **Surface and answer `AskUserQuestion` in `claude_tty` sessions.** The Claude TUI renders an `AskUserQuestion` as an interactive popup but withholds its `tool_use` record from the JSONL transcript until the popup is resolved — so the question was invisible to the transcript tailer while it blocked the turn, and the user only saw it once they interrupted (which declined it). The dialog poller now detects the question screen and sends `Esc`, which makes the TUI flush the full structured `questions` record to the JSONL; the armed normalizer surfaces that as a `waiting_input` `AskUserQuestion` tool_call — the exact card the frontend already renders for `claude_code` via `parseAskUserQuestion` — and swallows the resulting "user rejected" result so the card stays answerable. `answer_question` then delivers the choice as an ordinary user turn, the way `claude_code` carries it on a denied tool. No frontend changes: the existing card and `/answer-question` flow are reused.

2. **One turn-complete note per turn.** A turn's final assistant message can arrive as several records sharing one `message.id` — typically a thinking record then a text record, both stamped `stop_reason=end_turn`. The result synthesis fired per record, so a turn emitted a duplicate "Turn complete" note, and the thinking record's note landed before the visible text and flickered the status idle→running→idle. The note now fires at most once per `message.id` and defers off thinking-only records so it lands after the text.

## Changes

### Backend

- **`backends/claude_tty/pane_dialog.py`** — adds `PaneScreen.QUESTION`, classified by the popup's `"Tab/Arrow keys to navigate"` footer. Detection only; the form is dismissed and read from the transcript rather than parsed off the pane.
- **`backends/claude_tty/tailer.py`** — `_poll_dialog` detects a stable question popup, sends `Esc` (which flushes the structured record), and arms the normalizer; once the surfaced card drains it registers a `PendingTtyQuestion`. The dismissal fires once per appearance and resets when the pane leaves the question screen.
- **`backends/claude_tty/normalize.py`** — surfaces the armed `AskUserQuestion` as a `waiting_input` tool_call and swallows the resulting "user rejected" result and its idle note so the card stays answerable. Also emits the synthesized turn-complete note once per `message.id` and defers it off thinking-only records (the duplicate-note / status-flicker fix).
- **`backends/claude_tty/plugin.py`** — implements `answer_question`: delivers the answer as a normal user turn, emits a synthetic tool_result so the surfaced card resolves to answered, and records the styled `ask_user_question_answer` card. Pending-question state is cleared on terminate and on settings-restart.
- **`backends/claude_tty/transport.py`**, **`backends/claude_tty/_state.py`** — `PendingTtyQuestion` state; `interrupt` drops it alongside the pending approval.

### Tests

- **`test_claude_tty_pane_dialog.py`** — `QUESTION` classification, and the question popup is not mistaken for an approval.
- **`test_claude_tty_normalize.py`** — an armed question surfaces as `waiting_input` and swallows the rejection; an unarmed one stays a plain tool_call (and a genuine rejection still resolves to idle); the turn-complete note fires once per `message.id` and after the text on a thinking+text split.
- **`test_claude_tty_approval.py`** — the tailer Escs + arms a stable question and registers pending; `answer_question` delivers the message, resolves the card, and clears pending, with the no-pending / mismatched-id / interrupt cases.
- **`fixtures/claude_tty_pane/question_dialog.txt`** — a live-captured `AskUserQuestion` popup.

### Docs

- **`docs/coding_agent_plugins.md`** — documents the `claude_tty` `AskUserQuestion` surface-via-Esc-then-answer-as-text flow.

## Test Plan

- [x] `cd backend && uv run pytest` — 855 passed.
- [x] `cd backend && uv run pre-commit run --files <changed backend files>` — isort / black / ruff / codespell / mypy clean; hooks also ran clean per-commit.
- [x] Live e2e (backend restarted on this branch): spawned a `claude_tty` session, asked the agent to call `AskUserQuestion` with two questions — the session went to `waiting_input` and surfaced the card carrying the full 2-question structured payload, with no rejection text or idle note leaked.
- [x] Live e2e: answered via `answer-question` — a synthetic tool_result flipped the card to answered, the `ask_user_question_answer` card recorded the choices, and the agent consumed the answer and completed the turn.
- [x] The duplicate turn-complete note is covered by a deterministic unit test reproducing the exact captured split (`[thinking(end_turn), text(end_turn)]` sharing one `message.id`); e2e reproduction is nondeterministic since it depends on the model emitting a thinking block.
- [ ] No frontend changes in this PR — the existing `AskUserQuestionCard` / `/answer-question` path is reused, so no `tsc`/lint/build was run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)