### PR TITLE
fix: surface single-question AskUserQuestion dialogs in claude_tty

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -36,11 +36,15 @@ class PaneScreen(StrEnum):
 # brittle to that.
 _APPROVAL_FOOTER = "Esc to cancel · Tab to amend"
 _APPROVAL_QUESTION_MARKER = "Do you want to"
-# The AskUserQuestion popup carries its own navigation footer, distinct from the
-# permission dialog's "Tab to amend". We only need to recognize it: the dialog
-# is dismissed with Esc so the TUI flushes the structured questions to the
+# The AskUserQuestion popup. We only need to recognize it — the dialog is
+# dismissed with Esc so the TUI flushes the structured questions to the
 # transcript, which is surfaced from there rather than parsed off the pane.
-_QUESTION_FOOTER = "Tab/Arrow keys to navigate"
+# Match cctty's detector: the "Enter to select" / "Esc to cancel" footer plus
+# the always-present "Type something" free-text option. The navigation hint
+# itself is not stable — it reads "↑/↓ to navigate" for a single-question
+# dialog but "Tab/Arrow keys to navigate" for a multi-question one — so keying
+# on it would miss the single-question form.
+_QUESTION_MARKERS = ("Enter to select", "Esc to cancel", "Type something")
 _MODEL_FOOTER = "Enter to set as default"
 _MODEL_MARKER = "Select model"
 _EFFORT_FOOTER = "←/→ to adjust · Enter to confirm"
@@ -109,7 +113,7 @@ def classify(screen: str) -> PaneScreen:
         screen, compact, _APPROVAL_QUESTION_MARKER
     ):
         return PaneScreen.APPROVAL
-    if _contains(screen, compact, _QUESTION_FOOTER):
+    if all(_contains(screen, compact, marker) for marker in _QUESTION_MARKERS):
         return PaneScreen.QUESTION
     if _contains(screen, compact, _TRUST_MARKER):
         return PaneScreen.TRUST

--- a/backend/tests/fixtures/claude_tty_pane/question_dialog_single.txt
+++ b/backend/tests/fixtures/claude_tty_pane/question_dialog_single.txt
@@ -1,0 +1,15 @@
+● The backend is running, but on the old code — my runtime changes (#4 branch cleanup, --prune-branches) need a restart
+  to be exercised end-to-end. Per project rules I need your permission for that.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Restart backend
+May I restart the backend to run a full e2e validation against the new code?
+❯ 1. Yes, restart + e2e
+     Run `waypointctl restart backend`, then drive real commands: spawn a worktree session, set-permission-mode live,
+     reap --prune-branches, and confirm the branch/worktree are gone. Verifies #2 and #4 against the live stack.
+  2. No, skip restart
+     Leave the running backend as-is. I'll only e2e the parts that hit existing endpoints (set-permission-mode, model
+     warning) via `uv run waypoint`, and rely on unit tests for the runtime branch-cleanup.
+  3. Type something.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  4. Chat about this
+Enter to select · ↑/↓ to navigate · Esc to cancel

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -28,6 +28,7 @@ def _load(name: str) -> str:
         ("approval_write.txt", PaneScreen.APPROVAL),
         ("approval_bash.txt", PaneScreen.APPROVAL),
         ("question_dialog.txt", PaneScreen.QUESTION),
+        ("question_dialog_single.txt", PaneScreen.QUESTION),
         ("trust_dialog.txt", PaneScreen.TRUST),
         ("model_selector.txt", PaneScreen.MODEL_SELECTOR),
         ("effort_popup.txt", PaneScreen.EFFORT_POPUP),
@@ -37,6 +38,18 @@ def _load(name: str) -> str:
 )
 def test_classify(fixture: str, expected: PaneScreen) -> None:
     assert classify(_load(fixture)) is expected
+
+
+def test_single_and_multi_question_footers_both_classify() -> None:
+    # The navigation hint differs by arity — "↑/↓ to navigate" for one question,
+    # "Tab/Arrow keys to navigate" for several — so detection keys on the stable
+    # "Enter to select"/"Esc to cancel"/"Type something" markers, not the hint.
+    single = _load("question_dialog_single.txt")
+    multi = _load("question_dialog.txt")
+    assert "↑/↓ to navigate" in single
+    assert "Tab/Arrow keys to navigate" in multi
+    assert classify(single) is PaneScreen.QUESTION
+    assert classify(multi) is PaneScreen.QUESTION
 
 
 def test_question_dialog_not_mistaken_for_approval() -> None:


### PR DESCRIPTION
## Summary

A `claude_tty` session hung waiting for input without Waypoint surfacing the request. The agent had called `AskUserQuestion` with a **single** question, whose popup the dialog poller failed to classify, so it was never Esc-dismissed/surfaced and the turn blocked indefinitely.

The detector (added in the AskUserQuestion-surfacing change) keyed on the `"Tab/Arrow keys to navigate"` footer — but the TUI only renders that for a **multi-question** popup. A single question shows `"↑/↓ to navigate"` instead, so `classify` never returned `QUESTION`. Checking the cctty reference's `tty_question_from_form`, it keys on the stable `"Enter to select"` / `"Esc to cancel"` footer plus the always-present `"Type something"` free-text option — none of which depend on the question arity. This adopts the same markers.

## Changes

### Backend

- **`backends/claude_tty/pane_dialog.py`** — `classify` now recognizes the question popup by the `"Enter to select"` + `"Esc to cancel"` + `"Type something"` markers (matching cctty) instead of the arity-specific navigation hint, so both single- and multi-question dialogs are detected.

### Tests

- **`test_claude_tty_pane_dialog.py`** — classifies the single-question (`↑/↓`) variant as `QUESTION`, and asserts both footers (`↑/↓ to navigate` and `Tab/Arrow keys to navigate`) classify.
- **`fixtures/claude_tty_pane/question_dialog_single.txt`** — a live-captured single-question popup.

## Test Plan

- [x] `cd backend && uv run pytest` — 865 passed.
- [x] `cd backend && uv run pre-commit run --files backend/src/waypoint/backends/claude_tty/pane_dialog.py backend/tests/test_claude_tty_pane_dialog.py` — isort / black / ruff / codespell / mypy clean; hooks also ran clean per-commit.
- [x] Live e2e: reproduced with a real hung session (`claude_tty-b5d30256`, stuck `running` on a single-question `AskUserQuestion`). After deploying the fix and restarting the backend, boot-restore's dialog poller detected the popup, Esc-flushed it, and the session transitioned `running → waiting_input` within ~2s with the question surfaced as an answerable card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)