### PR TITLE
feat: add a pin toggle to the session detail header

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1248,6 +1248,16 @@ html[data-theme="light"] .session-header {
     transparent 100%
   );
   opacity: 0.55;
+  transition:
+    width 0.2s ease,
+    opacity 0.2s ease,
+    background 0.2s ease;
+}
+
+.session-header.pinned::before {
+  width: 3px;
+  background: var(--accent);
+  opacity: 1;
 }
 
 .session-header-top {
@@ -8992,6 +9002,33 @@ html[data-theme="light"] .term-compose-input {
 
 .edit-title-btn:hover {
   opacity: 1;
+}
+
+.session-header-pin {
+  font-size: 1.04rem;
+  line-height: 1;
+  padding: 0 4px;
+  color: var(--muted);
+  opacity: 0.7;
+  transition:
+    color 0.18s ease,
+    opacity 0.18s ease,
+    transform 0.18s ease;
+}
+
+.session-header-pin:hover {
+  color: var(--accent-strong);
+  opacity: 1;
+}
+
+.session-header-pin.active {
+  color: var(--accent);
+  opacity: 1;
+  text-shadow: 0 0 10px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.session-header-pin.active:hover {
+  transform: scale(1.08);
 }
 
 .session-card-title,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1250,8 +1250,7 @@ html[data-theme="light"] .session-header {
   opacity: 0.55;
   transition:
     width 0.2s ease,
-    opacity 0.2s ease,
-    background 0.2s ease;
+    opacity 0.2s ease;
 }
 
 .session-header.pinned::before {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -35,6 +35,7 @@ import {
   setSessionEffort,
   setSessionModel,
   setSessionPermissionMode,
+  setSessionPinned,
   setSessionTitle,
 } from "@/lib/api";
 import {
@@ -1187,6 +1188,22 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     [host, token, sessionId, handleAuthFailure],
   );
 
+  const handleSetPinned = useCallback(
+    async (pinned: boolean) => {
+      try {
+        const updated = await setSessionPinned(host, token, sessionId, pinned);
+        setSession(updated);
+      } catch (pinError) {
+        if (isAuthError(pinError)) {
+          handleAuthFailure();
+          return;
+        }
+        setError(pinError instanceof Error ? pinError.message : "failed to update pin");
+      }
+    },
+    [host, token, sessionId, handleAuthFailure],
+  );
+
   async function submitApproval(decision: string, text?: string, approvalId?: string) {
     try {
       await approveSession(host, token, sessionId, decision, text, approvalId);
@@ -1587,6 +1604,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           modelOptions={modelOptions}
           catalog={catalog}
           onSetTitle={handleSetTitle}
+          onSetPinned={handleSetPinned}
           assistant={assistant}
         />
       ) : (
@@ -3685,6 +3703,7 @@ function SessionHeader({
   modelOptions,
   catalog,
   onSetTitle,
+  onSetPinned,
   assistant = false,
 }: {
   session: SessionRecord;
@@ -3692,6 +3711,7 @@ function SessionHeader({
   modelOptions: BackendModelOption[];
   catalog: BackendCatalog;
   onSetTitle?: (title: string) => void | Promise<void>;
+  onSetPinned?: (pinned: boolean) => void | Promise<void>;
   assistant?: boolean;
 }) {
   const cwdSegments = formatCwdSegments(session.cwd);
@@ -3704,6 +3724,7 @@ function SessionHeader({
   const showHeaderTransport =
     headerAgentDefault !== null && session.transport !== headerAgentDefault;
   const sourceLabel = session.source === "managed" ? "Managed" : "Attached";
+  const pinned = Boolean(session.pinned_at);
   const [isEditing, setIsEditing] = useState(false);
   const [draftTitle, setDraftTitle] = useState("");
 
@@ -3731,7 +3752,7 @@ function SessionHeader({
   }
 
   return (
-    <header className="session-header">
+    <header className={`session-header${pinned ? " pinned" : ""}`}>
       <div className="session-header-top">
         <div className="session-header-title-row">
           {isEditing ? (
@@ -3756,6 +3777,18 @@ function SessionHeader({
                   aria-label="Rename session"
                 >
                   ✎
+                </button>
+              ) : null}
+              {onSetPinned && !assistant ? (
+                <button
+                  className={`link-button session-header-pin${pinned ? " active" : ""}`}
+                  type="button"
+                  onClick={() => void onSetPinned(!pinned)}
+                  title={pinned ? "Unpin session" : "Pin session"}
+                  aria-label={pinned ? "Unpin session" : "Pin session"}
+                  aria-pressed={pinned}
+                >
+                  {pinned ? "★" : "☆"}
                 </button>
               ) : null}
             </>


### PR DESCRIPTION
## Summary

Session pinning was reachable only from the homepage session cards. The session detail page already loads `pinned_at` and the pin endpoints (`POST`/`DELETE /api/sessions/{id}/pin`) are session-scoped, so this is a frontend-only change that surfaces the same toggle in the detail header.

User-visible outcomes:

1. **The session detail header has a pin toggle.** A star button sits beside the rename (✎) control — ☆ when unpinned, ★ when pinned — and clicking it pins/unpins the session. It's gated to non-assistant sessions, matching the rename control (pinning the persistent assistant isn't meaningful).
2. **Pinned state reads consistently across views.** When pinned, the header's left accent rail goes solid gold full-width, echoing the gold rail on pinned session *cards*, so "pinned" looks the same on the homepage and the detail page.

One known limitation: the toggle updates immediately from the pin endpoint's returned record, but the detail page's per-session socket doesn't receive a push if pinning happens from another client — it reflects on next load. This matches how title edits already behave.

## Changes

### Frontend

- **`components/SessionDetail.tsx`** — adds a `handleSetPinned` callback mirroring the existing `handleSetTitle` (calls `setSessionPinned`, updates local session state, same auth-failure handling), passes it into `SessionHeader`, and renders the star toggle in the title row. `SessionHeader` gains an `onSetPinned` prop and a `pinned` modifier class derived from `Boolean(session.pinned_at)`.
- **`app/globals.css`** — `.session-header-pin` gets muted/gold states matching the card pin link, and `.session-header.pinned::before` widens the left rail to solid gold. All colors resolve through theme variables, so light mode adapts without a separate override.

## Test Plan

- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run build` — compiled successfully.
- [x] Restarted the frontend (`waypointctl restart frontend`) — came up healthy serving this branch.
- [ ] Not run: in-app manual click-through that the toggle pins/unpins and the rail lights up in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)