### PR TITLE
fix: add permission mode to new-session launches

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8799,15 +8799,8 @@ html[data-theme="light"] .term-compose-input {
 .launch-body-grid {
   display: grid;
   gap: 12px;
-  grid-template-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   min-width: 0;
-}
-
-@media (min-width: 720px) {
-  .launch-body-grid.two-col {
-    grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
-    gap: 18px;
-  }
 }
 
 .launch-body-col {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -406,6 +406,7 @@ export default function HomePage() {
     transport: SessionTransport | null = null,
     args: string[] = [],
     configOverrides: string[] = [],
+    permissionMode: string | null = null,
   ) {
     try {
       const session = await createSession(host, token, {
@@ -419,6 +420,7 @@ export default function HomePage() {
         config_overrides: configOverrides,
         model,
         effort,
+        permission_mode: permissionMode,
       });
       setSessions((current) => [
         session,

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -20,7 +20,7 @@ import { ModelPicker } from "@/components/ModelPicker";
 import { ResumeThreadPanel } from "@/components/ResumeThreadPanel";
 import { WorkingDirectoryField } from "@/components/WorkingDirectoryField";
 import type { BackendCatalog } from "@/lib/backends";
-import { humaniseBackend } from "@/lib/backends";
+import { humaniseBackend, permissionModesFor } from "@/lib/backends";
 import {
   Backend,
   BackendModelListResponse,
@@ -61,6 +61,7 @@ interface LaunchPanelProps {
     transport: SessionTransport | null,
     args: string[],
     configOverrides: string[],
+    permissionMode: string | null,
   ) => Promise<void>;
   onAttach: (
     target: string,
@@ -100,11 +101,17 @@ export function LaunchPanel({
   const [model, setModel] = useState("");
   const [effort, setEffort] = useState("");
   const [transport, setTransport] = useTransportForAgent(backend, catalog);
+  const [permissionMode, setPermissionMode] = useState<string>("default");
   const [customArgsText, setCustomArgsText] = useState("");
   const [configOverridesText, setConfigOverridesText] = useState("");
   const [modelInfo, setModelInfo] = useState<BackendModelListResponse | null>(null);
   const [tmuxTarget, setTmuxTarget] = useState("");
   const [formBusy, setFormBusy] = useState(false);
+
+  const permissionOptions = useMemo(
+    () => permissionModesFor(backend, catalog),
+    [backend, catalog],
+  );
 
   const capabilities = catalog.byId(backend)?.capabilities;
   const supportsCustomArgs = capabilities?.supports_custom_cli_args ?? false;
@@ -127,6 +134,12 @@ export function LaunchPanel({
     setEffort("");
     setModelInfo(null);
   }, [defaultBackend]);
+
+  useEffect(() => {
+    if (!permissionOptions.some((option) => option.id === permissionMode)) {
+      setPermissionMode(permissionOptions[0]?.id ?? "default");
+    }
+  }, [permissionOptions, permissionMode]);
 
   // An "xhigh" effort carried over from one backend would be invalid
   // on the next, and per-backend model lists don't overlap.
@@ -192,6 +205,7 @@ export function LaunchPanel({
         transport || null,
         args,
         configOverrides,
+        permissionMode || null,
       );
       setTitle("");
     } finally {
@@ -233,42 +247,53 @@ export function LaunchPanel({
             onTransportChange={setTransport}
             catalog={catalog}
           />
-          <div className="launch-body-grid two-col">
-            <div className="launch-body-col">
-              <WorkingDirectoryField
-                cwd={cwd}
-                onChange={setCwd}
-                targetLabel={targetLabel}
-                recentCwds={recentCwds}
-              />
+          <div className="launch-body-grid">
+            <WorkingDirectoryField
+              cwd={cwd}
+              onChange={setCwd}
+              targetLabel={targetLabel}
+              recentCwds={recentCwds}
+            />
+            <label className="field">
+              <span>Title</span>
+              <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Optional" />
+            </label>
+            {permissionOptions.length > 0 ? (
               <label className="field">
-                <span>Title</span>
-                <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Optional" />
+                <span>Permission mode</span>
+                <select
+                  value={permissionMode}
+                  onChange={(event) => setPermissionMode(event.target.value)}
+                >
+                  {permissionOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
               </label>
-            </div>
-            <div className="launch-body-col">
-              <ModelPicker
-                key={`${backend}:${launchTargetId ?? "local"}`}
-                host={host}
-                token={token}
-                backend={backend}
-                launchTargetId={launchTargetId}
-                value={model}
-                onChange={setModel}
-                onAuthFailure={onAuthFailure}
-                onModelsLoaded={handleModelsLoaded}
+            ) : null}
+            <ModelPicker
+              key={`${backend}:${launchTargetId ?? "local"}`}
+              host={host}
+              token={token}
+              backend={backend}
+              launchTargetId={launchTargetId}
+              value={model}
+              onChange={setModel}
+              onAuthFailure={onAuthFailure}
+              onModelsLoaded={handleModelsLoaded}
+              disabled={formBusy}
+              defaultModelLabel={modelInfo?.default_model_label ?? null}
+            />
+            {effortSupported ? (
+              <EffortPicker
+                options={effortOptions}
+                value={effort}
+                onChange={setEffort}
                 disabled={formBusy}
-                defaultModelLabel={modelInfo?.default_model_label ?? null}
               />
-              {effortSupported ? (
-                <EffortPicker
-                  options={effortOptions}
-                  value={effort}
-                  onChange={setEffort}
-                  disabled={formBusy}
-                />
-              ) : null}
-            </div>
+            ) : null}
           </div>
           <LaunchOptionsDetails
             mode="new"

--- a/frontend/src/components/SchedulePanel.tsx
+++ b/frontend/src/components/SchedulePanel.tsx
@@ -255,7 +255,7 @@ export function SchedulePanel({
           </label>
           {permissionOptions.length > 0 ? (
             <label className="field">
-              <span>Starting permission mode</span>
+              <span>Permission mode</span>
               <select
                 value={permissionMode}
                 onChange={(event) => setPermissionMode(event.target.value)}


### PR DESCRIPTION
## Summary

New-session creation could not choose a permission mode, while scheduled sessions could. This adds the same permission-mode picker to the New session form, threads the selected value through the existing create-session payload, and renames the Schedule label from "Starting permission mode" to "Permission mode" so the wording matches the actual behavior.

The launch form layout also switches from a rigid two-column split to the same self-balancing grid pattern used by the Schedule panel. That keeps Permission mode before Model while avoiding the large empty left-column gap when the right side has more launch settings.

## Changes

### Frontend

- **`components/LaunchPanel.tsx`** — adds `permissionModesFor`-backed `Permission mode` state and select control to New session creation, ordered before Model, and passes the selected mode into the page-level create handler.
- **`app/page.tsx`** — includes `permission_mode` in the `createSession` payload for New sessions.
- **`components/SchedulePanel.tsx`** — renames the field label from `Starting permission mode` to `Permission mode`.
- **`app/globals.css`** — changes the launch form grid to `repeat(auto-fit, minmax(220px, 1fr))`, matching the Schedule panel's balanced form layout.

## Test Plan

- [x] `cd frontend && npm run lint` — clean.
- [x] Manual frontend validation from the running app: New session form shows Permission mode before Model, Schedule uses the shorter Permission mode label, and the launch form no longer has the prominent empty left-column gap.
- [ ] Not run: `cd frontend && npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)