### PR TITLE
fix: scope the pane-resume control to the terminal view

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -54,7 +54,6 @@ import {
   supportsFork,
   supportsPlanApproval,
   supportsReattachAfterExit,
-  supportsResume,
   supportsStructuredApproval,
   terminalInteractive,
   terminalResizable,
@@ -1290,11 +1289,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       : composerDisabled
         ? "Session has exited — composer disabled."
         : "Reply to the agent…";
-  // Tmux's Resume control only makes sense while the pane is alive; once the
-  // session has exited there is nothing to resume into.
-  const canResume = Boolean(
-    session && supportsResume(session.transport, catalog) && !sessionExited,
-  );
   // Whether the transport exposes a terminal pane (WS-backed xterm mirror).
   // Drives terminal tab visibility and the WS-pane effect below.
   const canShowTerminal = session
@@ -1796,6 +1790,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onTerminalScrollChange={handleTerminalScrollChange}
           onJumpToLive={handleJumpToLive}
           onRefresh={handleTerminalRefresh}
+          onResume={resumeSession}
           onReattach={reattach}
           onTerminate={terminate}
           onRemoveFromList={removeFromList}
@@ -2031,7 +2026,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
             session ? permissionModesFor(session.backend, catalog) : []
           }
           canDelete={sessionExited}
-          canResume={canResume}
           canReattach={dormantReattach}
           canTerminate={Boolean(session && !sessionExited)}
           connection={connection}
@@ -2078,7 +2072,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onRefresh={refresh}
           onRateLimitRefresh={handleRateLimitRefresh}
           onReattach={reattach}
-          onResume={resumeSession}
           onSwitchSession={openSwitcher}
           onSend={onSendWithOptimistic}
           attachmentsEnabled={
@@ -2105,7 +2098,6 @@ interface ReplyComposerProps {
   toolRunsExpanded: boolean;
   onToggleToolRuns: () => void;
   canDelete: boolean;
-  canResume: boolean;
   canReattach: boolean;
   canTerminate: boolean;
   connection: ConnectionState;
@@ -2137,7 +2129,6 @@ interface ReplyComposerProps {
   onRefresh: () => void;
   onRateLimitRefresh: () => void | Promise<void>;
   onReattach: () => void | Promise<void>;
-  onResume: () => void | Promise<void>;
   onSwitchSession: () => void;
   onSend: (
     text: string,
@@ -2159,7 +2150,6 @@ const ReplyComposer = memo(function ReplyComposer({
   agentBusy,
   permissionModeOptions,
   canDelete,
-  canResume,
   canReattach,
   canTerminate,
   connection,
@@ -2190,7 +2180,6 @@ const ReplyComposer = memo(function ReplyComposer({
   onRefresh,
   onRateLimitRefresh,
   onReattach,
-  onResume,
   onSwitchSession,
   onSend,
   attachmentsEnabled,
@@ -3091,20 +3080,6 @@ const ReplyComposer = memo(function ReplyComposer({
             </button>
             {overflowOpen ? (
               <div className="composer-overflow-menu" role="menu">
-                {canResume ? (
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className="composer-overflow-item"
-                    onClick={() => {
-                      setOverflowOpen(false);
-                      void onResume();
-                    }}
-                  >
-                    <span className="glyph">⟳</span>
-                    Resume session
-                  </button>
-                ) : null}
                   <button
                     type="button"
                     role="menuitem"

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -57,6 +57,7 @@ interface SessionTerminalViewProps {
   onJumpToLive: () => void;
   // Refresh reconnects the terminal WS, re-seeding the pane from the server.
   onRefresh: () => void;
+  onResume: () => void | Promise<void>;
   onReattach: () => void | Promise<void>;
   onTerminate: () => void | Promise<void>;
   onRemoveFromList: () => void | Promise<void>;
@@ -93,6 +94,7 @@ export function SessionTerminalView({
   onTerminalScrollChange,
   onJumpToLive,
   onRefresh,
+  onResume,
   onReattach,
   onTerminate,
   onRemoveFromList,
@@ -213,6 +215,17 @@ export function SessionTerminalView({
                 >
                   <span className="glyph">↺</span>
                   Reconnect session
+                </button>
+              ) : null}
+              {locked && !sessionExited && session?.status !== "running" ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="composer-overflow-item"
+                  onClick={() => fireFromMenu(onResume)}
+                >
+                  <span className="glyph">⟳</span>
+                  Resume pane
                 </button>
               ) : null}
               <button

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -72,7 +72,6 @@ const FALLBACK_STRUCTURED = new Set([
   "claude_tty",
   "opencode_http",
 ]);
-const FALLBACK_RESUMABLE = new Set(["tmux", "claude_tty"]);
 const FALLBACK_LIVE_TERMINAL = new Set(["tmux"]);
 const FALLBACK_HAS_TERMINAL_PANE = new Set(["tmux", "claude_tty"]);
 const FALLBACK_TERMINAL_INTERACTIVE = new Set(["tmux"]);
@@ -215,14 +214,6 @@ export function fidelityFor(
     ? caps.is_structured
     : FALLBACK_STRUCTURED.has(transport);
   return structured ? "structured" : "heuristic";
-}
-
-export function supportsResume(
-  transport: SessionTransport,
-  catalog?: BackendCatalog,
-): boolean {
-  const caps = catalog?.transportCaps(transport);
-  return caps ? caps.supports_resume : FALLBACK_RESUMABLE.has(transport);
 }
 
 // Whether the transport renders a live terminal (xterm pane + WS stream)


### PR DESCRIPTION
## Summary

The composer "+" overflow menu had a "Resume session" item that was mis-gated and, by construction, surfaced on exactly the wrong transport. It was gated on `canResume = supportsResume(transport) && !sessionExited`, but `supports_resume` is `true` only for `claude_tty` and `tmux`, and the composer that hosts the "+" menu only renders when `!liveTerminal(transport)`. Since `tmux` is the only `live_terminal` transport, the item never appeared for tmux and appeared *only* for `claude_tty` (Emulated) chat sessions — the inverse of the code's own comment ("Tmux's Resume control only makes sense while the pane is alive"). The action itself just sends a bare Enter to the tmux pane (`runtime.resume` → `TmuxTransport.resume` → `tmux send-keys Enter`), which is a live-terminal nudge, not a thread resume; on a structured Emulated chat it is at best a no-op and at worst injects a stray empty line.

The `claude_tty` `supports_resume=true` is an artifact of `ClaudeTtyTransport` subclassing `TmuxTransport` — it inherited the flag, not the meaningful behavior. This moves the control to the one place it is correct: the live terminal pane.

## Changes

### Frontend

- **`components/SessionDetail.tsx`** — removes the `canResume` derivation, the `supportsResume` import, and the `canResume`/`onResume` props from `ReplyComposer` (deleting the "Resume session" item from the chat composer "+" menu); wires `onResume={resumeSession}` into `SessionTerminalView` instead.
- **`components/SessionTerminalView.tsx`** — adds an `onResume` prop and a "Resume pane" item to the terminal overflow (`⋯`) menu, gated on `locked && !sessionExited && session?.status !== "running"` — i.e. only on a live, non-mid-turn Terminal pane. The relabel disambiguates it from "Reconnect session" (reattach after exit) and the home "Resume thread" import.

## Test Plan

- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npm run build` — compiled successfully.
- [ ] Not run: in-app manual check that "Resume pane" now appears only on a live tmux/Terminal session and is gone from claude_tty chat composers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)