### PR TITLE
fix: reliably deliver messages to tmux-wrapped agent sessions

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -18,6 +18,28 @@ if TYPE_CHECKING:
 
 
 @runtime_checkable
+class PaneSubmitConfirming(Protocol):
+    """A plugin whose tmux-wrapped TUI can absorb the submit ``Enter`` while it
+    is still ingesting a paste — e.g. the Claude TUI loading an image pasted by
+    path — leaving the message typed in the composer but unsent.
+
+    The tmux transport narrows to this protocol (``isinstance``) and, when a
+    plugin satisfies it, sends ``Enter`` and confirms the composer actually
+    cleared via :meth:`confirm_pane_submit`, retrying the keystroke if it was
+    swallowed. Agents whose composer submits synchronously simply do not
+    implement it and keep the single-``Enter`` path.
+    """
+
+    def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
+        """Return whether the just-sent input has left the composer (submitted),
+        given a ``capture-pane`` snapshot of the wrapped TUI and the text that
+        was sent. Agents that render input literally check that ``sent_text``
+        no longer occupies the composer; ones that collapse it (Claude pastes an
+        image to an ``[Image]`` chip) check that the composer is empty instead."""
+        ...
+
+
+@runtime_checkable
 class BackendPlugin(Protocol):
     """Source of truth for everything backend-specific.
 

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -44,6 +44,15 @@ class PaneSubmitConfirming(Protocol):
         pasting into a TUI that will drop the keystrokes."""
         ...
 
+    def pane_shows_blocking_dialog(self, pane_text: str) -> bool:
+        """Return whether a modal popup (tool-permission approval, trust prompt,
+        AskUserQuestion, model/effort picker) is on screen. Such dialogs capture
+        ``Enter`` to select an option, so the transport must not paste a message
+        or fire the submit ``Enter`` into one — that would silently approve a
+        tool or accept a prompt. Agents that cannot read their dialogs off the
+        pane return False (the guard is then a no-op for them)."""
+        ...
+
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         """Return whether the just-sent input has left the composer (submitted),
         given a ``capture-pane`` snapshot of the wrapped TUI and the text that

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -19,16 +19,30 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class PaneSubmitConfirming(Protocol):
-    """A plugin whose tmux-wrapped TUI can absorb the submit ``Enter`` while it
-    is still ingesting a paste — e.g. the Claude TUI loading an image pasted by
-    path — leaving the message typed in the composer but unsent.
+    """A plugin that can read its tmux-wrapped TUI's composer to drive input
+    reliably, against two failure modes of a raw ``send-keys`` submit:
 
-    The tmux transport narrows to this protocol (``isinstance``) and, when a
-    plugin satisfies it, sends ``Enter`` and confirms the composer actually
-    cleared via :meth:`confirm_pane_submit`, retrying the keystroke if it was
-    swallowed. Agents whose composer submits synchronously simply do not
-    implement it and keep the single-``Enter`` path.
+    - A freshly relaunched pane (reattach after exit, or a model/permission
+      restart) is still booting when the message is sent, so the composer does
+      not yet exist and the keystrokes are dropped.
+    - The composer exists but absorbs the submit ``Enter`` while ingesting the
+      paste — e.g. the Claude TUI loading an image pasted by path — leaving the
+      message typed but unsent.
+
+    The tmux transport narrows to this protocol (``isinstance``) and, for a
+    plugin that satisfies it, waits for :meth:`pane_ready_for_input` before
+    pasting, then sends ``Enter`` and confirms the composer cleared via
+    :meth:`confirm_pane_submit`, retrying the keystroke if it was swallowed.
+    Agents whose composer submits synchronously simply do not implement it and
+    keep the single-``Enter`` path.
     """
+
+    def pane_ready_for_input(self, pane_text: str) -> bool:
+        """Return whether the wrapped TUI's composer is rendered and able to
+        accept input, given a ``capture-pane`` snapshot. False while the pane is
+        still booting (no composer drawn yet), so the transport waits rather than
+        pasting into a TUI that will drop the keystrokes."""
+        ...
 
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         """Return whether the just-sent input has left the composer (submitted),

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -58,6 +58,7 @@ from waypoint.backends.claude_code.threads import (
     list_local_claude_threads,
 )
 from waypoint.backends.claude_code.threads_remote import RemoteClaudeThreadEnumerator
+from waypoint.backends.claude_tty.pane_dialog import composer_is_empty
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.backends.tmux.plugin import TmuxPlugin
@@ -183,6 +184,15 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         from waypoint.backends.claude_code.transport import ClaudeTransport
 
         return ClaudeTransport(runtime, self)
+
+    def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
+        # Over the tmux/Terminal transport the Claude TUI can absorb the submit
+        # Enter while loading an image pasted by path; the composer clearing is
+        # the signal the message was actually sent. The TUI collapses a pasted
+        # message to an ``[Image]``/``[Pasted text]`` chip, so the sent text is
+        # not literally on screen — emptiness is the only reliable signal.
+        # Shared with claude_tty, which wraps the same TUI.
+        return composer_is_empty(pane_text)
 
     def setup(self, runtime: "SessionRuntime") -> None:
         # Build the host-side support bundle, the CLI adapter, and the remote

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -58,7 +58,7 @@ from waypoint.backends.claude_code.threads import (
     list_local_claude_threads,
 )
 from waypoint.backends.claude_code.threads_remote import RemoteClaudeThreadEnumerator
-from waypoint.backends.claude_tty.pane_dialog import composer_is_empty
+from waypoint.backends.claude_tty.pane_dialog import composer_is_empty, composer_ready
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.backends.tmux.plugin import TmuxPlugin
@@ -184,6 +184,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         from waypoint.backends.claude_code.transport import ClaudeTransport
 
         return ClaudeTransport(runtime, self)
+
+    def pane_ready_for_input(self, pane_text: str) -> bool:
+        return composer_ready(pane_text)
 
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # Over the tmux/Terminal transport the Claude TUI can absorb the submit

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -58,7 +58,11 @@ from waypoint.backends.claude_code.threads import (
     list_local_claude_threads,
 )
 from waypoint.backends.claude_code.threads_remote import RemoteClaudeThreadEnumerator
-from waypoint.backends.claude_tty.pane_dialog import composer_is_empty, composer_ready
+from waypoint.backends.claude_tty.pane_dialog import (
+    composer_is_empty,
+    composer_ready,
+    shows_blocking_dialog,
+)
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.backends.tmux.plugin import TmuxPlugin
@@ -187,6 +191,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
 
     def pane_ready_for_input(self, pane_text: str) -> bool:
         return composer_ready(pane_text)
+
+    def pane_shows_blocking_dialog(self, pane_text: str) -> bool:
+        return shows_blocking_dialog(pane_text)
 
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # Over the tmux/Terminal transport the Claude TUI can absorb the submit

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -116,6 +116,17 @@ _COMPOSER_PROMPT = "❯"
 _COMPOSER_PLACEHOLDER_PREFIX = 'Try "'
 
 
+def composer_ready(screen: str) -> bool:
+    """Whether the Claude TUI composer prompt is drawn and able to take input.
+
+    True once the ``❯`` prompt line exists. A freshly relaunched pane (reattach
+    or restart) shows the boot screen with no prompt for a beat; the tmux
+    transport waits on this before pasting so the keystrokes are not dropped.
+    """
+    lines = _strip_ansi(screen).replace("\xa0", " ").splitlines()
+    return any(_COMPOSER_PROMPT in line for line in lines)
+
+
 def composer_is_empty(screen: str) -> bool:
     """Whether the Claude TUI composer (input box) is empty.
 
@@ -125,13 +136,14 @@ def composer_is_empty(screen: str) -> bool:
     and returns to a bare prompt (while a turn runs) or the idle placeholder
     (once idle) after — which is how the tmux submit-confirm loop tells an
     absorbed ``Enter`` (composer still populated) from a real submission. If no
-    prompt line is found, treat it as empty so the caller does not retry blindly
-    (its loop is bounded regardless).
+    prompt line is found the composer is not drawn (a booting or dead pane), so
+    nothing has been submitted — return False so the bounded confirm loop keeps
+    retrying rather than declaring a phantom success.
     """
     lines = _strip_ansi(screen).replace("\xa0", " ").splitlines()
     prompt_lines = [line for line in lines if _COMPOSER_PROMPT in line]
     if not prompt_lines:
-        return True
+        return False
     after_prompt = prompt_lines[-1].split(_COMPOSER_PROMPT, 1)[1].strip()
     return after_prompt == "" or after_prompt.startswith(_COMPOSER_PLACEHOLDER_PREFIX)
 

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -16,6 +16,8 @@ import re
 from dataclasses import dataclass
 from enum import StrEnum
 
+from waypoint.backends.pane_text import strip_ansi, strip_whitespace
+
 
 class PaneScreen(StrEnum):
     APPROVAL = "approval"
@@ -56,21 +58,14 @@ _TRUST_MARKER = "Is this a project you created or one you trust?"
 _OPTION_RE = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
 _QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
-_WHITESPACE_RE = re.compile(r"\s+")
-# CSI / OSC / two-byte escape sequences. A pane captured with `tmux capture-pane
-# -e` carries colour and cursor codes interleaved with the text, which would
-# shred the substring/regex anchors; strip them before any matching.
-_ANSI_RE = re.compile(
-    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
-)
 
 
 def _strip_ansi(text: str) -> str:
-    return _ANSI_RE.sub("", text)
+    return strip_ansi(text)
 
 
 def _compact(text: str) -> str:
-    return _WHITESPACE_RE.sub("", text)
+    return strip_whitespace(text)
 
 
 def _contains(screen: str, screen_compact: str, marker: str) -> bool:

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -165,6 +165,18 @@ def classify(screen: str) -> PaneScreen:
     return PaneScreen.OTHER
 
 
+def shows_blocking_dialog(screen: str) -> bool:
+    """Whether a modal popup is on screen that would capture ``Enter``.
+
+    The composer prompt glyph ``❯`` also marks the selected option of an
+    approval/trust dialog, so a snapshot showing a dialog looks "ready" to the
+    composer probes. The tmux transport consults this to avoid pasting or
+    submitting a message into a dialog (which would select an option — e.g.
+    auto-approve a tool).
+    """
+    return classify(screen) is not PaneScreen.OTHER
+
+
 def _parse_options(lines: list[str]) -> list[DialogOption]:
     options: list[DialogOption] = []
     for line in lines:

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -108,6 +108,34 @@ class ApprovalDialog:
         return None
 
 
+_COMPOSER_PROMPT = "❯"
+# An idle composer shows dim ghost placeholder text (``Try "…"``) after the
+# prompt rather than a bare prompt; it is empty for submit-confirmation
+# purposes. A pending message never collides with this — an attachment turn
+# leads with the ``[Image #N]`` chip / ``Attached files:`` block.
+_COMPOSER_PLACEHOLDER_PREFIX = 'Try "'
+
+
+def composer_is_empty(screen: str) -> bool:
+    """Whether the Claude TUI composer (input box) is empty.
+
+    The composer prompt (``❯``) is the bottom-most prompt line; a submitted user
+    turn echoes *above* it in the transcript with the same glyph, so the last
+    ``❯`` line is the live input. It holds the typed message before submission
+    and returns to a bare prompt (while a turn runs) or the idle placeholder
+    (once idle) after — which is how the tmux submit-confirm loop tells an
+    absorbed ``Enter`` (composer still populated) from a real submission. If no
+    prompt line is found, treat it as empty so the caller does not retry blindly
+    (its loop is bounded regardless).
+    """
+    lines = _strip_ansi(screen).replace("\xa0", " ").splitlines()
+    prompt_lines = [line for line in lines if _COMPOSER_PROMPT in line]
+    if not prompt_lines:
+        return True
+    after_prompt = prompt_lines[-1].split(_COMPOSER_PROMPT, 1)[1].strip()
+    return after_prompt == "" or after_prompt.startswith(_COMPOSER_PLACEHOLDER_PREFIX)
+
+
 def classify(screen: str) -> PaneScreen:
     screen = _strip_ansi(screen)
     compact = _compact(screen)

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -192,6 +192,9 @@ class ClaudeTtyPlugin:
     def pane_ready_for_input(self, pane_text: str) -> bool:
         return pane_dialog.composer_ready(pane_text)
 
+    def pane_shows_blocking_dialog(self, pane_text: str) -> bool:
+        return pane_dialog.shows_blocking_dialog(pane_text)
+
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # The Claude TUI can swallow the submit Enter while loading an image
         # pasted by path; the composer clearing is how the tmux transport

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -50,6 +50,7 @@ from waypoint.backends.claude_code.threads import (
     find_local_claude_thread,
     list_local_claude_threads,
 )
+from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.completions import static_slash_completions
@@ -187,6 +188,14 @@ class ClaudeTtyPlugin:
 
     def native_thread_id(self, session: SessionRecord) -> str | None:
         return self._tmux.native_thread_id(session)
+
+    def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
+        # The Claude TUI can swallow the submit Enter while loading an image
+        # pasted by path; the composer clearing is how the tmux transport
+        # confirms the message was actually sent (vs typed-but-unsent). The TUI
+        # collapses the paste to a chip, so emptiness — not the sent text — is
+        # the signal.
+        return pane_dialog.composer_is_empty(pane_text)
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -189,6 +189,9 @@ class ClaudeTtyPlugin:
     def native_thread_id(self, session: SessionRecord) -> str | None:
         return self._tmux.native_thread_id(session)
 
+    def pane_ready_for_input(self, pane_text: str) -> bool:
+        return pane_dialog.composer_ready(pane_text)
+
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # The Claude TUI can swallow the submit Enter while loading an image
         # pasted by path; the composer clearing is how the tmux transport

--- a/backend/src/waypoint/backends/codex/pane.py
+++ b/backend/src/waypoint/backends/codex/pane.py
@@ -1,0 +1,41 @@
+"""Detect whether the Codex TUI composer still holds unsent input.
+
+Used by the tmux transport's submit-confirm loop. Codex renders input — and
+attachment paths — as literal text, and an empty composer shows a *rotating*
+ghost suggestion rather than a fixed placeholder, so submission can't be keyed
+on matching a placeholder. Instead it is keyed on the sent text no longer
+occupying the composer prompt line. The composer prompt (``›``) is the
+bottom-most prompt line; a submitted message echoes above it with the same
+glyph, so only the last ``›`` line is the live composer.
+"""
+
+import re
+
+_ANSI_RE = re.compile(
+    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+_PROMPT = "›"
+# Enough of the message to be distinctive without tripping over the TUI
+# wrapping/truncating a long composer line.
+_PROBE_LEN = 24
+
+
+def _compact(text: str) -> str:
+    return _WHITESPACE_RE.sub("", _ANSI_RE.sub("", text))
+
+
+def composer_submitted(pane_text: str, sent_text: str) -> bool:
+    """Whether ``sent_text`` has left the Codex composer (i.e. was submitted).
+
+    Returns ``True`` when the composer prompt line no longer carries the start
+    of the message. If the message is empty or the composer can't be located,
+    returns ``True`` so the caller doesn't retry blindly (its loop is bounded).
+    """
+    probe = _compact(sent_text)[:_PROBE_LEN]
+    if not probe:
+        return True
+    prompt_lines = [line for line in pane_text.splitlines() if _PROMPT in line]
+    if not prompt_lines:
+        return True
+    return probe not in _compact(prompt_lines[-1])

--- a/backend/src/waypoint/backends/codex/pane.py
+++ b/backend/src/waypoint/backends/codex/pane.py
@@ -25,17 +25,28 @@ def _compact(text: str) -> str:
     return _WHITESPACE_RE.sub("", _ANSI_RE.sub("", text))
 
 
+def composer_ready(pane_text: str) -> bool:
+    """Whether the Codex composer prompt is drawn and able to take input.
+
+    True once a ``›`` prompt line exists. A freshly relaunched pane (reattach or
+    restart) shows the boot screen with no prompt for a beat; the tmux transport
+    waits on this before pasting so the keystrokes are not dropped.
+    """
+    return any(_PROMPT in line for line in pane_text.splitlines())
+
+
 def composer_submitted(pane_text: str, sent_text: str) -> bool:
     """Whether ``sent_text`` has left the Codex composer (i.e. was submitted).
 
     Returns ``True`` when the composer prompt line no longer carries the start
-    of the message. If the message is empty or the composer can't be located,
-    returns ``True`` so the caller doesn't retry blindly (its loop is bounded).
+    of the message. An empty message counts as submitted. If the composer can't
+    be located the pane is booting or dead, so nothing has been submitted —
+    return ``False`` so the bounded confirm loop keeps retrying.
     """
     probe = _compact(sent_text)[:_PROBE_LEN]
     if not probe:
         return True
     prompt_lines = [line for line in pane_text.splitlines() if _PROMPT in line]
     if not prompt_lines:
-        return True
+        return False
     return probe not in _compact(prompt_lines[-1])

--- a/backend/src/waypoint/backends/codex/pane.py
+++ b/backend/src/waypoint/backends/codex/pane.py
@@ -9,12 +9,8 @@ bottom-most prompt line; a submitted message echoes above it with the same
 glyph, so only the last ``›`` line is the live composer.
 """
 
-import re
+from waypoint.backends.pane_text import strip_ansi, strip_whitespace
 
-_ANSI_RE = re.compile(
-    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
-)
-_WHITESPACE_RE = re.compile(r"\s+")
 _PROMPT = "›"
 # Enough of the message to be distinctive without tripping over the TUI
 # wrapping/truncating a long composer line.
@@ -22,7 +18,7 @@ _PROBE_LEN = 24
 
 
 def _compact(text: str) -> str:
-    return _WHITESPACE_RE.sub("", _ANSI_RE.sub("", text))
+    return strip_whitespace(strip_ansi(text))
 
 
 def composer_ready(pane_text: str) -> bool:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -34,6 +34,7 @@ from waypoint.backends.codex.adapter import (
     CodexAppServerAdapter,
     default_client_factory,
 )
+from waypoint.backends.codex.pane import composer_submitted
 from waypoint.backends.codex.permission_modes import (
     CODEX_PERMISSION_MODE_IDS,
     CODEX_PERMISSION_MODE_SPECS,
@@ -179,6 +180,12 @@ class CodexPlugin(DefaultLaunchContract):
         from waypoint.backends.codex.transport import CodexTransport
 
         return CodexTransport(runtime, self)
+
+    def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
+        # Over the tmux/Terminal transport the Codex TUI can absorb the submit
+        # Enter while ingesting a long typed line, leaving it unsent; the
+        # composer no longer carrying the message is the signal it was sent.
+        return composer_submitted(pane_text, sent_text)
 
     def setup(self, runtime: "SessionRuntime") -> None:
         # Codex's adapter wires straight to the App Server SDK with no

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -34,7 +34,7 @@ from waypoint.backends.codex.adapter import (
     CodexAppServerAdapter,
     default_client_factory,
 )
-from waypoint.backends.codex.pane import composer_submitted
+from waypoint.backends.codex.pane import composer_ready, composer_submitted
 from waypoint.backends.codex.permission_modes import (
     CODEX_PERMISSION_MODE_IDS,
     CODEX_PERMISSION_MODE_SPECS,
@@ -180,6 +180,9 @@ class CodexPlugin(DefaultLaunchContract):
         from waypoint.backends.codex.transport import CodexTransport
 
         return CodexTransport(runtime, self)
+
+    def pane_ready_for_input(self, pane_text: str) -> bool:
+        return composer_ready(pane_text)
 
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # Over the tmux/Terminal transport the Codex TUI can absorb the submit

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -184,6 +184,13 @@ class CodexPlugin(DefaultLaunchContract):
     def pane_ready_for_input(self, pane_text: str) -> bool:
         return composer_ready(pane_text)
 
+    def pane_shows_blocking_dialog(self, pane_text: str) -> bool:
+        # Codex's approvals run inline in its own TUI and are not surfaced to
+        # Waypoint over the generic tmux transport, and there is no pane-dialog
+        # parser to read them off the screen, so the transport's dialog guard is
+        # a no-op here. Add detection if a collision is ever observed.
+        return False
+
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # Over the tmux/Terminal transport the Codex TUI can absorb the submit
         # Enter while ingesting a long typed line, leaving it unsent; the

--- a/backend/src/waypoint/backends/opencode/pane.py
+++ b/backend/src/waypoint/backends/opencode/pane.py
@@ -4,14 +4,16 @@ Used by the tmux transport's submit-confirm loop. The composer is a bordered
 box at the bottom of the pane: ``┃`` content lines closed by a ``╹▀▀`` bottom
 border. An empty composer shows the ``Ask anything…`` placeholder, a populated
 one the typed text (OpenCode renders input, and attachment paths, literally).
-Submitted messages echo in ``┃`` boxes higher up, so the live composer is the
-``┃`` region between the second-to-last box border and the last one; submission
+Submitted messages echo in ``┃`` boxes higher up, but only the composer box is
+closed by a ``╹`` bottom border; the transcript boxes are not. So the composer
+is the run of ``┃`` lines directly above the *last* ``╹`` border, and submission
 is confirmed by the sent text no longer occupying it.
 """
 
 from waypoint.backends.pane_text import strip_ansi, strip_whitespace
 
 _BORDER = "╹"
+_CONTENT = "┃"
 _PROBE_LEN = 24
 
 
@@ -40,11 +42,14 @@ def composer_submitted(pane_text: str, sent_text: str) -> bool:
     borders = [i for i, line in enumerate(lines) if _BORDER in line]
     if not borders:
         return False
-    # The live composer spans from just below the previous box border (the
-    # transcript's last box) to the last border. Scanning the whole box rather
-    # than a fixed window keeps a tall pasted message — whose start renders at
-    # the top, furthest from the bottom border — inside the searched region.
+    # Walk up from the border over the composer box's contiguous ``┃`` content
+    # lines, stopping at the blank gap above it. This covers the full typed
+    # message — whose start renders at the top of the box, however tall it grows
+    # with wrapping or attachment paths — without bleeding into the transcript,
+    # whose echoed user-message boxes carry no ``╹`` border to scan past.
     bottom = borders[-1]
-    top = borders[-2] + 1 if len(borders) >= 2 else 0
+    top = bottom
+    while top > 0 and _CONTENT in lines[top - 1]:
+        top -= 1
     region = strip_whitespace(" ".join(lines[top:bottom]))
     return probe not in region

--- a/backend/src/waypoint/backends/opencode/pane.py
+++ b/backend/src/waypoint/backends/opencode/pane.py
@@ -5,28 +5,14 @@ box at the bottom of the pane: ``┃`` content lines closed by a ``╹▀▀`` b
 border. An empty composer shows the ``Ask anything…`` placeholder, a populated
 one the typed text (OpenCode renders input, and attachment paths, literally).
 Submitted messages echo in ``┃`` boxes higher up, so the live composer is the
-``┃`` region directly above the *last* box border; submission is confirmed by
-the sent text no longer occupying it.
+``┃`` region between the second-to-last box border and the last one; submission
+is confirmed by the sent text no longer occupying it.
 """
 
-import re
+from waypoint.backends.pane_text import strip_ansi, strip_whitespace
 
-_ANSI_RE = re.compile(
-    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
-)
-_WHITESPACE_RE = re.compile(r"\s+")
 _BORDER = "╹"
-# Content rows of the composer box sit just above its bottom border.
-_COMPOSER_SPAN = 5
 _PROBE_LEN = 24
-
-
-def _strip(text: str) -> str:
-    return _ANSI_RE.sub("", text)
-
-
-def _compact(text: str) -> str:
-    return _WHITESPACE_RE.sub("", text)
 
 
 def composer_ready(pane_text: str) -> bool:
@@ -36,7 +22,7 @@ def composer_ready(pane_text: str) -> bool:
     or restart) shows the boot screen with no box for a beat; the tmux transport
     waits on this before pasting so the keystrokes are not dropped.
     """
-    return any(_BORDER in line for line in _strip(pane_text).splitlines())
+    return any(_BORDER in line for line in strip_ansi(pane_text).splitlines())
 
 
 def composer_submitted(pane_text: str, sent_text: str) -> bool:
@@ -47,13 +33,18 @@ def composer_submitted(pane_text: str, sent_text: str) -> bool:
     located the pane is booting or dead, so nothing has been submitted — return
     ``False`` so the bounded confirm loop keeps retrying.
     """
-    probe = _compact(sent_text)[:_PROBE_LEN]
+    probe = strip_whitespace(strip_ansi(sent_text))[:_PROBE_LEN]
     if not probe:
         return True
-    lines = _strip(pane_text).splitlines()
+    lines = strip_ansi(pane_text).splitlines()
     borders = [i for i, line in enumerate(lines) if _BORDER in line]
     if not borders:
         return False
+    # The live composer spans from just below the previous box border (the
+    # transcript's last box) to the last border. Scanning the whole box rather
+    # than a fixed window keeps a tall pasted message — whose start renders at
+    # the top, furthest from the bottom border — inside the searched region.
     bottom = borders[-1]
-    region = _compact(" ".join(lines[max(0, bottom - _COMPOSER_SPAN) : bottom]))
+    top = borders[-2] + 1 if len(borders) >= 2 else 0
+    region = strip_whitespace(" ".join(lines[top:bottom]))
     return probe not in region

--- a/backend/src/waypoint/backends/opencode/pane.py
+++ b/backend/src/waypoint/backends/opencode/pane.py
@@ -1,0 +1,48 @@
+"""Detect whether the OpenCode TUI composer still holds unsent input.
+
+Used by the tmux transport's submit-confirm loop. The composer is a bordered
+box at the bottom of the pane: ``┃`` content lines closed by a ``╹▀▀`` bottom
+border. An empty composer shows the ``Ask anything…`` placeholder, a populated
+one the typed text (OpenCode renders input, and attachment paths, literally).
+Submitted messages echo in ``┃`` boxes higher up, so the live composer is the
+``┃`` region directly above the *last* box border; submission is confirmed by
+the sent text no longer occupying it.
+"""
+
+import re
+
+_ANSI_RE = re.compile(
+    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+_BORDER = "╹"
+# Content rows of the composer box sit just above its bottom border.
+_COMPOSER_SPAN = 5
+_PROBE_LEN = 24
+
+
+def _strip(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _compact(text: str) -> str:
+    return _WHITESPACE_RE.sub("", text)
+
+
+def composer_submitted(pane_text: str, sent_text: str) -> bool:
+    """Whether ``sent_text`` has left the OpenCode composer (i.e. was submitted).
+
+    Returns ``True`` when the composer box no longer carries the start of the
+    message. If the message is empty or the composer box can't be located,
+    returns ``True`` so the caller doesn't retry blindly (its loop is bounded).
+    """
+    probe = _compact(sent_text)[:_PROBE_LEN]
+    if not probe:
+        return True
+    lines = _strip(pane_text).splitlines()
+    borders = [i for i, line in enumerate(lines) if _BORDER in line]
+    if not borders:
+        return True
+    bottom = borders[-1]
+    region = _compact(" ".join(lines[max(0, bottom - _COMPOSER_SPAN) : bottom]))
+    return probe not in region

--- a/backend/src/waypoint/backends/opencode/pane.py
+++ b/backend/src/waypoint/backends/opencode/pane.py
@@ -29,12 +29,23 @@ def _compact(text: str) -> str:
     return _WHITESPACE_RE.sub("", text)
 
 
+def composer_ready(pane_text: str) -> bool:
+    """Whether the OpenCode composer box is drawn and able to take input.
+
+    True once the ``╹`` box border exists. A freshly relaunched pane (reattach
+    or restart) shows the boot screen with no box for a beat; the tmux transport
+    waits on this before pasting so the keystrokes are not dropped.
+    """
+    return any(_BORDER in line for line in _strip(pane_text).splitlines())
+
+
 def composer_submitted(pane_text: str, sent_text: str) -> bool:
     """Whether ``sent_text`` has left the OpenCode composer (i.e. was submitted).
 
     Returns ``True`` when the composer box no longer carries the start of the
-    message. If the message is empty or the composer box can't be located,
-    returns ``True`` so the caller doesn't retry blindly (its loop is bounded).
+    message. An empty message counts as submitted. If the composer box can't be
+    located the pane is booting or dead, so nothing has been submitted — return
+    ``False`` so the bounded confirm loop keeps retrying.
     """
     probe = _compact(sent_text)[:_PROBE_LEN]
     if not probe:
@@ -42,7 +53,7 @@ def composer_submitted(pane_text: str, sent_text: str) -> bool:
     lines = _strip(pane_text).splitlines()
     borders = [i for i, line in enumerate(lines) if _BORDER in line]
     if not borders:
-        return True
+        return False
     bottom = borders[-1]
     region = _compact(" ".join(lines[max(0, bottom - _COMPOSER_SPAN) : bottom]))
     return probe not in region

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -18,7 +18,7 @@ from waypoint.backends.capabilities import (
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.opencode.adapter import OpenCodeAdapter, OpenCodeError
 from waypoint.backends.opencode.health import AdapterHealth
-from waypoint.backends.opencode.pane import composer_submitted
+from waypoint.backends.opencode.pane import composer_ready, composer_submitted
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -552,6 +552,9 @@ class OpenCodePlugin(DefaultLaunchContract):
         from waypoint.backends.opencode.transport import OpenCodeTransport
 
         return OpenCodeTransport(runtime, self)
+
+    def pane_ready_for_input(self, pane_text: str) -> bool:
+        return composer_ready(pane_text)
 
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # Over the tmux/Terminal transport the OpenCode TUI can absorb the

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -18,6 +18,7 @@ from waypoint.backends.capabilities import (
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.opencode.adapter import OpenCodeAdapter, OpenCodeError
 from waypoint.backends.opencode.health import AdapterHealth
+from waypoint.backends.opencode.pane import composer_submitted
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -551,6 +552,12 @@ class OpenCodePlugin(DefaultLaunchContract):
         from waypoint.backends.opencode.transport import OpenCodeTransport
 
         return OpenCodeTransport(runtime, self)
+
+    def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
+        # Over the tmux/Terminal transport the OpenCode TUI can absorb the
+        # submit Enter while ingesting input; the composer box no longer
+        # carrying the message is the signal it was sent.
+        return composer_submitted(pane_text, sent_text)
 
     def setup(self, runtime: "SessionRuntime") -> None:
         log.info("setting up opencode plugin")

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -556,6 +556,13 @@ class OpenCodePlugin(DefaultLaunchContract):
     def pane_ready_for_input(self, pane_text: str) -> bool:
         return composer_ready(pane_text)
 
+    def pane_shows_blocking_dialog(self, pane_text: str) -> bool:
+        # OpenCode's approvals run inline in its own TUI and are not surfaced to
+        # Waypoint over the generic tmux transport, and there is no pane-dialog
+        # parser to read them off the screen, so the transport's dialog guard is
+        # a no-op here. Add detection if a collision is ever observed.
+        return False
+
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         # Over the tmux/Terminal transport the OpenCode TUI can absorb the
         # submit Enter while ingesting input; the composer box no longer

--- a/backend/src/waypoint/backends/pane_text.py
+++ b/backend/src/waypoint/backends/pane_text.py
@@ -1,0 +1,22 @@
+"""Shared text helpers for parsing captured tmux pane snapshots.
+
+A pane captured with ``tmux capture-pane -e`` carries CSI / OSC / two-byte
+escape sequences interleaved with the text, and wraps or pads composer lines —
+both of which shred the substring and regex anchors the per-backend pane probes
+rely on. Strip them before any matching.
+"""
+
+import re
+
+_ANSI_RE = re.compile(
+    r"\x1b(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\))"
+)
+_WHITESPACE_RE = re.compile(r"\s+")
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def strip_whitespace(text: str) -> str:
+    return _WHITESPACE_RE.sub("", text)

--- a/backend/src/waypoint/backends/tmux/adapter.py
+++ b/backend/src/waypoint/backends/tmux/adapter.py
@@ -76,7 +76,16 @@ class TmuxAdapter:
         if text:
             await self._send_literal_text(target, text)
         if submit:
-            await self._run("send-keys", "-t", target, "Enter")
+            await self.submit(target)
+
+    async def submit(self, target: str) -> None:
+        """Send a bare Enter to submit the pane's current composer content.
+
+        Separated from :meth:`send_input` so a caller can paste with
+        ``submit=False`` and then drive the submit on its own — e.g. retrying it
+        when the wrapped TUI swallowed the keystroke while ingesting the paste.
+        """
+        await self._run("send-keys", "-t", target, "Enter")
 
     async def send_bytes(self, target: str, data: bytes) -> None:
         """Forward arbitrary terminal input bytes to the pane.

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -57,6 +57,10 @@ class TmuxTransport(TransportAdapter):
             if confirmer is None:
                 await self.adapter.send_input(target, payload, True)
                 return
+            # A reattach/restart relaunches the pane, and the wrapped TUI is
+            # still booting when this fires — pasting before the composer exists
+            # drops the keystrokes. Wait for it to draw first.
+            await self._await_pane_ready(target, confirmer)
             # Some wrapped TUIs absorb the submit Enter while still ingesting
             # the paste (the Claude TUI does this loading an image pasted by
             # path), leaving the message typed but unsent. Paste without
@@ -68,6 +72,26 @@ class TmuxTransport(TransportAdapter):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
+
+    async def _await_pane_ready(
+        self,
+        target: str,
+        confirmer: PaneSubmitConfirming,
+        *,
+        attempts: int = 20,
+        poll_seconds: float = 0.3,
+    ) -> None:
+        # Poll until the composer is drawn so the paste lands in it rather than
+        # the boot screen. Checked before sleeping so an already-ready pane (the
+        # common case — sending to a live session) costs one snapshot and no
+        # delay. Bounded; if the TUI never reports ready, fall through and send
+        # anyway rather than block the request indefinitely.
+        for _ in range(attempts):
+            if confirmer.pane_ready_for_input(
+                await self.adapter.capture_snapshot(target)
+            ):
+                return
+            await asyncio.sleep(poll_seconds)
 
     async def _submit_confirmed(
         self,

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -59,7 +59,9 @@ class TmuxTransport(TransportAdapter):
                 return
             # A reattach/restart relaunches the pane, and the wrapped TUI is
             # still booting when this fires — pasting before the composer exists
-            # drops the keystrokes. Wait for it to draw first.
+            # drops the keystrokes. Wait for it to draw first. This also refuses
+            # to send while a modal dialog is open, so the message is never
+            # pasted (and Enter'd) into an approval/trust prompt.
             await self._await_pane_ready(target, confirmer)
             # Some wrapped TUIs absorb the submit Enter while still ingesting
             # the paste (the Claude TUI does this loading an image pasted by
@@ -87,9 +89,15 @@ class TmuxTransport(TransportAdapter):
         # delay. Bounded; if the TUI never reports ready, fall through and send
         # anyway rather than block the request indefinitely.
         for _ in range(attempts):
-            if confirmer.pane_ready_for_input(
-                await self.adapter.capture_snapshot(target)
-            ):
+            snapshot = await self.adapter.capture_snapshot(target)
+            # Never paste/Enter into a modal dialog — that would select an
+            # option (e.g. approve a tool or accept a trust prompt). Surface it
+            # so the caller responds to the dialog instead of bulldozing it.
+            if confirmer.pane_shows_blocking_dialog(snapshot):
+                raise TmuxError(
+                    "the pane has an open dialog; respond to it before sending"
+                )
+            if confirmer.pane_ready_for_input(snapshot):
                 return
             await asyncio.sleep(poll_seconds)
 
@@ -102,11 +110,20 @@ class TmuxTransport(TransportAdapter):
         attempts: int = 8,
         poll_seconds: float = 0.4,
     ) -> None:
-        # Re-send Enter until the composer reports cleared. Stop on the first
-        # confirmed submit so a landed keystroke is never followed by a stray
-        # one (which could hit a started turn or a dialog). Bounded; if the TUI
+        # Re-send Enter until the composer reports cleared. Submit before
+        # confirming so at least one Enter always lands (a snapshot taken right
+        # after the paste can transiently read as empty before the text renders,
+        # which would otherwise end the loop having sent nothing). Stop on the
+        # first confirmed submit so a landed keystroke is never followed by a
+        # stray one. Before each Enter, bail if a modal dialog is on screen — the
+        # message already submitted and opened one (or one raced in), and an
+        # Enter would select an option (e.g. approve a tool). Bounded; if the TUI
         # never confirms, leave the input rather than spamming keystrokes.
         for _ in range(attempts):
+            if confirmer.pane_shows_blocking_dialog(
+                await self.adapter.capture_snapshot(target)
+            ):
+                return
             await self.adapter.submit(target)
             await asyncio.sleep(poll_seconds)
             if confirmer.confirm_pane_submit(

--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, status
 
 from waypoint.attachments import ResolvedAttachment, append_attachment_paths
 from waypoint.backends.approvals import is_approve_decision
+from waypoint.backends.base import PaneSubmitConfirming
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import (
     SessionInputRequest,
@@ -45,12 +46,49 @@ class TmuxTransport(TransportAdapter):
         # A raw terminal can't carry binary, so attachments degrade to their
         # host paths appended to the message; the inner CLI reads them itself.
         payload = append_attachment_paths(text, attachments or [])
+        target = self._target(session)
+        # Resolve the *agent* plugin (by backend), not plugin_for(session),
+        # which is transport-keyed and returns this TmuxPlugin for the generic
+        # tmux transport — the agent (Claude/Codex/OpenCode) owns the
+        # composer-confirmation knowledge.
+        plugin = self._runtime.registry.get(session.backend)
+        confirmer = plugin if isinstance(plugin, PaneSubmitConfirming) else None
         try:
-            await self.adapter.send_input(self._target(session), payload, True)
+            if confirmer is None:
+                await self.adapter.send_input(target, payload, True)
+                return
+            # Some wrapped TUIs absorb the submit Enter while still ingesting
+            # the paste (the Claude TUI does this loading an image pasted by
+            # path), leaving the message typed but unsent. Paste without
+            # submitting, then send Enter and confirm the composer cleared,
+            # retrying the keystroke if it was swallowed.
+            await self.adapter.send_input(target, payload, submit=False)
+            await self._submit_confirmed(target, confirmer, payload)
         except TmuxError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
+
+    async def _submit_confirmed(
+        self,
+        target: str,
+        confirmer: PaneSubmitConfirming,
+        sent_text: str,
+        *,
+        attempts: int = 8,
+        poll_seconds: float = 0.4,
+    ) -> None:
+        # Re-send Enter until the composer reports cleared. Stop on the first
+        # confirmed submit so a landed keystroke is never followed by a stray
+        # one (which could hit a started turn or a dialog). Bounded; if the TUI
+        # never confirms, leave the input rather than spamming keystrokes.
+        for _ in range(attempts):
+            await self.adapter.submit(target)
+            await asyncio.sleep(poll_seconds)
+            if confirmer.confirm_pane_submit(
+                await self.adapter.capture_snapshot(target), sent_text
+            ):
+                return
 
     async def interrupt(self, session: SessionRecord) -> None:
         await self.adapter.interrupt(self._target(session))

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1204,6 +1204,11 @@ class SessionRuntime:
 
     async def resume(self, session_id: str) -> SessionRecord:
         session = self.get_session(session_id)
+        # A terminated session has no live pane to wake — sending Enter to the
+        # dead target would raise. Relaunch it instead, mirroring handle_input's
+        # reattach guard, so "Resume" on an exited session brings it back.
+        if session.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
+            return await self._reattach_session(session)
         await self.transport_for(session).resume(session)
         await self._record_system_event(
             session.id, "Sent resume", status=SessionStatus.RUNNING

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -11,6 +11,7 @@ import pytest
 from waypoint.backends.claude_tty.pane_dialog import (
     PaneScreen,
     classify,
+    composer_is_empty,
     parse_approval,
     parse_model_selector,
 )
@@ -168,3 +169,54 @@ def test_classify_robust_to_wrapped_footer() -> None:
         "Esc to cancel · Tab to amend", "Esc to cancel · Tab to\namend"
     )
     assert classify(screen) is PaneScreen.APPROVAL
+
+
+def test_composer_is_empty_for_bare_prompt() -> None:
+    # After a real submit the composer clears to a bare ``❯`` above the footer.
+    screen = "\n".join(
+        [
+            "● Done",
+            "────────────────────────────",
+            "❯ ",
+            "────────────────────────────",
+            "  ⏸ plan mode on (shift+tab to cycle)",
+        ]
+    )
+    assert composer_is_empty(screen) is True
+
+
+def test_composer_not_empty_while_message_pending() -> None:
+    # The pasted message (incl. an image chip) sits on the last ``❯`` line; a
+    # prior submitted turn echoes above with the same glyph and must be ignored.
+    screen = "\n".join(
+        [
+            "❯ earlier submitted message",
+            "────────────────────────────",
+            "❯ [Image #1]Describe the image.",
+            "  Attached files:",
+            "  - /tmp/x.png",
+            "────────────────────────────",
+            "  ⏸ plan mode on (shift+tab to cycle)",
+        ]
+    )
+    assert composer_is_empty(screen) is False
+
+
+def test_composer_is_empty_tolerates_ansi_and_nbsp() -> None:
+    # capture-pane -e carries colour codes, and the prompt is padded with a
+    # non-breaking space; both must be normalized before the emptiness check.
+    screen = "\x1b[2m❯\xa0\x1b[0m   "
+    assert composer_is_empty(screen) is True
+
+
+def test_composer_is_empty_when_no_prompt_found() -> None:
+    # No locatable composer → treat as empty so the caller does not retry
+    # blindly (its loop is bounded regardless).
+    assert composer_is_empty("just some text\nno prompt here") is True
+
+
+def test_composer_is_empty_for_idle_placeholder() -> None:
+    # An idle composer renders dim ghost placeholder text after the prompt
+    # (e.g. ``❯ Try "fix typecheck errors"``); it is empty for submit-confirm
+    # purposes, so the confirm loop must not keep firing Enter at it.
+    assert composer_is_empty(_load("ready.txt")) is True

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -15,6 +15,7 @@ from waypoint.backends.claude_tty.pane_dialog import (
     composer_ready,
     parse_approval,
     parse_model_selector,
+    shows_blocking_dialog,
 )
 
 FIXTURES = Path(__file__).parent / "fixtures" / "claude_tty_pane"
@@ -41,6 +42,26 @@ def _load(name: str) -> str:
 )
 def test_classify(fixture: str, expected: PaneScreen) -> None:
     assert classify(_load(fixture)) is expected
+
+
+@pytest.mark.parametrize(
+    "fixture, blocks",
+    [
+        ("approval_write.txt", True),
+        ("approval_bash.txt", True),
+        ("question_dialog.txt", True),
+        ("trust_dialog.txt", True),
+        ("model_selector.txt", True),
+        ("effort_popup.txt", True),
+        ("ready.txt", False),
+        ("slash_menu.txt", False),
+    ],
+)
+def test_shows_blocking_dialog(fixture: str, blocks: bool) -> None:
+    # The composer glyph ❯ also marks a dialog's selected option, so the tmux
+    # transport must treat any non-composer screen as blocking and refuse to
+    # paste/Enter into it (which would auto-select — e.g. approve a tool).
+    assert shows_blocking_dialog(_load(fixture)) is blocks
 
 
 def test_question_footers_across_variants_classify() -> None:

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -12,6 +12,7 @@ from waypoint.backends.claude_tty.pane_dialog import (
     PaneScreen,
     classify,
     composer_is_empty,
+    composer_ready,
     parse_approval,
     parse_model_selector,
 )
@@ -210,9 +211,9 @@ def test_composer_is_empty_tolerates_ansi_and_nbsp() -> None:
 
 
 def test_composer_is_empty_when_no_prompt_found() -> None:
-    # No locatable composer → treat as empty so the caller does not retry
-    # blindly (its loop is bounded regardless).
-    assert composer_is_empty("just some text\nno prompt here") is True
+    # No locatable composer → the pane is booting or dead, so nothing has been
+    # submitted; report not-empty so the confirm loop keeps retrying.
+    assert composer_is_empty("just some text\nno prompt here") is False
 
 
 def test_composer_is_empty_for_idle_placeholder() -> None:
@@ -220,3 +221,15 @@ def test_composer_is_empty_for_idle_placeholder() -> None:
     # (e.g. ``❯ Try "fix typecheck errors"``); it is empty for submit-confirm
     # purposes, so the confirm loop must not keep firing Enter at it.
     assert composer_is_empty(_load("ready.txt")) is True
+
+
+def test_composer_ready_when_prompt_drawn() -> None:
+    # The composer prompt is present once the TUI has booted.
+    assert composer_ready("❯ ") is True
+    assert composer_ready(_load("ready.txt")) is True
+
+
+def test_composer_not_ready_while_booting() -> None:
+    # A freshly relaunched pane has no prompt yet; the transport must wait
+    # rather than paste into the boot screen.
+    assert composer_ready("loading Claude...\nno prompt yet") is False

--- a/backend/tests/test_codex_pane.py
+++ b/backend/tests/test_codex_pane.py
@@ -1,0 +1,42 @@
+"""Offline validation of Codex composer-submit detection used by the tmux
+submit-confirm loop. Codex renders input literally and shows a rotating ghost
+placeholder when empty, so submission is keyed on the sent text leaving the
+last ``›`` prompt line (the live composer; submitted turns echo above it)."""
+
+from waypoint.backends.codex.pane import composer_submitted
+
+SENT = "Reply with exactly the token X and nothing else.\n\nAttached files:\n- /tmp/a"
+
+
+def test_not_submitted_while_message_in_composer() -> None:
+    pane = "\n".join(
+        [
+            "› Reply with exactly the token X and nothing else.",
+            "  Attached files:",
+            "  - /tmp/a",
+            "  gpt-5.5 xhigh · ~/waypoint",
+        ]
+    )
+    assert composer_submitted(pane, SENT) is False
+
+
+def test_submitted_when_composer_shows_rotating_placeholder() -> None:
+    # After submit the message echoes above (same glyph) and the live composer
+    # is the last ``›`` line — a ghost suggestion, never the sent text.
+    pane = "\n".join(
+        [
+            "› Reply with exactly the token X and nothing else.",  # transcript echo
+            "● working…",
+            "› Summarize recent commits",  # composer placeholder (rotates)
+            "  gpt-5.5 xhigh · ~/waypoint",
+        ]
+    )
+    assert composer_submitted(pane, SENT) is True
+
+
+def test_submitted_when_no_prompt_line() -> None:
+    assert composer_submitted("just booting\nno prompt yet", SENT) is True
+
+
+def test_empty_message_treated_as_submitted() -> None:
+    assert composer_submitted("› anything", "") is True

--- a/backend/tests/test_codex_pane.py
+++ b/backend/tests/test_codex_pane.py
@@ -3,7 +3,7 @@ submit-confirm loop. Codex renders input literally and shows a rotating ghost
 placeholder when empty, so submission is keyed on the sent text leaving the
 last ``›`` prompt line (the live composer; submitted turns echo above it)."""
 
-from waypoint.backends.codex.pane import composer_submitted
+from waypoint.backends.codex.pane import composer_ready, composer_submitted
 
 SENT = "Reply with exactly the token X and nothing else.\n\nAttached files:\n- /tmp/a"
 
@@ -34,9 +34,18 @@ def test_submitted_when_composer_shows_rotating_placeholder() -> None:
     assert composer_submitted(pane, SENT) is True
 
 
-def test_submitted_when_no_prompt_line() -> None:
-    assert composer_submitted("just booting\nno prompt yet", SENT) is True
+def test_not_submitted_when_no_prompt_line() -> None:
+    # No composer drawn → booting/dead pane, nothing submitted; keep retrying.
+    assert composer_submitted("just booting\nno prompt yet", SENT) is False
 
 
 def test_empty_message_treated_as_submitted() -> None:
     assert composer_submitted("› anything", "") is True
+
+
+def test_composer_ready_when_prompt_drawn() -> None:
+    assert composer_ready("› Summarize recent commits\n  gpt-5.5 · ~/waypoint") is True
+
+
+def test_composer_not_ready_while_booting() -> None:
+    assert composer_ready("starting codex...\nno prompt yet") is False

--- a/backend/tests/test_opencode_pane.py
+++ b/backend/tests/test_opencode_pane.py
@@ -1,0 +1,52 @@
+"""Offline validation of OpenCode composer-submit detection used by the tmux
+submit-confirm loop. The composer is a ``┃`` box closed by a ``╹▀▀`` border;
+submitted messages echo in ``┃`` boxes above, so the live composer is the
+region directly above the *last* border. Submission is keyed on the sent text
+leaving that region (an empty composer shows the ``Ask anything…`` placeholder)."""
+
+from waypoint.backends.opencode.pane import composer_submitted
+
+SENT = "Reply with exactly the token X and nothing else.\n\nAttached files:\n- /tmp/a"
+
+
+def test_not_submitted_while_message_in_composer_box() -> None:
+    pane = "\n".join(
+        [
+            "┃  earlier conversation",
+            "╹▀▀▀▀▀▀▀▀",
+            "  tab agents  ctrl+p commands",
+            "┃",
+            "┃  Reply with exactly the token X and nothing else.",
+            "┃",
+            "┃  Build · Gemini 3.1 Pro Preview Google · high",
+            "╹▀▀▀▀▀▀▀▀",
+            "  tab agents  ctrl+p commands",
+        ]
+    )
+    assert composer_submitted(pane, SENT) is False
+
+
+def test_submitted_when_composer_shows_placeholder() -> None:
+    # The message echoes in a box above; the live composer (above the last
+    # border) is back to the placeholder.
+    pane = "\n".join(
+        [
+            "┃  Reply with exactly the token X and nothing else.",  # transcript echo
+            "╹▀▀▀▀▀▀▀▀",
+            "┃",
+            '┃  Ask anything... "Fix broken tests"',
+            "┃",
+            "┃  Build · Gemini 3.1 Pro Preview Google · high",
+            "╹▀▀▀▀▀▀▀▀",
+            "  tab agents  ctrl+p commands",
+        ]
+    )
+    assert composer_submitted(pane, SENT) is True
+
+
+def test_submitted_when_no_border_found() -> None:
+    assert composer_submitted("booting opencode...", SENT) is True
+
+
+def test_empty_message_treated_as_submitted() -> None:
+    assert composer_submitted("┃  Ask anything...\n╹▀▀▀", "") is True

--- a/backend/tests/test_opencode_pane.py
+++ b/backend/tests/test_opencode_pane.py
@@ -1,68 +1,109 @@
 """Offline validation of OpenCode composer-submit detection used by the tmux
-submit-confirm loop. The composer is a ``┃`` box closed by a ``╹▀▀`` border;
-submitted messages echo in ``┃`` boxes above, so the live composer is the
-region directly above the *last* border. Submission is keyed on the sent text
-leaving that region (an empty composer shows the ``Ask anything…`` placeholder)."""
+submit-confirm loop. Captured from a live OpenCode 1.17.7 pane: the composer is
+the run of ``┃`` lines directly above the *only* ``╹▀▀`` border (its bottom),
+with the typed message at the top of the box and the model/status footer at the
+bottom. Submitted messages echo in ``┃`` boxes higher up, but those carry no
+``╹`` border, so submission is keyed on the sent text leaving the composer box."""
 
 from waypoint.backends.opencode.pane import composer_ready, composer_submitted
 
 SENT = "Reply with exactly the token X and nothing else.\n\nAttached files:\n- /tmp/a"
 
+# Live capture with the message typed but not yet submitted: a prior turn echoes
+# in a borderless ``┃`` box at the top, the composer box sits at the bottom
+# closed by the lone ``╹`` border.
+POPULATED = "\n".join(
+    [
+        "",
+        "  ┃",
+        "  ┃  Say PING-1 and stop.",
+        "  ┃",
+        "",
+        "     PING-1",
+        "",
+        "",
+        "  ┃",
+        "  ┃  Reply with exactly the token X and nothing else.",
+        "  ┃",
+        "  ┃  Attached files:",
+        "  ┃  - /tmp/a",
+        "  ┃  Build · Gemini 3.1 Pro Preview Google · high",
+        "  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
+        "                                            9.8K (1%)",
+    ]
+)
+
+# Same pane just after submitting: the composer is empty and the just-sent
+# message now echoes in the transcript box at the top.
+AFTER_SUBMIT = "\n".join(
+    [
+        "",
+        "  ┃",
+        "  ┃  Reply with exactly the token X and nothing else.",
+        "  ┃",
+        "",
+        "     X",
+        "",
+        "",
+        "  ┃",
+        "  ┃",
+        "  ┃",
+        "  ┃  Build · Gemini 3.1 Pro Preview Google · high",
+        "  ╹▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀",
+        "                                            9.8K (1%)",
+    ]
+)
+
 
 def test_not_submitted_while_message_in_composer_box() -> None:
-    pane = "\n".join(
-        [
-            "┃  earlier conversation",
-            "╹▀▀▀▀▀▀▀▀",
-            "  tab agents  ctrl+p commands",
-            "┃",
-            "┃  Reply with exactly the token X and nothing else.",
-            "┃",
-            "┃  Build · Gemini 3.1 Pro Preview Google · high",
-            "╹▀▀▀▀▀▀▀▀",
-            "  tab agents  ctrl+p commands",
-        ]
-    )
-    assert composer_submitted(pane, SENT) is False
+    assert composer_submitted(POPULATED, SENT) is False
+
+
+def test_submitted_when_composer_is_empty_after_send() -> None:
+    # The just-sent message echoes in the transcript box at the top; the scan
+    # must stay within the composer box so that echo is not mistaken for an
+    # unsent message (the regression that made every send burn the full retry
+    # budget).
+    assert composer_submitted(AFTER_SUBMIT, SENT) is True
 
 
 def test_submitted_when_composer_shows_placeholder() -> None:
-    # The message echoes in a box above; the live composer (above the last
-    # border) is back to the placeholder.
     pane = "\n".join(
         [
-            "┃  Reply with exactly the token X and nothing else.",  # transcript echo
-            "╹▀▀▀▀▀▀▀▀",
-            "┃",
-            '┃  Ask anything... "Fix broken tests"',
-            "┃",
-            "┃  Build · Gemini 3.1 Pro Preview Google · high",
-            "╹▀▀▀▀▀▀▀▀",
-            "  tab agents  ctrl+p commands",
+            "  ┃",
+            "  ┃  Reply with exactly the token X and nothing else.",  # transcript echo
+            "  ┃",
+            "",
+            "  ┃",
+            '  ┃  Ask anything... "Fix broken tests"',
+            "  ┃",
+            "  ┃  Build · Gemini 3.1 Pro Preview Google · high",
+            "  ╹▀▀▀▀▀▀▀▀",
+            "                                            9.8K (1%)",
         ]
     )
     assert composer_submitted(pane, SENT) is True
 
 
 def test_not_submitted_when_message_taller_than_a_fixed_window() -> None:
-    # A long pasted message renders its start at the TOP of the composer box,
-    # far from the bottom border; the scan must cover the whole box (between the
-    # previous border and the last) so the probe is still found and the loop
-    # does not declare a premature success.
+    # The message start renders at the TOP of the composer box, far from the
+    # bottom border; scanning the whole box (not a fixed window) keeps it found.
     pane = "\n".join(
         [
-            "┃  earlier conversation",
-            "╹▀▀▀▀▀▀▀▀",
-            "┃",
-            "┃  Reply with exactly the token X and nothing else.",
-            "┃  line 2 of the pasted message",
-            "┃  line 3 of the pasted message",
-            "┃  line 4 of the pasted message",
-            "┃  Attached files:",
-            "┃  - /tmp/a",
-            "┃  Build · Gemini 3.1 Pro Preview Google · high",
-            "╹▀▀▀▀▀▀▀▀",
-            "  tab agents  ctrl+p commands",
+            "  ┃",
+            "  ┃  earlier conversation",
+            "  ┃",
+            "",
+            "  ┃",
+            "  ┃  Reply with exactly the token X and nothing else.",
+            "  ┃  line 2 of the pasted message",
+            "  ┃  line 3 of the pasted message",
+            "  ┃  line 4 of the pasted message",
+            "  ┃  Attached files:",
+            "  ┃  - /tmp/a",
+            "  ┃  Build · Gemini 3.1 Pro Preview Google · high",
+            "  ╹▀▀▀▀▀▀▀▀",
+            "                                            9.8K (1%)",
         ]
     )
     assert composer_submitted(pane, SENT) is False

--- a/backend/tests/test_opencode_pane.py
+++ b/backend/tests/test_opencode_pane.py
@@ -44,6 +44,30 @@ def test_submitted_when_composer_shows_placeholder() -> None:
     assert composer_submitted(pane, SENT) is True
 
 
+def test_not_submitted_when_message_taller_than_a_fixed_window() -> None:
+    # A long pasted message renders its start at the TOP of the composer box,
+    # far from the bottom border; the scan must cover the whole box (between the
+    # previous border and the last) so the probe is still found and the loop
+    # does not declare a premature success.
+    pane = "\n".join(
+        [
+            "┃  earlier conversation",
+            "╹▀▀▀▀▀▀▀▀",
+            "┃",
+            "┃  Reply with exactly the token X and nothing else.",
+            "┃  line 2 of the pasted message",
+            "┃  line 3 of the pasted message",
+            "┃  line 4 of the pasted message",
+            "┃  Attached files:",
+            "┃  - /tmp/a",
+            "┃  Build · Gemini 3.1 Pro Preview Google · high",
+            "╹▀▀▀▀▀▀▀▀",
+            "  tab agents  ctrl+p commands",
+        ]
+    )
+    assert composer_submitted(pane, SENT) is False
+
+
 def test_not_submitted_when_no_border_found() -> None:
     # No composer box drawn → booting/dead pane, nothing submitted; keep trying.
     assert composer_submitted("booting opencode...", SENT) is False

--- a/backend/tests/test_opencode_pane.py
+++ b/backend/tests/test_opencode_pane.py
@@ -4,7 +4,7 @@ submitted messages echo in ``┃`` boxes above, so the live composer is the
 region directly above the *last* border. Submission is keyed on the sent text
 leaving that region (an empty composer shows the ``Ask anything…`` placeholder)."""
 
-from waypoint.backends.opencode.pane import composer_submitted
+from waypoint.backends.opencode.pane import composer_ready, composer_submitted
 
 SENT = "Reply with exactly the token X and nothing else.\n\nAttached files:\n- /tmp/a"
 
@@ -44,9 +44,18 @@ def test_submitted_when_composer_shows_placeholder() -> None:
     assert composer_submitted(pane, SENT) is True
 
 
-def test_submitted_when_no_border_found() -> None:
-    assert composer_submitted("booting opencode...", SENT) is True
+def test_not_submitted_when_no_border_found() -> None:
+    # No composer box drawn → booting/dead pane, nothing submitted; keep trying.
+    assert composer_submitted("booting opencode...", SENT) is False
 
 
 def test_empty_message_treated_as_submitted() -> None:
     assert composer_submitted("┃  Ask anything...\n╹▀▀▀", "") is True
+
+
+def test_composer_ready_when_box_drawn() -> None:
+    assert composer_ready("┃  Ask anything...\n╹▀▀▀▀▀▀▀▀") is True
+
+
+def test_composer_not_ready_while_booting() -> None:
+    assert composer_ready("starting opencode...\nno box yet") is False

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1143,6 +1143,31 @@ async def test_handle_input_reattaches_exited_codex_session(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_resume_reattaches_exited_session(tmp_path) -> None:
+    # The "Resume" endpoint on a terminated session must relaunch it, not send
+    # Enter to the dead pane (which raised a 500). Mirror handle_input's guard.
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeCodexRuntimeAdapter()
+    _codex_plugin(runtime).adapter = cast(Any, fake)
+    session = make_session(
+        settings,
+        status=SessionStatus.EXITED,
+        thread_id="thread-resume",
+    )
+    storage.create_session(session)
+
+    updated = await runtime.resume("sess")
+
+    # Relaunched via restore (no input forwarded), and never poked the dead pane.
+    # Reattach leaves it IDLE (alive, ready), not RUNNING — no turn was started.
+    assert fake.restore_calls == [
+        ("sess", "/tmp/project", "thread-resume", None, None, None)
+    ]
+    assert fake.inputs == []
+    assert updated.status == SessionStatus.IDLE
+
+
+@pytest.mark.asyncio
 async def test_handle_input_reattaches_errored_claude_session(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
     fake = FakeClaudeAdapter()

--- a/backend/tests/test_tmux.py
+++ b/backend/tests/test_tmux.py
@@ -2,6 +2,7 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
 from waypoint.backends.tmux.transport import TmuxTransport
@@ -286,19 +287,27 @@ def test_submit_sends_bare_enter() -> None:
 
 
 class _FakeAdapter:
-    """Adapter stub for the transport submit-confirm loop: counts Enters and
-    replays a scripted sequence of pane snapshots (one per Enter)."""
+    """Adapter stub for the transport submit-confirm loop. The pane state is a
+    function of how many Enters have landed: the composer reports cleared once
+    ``clear_after`` submits land, and a modal dialog appears once
+    ``dialog_after`` submits land (the message submitted and opened one)."""
 
-    def __init__(self, snapshots: list[str]) -> None:
-        self._snapshots = snapshots
+    def __init__(
+        self, *, clear_after: int = 1, dialog_after: int | None = None
+    ) -> None:
         self.submits = 0
+        self.captures = 0
+        self._clear_after = clear_after
+        self._dialog_after = dialog_after
 
     async def submit(self, target: str) -> None:
         self.submits += 1
 
     async def capture_snapshot(self, target: str, start_line: int = -200) -> str:
-        idx = min(self.submits - 1, len(self._snapshots) - 1)
-        return self._snapshots[idx]
+        self.captures += 1
+        if self._dialog_after is not None and self.submits >= self._dialog_after:
+            return "DIALOG"
+        return "SUBMITTED" if self.submits >= self._clear_after else "PENDING"
 
 
 class _Confirmer:
@@ -308,14 +317,17 @@ class _Confirmer:
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         return pane_text == "SUBMITTED"
 
+    def pane_shows_blocking_dialog(self, pane_text: str) -> bool:
+        return pane_text == "DIALOG"
+
 
 def _transport(adapter: _FakeAdapter) -> TmuxTransport:
     return TmuxTransport(SimpleNamespace(tmux=adapter))  # type: ignore[arg-type]
 
 
 def test_submit_confirmed_retries_until_composer_clears() -> None:
-    # First two Enters absorbed (composer still populated), third lands.
-    adapter = _FakeAdapter(["PENDING", "PENDING", "SUBMITTED"])
+    # First Enter absorbed (composer still populated), second lands.
+    adapter = _FakeAdapter(clear_after=2)
     transport = _transport(adapter)
 
     asyncio.run(
@@ -324,13 +336,13 @@ def test_submit_confirmed_retries_until_composer_clears() -> None:
         )
     )
 
-    assert adapter.submits == 3
+    assert adapter.submits == 2
 
 
 def test_submit_confirmed_stops_after_first_success() -> None:
     # A landed Enter must not be followed by a stray one (could hit a started
     # turn or a dialog).
-    adapter = _FakeAdapter(["SUBMITTED"])
+    adapter = _FakeAdapter(clear_after=1)
     transport = _transport(adapter)
 
     asyncio.run(
@@ -344,7 +356,7 @@ def test_submit_confirmed_stops_after_first_success() -> None:
 
 def test_submit_confirmed_is_bounded_when_never_confirmed() -> None:
     # If the TUI never confirms, stop after `attempts` rather than spamming.
-    adapter = _FakeAdapter(["PENDING"])
+    adapter = _FakeAdapter(clear_after=999)
     transport = _transport(adapter)
 
     asyncio.run(
@@ -356,46 +368,73 @@ def test_submit_confirmed_is_bounded_when_never_confirmed() -> None:
     assert adapter.submits == 4
 
 
+def test_submit_confirmed_stops_when_dialog_appears() -> None:
+    # The message submits (one Enter) and opens a dialog; the loop must stop
+    # rather than drive a second Enter into it — which would select an option
+    # (e.g. auto-approve a tool).
+    adapter = _FakeAdapter(clear_after=999, dialog_after=1)
+    transport = _transport(adapter)
+
+    asyncio.run(
+        transport._submit_confirmed(
+            "%1", _Confirmer(), "msg", attempts=8, poll_seconds=0.0
+        )
+    )
+
+    assert adapter.submits == 1
+
+
 class _RecordingAdapter:
     """Records the high-level calls send_input makes so we can assert which
     submit path (confirm-retry vs single Enter) the transport chose. Replays
     `boot_frames` "BOOTING" snapshots before "SUBMITTED" to model a pane that is
     still launching when the message arrives."""
 
-    def __init__(self, boot_frames: int = 0) -> None:
+    def __init__(self, boot_frames: int = 0, dialog: bool = False) -> None:
         self.calls: list[tuple] = []
         self._boot_frames = boot_frames
+        self._dialog = dialog
         self._captures = 0
+        self.submits = 0
 
     async def send_input(self, target, text, submit=True):
         self.calls.append(("send_input", target, text, submit))
 
     async def submit(self, target):
         self.calls.append(("submit", target))
+        self.submits += 1
 
     async def capture_snapshot(self, target, start_line=-200):
         self.calls.append(("capture", target))
-        frame = "BOOTING" if self._captures < self._boot_frames else "SUBMITTED"
+        if self._dialog:
+            return "DIALOG"
+        if self._captures < self._boot_frames:
+            self._captures += 1
+            return "BOOTING"  # composer not drawn yet
         self._captures += 1
-        return frame  # confirmer (below) treats "SUBMITTED" as ready/cleared
+        # Composer is drawn (READY); it reports cleared only once an Enter lands.
+        return "SUBMITTED" if self.submits > 0 else "READY"
 
 
 class _AgentConfirmer:
     id = "codex"
 
     def pane_ready_for_input(self, pane_text):
-        return pane_text == "SUBMITTED"
+        return pane_text in ("READY", "SUBMITTED")
 
     def confirm_pane_submit(self, pane_text, sent_text):
         return pane_text == "SUBMITTED"
+
+    def pane_shows_blocking_dialog(self, pane_text):
+        return pane_text == "DIALOG"
 
 
 class _PlainAgent:
     id = "opencode"  # no pane hooks -> not a confirmer
 
 
-def _transport_with(agent, boot_frames: int = 0):
-    adapter = _RecordingAdapter(boot_frames)
+def _transport_with(agent, boot_frames: int = 0, dialog: bool = False):
+    adapter = _RecordingAdapter(boot_frames, dialog)
     registry = SimpleNamespace(get=lambda backend_id: agent)
     runtime = SimpleNamespace(tmux=adapter, registry=registry)
     return TmuxTransport(runtime), adapter  # type: ignore[arg-type]
@@ -441,3 +480,23 @@ def test_await_pane_ready_is_bounded_when_never_ready() -> None:
         )
     )
     assert adapter.calls.count(("capture", "%9")) == 4
+
+
+def test_await_pane_ready_raises_on_blocking_dialog() -> None:
+    # A modal dialog must not be treated as a ready composer; surface it instead
+    # of pasting/Enter'ing into it.
+    transport, _ = _transport_with(_AgentConfirmer(), dialog=True)
+    with pytest.raises(TmuxError):
+        asyncio.run(transport._await_pane_ready("%9", _AgentConfirmer()))
+
+
+def test_send_input_refuses_when_dialog_open() -> None:
+    # Sending a message while an approval/trust dialog is open must not paste or
+    # fire Enter into it (which would select an option). It surfaces an error
+    # and never reaches the paste.
+    transport, adapter = _transport_with(_AgentConfirmer(), dialog=True)
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(transport.send_input(_session("codex"), "hi"))
+    assert exc.value.status_code == 400
+    assert not any(c[0] == "send_input" for c in adapter.calls)
+    assert not any(c[0] == "submit" for c in adapter.calls)

--- a/backend/tests/test_tmux.py
+++ b/backend/tests/test_tmux.py
@@ -302,6 +302,9 @@ class _FakeAdapter:
 
 
 class _Confirmer:
+    def pane_ready_for_input(self, pane_text: str) -> bool:
+        return True
+
     def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
         return pane_text == "SUBMITTED"
 
@@ -355,10 +358,14 @@ def test_submit_confirmed_is_bounded_when_never_confirmed() -> None:
 
 class _RecordingAdapter:
     """Records the high-level calls send_input makes so we can assert which
-    submit path (confirm-retry vs single Enter) the transport chose."""
+    submit path (confirm-retry vs single Enter) the transport chose. Replays
+    `boot_frames` "BOOTING" snapshots before "SUBMITTED" to model a pane that is
+    still launching when the message arrives."""
 
-    def __init__(self) -> None:
+    def __init__(self, boot_frames: int = 0) -> None:
         self.calls: list[tuple] = []
+        self._boot_frames = boot_frames
+        self._captures = 0
 
     async def send_input(self, target, text, submit=True):
         self.calls.append(("send_input", target, text, submit))
@@ -367,22 +374,28 @@ class _RecordingAdapter:
         self.calls.append(("submit", target))
 
     async def capture_snapshot(self, target, start_line=-200):
-        return "SUBMITTED"  # confirmer (below) treats this as cleared
+        self.calls.append(("capture", target))
+        frame = "BOOTING" if self._captures < self._boot_frames else "SUBMITTED"
+        self._captures += 1
+        return frame  # confirmer (below) treats "SUBMITTED" as ready/cleared
 
 
 class _AgentConfirmer:
     id = "codex"
+
+    def pane_ready_for_input(self, pane_text):
+        return pane_text == "SUBMITTED"
 
     def confirm_pane_submit(self, pane_text, sent_text):
         return pane_text == "SUBMITTED"
 
 
 class _PlainAgent:
-    id = "opencode"  # no confirm_pane_submit -> not a confirmer
+    id = "opencode"  # no pane hooks -> not a confirmer
 
 
-def _transport_with(agent):
-    adapter = _RecordingAdapter()
+def _transport_with(agent, boot_frames: int = 0):
+    adapter = _RecordingAdapter(boot_frames)
     registry = SimpleNamespace(get=lambda backend_id: agent)
     runtime = SimpleNamespace(tmux=adapter, registry=registry)
     return TmuxTransport(runtime), adapter  # type: ignore[arg-type]
@@ -397,7 +410,7 @@ def test_send_input_uses_confirm_path_for_confirmer_agent() -> None:
     asyncio.run(transport.send_input(_session("codex"), "hi"))
     # Pastes without submitting, then drives submit via the confirm loop —
     # NOT a single bundled submit. Resolved by agent id, not the tmux transport.
-    assert adapter.calls[0] == ("send_input", "%9", "hi", False)
+    assert ("send_input", "%9", "hi", False) in adapter.calls
     assert ("submit", "%9") in adapter.calls
     assert not any(c == ("send_input", "%9", "hi", True) for c in adapter.calls)
 
@@ -406,3 +419,25 @@ def test_send_input_single_enter_for_non_confirmer_agent() -> None:
     transport, adapter = _transport_with(_PlainAgent())
     asyncio.run(transport.send_input(_session("opencode"), "hi"))
     assert adapter.calls == [("send_input", "%9", "hi", True)]
+
+
+def test_send_input_waits_for_ready_before_pasting() -> None:
+    # A relaunched pane needs two frames to draw its composer; the transport
+    # must poll readiness and only paste once it is ready, never into the boot
+    # screen (which would drop the keystrokes).
+    transport, adapter = _transport_with(_AgentConfirmer(), boot_frames=2)
+    asyncio.run(transport.send_input(_session("codex"), "hi"))
+    paste_idx = adapter.calls.index(("send_input", "%9", "hi", False))
+    captures_before_paste = adapter.calls[:paste_idx].count(("capture", "%9"))
+    assert captures_before_paste == 3  # two BOOTING frames, then ready
+
+
+def test_await_pane_ready_is_bounded_when_never_ready() -> None:
+    # A pane that never draws its composer must not block the request forever.
+    transport, adapter = _transport_with(_AgentConfirmer(), boot_frames=99)
+    asyncio.run(
+        transport._await_pane_ready(
+            "%9", _AgentConfirmer(), attempts=4, poll_seconds=0.0
+        )
+    )
+    assert adapter.calls.count(("capture", "%9")) == 4

--- a/backend/tests/test_tmux.py
+++ b/backend/tests/test_tmux.py
@@ -1,8 +1,10 @@
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
+from waypoint.backends.tmux.transport import TmuxTransport
 
 
 def test_send_input_uses_literal_mode_and_submit() -> None:
@@ -266,3 +268,141 @@ def test_target_exists_false_for_missing_pane() -> None:
     adapter._run = fake_run  # type: ignore[method-assign]
 
     assert asyncio.run(adapter.target_exists("%77")) is False
+
+
+def test_submit_sends_bare_enter() -> None:
+    commands: list[tuple[str, ...]] = []
+
+    async def fake_run(*args: str) -> str:
+        commands.append(args)
+        return ""
+
+    adapter = TmuxAdapter()
+    adapter._run = fake_run  # type: ignore[method-assign]
+
+    asyncio.run(adapter.submit("%1"))
+
+    assert commands == [("send-keys", "-t", "%1", "Enter")]
+
+
+class _FakeAdapter:
+    """Adapter stub for the transport submit-confirm loop: counts Enters and
+    replays a scripted sequence of pane snapshots (one per Enter)."""
+
+    def __init__(self, snapshots: list[str]) -> None:
+        self._snapshots = snapshots
+        self.submits = 0
+
+    async def submit(self, target: str) -> None:
+        self.submits += 1
+
+    async def capture_snapshot(self, target: str, start_line: int = -200) -> str:
+        idx = min(self.submits - 1, len(self._snapshots) - 1)
+        return self._snapshots[idx]
+
+
+class _Confirmer:
+    def confirm_pane_submit(self, pane_text: str, sent_text: str) -> bool:
+        return pane_text == "SUBMITTED"
+
+
+def _transport(adapter: _FakeAdapter) -> TmuxTransport:
+    return TmuxTransport(SimpleNamespace(tmux=adapter))  # type: ignore[arg-type]
+
+
+def test_submit_confirmed_retries_until_composer_clears() -> None:
+    # First two Enters absorbed (composer still populated), third lands.
+    adapter = _FakeAdapter(["PENDING", "PENDING", "SUBMITTED"])
+    transport = _transport(adapter)
+
+    asyncio.run(
+        transport._submit_confirmed(
+            "%1", _Confirmer(), "msg", attempts=8, poll_seconds=0.0
+        )
+    )
+
+    assert adapter.submits == 3
+
+
+def test_submit_confirmed_stops_after_first_success() -> None:
+    # A landed Enter must not be followed by a stray one (could hit a started
+    # turn or a dialog).
+    adapter = _FakeAdapter(["SUBMITTED"])
+    transport = _transport(adapter)
+
+    asyncio.run(
+        transport._submit_confirmed(
+            "%1", _Confirmer(), "msg", attempts=8, poll_seconds=0.0
+        )
+    )
+
+    assert adapter.submits == 1
+
+
+def test_submit_confirmed_is_bounded_when_never_confirmed() -> None:
+    # If the TUI never confirms, stop after `attempts` rather than spamming.
+    adapter = _FakeAdapter(["PENDING"])
+    transport = _transport(adapter)
+
+    asyncio.run(
+        transport._submit_confirmed(
+            "%1", _Confirmer(), "msg", attempts=4, poll_seconds=0.0
+        )
+    )
+
+    assert adapter.submits == 4
+
+
+class _RecordingAdapter:
+    """Records the high-level calls send_input makes so we can assert which
+    submit path (confirm-retry vs single Enter) the transport chose."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple] = []
+
+    async def send_input(self, target, text, submit=True):
+        self.calls.append(("send_input", target, text, submit))
+
+    async def submit(self, target):
+        self.calls.append(("submit", target))
+
+    async def capture_snapshot(self, target, start_line=-200):
+        return "SUBMITTED"  # confirmer (below) treats this as cleared
+
+
+class _AgentConfirmer:
+    id = "codex"
+
+    def confirm_pane_submit(self, pane_text, sent_text):
+        return pane_text == "SUBMITTED"
+
+
+class _PlainAgent:
+    id = "opencode"  # no confirm_pane_submit -> not a confirmer
+
+
+def _transport_with(agent):
+    adapter = _RecordingAdapter()
+    registry = SimpleNamespace(get=lambda backend_id: agent)
+    runtime = SimpleNamespace(tmux=adapter, registry=registry)
+    return TmuxTransport(runtime), adapter  # type: ignore[arg-type]
+
+
+def _session(backend):
+    return SimpleNamespace(backend=backend, transport_state={"tmux_pane": "%9"})
+
+
+def test_send_input_uses_confirm_path_for_confirmer_agent() -> None:
+    transport, adapter = _transport_with(_AgentConfirmer())
+    asyncio.run(transport.send_input(_session("codex"), "hi"))
+    # Pastes without submitting, then drives submit via the confirm loop —
+    # NOT a single bundled submit. Resolved by agent id, not the tmux transport.
+    assert adapter.calls[0] == ("send_input", "%9", "hi", False)
+    assert ("submit", "%9") in adapter.calls
+    assert not any(c == ("send_input", "%9", "hi", True) for c in adapter.calls)
+
+
+def test_send_input_single_enter_for_non_confirmer_agent() -> None:
+    transport, adapter = _transport_with(_PlainAgent())
+    asyncio.run(transport.send_input(_session("opencode"), "hi"))
+    assert adapter.calls == [("send_input", "%9", "hi", True)]


### PR DESCRIPTION
Attaching a file — most reliably an image — and hitting send in a tmux-wrapped agent session sometimes left the message typed in the composer but unsent. The wrapped TUI absorbs the submit `Enter` while it is still ingesting the input (the Claude TUI does this loading an image pasted by path; the Codex and OpenCode TUIs do it ingesting a long typed line), so the keystroke lands on nothing.

This adds a `PaneSubmitConfirming` capability protocol that the tmux transport narrows to via `isinstance`. When the wrapped agent satisfies it, the transport pastes without submitting, then sends `Enter` and polls a `capture-pane` snapshot until the agent confirms the composer cleared, retrying the swallowed keystroke up to a bound (stopping on the first confirmed submit). Agents whose composer submits synchronously keep the single-`Enter` path — no per-backend branching in the transport.

The confirmer is resolved from the agent plugin (`registry.get(session.backend)`), not the transport plugin (`plugin_for`, which is transport-keyed and returns the generic `TmuxPlugin`), so the hook is reachable for Codex and OpenCode over the generic tmux transport and not just for Claude over claude_tty.

Each agent supplies the composer check it knows: Claude collapses a pasted message to an `[Image]`/`[Pasted text]` chip, so it checks the composer is empty; Codex and OpenCode render input literally, so they check the sent text no longer occupies the composer box (scanned by walking the box's contiguous `┃` lines up from its lone `╹` border, captured from a live pane).

## Resume race on reattach
Resuming a terminated session (or a model/permission restart) relaunches the agent's TUI in a fresh tmux pane, but the runtime sent the message before the composer had drawn, so the submit `Enter` was dropped. The protocol gained `pane_ready_for_input`; the transport waits for the composer to render before pasting (an already-ready pane costs one snapshot, no delay). `composer_is_empty` / `composer_submitted` treat an absent composer as not-submitted so the bounded loop keeps retrying. Covers claude_tty and Codex/OpenCode over generic tmux, which relaunch a pane on reattach (`TmuxPlugin.restore_session`).

## Audit hardening
A follow-up audit of the send path surfaced two further bugs, both fixed here:

- **Approval bypass (security).** Sending a message while a tool-permission/trust dialog was pending drove the confirm loop's `Enter` into the dialog and selected "Yes", silently approving the tool. The composer probes key on the same `❯`/`›`/`╹` glyphs a dialog's selected option draws. Added `pane_shows_blocking_dialog` to the protocol: the readiness gate refuses to send while a modal dialog is open, and the submit loop bails before each `Enter` if a dialog is on screen. Claude detects dialogs via `classify()`; Codex/OpenCode don't surface approvals to Waypoint over generic tmux and have no pane parser, so their guard is a documented no-op. The submit loop also now `Enter`s before confirming, so a snapshot taken before the paste renders can't end the loop having sent nothing.
- **`resume()` on a terminated session returned 500.** The endpoint sent a bare `Enter` to a dead pane with no status check. It now reattaches an EXITED/ERROR session via the same path as `handle_input`.

## Testing
- `uv run pytest` (984 tests; new pane/transport/runtime cases incl. the dialog guard, submit-first ordering, the resume reattach, and OpenCode composer-box scan from real captures)
- `uv run pre-commit run --all-files` (black, isort, ruff, codespell, mypy)
- Live, on a running stack: text / text+image / text+file across Claude Code (claude_tty), Codex (tmux), OpenCode (tmux); the resume race (terminate → send) for all three; the approval-bypass repro (now refused 400, file not created) and that a legitimate approval still creates the file; `resume()` on a terminated session (now reattaches, HTTP 200); cold-launch first send (now submits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)