### PR TITLE
feat: add a transport axis to the personal assistant

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -170,6 +170,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # session, never deleted.
         return await context.runtime.reset_assistant(
             backend=body.backend,
+            transport=body.transport,
             model=body.model,
             effort=body.effort,
             permission_mode=body.permission_mode,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -514,6 +514,7 @@ class SessionRuntime:
             model=assistant.model,
             effort=assistant.effort,
             permission_mode=assistant.permission_mode,
+            transport=assistant.transport,
         )
         self.assistant_session_id = created.id
 
@@ -524,6 +525,7 @@ class SessionRuntime:
         model: str | None,
         effort: str | None,
         permission_mode: str | None,
+        transport: str | None,
     ) -> SessionRecord:
         plugin = self.registry.get(backend)
         validated_mode = (
@@ -539,6 +541,7 @@ class SessionRuntime:
             model=model,
             effort=effort,
             permission_mode=validated_mode,
+            transport=transport,
         )
         session = await self.create_session(request)
         return self.storage.update_session(
@@ -575,6 +578,7 @@ class SessionRuntime:
         return AssistantSummary(
             session_id=session.id,
             backend=session.backend,
+            transport=session.transport,
             native_thread_id=plugin.native_thread_id(session),
             status=session.status,
             supports_reattach=plugin.capabilities.supports_reattach_after_exit,
@@ -593,6 +597,7 @@ class SessionRuntime:
         self,
         *,
         backend: str | None = None,
+        transport: str | None = None,
         model: str | None = None,
         effort: str | None = None,
         permission_mode: str | None = None,
@@ -600,10 +605,11 @@ class SessionRuntime:
         """Rebuild the assistant on a fresh thread (clear context / switch backend).
 
         Clearing context keeps the *current* thread's backend and live config
-        (model / effort / permission mode), so a context wipe doesn't silently
-        revert tuning done from the UI; only an explicit ``backend`` switch
-        overrides them, since model/effort are backend-specific. waypoint.yaml
-        only seeds the first creation, when no live thread exists.
+        (model / effort / permission mode / transport), so a context wipe
+        doesn't silently revert tuning done from the UI; only an explicit
+        ``backend`` switch overrides them, since model/effort/transport are
+        backend-specific. waypoint.yaml only seeds the first creation, when no
+        live thread exists.
 
         The previous thread is demoted to an ordinary stopped session so its
         transcript survives in the normal session list — it is never deleted.
@@ -626,18 +632,23 @@ class SessionRuntime:
             )
         # Inherit the live thread's config when staying on the same backend;
         # an explicit request value always wins. A backend switch starts from
-        # that backend's defaults because model/effort don't transfer.
+        # that backend's defaults because model/effort/transport don't transfer.
         if old is not None and chosen == old.backend:
             model = model if model is not None else old.model
             effort = effort if effort is not None else old.effort
             permission_mode = (
                 permission_mode if permission_mode is not None else old.permission_mode
             )
+            transport = transport if transport is not None else old.transport
         # Spawn the replacement before touching the current thread so a failed
         # launch (e.g. a misconfigured backend) leaves the live, pinned
         # assistant intact rather than orphaning the pointer at a stopped row.
         created = await self._create_assistant_session(
-            chosen, model=model, effort=effort, permission_mode=permission_mode
+            chosen,
+            model=model,
+            effort=effort,
+            permission_mode=permission_mode,
+            transport=transport,
         )
         self.assistant_session_id = created.id
         await self._retire_previous_assistant(old, created.id)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -288,6 +288,9 @@ class LaunchTargetSummary(BaseModel):
 class AssistantSummary(BaseModel):
     session_id: str
     backend: BackendId
+    # Transport the assistant is driven over, so the UI can label it (Chat /
+    # Emulated / Terminal) and preselect it in the settings popover.
+    transport: SessionTransportId
     # Backend-native conversation id (e.g. the value for `claude --resume`).
     # Surfaced alongside ``session_id`` so a user can recover the thread
     # outside the app. ``None`` when the backend has no resumable id.
@@ -301,8 +304,11 @@ class AssistantSummary(BaseModel):
 class AssistantResetRequest(BaseModel):
     # Rebuild the assistant on a fresh thread. ``backend`` switches the coding
     # agent (``None`` keeps the current one); the rest seed the new thread,
-    # where ``None`` means the backend's default.
+    # where ``None`` means the backend's default. ``transport`` repins the
+    # interface (``None`` keeps the current one on a clear, or the agent's
+    # default on a backend switch).
     backend: BackendId | None = None
+    transport: SessionTransportId | None = None
     model: str | None = None
     effort: str | None = None
     permission_mode: str | None = None

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from waypoint.backends.plugin_config import PluginConfig
 from waypoint.backends.registry import get_registry
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.schemas import BackendId
+from waypoint.schemas import BackendId, SessionTransportId
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
@@ -73,8 +73,9 @@ class AssistantConfig(BaseModel):
     The assistant is a long-lived session of an ordinary coding backend
     (chosen by ``backend``, falling back to ``default_backend``) that the
     runtime creates and keeps alive on its own. ``model`` / ``effort`` /
-    ``permission_mode`` seed the initial thread; the user can override them
-    live from the assistant UI, so these are defaults, not a lockdown.
+    ``permission_mode`` / ``transport`` seed the initial thread; the user can
+    override them live from the assistant UI, so these are defaults, not a
+    lockdown.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -84,6 +85,10 @@ class AssistantConfig(BaseModel):
     backend: BackendId | None = None
     model: str | None = None
     effort: str | None = None
+    # Transport the agent is driven over. ``None`` lets the agent pick its
+    # default (Emulated for Claude Code); must be one of the agent's supported
+    # transports, validated when the thread launches.
+    transport: SessionTransportId | None = None
     # Permission mode passed through to the backend. ``None`` lets the
     # backend pick its default (which usually prompts for approvals — set an
     # autonomous mode here for an unattended assistant).

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -4117,6 +4117,35 @@ async def test_assistant_recreates_when_prior_thread_exited(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_assistant_first_boot_seeds_config_transport(tmp_path) -> None:
+    # The waypoint.yaml `transport` seed is forwarded on first creation; the
+    # resolution itself (None => the agent default) is covered by the
+    # create_session default-transport tests.
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="claude_code", transport="claude_cli")
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(backend: str, **kwargs: Any) -> SessionRecord:
+        captured.update(backend=backend, **kwargs)
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="claude-fresh",
+            backend="claude_code",
+            status=SessionStatus.STARTING,
+            transport="claude_cli",
+            cwd=str(runtime._assistant_workspace_dir()),
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime._ensure_assistant_session()
+
+    assert runtime.assistant_session_id == "claude-fresh"
+    assert captured["transport"] == "claude_cli"
+
+
+@pytest.mark.asyncio
 async def test_delete_and_terminate_protect_assistant(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
     _make_assistant_row(
@@ -4157,6 +4186,7 @@ async def test_assistant_summary_reports_native_thread_id(tmp_path) -> None:
     assert summary is not None
     assert summary.session_id == "codex-assistant"
     assert summary.backend == "codex"
+    assert summary.transport == "codex_app_server"
     assert summary.native_thread_id == "thread-1"
     assert summary.status == SessionStatus.IDLE
     assert (
@@ -4342,10 +4372,19 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
     captured: dict[str, Any] = {}
 
     async def _fake_create(
-        backend: str, *, model: Any, effort: Any, permission_mode: Any
+        backend: str,
+        *,
+        model: Any,
+        effort: Any,
+        permission_mode: Any,
+        transport: Any,
     ) -> SessionRecord:
         captured.update(
-            backend=backend, model=model, effort=effort, permission_mode=permission_mode
+            backend=backend,
+            model=model,
+            effort=effort,
+            permission_mode=permission_mode,
+            transport=transport,
         )
         return _make_assistant_row(
             storage,
@@ -4364,13 +4403,14 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
     assert summary.session_id == "claude-new"
     assert runtime.assistant_session_id == "claude-new"
     assert terminated == ["codex-old"]
-    # New backend starts from its own defaults — codex's model/effort/mode do
-    # not transfer to claude_code.
+    # New backend starts from its own defaults — codex's model/effort/mode and
+    # transport do not transfer to claude_code (None => the agent default).
     assert captured == {
         "backend": "claude_code",
         "model": None,
         "effort": None,
         "permission_mode": None,
+        "transport": None,
     }
     old = storage.get_session("codex-old")
     assert old is not None
@@ -4408,10 +4448,19 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
     captured: dict[str, Any] = {}
 
     async def _fake_create(
-        backend: str, *, model: Any, effort: Any, permission_mode: Any
+        backend: str,
+        *,
+        model: Any,
+        effort: Any,
+        permission_mode: Any,
+        transport: Any,
     ) -> SessionRecord:
         captured.update(
-            backend=backend, model=model, effort=effort, permission_mode=permission_mode
+            backend=backend,
+            model=model,
+            effort=effort,
+            permission_mode=permission_mode,
+            transport=transport,
         )
         return _make_assistant_row(
             storage,
@@ -4427,11 +4476,13 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
 
     await runtime.reset_assistant()
 
+    # Clearing context inherits the live thread's tuned config and transport.
     assert captured == {
         "backend": "codex",
         "model": "gpt-5",
         "effort": "high",
         "permission_mode": "full-access",
+        "transport": "codex_app_server",
     }
 
 
@@ -4453,7 +4504,12 @@ async def test_reset_assistant_keeps_current_thread_when_create_fails(tmp_path) 
     runtime.assistant_session_id = "codex-live"
 
     async def _boom(
-        backend: str, *, model: Any, effort: Any, permission_mode: Any
+        backend: str,
+        *,
+        model: Any,
+        effort: Any,
+        permission_mode: Any,
+        transport: Any,
     ) -> SessionRecord:
         raise RuntimeError("spawn failed")
 

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -48,14 +48,15 @@ plugin_configs:
 # long-lived session of `backend` alive, reachable from the assistant UI
 # page. It can answer host-environment questions, inspect Waypoint
 # sessions, and manage them via the `waypoint sessions` CLI. `model`,
-# `effort`, and `permission_mode` seed the thread; the UI can override
-# them live. Switching `backend` replaces the thread on next restart.
+# `effort`, `permission_mode`, and `transport` seed the thread; the UI can
+# override them live. Switching `backend` replaces the thread on next restart.
 # assistant:
 #   enabled: true
 #   backend: claude_code          # defaults to `default_backend`
 #   model: opus                   # must exist in the backend's catalogue
 #   effort: high                  # ignored by backends without an effort knob
 #   permission_mode: bypassPermissions  # backend default (usually prompts) if unset
+#   transport: claude_cli         # agent default (Emulated for Claude Code) if unset
 
 ssh_targets:
   - id: devbox

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -1,11 +1,12 @@
 # Personal assistant
 
 The personal assistant is a single, long-lived conversation thread, separate
-from the coding sessions you launch for tasks. It runs an ordinary coding
-backend but is created and kept alive by the runtime, reachable from a
-dedicated page in the app. Use it to ask about the host machine, to ground
-questions in your running Waypoint sessions, and to spin up or steer those
-sessions on your behalf.
+from the coding sessions you launch for tasks. Like any session it is an
+(agent, transport) pair — a coding agent driven over a chosen interface — but
+it is created and kept alive by the runtime, reachable from a dedicated page in
+the app. Use it to ask about the host machine, to ground questions in your
+running Waypoint sessions, and to spin up or steer those sessions on your
+behalf.
 
 It is not a new backend — it reuses the existing plugin, runtime, storage, and
 streaming machinery. Its only distinguishing traits are a dedicated session
@@ -20,15 +21,18 @@ Add an `assistant` block to `waypoint.yaml` (see `backend/waypoint.example.yaml`
 assistant:
   enabled: true                       # omit the whole block to disable
   backend: claude_code                # defaults to `default_backend`
+  transport: claude_cli               # the agent's default interface if unset
   model: opus                         # must exist in the backend's catalogue
   effort: high                        # ignored by backends without an effort knob
   permission_mode: bypassPermissions  # see the security note below
 ```
 
-`model`, `effort`, and `permission_mode` seed the thread; they can be changed
-live from the assistant page, so treat them as defaults rather than a lockdown.
-The block is enabled by default when present — set `enabled: false` to keep the
-config but turn the assistant off.
+`backend`, `transport`, `model`, `effort`, and `permission_mode` seed the
+thread; they can be changed live from the assistant page, so treat them as
+defaults rather than a lockdown. `transport` must be one of the agent's
+supported interfaces; omitting it uses the agent's default (the Emulated
+chat interface for Claude Code). The block is enabled by default when present —
+set `enabled: false` to keep the config but turn the assistant off.
 
 The assistant always runs in a managed working directory (`<data_dir>/assistant`),
 so it has no `cwd` setting. The runtime links repo-tracked assistant assets into
@@ -43,10 +47,11 @@ inspection is unaffected.
 
 - On startup the runtime refreshes the assistant workspace asset links, then
   reuses any still-alive assistant thread that lives in the managed workspace,
-  **regardless of its backend**. The live thread is the source of truth, so a
-  backend chosen from the UI survives a redeploy. The `assistant` block in
-  `waypoint.yaml` only seeds the *first* creation; editing `assistant.backend`
-  later has no effect while a thread exists — clear the context to re-seed.
+  **regardless of its agent or interface**. The live thread is the source of
+  truth, so an agent and interface chosen from the UI survive a redeploy. The
+  `assistant` block in `waypoint.yaml` only seeds the *first* creation; editing
+  `assistant.backend` / `assistant.transport` later has no effect while a thread
+  exists — clear the context to re-seed.
 - If no live thread exists (first boot, or the previous one exited), a fresh
   thread is created from the `waypoint.yaml` defaults.
 - The assistant cannot be **deleted**, and the generic session terminate/delete
@@ -55,32 +60,39 @@ inspection is unaffected.
 ### Controls (assistant page)
 
 The **settings popover** (⚙, next to the composer) holds configuration. Changing
-the backend or picking a thread there stages an inline confirm, since both
-replace the conversation:
+the agent, the interface, or picking a thread there stages an inline confirm,
+since each replaces the conversation:
 
-- **Switch backend** — rebuild the assistant on a different coding agent. The
-  conversation cannot migrate between backends, so this starts a fresh thread
-  at the new backend's default model/effort/permission mode.
+- **Agent** — rebuild the assistant on a different coding agent. The
+  conversation cannot migrate between agents, so this starts a fresh thread at
+  the new agent's default interface, model, effort, and permission mode.
+- **Interface** — rebuild the assistant over a different transport (Chat /
+  Emulated / Terminal, whatever the agent supports). The transport is fixed at
+  launch, so changing it also starts a fresh thread. Shown only when the agent
+  supports more than one interface; it defaults to the agent's default (Emulated
+  for Claude Code).
 - **Resume thread** — attach the assistant to an existing backend-native thread
-  (one discovered by the chosen backend's thread enumeration). The thread is
-  imported as-is: it resumes its own conversation and working directory, so the
-  assistant charter — which lives in the managed workspace — does **not** apply.
-  Offered only for backends that support thread discovery and import.
+  (one discovered by the chosen agent's thread enumeration). The thread is
+  imported as-is over the agent's native interface: it resumes its own
+  conversation and working directory, so the assistant charter — which lives in
+  the managed workspace — does **not** apply, and the **Interface** picker does
+  not. Offered only for agents that support thread discovery and import.
 - **Model / effort / permission mode** — applied live to the running thread; no
   context is lost.
 
 The **overflow menu** (⋯) holds the standalone lifecycle actions, mirroring
 where ordinary sessions keep terminate/delete:
 
-- **Clear context** — start a fresh thread on the same backend.
+- **Clear context** — start a fresh thread on the same agent and interface,
+  keeping the live model/effort/permission mode.
 - **Terminate / Reattach** — stop the thread (keeping it the pinned singleton)
   and later revive the same conversation. Reattach is offered only when the
   backend can resume after exit.
 
-Switching backend, attaching a thread, and clearing context all replace the
-current conversation: the previous thread is **demoted to an ordinary stopped
-session** (its transcript is preserved and it becomes deletable), never
-destroyed.
+Switching agent or interface, attaching a thread, and clearing context all
+replace the current conversation: the previous thread is **demoted to an
+ordinary stopped session** (its transcript is preserved and it becomes
+deletable), never destroyed.
 
 A terminated assistant survives reattach only within the running deployment; a
 redeploy cannot reattach an exited thread, so it demotes that thread to a normal

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -16,11 +16,17 @@ import {
   resetAssistant,
   terminateAssistant,
 } from "@/lib/api";
-import { buildCatalog, humaniseBackend } from "@/lib/backends";
+import { buildCatalog, humaniseBackend, transportPresentation } from "@/lib/backends";
 import { copyText } from "@/lib/clipboard";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
-import { AssistantSummary, Backend, BackendDescriptor, SessionStatus } from "@/lib/types";
+import {
+  AssistantSummary,
+  Backend,
+  BackendDescriptor,
+  SessionStatus,
+  SessionTransport,
+} from "@/lib/types";
 
 type LoadState = "loading" | "ready" | "disabled" | "error";
 
@@ -155,8 +161,8 @@ export default function AssistantPage() {
     () => ({
       backends,
       supportsReattach: assistant?.supports_reattach ?? false,
-      onSwitchBackend: (backend: Backend) =>
-        applyControl(() => resetAssistant(host, token, { backend })),
+      onSwitchBackend: (backend: Backend, transport: SessionTransport) =>
+        applyControl(() => resetAssistant(host, token, { backend, transport })),
       onAttachThread: (backend: Backend, threadId: string) =>
         applyControl(() =>
           attachAssistant(host, token, { backend, thread_id: threadId }),
@@ -229,7 +235,8 @@ export default function AssistantPage() {
               </span>
               <div className="assistant-banner-text">
                 <p className="assistant-banner-eyebrow">
-                  {humaniseBackend(assistant.backend, catalog)}
+                  {humaniseBackend(assistant.backend, catalog)} ·{" "}
+                  {transportPresentation(assistant.transport, catalog).name}
                 </p>
                 <p className="assistant-banner-note">
                   Your persistent assistant — ask about this host or your running

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2666,7 +2666,12 @@ const ReplyComposer = memo(function ReplyComposer({
                           return;
                         }
                         setPendingBackend(next);
-                        setAssistantConfirm("switch");
+                        // Stage the confirm only once the new agent's default
+                        // interface resolves; until the catalog loads it would
+                        // be set but not renderable.
+                        setAssistantConfirm(
+                          defaultTransportFor(next, catalog) ? "switch" : null,
+                        );
                       }}
                       disabled={assistantBusy}
                     >

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -38,6 +38,7 @@ import {
   setSessionTitle,
 } from "@/lib/api";
 import {
+  agentTransports,
   approvalDecisionsFor,
   type BackendCatalog,
   defaultTransportFor,
@@ -45,6 +46,7 @@ import {
   fidelityFor,
   hasTerminalPane,
   humaniseBackend,
+  launchableAgents,
   liveTerminal,
   permissionModesFor,
   supportsApprovalNote,
@@ -57,6 +59,7 @@ import {
   terminalInteractive,
   terminalResizable,
   transportLabel,
+  transportPresentation,
   useBackendCatalog,
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
@@ -247,7 +250,12 @@ export interface AssistantThreadOption {
 export interface AssistantControls {
   backends: BackendDescriptor[];
   supportsReattach: boolean;
-  onSwitchBackend: (backend: Backend) => Promise<void> | void;
+  // Rebuild the assistant on the chosen agent and transport. Changing either
+  // starts a fresh thread, since the transport is fixed at launch.
+  onSwitchBackend: (
+    backend: Backend,
+    transport: SessionTransport,
+  ) => Promise<void> | void;
   onAttachThread: (backend: Backend, threadId: string) => Promise<void> | void;
   onClearContext: () => Promise<void> | void;
   onTerminate: () => Promise<void> | void;
@@ -2211,6 +2219,10 @@ const ReplyComposer = memo(function ReplyComposer({
     "switch" | "attach" | null
   >(null);
   const [pendingBackend, setPendingBackend] = useState<Backend | null>(null);
+  // Staged transport for the switch confirm; `null` keeps the live one (or the
+  // newly-picked agent's default once a different agent is staged).
+  const [pendingTransport, setPendingTransport] =
+    useState<SessionTransport | null>(null);
   const [selectedThreadId, setSelectedThreadId] = useState("");
   const [threadOptions, setThreadOptions] = useState<AssistantThreadOption[]>([]);
   // Pending effort for backends that need a session restart to apply (Claude)
@@ -2521,6 +2533,32 @@ const ReplyComposer = memo(function ReplyComposer({
     assistantTargetCaps?.supports_thread_discovery &&
       assistantTargetCaps?.supports_thread_import,
   );
+  // Agent-primary list, folding out the tmux/tty wrappers and the managed
+  // fallback, plus the transports the staged agent can run over.
+  const assistantAgentOptions =
+    assistantOps && session
+      ? launchableAgents(
+          assistantOps.backends.map((b) => b.id),
+          catalog,
+        )
+      : [];
+  const assistantTransportOptions = assistantTargetBackend
+    ? agentTransports(assistantTargetBackend, catalog)
+    : [];
+  // The transport the switch will launch over: an explicit pick, else the new
+  // agent's default when the agent changed, else the live transport.
+  const assistantTargetTransport: SessionTransport | null =
+    pendingTransport ??
+    (pendingBackend
+      ? defaultTransportFor(pendingBackend, catalog)
+      : session?.transport ?? null);
+  const assistantSwitchDiffers = Boolean(
+    session &&
+      assistantTargetBackend &&
+      assistantTargetTransport &&
+      (assistantTargetBackend !== session.backend ||
+        assistantTargetTransport !== session.transport),
+  );
   // Load resumable threads for the target backend when the popover is open.
   useEffect(() => {
     if (
@@ -2550,6 +2588,7 @@ const ReplyComposer = memo(function ReplyComposer({
       // the user can retry or cancel.
       setAssistantConfirm(null);
       setPendingBackend(null);
+      setPendingTransport(null);
       setSelectedThreadId("");
     } catch (err) {
       onError(err instanceof Error ? err.message : "Action failed");
@@ -2610,14 +2649,17 @@ const ReplyComposer = memo(function ReplyComposer({
               >
                 {assistantOps && session ? (
                   <label className="composer-tune-field">
-                    <span>Backend</span>
+                    <span>Agent</span>
                     <select
                       value={pendingBackend ?? session.backend}
                       onChange={(event) => {
                         const next = event.target.value;
                         onError("");
-                        // Threads are per-backend; drop any thread selection.
+                        // Threads and transports are per-agent; drop any thread
+                        // selection and let the transport fall to the new
+                        // agent's default.
                         setSelectedThreadId("");
+                        setPendingTransport(null);
                         if (next === session.backend) {
                           setPendingBackend(null);
                           setAssistantConfirm(null);
@@ -2628,9 +2670,37 @@ const ReplyComposer = memo(function ReplyComposer({
                       }}
                       disabled={assistantBusy}
                     >
-                      {assistantOps.backends.map((backend) => (
-                        <option key={backend.id} value={backend.id}>
-                          {backend.label}
+                      {assistantAgentOptions.map((backend) => (
+                        <option key={backend} value={backend}>
+                          {humaniseBackend(backend, catalog)}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                {assistantOps && session && assistantTransportOptions.length > 1 ? (
+                  <label className="composer-tune-field">
+                    <span>Interface</span>
+                    <select
+                      value={assistantTargetTransport ?? ""}
+                      onChange={(event) => {
+                        const next = event.target.value as SessionTransport;
+                        onError("");
+                        // Picking a thread takes priority; a fresh transport
+                        // pick rebuilds the thread like an agent switch.
+                        setSelectedThreadId("");
+                        setPendingTransport(next);
+                        const stagedBackend = pendingBackend ?? session.backend;
+                        const differs =
+                          stagedBackend !== session.backend ||
+                          next !== session.transport;
+                        setAssistantConfirm(differs ? "switch" : null);
+                      }}
+                      disabled={assistantBusy}
+                    >
+                      {assistantTransportOptions.map((transportId) => (
+                        <option key={transportId} value={transportId}>
+                          {transportPresentation(transportId, catalog).name}
                         </option>
                       ))}
                     </select>
@@ -2652,9 +2722,7 @@ const ReplyComposer = memo(function ReplyComposer({
                           setAssistantConfirm("attach");
                         } else {
                           setAssistantConfirm(
-                            pendingBackend && pendingBackend !== session.backend
-                              ? "switch"
-                              : null,
+                            assistantSwitchDiffers ? "switch" : null,
                           );
                         }
                       }}
@@ -2754,14 +2822,24 @@ const ReplyComposer = memo(function ReplyComposer({
                 ) : null}
                 {assistantOps &&
                 assistantConfirm === "switch" &&
-                pendingBackend ? (
+                assistantSwitchDiffers &&
+                assistantTargetBackend &&
+                assistantTargetTransport ? (
                   <div className="composer-tune-lifecycle">
                     <div className="composer-tune-confirm">
                       <p>
                         Switch to{" "}
-                        <strong>{humaniseBackend(pendingBackend, catalog)}</strong>? This
-                        starts a new conversation; the current one is kept as a
-                        stopped session.
+                        <strong>
+                          {humaniseBackend(assistantTargetBackend, catalog)} ·{" "}
+                          {
+                            transportPresentation(
+                              assistantTargetTransport,
+                              catalog,
+                            ).name
+                          }
+                        </strong>
+                        ? This starts a new conversation; the current one is kept
+                        as a stopped session.
                       </p>
                       <div className="composer-tune-confirm-actions">
                         <button
@@ -2769,6 +2847,7 @@ const ReplyComposer = memo(function ReplyComposer({
                           className="composer-tune-confirm-cancel"
                           onClick={() => {
                             setPendingBackend(null);
+                            setPendingTransport(null);
                             setAssistantConfirm(null);
                             onError("");
                           }}
@@ -2781,12 +2860,15 @@ const ReplyComposer = memo(function ReplyComposer({
                           className="composer-tune-confirm-apply"
                           onClick={() =>
                             void runAssistantAction(() =>
-                              assistantOps.onSwitchBackend(pendingBackend),
+                              assistantOps.onSwitchBackend(
+                                assistantTargetBackend,
+                                assistantTargetTransport,
+                              ),
                             )
                           }
                           disabled={assistantBusy}
                         >
-                          {assistantBusy ? "Switching…" : "Switch backend"}
+                          {assistantBusy ? "Switching…" : "Switch"}
                         </button>
                       </div>
                     </div>
@@ -2813,9 +2895,7 @@ const ReplyComposer = memo(function ReplyComposer({
                           onClick={() => {
                             setSelectedThreadId("");
                             setAssistantConfirm(
-                              pendingBackend && pendingBackend !== session?.backend
-                                ? "switch"
-                                : null,
+                              assistantSwitchDiffers ? "switch" : null,
                             );
                             onError("");
                           }}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -264,6 +264,9 @@ export interface BackendDescriptor {
 export interface AssistantSummary {
   session_id: string;
   backend: Backend;
+  // Transport the assistant runs over (Chat / Emulated / Terminal); lets the
+  // UI label it and preselect it in the settings popover.
+  transport: SessionTransport;
   native_thread_id: string | null;
   status: SessionStatus;
   // Whether the backend can revive the thread after it exits — drives the
@@ -273,6 +276,7 @@ export interface AssistantSummary {
 
 export interface AssistantResetRequest {
   backend?: Backend;
+  transport?: SessionTransport | null;
   model?: string | null;
   effort?: string | null;
   permission_mode?: string | null;


### PR DESCRIPTION
## Summary

The personal assistant was the one surface the agent/transport refactor (#110) left unmigrated. Its settings popover only chose an *agent*, driving its dropdown from the raw `/api/backends` descriptor list — so the `tmux` and `claude_tty` transports leaked in as selectable "agents", and a freshly-seeded Claude Code assistant silently ran the Emulated interface with no way to change it.

This threads a transport through the assistant the same way ordinary sessions carry one, and reworks the popover into an agent-primary control matching the launch panel.

User-visible outcomes:

1. **The assistant settings popover now picks an Agent and an Interface.** The Agent select lists only real agents (Claude Code / Codex / OpenCode) — `launchableAgents` folds the `tmux` and `claude_tty` wrappers back into their owning agent, so they no longer masquerade as agents. A new Interface select offers the chosen agent's supported transports (Chat / Emulated / Terminal), collapsing when an agent has only one.
2. **The assistant's interface is configurable and persisted.** `transport` is a seed in `waypoint.yaml` and is reported in `/api/me`, so the banner shows the agent and its interface and the popover preselects the live one. A `None` seed resolves to the agent's default (Emulated for Claude Code), matching every other launch path.
3. **Switching agent or interface rebuilds the thread coherently.** The transport is fixed at launch, so changing either starts a fresh thread; clearing context inherits the live thread's transport, while an agent switch resets to the new agent's default. Attaching an existing thread still resumes over the agent's native interface.

## Changes

### Backend

- **`settings.py`** — `AssistantConfig` gains an optional `transport` seed (validated against the agent's supported transports at launch; `None` uses the agent default).
- **`schemas.py`** — `AssistantResetRequest.transport` repins the interface; `AssistantSummary.transport` reports the live one.
- **`runtime.py`** — `_create_assistant_session` / `_ensure_assistant_session` forward the seed, and `reset_assistant` inherits the live transport on a clear-context but resets to the agent default on an agent switch (transports are agent-specific); `assistant_summary` surfaces `session.transport`.
- **`api.py`** — `/api/assistant/reset` passes the requested transport through.

### Frontend

- **`components/SessionDetail.tsx`** — the assistant settings popover drives its Agent select from `launchableAgents(catalog)` (folding out the wrappers) and adds an Interface select fed by `agentTransports` with `transportPresentation` labels, collapsing on a single transport; the switch confirm and `onSwitchBackend` now carry the chosen `(agent, transport)` pair.
- **`app/assistant/page.tsx`** — wires the transport into `resetAssistant` and shows `agent · interface` in the banner.
- **`lib/types.ts`** — `AssistantSummary` / `AssistantResetRequest` gain the `transport` field.

### Tests

- **`test_runtime.py`** — the first-boot seed forwards the config transport; `reset_assistant` inherits the live transport on a clear-context and resets to `None` (the agent default) on an agent switch; `assistant_summary` reports the transport.

### Docs

- **`docs/personal_assistant.md`** — rewritten around the `(agent, transport)` model: the popover picks both, the `transport` seed defaults to the agent's own default (Emulated for Claude Code), and an attached thread resumes over the agent's native interface.
- **`backend/waypoint.example.yaml`** — documents the `transport` seed.

## Test Plan

- [x] `cd backend && uv run pytest` — 901 passed.
- [x] `cd backend && uv run pre-commit run --files <changed>` — black / isort / ruff / codespell / mypy clean.
- [x] `cd frontend && npm run lint && npm run build` — clean.
- [x] Manual e2e on the restarted stack: `/api/me` reports the assistant `transport`; `/api/assistant/reset` switches to `claude_code/claude_tty` (Emulated default) with no transport, to `claude_cli` when pinned, and a clear-context inherits `claude_cli`. After reloading the assistant page the Agent dropdown lists only Claude Code / Codex / OpenCode (no Tmux / Claude TUI) with a separate Interface dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)