### PR TITLE
fix: emit file-edit diffs and resolve stuck turns on claude_tty

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -31,7 +31,13 @@ from waypoint.backends.claude_code.normalize import (
     iter_content_blocks,
     stringify_tool_result,
 )
+from waypoint.backends.diff_preview import (
+    build_preview,
+    files_from_claude_tool_result,
+)
 from waypoint.schemas import EventKind, SessionStatus
+
+FILE_EDIT_TOOL_NAMES: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
 
 # Allowlist of record types we handle; everything else is dropped silently.
 # This is an allowlist rather than a denylist so undocumented TUI record types
@@ -81,6 +87,10 @@ class TranscriptNormalizer:
         # plain tool_call, and to swallow the synthetic rejection.
         self._expect_dismissed_question: bool = False
         self._dismissed_question_ids: set[str] = set()
+        # tool_use ids of file-edit calls, so the matching tool_result record
+        # (which carries the applied diff in its toolUseResult) can attach a
+        # diff preview. The TUI records the change on the result, not the call.
+        self._file_edit_tool_use_ids: set[str] = set()
 
     def arm_question_dismissal(self) -> None:
         self._expect_dismissed_question = True
@@ -176,6 +186,8 @@ class TranscriptNormalizer:
                         if tool_use_id:
                             self._suppressed_result_tool_use_ids.add(tool_use_id)
                     continue
+                if tool_name in FILE_EDIT_TOOL_NAMES and tool_use_id:
+                    self._file_edit_tool_use_ids.add(tool_use_id)
                 input_text = json.dumps(block.get("input") or {}, indent=2)
                 events.append(
                     NormalizedEvent(
@@ -291,18 +303,25 @@ class TranscriptNormalizer:
                 continue
             text = stringify_tool_result(block.get("content"))
             is_error = bool(block.get("is_error"))
+            metadata: dict[str, Any] = {
+                "method": "user.tool_result",
+                "item_id": tool_use_id,
+                "tool_use_id": tool_use_id,
+                "is_error": is_error,
+                "payload": block,
+                "status": SessionStatus.RUNNING,
+            }
+            if tool_use_id in self._file_edit_tool_use_ids:
+                self._file_edit_tool_use_ids.discard(tool_use_id)
+                if not is_error:
+                    diff_preview = _diff_preview_from_tool_result(record)
+                    if diff_preview is not None:
+                        metadata["diff_preview"] = diff_preview
             events.append(
                 NormalizedEvent(
                     kind=EventKind.TOOL_RESULT,
                     text=text,
-                    metadata={
-                        "method": "user.tool_result",
-                        "item_id": tool_use_id,
-                        "tool_use_id": tool_use_id,
-                        "is_error": is_error,
-                        "payload": block,
-                        "status": SessionStatus.RUNNING,
-                    },
+                    metadata=metadata,
                     status=SessionStatus.RUNNING,
                 )
             )
@@ -344,6 +363,15 @@ class TranscriptNormalizer:
                 status=SessionStatus.RUNNING,
             )
         ]
+
+
+def _diff_preview_from_tool_result(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Build an applied-phase diff preview from an edit's ``toolUseResult``."""
+    files = files_from_claude_tool_result(record.get("toolUseResult"))
+    if not files:
+        return None
+    preview = build_preview("applied", files)
+    return preview.model_dump(mode="json") if preview else None
 
 
 def _is_injected_turn(content: Any) -> bool:

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -21,9 +21,13 @@ Key invariants (all verified against real transcripts in Phase 0):
   an injected continuation summary, with no terminal assistant record, so a
   synthesized result (SYSTEM_NOTE, status=IDLE) is emitted off the boundary to
   resolve the turn. Auto-compaction fires mid-turn and is left alone.
+- A builtin local slash command (e.g. ``/compact`` with nothing to compact,
+  ``/status``) prints a ``local_command`` system record and runs no model turn,
+  so it too is resolved to IDLE off that record with its stdout as the note.
 """
 
 import json
+import re
 import uuid
 from typing import Any
 
@@ -106,13 +110,19 @@ class TranscriptNormalizer:
         return []
 
     def _process_system(self, record: dict[str, Any]) -> list[NormalizedEvent]:
+        subtype = record.get("subtype")
+        if subtype == "compact_boundary":
+            return self._compact_boundary_event(record)
+        if subtype == "local_command":
+            return self._local_command_event(record)
+        return []
+
+    def _compact_boundary_event(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         # A manual /compact is a turn whose only output is the compaction
         # boundary and an injected continuation summary, both otherwise dropped.
         # Without a terminal assistant record the session never resolves, so
         # synthesize the result note here. Auto-compaction fires mid-turn and the
         # surrounding turn ends with its own end_turn, so it needs no note.
-        if record.get("subtype") != "compact_boundary":
-            return []
         meta: dict[str, Any] = record.get("compactMetadata") or {}
         if meta.get("trigger") != "manual":
             return []
@@ -122,18 +132,28 @@ class TranscriptNormalizer:
             if pre_tokens
             else "Context compacted"
         )
-        return [
-            NormalizedEvent(
-                kind=EventKind.SYSTEM_NOTE,
-                text=text,
-                metadata={
-                    "method": "result",
-                    "stop_reason": "compact",
-                    "status": SessionStatus.IDLE,
-                },
-                status=SessionStatus.IDLE,
-            )
-        ]
+        return [self._result_note(text, "compact")]
+
+    def _local_command_event(self, record: dict[str, Any]) -> list[NormalizedEvent]:
+        # A builtin slash command that runs locally (e.g. /compact when there is
+        # nothing to compact, /status) prints to stdout and returns without a
+        # model turn. handle_input already flipped the session to RUNNING on
+        # send, and nothing else follows, so resolve it here and surface the
+        # command's output as the note.
+        text = _strip_local_command_output(record.get("content")) or "Command complete"
+        return [self._result_note(text, "local_command")]
+
+    def _result_note(self, text: str, stop_reason: str) -> NormalizedEvent:
+        return NormalizedEvent(
+            kind=EventKind.SYSTEM_NOTE,
+            text=text,
+            metadata={
+                "method": "result",
+                "stop_reason": stop_reason,
+                "status": SessionStatus.IDLE,
+            },
+            status=SessionStatus.IDLE,
+        )
 
     def _process_assistant(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         message: dict[str, Any] = record.get("message") or {}
@@ -404,6 +424,24 @@ def _diff_preview_from_tool_result(record: dict[str, Any]) -> dict[str, Any] | N
         return None
     preview = build_preview("applied", files)
     return preview.model_dump(mode="json") if preview else None
+
+
+_LOCAL_COMMAND_OUTPUT_RE = re.compile(
+    r"<local-command-(?:stdout|stderr)>(.*?)</local-command-(?:stdout|stderr)>",
+    re.DOTALL,
+)
+_LOCAL_COMMAND_MAX_LEN = 500
+
+
+def _strip_local_command_output(content: Any) -> str:
+    """Pull the human-readable text out of a local_command record's content."""
+    if not isinstance(content, str):
+        return ""
+    parts = _LOCAL_COMMAND_OUTPUT_RE.findall(content)
+    text = "\n".join(parts).strip() if parts else content.strip()
+    if len(text) > _LOCAL_COMMAND_MAX_LEN:
+        text = text[: _LOCAL_COMMAND_MAX_LEN - 1].rstrip() + "…"
+    return text
 
 
 def _is_injected_turn(content: Any) -> bool:

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -139,7 +139,10 @@ class TranscriptNormalizer:
         # nothing to compact, /status) prints to stdout and returns without a
         # model turn. handle_input already flipped the session to RUNNING on
         # send, and nothing else follows, so resolve it here and surface the
-        # command's output as the note.
+        # command's output as the note. Commands that DO run a turn expand into
+        # a user prompt rather than emitting this subtype, so resolving to idle
+        # here is safe; a stray case would self-correct on the next assistant
+        # record (which re-asserts RUNNING).
         text = _strip_local_command_output(record.get("content")) or "Command complete"
         return [self._result_note(text, "local_command")]
 

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -17,6 +17,10 @@ Key invariants (all verified against real transcripts in Phase 0):
   ``tool_use``) and contains no ``tool_use`` blocks.
 - Injected harness user turns (``<task-notification>`` and context-window
   summaries beginning with "This session is being continued") are dropped.
+- A manual ``/compact`` produces only a ``compact_boundary`` system record and
+  an injected continuation summary, with no terminal assistant record, so a
+  synthesized result (SYSTEM_NOTE, status=IDLE) is emitted off the boundary to
+  resolve the turn. Auto-compaction fires mid-turn and is left alone.
 """
 
 import json
@@ -38,12 +42,6 @@ from waypoint.backends.diff_preview import (
 from waypoint.schemas import EventKind, SessionStatus
 
 FILE_EDIT_TOOL_NAMES: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
-
-# Allowlist of record types we handle; everything else is dropped silently.
-# This is an allowlist rather than a denylist so undocumented TUI record types
-# (e.g. the ``pr-link`` type observed in real transcripts) are dropped rather
-# than mis-rendered.
-HANDLED_RECORD_TYPES: frozenset[str] = frozenset({"assistant", "user"})
 
 
 class NormalizedEvent:
@@ -101,7 +99,41 @@ class TranscriptNormalizer:
             return self._process_assistant(record)
         if rec_type == "user":
             return self._process_user(record)
+        if rec_type == "system":
+            return self._process_system(record)
+        # Allowlist dispatch: undocumented TUI record types (e.g. the ``pr-link``
+        # type seen in real transcripts) are dropped rather than mis-rendered.
         return []
+
+    def _process_system(self, record: dict[str, Any]) -> list[NormalizedEvent]:
+        # A manual /compact is a turn whose only output is the compaction
+        # boundary and an injected continuation summary, both otherwise dropped.
+        # Without a terminal assistant record the session never resolves, so
+        # synthesize the result note here. Auto-compaction fires mid-turn and the
+        # surrounding turn ends with its own end_turn, so it needs no note.
+        if record.get("subtype") != "compact_boundary":
+            return []
+        meta: dict[str, Any] = record.get("compactMetadata") or {}
+        if meta.get("trigger") != "manual":
+            return []
+        pre_tokens = meta.get("preTokens")
+        text = (
+            f"Context compacted · {pre_tokens} tokens"
+            if pre_tokens
+            else "Context compacted"
+        )
+        return [
+            NormalizedEvent(
+                kind=EventKind.SYSTEM_NOTE,
+                text=text,
+                metadata={
+                    "method": "result",
+                    "stop_reason": "compact",
+                    "status": SessionStatus.IDLE,
+                },
+                status=SessionStatus.IDLE,
+            )
+        ]
 
     def _process_assistant(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         message: dict[str, Any] = record.get("message") or {}

--- a/backend/src/waypoint/backends/diff_preview.py
+++ b/backend/src/waypoint/backends/diff_preview.py
@@ -279,6 +279,61 @@ def files_from_opencode_diffs(diffs: Any) -> list[DiffPreviewFile]:
     return files
 
 
+def files_from_claude_tool_result(tool_use_result: Any) -> list[DiffPreviewFile]:
+    """Build diff files from a Claude TUI ``toolUseResult`` for a file edit.
+
+    The TUI records the applied change on the tool's ``user`` result rather than
+    on the call, so this reconstructs the diff after the fact: ``create`` carries
+    the full new ``content``; ``update`` carries a ``structuredPatch`` of hunks
+    (``oldStart``/``oldLines``/``newStart``/``newLines``/``lines``) that we render
+    back into a unified diff.
+    """
+    if not isinstance(tool_use_result, dict):
+        return []
+    path = str(tool_use_result.get("filePath") or "").strip()
+    if not path:
+        return []
+    change_type = _normalize_change_type(tool_use_result.get("type"))
+    if change_type == "add":
+        content = tool_use_result.get("content")
+        if isinstance(content, str):
+            return [file_from_old_new(path, "", content, "add")]
+        return []
+    patch = tool_use_result.get("structuredPatch")
+    diff = _unified_diff_from_structured_patch(path, patch)
+    if diff is None:
+        return []
+    return [file_from_unified_diff(path, diff, "update")]
+
+
+def _unified_diff_from_structured_patch(path: str, patch: Any) -> str | None:
+    if not isinstance(patch, list) or not patch:
+        return None
+    out: list[str] = [f"--- {path}", f"+++ {path}"]
+    for hunk in patch:
+        if not isinstance(hunk, dict):
+            continue
+        lines = hunk.get("lines")
+        if not isinstance(lines, list):
+            continue
+        old_start = _patch_int(hunk.get("oldStart"))
+        old_lines = _patch_int(hunk.get("oldLines"))
+        new_start = _patch_int(hunk.get("newStart"))
+        new_lines = _patch_int(hunk.get("newLines"))
+        out.append(f"@@ -{old_start},{old_lines} +{new_start},{new_lines} @@")
+        out.extend(str(line) for line in lines)
+    if len(out) <= 2:
+        return None
+    return "\n".join(out) + "\n"
+
+
+def _patch_int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def preview_to_metadata(preview: DiffPreviewPayload | None) -> dict[str, Any]:
     if preview is None:
         return {}

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -637,6 +637,46 @@ def test_compact_summary_user_record_still_dropped() -> None:
     assert norm.process_record(record) == []
 
 
+def test_local_command_resolves_session_to_idle_with_stdout() -> None:
+    # A rejected /compact (and other builtin local commands) prints a
+    # local_command record and runs no turn, leaving the send-flipped RUNNING
+    # status unresolved without this.
+    norm = TranscriptNormalizer()
+    record = {
+        "type": "system",
+        "subtype": "local_command",
+        "content": "<local-command-stdout>Not enough messages to compact.</local-command-stdout>",
+    }
+    events = norm.process_record(record)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == EventKind.SYSTEM_NOTE
+    assert ev.status == SessionStatus.IDLE
+    assert ev.metadata["stop_reason"] == "local_command"
+    assert ev.text == "Not enough messages to compact."
+
+
+def test_local_command_without_stdout_falls_back_to_generic_note() -> None:
+    norm = TranscriptNormalizer()
+    record = {"type": "system", "subtype": "local_command", "content": ""}
+    events = norm.process_record(record)
+    assert events[0].text == "Command complete"
+    assert events[0].status == SessionStatus.IDLE
+
+
+def test_local_command_stdout_is_truncated() -> None:
+    norm = TranscriptNormalizer()
+    body = "x" * 1000
+    record = {
+        "type": "system",
+        "subtype": "local_command",
+        "content": f"<local-command-stdout>{body}</local-command-stdout>",
+    }
+    text = norm.process_record(record)[0].text
+    assert len(text) <= 500
+    assert text.endswith("…")
+
+
 # ── result text formatting ────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -525,6 +525,104 @@ def test_edit_result_attaches_update_diff_from_structured_patch() -> None:
     assert file["additions"] == 1
 
 
+def _update_result_record(tool_use_id: str, structured_patch: list) -> dict:
+    return _edit_result_record(
+        tool_use_id,
+        {
+            "type": "update",
+            "filePath": "/repo/a.py",
+            "structuredPatch": structured_patch,
+        },
+    )
+
+
+def _diff_from_edit(tool_name: str, structured_patch: list[dict]) -> dict:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msg",
+            [_tool_use_block("tu1", tool_name, {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    events = norm.process_record(_update_result_record("tu1", structured_patch))
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    return result.metadata["diff_preview"]["files"][0]
+
+
+def test_multiedit_multi_hunk_patch_preserves_order_and_counts() -> None:
+    file = _diff_from_edit(
+        "MultiEdit",
+        [
+            {
+                "oldStart": 1,
+                "oldLines": 1,
+                "newStart": 1,
+                "newLines": 2,
+                "lines": [" a", "+b"],
+            },
+            {
+                "oldStart": 10,
+                "oldLines": 2,
+                "newStart": 11,
+                "newLines": 1,
+                "lines": [" c", "-d"],
+            },
+        ],
+    )
+    diff = file["diff"]
+    assert "@@ -1,1 +1,2 @@" in diff
+    assert "@@ -10,2 +11,1 @@" in diff
+    assert diff.index("@@ -1,1") < diff.index("@@ -10,2")
+    assert file["additions"] == 1
+    assert file["deletions"] == 1
+
+
+def test_structured_patch_deletion_and_no_newline_marker() -> None:
+    file = _diff_from_edit(
+        "Edit",
+        [
+            {
+                "oldStart": 1,
+                "oldLines": 2,
+                "newStart": 1,
+                "newLines": 1,
+                "lines": [" keep", "-gone", "\\ No newline at end of file"],
+            },
+        ],
+    )
+    assert "-gone" in file["diff"]
+    assert "\\ No newline at end of file" in file["diff"]
+    # The marker line must not be counted as a deletion.
+    assert file["deletions"] == 1
+    assert file["additions"] == 0
+
+
+def test_structured_patch_non_int_counters_coerced_to_zero() -> None:
+    file = _diff_from_edit(
+        "Edit",
+        [{"oldStart": None, "newStart": "x", "lines": [" a", "+b"]}],
+    )
+    assert "@@ -0,0 +0,0 @@" in file["diff"]
+    assert "+b" in file["diff"]
+
+
+def test_structured_patch_all_hunks_malformed_yields_no_preview() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msg",
+            [_tool_use_block("tu1", "Edit", {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    events = norm.process_record(
+        _update_result_record("tu1", ["not-a-dict", {"no_lines": True}])
+    )
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    assert "diff_preview" not in result.metadata
+
+
 def test_non_edit_tool_result_has_no_diff_preview() -> None:
     norm = TranscriptNormalizer()
     norm.process_record(
@@ -662,6 +760,20 @@ def test_local_command_without_stdout_falls_back_to_generic_note() -> None:
     events = norm.process_record(record)
     assert events[0].text == "Command complete"
     assert events[0].status == SessionStatus.IDLE
+
+
+def test_local_command_joins_multiple_output_blocks() -> None:
+    norm = TranscriptNormalizer()
+    record = {
+        "type": "system",
+        "subtype": "local_command",
+        "content": (
+            "<local-command-stdout>first</local-command-stdout>"
+            "ignored between blocks"
+            "<local-command-stderr>second</local-command-stderr>"
+        ),
+    }
+    assert norm.process_record(record)[0].text == "first\nsecond"
 
 
 def test_local_command_stdout_is_truncated() -> None:

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -50,6 +50,18 @@ def _text_block(text: str) -> dict:
     return {"type": "text", "text": text}
 
 
+def _edit_result_record(
+    tool_use_id: str, tool_use_result: dict, is_error: bool = False
+) -> dict:
+    return {
+        "type": "user",
+        "message": {
+            "content": [_tool_result_block(tool_use_id, "ok", is_error=is_error)]
+        },
+        "toolUseResult": tool_use_result,
+    }
+
+
 # ── _is_injected_turn ─────────────────────────────────────────────────────────
 
 
@@ -449,6 +461,126 @@ def test_interleaved_tool_use_and_tool_result() -> None:
     # r3 with same id is not first_seen → usage dict should be empty)
     result3 = next(e for e in ev3 if e.metadata.get("method") == "result")
     assert result3.metadata["usage"] == {}
+
+
+# ── file-edit diff previews ───────────────────────────────────────────────────
+
+
+def test_write_result_attaches_add_diff_preview() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msgW",
+            [_tool_use_block("tu1", "Write", {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    events = norm.process_record(
+        _edit_result_record(
+            "tu1",
+            {"type": "create", "filePath": "/repo/a.py", "content": "x = 1\n"},
+        )
+    )
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    preview = result.metadata["diff_preview"]
+    assert preview["phase"] == "applied"
+    file = preview["files"][0]
+    assert file["change_type"] == "add"
+    assert file["path"] == "/repo/a.py"
+    assert file["additions"] == 1
+
+
+def test_edit_result_attaches_update_diff_from_structured_patch() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msgE",
+            [_tool_use_block("tu1", "Edit", {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    events = norm.process_record(
+        _edit_result_record(
+            "tu1",
+            {
+                "type": "update",
+                "filePath": "/repo/a.py",
+                "structuredPatch": [
+                    {
+                        "oldStart": 1,
+                        "oldLines": 1,
+                        "newStart": 1,
+                        "newLines": 2,
+                        "lines": [" keep", "+added"],
+                    }
+                ],
+            },
+        )
+    )
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    file = result.metadata["diff_preview"]["files"][0]
+    assert file["change_type"] == "update"
+    assert "@@ -1,1 +1,2 @@" in file["diff"]
+    assert "+added" in file["diff"]
+    assert file["additions"] == 1
+
+
+def test_non_edit_tool_result_has_no_diff_preview() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msgR",
+            [_tool_use_block("tu1", "Read", {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    events = norm.process_record(_user_record([_tool_result_block("tu1", "data")]))
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    assert "diff_preview" not in result.metadata
+
+
+def test_failed_edit_result_has_no_diff_preview() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msgF",
+            [_tool_use_block("tu1", "Edit", {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    events = norm.process_record(
+        _edit_result_record(
+            "tu1",
+            {"type": "update", "filePath": "/repo/a.py", "structuredPatch": []},
+            is_error=True,
+        )
+    )
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    assert "diff_preview" not in result.metadata
+
+
+def test_rejected_file_edit_has_no_diff_preview_and_aborts_turn() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msgX",
+            [_tool_use_block("tu1", "Edit", {"file_path": "a.py"})],
+            stop_reason="tool_use",
+        )
+    )
+    rejection = {
+        "type": "user",
+        "message": {"content": [_tool_result_block("tu1", "denied", is_error=True)]},
+        "toolUseResult": "User rejected tool use",
+    }
+    events = norm.process_record(rejection)
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    assert "diff_preview" not in result.metadata
+    assert any(
+        e.kind == EventKind.SYSTEM_NOTE
+        and e.metadata.get("stop_reason") == "tool_rejected"
+        for e in events
+    )
 
 
 # ── result text formatting ────────────────────────────────────────────────────

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -583,6 +583,60 @@ def test_rejected_file_edit_has_no_diff_preview_and_aborts_turn() -> None:
     )
 
 
+# ── compaction ────────────────────────────────────────────────────────────────
+
+
+def _compact_boundary_record(trigger: str, pre_tokens: int | None = None) -> dict:
+    meta: dict = {"trigger": trigger}
+    if pre_tokens is not None:
+        meta["preTokens"] = pre_tokens
+    return {
+        "type": "system",
+        "subtype": "compact_boundary",
+        "content": "Conversation compacted",
+        "compactMetadata": meta,
+    }
+
+
+def test_manual_compact_resolves_session_to_idle() -> None:
+    norm = TranscriptNormalizer()
+    events = norm.process_record(_compact_boundary_record("manual", pre_tokens=89941))
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind == EventKind.SYSTEM_NOTE
+    assert ev.status == SessionStatus.IDLE
+    assert ev.metadata["stop_reason"] == "compact"
+    assert "89941" in ev.text
+
+
+def test_manual_compact_without_pre_tokens_uses_plain_text() -> None:
+    norm = TranscriptNormalizer()
+    events = norm.process_record(_compact_boundary_record("manual"))
+    assert events[0].text == "Context compacted"
+
+
+def test_auto_compact_emits_no_event() -> None:
+    norm = TranscriptNormalizer()
+    assert (
+        norm.process_record(_compact_boundary_record("auto", pre_tokens=120000)) == []
+    )
+
+
+def test_compact_boundary_without_metadata_emits_no_event() -> None:
+    # Missing compactMetadata means no trigger, so it cannot be confirmed manual.
+    norm = TranscriptNormalizer()
+    record = {"type": "system", "subtype": "compact_boundary"}
+    assert norm.process_record(record) == []
+
+
+def test_compact_summary_user_record_still_dropped() -> None:
+    norm = TranscriptNormalizer()
+    record = _user_record(
+        "This session is being continued from a previous conversation"
+    )
+    assert norm.process_record(record) == []
+
+
 # ── result text formatting ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Three gaps in the `claude_tty` (Emulated) transport's transcript normalizer, all stemming from records it dropped without emitting an event or resolving status.

1. **File-edit tools emitted no diff.** `Edit`/`Write`/`MultiEdit` surfaced only as bare tool calls, so the UI fell back to an empty diff placeholder. The structured `claude_code` adapter builds a preview from the tool input *before* the edit applies, but `claude_tty` tails the TUI transcript *after* the fact — so the diff has to be reconstructed from the result record instead.
2. **A manual `/compact` left the session stuck `running`.** Compaction writes only a `compact_boundary` system record and an injected continuation summary, both dropped; with no terminal assistant record the session never returned to idle.
3. **A rejected/no-op local slash command left the session stuck `running`.** `/compact` with nothing to compact (and other local builtins like `/status`) writes a `local_command` system record and runs no model turn, so the `RUNNING` status that `handle_input` sets on send was never resolved.

Backend-only — the frontend already renders `diff_preview` and the session status.

## Changes

### Backend

- **`backends/diff_preview.py`** — `files_from_claude_tool_result()` builds diff files from a Claude TUI `toolUseResult`: `create` carries the full new `content` (rendered as an add-diff); `update` carries a `structuredPatch` of hunks that `_unified_diff_from_structured_patch()` renders back into a unified diff (hunk counters coerced via `_patch_int`).
- **`backends/claude_tty/normalize.py`**
  - Tracks file-edit `tool_use` ids on the assistant pass and, on the matching `tool_result` record, attaches an `applied`-phase `diff_preview` reconstructed from `toolUseResult` (skipped on error/rejected results).
  - New `_process_system` dispatch: a manual-trigger `compact_boundary` synthesizes a terminal result note (`Context compacted · N tokens`); a `local_command` record resolves to idle, surfacing the command's stdout (stripped of `<local-command-*>` wrappers, truncated to 500 chars, `Command complete` fallback). Auto-compaction is left alone — it fires mid-turn and the surrounding turn ends with its own `end_turn`.
  - Removed the dead, now-misleading `HANDLED_RECORD_TYPES` constant; its rationale moved onto the dispatch fallthrough.

### Tests

- **`tests/test_claude_tty_normalize.py`** — add/update diff previews (incl. the rejected-edit and missing-metadata edge cases); manual vs. auto compaction; the `local_command` idle resolution (stdout surfaced, empty fallback, truncation).

## Test Plan

- [x] `cd backend && uv run pytest` — 997 passed.
- [x] `cd backend && uv run pre-commit run --files <changed files>` — isort / black / ruff / codespell / mypy clean.
- [x] Live e2e on a restarted stack (spawned `claude_tty` children): `Edit`→update and `Write`→add diff previews render with correct hunks/counts and visually in the UI; manual `/compact` resolves to idle (`Context compacted · 29176 tokens`); rejected `/compact` resolves to idle (`Not enough messages to compact.`); normal turns unregressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)