### PR TITLE
feat: surface context usage for claude_tty and tmux-transport sessions

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -12,6 +12,7 @@ from waypoint.transports.base import TransportAdapter
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
+    from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.launch_targets import SshLaunchTargetConfig
     from waypoint.runtime import SessionRuntime
 
@@ -328,6 +329,18 @@ class BackendPlugin(Protocol):
         Plugins that cache cross-session metadata (e.g. Claude's remote
         thread enumerator) invalidate here so the next listing reflects
         the deletion.
+        """
+        ...
+
+    def create_context_usage_source(
+        self, session: SessionRecord, runtime: "SessionRuntime"
+    ) -> "ContextUsageSource | None":
+        """Return a background source that publishes context usage, or ``None``.
+
+        Only called for sessions whose active transport has
+        ``is_structured == False``.  The runtime starts the returned source as a
+        tracked asyncio task and cancels it when the session exits.
+        Default returns ``None`` (no-op).
         """
         ...
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -80,6 +80,7 @@ from waypoint.schemas import (
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
+    from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.runtime import SessionRuntime
 
 
@@ -348,6 +349,11 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # Drop any todo tracker stashed for a respawn that will never come.
         if self.adapter is not None:
             self.adapter.discard_session(session.id)
+
+    def create_context_usage_source(
+        self, session: SessionRecord, runtime: "SessionRuntime"
+    ) -> "ContextUsageSource | None":
+        return None
 
     def register_routes(self, app: FastAPI, context: Any) -> None:
         # Tool approval now rides the `can_use_tool` control protocol over the

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -353,7 +353,21 @@ class ClaudeCodePlugin(DefaultLaunchContract):
     def create_context_usage_source(
         self, session: SessionRecord, runtime: "SessionRuntime"
     ) -> "ContextUsageSource | None":
-        return None
+        if session.transport != "tmux":
+            return None
+        thread_id = session.transport_state.get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id:
+            return None
+        from waypoint.backends.claude_code.usage_source import (
+            TranscriptContextUsageSource,
+        )
+
+        return TranscriptContextUsageSource(
+            session_id=session.id,
+            session_uuid=thread_id,
+            cwd=session.cwd,
+            runtime=runtime,
+        )
 
     def register_routes(self, app: FastAPI, context: Any) -> None:
         # Tool approval now rides the `can_use_tool` control protocol over the

--- a/backend/src/waypoint/backends/claude_code/usage_source.py
+++ b/backend/src/waypoint/backends/claude_code/usage_source.py
@@ -1,0 +1,104 @@
+"""Context-usage source for the claude_code plugin on the generic tmux transport.
+
+Tails the Claude TUI JSONL transcript (same file as the claude_tty tailer)
+to extract context-usage data and publish it to the runtime without the
+dialog/pane-management machinery that claude_tty needs.
+"""
+
+import asyncio
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from waypoint.backends.claude_code.adapter import _context_usage_snapshot_from_message
+from waypoint.backends.claude_tty.tailer import transcript_path
+from waypoint.backends.context_usage_source import ContextUsageSource
+
+if TYPE_CHECKING:
+    from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.claude_code")
+
+_POLL_INTERVAL = 0.5
+
+
+class TranscriptContextUsageSource(ContextUsageSource):
+    """Tails the Claude TUI transcript and publishes context usage for tmux-wrapped sessions."""
+
+    def __init__(
+        self,
+        session_id: str,
+        session_uuid: str,
+        cwd: str,
+        runtime: "SessionRuntime",
+    ) -> None:
+        self._session_id = session_id
+        self._path = transcript_path(cwd, session_uuid)
+        self._runtime = runtime
+        self._offset = 0
+        self._context_usage_signature: tuple[int, int | None] | None = None
+
+    def _read_new_bytes(self) -> bytes:
+        if not self._path.exists():
+            return b""
+        try:
+            with self._path.open("rb") as fh:
+                fh.seek(self._offset)
+                return fh.read()
+        except OSError:
+            return b""
+
+    async def _drain(self) -> None:
+        data = await asyncio.to_thread(self._read_new_bytes)
+        if not data:
+            return
+
+        lines = data.split(b"\n")
+        consumed = len(data)
+        if not data.endswith(b"\n"):
+            partial = lines.pop()
+            consumed -= len(partial)
+        self._offset += consumed
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(line)
+            except json.JSONDecodeError:
+                log.warning(
+                    "transcript JSON decode error",
+                    extra={"session_id": self._session_id, "line": raw_line[:200]},
+                )
+                continue
+            if record.get("type") == "assistant":
+                await self._maybe_publish_context_usage(record)
+
+    async def _maybe_publish_context_usage(self, record: dict[str, Any]) -> None:
+        message: dict[str, Any] = record.get("message") or {}
+        usage: dict[str, Any] = message.get("usage") or {}
+        model = str(message.get("model") or "") or None
+        snapshot = _context_usage_snapshot_from_message(model, usage)
+        if snapshot is None:
+            return
+        sig = (snapshot.used_tokens, snapshot.context_window_tokens)
+        if sig == self._context_usage_signature:
+            return
+        self._context_usage_signature = sig
+        await self._runtime.update_session_fields(
+            self._session_id, context_usage=snapshot
+        )
+
+    async def run(self) -> None:
+        try:
+            while True:
+                await self._drain()
+                await asyncio.sleep(_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception(
+                "context usage tailer crashed",
+                extra={"session_id": self._session_id},
+            )

--- a/backend/src/waypoint/backends/claude_code/usage_source.py
+++ b/backend/src/waypoint/backends/claude_code/usage_source.py
@@ -78,7 +78,14 @@ class TranscriptContextUsageSource(ContextUsageSource):
     async def _maybe_publish_context_usage(self, record: dict[str, Any]) -> None:
         message: dict[str, Any] = record.get("message") or {}
         usage: dict[str, Any] = message.get("usage") or {}
-        model = str(message.get("model") or "") or None
+        # Prefer the session's configured model alias for the window: it carries
+        # the ``[1m]`` marker (→ 1M window), whereas the transcript's resolved API
+        # id normalizes to the base family and loses it. Read it fresh each publish
+        # so a dynamic model change is reflected on the next snapshot.
+        session = self._runtime.storage.get_session(self._session_id)
+        model = (session.model if session is not None else None) or (
+            str(message.get("model") or "") or None
+        )
         snapshot = _context_usage_snapshot_from_message(model, usage)
         if snapshot is None:
             return

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -71,6 +71,7 @@ from waypoint.schemas import (
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
+    from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.runtime import SessionRuntime
 
 log = logging.getLogger("waypoint.backends.claude_tty")
@@ -174,6 +175,11 @@ class ClaudeTtyPlugin:
         return None
 
     async def shutdown(self, runtime: "SessionRuntime") -> None:
+        return None
+
+    def create_context_usage_source(
+        self, session: SessionRecord, runtime: "SessionRuntime"
+    ) -> "ContextUsageSource | None":
         return None
 
     def register_routes(self, app: Any, context: Any) -> None:

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -155,7 +155,14 @@ class TranscriptTailer:
     async def _maybe_publish_context_usage(self, record: dict[str, Any]) -> None:
         message: dict[str, Any] = record.get("message") or {}
         usage: dict[str, Any] = message.get("usage") or {}
-        model = str(message.get("model") or "") or None
+        # Prefer the session's configured model alias for the window: it carries
+        # the ``[1m]`` marker (→ 1M window), whereas the transcript's resolved API
+        # id normalizes to the base family and loses it. Read it fresh each publish
+        # so a dynamic model change is reflected on the next snapshot.
+        session = self._runtime.storage.get_session(self._session_id)
+        model = (session.model if session is not None else None) or (
+            str(message.get("model") or "") or None
+        )
         snapshot = _context_usage_snapshot_from_message(model, usage)
         if snapshot is None:
             return

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -16,6 +16,7 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from waypoint.backends.claude_code.adapter import _context_usage_snapshot_from_message
 from waypoint.backends.claude_code.normalize import format_approval_text
 from waypoint.backends.claude_code.threads import (
     claude_projects_root,
@@ -79,6 +80,7 @@ class TranscriptTailer:
         self._offset = (
             self._path.stat().st_size if start_at_end and self._path.exists() else 0
         )
+        self._context_usage_signature: tuple[int, int | None] | None = None
         # Dialog debounce state
         self._prev_dialog_sig: str | None = None
         self._dialog_stable_count: int = 0
@@ -147,6 +149,23 @@ class TranscriptTailer:
                     ev.metadata,
                     ev.status,
                 )
+            if record.get("type") == "assistant":
+                await self._maybe_publish_context_usage(record)
+
+    async def _maybe_publish_context_usage(self, record: dict[str, Any]) -> None:
+        message: dict[str, Any] = record.get("message") or {}
+        usage: dict[str, Any] = message.get("usage") or {}
+        model = str(message.get("model") or "") or None
+        snapshot = _context_usage_snapshot_from_message(model, usage)
+        if snapshot is None:
+            return
+        sig = (snapshot.used_tokens, snapshot.context_window_tokens)
+        if sig == self._context_usage_signature:
+            return
+        self._context_usage_signature = sig
+        await self._runtime.update_session_fields(
+            self._session_id, context_usage=snapshot
+        )
 
     async def _poll_dialog(self) -> None:
         """Capture the live pane and surface any stable tool-permission dialog.

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -70,6 +70,7 @@ from waypoint.schemas import (
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
+    from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.runtime import SessionRuntime
 
 log = logging.getLogger("waypoint.backends.codex")
@@ -303,6 +304,11 @@ class CodexPlugin(DefaultLaunchContract):
         plan = _find_prefixed(snapshot.notes, _PLAN_PREFIX)
         label = f"{email} · plan: {plan}" if plan else email
         return f"{self.id}:{email}", label
+
+    def create_context_usage_source(
+        self, session: SessionRecord, runtime: "SessionRuntime"
+    ) -> "ContextUsageSource | None":
+        return None
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -308,7 +308,11 @@ class CodexPlugin(DefaultLaunchContract):
     def create_context_usage_source(
         self, session: SessionRecord, runtime: "SessionRuntime"
     ) -> "ContextUsageSource | None":
-        return None
+        if session.transport != "tmux":
+            return None
+        from waypoint.backends.codex.usage_source import CodexRolloutUsageSource
+
+        return CodexRolloutUsageSource(session.id, runtime)
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None

--- a/backend/src/waypoint/backends/codex/usage_source.py
+++ b/backend/src/waypoint/backends/codex/usage_source.py
@@ -1,0 +1,159 @@
+"""ContextUsageSource for Codex sessions running over the generic tmux transport.
+
+Tails the Codex rollout JSONL by byte offset and publishes SessionContextUsage
+whenever a ``token_count`` event appears.  The rollout format uses snake_case
+(``last_token_usage``, ``model_context_window``) which differs from the
+camelCase fields in the app-server notification path.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from waypoint.backends.codex.adapter import _positive_int
+from waypoint.backends.context_usage_source import ContextUsageSource
+from waypoint.schemas import SessionContextUsage
+
+if TYPE_CHECKING:
+    from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.codex")
+
+_POLL_INTERVAL = 1.0
+
+
+def _find_rollout_path(thread_id: str) -> Path | None:
+    codex_home = Path(os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
+    sessions_dir = codex_home / "sessions"
+    if not sessions_dir.is_dir():
+        return None
+    suffix = f"-{thread_id}.jsonl"
+    return next(sessions_dir.glob(f"*/*/*/rollout-*{suffix}"), None)
+
+
+def _parse_token_count_record(record: dict[str, Any]) -> SessionContextUsage | None:
+    """Extract a SessionContextUsage from a rollout ``token_count`` event_msg.
+
+    Rollout fields are snake_case; the camelCase app-server path is handled
+    separately by ``_context_usage_snapshot_from_thread_token_usage``.
+    """
+    if record.get("type") != "event_msg":
+        return None
+    payload = record.get("payload")
+    if not isinstance(payload, dict) or payload.get("type") != "token_count":
+        return None
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        return None
+    last_usage = info.get("last_token_usage")
+    if not isinstance(last_usage, dict):
+        return None
+    used_tokens = _positive_int(last_usage.get("total_tokens"))
+    if used_tokens is None:
+        return None
+    context_window = _positive_int(info.get("model_context_window"))
+    breakdown = {
+        key: value
+        for key, value in {
+            "input_tokens": _positive_int(last_usage.get("input_tokens")),
+            "cached_input_tokens": _positive_int(last_usage.get("cached_input_tokens")),
+            "output_tokens": _positive_int(last_usage.get("output_tokens")),
+            "reasoning_output_tokens": _positive_int(
+                last_usage.get("reasoning_output_tokens")
+            ),
+        }.items()
+        if value is not None
+    }
+    return SessionContextUsage(
+        used_tokens=used_tokens,
+        context_window_tokens=context_window,
+        updated_at=datetime.now(UTC),
+        source="codex",
+        breakdown=breakdown,
+    )
+
+
+class CodexRolloutUsageSource(ContextUsageSource):
+    """Tails a Codex rollout JSONL and publishes context usage for tmux sessions."""
+
+    def __init__(self, session_id: str, runtime: "SessionRuntime") -> None:
+        self._session_id = session_id
+        self._runtime = runtime
+        self._offset = 0
+        self._context_usage_signature: tuple[int, int | None] | None = None
+
+    def _read_new_bytes(self, path: Path) -> bytes:
+        try:
+            with path.open("rb") as fh:
+                fh.seek(self._offset)
+                return fh.read()
+        except OSError:
+            return b""
+
+    async def _drain(self, path: Path) -> None:
+        data = await asyncio.to_thread(self._read_new_bytes, path)
+        if not data:
+            return
+
+        lines = data.split(b"\n")
+        consumed = len(data)
+        if not data.endswith(b"\n"):
+            partial = lines.pop()
+            consumed -= len(partial)
+        self._offset += consumed
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record: dict[str, Any] = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            snapshot = _parse_token_count_record(record)
+            if snapshot is None:
+                continue
+            sig = (snapshot.used_tokens, snapshot.context_window_tokens)
+            if sig == self._context_usage_signature:
+                continue
+            self._context_usage_signature = sig
+            await self._runtime.update_session_fields(
+                self._session_id, context_usage=snapshot
+            )
+
+    async def run(self) -> None:
+        try:
+            thread_id: str | None = None
+            while thread_id is None:
+                session = self._runtime.storage.get_session(self._session_id)
+                if session is None:
+                    return
+                tid = session.transport_state.get("thread_id")
+                if isinstance(tid, str) and tid:
+                    thread_id = tid
+                else:
+                    await asyncio.sleep(_POLL_INTERVAL)
+
+            path: Path | None = None
+            while path is None:
+                path = await asyncio.to_thread(_find_rollout_path, thread_id)
+                if path is None:
+                    await asyncio.sleep(_POLL_INTERVAL)
+
+            while True:
+                session = self._runtime.storage.get_session(self._session_id)
+                if session is None:
+                    return
+                await self._drain(path)
+                await asyncio.sleep(_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception(
+                "codex rollout usage source crashed",
+                extra={"session_id": self._session_id},
+            )

--- a/backend/src/waypoint/backends/context_usage_source.py
+++ b/backend/src/waypoint/backends/context_usage_source.py
@@ -1,0 +1,14 @@
+from abc import ABC, abstractmethod
+
+
+class ContextUsageSource(ABC):
+    """Cancellable background task that publishes context usage for
+    non-structured-transport sessions.
+
+    The runtime wraps :meth:`run` in an ``asyncio.Task`` and cancels it
+    when the session exits.  Concrete implementations poll an agent artifact
+    and push updates via ``runtime.update_session_fields(context_usage=...)``.
+    """
+
+    @abstractmethod
+    async def run(self) -> None: ...

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -36,6 +36,7 @@ from waypoint.schemas import (
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
+    from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.runtime import SessionRuntime
 
 log = logging.getLogger("waypoint.backends.opencode")
@@ -647,6 +648,11 @@ class OpenCodePlugin(DefaultLaunchContract):
             task = asyncio.create_task(adapter.terminate_session(session.id))
             self._pending_tasks.add(task)
             task.add_done_callback(self._pending_tasks.discard)
+
+    def create_context_usage_source(
+        self, session: SessionRecord, runtime: "SessionRuntime"
+    ) -> "ContextUsageSource | None":
+        return None
 
     def register_routes(self, app: FastAPI, context: Any) -> None:
         pass

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -652,7 +652,19 @@ class OpenCodePlugin(DefaultLaunchContract):
     def create_context_usage_source(
         self, session: SessionRecord, runtime: "SessionRuntime"
     ) -> "ContextUsageSource | None":
-        return None
+        if session.transport != "tmux":
+            return None
+        from waypoint.backends.opencode.usage_source import (
+            OpenCodeTmuxUsageSource,
+            _opencode_db_dir,
+        )
+
+        return OpenCodeTmuxUsageSource(
+            session_id=session.id,
+            cwd=session.cwd,
+            runtime=runtime,
+            db_dir=_opencode_db_dir(),
+        )
 
     def register_routes(self, app: FastAPI, context: Any) -> None:
         pass

--- a/backend/src/waypoint/backends/opencode/usage_source.py
+++ b/backend/src/waypoint/backends/opencode/usage_source.py
@@ -1,0 +1,179 @@
+"""SQLite-based ContextUsageSource for opencode sessions over the tmux transport.
+
+Polls the opencode SQLite DB (read-only) to extract token counts from the latest
+assistant message and publishes SessionContextUsage updates to the runtime.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from waypoint.backends.context_usage_source import ContextUsageSource
+from waypoint.backends.opencode.adapter import _non_negative_int
+from waypoint.schemas import SessionContextUsage
+
+if TYPE_CHECKING:
+    from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.opencode")
+
+_POLL_INTERVAL = 1.5
+
+
+def _opencode_db_dir() -> Path:
+    xdg_data = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
+    return Path(xdg_data) / "opencode"
+
+
+def _connect_ro(db_path: Path) -> sqlite3.Connection:
+    uri = f"file:{db_path}?mode=ro&immutable=1"
+    return sqlite3.connect(uri, uri=True)
+
+
+def _normalize_path(p: str) -> str:
+    return os.path.realpath(os.path.normpath(p))
+
+
+def _find_session_id(conn: sqlite3.Connection, cwd: str) -> str | None:
+    cur = conn.cursor()
+    # Fast exact match first.
+    cur.execute(
+        "SELECT id FROM session WHERE directory = ? ORDER BY time_updated DESC LIMIT 1",
+        (cwd,),
+    )
+    row = cur.fetchone()
+    if row is not None:
+        return row[0]
+    # Normalized fallback — handles trailing slashes, symlinked worktrees, and
+    # platform realpath differences (e.g. /tmp vs /private/tmp on macOS).
+    normalized_cwd = _normalize_path(cwd)
+    cur.execute("SELECT id, directory FROM session ORDER BY time_updated DESC")
+    for sess_id, directory in cur.fetchall():
+        if _normalize_path(directory) == normalized_cwd:
+            return sess_id
+    return None
+
+
+def _snapshot_from_data(data: dict[str, Any]) -> SessionContextUsage | None:
+    tokens = data.get("tokens")
+    if not isinstance(tokens, dict):
+        return None
+
+    input_tokens = _non_negative_int(tokens.get("input"))
+    output_tokens = _non_negative_int(tokens.get("output"))
+    reasoning_tokens = _non_negative_int(tokens.get("reasoning"))
+    cache = tokens.get("cache")
+    if not isinstance(cache, dict):
+        cache = {}
+    cache_read_tokens = _non_negative_int(cache.get("read"))
+    cache_write_tokens = _non_negative_int(cache.get("write"))
+
+    used_tokens = sum(
+        v
+        for v in (input_tokens, cache_read_tokens, cache_write_tokens)
+        if v is not None
+    )
+    if used_tokens <= 0:
+        return None
+
+    breakdown = {
+        key: value
+        for key, value in {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "reasoning_tokens": reasoning_tokens,
+            "cache_read_tokens": cache_read_tokens,
+            "cache_write_tokens": cache_write_tokens,
+        }.items()
+        if value is not None
+    }
+    return SessionContextUsage(
+        used_tokens=used_tokens,
+        context_window_tokens=None,
+        updated_at=datetime.now(UTC),
+        source="opencode",
+        breakdown=breakdown,
+    )
+
+
+def _latest_assistant_snapshot(
+    conn: sqlite3.Connection, opencode_session_id: str
+) -> SessionContextUsage | None:
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT data FROM message
+        WHERE session_id = ? AND json_extract(data, '$.role') = 'assistant'
+        ORDER BY time_updated DESC LIMIT 1
+        """,
+        (opencode_session_id,),
+    )
+    row = cur.fetchone()
+    if row is None:
+        return None
+    try:
+        data: dict[str, Any] = json.loads(row[0])
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return _snapshot_from_data(data)
+
+
+class OpenCodeTmuxUsageSource(ContextUsageSource):
+    def __init__(
+        self,
+        session_id: str,
+        cwd: str,
+        runtime: "SessionRuntime",
+        db_dir: Path,
+    ) -> None:
+        self._session_id = session_id
+        self._cwd = cwd
+        self._runtime = runtime
+        self._db_dir = db_dir
+        self._signature: tuple[int, int | None] | None = None
+
+    def _query_snapshot(self) -> SessionContextUsage | None:
+        db_path = self._db_dir / "opencode.db"
+        if not db_path.exists():
+            return None
+        try:
+            conn = _connect_ro(db_path)
+            try:
+                opencode_session_id = _find_session_id(conn, self._cwd)
+                if opencode_session_id is None:
+                    return None
+                return _latest_assistant_snapshot(conn, opencode_session_id)
+            finally:
+                conn.close()
+        except Exception:
+            log.debug(
+                "opencode DB poll failed",
+                extra={"session_id": self._session_id},
+                exc_info=True,
+            )
+            return None
+
+    async def run(self) -> None:
+        try:
+            while True:
+                snapshot = await asyncio.to_thread(self._query_snapshot)
+                if snapshot is not None:
+                    sig = (snapshot.used_tokens, snapshot.context_window_tokens)
+                    if sig != self._signature:
+                        self._signature = sig
+                        await self._runtime.update_session_fields(
+                            self._session_id, context_usage=snapshot
+                        )
+                await asyncio.sleep(_POLL_INTERVAL)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception(
+                "opencode usage source crashed",
+                extra={"session_id": self._session_id},
+            )

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -105,7 +105,17 @@ class TmuxPlugin:
     def create_context_usage_source(
         self, session: SessionRecord, runtime: "SessionRuntime"
     ) -> "ContextUsageSource | None":
-        return None
+        # Tmux is the transport wrapper; context usage is an agent-axis
+        # concern, so delegate to the wrapped agent plugin (which reads its
+        # own on-disk artifact). Mirrors how the wrapper delegates other
+        # agent-specific calls (built-ins, rate-limit probe, resume).
+        if session.backend == self.id or not runtime.registry.has_backend(
+            session.backend
+        ):
+            return None
+        return runtime.registry.get(session.backend).create_context_usage_source(
+            session, runtime
+        )
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -37,6 +37,7 @@ from waypoint.schemas import (
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
+    from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.runtime import SessionRuntime
 
 log = logging.getLogger("waypoint.backends.tmux")
@@ -99,6 +100,11 @@ class TmuxPlugin:
         return None
 
     async def shutdown(self, runtime: "SessionRuntime") -> None:
+        return None
+
+    def create_context_usage_source(
+        self, session: SessionRecord, runtime: "SessionRuntime"
+    ) -> "ContextUsageSource | None":
         return None
 
     def register_routes(self, app: Any, context: Any) -> None:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -162,6 +162,10 @@ class SessionRuntime:
         # sessions have no adapter and need this fallback to keep the usage pill
         # live.
         self._rate_limit_watchers: dict[str, asyncio.Task[None]] = {}
+        # Per-session context-usage sources for non-structured transports.
+        # Started when a session with is_structured=False is created or restored;
+        # cancelled on session exit alongside the other per-session tasks.
+        self._context_usage_sources: dict[str, asyncio.Task[None]] = {}
         self._restore_tasks: set[asyncio.Task[None]] = set()
         self._completion_cache: dict[CompletionCacheKey, list[CommandCompletion]] = {}
         self._completion_cache_updated_at: dict[CompletionCacheKey, float] = {}
@@ -234,6 +238,12 @@ class SessionRuntime:
             with suppress(asyncio.CancelledError):
                 await task
         self.monitor_tasks.clear()
+        for task in self._context_usage_sources.values():
+            task.cancel()
+        for task in self._context_usage_sources.values():
+            with suppress(asyncio.CancelledError):
+                await task
+        self._context_usage_sources.clear()
         restore_tasks = list(self._restore_tasks)
         for task in restore_tasks:
             task.cancel()
@@ -423,6 +433,7 @@ class SessionRuntime:
                 session.id, worktree_path=request.worktree_path
             )
         self._warm_command_completions(session)
+        self._start_context_usage_source(session)
         return session
 
     def _effective_permission_mode(self, request: SessionCreateRequest) -> str | None:
@@ -1045,6 +1056,7 @@ class SessionRuntime:
             # ``create_session`` / fork; reattached ones fall back to
             # stale-while-revalidate on the first `/` press.
             self._warm_command_completions(refreshed, include_remote=False)
+            self._start_context_usage_source(refreshed)
 
     def _warm_command_completions(
         self, session: SessionRecord, *, include_remote: bool = True
@@ -1215,6 +1227,7 @@ class SessionRuntime:
         # adapter is missing.
         plugin = self.registry.plugin_for(session)
         await plugin.terminate_session(self, session)
+        await self._cancel_context_usage_source(session_id)
         await self._record_system_event(
             session.id, "Session terminated", status=SessionStatus.EXITED
         )
@@ -1252,6 +1265,7 @@ class SessionRuntime:
                 detail="this session cannot be reattached after exit",
             )
         await plugin.terminate_session(self, session)
+        await self._cancel_context_usage_source(session.id)
         # User-initiated retry: bypass any per-target cooldown / circuit
         # breaker so the click takes effect immediately. Plugins without
         # this opt-in hook ignore the call.
@@ -1270,6 +1284,7 @@ class SessionRuntime:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"failed to reattach session ({refreshed.status})",
             )
+        self._start_context_usage_source(refreshed)
         return refreshed
 
     async def delete(
@@ -1291,6 +1306,9 @@ class SessionRuntime:
                     await self.terminate(session_id)
             else:
                 await self.terminate(session_id)
+        # terminate() covers the non-EXITED path; cover the already-EXITED
+        # case (natural exit never called terminate()) here.
+        await self._cancel_context_usage_source(session_id)
         self._close_structured_log(session_id)
         self.storage.delete_session(session_id)
         if session.worktree_path is not None:
@@ -1719,6 +1737,8 @@ class SessionRuntime:
         persisted = self.storage.append_event(event)
         self._append_structured_log(session_id, persisted)
         await self._publish_event(persisted)
+        if status in {SessionStatus.EXITED, SessionStatus.ERROR}:
+            await self._cancel_context_usage_source(session_id)
 
     async def update_session_fields(
         self, session_id: str, *, publish: bool = True, **updates: Any
@@ -1886,6 +1906,28 @@ class SessionRuntime:
                 if alias and alias.lower() in lowered:
                     return plugin.id
         return self.settings.default_backend
+
+    def _start_context_usage_source(self, session: SessionRecord) -> None:
+        transport = self._transports.get(session.transport)
+        if transport is None or transport.is_structured:
+            return
+        plugin = self.registry.plugin_for(session)
+        source = plugin.create_context_usage_source(session, self)
+        if source is None:
+            return
+        old = self._context_usage_sources.pop(session.id, None)
+        if old is not None:
+            old.cancel()
+        self._context_usage_sources[session.id] = asyncio.create_task(
+            source.run(), name=f"ctx-usage-{session.id}"
+        )
+
+    async def _cancel_context_usage_source(self, session_id: str) -> None:
+        task = self._context_usage_sources.pop(session_id, None)
+        if task is not None:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
 
     def _ensure_monitor(self, session_id: str) -> None:
         if session_id in self.monitor_tasks:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1908,6 +1908,11 @@ class SessionRuntime:
         return self.settings.default_backend
 
     def _start_context_usage_source(self, session: SessionRecord) -> None:
+        if session.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
+            # Boot-restore passes already-terminal sessions through here; a
+            # source started for one would poll until delete with nothing to
+            # cancel it (the terminal transition already fired).
+            return
         transport = self._transports.get(session.transport)
         if transport is None or transport.is_structured:
             return

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -125,6 +125,9 @@ class _StubPlugin:
     async def shutdown(self, runtime: Any) -> None:
         return None
 
+    def create_context_usage_source(self, session: Any, runtime: Any) -> None:
+        return None
+
     def register_routes(self, app: Any, context: Any) -> None:
         return None
 

--- a/backend/tests/test_claude_code_usage_source.py
+++ b/backend/tests/test_claude_code_usage_source.py
@@ -1,0 +1,159 @@
+"""Unit tests for TranscriptContextUsageSource."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from waypoint.backends.claude_code.usage_source import TranscriptContextUsageSource
+
+
+def _make_runtime() -> MagicMock:
+    runtime = MagicMock()
+    runtime.update_session_fields = AsyncMock()
+    return runtime
+
+
+def _make_source(
+    runtime: MagicMock,
+    tmp_path: Path,
+    session_id: str = "sess-1",
+    session_uuid: str = "uuid-1",
+) -> TranscriptContextUsageSource:
+    cwd = str(tmp_path)
+    source = TranscriptContextUsageSource(
+        session_id=session_id,
+        session_uuid=session_uuid,
+        cwd=cwd,
+        runtime=runtime,
+    )
+    return source
+
+
+def _jsonl(*records: dict[str, object]) -> bytes:
+    return b"\n".join(json.dumps(r).encode() for r in records) + b"\n"
+
+
+def _assistant_record(
+    model: str = "claude-sonnet-4-5",
+    usage: dict | None = None,
+) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "model": model,
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": "end_turn",
+            "usage": usage or {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_drain_publishes_context_usage_on_assistant_record(
+    tmp_path: Path,
+) -> None:
+    runtime = _make_runtime()
+    source = _make_source(runtime, tmp_path)
+
+    record = _assistant_record(
+        usage={"input_tokens": 15, "cache_read_input_tokens": 4, "output_tokens": 6}
+    )
+    data = _jsonl(record)
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    runtime.update_session_fields.assert_called_once()
+    call_args = runtime.update_session_fields.call_args
+    assert call_args.args[0] == "sess-1"
+    snapshot = call_args.kwargs["context_usage"]
+    # input_tokens(15) + cache_read_input_tokens(4) = 19 used tokens
+    assert snapshot.used_tokens == 19
+    assert snapshot.context_window_tokens == 200_000
+    assert snapshot.source == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_drain_dedupes_unchanged_context_usage(tmp_path: Path) -> None:
+    runtime = _make_runtime()
+    source = _make_source(runtime, tmp_path)
+
+    usage = {"input_tokens": 10, "output_tokens": 5}
+    record1 = _assistant_record(usage=usage)
+    record2 = _assistant_record(usage=usage)
+    data = _jsonl(record1, record2)
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    # Same (used_tokens, context_window_tokens) — only one publish
+    assert runtime.update_session_fields.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_publishes_again_when_usage_changes(tmp_path: Path) -> None:
+    runtime = _make_runtime()
+    source = _make_source(runtime, tmp_path)
+
+    record1 = _assistant_record(usage={"input_tokens": 10, "output_tokens": 5})
+    record2 = _assistant_record(usage={"input_tokens": 20, "output_tokens": 5})
+    data = _jsonl(record1, record2)
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    assert runtime.update_session_fields.call_count == 2
+    snapshots = [
+        c.kwargs["context_usage"] for c in runtime.update_session_fields.call_args_list
+    ]
+    assert snapshots[0].used_tokens == 10
+    assert snapshots[1].used_tokens == 20
+
+
+@pytest.mark.asyncio
+async def test_drain_skips_non_assistant_records(tmp_path: Path) -> None:
+    runtime = _make_runtime()
+    source = _make_source(runtime, tmp_path)
+
+    data = _jsonl(
+        {"type": "user", "message": {"role": "user", "content": "hi"}},
+        {"type": "system", "content": "init"},
+    )
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    runtime.update_session_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_drain_skips_unknown_model(tmp_path: Path) -> None:
+    runtime = _make_runtime()
+    source = _make_source(runtime, tmp_path)
+
+    # Model not in the Claude catalogue — context window is unknown, so no publish
+    record = _assistant_record(
+        model="gpt-4",
+        usage={"input_tokens": 10, "output_tokens": 5},
+    )
+    data = _jsonl(record)
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    runtime.update_session_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_drain_tolerates_missing_file(tmp_path: Path) -> None:
+    runtime = _make_runtime()
+    source = _make_source(runtime, tmp_path)
+
+    # _read_new_bytes returns empty bytes when the file doesn't exist
+    with patch.object(source, "_read_new_bytes", return_value=b""):
+        await source._drain()
+
+    runtime.update_session_fields.assert_not_called()

--- a/backend/tests/test_claude_code_usage_source.py
+++ b/backend/tests/test_claude_code_usage_source.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -9,9 +10,14 @@ import pytest
 from waypoint.backends.claude_code.usage_source import TranscriptContextUsageSource
 
 
-def _make_runtime() -> MagicMock:
+def _make_runtime(session_model: str | None = None) -> MagicMock:
     runtime = MagicMock()
     runtime.update_session_fields = AsyncMock()
+    # The source reads the session's configured model fresh on each publish to
+    # resolve the context window (the transcript only carries the resolved API
+    # id, which loses the ``[1m]`` marker). Tests reassign
+    # ``get_session.return_value`` to simulate a dynamic model change mid-run.
+    runtime.storage.get_session.return_value = SimpleNamespace(model=session_model)
     return runtime
 
 
@@ -157,3 +163,51 @@ async def test_drain_tolerates_missing_file(tmp_path: Path) -> None:
         await source._drain()
 
     runtime.update_session_fields.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_session_model_overrides_transcript_for_1m_window(tmp_path: Path) -> None:
+    # Session configured with the [1m] alias must yield the 1M window even though
+    # the transcript's resolved API id (claude-opus-4-8) normalizes to base opus.
+    runtime = _make_runtime(session_model="opus[1m]")
+    source = _make_source(runtime, tmp_path)
+    record = _assistant_record(
+        model="claude-opus-4-8",
+        usage={"input_tokens": 20, "cache_read_input_tokens": 5, "output_tokens": 3},
+    )
+    with patch.object(source, "_read_new_bytes", return_value=_jsonl(record)):
+        await source._drain()
+    snapshot = runtime.update_session_fields.call_args.kwargs["context_usage"]
+    assert snapshot.context_window_tokens == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_dynamic_model_change_updates_window(tmp_path: Path) -> None:
+    # A model switch mid-session must be reflected: the window follows the
+    # session's current model, read fresh on each publish.
+    runtime = _make_runtime(session_model="sonnet[1m]")
+    source = _make_source(runtime, tmp_path)
+    rec1 = _assistant_record(
+        model="claude-sonnet-4-6", usage={"input_tokens": 11, "output_tokens": 1}
+    )
+    with patch.object(source, "_read_new_bytes", return_value=_jsonl(rec1)):
+        await source._drain()
+    assert (
+        runtime.update_session_fields.call_args.kwargs[
+            "context_usage"
+        ].context_window_tokens
+        == 1_000_000
+    )
+    # Switch the configured model to the base alias; next publish uses 200k.
+    runtime.storage.get_session.return_value = SimpleNamespace(model="sonnet")
+    rec2 = _assistant_record(
+        model="claude-sonnet-4-6", usage={"input_tokens": 99, "output_tokens": 1}
+    )
+    with patch.object(source, "_read_new_bytes", return_value=_jsonl(rec2)):
+        await source._drain()
+    assert (
+        runtime.update_session_fields.call_args.kwargs[
+            "context_usage"
+        ].context_window_tokens
+        == 200_000
+    )

--- a/backend/tests/test_claude_tty_tailer.py
+++ b/backend/tests/test_claude_tty_tailer.py
@@ -1,0 +1,150 @@
+"""Unit tests for TranscriptTailer context-usage publishing."""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from waypoint.backends.claude_tty.tailer import TranscriptTailer
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+
+def _make_session(session_id: str = "sess-1") -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=session_id,
+        backend="claude_tty",
+        source=SessionSource.MANAGED,
+        transport="claude_tty",
+        title="test",
+        cwd="/tmp",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/structured.log",
+        transport_state={
+            "tmux_session": session_id,
+            "tmux_window": "0",
+            "tmux_pane": "%0",
+            "thread_id": "thread-1",
+        },
+    )
+
+
+def _make_runtime(session: SessionRecord) -> MagicMock:
+    runtime = MagicMock()
+    runtime.storage.get_session.return_value = session
+    runtime._emit_adapter_event = AsyncMock()
+    runtime.update_session_fields = AsyncMock()
+    return runtime
+
+
+def _make_tailer(runtime: MagicMock, session_id: str = "sess-1") -> TranscriptTailer:
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    return TranscriptTailer(
+        session_id=session_id,
+        session_uuid="thread-1",
+        cwd="/nonexistent",
+        runtime=runtime,
+        plugin=plugin,
+    )
+
+
+def _jsonl(*records: dict) -> bytes:
+    return b"\n".join(json.dumps(r).encode() for r in records) + b"\n"
+
+
+def _assistant_record(
+    message_id: str = "msg_1",
+    model: str = "claude-sonnet-4-5",
+    usage: dict | None = None,
+    stop_reason: str = "end_turn",
+) -> dict:
+    return {
+        "type": "assistant",
+        "message": {
+            "id": message_id,
+            "model": model,
+            "content": [{"type": "text", "text": "hello"}],
+            "stop_reason": stop_reason,
+            "usage": usage or {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_drain_publishes_context_usage_on_assistant_record() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    tailer = _make_tailer(runtime)
+
+    record = _assistant_record(
+        usage={"input_tokens": 15, "cache_read_input_tokens": 4, "output_tokens": 6}
+    )
+    data = _jsonl(record)
+
+    with patch.object(tailer, "_read_new_bytes", return_value=data):
+        await tailer._drain()
+
+    runtime.update_session_fields.assert_called_once()
+    call_kwargs = runtime.update_session_fields.call_args
+    assert call_kwargs.args[0] == "sess-1"
+    snapshot = call_kwargs.kwargs["context_usage"]
+    # input_tokens(15) + cache_read_input_tokens(4) = 19 used tokens
+    assert snapshot.used_tokens == 19
+    assert snapshot.context_window_tokens == 200_000
+    assert snapshot.source == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_drain_dedupes_unchanged_context_usage() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    tailer = _make_tailer(runtime)
+
+    usage = {"input_tokens": 10, "output_tokens": 5}
+    record1 = _assistant_record(message_id="msg_1", usage=usage)
+    record2 = _assistant_record(message_id="msg_2", usage=usage)
+    data = _jsonl(record1, record2)
+
+    with patch.object(tailer, "_read_new_bytes", return_value=data):
+        await tailer._drain()
+
+    # Same (used_tokens, context_window_tokens) — only one publish
+    assert runtime.update_session_fields.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_drain_publishes_again_when_usage_changes() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    tailer = _make_tailer(runtime)
+
+    record1 = _assistant_record(
+        message_id="msg_1", usage={"input_tokens": 10, "output_tokens": 5}
+    )
+    data1 = _jsonl(record1)
+    with patch.object(tailer, "_read_new_bytes", return_value=data1):
+        await tailer._drain()
+
+    assert runtime.update_session_fields.call_count == 1
+    first_used = runtime.update_session_fields.call_args.kwargs[
+        "context_usage"
+    ].used_tokens
+
+    record2 = _assistant_record(
+        message_id="msg_2", usage={"input_tokens": 20, "output_tokens": 8}
+    )
+    data2 = _jsonl(record2)
+    with patch.object(tailer, "_read_new_bytes", return_value=data2):
+        await tailer._drain()
+
+    assert runtime.update_session_fields.call_count == 2
+    second_used = runtime.update_session_fields.call_args.kwargs[
+        "context_usage"
+    ].used_tokens
+    assert second_used > first_used

--- a/backend/tests/test_codex_plugin.py
+++ b/backend/tests/test_codex_plugin.py
@@ -5,11 +5,15 @@ import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from waypoint.backends.codex.plugin import CodexPlugin
-from waypoint.backends.codex.usage_source import _parse_token_count_record
+from waypoint.backends.codex.usage_source import (
+    CodexRolloutUsageSource,
+    _parse_token_count_record,
+)
 from waypoint.launch_targets import SshLaunchTargetConfig
 
 
@@ -261,3 +265,51 @@ def test_parse_token_count_record_omits_zero_breakdown_fields() -> None:
     snapshot = _parse_token_count_record(record)
     assert snapshot is not None
     assert "cached_input_tokens" not in snapshot.breakdown
+
+
+def _token_count_line(total: int) -> str:
+    return json.dumps(
+        {
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "last_token_usage": {"total_tokens": total, "input_tokens": total},
+                    "model_context_window": 200000,
+                },
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_rollout_drain_publishes_and_dedupes(tmp_path: Path) -> None:
+    runtime = MagicMock()
+    runtime.update_session_fields = AsyncMock()
+    source = CodexRolloutUsageSource("sess-1", runtime)
+
+    path = tmp_path / "rollout.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps({"type": "session_meta", "payload": {"cwd": "/x"}}),
+                _token_count_line(5000),
+                _token_count_line(5000),  # unchanged -> deduped
+                _token_count_line(9000),
+            ]
+        )
+        + "\n"
+    )
+
+    await source._drain(path)
+
+    # 5000 (publish), 5000 (dedup), 9000 (publish) => two publishes
+    assert runtime.update_session_fields.call_count == 2
+    snapshots = [
+        c.kwargs["context_usage"] for c in runtime.update_session_fields.call_args_list
+    ]
+    assert [s.used_tokens for s in snapshots] == [5000, 9000]
+    assert snapshots[0].context_window_tokens == 200000
+    assert all(
+        c.args[0] == "sess-1" for c in runtime.update_session_fields.call_args_list
+    )

--- a/backend/tests/test_codex_plugin.py
+++ b/backend/tests/test_codex_plugin.py
@@ -9,6 +9,7 @@ from typing import Any
 import pytest
 
 from waypoint.backends.codex.plugin import CodexPlugin
+from waypoint.backends.codex.usage_source import _parse_token_count_record
 from waypoint.launch_targets import SshLaunchTargetConfig
 
 
@@ -202,3 +203,61 @@ async def test_capture_thread_id_pulls_uuid_from_filename(
     )
 
     assert captured["sess-1"] == {"transport_state": {"thread_id": uuid_str}}
+
+
+def test_parse_token_count_record_returns_snapshot() -> None:
+    record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "total_tokens": 8000,
+                    "input_tokens": 6000,
+                    "cached_input_tokens": 1500,
+                    "output_tokens": 400,
+                    "reasoning_output_tokens": 100,
+                },
+                "model_context_window": 200000,
+            },
+        },
+    }
+    snapshot = _parse_token_count_record(record)
+    assert snapshot is not None
+    assert snapshot.used_tokens == 8000
+    assert snapshot.context_window_tokens == 200000
+    assert snapshot.source == "codex"
+    assert snapshot.breakdown == {
+        "input_tokens": 6000,
+        "cached_input_tokens": 1500,
+        "output_tokens": 400,
+        "reasoning_output_tokens": 100,
+    }
+
+
+def test_parse_token_count_record_ignores_non_token_count() -> None:
+    assert _parse_token_count_record({"type": "session_meta", "payload": {}}) is None
+    assert (
+        _parse_token_count_record({"type": "event_msg", "payload": {"type": "other"}})
+        is None
+    )
+
+
+def test_parse_token_count_record_omits_zero_breakdown_fields() -> None:
+    record = {
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "total_tokens": 100,
+                    "input_tokens": 100,
+                    "cached_input_tokens": 0,
+                },
+                "model_context_window": 50000,
+            },
+        },
+    }
+    snapshot = _parse_token_count_record(record)
+    assert snapshot is not None
+    assert "cached_input_tokens" not in snapshot.breakdown

--- a/backend/tests/test_context_usage_source.py
+++ b/backend/tests/test_context_usage_source.py
@@ -203,3 +203,17 @@ async def test_source_cancelled_on_delete_already_exited(tmp_path: Path) -> None
     await runtime.delete(session.id)
 
     assert session.id not in runtime._context_usage_sources
+
+
+async def test_source_not_started_for_terminal_session(tmp_path: Path) -> None:
+    """Boot-restore can pass an already-terminal session; no source should start
+    (its poll loop would leak with nothing to cancel it until delete)."""
+    _RunningSource.started = False
+    runtime = _make_runtime(tmp_path, _RunningSource(), is_structured=False)
+
+    for status in (SessionStatus.EXITED, SessionStatus.ERROR):
+        session = _make_session(tmp_path).model_copy(update={"status": status})
+        runtime._start_context_usage_source(session)
+        assert session.id not in runtime._context_usage_sources
+
+    assert not _RunningSource.started

--- a/backend/tests/test_context_usage_source.py
+++ b/backend/tests/test_context_usage_source.py
@@ -1,0 +1,205 @@
+"""Unit tests for the ContextUsageSource lifecycle wiring in SessionRuntime.
+
+Verifies that:
+- A plugin returning a non-None source has it started as a tracked asyncio task
+  when the active transport has is_structured=False.
+- A plugin returning a non-None source has nothing started when the active
+  transport has is_structured=True.
+- The task is cancelled by _cancel_context_usage_source.
+- A plugin returning None from the hook starts no task.
+- A source is cancelled when the session transitions to EXITED/ERROR via
+  _record_system_event (natural tmux exits).
+- A source is cancelled by delete() even when the session is already EXITED.
+"""
+
+import asyncio
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from waypoint.backends.context_usage_source import ContextUsageSource
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _RunningSource(ContextUsageSource):
+    """Blocks forever until cancelled; records that it was started."""
+
+    started = False
+
+    async def run(self) -> None:
+        _RunningSource.started = True
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            raise
+
+
+class _FakeTransport:
+    def __init__(self, *, is_structured: bool) -> None:
+        self.is_structured = is_structured
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_session(tmp_path: Path) -> SessionRecord:
+    now = datetime.now(UTC)
+    raw = tmp_path / "raw.log"
+    raw.touch()
+    # Use "tmux" as backend/transport — always registered in the default registry.
+    return SessionRecord(
+        id="sess-1",
+        backend="tmux",
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="t",
+        cwd=str(tmp_path),
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(raw),
+        structured_log_path=str(tmp_path / "events.jsonl"),
+    )
+
+
+def _make_runtime(
+    tmp_path: Path,
+    source: ContextUsageSource | None,
+    *,
+    is_structured: bool,
+) -> SessionRuntime:
+    """Create a SessionRuntime with a fully isolated mock registry and transport."""
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+
+    plugin = MagicMock()
+    plugin.create_context_usage_source.return_value = source
+
+    registry = MagicMock()
+    registry.all.return_value = []  # prevents _transports from calling real plugins
+    registry.plugin_for.return_value = plugin
+
+    runtime = SessionRuntime(settings, storage, registry=registry)
+    # Inject the fake transport for the session's transport id.
+    runtime._transports["tmux"] = _FakeTransport(is_structured=is_structured)  # type: ignore[assignment]
+    return runtime
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_source_started_for_unstructured_transport(tmp_path: Path) -> None:
+    """A plugin returning a source has it started when transport.is_structured=False."""
+    _RunningSource.started = False
+    source = _RunningSource()
+
+    runtime = _make_runtime(tmp_path, source, is_structured=False)
+    session = _make_session(tmp_path)
+    runtime.storage.create_session(session)
+
+    runtime._start_context_usage_source(session)
+
+    assert session.id in runtime._context_usage_sources
+    task = runtime._context_usage_sources[session.id]
+    assert not task.done()
+    await asyncio.sleep(0)
+    assert _RunningSource.started
+
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+
+async def test_source_not_started_for_structured_transport(tmp_path: Path) -> None:
+    """A plugin returning a source has nothing started when transport.is_structured=True."""
+    source = _RunningSource()
+
+    runtime = _make_runtime(tmp_path, source, is_structured=True)
+    session = _make_session(tmp_path)
+    runtime.storage.create_session(session)
+
+    runtime._start_context_usage_source(session)
+
+    assert session.id not in runtime._context_usage_sources
+
+
+async def test_source_cancelled_on_cancel(tmp_path: Path) -> None:
+    """_cancel_context_usage_source cancels and removes the task."""
+    source = _RunningSource()
+
+    runtime = _make_runtime(tmp_path, source, is_structured=False)
+    session = _make_session(tmp_path)
+    runtime.storage.create_session(session)
+
+    runtime._start_context_usage_source(session)
+    assert session.id in runtime._context_usage_sources
+
+    await runtime._cancel_context_usage_source(session.id)
+
+    assert session.id not in runtime._context_usage_sources
+
+
+async def test_none_source_starts_nothing(tmp_path: Path) -> None:
+    """A plugin returning None from create_context_usage_source starts no task."""
+    runtime = _make_runtime(tmp_path, None, is_structured=False)
+    session = _make_session(tmp_path)
+    runtime.storage.create_session(session)
+
+    runtime._start_context_usage_source(session)
+
+    assert session.id not in runtime._context_usage_sources
+
+
+async def test_source_cancelled_on_natural_exit_via_record_system_event(
+    tmp_path: Path,
+) -> None:
+    """Natural exits (tmux pane dead, lost target, monitor failure) route through
+    _record_system_event; the source must be cancelled there, not only on terminate().
+    """
+    source = _RunningSource()
+
+    runtime = _make_runtime(tmp_path, source, is_structured=False)
+    session = _make_session(tmp_path)
+    runtime.storage.create_session(session)
+    runtime._start_context_usage_source(session)
+    assert session.id in runtime._context_usage_sources
+
+    await runtime._record_system_event(
+        session.id, "tmux pane closed", status=SessionStatus.EXITED
+    )
+
+    assert session.id not in runtime._context_usage_sources
+
+
+async def test_source_cancelled_on_delete_already_exited(tmp_path: Path) -> None:
+    """delete() of an already-EXITED session must cancel any lingering source
+    since terminate() is skipped for EXITED sessions."""
+    source = _RunningSource()
+
+    runtime = _make_runtime(tmp_path, source, is_structured=False)
+    session = _make_session(tmp_path)
+    runtime.storage.create_session(session)
+
+    # Manually start the source and mark the session EXITED without routing
+    # through _record_system_event, simulating a source that leaked.
+    runtime._start_context_usage_source(session)
+    runtime.storage.update_session(session.id, status=SessionStatus.EXITED)
+    assert session.id in runtime._context_usage_sources
+
+    await runtime.delete(session.id)
+
+    assert session.id not in runtime._context_usage_sources

--- a/backend/tests/test_opencode_usage_source.py
+++ b/backend/tests/test_opencode_usage_source.py
@@ -1,0 +1,348 @@
+"""Unit tests for the opencode SQLite-based ContextUsageSource."""
+
+import asyncio
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from waypoint.backends.opencode.usage_source import (
+    OpenCodeTmuxUsageSource,
+    _find_session_id,
+    _latest_assistant_snapshot,
+    _snapshot_from_data,
+)
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db_path = tmp_path / "opencode.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("""
+        CREATE TABLE session (
+            id TEXT PRIMARY KEY,
+            directory TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE message (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            time_created INTEGER NOT NULL,
+            time_updated INTEGER NOT NULL,
+            data TEXT NOT NULL
+        )
+    """)
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_session(
+    db_path: Path, session_id: str, directory: str, time_updated: int = 1000
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO session (id, directory, time_created, time_updated) VALUES (?, ?, ?, ?)",
+        (session_id, directory, time_updated, time_updated),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _insert_message(
+    db_path: Path, msg_id: str, session_id: str, data: dict, time_updated: int = 1000
+) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?, ?, ?, ?, ?)",
+        (msg_id, session_id, time_updated, time_updated, json.dumps(data)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_snapshot_from_data_basic() -> None:
+    data = {
+        "role": "assistant",
+        "modelID": "gemini-3.1-pro-preview",
+        "providerID": "google",
+        "tokens": {
+            "input": 10200,
+            "output": 18,
+            "reasoning": 77,
+            "cache": {"write": 0, "read": 0},
+        },
+    }
+    snapshot = _snapshot_from_data(data)
+    assert snapshot is not None
+    assert snapshot.used_tokens == 10200  # input + cache_read + cache_write = 10200+0+0
+    assert snapshot.context_window_tokens is None
+    assert snapshot.source == "opencode"
+    assert snapshot.breakdown["input_tokens"] == 10200
+    assert snapshot.breakdown["output_tokens"] == 18
+    assert snapshot.breakdown["reasoning_tokens"] == 77
+
+
+def test_snapshot_from_data_with_cache_tokens() -> None:
+    data = {
+        "role": "assistant",
+        "tokens": {
+            "input": 5000,
+            "output": 100,
+            "cache": {"write": 200, "read": 1500},
+        },
+    }
+    snapshot = _snapshot_from_data(data)
+    assert snapshot is not None
+    assert snapshot.used_tokens == 5000 + 200 + 1500
+    assert snapshot.breakdown["cache_read_tokens"] == 1500
+    assert snapshot.breakdown["cache_write_tokens"] == 200
+
+
+def test_snapshot_from_data_no_tokens() -> None:
+    data = {"role": "assistant"}
+    assert _snapshot_from_data(data) is None
+
+
+def test_snapshot_from_data_zero_used_tokens() -> None:
+    data = {
+        "role": "assistant",
+        "tokens": {"input": 0, "output": 5, "cache": {"write": 0, "read": 0}},
+    }
+    assert _snapshot_from_data(data) is None
+
+
+def test_find_session_id_matches_directory(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_abc", "/some/dir", time_updated=1000)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert _find_session_id(conn, "/some/dir") == "ses_abc"
+        assert _find_session_id(conn, "/other/dir") is None
+    finally:
+        conn.close()
+
+
+def test_find_session_id_most_recent(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_old", "/proj", time_updated=1000)
+    _insert_session(db_path, "ses_new", "/proj", time_updated=2000)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert _find_session_id(conn, "/proj") == "ses_new"
+    finally:
+        conn.close()
+
+
+def test_find_session_id_trailing_slash(tmp_path: Path) -> None:
+    """Stored directory with a trailing slash matches cwd without one (and vice versa)."""
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_slash", "/some/dir/", time_updated=1000)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert _find_session_id(conn, "/some/dir") == "ses_slash"
+    finally:
+        conn.close()
+
+
+def test_find_session_id_symlink(tmp_path: Path) -> None:
+    """A cwd that is a symlink to the stored directory is still matched."""
+    real_dir = tmp_path / "real"
+    real_dir.mkdir()
+    link_dir = tmp_path / "link"
+    link_dir.symlink_to(real_dir)
+
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_real", str(real_dir), time_updated=1000)
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        # cwd is the symlink path; DB stores the real path — must still match.
+        assert _find_session_id(conn, str(link_dir)) == "ses_real"
+    finally:
+        conn.close()
+
+
+def test_latest_assistant_snapshot_yields_snapshot(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_1", "/repo")
+    _insert_message(
+        db_path,
+        "msg_1",
+        "ses_1",
+        {
+            "role": "assistant",
+            "modelID": "claude-opus-4-5",
+            "providerID": "anthropic",
+            "tokens": {
+                "input": 8000,
+                "output": 200,
+                "reasoning": 0,
+                "cache": {"write": 100, "read": 500},
+            },
+        },
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        snapshot = _latest_assistant_snapshot(conn, "ses_1")
+    finally:
+        conn.close()
+
+    assert snapshot is not None
+    assert snapshot.used_tokens == 8000 + 100 + 500
+    assert snapshot.context_window_tokens is None
+    assert snapshot.source == "opencode"
+
+
+def test_latest_assistant_snapshot_returns_newest(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_1", "/repo")
+    _insert_message(
+        db_path,
+        "msg_1",
+        "ses_1",
+        {
+            "role": "assistant",
+            "tokens": {"input": 100, "output": 5, "cache": {"write": 0, "read": 0}},
+        },
+        time_updated=100,
+    )
+    _insert_message(
+        db_path,
+        "msg_2",
+        "ses_1",
+        {
+            "role": "assistant",
+            "tokens": {"input": 999, "output": 10, "cache": {"write": 0, "read": 0}},
+        },
+        time_updated=200,
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        snapshot = _latest_assistant_snapshot(conn, "ses_1")
+    finally:
+        conn.close()
+
+    assert snapshot is not None
+    assert snapshot.used_tokens == 999
+
+
+def test_latest_assistant_snapshot_ignores_user_messages(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_1", "/repo")
+    _insert_message(
+        db_path,
+        "msg_1",
+        "ses_1",
+        {
+            "role": "user",
+            "tokens": {"input": 999, "output": 0, "cache": {"write": 0, "read": 0}},
+        },
+    )
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        snapshot = _latest_assistant_snapshot(conn, "ses_1")
+    finally:
+        conn.close()
+
+    assert snapshot is None
+
+
+async def test_run_publishes_on_change(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_1", "/repo")
+    _insert_message(
+        db_path,
+        "msg_1",
+        "ses_1",
+        {
+            "role": "assistant",
+            "tokens": {"input": 3000, "output": 50, "cache": {"write": 0, "read": 0}},
+        },
+    )
+
+    runtime = MagicMock()
+    runtime.update_session_fields = AsyncMock()
+
+    source = OpenCodeTmuxUsageSource(
+        session_id="s1",
+        cwd="/repo",
+        runtime=runtime,
+        db_dir=tmp_path,
+    )
+
+    task = asyncio.create_task(source.run())
+    await asyncio.sleep(0.05)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    runtime.update_session_fields.assert_called_once()
+    _, kwargs = runtime.update_session_fields.call_args
+    snapshot = kwargs["context_usage"]
+    assert snapshot.used_tokens == 3000
+
+
+async def test_run_deduplicates_same_snapshot(tmp_path: Path) -> None:
+    db_path = _make_db(tmp_path)
+    _insert_session(db_path, "ses_1", "/repo")
+    _insert_message(
+        db_path,
+        "msg_1",
+        "ses_1",
+        {
+            "role": "assistant",
+            "tokens": {"input": 1000, "output": 20, "cache": {"write": 0, "read": 0}},
+        },
+    )
+
+    runtime = MagicMock()
+    runtime.update_session_fields = AsyncMock()
+
+    source = OpenCodeTmuxUsageSource(
+        session_id="s1",
+        cwd="/repo",
+        runtime=runtime,
+        db_dir=tmp_path,
+        # Override poll interval so we get two polls quickly
+    )
+    # Patch the poll interval for the test by running two iterations
+    source._signature = None
+
+    # First call publishes
+    snap1 = await asyncio.to_thread(source._query_snapshot)
+    assert snap1 is not None
+    sig1 = (snap1.used_tokens, snap1.context_window_tokens)
+    assert sig1 != source._signature
+    source._signature = sig1
+    await runtime.update_session_fields(source._session_id, context_usage=snap1)
+
+    # Second call with same DB — should NOT publish again
+    snap2 = await asyncio.to_thread(source._query_snapshot)
+    assert snap2 is not None
+    sig2 = (snap2.used_tokens, snap2.context_window_tokens)
+    assert sig2 == source._signature  # deduped
+
+    # update_session_fields called exactly once (only in the first call above)
+    assert runtime.update_session_fields.call_count == 1
+
+
+def test_query_snapshot_missing_db(tmp_path: Path) -> None:
+    runtime = MagicMock()
+    source = OpenCodeTmuxUsageSource(
+        session_id="s1",
+        cwd="/repo",
+        runtime=runtime,
+        db_dir=tmp_path / "nonexistent",
+    )
+    assert source._query_snapshot() is None

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -843,3 +843,73 @@ async def test_rate_limit_watcher_stops_on_natural_exit(
     # The loop's next iteration should observe the EXITED status and exit.
     await asyncio.wait_for(task, timeout=1.0)
     assert session.id not in runtime._rate_limit_watchers
+
+
+def _ctx_session(backend: str) -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id="s-ctx",
+        backend=backend,
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="t",
+        cwd="/proj",
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        transport_state={},
+        raw_log_path="/tmp/s-ctx.raw.log",
+        structured_log_path="/tmp/s-ctx.events.jsonl",
+    )
+
+
+class _CtxRegistry:
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def has_backend(self, backend_id: str) -> bool:
+        return backend_id == "claude_code"
+
+    def get(self, _backend_id: str) -> Any:
+        return self._inner
+
+
+class _CtxRuntime:
+    def __init__(self, inner: Any) -> None:
+        self.registry = _CtxRegistry(inner)
+
+
+def test_create_context_usage_source_delegates_to_inner_agent(
+    plugin: TmuxPlugin,
+) -> None:
+    sentinel = object()
+    captured: dict[str, Any] = {}
+
+    class _Inner:
+        def create_context_usage_source(self, session: Any, runtime: Any) -> Any:
+            captured["session"] = session
+            return sentinel
+
+    session = _ctx_session("claude_code")
+    runtime = _CtxRuntime(_Inner())
+    result = plugin.create_context_usage_source(session, cast(Any, runtime))
+    assert result is sentinel
+    assert captured["session"] is session
+
+
+def test_create_context_usage_source_none_for_self_or_unknown_backend(
+    plugin: TmuxPlugin,
+) -> None:
+    runtime = _CtxRuntime(object())
+    # wrapper's own id -> no inner agent to delegate to
+    assert (
+        plugin.create_context_usage_source(_ctx_session("tmux"), cast(Any, runtime))
+        is None
+    )
+    # a valid agent the registry doesn't have loaded -> None, no delegation
+    # (_CtxRegistry.has_backend only knows claude_code)
+    assert (
+        plugin.create_context_usage_source(_ctx_session("codex"), cast(Any, runtime))
+        is None
+    )


### PR DESCRIPTION
## Summary

Context usage (the per-session token pill) was populated only by the native structured adapters (`claude_cli`, `codex_app_server`, `opencode_http`). Sessions on the Emulated `claude_tty` transport and on the generic `tmux` transport showed nothing, because neither exposes a live structured usage stream.

The key observation: **context usage is an agent-axis concern, not a transport one** — the token counts always live in the agent's own on-disk artifact, regardless of how Waypoint drives it. So this adds a per-plugin usage *source* plus a small lifecycle gate, with no per-backend branching in the runtime or transports. The frontend already renders `context_usage`, so this is backend-only.

User-visible outcomes:

1. **`claude_tty` sessions now show context usage.** The existing transcript tailer already parsed `message.usage`; it now also publishes a `SessionContextUsage` snapshot.
2. **`tmux`-transport sessions show context usage**, recovered from each agent's own artifact: Claude's transcript JSONL (byte-offset tail), Codex's rollout JSONL (`token_count` events, snake-case fields), and OpenCode's SQLite DB (`opencode.db`, read-only poll of the latest assistant message).
3. **The context window respects the configured model.** The window is resolved from the session's model alias (which carries the `[1m]` marker), not the transcript's resolved API id — so a 1M-context session reports 1,000,000, and a mid-session model switch is reflected on the next snapshot.

## Changes

### Backend

- **`backends/context_usage_source.py`** *(new)* — `ContextUsageSource`, a cancellable background task that reads an agent artifact and publishes via `runtime.update_session_fields(context_usage=...)`.
- **`backends/base.py`** — `BackendPlugin.create_context_usage_source(session, runtime) -> ContextUsageSource | None`, default `None`.
- **`runtime.py`** — starts the plugin's source for any session whose active transport has `is_structured == False`, tracks it per-session, and cancels it on every terminal transition (the `_record_system_event` chokepoint covers natural tmux exits — `/exit`, pane-dead, monitor failure — plus explicit terminate and delete-of-already-exited).
- **`backends/claude_tty/tailer.py`** — the transcript tailer builds and publishes a snapshot per assistant record (reusing `_context_usage_snapshot_from_message`), with `(used_tokens, context_window_tokens)` signature dedup.
- **`backends/claude_code/usage_source.py`** *(new)* — `TranscriptContextUsageSource` tails the Claude TUI transcript for `tmux`-wrapped Claude sessions (transcript located via the pregenerated `thread_id`).
- **`backends/codex/usage_source.py`** *(new)* — `CodexRolloutUsageSource` tails `~/.codex/sessions/.../rollout-*.jsonl`, polling `transport_state` for the watcher-supplied `thread_id`, and maps the rollout's snake-case `last_token_usage.total_tokens` / `model_context_window`.
- **`backends/opencode/usage_source.py`** *(new)* — `OpenCodeTmuxUsageSource` polls `opencode.db` read-only (`mode=ro&immutable=1`), matching the session row by realpath-normalized directory and summing `input + cache.read + cache.write` from the latest assistant message.
- **`backends/{claude_code,codex,opencode}/plugin.py`** — each agent plugin returns its source only for the `tmux` transport; **`backends/tmux/plugin.py`** delegates `create_context_usage_source` to the wrapped agent plugin (the wrapper, not the agent, is what `plugin_for` resolves for a tmux session).
- **`backends/claude_tty/tailer.py`, `backends/claude_code/usage_source.py`** — resolve the context window from the session's configured model, read fresh on each publish so a dynamic model change is reflected.

### Tests

- New unit suites for the spine lifecycle, the claude_tty publish, and each of the three usage sources (including the `[1m]` window, a dynamic model-change, the Codex `token_count` mapping, and the OpenCode trailing-slash / symlink directory match).
- **`tests/test_tmux_plugin.py`** — the tmux wrapper delegates to the inner agent plugin (and returns `None` for its own id or an unknown backend).

## Test Plan

- [x] `cd backend && uv run pytest` — 941 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort / black / ruff / codespell / mypy clean.
- [x] Live, on the restarted stack: a `claude_tty` `opus[1m]` session reported `context_window_tokens=1000000`; a `claude_code`/`tmux` `sonnet[1m]` session populated `context_usage` with the 1M window (both initially regressed and were fixed — the tmux delegation and the session-model window).

🤖 Generated with [Claude Code](https://claude.com/claude-code)