### PR TITLE
fix: surface AskUserQuestion dialogs that have no inline free-text option

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -38,13 +38,14 @@ _APPROVAL_FOOTER = "Esc to cancel · Tab to amend"
 _APPROVAL_QUESTION_MARKER = "Do you want to"
 # The AskUserQuestion popup. We only need to recognize it — the dialog is
 # dismissed with Esc so the TUI flushes the structured questions to the
-# transcript, which is surfaced from there rather than parsed off the pane.
-# Match cctty's detector: the "Enter to select" / "Esc to cancel" footer plus
-# the always-present "Type something" free-text option. The navigation hint
-# itself is not stable — it reads "↑/↓ to navigate" for a single-question
-# dialog but "Tab/Arrow keys to navigate" for a multi-question one — so keying
-# on it would miss the single-question form.
-_QUESTION_MARKERS = ("Enter to select", "Esc to cancel", "Type something")
+# transcript, which is surfaced from there rather than parsed off the pane. The
+# only footer tokens stable across every layout are "Enter to select" (unique
+# to this popup) and "Esc to cancel". Everything else varies: the navigation
+# hint reads "↑/↓ to navigate" / "Tab/Arrow keys to navigate" by arity, and a
+# dialog with option previews offers free-text via "n to add notes" instead of
+# an inline "Type something" option — so requiring "Type something" (as cctty
+# does for its form parsing) misses the preview/notes variant entirely.
+_QUESTION_MARKERS = ("Enter to select", "Esc to cancel")
 _MODEL_FOOTER = "Enter to set as default"
 _MODEL_MARKER = "Select model"
 _EFFORT_FOOTER = "←/→ to adjust · Enter to confirm"

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -40,7 +40,8 @@ _APPROVAL_QUESTION_MARKER = "Do you want to"
 # dismissed with Esc so the TUI flushes the structured questions to the
 # transcript, which is surfaced from there rather than parsed off the pane. The
 # only footer tokens stable across every layout are "Enter to select" (unique
-# to this popup) and "Esc to cancel". Everything else varies: the navigation
+# to this popup among the screens we classify, as of the fixture-pinned Claude
+# Code version) and "Esc to cancel". Everything else varies: the navigation
 # hint reads "↑/↓ to navigate" / "Tab/Arrow keys to navigate" by arity, and a
 # dialog with option previews offers free-text via "n to add notes" instead of
 # an inline "Type something" option — so requiring "Type something" (as cctty

--- a/backend/tests/fixtures/claude_tty_pane/question_dialog_notes.txt
+++ b/backend/tests/fixtures/claude_tty_pane/question_dialog_notes.txt
@@ -1,0 +1,27 @@
+ ☐ Merge scope
+
+How far do you want to take the Schedule → Start Session merge?
+
+ 1. 4th mode + extract shared     ┌───────────────────────────────────────────────┐
+   fields                         │ [ New | Resume | Attach | Schedule ]          │
+ 2. Extract shared fields only    │                                               │
+                                  │ <shared form fields>                          │
+  3. Leave as-is                  │   Working directory                           │
+                                  │   Title                                       │
+                                  │   Permission · Model · Effort                 │
+                                  │   (Advanced: args, overrides)                 │
+                                  │                                               │
+                                  │ Schedule-only (when tab active):              │
+                                  │   Initial prompt                              │
+                                  │   After delay | At specific time              │
+                                  │                                               │
+                                  │ --- Scheduled sessions (separate section) --- │
+                                  │   Upcoming · Recent · Clear                   │
+                                  └───────────────────────────────────────────────┘
+
+                                  Notes: press n to add notes
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  Chat about this
+
+Enter to select · ↑/↓ to navigate · n to add notes · Esc to cancel

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -29,6 +29,7 @@ def _load(name: str) -> str:
         ("approval_bash.txt", PaneScreen.APPROVAL),
         ("question_dialog.txt", PaneScreen.QUESTION),
         ("question_dialog_single.txt", PaneScreen.QUESTION),
+        ("question_dialog_notes.txt", PaneScreen.QUESTION),
         ("trust_dialog.txt", PaneScreen.TRUST),
         ("model_selector.txt", PaneScreen.MODEL_SELECTOR),
         ("effort_popup.txt", PaneScreen.EFFORT_POPUP),
@@ -40,16 +41,21 @@ def test_classify(fixture: str, expected: PaneScreen) -> None:
     assert classify(_load(fixture)) is expected
 
 
-def test_single_and_multi_question_footers_both_classify() -> None:
-    # The navigation hint differs by arity — "↑/↓ to navigate" for one question,
-    # "Tab/Arrow keys to navigate" for several — so detection keys on the stable
-    # "Enter to select"/"Esc to cancel"/"Type something" markers, not the hint.
+def test_question_footers_across_variants_classify() -> None:
+    # Detection keys only on the stable "Enter to select"/"Esc to cancel" footer.
+    # Everything else varies: the nav hint reads "↑/↓ to navigate" for one
+    # question vs "Tab/Arrow keys to navigate" for several, and a dialog with
+    # option previews offers free-text via "n to add notes" with no inline
+    # "Type something" option — so requiring "Type something" misses it.
     single = _load("question_dialog_single.txt")
     multi = _load("question_dialog.txt")
+    notes = _load("question_dialog_notes.txt")
     assert "↑/↓ to navigate" in single
     assert "Tab/Arrow keys to navigate" in multi
+    assert "n to add notes" in notes and "Type something" not in notes
     assert classify(single) is PaneScreen.QUESTION
     assert classify(multi) is PaneScreen.QUESTION
+    assert classify(notes) is PaneScreen.QUESTION
 
 
 def test_question_dialog_not_mistaken_for_approval() -> None:


### PR DESCRIPTION
## Summary

A `claude_code`-agent / `claude_tty`-transport session hung waiting for input without Waypoint surfacing the request. The agent had asked an `AskUserQuestion` whose options carried **previews**, which the TUI renders with an `n to add notes` free-text affordance and **no inline "Type something" option**.

The dialog detector required `"Type something"` (alongside the `"Enter to select"` / `"Esc to cancel"` footer) — a marker borrowed from cctty's *form parser*. That option is absent in the preview/notes layout, so `classify` never returned `QUESTION`, the poller never Esc-flushed it, and the turn blocked indefinitely. Since Waypoint only needs to *detect* the popup (it dismisses with Esc and reads the structured questions from the transcript, rather than parsing options off the pane), the robust signal is just the footer: `"Enter to select"` (unique to this popup) + `"Esc to cancel"`, which is stable across the single- (`↑/↓`), multi- (`Tab/Arrow`), and preview/notes layouts.

## Changes

### Backend

- **`backends/claude_tty/pane_dialog.py`** — `_QUESTION_MARKERS` drops `"Type something"`; `classify` keys only on the `"Enter to select"` + `"Esc to cancel"` footer.

### Tests

- **`test_claude_tty_pane_dialog.py`** — classifies the preview/notes variant as `QUESTION`; asserts it has `n to add notes` and no `Type something`.
- **`fixtures/claude_tty_pane/question_dialog_notes.txt`** — a live-captured preview/notes `AskUserQuestion` popup.

## Test Plan

- [x] `cd backend && uv run pytest` — 902 passed.
- [x] `cd backend && uv run pre-commit run --files <changed files>` — isort / black / ruff / codespell / mypy clean.
- [x] Verified `classify` against the live hung pane (`claude_code-52aaa567`, pane `%126`) and all existing fixtures: the preview/notes capture now classifies as `QUESTION`, with no regression on approval/trust/model/effort/ready/slash.
- [ ] Live e2e (surface the hung session) pending a backend redeploy with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)