### PR TITLE
fix: a claude_tty settings change before the first turn killed the session

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -717,9 +717,18 @@ class ClaudeTtyPlugin(TmuxPlugin):
             flag_pairs += ["--effort", merged[1]]
         if merged[2]:
             flag_pairs += ["--permission-mode", merged[2]]
-        launch_args = ["--resume", thread_id, *flag_pairs, *base_args]
 
         launch_target = runtime._find_launch_target(session.launch_target_id)
+        # The thread file is only written on first input, so a settings change
+        # made before the session's first turn has nothing to resume — relaunching
+        # with `--resume` makes the CLI exit with "no conversation found" and kills
+        # the pane. Reuse the same thread id via `--session-id` in that case so the
+        # relaunch starts the (still-empty) conversation cleanly with the new flags.
+        resumed = await self._conversation_exists(
+            "claude_code", thread_id, session.cwd, launch_target
+        )
+        identity = ["--resume", thread_id] if resumed else ["--session-id", thread_id]
+        launch_args = [*identity, *flag_pairs, *base_args]
         command = runtime._command_for_backend(
             self.id,
             launch_args,
@@ -766,10 +775,11 @@ class ClaudeTtyPlugin(TmuxPlugin):
             note,
             status=SessionStatus.IDLE,
         )
-        # The resumed thread reopens its already-populated transcript, whose
-        # records are in the event DB; tail from the end so they aren't replayed.
+        # A resumed thread reopens its already-populated transcript (records are
+        # in the event DB) so tail from the end; a fresh --session-id thread
+        # starts an empty file, so read from byte 0.
         self._start_tailer(
-            runtime, session.id, thread_id, session.cwd, start_at_end=True
+            runtime, session.id, thread_id, session.cwd, start_at_end=resumed
         )
         return True
 

--- a/backend/src/waypoint/backends/tmux/adapter.py
+++ b/backend/src/waypoint/backends/tmux/adapter.py
@@ -51,9 +51,16 @@ class TmuxAdapter:
     async def describe_target(self, target: str) -> TmuxTarget:
         template = "#{session_name}|#{window_index}|#{pane_id}|#{pane_current_path}|#{pane_dead}|#{pane_pid}"
         output = await self._run("display-message", "-p", "-t", target, template)
-        session_name, window_index, pane_id, cwd, pane_dead, pane_pid = (
-            output.strip().split("|")
-        )
+        fields = output.strip().split("|")
+        # Unlike capture-pane/send-keys, `display-message -t` does not validate
+        # the target: a missing pane expands the format with empty fields and
+        # exits 0 (e.g. "|||||"), so an empty pane id means the target no longer
+        # exists. Raise here so liveness checks (`_pane_alive`, `target_exists`,
+        # `_refresh_state`) see a dead pane instead of a phantom one whose
+        # ``pane_dead`` parses to False.
+        if len(fields) != 6 or not fields[2]:
+            raise TmuxError(f"can't find target: {target}")
+        session_name, window_index, pane_id, cwd, pane_dead, pane_pid = fields
         return TmuxTarget(
             session=session_name,
             window=window_index,

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -104,6 +104,9 @@ def _stub_lifecycle(plugin: ClaudeTtyPlugin) -> dict[str, object]:
 
     plugin._start_tailer = _fake_start_tailer  # type: ignore[method-assign]
     plugin._spawn_rate_limit_watcher = MagicMock()  # type: ignore[method-assign]
+    # Default to a persisted conversation so restarts resume; the
+    # before-first-turn case overrides this to False.
+    plugin._conversation_exists = AsyncMock(return_value=True)  # type: ignore[method-assign]
     return captured
 
 
@@ -227,6 +230,31 @@ async def test_restart_rebuilds_resume_flags_preserving_custom_args() -> None:
     assert update_kwargs["transport_state"]["thread_id"] == "thread-1"
     # Resumed transcript is already populated → tail from the end.
     assert captured["start_at_end"] is True
+
+
+async def test_restart_before_first_turn_uses_session_id_not_resume() -> None:
+    # A settings change made before the first message has no persisted thread to
+    # resume; relaunching with --resume would make the CLI exit with "no
+    # conversation found" and kill the pane. The relaunch must reuse the same
+    # thread id via --session-id instead.
+    plugin = ClaudeTtyPlugin()
+    captured = _stub_lifecycle(plugin)
+    plugin._conversation_exists = AsyncMock(return_value=False)  # type: ignore[method-assign]
+    session = _make_session(
+        permission_mode="auto",
+        launch_args=["--session-id", "thread-1", "--permission-mode", "auto"],
+    )
+    runtime, _ = _restart_runtime()
+
+    result = await plugin._restart_with_args(runtime, session, permission_mode="plan")
+
+    assert result is True
+    built_args = runtime._command_for_backend.call_args.args[1]
+    assert built_args[:2] == ["--session-id", "thread-1"]
+    assert "--resume" not in built_args
+    assert "--permission-mode" in built_args and "plan" in built_args
+    # A never-written transcript is read from the start, not tailed from the end.
+    assert captured["start_at_end"] is False
 
 
 async def test_restart_clears_pending_approval_and_tailer() -> None:

--- a/backend/tests/test_tmux.py
+++ b/backend/tests/test_tmux.py
@@ -1,6 +1,8 @@
 import asyncio
 
-from waypoint.backends.tmux.adapter import TmuxAdapter
+import pytest
+
+from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
 
 
 def test_send_input_uses_literal_mode_and_submit() -> None:
@@ -149,3 +151,41 @@ def test_pane_screen_state_handles_normal_screen() -> None:
     alt, col, row = asyncio.run(adapter.pane_screen_state("%4"))
     assert alt is False
     assert (col, row) == (1, 1)
+
+
+def test_describe_target_parses_live_pane() -> None:
+    async def fake_run(*args: str) -> str:
+        return "sess|0|%7|/home/u|0|4242\n"
+
+    adapter = TmuxAdapter()
+    adapter._run = fake_run  # type: ignore[method-assign]
+
+    target = asyncio.run(adapter.describe_target("%7"))
+    assert target.pane == "%7"
+    assert target.pane_dead is False
+    assert target.pane_pid == 4242
+
+
+def test_describe_target_raises_on_missing_pane() -> None:
+    # `display-message -t` does not validate the target: a missing pane expands
+    # to all-empty fields with exit 0 ("|||||"). describe_target must treat that
+    # as a dead target so liveness checks mark the session exited instead of
+    # seeing pane_dead=False on a phantom pane.
+    async def fake_run(*args: str) -> str:
+        return "|||||"
+
+    adapter = TmuxAdapter()
+    adapter._run = fake_run  # type: ignore[method-assign]
+
+    with pytest.raises(TmuxError):
+        asyncio.run(adapter.describe_target("%77"))
+
+
+def test_target_exists_false_for_missing_pane() -> None:
+    async def fake_run(*args: str) -> str:
+        return "|||||"
+
+    adapter = TmuxAdapter()
+    adapter._run = fake_run  # type: ignore[method-assign]
+
+    assert asyncio.run(adapter.target_exists("%77")) is False


### PR DESCRIPTION
## Summary

Reported as a `claude_tty` session stuck `idle` after changing its settings, with every `send`/`interrupt` returning a raw `can't find pane: %NN`. Two distinct bugs, one incident — the first creates the dead pane, the second hides it.

1. **A settings change before the first turn killed the pane (root cause).** `_restart_with_args` relaunches the pane with `claude --resume <thread>` to apply a model/effort/permission-mode change. But the thread's transcript file is written only on first input, so changing a setting before sending any message resumed a thread that didn't exist yet — the CLI printed `No conversation found with session ID: …` and exited, killing the pane. (Confirmed from the dead session's `raw.log`.) The EXITED-reconnect path in `restore_session` already guards this with `_conversation_exists`; the restart path didn't. Now it resumes only when the conversation exists, otherwise reuses the same thread id via `--session-id` (and reads the fresh transcript from the start instead of tailing the end).

2. **A dead tmux pane read as alive, so the session never resolved (why it stuck).** `tmux display-message -t <target>` does not validate its target: for a missing pane it expands the format to all-empty fields and exits `0` (e.g. `|||||`), unlike `capture-pane`/`send-keys` which error. `describe_target` parsed `pane_dead` from the empty field as `False`, so a dead pane looked alive to every liveness check that depends on it — `_pane_alive` (the tailer's 10-s poll), `target_exists`, and `_refresh_state`. None could mark the session `exited`, so it lingered in `idle` and each pane op hit the raw tmux error. `describe_target` now raises `TmuxError` when the target resolves to empty fields, repairing all three detectors at the source.

## Changes

### Backend

- **`backends/claude_tty/plugin.py`** — `_restart_with_args` calls `_conversation_exists` and uses `--resume <thread>` only when the conversation is persisted, else `--session-id <thread>`; `start_at_end` follows the same flag (tail a resumed transcript, read a fresh one from 0).
- **`backends/tmux/adapter.py`** — `describe_target` raises `TmuxError` on an empty-field (missing) target instead of returning a phantom `TmuxTarget` with `pane_dead=False`.

### Tests

- **`test_claude_tty_controls.py`** — a restart before the first turn relaunches with `--session-id` (not `--resume`) and reads the transcript from the start.
- **`test_tmux.py`** — `describe_target` parses a live pane, raises on the all-empty missing-pane expansion, and `target_exists` returns `False` for a missing pane.

## Test Plan

- [x] `cd backend && uv run pytest` — 860 passed.
- [x] `cd backend && uv run pre-commit run --files <changed files>` — isort / black / ruff / codespell / mypy clean; hooks also ran clean per-commit.
- [x] Live e2e (detection): reproduced the stuck session `claude_tty-a5c44438` (status `idle`, pane `%77` gone, `display-message -t %77` → `|||||` exit 0). After deploying the detection fix and restarting the backend, boot-restore's liveness check flipped it `idle → exited` within ~2s.
- [x] Live e2e (prevention): deployed both fixes, created a `claude_tty` session, changed its permission mode (auto→plan) *before any message* — the pane stayed alive (`idle`, `pane_dead=0`) instead of dying, and the session then answered a follow-up message, confirming it is fully functional after a pre-first-turn settings change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)