### PR TITLE
chore: refresh docs and CLI prose for the agent/transport split

### DIFF
--- a/.agents/skills/waypoint-comms/references/send-and-reply.md
+++ b/.agents/skills/waypoint-comms/references/send-and-reply.md
@@ -45,8 +45,9 @@ waypoint sessions events <target-id> --messages 20
 ```
 
 Filter events for `kind == "agent_output"` to get the reply; skip
-`system_note`, `tool_call`, and `tool_result`. (For the `tmux` backend, kinds
-are heuristic — also check `raw_terminal_chunk`.) This path does not disturb your
+`system_note`, `tool_call`, and `tool_result`. (For sessions on the `tmux`
+(Terminal) transport, kinds are heuristic — also check `raw_terminal_chunk`.)
+This path does not disturb your
 own turn: you choose when to look.
 
 ## Push: the answer arrives in your input (you set `reply-to`)

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -12,8 +12,9 @@ waypoint sessions events <session-id> --before-sequence <sequence>   # page back
 
 `events` returns JSON. Filter for `kind == "agent_output"` to read the agent's
 replies; skip the verbose `system_note` init payload and the `tool_call` /
-`tool_result` chatter. For the `tmux` backend, event kinds are inferred
-heuristically — also check `raw_terminal_chunk` if a reply seems missing.
+`tool_result` chatter. For sessions on the `tmux` (Terminal) transport, event
+kinds are inferred heuristically — also check `raw_terminal_chunk` if a reply
+seems missing.
 
 Quote only the minimum transcript text needed to justify your conclusion;
 summarize the rest. Distinguish the reported `status` from your interpretation of

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -68,8 +68,8 @@ posture — but widening is a deliberate act, not a default. Guidance:
 ## Fix a posture without respawning
 
 If a worker is already stalling on `default`, you do **not** have to reap and
-respawn it. On structured backends (claude_code / codex / opencode / claude_tty)
-you can widen its mode in place:
+respawn it. On structured agents (claude_code / codex / opencode), including
+over the Emulated (`claude_tty`) transport, you can widen its mode in place:
 
 ```bash
 waypoint sessions set-permission-mode <child-id> <mode>   # alias: sessions mode

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -4,16 +4,21 @@
 
 ```bash
 waypoint sessions start \
-  --backend <id> \
+  --backend <agent-id> \
   --cwd <path> \
   --title "subagent:<short-purpose>" \
-  [--model <model>] [--effort <effort>] [--permission-mode <mode>]
+  [--transport <transport-id>] [--model <model>] [--effort <effort>] [--permission-mode <mode>]
 ```
 
-- Pick `--backend` deliberately — this is the main reason to use a Waypoint
-  sub-session over a harness subagent. Use `waypoint backends` to see which
-  backend ids are registered, and `waypoint doctor` to check local CLI
-  availability when launch fails.
+- Pick `--backend` (the agent) deliberately — this is the main reason to use a
+  Waypoint sub-session over a harness subagent. Use `waypoint backends` to see
+  which agent ids are registered (and their `supported_transports`), and
+  `waypoint doctor` to check local CLI availability when launch fails.
+- `--transport` is an optional secondary axis selecting the interface — Chat
+  (`claude_cli`), Emulated (`claude_tty`), or Terminal (`tmux`). Omit it to take
+  the agent's `default_transport` (a local `claude_code` child defaults to the
+  Emulated `claude_tty` transport). Set it explicitly when the task needs a
+  specific interface; `claude_tty`/`tmux` are transports, not `--backend` values.
 - Pick `--model` / `--effort` from `waypoint models <backend>`, which reports the
   ids and efforts that backend actually offers. Pass them verbatim; do not guess
   model names from memory.

--- a/.agents/skills/waypoint-workqueue/references/backends.md
+++ b/.agents/skills/waypoint-workqueue/references/backends.md
@@ -16,8 +16,9 @@ waypoint models      # the model ids and reasoning efforts each backend offers
 ```
 
 `codex` and `opencode` discover their model lists live; `claude_code` serves a
-static curated list; `claude_tty` has none (it tails Claude's TTY output, no
-separate model registry). `waypoint models` reports the exact ids and efforts
+static curated Claude catalogue, which it reuses over the Emulated `claude_tty`
+transport as well (`waypoint models claude_tty` returns the same ids). `waypoint
+models` reports the exact ids and efforts
 each backend offers right now — run it and pass those ids verbatim to `--model`
 / `--effort`, rather than guessing from memory. With no argument it sweeps every
 selectable backend id (`tmux`, a pure transport, is excluded); a backend

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -27,6 +27,12 @@ it off. Pre-spawn checklist, all settled **before** the `sessions start`:
   user rather than spawning blind.
 - **Placement.** `--cwd` is the repo root the worktree is cut from; place the
   worker where its code lives.
+- **Transport (optional).** `--backend` is the agent; `--transport` picks the
+  interface. Omit it to take the agent's `default_transport` — a `claude_code`
+  worker then runs over the Emulated (`claude_tty`) transport, where model /
+  permission swaps relaunch the pane rather than applying inline. Pass
+  `--transport <id>` when a task needs a specific interface; `claude_tty` /
+  `tmux` are transport ids, not `--backend` values.
 
 ```bash
 n=3
@@ -35,7 +41,7 @@ lead=$WAYPOINT_SESSION_ID   # the lead's own session id; set --spawner-session-i
 # sibling worktree, records the path on the session for cleanup, and launches
 # the worker there — no manual `git worktree add`.
 sid=$(waypoint sessions start \
-  --backend <backend> --model <model-id> --permission-mode <auto-approving-mode> \
+  --backend <agent> --model <model-id> --permission-mode <auto-approving-mode> \
   --cwd "$repo" --worktree "wq/$job-t$n" --worktree-base "wq/$job" \
   --title "subagent:wq-$job-$n" --spawner-session-id "$lead" \
   | jq -r .session.id)

--- a/.agents/skills/waypoint/references/sessions-launch.md
+++ b/.agents/skills/waypoint/references/sessions-launch.md
@@ -3,18 +3,28 @@
 Launch through the running server:
 
 ```bash
-waypoint sessions start --backend <id> --cwd <path>
-waypoint sessions start --backend <id> --cwd <path> --title <title>
-waypoint sessions start --backend <id> --cwd <path> --model <model>
-waypoint sessions start --backend <id> --cwd <path> --effort <effort>
-waypoint sessions start --backend <id> --cwd <path> --permission-mode <mode>
+waypoint sessions start --backend <agent-id> --cwd <path>
+waypoint sessions start --backend <agent-id> --cwd <path> --title <title>
+waypoint sessions start --backend <agent-id> --cwd <path> --model <model>
+waypoint sessions start --backend <agent-id> --cwd <path> --effort <effort>
+waypoint sessions start --backend <agent-id> --cwd <path> --permission-mode <mode>
+waypoint sessions start --backend <agent-id> --cwd <path> --transport <transport-id>
 ```
 
-Use `waypoint backends` to discover registered backend ids and capabilities.
-Use `waypoint models [backend]` to confirm the model ids and reasoning efforts a
-backend actually offers before passing `--model` / `--effort` — pass those ids
-verbatim rather than guessing. Use `waypoint doctor` for local CLI availability
-when launch fails, and `waypoint sessions start --help` for the installed flag
+`--backend` selects the **agent** (`claude_code`, `codex`, `opencode`);
+`--transport` is a secondary axis that picks the interface — Chat
+(`claude_cli`), Emulated (`claude_tty`), or Terminal (`tmux`). `claude_tty` and
+`tmux` are transports, not agents: drive the Emulated TUI with `--backend
+claude_code --transport claude_tty`, not `--backend claude_tty` (a legacy
+alias). Omitting `--transport` uses the agent's default transport, which for a
+local `claude_code` launch is Emulated (`claude_tty`).
+
+Use `waypoint backends` to discover registered agent ids, their
+`supported_transports` / `default_transport`, and capabilities. Use `waypoint
+models [backend]` to confirm the model ids and reasoning efforts a backend
+actually offers before passing `--model` / `--effort` — pass those ids verbatim
+rather than guessing. Use `waypoint doctor` for local CLI availability when
+launch fails, and `waypoint sessions start --help` for the installed flag
 surface.
 
 Choose `cwd` deliberately. For repository work, use the repo root. For host

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Use GitHub Issues directly for active bugs and feature requests.
 ## Layout
 
 - `backend/` — FastAPI daemon, tmux/session runtime, auth, persistence
-- `backend/src/waypoint/backends/` — one package per coding agent (`claude_code/`, `claude_tty/`, `codex/`, `opencode/`), plus `tmux/` which is a shared transport; see [`docs/coding_agent_plugins.md`](docs/coding_agent_plugins.md) for the plugin contract and extension recipe
+- `backend/src/waypoint/backends/` — one package per coding agent (`claude_code/`, `codex/`, `opencode/`) plus the transport packages (`claude_tty/` for the tty-tail Emulated transport, `tmux/` for the raw Terminal transport); see [`docs/coding_agent_plugins.md`](docs/coding_agent_plugins.md) for the plugin contract and extension recipe
 - `waypointctl/` — standalone control-plane package and daemon (`uv tool install ./waypointctl`, `pipx install ./waypointctl`)
 - `frontend/` — Next.js PWA client
 - `3rdparty/codex/` — pinned Codex submodule used for the local app-server SDK
@@ -34,10 +34,10 @@ Waypoint speaks to Claude Code, Codex, and OpenCode through wire formats that ch
 
 | Agent       | Tested versions   | Wire entry point                                                     | Notes                                                                                       |
 | ----------- | ----------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
-| Claude Code | `2.1.157` | `claude -p --input-format=stream-json --output-format=stream-json --permission-prompt-tool stdio` | Approvals ride the `can_use_tool` control protocol; `CLAUDE_CODE_WORKFLOWS=1` enables the Workflow tool. Also relies on `--include-hook-events`, the `system/status`/`compact_boundary` events, and `--session-id`/`--resume`. |
-| Codex CLI   | `0.125.0`-`0.129.0` | `codex app-server --listen stdio://`                                 | Driven via the vendored Python SDK in `3rdparty/codex/sdk/python` (`thread_*` / `turn_*` RPCs). |
-| Codex SDK   | `0.116.0a1`       | `3rdparty/codex/` submodule pin                                      | Bumped together with Codex CLI; track via `git submodule update --remote 3rdparty/codex`.   |
-| OpenCode   | `1.14.30`        | `opencode serve` with REST + SSE API                             | HTTP-based; discovers models from `/provider`. |
+| Claude Code | `2.1.178` | `claude -p --input-format=stream-json --output-format=stream-json --permission-prompt-tool stdio` | Approvals ride the `can_use_tool` control protocol; `CLAUDE_CODE_WORKFLOWS=1` enables the Workflow tool. Also relies on `--include-hook-events`, the `system/status`/`compact_boundary` events, and `--session-id`/`--resume`. |
+| Codex CLI   | `0.139.0` | `codex app-server --listen stdio://`                                 | Driven via the vendored Python SDK in `3rdparty/codex/sdk/python` (`thread_*` / `turn_*` RPCs). |
+| Codex SDK   | `python-v0.1.0b2` | `3rdparty/codex/` submodule pin                                      | Bumped together with Codex CLI; track via `git submodule update --remote 3rdparty/codex`.   |
+| OpenCode   | `1.17.4`        | `opencode serve` with REST + SSE API                             | HTTP-based; discovers models from `/provider`. |
 
 To extend this matrix:
 
@@ -48,7 +48,7 @@ To extend this matrix:
    - OpenCode: `backend/src/waypoint/backends/opencode/normalize.py::map_event` and the HTTP/SSE adapter in `backends/opencode/adapter.py::OpenCodeAdapter`.
 3. If a bump breaks an event shape, prefer adding a branch in the relevant `normalize.py` over hard-pinning.
 
-Adding a brand-new coding agent (Aider, …) is its own flow — the runtime, API, and frontend dispatch by plugin id, so a new backend is "implement [`BackendPlugin`](backend/src/waypoint/backends/base.py) and register it." See [`docs/coding_agent_plugins.md`](docs/coding_agent_plugins.md) for the contract, capability descriptor, and a step-by-step recipe.
+Adding a brand-new coding agent (Aider, …) is its own flow — the runtime, API, and frontend dispatch by plugin id, so a new agent is "implement an agent plugin that satisfies the [`BackendPlugin`](backend/src/waypoint/backends/base.py) protocol, declare its supported transports, and register it." See [`docs/coding_agent_plugins.md`](docs/coding_agent_plugins.md) for the contract, capability descriptor, and a step-by-step recipe.
 
 ## Quick start
 

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -59,8 +59,9 @@ def append_attachment_paths(text: str, attachments: list[ResolvedAttachment]) ->
     """Append absolute attachment paths to ``text`` for text-only transports.
 
     The underlying CLI agent reads the referenced files itself, so this is the
-    universal fallback for backends without native attachment support (tmux)
-    and for non-image files on backends that only embed images inline.
+    universal fallback for transports without native attachment support (the
+    tmux/Terminal transport) and for non-image files on transports that only
+    embed images inline.
     """
     if not attachments:
         return text

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -1,4 +1,4 @@
-"""Transcript-record → canonical-event normalization for the claude_tty backend.
+"""Transcript-record → canonical-event normalization for the claude_tty (Emulated) transport.
 
 The Claude TUI writes a JSONL transcript to
 ``~/.claude/projects/<dashed-cwd>/<session-id>.jsonl``.  Each record wraps the

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1,8 +1,8 @@
-"""Claude TUI backend plugin (claude_tty).
+"""Claude TUI / Emulated transport plugin (claude_tty).
 
 Drives the interactive Claude Code TUI (``claude``) instead of ``claude -p``
 (stream-json mode).  The TUI path is exempt from the API rate limit applied to
-``claude -p``, making it the preferred backend for autonomous Waypoint sessions.
+``claude -p``, making it the preferred transport for autonomous Claude Code sessions.
 
 This is the ``claude_code`` agent driven over a tty-tail transport rather
 than the structured ``claude -p`` adapter. It is a session shaped as an

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -1,4 +1,4 @@
-"""Transcript file tailer for the claude_tty backend.
+"""Transcript file tailer for the claude_tty (Emulated) transport.
 
 Polls the session JSONL transcript by byte offset, normalizes each new record
 into canonical events, and emits them through the runtime.  Periodically checks

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -1,4 +1,4 @@
-"""Transport adapter for the claude_tty backend.
+"""Transport adapter for the claude_tty (Emulated) transport.
 
 Thin subclass of ``TmuxTransport`` that overrides:
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -56,12 +56,11 @@ def _backend_choices() -> list[str]:
 
     Excludes only the managed-launch fallback wrapper (``tmux``, flagged
     ``is_fallback_for_managed_launch``): it is routed to via the registry, not
-    selected directly. ``claude_tty`` stays selectable — it currently bundles
-    the Claude agent with its tty-tail transport under one id, and there is no
-    ``--launch-mode`` value that selects the tty-tail transport on
-    ``claude_code`` yet, so ``--backend claude_tty`` is its only launch path.
-    Demoting it to a pure transport selected via ``--launch-mode`` waits on the
-    deeper agent×transport launch wiring (Phase 3 frontend).
+    selected directly. ``claude_tty`` stays selectable as a legacy alias that
+    bundles the Claude agent with its tty-tail transport under one id; the
+    preferred way to reach that transport is ``--backend claude_code
+    --transport claude_tty`` (or omitting ``--transport``, since ``claude_code``
+    defaults to the Emulated transport).
     """
     return [
         plugin.id
@@ -334,10 +333,11 @@ def session_start(
     transport: Annotated[
         str | None,
         typer.Option(
-            help="Pin the transport id the agent is driven over (e.g. "
-            "'claude_cli', 'claude_tty', 'tmux'). Must be one of the agent's "
-            "supported transports; takes precedence over --launch-mode. "
-            "Omit to keep the --launch-mode-derived behavior.",
+            help="Pin the transport (interface) the agent is driven over: "
+            "'claude_cli' (Chat), 'claude_tty' (Emulated), or 'tmux' (Terminal). "
+            "Must be one of the agent's supported transports; takes precedence "
+            "over --launch-mode. Omit to use the agent's default transport "
+            "(claude_code defaults to Emulated).",
         ),
     ] = None,
     title: Annotated[str | None, typer.Option()] = None,
@@ -1044,10 +1044,11 @@ def sessions_start(
     transport: Annotated[
         str | None,
         typer.Option(
-            help="Pin the transport id the agent is driven over (e.g. "
-            "'claude_cli', 'claude_tty', 'tmux'). Must be one of the agent's "
-            "supported transports; takes precedence over --launch-mode. "
-            "Omit to keep the --launch-mode-derived behavior.",
+            help="Pin the transport (interface) the agent is driven over: "
+            "'claude_cli' (Chat), 'claude_tty' (Emulated), or 'tmux' (Terminal). "
+            "Must be one of the agent's supported transports; takes precedence "
+            "over --launch-mode. Omit to use the agent's default transport "
+            "(claude_code defaults to Emulated).",
         ),
     ] = None,
     title: Annotated[str | None, typer.Option()] = None,
@@ -1708,10 +1709,11 @@ def schedule_create(
     transport: Annotated[
         str | None,
         typer.Option(
-            help="Pin the transport id the scheduled agent is driven over (e.g. "
-            "'claude_cli', 'claude_tty', 'tmux'). Must be one of the agent's "
-            "supported transports; takes precedence over --launch-mode. "
-            "Omit to keep the --launch-mode-derived behavior.",
+            help="Pin the transport (interface) the scheduled agent is driven "
+            "over: 'claude_cli' (Chat), 'claude_tty' (Emulated), or 'tmux' "
+            "(Terminal). Must be one of the agent's supported transports; takes "
+            "precedence over --launch-mode. Omit to use the agent's default "
+            "transport (claude_code defaults to Emulated).",
         ),
     ] = None,
     title: Annotated[str | None, typer.Option()] = None,

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -4,13 +4,15 @@ Waypoint orchestrates each coding session as an **(agent, transport) pair** thro
 
 The split matters because the generic transports drive *any* agent without knowing which one it is: the launch knowledge lives on the agent, so the `tmux` pane wrapper holds **no** `if backend == "codex"` branches — it calls `registry.get(session.backend)` and dispatches through the `AgentLaunchContract`. A new agent gets pane-wrapping for free.
 
-The runtime, API, scheduler, storage, and frontend catalog all dispatch by plugin id; adding a new backend means writing a plugin module, not editing the core. This doc covers the design, the two contracts a plugin satisfies, the capability split, and recipes for shipping a new agent or transport.
+The runtime, API, scheduler, storage, and frontend catalog all dispatch by plugin id; adding a new agent or transport means writing a plugin module, not editing the core. This doc covers the design, the two contracts a plugin satisfies, the capability split, and recipes for shipping a new agent or transport.
 
 ## Goals
 
-- One place per backend for everything backend-specific: lifecycle,
-  control surface, model/thread discovery, transport, event
-  normalization, route registration.
+- One place per plugin for everything it owns, with no concern
+  implemented twice: an agent owns protocol, model/thread discovery,
+  event normalization, route registration, and the launch contract; a
+  transport owns the control surface and lifecycle (send, interrupt,
+  approval, teardown).
 - The runtime — and the generic transports — stay agent-agnostic. No
   `if backend == "codex"` branches anywhere in `runtime.py`, `api.py`,
   `scheduler.py`, or `backends/tmux/`.


### PR DESCRIPTION
## Summary

PR #110 reworked the backend into an (agent, transport) model, but left stale wording in several docs, skill references, and code comments/CLI help that still describe the old backend-as-agent world. This is a prose-only sweep of what #110 missed — no behavior changes.

## Changes

### Docs

- **`README.md`** — the `backends/` layout line now lists `claude_code`/`codex`/`opencode` as agents and `claude_tty`/`tmux` as transport packages; the supported-agent version matrix is bumped to the currently-tested releases (Claude Code `2.1.178`, Codex CLI `0.139.0`, Codex SDK `python-v0.1.0b2`, OpenCode `1.17.4`); the "adding a new agent" note keeps the `BackendPlugin` protocol symbol (still its name) but frames a new agent as declaring supported transports.
- **`docs/coding_agent_plugins.md`** — "adding a new backend" → "adding a new agent or transport"; the Goals bullet that listed `transport` as a per-backend concern is reframed around the agent-owns-protocol / transport-owns-control-surface split it contradicted.

### Skills (`.agents/skills/`)

- **`waypoint/references/sessions-launch.md`**, **`waypoint-subagents/references/spawn-and-poll.md`**, **`waypoint-workqueue/references/playbook.md`** — document the `--transport` launch axis (Chat / Emulated / Terminal), that `claude_code` defaults to the Emulated `claude_tty` transport, and that `claude_tty`/`tmux` are transport ids rather than `--backend` values.
- **`waypoint-workqueue/references/backends.md`** — corrects the false claim that `claude_tty` has no model catalogue (`waypoint models claude_tty` returns the static Claude catalogue).
- **`waypoint-subagents/references/{collect-and-steer,permissions}.md`**, **`waypoint-comms/references/send-and-reply.md`** — "the `tmux` backend" → the `tmux` (Terminal) transport; drop `claude_tty` from the structured-agents list.

### Backend (comments / CLI help)

- **`cli.py`** — rewrites the `_backend_choices` note (the "`--backend claude_tty` is its only launch path / Phase 3 frontend" rationale is obsolete now that `--transport` exists) and the `--transport` help on `sessions start` and `schedule` to map `claude_cli`/`claude_tty`/`tmux` to Chat/Emulated/Terminal and explain default-transport resolution.
- **`backends/claude_tty/{plugin,transport,normalize,tailer}.py`** — module docstrings call `claude_tty` the Emulated transport rather than a "backend".
- **`attachments.py`** — the path-append fallback comment is reframed around transports without native attachment support.

## Test Plan

- [x] `cd backend && uv run pre-commit run --files <changed py>` — isort / black / ruff / codespell / mypy all pass.
- [x] `cd backend && uv run pytest tests/test_cli.py` — 74 passed (covers CLI help rendering and backend choices).
- Prose-only change; no frontend code touched, so no `npm` run applies. Version-matrix values were read from the locally installed `claude`/`codex`/`opencode` CLIs and the `3rdparty/codex` submodule pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)