### PR TITLE
feat: read-only terminal pane for claude_tty, drop eager log snapshot

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -53,7 +53,6 @@ from waypoint.schemas import (
     SessionPlanApprovalRequest,
     SessionStatus,
     SessionTitleRequest,
-    TerminalSnapshot,
 )
 from waypoint.settings import Settings, load_settings
 from waypoint.storage import Storage
@@ -763,17 +762,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         return page.model_dump(mode="json")
 
-    @app.get(
-        "/api/sessions/{session_id}/terminal-snapshot", response_model=TerminalSnapshot
-    )
-    async def terminal_snapshot(
-        session_id: str,
-        _: Annotated[str, Depends(token_dependency())],
-    ) -> TerminalSnapshot:
-        return TerminalSnapshot(
-            session_id=session_id, text=context.runtime.terminal_snapshot(session_id)
-        )
-
     @app.websocket("/ws/sessions")
     async def ws_sessions(websocket: WebSocket) -> None:
         await websocket.accept()
@@ -845,12 +833,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         except HTTPException:
             await websocket.close(code=4404)
             return
-        # Only a live-terminal transport gives us a pane to mirror; structured
-        # backends already publish to the event stream and have no pty to wrap.
+        # Only transports with a terminal pane can be mirrored here; backends
+        # with no pane (pure structured streams) publish via the event WS.
         plugin = context.runtime.registry.plugin_for(session)
-        if not plugin.capabilities.live_terminal:
+        caps = plugin.capabilities
+        if not caps.has_terminal_pane:
             await websocket.close(code=4403)
             return
+        terminal_interactive = caps.terminal_interactive
+        terminal_resizable = caps.terminal_resizable
         # Refuse to attach to an already-dead pane — the renderer would
         # seed from a stale capture and the stream would never produce
         # bytes. 4410 tells the frontend to surface the reconnect
@@ -864,40 +855,51 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         adapter = context.runtime.tmux
         raw_log_path = Path(session.raw_log_path)
 
-        # Wait briefly for the client's initial resize so the capture-pane
-        # seed is rendered at the viewport's dimensions, not the pane's
-        # previous size. The frontend always sends a resize on socket open,
-        # so the timeout only matters when an unusual client connects.
-        viewport_cols = 0
-        viewport_rows = 0
-        try:
-            first = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
-            handshake = json.loads(first)
-            if handshake.get("type") == "resize":
-                try:
-                    viewport_cols = int(handshake.get("cols", 0))
-                    viewport_rows = int(handshake.get("rows", 0))
-                except (TypeError, ValueError):
-                    viewport_cols = viewport_rows = 0
-                if viewport_cols > 0 and viewport_rows > 0:
-                    with suppress(TmuxError):
-                        await adapter.resize_window(
-                            tmux_session, viewport_cols, viewport_rows
-                        )
-                        await adapter.resize_pane(pane, viewport_cols, viewport_rows)
-        except WebSocketDisconnect:
-            # Client closed during the handshake; nothing left to seed.
-            return
-        except (TimeoutError, json.JSONDecodeError):
-            # No handshake — fall through with default viewport.
-            pass
-
-        # Give the pane process a beat to handle SIGWINCH and emit its
-        # redraw before we capture — otherwise the seed reflects the stale
-        # pre-resize buffer (cursor at the old pane's bottom row, content
-        # clipped to the old size) and the live stream has to overpaint it.
-        if viewport_cols and viewport_rows:
-            await asyncio.sleep(0.1)
+        # Resizable transports wait for the client's initial resize frame so
+        # the seed is rendered at the viewport's dimensions. Non-resizable
+        # transports (claude_tty) have their size fixed by the pane manager;
+        # query the actual dimensions instead.
+        cols = 80
+        rows = 24
+        if terminal_resizable:
+            viewport_cols = 0
+            viewport_rows = 0
+            try:
+                first = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
+                handshake = json.loads(first)
+                if handshake.get("type") == "resize":
+                    try:
+                        viewport_cols = int(handshake.get("cols", 0))
+                        viewport_rows = int(handshake.get("rows", 0))
+                    except (TypeError, ValueError):
+                        viewport_cols = viewport_rows = 0
+                    if viewport_cols > 0 and viewport_rows > 0:
+                        with suppress(TmuxError):
+                            await adapter.resize_window(
+                                tmux_session, viewport_cols, viewport_rows
+                            )
+                            await adapter.resize_pane(
+                                pane, viewport_cols, viewport_rows
+                            )
+            except WebSocketDisconnect:
+                # Client closed during the handshake; nothing left to seed.
+                return
+            except (TimeoutError, json.JSONDecodeError):
+                # No handshake — fall through with default viewport.
+                pass
+            cols = viewport_cols or 80
+            rows = viewport_rows or 24
+            # Give the pane process a beat to handle SIGWINCH and emit its
+            # redraw before we capture — otherwise the seed reflects the stale
+            # pre-resize buffer (cursor at the old pane's bottom row, content
+            # clipped to the old size) and the live stream has to overpaint it.
+            if viewport_cols and viewport_rows:
+                await asyncio.sleep(0.1)
+        else:
+            # Seed the renderer at the pane's actual current dimensions so
+            # the diff encoding matches what the pane produces.
+            with suppress(TmuxError):
+                cols, rows = await adapter.pane_dimensions(pane)
 
         # Server-side terminal emulator: bytes from the pane go through
         # pyte, which maintains the authoritative screen state. The
@@ -906,8 +908,6 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # has to interpret DECSTBM scroll regions, partial sync-output
         # frames, or other sequences browser emulators handle
         # inconsistently from native terminals.
-        cols = viewport_cols or 80
-        rows = viewport_rows or 24
         renderer = make_renderer(cols, rows)
 
         # Seed pyte with the pane's current ANSI snapshot so the renderer
@@ -1074,6 +1074,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         with suppress(Exception):
                             await websocket.close(code=4410)
                         break
+                    # For non-resizable panes (e.g. claude_tty) the pane is
+                    # replaced on each relaunch. Detect a target change and
+                    # close so the client reconnects to the new pane.
+                    if not terminal_resizable:
+                        cur_state = current.transport_state or {}
+                        cur_pane = cur_state.get("tmux_pane") or current.id
+                        if cur_pane != pane:
+                            await emit_diff()
+                            with suppress(Exception):
+                                await websocket.close(code=4410)
+                            break
                 # 20ms keeps perceived latency below the threshold most
                 # users notice for typing echo without burning CPU on
                 # idle polling.
@@ -1114,17 +1125,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         continue
                     kind = payload.get("type")
                     if kind == "input":
-                        data = payload.get("data", "")
-                        if isinstance(data, str) and data:
-                            input_bytes += data.encode("utf-8")
+                        if terminal_interactive:
+                            data = payload.get("data", "")
+                            if isinstance(data, str) and data:
+                                input_bytes += data.encode("utf-8")
                     elif kind == "input_submit":
-                        text = payload.get("text", "")
-                        if not isinstance(text, str):
-                            continue
-                        submit = bool(payload.get("submit", True))
-                        if text or submit:
-                            submits.append((text, submit))
+                        if terminal_interactive:
+                            text = payload.get("text", "")
+                            if not isinstance(text, str):
+                                continue
+                            submit = bool(payload.get("submit", True))
+                            if text or submit:
+                                submits.append((text, submit))
                     elif kind == "resize":
+                        if not terminal_resizable:
+                            continue
                         try:
                             r_cols = int(payload.get("cols", 0))
                             r_rows = int(payload.get("rows", 0))
@@ -1133,13 +1148,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                         if r_cols > 0 and r_rows > 0:
                             resize_target = (r_cols, r_rows)
 
-                if input_bytes:
-                    with suppress(TmuxError):
-                        await adapter.send_bytes(pane, input_bytes)
-                for text, submit in submits:
-                    with suppress(TmuxError):
-                        await adapter.send_input(pane, text, submit=submit)
-                if resize_target is not None:
+                if terminal_interactive:
+                    if input_bytes:
+                        with suppress(TmuxError):
+                            await adapter.send_bytes(pane, input_bytes)
+                    for text, submit in submits:
+                        with suppress(TmuxError):
+                            await adapter.send_input(pane, text, submit=submit)
+                if terminal_resizable and resize_target is not None:
                     new_cols, new_rows = resize_target
                     renderer.resize(new_cols, new_rows)
                     with suppress(TmuxError):

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -83,6 +83,16 @@ class TransportCapabilities(_FrozenModel):
     # wrapper only; structured transports (including claude_tty, which runs in
     # a pane but is tailed from its transcript) publish to the event stream.
     live_terminal: bool = False
+    # The transport exposes a tmux pane that the terminal websocket can mirror.
+    # Unlike live_terminal (raw-scrape-only), a terminal pane may be read-only
+    # (terminal_interactive=False) or fixed-size (terminal_resizable=False).
+    has_terminal_pane: bool = False
+    # The terminal pane accepts keyboard input forwarded from the frontend.
+    # False for claude_tty (read-only mirror of the structured TUI).
+    terminal_interactive: bool = False
+    # The terminal pane's dimensions can be driven by the client viewport.
+    # False for claude_tty (pane is managed by the structured relaunch cycle).
+    terminal_resizable: bool = False
     is_fallback_for_managed_launch: bool = False
 
 
@@ -128,6 +138,12 @@ class BackendCapabilities(_FrozenModel):
     # runtime tails its raw log to scrape state and the frontend can mirror the
     # pane over the terminal websocket. True for the generic tmux wrapper only.
     live_terminal: bool = False
+    # The transport exposes a tmux pane the terminal websocket can mirror.
+    has_terminal_pane: bool = False
+    # The terminal pane accepts keyboard input forwarded from the frontend.
+    terminal_interactive: bool = False
+    # The terminal pane's dimensions can be driven by the client viewport.
+    terminal_resizable: bool = False
     supports_thread_discovery: bool = False
     supports_thread_import: bool = False
     supports_fork: bool = False
@@ -203,6 +219,9 @@ class BackendCapabilities(_FrozenModel):
             supports_set_permission_mode_inline=self.supports_set_permission_mode_inline,
             settings_change_interrupts_turn=self.settings_change_interrupts_turn,
             live_terminal=self.live_terminal,
+            has_terminal_pane=self.has_terminal_pane,
+            terminal_interactive=self.terminal_interactive,
+            terminal_resizable=self.terminal_resizable,
             is_fallback_for_managed_launch=self.is_fallback_for_managed_launch,
         )
 

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -304,7 +304,6 @@ class ClaudeSessionState:
     pending_task_creates: dict[str, dict[str, Any]] = field(default_factory=dict)
     task_card_item_id: str | None = None
     last_message_text: dict[str, str] = field(default_factory=dict)
-    terminal_fragments: list[str] = field(default_factory=list)
     stderr_tail: deque[str] = field(
         default_factory=lambda: deque(maxlen=STDERR_TAIL_LINES)
     )
@@ -1194,12 +1193,6 @@ class ClaudeCliAdapter:
         for session_id in list(self._sessions.keys()):
             await self.terminate_session(session_id)
 
-    def terminal_snapshot(self, session_id: str) -> str:
-        state = self._sessions.get(session_id)
-        if state is None:
-            return ""
-        return "".join(state.terminal_fragments)
-
     async def _spawn(
         self,
         session_id: str,
@@ -1718,7 +1711,6 @@ class ClaudeCliAdapter:
                 "status": status,
             }
             if tool_use_id:
-                state.terminal_fragments.append(text + "\n")
                 preview_metadata = state.file_edit_preview_metadata.pop(
                     tool_use_id, None
                 )

--- a/backend/src/waypoint/backends/claude_code/transport.py
+++ b/backend/src/waypoint/backends/claude_code/transport.py
@@ -74,8 +74,3 @@ class ClaudeTransport(TransportAdapter):
         if self.adapter is None:
             return False
         return self.adapter.has_pending_approval(session.id)
-
-    def terminal_snapshot(self, session: SessionRecord) -> str:
-        if self.adapter is None:
-            return ""
-        return self.adapter.terminal_snapshot(session.id)

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -145,6 +145,9 @@ class ClaudeTtyPlugin:
         permission_modes=ClaudeCodePlugin.capabilities.permission_modes,
         slash_commands=ClaudeCodePlugin.capabilities.slash_commands,
         badges={"glyph": "C", "color": "#a78bfa"},
+        has_terminal_pane=True,
+        terminal_interactive=False,
+        terminal_resizable=False,
         cli_binary="claude",
         target_aliases=("claude_tty",),
     )

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -147,7 +147,6 @@ class CodexSessionState:
     active_turn_id: str | None = None
     stream_task: asyncio.Task[None] | None = None
     pending_approval: PendingApproval | None = None
-    terminal_fragments: list[str] = field(default_factory=list)
     streamed_tool_result_ids: set[str] = field(default_factory=set)
     file_diff_previews: dict[str, DiffPreviewPayload] = field(default_factory=dict)
     # Most recent model selection. Codex's protocol exposes model as a per-turn
@@ -562,12 +561,6 @@ class CodexAppServerAdapter:
         state = self._sessions.get(session_id)
         return bool(state and state.pending_approval is not None)
 
-    def terminal_snapshot(self, session_id: str) -> str:
-        state = self._sessions.get(session_id)
-        if state is None:
-            return ""
-        return "".join(state.terminal_fragments)
-
     async def shutdown(self) -> None:
         for session_id in list(self._sessions.keys()):
             await self.terminate_session(session_id)
@@ -624,8 +617,6 @@ class CodexAppServerAdapter:
                     }
                 kind, text, status = map_notification(notification.method, payload)
                 if kind is not None and text:
-                    if notification.method == "item/commandExecution/outputDelta":
-                        state.terminal_fragments.append(text)
                     diff_preview = diff_preview_for_notification(
                         notification.method, payload
                     )

--- a/backend/src/waypoint/backends/codex/transport.py
+++ b/backend/src/waypoint/backends/codex/transport.py
@@ -75,9 +75,6 @@ class CodexTransport(TransportAdapter):
     def has_pending_approval(self, session: SessionRecord) -> bool:
         return self.adapter.has_pending_approval(session.id)
 
-    def terminal_snapshot(self, session: SessionRecord) -> str:
-        return self.adapter.terminal_snapshot(session.id)
-
 
 def _input_items(
     text: str, attachments: list[ResolvedAttachment]

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -1320,9 +1320,6 @@ class OpenCodeAdapter:
         self._part_sessions.clear()
         self._started = False
 
-    def terminal_snapshot(self, session_id: str) -> str:
-        return ""
-
     def has_pending_approval(self, session_id: str) -> bool:
         state = self._sessions.get(session_id)
         return bool(state and state.pending_permission_ids)

--- a/backend/src/waypoint/backends/opencode/transport.py
+++ b/backend/src/waypoint/backends/opencode/transport.py
@@ -87,16 +87,3 @@ class OpenCodeTransport(TransportAdapter):
         if adapter is None:
             return False
         return adapter.has_pending_approval(session.id)
-
-    def terminal_snapshot(self, session: SessionRecord) -> str:
-        adapter = self._plugin._adapters.get(
-            self._plugin._adapter_key(
-                self._runtime,
-                session.launch_target_id,
-                session.cwd,
-                self._effective_args(session),
-            )
-        )
-        if adapter is None:
-            return ""
-        return adapter.terminal_snapshot(session.id)

--- a/backend/src/waypoint/backends/tmux/adapter.py
+++ b/backend/src/waypoint/backends/tmux/adapter.py
@@ -137,6 +137,14 @@ class TmuxAdapter:
             "capture-pane", "-p", "-J", "-e", "-t", target, "-S", str(start_line)
         )
 
+    async def pane_dimensions(self, target: str) -> tuple[int, int]:
+        """Return the pane's current (width, height) in columns and rows."""
+        output = await self._run(
+            "display-message", "-p", "-t", target, "#{pane_width}|#{pane_height}"
+        )
+        w_str, h_str = output.strip().split("|")
+        return int(w_str), int(h_str)
+
     async def pane_screen_state(self, target: str) -> tuple[bool, int, int]:
         """Return whether the pane is on the alternate screen and the
         program's current cursor position (1-based row, col).

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -84,6 +84,9 @@ class TmuxPlugin:
         model_source=ModelSource.NONE,
         badges={"glyph": "T", "color": "#94a3b8"},
         live_terminal=True,
+        has_terminal_pane=True,
+        terminal_interactive=True,
+        terminal_resizable=True,
         is_fallback_for_managed_launch=True,
     )
 

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
@@ -92,12 +91,3 @@ class TmuxTransport(TransportAdapter):
 
     def has_pending_approval(self, session: SessionRecord) -> bool:
         return False
-
-    def terminal_snapshot(self, session: SessionRecord) -> str:
-        raw_log_path = Path(session.raw_log_path)
-        if not raw_log_path.exists():
-            return ""
-        # Return the pipe-pane bytes verbatim — ANSI sequences included —
-        # so the frontend's terminal emulator can render colors, cursor
-        # moves, and alternate-screen redraws produced by the agent's TUI.
-        return raw_log_path.read_text(encoding="utf-8", errors="ignore")

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1616,10 +1616,6 @@ class SessionRuntime:
             )
         return EventsPageResponse(events=events, has_more=has_more)
 
-    def terminal_snapshot(self, session_id: str) -> str:
-        session = self.get_session(session_id)
-        return self.transport_for(session).terminal_snapshot(session)
-
     def launch_target_summaries(self) -> list[dict[str, Any]]:
         summaries: list[dict[str, Any]] = []
         for target in self.ssh_targets.values():

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -444,12 +444,6 @@ class SessionAnswerQuestionRequest(BaseModel):
     answers: list[AskQuestionAnswer] | None = None
 
 
-class TerminalSnapshot(BaseModel):
-    session_id: str
-    text: str
-    from_raw_log: bool = True
-
-
 class ScheduleStatus(StrEnum):
     PENDING = "pending"
     LAUNCHED = "launched"

--- a/backend/src/waypoint/transports/base.py
+++ b/backend/src/waypoint/transports/base.py
@@ -45,9 +45,6 @@ class TransportAdapter(ABC):
     @abstractmethod
     def has_pending_approval(self, session: SessionRecord) -> bool: ...
 
-    @abstractmethod
-    def terminal_snapshot(self, session: SessionRecord) -> str: ...
-
     async def resume(self, session: SessionRecord) -> None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/backend/tests/golden/backends_payload.json
+++ b/backend/tests/golden/backends_payload.json
@@ -24,6 +24,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
       "live_terminal": false,
+      "has_terminal_pane": false,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "supports_thread_discovery": true,
       "supports_thread_import": true,
       "supports_fork": true,
@@ -261,6 +264,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
       "live_terminal": false,
+      "has_terminal_pane": false,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "is_fallback_for_managed_launch": false
     }
   },
@@ -287,6 +293,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": true,
       "live_terminal": false,
+      "has_terminal_pane": true,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "supports_thread_discovery": true,
       "supports_thread_import": true,
       "supports_fork": true,
@@ -524,6 +533,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": true,
       "live_terminal": false,
+      "has_terminal_pane": true,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "is_fallback_for_managed_launch": false
     }
   },
@@ -551,6 +563,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
       "live_terminal": false,
+      "has_terminal_pane": false,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "supports_thread_discovery": true,
       "supports_thread_import": true,
       "supports_fork": true,
@@ -696,6 +711,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
       "live_terminal": false,
+      "has_terminal_pane": false,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "is_fallback_for_managed_launch": false
     }
   },
@@ -723,6 +741,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
       "live_terminal": false,
+      "has_terminal_pane": false,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "supports_thread_discovery": true,
       "supports_thread_import": true,
       "supports_fork": true,
@@ -880,6 +901,9 @@
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
       "live_terminal": false,
+      "has_terminal_pane": false,
+      "terminal_interactive": false,
+      "terminal_resizable": false,
       "is_fallback_for_managed_launch": false
     }
   },
@@ -906,6 +930,9 @@
       "supports_set_permission_mode_inline": false,
       "settings_change_interrupts_turn": false,
       "live_terminal": true,
+      "has_terminal_pane": true,
+      "terminal_interactive": true,
+      "terminal_resizable": true,
       "supports_thread_discovery": false,
       "supports_thread_import": false,
       "supports_fork": false,
@@ -963,6 +990,9 @@
       "supports_set_permission_mode_inline": false,
       "settings_change_interrupts_turn": false,
       "live_terminal": true,
+      "has_terminal_pane": true,
+      "terminal_interactive": true,
+      "terminal_resizable": true,
       "is_fallback_for_managed_launch": true
     }
   }

--- a/backend/tests/test_backend_capabilities_split.py
+++ b/backend/tests/test_backend_capabilities_split.py
@@ -58,6 +58,29 @@ def test_live_terminal_flag_is_tmux_only() -> None:
         assert plugin.capabilities.transport_capabilities().live_terminal is expected
 
 
+def test_terminal_pane_caps() -> None:
+    """has_terminal_pane is set for tmux (interactive+resizable) and claude_tty
+    (read-only, fixed-size); all other plugins leave all three False."""
+    registry = build_default_registry()
+    caps_by_id = {p.id: p.capabilities for p in registry.all()}
+
+    tmux = caps_by_id["tmux"]
+    assert tmux.has_terminal_pane is True
+    assert tmux.terminal_interactive is True
+    assert tmux.terminal_resizable is True
+
+    tty = caps_by_id["claude_tty"]
+    assert tty.has_terminal_pane is True
+    assert tty.terminal_interactive is False
+    assert tty.terminal_resizable is False
+
+    for pid in ("claude_code", "codex", "opencode"):
+        c = caps_by_id[pid]
+        assert c.has_terminal_pane is False
+        assert c.terminal_interactive is False
+        assert c.terminal_resizable is False
+
+
 def test_backends_payload_matches_golden() -> None:
     """``GET /api/backends`` matches the pinned superset payload.
 

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -556,26 +556,6 @@ async def test_terminate_session_returns_false_for_unknown_id() -> None:
 
 
 @pytest.mark.asyncio
-async def test_terminal_snapshot_returns_command_fragments() -> None:
-    emitted: list = []
-    adapter, _ = make_adapter(emitted)
-    await adapter.start_session("sess", "/tmp/work")
-    state = adapter._sessions["sess"]
-    state.terminal_fragments.extend(["one\n", "two\n"])
-    assert adapter.terminal_snapshot("sess") == "one\ntwo\n"
-
-
-def test_terminal_snapshot_returns_empty_for_inactive_session() -> None:
-    # Terminated/exited Codex sessions are popped from `_sessions` but the
-    # session record still lives in storage; the API still calls into us when
-    # the user opens the session detail page. Mirror the Claude adapter's
-    # graceful empty-string fallback instead of raising.
-    emitted: list = []
-    adapter, _ = make_adapter(emitted)
-    assert adapter.terminal_snapshot("never-started") == ""
-
-
-@pytest.mark.asyncio
 async def test_streamed_tool_result_suppresses_duplicate_completed_event() -> None:
     emitted: list[tuple[str, EventKind, str, dict[str, Any], SessionStatus]] = []
     adapter, fake = make_adapter(emitted)

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -488,10 +488,6 @@ class _FakeAdapter:
         self.calls.append(("has_pending_approval", session_id, ()))
         return True
 
-    def terminal_snapshot(self, session_id: str) -> str:
-        self.calls.append(("terminal_snapshot", session_id, ()))
-        return "snapshot"
-
 
 @pytest.mark.asyncio
 async def test_transport_routes_calls_by_session_launch_target() -> None:
@@ -555,7 +551,6 @@ async def test_transport_routes_calls_by_session_launch_target() -> None:
         ("approve",),
     )
     assert transport.has_pending_approval(remote_session) is True
-    assert transport.terminal_snapshot(remote_session) == "snapshot"
 
 
 @pytest.mark.asyncio

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,6 +58,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1355,6 +1356,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1420,6 +1422,7 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1959,6 +1962,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2313,6 +2317,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2959,6 +2964,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3144,6 +3150,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6057,6 +6064,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6066,6 +6074,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6876,6 +6885,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7058,6 +7068,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7448,6 +7459,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -58,7 +58,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1356,7 +1355,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1422,7 +1420,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -1962,7 +1959,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2317,7 +2313,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2964,7 +2959,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3150,7 +3144,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6064,7 +6057,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6074,7 +6066,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6885,7 +6876,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7068,7 +7058,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7459,7 +7448,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8373,7 +8373,7 @@ html[data-theme="light"] .term-compose {
   );
 }
 
-/* When the drawer is rendered (liveTmux only), the keybar's own
+/* When the drawer is rendered (interactive terminals only), the keybar's own
    safe-area inset would double-pad the gesture area. Flatten it so
    the gap lives on .term-compose where the visible anchor is. */
 .session-terminal:has(.term-compose) .term-keys {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -27,7 +27,6 @@ import {
   fetchBackendModels,
   fetchEvents,
   fetchSession,
-  fetchTerminalSnapshot,
   forkSession,
   isAuthError,
   postAction,
@@ -44,6 +43,7 @@ import {
   defaultTransportFor,
   displayAgentFor,
   fidelityFor,
+  hasTerminalPane,
   humaniseBackend,
   liveTerminal,
   permissionModesFor,
@@ -54,6 +54,8 @@ import {
   supportsReattachAfterExit,
   supportsResume,
   supportsStructuredApproval,
+  terminalInteractive,
+  terminalResizable,
   transportLabel,
   useBackendCatalog,
 } from "@/lib/backends";
@@ -321,8 +323,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       setDismissedTaskSequence(null);
     }
   }, [sessionId]);
-  const [snapshot, setSnapshot] = useState("");
-  const [snapshotLoading, setSnapshotLoading] = useState(false);
   const [view, setView] = useState<ViewMode>("chat");
   const [filterMode, setFilterMode] = useState<FilterMode>("important");
   const [toolRunsExpanded, setToolRunsExpanded] = useState(false);
@@ -416,22 +416,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     onAuthFailure?.();
     router.replace("/");
   }, [onAuthFailure, router]);
-
-  const refreshSnapshot = useCallback(async () => {
-    setSnapshotLoading(true);
-    try {
-      const text = await fetchTerminalSnapshot(host, token, sessionId);
-      setSnapshot(text);
-    } catch (snapshotError) {
-      if (isAuthError(snapshotError)) {
-        handleAuthFailure();
-        return;
-      }
-      setError(snapshotError instanceof Error ? snapshotError.message : "failed to fetch terminal snapshot");
-    } finally {
-      setSnapshotLoading(false);
-    }
-  }, [handleAuthFailure, host, token, sessionId]);
 
   const scrollToBottom = useCallback((behavior: ScrollBehavior = "smooth") => {
     // Scroll the actual document to its full height — using the document
@@ -721,10 +705,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     let active = true;
     async function load() {
       try {
-        const [loadedSession, loadedPage, loadedSnapshot] = await Promise.all([
+        const [loadedSession, loadedPage] = await Promise.all([
           fetchSession(host, token, sessionId),
           fetchEvents(host, token, sessionId),
-          fetchTerminalSnapshot(host, token, sessionId),
         ]);
         if (!active) {
           return;
@@ -738,7 +721,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         setEvents(coalesced);
         setHasOlderEvents(loadedPage.has_more);
         setOldestRawSequence(minRawSequence(sanitized));
-        setSnapshot(loadedSnapshot);
       } catch (loadError) {
         if (active) {
           if (isAuthError(loadError)) {
@@ -841,12 +823,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       socket?.close();
     };
   }, [handleAuthFailure, host, token, sessionId, queueIncomingEvent]);
-
-  useEffect(() => {
-    if (view === "terminal") {
-      void refreshSnapshot();
-    }
-  }, [view, refreshSnapshot]);
 
   useEffect(() => {
     if (!session) return;
@@ -1311,21 +1287,35 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const canResume = Boolean(
     session && supportsResume(session.transport, catalog) && !sessionExited,
   );
-  const activeView: ViewMode = terminalOnly ? "terminal" : view;
+  // Whether the transport exposes a terminal pane (WS-backed xterm mirror).
+  // Drives terminal tab visibility and the WS-pane effect below.
+  const canShowTerminal = session
+    ? hasTerminalPane(session.transport, catalog)
+    : false;
+  // Whether the user can type into the terminal pane.
+  const canTerminalInteract = session
+    ? terminalInteractive(session.transport, catalog)
+    : false;
+  // Whether the terminal pane accepts resize frames.
+  const canTerminalResize = session
+    ? terminalResizable(session.transport, catalog)
+    : false;
+  const activeView: ViewMode = terminalOnly
+    ? "terminal"
+    : !canShowTerminal
+      ? "chat"
+      : view;
   const showTaskDock =
     activeView === "chat" &&
     taskProgress !== null &&
     currentTaskEvent !== null &&
     dismissedTaskSequence !== undefined &&
     currentTaskEvent.sequence !== dismissedTaskSequence;
-  // The live-terminal transport (tmux) streams its pane over a WebSocket; the
-  // WS-pane effects below key off this rather than a hardcoded transport id.
-  const liveTmux = terminalOnly;
   const { theme } = useTheme();
   const terminalRef = useRef<XTerminalHandle | null>(null);
   const terminalSocketRef = useRef<WebSocket | null>(null);
-  // Bumped on every EXITED → live transition so the terminal-WS effect
-  // re-runs against the reborn tmux pane instead of the closed socket.
+  // Bumped to reconnect the terminal WS: on EXITED → live transitions and
+  // when the pane target (tmux_pane) changes under a running session.
   const [terminalEpoch, setTerminalEpoch] = useState(0);
   const prevSessionExitedRef = useRef(sessionExited);
   useEffect(() => {
@@ -1334,34 +1324,37 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     }
     prevSessionExitedRef.current = sessionExited;
   }, [sessionExited]);
-  // Push the latest REST snapshot to xterm whenever it changes (or when the
-  // terminal tab mounts). For tmux sessions the WebSocket below seeds and
-  // streams the pane directly, so skip the REST replay to avoid duplicating
-  // content.
+  const tmuxPane =
+    typeof session?.transport_state?.tmux_pane === "string"
+      ? session.transport_state.tmux_pane
+      : null;
+  const prevTmuxPaneRef = useRef<string | null>(null);
   useEffect(() => {
-    if (activeView !== "terminal") return;
-    if (liveTmux) return;
-    const term = terminalRef.current;
-    if (!term) return;
-    term.reset();
-    if (snapshot) {
-      term.write(snapshot);
+    if (
+      prevTmuxPaneRef.current !== null &&
+      tmuxPane !== null &&
+      tmuxPane !== prevTmuxPaneRef.current
+    ) {
+      setTerminalEpoch((e) => e + 1);
     }
-  }, [activeView, snapshot, liveTmux]);
+    prevTmuxPaneRef.current = tmuxPane;
+  }, [tmuxPane]);
 
-  // Live tmux pane: connect a WebSocket, write streamed bytes into xterm,
-  // forward keystrokes and viewport-resize back to the pane. Reconnects with
-  // capped exponential backoff on transient drops.
+  // Terminal pane: connect a WebSocket when the terminal tab is open and the
+  // transport has a pane (lazy — defers connection until the tab is visible).
+  // Write streamed bytes into xterm; for interactive transports forward
+  // keystrokes and resize frames back. Reconnects with capped exponential
+  // backoff on transient drops.
   //
   // Deliberately does NOT depend on the full ``session`` object — the
   // session-state WS pushes updated SessionRecord references on every change
   // (effort/model/etc.), and re-running this effect would close the terminal
   // socket and ``term.reset()`` xterm on every push, which the user sees as
-  // the whole pane blanking out and re-painting. ``liveTmux`` already implies
-  // ``session !== null``.
+  // the whole pane blanking out and re-painting.
+  const paneTransport = session?.transport ?? null;
   useEffect(() => {
     if (activeView !== "terminal") return;
-    if (!liveTmux) return;
+    if (!paneTransport || !hasTerminalPane(paneTransport, catalog)) return;
     let active = true;
     let socket: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1417,7 +1410,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       socket?.close();
       terminalSocketRef.current = null;
     };
-  }, [activeView, liveTmux, host, token, sessionId, handleAuthFailure, terminalEpoch]);
+  }, [activeView, paneTransport, catalog, host, token, sessionId, handleAuthFailure, terminalEpoch]);
 
   const handleTerminalInput = useCallback((data: string) => {
     const socket = terminalSocketRef.current;
@@ -1497,12 +1490,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const handleTerminalResize = useCallback(
     ({ cols, rows }: { cols: number; rows: number }) => {
       setTerminalDims({ cols, rows });
+      if (!canTerminalResize) return;
       const socket = terminalSocketRef.current;
       if (socket?.readyState === WebSocket.OPEN) {
         socket.send(JSON.stringify({ type: "resize", cols, rows }));
       }
     },
-    [],
+    [canTerminalResize],
   );
   const handleTerminalScrollChip = useCallback(
     (direction: "up" | "down") => {
@@ -1554,19 +1548,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const handleTerminalScrollChange = useCallback((atBottom: boolean) => {
     setTermAtBottom(atBottom);
   }, []);
-  // "Refresh" on the terminal page means different things for live vs.
-  // read-only sessions: live tmux already streams every byte, so the
-  // useful refresh is bumping the WS epoch — that closes the current
-  // socket, opens a fresh one, and re-seeds the pane from the server's
-  // current state. For read-only snapshots we still hit the REST
-  // /snapshot endpoint to pull the latest capture.
   const handleTerminalRefresh = useCallback(() => {
-    if (liveTmux) {
-      setTerminalEpoch((e) => e + 1);
-    } else {
-      void refreshSnapshot();
-    }
-  }, [liveTmux, refreshSnapshot]);
+    setTerminalEpoch((e) => e + 1);
+  }, []);
   const interruptSession = useCallback(() => {
     void runAction("interrupt");
   }, [runAction]);
@@ -1609,7 +1593,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
             <div className="segmented segmented-quiet" aria-label="View mode">
               <span className="segmented-item active">Terminal</span>
             </div>
-          ) : (
+          ) : canShowTerminal ? (
             <div className="segmented" role="tablist" aria-label="View">
               <button
                 type="button"
@@ -1630,7 +1614,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                 Terminal
               </button>
             </div>
-          )}
+          ) : null}
           {!terminalOnly && activeView === "chat" ? (
             <div className="segmented segmented-quiet" role="radiogroup" aria-label="Event filter">
               <button
@@ -1773,11 +1757,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           token={token}
           sessionId={sessionId}
           session={session}
-          liveTmux={liveTmux}
+          interactive={canTerminalInteract}
           terminalRef={terminalRef}
           theme={theme}
           terminalDims={terminalDims}
-          snapshotLoading={snapshotLoading}
           sessionExited={sessionExited}
           dormantReattach={dormantReattach}
           locked={terminalOnly}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1371,7 +1371,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           // not have mounted at connect() time; the closure captured null
           // would silently skip this resize and leave the pane stuck at
           // xterm's default 80x24 if fit() produces the same dims and
-          // never fires onResize.
+          // never fires onResize. Non-resizable panes (claude_tty) own their
+          // geometry server-side and must never be resized from here, so skip
+          // the seed resize entirely for them.
+          if (!paneTransport || !terminalResizable(paneTransport, catalog)) {
+            return;
+          }
           const term = terminalRef.current;
           const cols = term?.cols();
           const rows = term?.rows();

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -19,11 +19,10 @@ interface SessionTerminalViewProps {
   token: string;
   sessionId: string;
   session: SessionRecord | null;
-  liveTmux: boolean;
+  interactive: boolean;
   terminalRef: MutableRefObject<XTerminalHandle | null>;
   theme: "dark" | "light";
   terminalDims: { cols: number; rows: number } | null;
-  snapshotLoading: boolean;
   sessionExited: boolean;
   dormantReattach: boolean;
   termMenuOpen: boolean;
@@ -56,9 +55,7 @@ interface SessionTerminalViewProps {
   onTerminalScrollChip: (direction: "up" | "down") => void;
   onTerminalScrollChange: (atBottom: boolean) => void;
   onJumpToLive: () => void;
-  // Refresh means "re-seed the terminal from the server". For live tmux
-  // that's a WS reconnect; for read-only snapshots that's a REST fetch.
-  // The parent picks which based on session.transport.
+  // Refresh reconnects the terminal WS, re-seeding the pane from the server.
   onRefresh: () => void;
   onReattach: () => void | Promise<void>;
   onTerminate: () => void | Promise<void>;
@@ -72,11 +69,10 @@ export function SessionTerminalView({
   token,
   sessionId,
   session,
-  liveTmux,
+  interactive,
   terminalRef,
   theme,
   terminalDims,
-  snapshotLoading,
   sessionExited,
   dormantReattach,
   termMenuOpen,
@@ -106,12 +102,10 @@ export function SessionTerminalView({
   const catalog = useBackendCatalog(host || null, token || null, null);
   // Primary action shown as a pill button next to the overflow trigger.
   // Only states the user can't trivially reach inside the pane — Reconnect
-  // when exited (the pane is gone) and Refresh for read-only snapshots.
-  // We deliberately do NOT surface "Interrupt" here because the keybar's
-  // ^C already sends SIGINT to the pane (the backend /interrupt action
-  // for tmux just writes ^C anyway).
+  // when exited (the pane is gone). We deliberately do NOT surface "Interrupt"
+  // here because the keybar's ^C already sends SIGINT to the pane.
   type PrimaryAction = {
-    kind: "refresh" | "reconnect";
+    kind: "reconnect";
     label: string;
     onClick: () => void;
     tone?: "primary";
@@ -124,12 +118,6 @@ export function SessionTerminalView({
       onClick: () => void onReattach(),
       tone: "primary",
     };
-  } else if (!liveTmux && session) {
-    primary = {
-      kind: "refresh",
-      label: snapshotLoading ? "Refreshing…" : "Refresh",
-      onClick: onRefresh,
-    };
   }
 
   const closeMenu = () => setTermMenuOpen(false);
@@ -140,9 +128,9 @@ export function SessionTerminalView({
 
   const [composeOpen, setComposeOpen] = useState(false);
   // The compose drawer collapses back to a hairline handle when the
-  // session isn't live, so we don't carry stale "open" state across a
+  // session isn't interactive, so we don't carry stale "open" state across a
   // disconnect / view switch.
-  const composeEnabled = liveTmux;
+  const composeEnabled = interactive;
   const refocusTerminal = useCallback(() => {
     terminalRef.current?.focus();
   }, [terminalRef]);
@@ -169,7 +157,7 @@ export function SessionTerminalView({
           anchored
         />
         <span className="term-bar-spacer" />
-        {liveTmux && terminalDims ? (
+        {interactive && terminalDims ? (
           <span className="term-bar-dims" aria-label="Pane dimensions">
             {terminalDims.cols}×{terminalDims.rows}
           </span>
@@ -179,7 +167,6 @@ export function SessionTerminalView({
             type="button"
             className={`term-bar-action ${primary.tone === "primary" ? "primary" : ""}`}
             onClick={primary.onClick}
-            disabled={snapshotLoading && primary.kind === "refresh"}
           >
             {primary.label}
           </button>
@@ -203,7 +190,7 @@ export function SessionTerminalView({
               data-term-overflow-menu
               style={overflowMenuStyle ?? undefined}
             >
-              {session && primary?.kind !== "refresh" ? (
+              {session ? (
                 <button
                   type="button"
                   role="menuitem"
@@ -212,7 +199,6 @@ export function SessionTerminalView({
                     closeMenu();
                     onRefresh();
                   }}
-                  disabled={snapshotLoading}
                 >
                   <span className="glyph">↻</span>
                   Refresh
@@ -280,13 +266,13 @@ export function SessionTerminalView({
           <XTerminal
             ref={terminalRef}
             theme={theme}
-            readOnly={!liveTmux}
-            onData={liveTmux ? onTerminalInput : undefined}
+            readOnly={!interactive}
+            onData={interactive ? onTerminalInput : undefined}
             onResize={onTerminalResize}
-            onScrollChange={liveTmux ? onTerminalScrollChange : undefined}
+            onScrollChange={interactive ? onTerminalScrollChange : undefined}
           />
         </div>
-        {liveTmux && !termAtBottom ? (
+        {interactive && !termAtBottom ? (
           <button
             type="button"
             className="term-jump"
@@ -296,14 +282,14 @@ export function SessionTerminalView({
             ↡ Jump to live
           </button>
         ) : null}
-        {liveTmux ? (
+        {interactive ? (
           <TerminalScrollChips
             onWheel={onTerminalScrollChip}
             withJump={!termAtBottom}
           />
         ) : null}
       </div>
-      {liveTmux ? (
+      {interactive ? (
         <TerminalKeyBar
           onSend={onTerminalInput}
           onRequestPaste={onRequestPaste}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -235,16 +235,6 @@ export async function fetchEvents(
   };
 }
 
-export async function fetchTerminalSnapshot(host: string, token: string, sessionId: string): Promise<string> {
-  const response = await fetch(`${host}/api/sessions/${sessionId}/terminal-snapshot`, {
-    headers: { Authorization: `Bearer ${token}` },
-    cache: "no-store",
-  });
-  await ensureOk(response, "failed to fetch terminal snapshot");
-  const payload = await response.json();
-  return payload.text as string;
-}
-
 export async function createSession(
   host: string,
   token: string,

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -74,6 +74,9 @@ const FALLBACK_STRUCTURED = new Set([
 ]);
 const FALLBACK_RESUMABLE = new Set(["tmux", "claude_tty"]);
 const FALLBACK_LIVE_TERMINAL = new Set(["tmux"]);
+const FALLBACK_HAS_TERMINAL_PANE = new Set(["tmux", "claude_tty"]);
+const FALLBACK_TERMINAL_INTERACTIVE = new Set(["tmux"]);
+const FALLBACK_TERMINAL_RESIZABLE = new Set(["tmux"]);
 const FALLBACK_APPROVAL_NOTE = new Set(["claude_code", "opencode"]);
 const FALLBACK_PLAN_APPROVAL = new Set(["codex"]);
 // Every agent can fork except the generic tmux fallback.
@@ -230,6 +233,34 @@ export function liveTerminal(
 ): boolean {
   const caps = catalog?.transportCaps(transport);
   return caps ? caps.live_terminal : FALLBACK_LIVE_TERMINAL.has(transport);
+}
+
+// Whether the transport exposes a terminal pane — a WS-backed xterm mirror
+// that may be read-only (claude_tty) or fully interactive (tmux).
+export function hasTerminalPane(
+  transport: SessionTransport,
+  catalog?: BackendCatalog,
+): boolean {
+  const caps = catalog?.transportCaps(transport);
+  return caps ? caps.has_terminal_pane : FALLBACK_HAS_TERMINAL_PANE.has(transport);
+}
+
+// Whether the terminal pane accepts keystroke input from the user.
+export function terminalInteractive(
+  transport: SessionTransport,
+  catalog?: BackendCatalog,
+): boolean {
+  const caps = catalog?.transportCaps(transport);
+  return caps ? caps.terminal_interactive : FALLBACK_TERMINAL_INTERACTIVE.has(transport);
+}
+
+// Whether the terminal pane accepts resize frames from the frontend.
+export function terminalResizable(
+  transport: SessionTransport,
+  catalog?: BackendCatalog,
+): boolean {
+  const caps = catalog?.transportCaps(transport);
+  return caps ? caps.terminal_resizable : FALLBACK_TERMINAL_RESIZABLE.has(transport);
 }
 
 // Reattach-after-exit is a transport-level property, advertised on each

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -185,6 +185,9 @@ export interface TransportCapabilities {
   supports_set_permission_mode_inline: boolean;
   settings_change_interrupts_turn: boolean;
   live_terminal: boolean;
+  has_terminal_pane: boolean;
+  terminal_interactive: boolean;
+  terminal_resizable: boolean;
   is_fallback_for_managed_launch: boolean;
 }
 
@@ -218,6 +221,9 @@ export interface BackendCapabilities {
   supports_set_permission_mode_inline: boolean;
   settings_change_interrupts_turn: boolean;
   live_terminal: boolean;
+  has_terminal_pane: boolean;
+  terminal_interactive: boolean;
+  terminal_resizable: boolean;
   supports_thread_discovery: boolean;
   supports_thread_import: boolean;
   supports_fork: boolean;
@@ -384,7 +390,6 @@ export interface SessionEnvelope {
     | "session_list_update"
     | "event"
     | "session_state"
-    | "terminal_snapshot_ready"
     | "auth_revoked"
     | "schedule_list_update"
     | "board_update"


### PR DESCRIPTION
## Summary

Opening the session page for a long-running `claude_tty` session was slow. On mount the frontend blocked its initial render on a three-way `Promise.all` that unconditionally fetched the terminal snapshot, and `claude_tty`'s snapshot (inherited from `TmuxTransport`) is `raw_log_path.read_text()` — the entire `pipe-pane` capture of the Claude TUI, an alt-screen app that redraws the whole viewport on every spinner tick, so the file grows unbounded. The page couldn't paint until that multi-megabyte read serialized and crossed the wire, and for the structured chat view the result was then discarded.

The real fix isn't to lazy-load or byte-cap that read — it's to recognize that `claude_tty` is the only transport that has *both* a structured transcript (rich chat, tailed from the JSONL) *and* a real tmux pane (a genuine live terminal). So it should offer both views, and its terminal should be the same WS-streamed pane the generic `tmux` transport already uses — which never reads the raw log in full (it seeds from `capture-pane` and tails from EOF). Adopting that path deletes the eager full-file read entirely.

The blocker is that a live pane must not perturb the structured layer: `claude_tty` pins its pane to a fixed `120x50` and the approval-dialog parser (`pane_dialog.py`) is documented to depend on that width, so resizing the pane to a browser viewport would break approval detection. The terminal is therefore read-only and non-resizing for `claude_tty`.

User-visible outcomes:

1. **`claude_tty` sessions load fast and gain a Terminal tab.** The unbounded snapshot read is gone from the load path; the chat view is the bounded events page as before. A read-only Terminal tab mirrors the live Claude TUI, connecting lazily only when the tab is opened.
2. **The `claude_tty` terminal never resizes or accepts input.** The pane stays at its fixed `120x50` (preserving the approval parser's geometry) and input is rejected server-side, so mirroring the pane can't corrupt the running session or its dialog detection.
3. **Pure-structured sessions are honestly chat-only.** `claude_code` (native), `codex`, and `opencode` have no pty to mirror, so their (previously empty, snapshot-backed) Terminal tab is removed and the view is forced to chat.

## Changes

### Backend

- **`backends/capabilities.py`** — adds three transport flags (default `False`) to `TransportCapabilities`/`BackendCapabilities`, wired through `transport_capabilities()`: `has_terminal_pane` (a pty the terminal WS can mirror), `terminal_interactive` (forwards keystrokes), `terminal_resizable` (client viewport drives pane size). `live_terminal` is unchanged — it still means "terminal-only presentation + raw-log state scrape" and stays tmux-only, so `claude_tty` keeps using its transcript tailer rather than the raw-output monitor.
- **`backends/tmux/plugin.py`** — `has_terminal_pane`/`terminal_interactive`/`terminal_resizable` all `True`. **`backends/claude_tty/plugin.py`** — `has_terminal_pane=True`, the other two `False`; `live_terminal` stays `False`.
- **`backends/tmux/adapter.py`** — adds `pane_dimensions()` (`tmux display-message #{pane_width}|#{pane_height}`) so a non-resizable pane can seed the renderer at its actual size.
- **`api.py`** — the terminal WS (`/ws/sessions/{id}/terminal`) gates on `has_terminal_pane` instead of `live_terminal`. When `terminal_resizable` is false it skips the resize handshake and the `resize_window`/`resize_pane` calls, seeds the pyte renderer at the pane's actual dimensions, and ignores inbound `resize` frames; when `terminal_interactive` is false it drops inbound input server-side (no `send_bytes`/`send_input`). For a non-resizable pane it also closes the socket when the `tmux_pane` target changes, so the client reconnects after a `claude_tty` relaunch.
- **Snapshot path deleted** — removes `GET /api/sessions/{id}/terminal-snapshot`, `runtime.terminal_snapshot`, `schemas.TerminalSnapshot`, the `terminal_snapshot` method on `transports/base.py` and every transport adapter, and the `terminal_fragments` accumulation in the `claude_code`/`codex`/`opencode` native adapters.

### Frontend

- **`lib/backends.ts`** — surfaces the three caps and adds `hasTerminalPane`/`terminalInteractive`/`terminalResizable` helpers (each with a fallback set), mirroring `liveTerminal`/`fidelityFor`. `terminalOnly`/`liveTerminal` semantics are unchanged.
- **`lib/api.ts`, `lib/types.ts`** — removes `fetchTerminalSnapshot`, the `terminal_snapshot_ready` envelope variant, and adds the cap fields to the catalog types.
- **`components/SessionDetail.tsx`** — drops `fetchTerminalSnapshot` from the mount `Promise.all` (and the `snapshot` state + REST-seed effect) — the perf fix. Computes `canShowTerminal = terminalOnly || hasTerminalPane`, rendering the Terminal toggle/view only when true and forcing `activeView` to `chat` otherwise. The terminal WS effect now keys on `activeView === "terminal" && hasTerminalPane` (lazy connect on tab open) and reconnects when `transport_state.tmux_pane` changes. The `onOpen` seed-resize and `handleTerminalResize` are gated on `terminalResizable`, so a `claude_tty` pane is never resized from the client.
- **`components/SessionTerminalView.tsx`** — takes an `interactive` prop in place of `liveTmux`: when false the `XTerminal` is read-only with no `onData`, and the keybar, compose drawer, paste, scroll chips, and pane-dimensions readout are suppressed.

### Tests

- **`test_backend_capabilities_split.py` (+ `tests/golden/backends_payload.json`)** — the new caps in the additive `/api/backends` payload (other backends serialize `false`) and a `claude_tty` = `T/F/F`, `tmux` = `T/T/T` assertion.
- **`test_codex_app_server.py` / `test_opencode_plugin.py`** — drop the removed `terminal_snapshot`/`terminal_fragments` assertions.

## Test Plan

- [x] `cd backend && uv run pytest` — 900 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort / black / ruff / codespell / mypy clean.
- [x] `cd frontend && npm run lint && npm run build` — clean.
- [x] Live e2e (stack restarted on this branch): `/api/backends` serves `claude_tty` = `has_terminal_pane:true, terminal_interactive:false, terminal_resizable:false`, `tmux` = all true, the three structured backends all false, and `live_terminal` unchanged; `GET /api/sessions/<id>/terminal-snapshot` → **404** (route gone); a live `claude_tty` chat page loaded in **0.81s** over the bounded events page.
- [x] Live e2e: the `claude_tty` terminal WS **accepted and sent a seed frame**, and after a client `resize 40x20` the pane **stayed `120x50`** (non-resize enforced, approval-parser geometry preserved); the tmux-transport WS accepted; the frontend session page returned **200**; the exercised session was undisturbed (still idle, pane alive).
- [x] The `4403` close for paneless backends is exercised by the capability matrix above and the gated handler (`if not has_terminal_pane: close(4403)`); not driven against a live structured session (the only one available was the Personal Assistant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)