### PR TITLE
feat: session permission-mode CLI, worktree branch pruning, and start-time model warning

### DIFF
--- a/.agents/skills/waypoint-subagents/SKILL.md
+++ b/.agents/skills/waypoint-subagents/SKILL.md
@@ -87,3 +87,7 @@ visible to a downstream lead reading the board.
 - Reap what you spawn. Leaving orphaned `subagent:*` sessions behind is a bug.
 - Ground every status claim in `waypoint sessions show`/`events` output, not
   assumption.
+- **Be inquisitive about environmental choices.** When the permission mode,
+  model, or backend for a child would otherwise be a silent guess — especially
+  for unattended work — surface it to the user (ask-question tool) rather than
+  guessing and discovering the stall or turn-1 death later.

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -56,9 +56,28 @@ posture — but widening is a deliberate act, not a default. Guidance:
   auto-approving modes are `auto` / `dontAsk` / `bypassPermissions`; codex
   `full_access`; opencode `allow`). An auto-approving child runs tools without
   prompting, so only choose one for work you would pre-approve yourself.
-- If you cannot determine your own posture and need the child to run unattended,
-  prefer leaving it in `default` and servicing approvals over guessing a
-  permissive mode.
+- **When the child must run unattended, decide its posture before spawning.** A
+  child left on `default` parks silently on its first approval — it sits in
+  `waiting_input` while you block waiting for it, with no prompt back to you. If
+  you cannot determine a safe auto-approving mode yourself, **ask the user** which
+  `--permission-mode` to use (use the ask-question tool) rather than spawning on
+  `default` and discovering the stall later. Leaving it on `default` is only the
+  right default when you will be **interactively servicing** the child's approvals
+  yourself.
+
+## Fix a posture without respawning
+
+If a worker is already stalling on `default`, you do **not** have to reap and
+respawn it. On structured backends (claude_code / codex / opencode / claude_tty)
+you can widen its mode in place:
+
+```bash
+waypoint sessions set-permission-mode <child-id> <mode>   # alias: sessions mode
+```
+
+The command validates `<mode>` against the backend's advertised ids and reports
+them on a mismatch. Backends that can't change mode live are rejected cleanly —
+for those, reap and respawn remains the only path.
 
 ## Service a child's approvals
 

--- a/.agents/skills/waypoint-workqueue/SKILL.md
+++ b/.agents/skills/waypoint-workqueue/SKILL.md
@@ -65,3 +65,8 @@ harness and model with `references/backends.md`.
 - Give each worker a task it can do with no other context, and its own worktree —
   never let two workers share a tree.
 - Check the **final merged** result, not just per-task success.
+- **Be inquisitive about environmental choices.** A crew runs unattended, so a
+  silently-guessed permission mode (workers park on `default`) or model (a wrong
+  id dies on turn 1) stalls the whole job. Settle both before spawning — pass ids
+  verbatim from `waypoint models`/`waypoint backends`, and ask the user when
+  unsure rather than guessing.

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -14,25 +14,41 @@ git -C "$repo" switch -c "wq/$job" "$base"
 ```
 
 Assign — for each free worker and each `todo` task, give it a worktree and send
-it off. **Choose the backend and model for the task**, and place the worker where
-its code lives:
+it off. Pre-spawn checklist, all settled **before** the `sessions start`:
+
+- **Model.** Run `waypoint models <backend>` and pass an id **verbatim** — never
+  guess from memory (a wrong id spawns fine and only dies on turn 1). Unsure
+  which tier fits? Ask the user. `sessions start` warns if the id isn't in the
+  backend's catalogue, but treat that as a backstop, not the check.
+- **Permission mode.** A crew runs unattended, so the workers must auto-approve —
+  do **not** leave them on the inherited `default` (they park silently on the
+  first approval). Pick an auto-approving `--permission-mode` for the backend
+  (`waypoint backends` lists the ids); if you can't determine a safe one, ask the
+  user rather than spawning blind.
+- **Placement.** `--cwd` is the repo root the worktree is cut from; place the
+  worker where its code lives.
 
 ```bash
 n=3
 lead=$WAYPOINT_SESSION_ID   # the lead's own session id; set --spawner-session-id explicitly if unset
 # `--worktree` creates branch `wq/$job-t$n` off the integration branch in a
 # sibling worktree, records the path on the session for cleanup, and launches
-# the worker there — no manual `git worktree add`. `--cwd` is the repo root the
-# worktree is cut from.
+# the worker there — no manual `git worktree add`.
 sid=$(waypoint sessions start \
-  --backend codex --model gpt-5-codex \
+  --backend <backend> --model <model-id> --permission-mode <auto-approving-mode> \
   --cwd "$repo" --worktree "wq/$job-t$n" --worktree-base "wq/$job" \
   --title "subagent:wq-$job-$n" --spawner-session-id "$lead" \
   | jq -r .session.id)
 # task:<n> is the immutable contract — never rewritten. Update status:<n> only.
 waypoint board set-meta job:$job --key status:$n --meta state=doing --meta assignee=$sid
 # then send the worker the fixed message from org-template.md
+# Confirm the worker actually started its turn before treating it as assigned —
+# a green `start` is not proof the model/mode were accepted:
+waypoint sessions show "$sid"   # expect running/working, not exited/error on turn 1
 ```
+
+A stalled worker isn't a respawn: widen its mode in place with
+`waypoint sessions set-permission-mode <sid> <mode>`.
 
 `--worktree` removes the whole class of plumbing this step used to need: it picks
 a sibling path outside the working tree (so nothing shows up as untracked) and
@@ -101,8 +117,10 @@ then — for a server/CLI/integration artifact — **exercise the real thing**, 
 just unit tests. Green mocked tests routinely miss wiring bugs (a 422 from an
 unset field, git chatter polluting stdout); start the app and run the new paths
 once. Post a summary to the board, reap the workers with `waypoint sessions reap
---spawned-by "$lead"` (this also removes their recorded worktrees), and report
-integrated vs. blocked counts.
+--spawned-by "$lead" --prune-branches` (this removes their recorded worktrees
+*and* force-deletes the leftover `wq/$job-t<n>` branches; without
+`--prune-branches`, an unmerged worker branch survives and collides with a later
+respawn's `--worktree`), and report integrated vs. blocked counts.
 
 ## Worker
 

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -521,11 +521,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session_id: str,
         _: Annotated[str, Depends(token_dependency())],
         force: Annotated[bool, Query()] = False,
+        prune_branches: Annotated[bool, Query()] = False,
     ) -> Any:
         # `force=true` skips terminate failures entirely — last-resort escape
         # hatch when the adapter is wedged (SSH stuck, etc.) and the
-        # graceful path won't complete.
-        await context.runtime.delete(session_id, force=force)
+        # graceful path won't complete. `prune_branches=true` force-deletes a
+        # worktree session's branch even when unmerged (crew teardown).
+        await context.runtime.delete(
+            session_id, force=force, prune_branches=prune_branches
+        )
         return {"deleted": session_id}
 
     @app.get("/api/board")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1107,9 +1107,21 @@ def sessions_delete(
             help="Drop the record even if graceful terminate fails (wedged adapter).",
         ),
     ] = False,
+    prune_branches: Annotated[
+        bool,
+        typer.Option(
+            "--prune-branches",
+            help="Force-delete the worktree's branch even if unmerged. Without "
+            "this, an unmerged branch is left in place (merged ones are always "
+            "pruned).",
+        ),
+    ] = False,
 ) -> None:
     """Terminate (if needed) and remove a session record."""
-    _emit(_settings_from_ctx(ctx), lambda c: c.delete(session_id, force=force))
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: c.delete(session_id, force=force, prune_branches=prune_branches),
+    )
 
 
 @sessions_app.command("reap")
@@ -1135,6 +1147,15 @@ def sessions_reap(
             help="Reap all sessions regardless of spawner. Required when no scope is given.",
         ),
     ] = False,
+    prune_branches: Annotated[
+        bool,
+        typer.Option(
+            "--prune-branches",
+            help="Force-delete each reaped worktree's branch even if unmerged. "
+            "Use for crew teardown where worker branches are discarded; "
+            "leftover branches otherwise collide with a respawn's --worktree.",
+        ),
+    ] = False,
 ) -> None:
     """Terminate and delete sessions in bulk."""
     if mine:
@@ -1158,7 +1179,7 @@ def sessions_reap(
         for session in sessions:
             sid = session["id"]
             try:
-                client.delete(sid)
+                client.delete(sid, prune_branches=prune_branches)
                 reaped.append(sid)
             except Exception:
                 failed.append(sid)

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1029,6 +1029,57 @@ def sessions_send(
         raise typer.Exit(code=1)
 
 
+def _validate_permission_mode(
+    client: WaypointClient, session: dict[str, Any], mode: str
+) -> None:
+    """Validate ``mode`` against the session's backend before the round trip.
+
+    Keeps the error local and lists the accepted ids rather than relaying a
+    bare server 400. A backend that doesn't advertise its modes (or that the
+    catalogue can't resolve) is left to the server to reject.
+    """
+    backend = session.get("backend")
+    descriptor = next(
+        (b for b in client.list_backends() if b.get("id") == backend), None
+    )
+    if descriptor is None:
+        return
+    caps = descriptor.get("capabilities", {})
+    if not caps.get("supports_set_permission_mode_inline"):
+        raise typer.BadParameter(
+            f"backend {backend!r} does not support setting the permission mode",
+            param_hint="MODE",
+        )
+    valid = [spec["id"] for spec in caps.get("permission_modes", [])]
+    if valid and mode not in valid:
+        raise typer.BadParameter(
+            f"unknown permission mode {mode!r} for backend {backend!r}; "
+            f"choose one of: {', '.join(valid)}",
+            param_hint="MODE",
+        )
+
+
+@sessions_app.command("set-permission-mode")
+@sessions_app.command("mode")
+def sessions_set_permission_mode(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    mode: Annotated[str, typer.Argument()],
+) -> None:
+    """Change a running session's permission mode in place.
+
+    Only structured backends that apply the change live accept it; others are
+    rejected with the accepted ids. Avoids reap + respawn just to widen a
+    stalled worker's auto-approval posture.
+    """
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        _validate_permission_mode(c, c.get_session(session_id), mode)
+        return {"session": c.set_permission_mode(session_id, mode)}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
 @sessions_app.command("interrupt")
 def sessions_interrupt(
     ctx: typer.Context, session_id: Annotated[str, typer.Argument()]

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -932,6 +932,39 @@ def _create_worktree(branch: str, base: str | None, cwd: str) -> str:
     return worktree_path
 
 
+def _warn_unknown_model(
+    client: WaypointClient,
+    backend: str,
+    model: str,
+    launch_target_id: str | None,
+) -> None:
+    """Warn (never block) when ``--model`` isn't in the backend's catalogue.
+
+    A wrong id spawns fine and only dies on the first turn, so surfacing it
+    here gives a fast hint. Backends accept free-text ids, so this only warns;
+    if discovery is unavailable the check is skipped rather than guessed.
+    """
+    try:
+        catalog = client.list_models(backend, launch_target_id=launch_target_id)
+    except WaypointError:
+        return
+    ids = {m.get("id") for m in catalog.get("models", []) if m.get("id")}
+    if not ids or model in ids:
+        return
+    if catalog.get("supports_free_text"):
+        tail = (
+            "the backend accepts free-text ids, but confirm the worker survives "
+            "its first turn"
+        )
+    else:
+        tail = "it will likely be rejected on the first turn"
+    typer.echo(
+        f"warning: model {model!r} is not among {backend}'s advertised models "
+        f"({', '.join(sorted(ids))}); {tail}.",
+        err=True,
+    )
+
+
 @sessions_app.command("start")
 def sessions_start(
     ctx: typer.Context,
@@ -973,9 +1006,10 @@ def sessions_start(
         worktree_path = _create_worktree(worktree, worktree_base, cwd)
         effective_cwd = worktree_path
 
-    _emit(
-        _settings_from_ctx(ctx),
-        lambda c: {
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        if model is not None:
+            _warn_unknown_model(c, backend, model, launch_target_id)
+        return {
             "session": c.create_session(
                 backend=backend,
                 cwd=effective_cwd,
@@ -988,8 +1022,9 @@ def sessions_start(
                 worktree_path=worktree_path,
                 args=list(args or []),
             )
-        },
-    )
+        }
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @sessions_app.command("send")

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -355,11 +355,18 @@ class WaypointClient:
         ).json()["session"]
         return data
 
-    def delete(self, session_id: str, *, force: bool = False) -> dict[str, Any]:
+    def delete(
+        self, session_id: str, *, force: bool = False, prune_branches: bool = False
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if force:
+            params["force"] = force
+        if prune_branches:
+            params["prune_branches"] = prune_branches
         data: dict[str, Any] = self._request(
             "DELETE",
             f"/api/sessions/{session_id}",
-            params={"force": force} if force else None,
+            params=params or None,
         ).json()
         return data
 

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -335,6 +335,14 @@ class WaypointClient:
         ).json()["session"]
         return data
 
+    def set_permission_mode(self, session_id: str, mode: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST",
+            f"/api/sessions/{session_id}/mode",
+            json={"mode": mode},
+        ).json()["session"]
+        return data
+
     def interrupt(self, session_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
             "POST", f"/api/sessions/{session_id}/interrupt"

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1176,7 +1176,9 @@ class SessionRuntime:
             )
         return refreshed
 
-    async def delete(self, session_id: str, *, force: bool = False) -> None:
+    async def delete(
+        self, session_id: str, *, force: bool = False, prune_branches: bool = False
+    ) -> None:
         session = self.get_session(session_id)
         if session.source == SessionSource.ASSISTANT:
             raise HTTPException(
@@ -1196,11 +1198,7 @@ class SessionRuntime:
         self._close_structured_log(session_id)
         self.storage.delete_session(session_id)
         if session.worktree_path is not None:
-            with suppress(Exception):
-                subprocess.run(
-                    ["git", "worktree", "remove", "--force", session.worktree_path],
-                    check=False,
-                )
+            self._remove_worktree(session.worktree_path, prune_branches=prune_branches)
         # Reclaim the session's uploaded blobs, which can be large.
         self.attachments.discard(session_id)
         # Drop this session's blackboard posts along with its record.
@@ -1209,6 +1207,53 @@ class SessionRuntime:
         await self._broadcast_session_list()
         if pruned:
             await self._publish_board_update(None)
+
+    @staticmethod
+    def _git_capture(cwd: str, *args: str) -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "-C", cwd, *args],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        return (result.stdout or "").strip() or None
+
+    def _remove_worktree(self, worktree_path: str, *, prune_branches: bool) -> None:
+        """Remove a session's worktree and, where safe, its branch.
+
+        The branch and the main repo root are captured from the live worktree
+        *before* removal so cleanup needs no stored branch name and never
+        stats a path git already deleted. ``git branch -d`` (the default)
+        refuses unmerged branches, protecting a worker reaped before its work
+        merged; ``prune_branches`` upgrades to ``-D`` for crew teardown where
+        the branches are meant to be discarded. Only the branch the worktree
+        owned is ever touched, and a branch checked out elsewhere is left for
+        git to refuse.
+        """
+        branch = self._git_capture(worktree_path, "rev-parse", "--abbrev-ref", "HEAD")
+        common_dir = self._git_capture(
+            worktree_path, "rev-parse", "--path-format=absolute", "--git-common-dir"
+        )
+        repo_root = str(Path(common_dir).parent) if common_dir else None
+        # Drive the removal (and branch delete) from the main worktree, not the
+        # server's cwd which may sit outside this session's repo.
+        remove_cmd = ["git", "worktree", "remove", "--force", worktree_path]
+        if repo_root is not None:
+            remove_cmd[1:1] = ["-C", repo_root]
+        with suppress(Exception):
+            subprocess.run(remove_cmd, check=False)
+        if branch is None or branch == "HEAD" or repo_root is None:
+            return
+        flag = "-D" if prune_branches else "-d"
+        with suppress(Exception):
+            subprocess.run(
+                ["git", "-C", repo_root, "branch", flag, branch],
+                capture_output=True,
+                check=False,
+            )
 
     async def post_board_entry(
         self, channel: str, request: BoardPostRequest

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1907,3 +1907,42 @@ def test_set_permission_mode_rejects_unsupported_backend(
     assert result.exit_code != 0
     assert "does not support" in result.output
     assert posted == []
+
+
+def test_start_warns_on_unknown_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/backends/codex/models":
+            return httpx.Response(
+                200,
+                json={
+                    "backend": "codex",
+                    "models": [{"id": "gpt-5"}],
+                    "supports_free_text": True,
+                },
+            )
+        if path == "/api/sessions" and request.method == "POST":
+            return httpx.Response(200, json={"session": {"id": "new"}})
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp",
+            "--model",
+            "gpt-5-codex",
+        ],
+    )
+    # Warning, not rejection: the session is still created.
+    assert result.exit_code == 0
+    assert "is not among" in result.output

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1795,3 +1795,115 @@ def test_board_help_lists_log_command() -> None:
     result = runner.invoke(app, ["board", "--help"])
     assert result.exit_code == 0
     assert "log" in result.stdout
+
+
+def _permission_mode_handler(
+    posted: list[dict[str, Any]],
+    *,
+    backend: str,
+    supports_inline: bool,
+    modes: list[str],
+) -> Any:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/sessions/s1":
+            return httpx.Response(
+                200, json={"session": {"id": "s1", "backend": backend}}
+            )
+        if path == "/api/backends":
+            return httpx.Response(
+                200,
+                json={
+                    "backends": [
+                        {
+                            "id": backend,
+                            "capabilities": {
+                                "supports_set_permission_mode_inline": supports_inline,
+                                "permission_modes": [{"id": m} for m in modes],
+                            },
+                        }
+                    ]
+                },
+            )
+        if path == "/api/sessions/s1/mode":
+            posted.append(json.loads(request.content))
+            return httpx.Response(
+                200, json={"session": {"id": "s1", "permission_mode": "auto"}}
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    return handler
+
+
+def _fake_client_factory(handler: Any) -> Any:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    return fake_client
+
+
+def test_set_permission_mode_posts_valid_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    posted: list[dict[str, Any]] = []
+    handler = _permission_mode_handler(
+        posted, backend="claude_code", supports_inline=True, modes=["default", "auto"]
+    )
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "set-permission-mode",
+            "s1",
+            "auto",
+        ],
+    )
+    assert result.exit_code == 0
+    assert posted == [{"mode": "auto"}]
+    assert json.loads(result.stdout)["session"]["permission_mode"] == "auto"
+
+
+def test_set_permission_mode_rejects_unknown_mode_locally(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    posted: list[dict[str, Any]] = []
+    handler = _permission_mode_handler(
+        posted, backend="claude_code", supports_inline=True, modes=["default", "auto"]
+    )
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "mode", "s1", "bogus"],
+    )
+    assert result.exit_code != 0
+    assert "unknown permission mode" in result.output
+    # Validation is local — the server is never asked to set a bad mode.
+    assert posted == []
+
+
+def test_set_permission_mode_rejects_unsupported_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    posted: list[dict[str, Any]] = []
+    handler = _permission_mode_handler(
+        posted, backend="tmux", supports_inline=False, modes=[]
+    )
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "set-permission-mode",
+            "s1",
+            "auto",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "does not support" in result.output
+    assert posted == []

--- a/backend/tests/test_worktree.py
+++ b/backend/tests/test_worktree.py
@@ -123,6 +123,88 @@ def test_delete_removes_worktree(tmp_path: Path) -> None:
     assert storage.get_session("wt-del") is None
 
 
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo_with_worktree(tmp_path: Path, branch: str) -> tuple[Path, Path]:
+    """Init a repo with one commit and a worktree on ``branch``; return both paths."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Test")
+    (repo / "README.md").write_text("hi\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "init")
+    worktree = tmp_path / f"repo-{branch.replace('/', '-')}"
+    _git(repo, "worktree", "add", "-q", str(worktree), "-b", branch)
+    return repo, worktree
+
+
+def _branch_exists(repo: Path, branch: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "--verify", "--quiet", branch],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _delete_worktree_session(
+    tmp_path: Path, worktree: Path, *, prune_branches: bool
+) -> None:
+    from waypoint.runtime import SessionRuntime
+    from waypoint.settings import Settings
+
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+    session = _make_session(
+        settings, settings.sessions_dir, id="wt", worktree_path=str(worktree)
+    )
+    storage.create_session(session)
+    asyncio.run(runtime.delete("wt", prune_branches=prune_branches))
+
+
+def test_delete_prunes_merged_worktree_branch(tmp_path: Path) -> None:
+    repo, worktree = _init_repo_with_worktree(tmp_path, "wq/job-t1")
+    # The branch is at the integration tip — merged — so the safe `-d` prunes it.
+    _delete_worktree_session(tmp_path, worktree, prune_branches=False)
+    assert not worktree.exists()
+    assert not _branch_exists(repo, "wq/job-t1")
+
+
+def test_delete_keeps_unmerged_branch_without_prune(tmp_path: Path) -> None:
+    repo, worktree = _init_repo_with_worktree(tmp_path, "wq/job-t2")
+    (worktree / "work.txt").write_text("wip\n")
+    _git(worktree, "add", "-A")
+    _git(worktree, "commit", "-q", "-m", "wip")
+    # Unmerged work: `-d` must refuse, leaving the branch for the lead to merge.
+    _delete_worktree_session(tmp_path, worktree, prune_branches=False)
+    assert not worktree.exists()
+    assert _branch_exists(repo, "wq/job-t2")
+
+
+def test_delete_force_prunes_unmerged_branch(tmp_path: Path) -> None:
+    repo, worktree = _init_repo_with_worktree(tmp_path, "wq/job-t3")
+    (worktree / "work.txt").write_text("wip\n")
+    _git(worktree, "add", "-A")
+    _git(worktree, "commit", "-q", "-m", "wip")
+    # Crew teardown: --prune-branches force-deletes even the unmerged branch.
+    _delete_worktree_session(tmp_path, worktree, prune_branches=True)
+    assert not worktree.exists()
+    assert not _branch_exists(repo, "wq/job-t3")
+
+
 def test_delete_skips_worktree_removal_when_none(tmp_path: Path) -> None:
     from waypoint.runtime import SessionRuntime
     from waypoint.settings import Settings


### PR DESCRIPTION
## Summary

Three workqueue/subagent follow-ups surfaced while running a parallel crew, where children silently stalled on permission approvals, a leftover worktree branch collided with a respawn, and a wrong `--model` only failed on turn 1. Plus the skill docs that steer agents away from those traps.

1. **A `sessions set-permission-mode` CLI command (alias `mode`).** The runtime already applies a permission-mode change inline, but from the CLI the only way to widen a stalled worker's posture was reap + respawn. The new command posts to the existing `POST /api/sessions/{id}/mode` endpoint and validates the mode against the backend's advertised `permission_modes` locally first, so an unknown id or an unsupported backend (e.g. `tmux`) is reported with the accepted ids before the round trip.

2. **Worktree branches are cleaned up on delete and reap.** Deleting or reaping a worktree-backed session removed the worktree directory but left its `wq/<job>-t<n>` branch behind, which then collided with a respawn's `--worktree` (it recreates the same branch via `git worktree add -b`). The delete path now captures the branch and the main repo root from the live worktree *before* removal, then runs `git branch -d` — which refuses unmerged branches, protecting a worker reaped before its work merged. A new `--prune-branches` flag on `delete`/`reap` upgrades to `git branch -D` for crew teardown where the worker branches are meant to be discarded. Removal also now runs from the session's own repo rather than the server's cwd.

3. **`sessions start` warns on an unknown `--model`.** A wrong model id is accepted at spawn and only surfaces as a turn-1 failure, long after the session looks started. `start` now checks `--model` against the backend's advertised models and warns when it is absent. It stays a warning, never a rejection — backends accept free-text ids and discovery may be unavailable — so the session is still created.

## Changes

### Backend

- **`client.py`** — adds `set_permission_mode(session_id, mode)` over the existing `/mode` endpoint, and threads `prune_branches` through `delete()` (forwarded as a query param only when truthy, preserving the prior `params=None` shape).
- **`api.py`** — the delete endpoint accepts `prune_branches` and passes it to `runtime.delete`.
- **`runtime.py`** — `_remove_worktree` captures the branch (`git rev-parse --abbrev-ref HEAD`) and repo root (`--git-common-dir`) from the live worktree before removal, removes the worktree from that repo root, then `git branch -d` (or `-D` under `prune_branches`); a `_git_capture` helper runs the read-only git queries. `delete` gains a `prune_branches` parameter.
- **`cli.py`** — new `sessions set-permission-mode`/`mode` command with `_validate_permission_mode` (local capability check listing the accepted ids); `--prune-branches` on `sessions delete` and `sessions reap`; `_warn_unknown_model` invoked from `sessions start`.

### Tests

- **`test_cli.py`** — `set-permission-mode` posts a valid mode, rejects an unknown mode locally without hitting the server, rejects an unsupported backend, and `sessions start` warns (but still creates) on an unknown model.
- **`test_worktree.py`** — real-git coverage of the branch matrix: a merged branch is pruned by the default `-d`, an unmerged branch survives a plain delete, and `--prune-branches` force-deletes an unmerged branch.

### Docs

- **`.agents/skills/waypoint-subagents`** (`SKILL.md`, `references/permissions.md`) — decide a child's permission mode before unattended spawning and ask the user when unsure rather than inheriting `default` and stalling silently; fix a posture in place with `sessions set-permission-mode` instead of reap + respawn.
- **`.agents/skills/waypoint-workqueue`** (`SKILL.md`, `references/playbook.md`) — a pre-spawn checklist (model id verbatim, an auto-approving permission mode, placement), confirm the worker survived turn 1 before treating it as assigned, and reap with `--prune-branches`; replaces the literal `gpt-5-codex` example that was the original wrong-model foot-gun.

## Test Plan

- [x] `cd backend && uv run pytest` — 859 passed.
- [x] `cd backend && uv run pre-commit run --files <changed files>` — isort / black / ruff / codespell / mypy clean; hooks also ran clean per-commit.
- [x] Live e2e (backend restarted on this branch): spawned a worktree-backed session, confirmed the worktree dir + branch were created; `sessions mode <sid> bogus-mode` was rejected locally listing the valid ids, `set-permission-mode <sid> plan` applied live (`permission_mode -> plan`).
- [x] Live e2e: `delete --prune-branches` removed both the worktree and its branch; a plain `delete` on a worktree with an unmerged commit removed the dir but kept the branch (safe `-d` default); `start --model totally-bogus-9z` printed the warning listing the real models and still created the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)