### PR TITLE
feat: redesign the blackboard layout for density and hierarchy

### DIFF
--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
   type KeyboardEvent,
+  type ReactNode,
 } from "react";
 
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -36,6 +37,28 @@ type LoadState = "loading" | "ready" | "error";
 
 function shortId(value: string): string {
   return value.length > 16 ? `${value.slice(0, 16)}…` : value;
+}
+
+// A scalar cell holds a short single-line value (a status flag, a count). It
+// renders as a compact strip row instead of a card so a wall of one-word cells
+// doesn't dominate the board.
+const SCALAR_MAX_LEN = 64;
+function isScalarCell(entry: BoardEntry): boolean {
+  return !entry.text.includes("\n") && entry.text.trim().length <= SCALAR_MAX_LEN;
+}
+
+// The brief cell, promoted above the rest of the board.
+const HERO_CELL_KEY = "plan";
+
+// The common author of a set of entries, or null when they disagree or none
+// has one. Lets the board state authorship once instead of on every card.
+function uniformAuthor(entries: BoardEntry[]): string | null {
+  if (entries.length === 0) return null;
+  const first = entries[0].author_session_id;
+  if (!first) return null;
+  return entries.every((entry) => entry.author_session_id === first)
+    ? first
+    : null;
 }
 
 function MetaChips({ metadata }: { metadata: Record<string, unknown> }) {
@@ -210,6 +233,65 @@ function EntryDetail({
   );
 }
 
+interface EntryControls {
+  editingId: number | null;
+  editDraft: string;
+  savingEdit: boolean;
+  expandedId: number | null;
+  confirmDeleteId: number | null;
+  onEditChange: (value: string) => void;
+  onEditSave: (entry: BoardEntry) => void;
+  onEditCancel: () => void;
+  onStartEdit: (entry: BoardEntry) => void;
+  onRequestDelete: (entry: BoardEntry) => void;
+  onConfirmDelete: (entry: BoardEntry) => void;
+  onCancelDelete: () => void;
+}
+
+// Shared body for every expandable entry: the editor swaps in for the value
+// while editing, and the detail panel appends while expanded. `children` is the
+// value markup, which differs per layout (card, hero, log line). State-strip
+// rows render their value inline in the row instead and pass `null`, so they
+// get only the editor/detail behavior.
+function EntryExpansion({
+  entry,
+  controls,
+  children,
+}: {
+  entry: BoardEntry;
+  controls: EntryControls;
+  children: ReactNode;
+}) {
+  const editing = controls.editingId === entry.id;
+  const expanded = controls.expandedId === entry.id;
+  return (
+    <>
+      {editing ? (
+        <EntryEditor
+          entry={entry}
+          draft={controls.editDraft}
+          saving={controls.savingEdit}
+          onChange={controls.onEditChange}
+          onSave={controls.onEditSave}
+          onCancel={controls.onEditCancel}
+        />
+      ) : (
+        children
+      )}
+      {expanded && !editing ? (
+        <EntryDetail
+          entry={entry}
+          confirmingDelete={controls.confirmDeleteId === entry.id}
+          onStartEdit={controls.onStartEdit}
+          onRequestDelete={controls.onRequestDelete}
+          onConfirmDelete={controls.onConfirmDelete}
+          onCancelDelete={controls.onCancelDelete}
+        />
+      ) : null}
+    </>
+  );
+}
+
 export default function BoardPage() {
   const router = useRouter();
   const { theme } = useTheme();
@@ -226,6 +308,7 @@ export default function BoardPage() {
   const [draftText, setDraftText] = useState("");
   const [draftKey, setDraftKey] = useState("");
   const [posting, setPosting] = useState(false);
+  const [composerOpen, setComposerOpen] = useState(false);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editDraft, setEditDraft] = useState("");
@@ -606,6 +689,36 @@ export default function BoardPage() {
   const log = entries.filter((entry) => !entry.key).reverse();
   const hasOlder = log.length < logTotal;
 
+  // Cells are ranked by shape rather than rendered uniformly: `plan` is the
+  // brief and leads as a hero; short scalars collapse into a state strip; the
+  // rest stay as cards.
+  const heroCell = cells.find((entry) => entry.key === HERO_CELL_KEY) ?? null;
+  const bodyCells = cells.filter((entry) => entry !== heroCell);
+  const scalarCells = bodyCells.filter(isScalarCell);
+  const cardCells = bodyCells.filter((entry) => !isScalarCell(entry));
+  // When every cell shares an author, name them once above the grid and drop
+  // the repeated per-card line. Cells always load in full, so this is stable;
+  // the log is paginated, so only collapse its author once the whole log is
+  // loaded — otherwise "Load older" could reveal a new author and make the
+  // header flip away mid-session.
+  const cellAuthor = uniformAuthor(cells);
+  const logAuthor = hasOlder ? null : uniformAuthor(log);
+
+  const controls: EntryControls = {
+    editingId,
+    editDraft,
+    savingEdit,
+    expandedId,
+    confirmDeleteId,
+    onEditChange: setEditDraft,
+    onEditSave: handleEditSave,
+    onEditCancel: cancelEdit,
+    onStartEdit: startEdit,
+    onRequestDelete: requestDelete,
+    onConfirmDelete: handleDeleteEntry,
+    onCancelDelete: cancelDelete,
+  };
+
   return (
     <main className="page-shell">
       <header className="app-bar">
@@ -645,46 +758,72 @@ export default function BoardPage() {
         </div>
       ) : null}
 
-      <section className="panel board-composer" aria-label="Post to a channel">
-        <div className="board-composer-fields">
-          <input
-            className="board-input board-input-channel"
-            placeholder="channel — e.g. topic:plan"
-            value={draftChannel}
-            onChange={(event) => setDraftChannel(event.target.value)}
-            aria-label="Channel"
-          />
-          <span className="board-composer-sep" aria-hidden="true">
-            /
+      <section
+        className={`panel board-composer${composerOpen ? " is-open" : ""}`}
+        aria-label="Post to a channel"
+      >
+        <button
+          type="button"
+          className="board-composer-toggle"
+          onClick={() => setComposerOpen((open) => !open)}
+          aria-expanded={composerOpen}
+        >
+          <span className="board-composer-cue" aria-hidden="true">
+            ＋
           </span>
-          <input
-            className="board-input board-input-key"
-            placeholder="key — blank appends to the log"
-            value={draftKey}
-            onChange={(event) => setDraftKey(event.target.value)}
-            aria-label="Key"
-          />
-        </div>
-        <div className="board-composer-row">
-          <input
-            className="board-input board-input-text"
-            placeholder="message"
-            value={draftText}
-            onChange={(event) => setDraftText(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") void handlePost();
-            }}
-            aria-label="Message"
-          />
-          <button
-            type="button"
-            className="primary"
-            onClick={() => void handlePost()}
-            disabled={posting || !draftChannel.trim() || !draftText.trim()}
-          >
-            {draftKey.trim() ? "Set cell" : "Post"}
-          </button>
-        </div>
+          <span className="board-composer-toggle-label">Post to a channel</span>
+          {!composerOpen && (draftChannel.trim() || activeChannel) ? (
+            <span className="board-composer-target">
+              {draftChannel.trim() || activeChannel}
+            </span>
+          ) : null}
+          <span className="board-composer-chevron" aria-hidden="true">
+            ›
+          </span>
+        </button>
+        {composerOpen ? (
+          <div className="board-composer-body">
+            <div className="board-composer-fields">
+              <input
+                className="board-input board-input-channel"
+                placeholder="channel — e.g. topic:plan"
+                value={draftChannel}
+                onChange={(event) => setDraftChannel(event.target.value)}
+                aria-label="Channel"
+              />
+              <span className="board-composer-sep" aria-hidden="true">
+                /
+              </span>
+              <input
+                className="board-input board-input-key"
+                placeholder="key — blank appends to the log"
+                value={draftKey}
+                onChange={(event) => setDraftKey(event.target.value)}
+                aria-label="Key"
+              />
+            </div>
+            <div className="board-composer-row">
+              <input
+                className="board-input board-input-text"
+                placeholder="message"
+                value={draftText}
+                onChange={(event) => setDraftText(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") void handlePost();
+                }}
+                aria-label="Message"
+              />
+              <button
+                type="button"
+                className="primary"
+                onClick={() => void handlePost()}
+                disabled={posting || !draftChannel.trim() || !draftText.trim()}
+              >
+                {draftKey.trim() ? "Set cell" : "Post"}
+              </button>
+            </div>
+          </div>
+        ) : null}
       </section>
 
       {state === "ready" && channels.length === 0 ? (
@@ -757,69 +896,154 @@ export default function BoardPage() {
             ) : null}
 
             {cells.length > 0 ? (
-              <section aria-label="Cells">
-                <h3 className="board-group-label">Cells · latest value</h3>
-                <div className="board-cell-grid">
-                  {cells.map((entry) => (
-                    <article
-                      key={entry.id}
-                      className={`board-cell${
-                        expandedId === entry.id ? " is-expanded" : ""
-                      }`}
-                      role="button"
-                      tabIndex={0}
-                      aria-expanded={expandedId === entry.id}
-                      onClick={() => activateEntry(entry.id)}
-                      onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
-                    >
-                      <header className="board-cell-head">
-                        <span className="board-cell-key">{entry.key}</span>
-                        <span className="board-cell-time">
-                          {formatRelativeTime(entry.created_at)}
-                          {entry.edited_at ? (
-                            <span className="board-edited"> · edited</span>
-                          ) : null}
+              <section className="board-cells" aria-label="Cells">
+                <h3 className="board-group-label">
+                  Cells · latest value
+                  {cellAuthor ? (
+                    <span className="board-group-by">
+                      {" · all by "}
+                      {shortId(cellAuthor)}
+                    </span>
+                  ) : null}
+                </h3>
+
+                {heroCell ? (
+                  <article
+                    className={`board-hero${
+                      expandedId === heroCell.id ? " is-expanded" : ""
+                    }`}
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={expandedId === heroCell.id}
+                    onClick={() => activateEntry(heroCell.id)}
+                    onKeyDown={(event) => onEntryKeyDown(event, heroCell.id)}
+                  >
+                    <header className="board-hero-head">
+                      <span className="board-hero-key">{heroCell.key}</span>
+                      <span className="board-cell-time">
+                        {formatRelativeTime(heroCell.created_at)}
+                        {heroCell.edited_at ? (
+                          <span className="board-edited"> · edited</span>
+                        ) : null}
+                        <span className="board-expand-cue" aria-hidden="true">
+                          ›
                         </span>
-                      </header>
-                      {editingId === entry.id ? (
-                        <EntryEditor
-                          entry={entry}
-                          draft={editDraft}
-                          saving={savingEdit}
-                          onChange={setEditDraft}
-                          onSave={handleEditSave}
-                          onCancel={cancelEdit}
-                        />
-                      ) : (
-                        <p className="board-cell-value">{entry.text}</p>
-                      )}
-                      <footer className="board-cell-foot">
-                        <span className="board-cell-author">
-                          {entry.author_session_id
-                            ? shortId(entry.author_session_id)
-                            : "—"}
-                        </span>
-                      </footer>
-                      <MetaChips metadata={entry.metadata} />
-                      {expandedId === entry.id && editingId !== entry.id ? (
-                        <EntryDetail
-                          entry={entry}
-                          confirmingDelete={confirmDeleteId === entry.id}
-                          onStartEdit={startEdit}
-                          onRequestDelete={requestDelete}
-                          onConfirmDelete={handleDeleteEntry}
-                          onCancelDelete={cancelDelete}
-                        />
-                      ) : null}
-                    </article>
-                  ))}
-                </div>
+                      </span>
+                    </header>
+                    <EntryExpansion entry={heroCell} controls={controls}>
+                      <>
+                        <p className="board-hero-value">{heroCell.text}</p>
+                        <MetaChips metadata={heroCell.metadata} />
+                      </>
+                    </EntryExpansion>
+                  </article>
+                ) : null}
+
+                {scalarCells.length > 0 ? (
+                  <ul className="board-state-list">
+                    {scalarCells.map((entry) => (
+                      <li key={entry.id} className="board-state-wrap">
+                        <div
+                          className={`board-state-row${
+                            expandedId === entry.id ? " is-expanded" : ""
+                          }`}
+                          role="button"
+                          tabIndex={0}
+                          aria-expanded={expandedId === entry.id}
+                          onClick={() => activateEntry(entry.id)}
+                          onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
+                        >
+                          <span className="board-state-key">{entry.key}</span>
+                          {editingId === entry.id ? null : (
+                            <span className="board-state-value">
+                              {entry.text}
+                            </span>
+                          )}
+                          <MetaChips metadata={entry.metadata} />
+                          {cellAuthor ? null : (
+                            <span className="board-state-author">
+                              {entry.author_session_id
+                                ? shortId(entry.author_session_id)
+                                : "—"}
+                            </span>
+                          )}
+                          <span className="board-state-time">
+                            {formatRelativeTime(entry.created_at)}
+                            {entry.edited_at ? (
+                              <span className="board-edited"> · edited</span>
+                            ) : null}
+                            <span className="board-expand-cue" aria-hidden="true">
+                              ›
+                            </span>
+                          </span>
+                        </div>
+                        <EntryExpansion entry={entry} controls={controls}>
+                          {null}
+                        </EntryExpansion>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+
+                {cardCells.length > 0 ? (
+                  <div className="board-cell-grid">
+                    {cardCells.map((entry) => (
+                      <article
+                        key={entry.id}
+                        className={`board-cell${
+                          expandedId === entry.id ? " is-expanded" : ""
+                        }`}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={expandedId === entry.id}
+                        onClick={() => activateEntry(entry.id)}
+                        onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
+                      >
+                        <header className="board-cell-head">
+                          <span className="board-cell-key">{entry.key}</span>
+                          <span className="board-cell-time">
+                            {formatRelativeTime(entry.created_at)}
+                            {entry.edited_at ? (
+                              <span className="board-edited"> · edited</span>
+                            ) : null}
+                            <span className="board-expand-cue" aria-hidden="true">
+                              ›
+                            </span>
+                          </span>
+                        </header>
+                        <EntryExpansion entry={entry} controls={controls}>
+                          <>
+                            <p className="board-cell-value">{entry.text}</p>
+                            {cellAuthor ? null : (
+                              <footer className="board-cell-foot">
+                                <span className="board-cell-author">
+                                  {entry.author_session_id
+                                    ? shortId(entry.author_session_id)
+                                    : "—"}
+                                </span>
+                              </footer>
+                            )}
+                            <MetaChips metadata={entry.metadata} />
+                          </>
+                        </EntryExpansion>
+                      </article>
+                    ))}
+                  </div>
+                ) : null}
               </section>
             ) : null}
 
-            <section aria-label="Log">
+            <section className="board-log" aria-label="Log">
               {cells.length > 0 ? (
-                <h3 className="board-group-label">Log · newest first</h3>
+                <h3 className="board-group-label">
+                  Log · newest first
+                  {logAuthor ? (
+                    <span className="board-group-by">
+                      {" · all by "}
+                      {shortId(logAuthor)}
+                    </span>
+                  ) : null}
+                </h3>
               ) : null}
               {log.length === 0 ? (
                 <p className="board-log-empty">
@@ -842,42 +1066,27 @@ export default function BoardPage() {
                         onClick={() => activateEntry(entry.id)}
                         onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
                       >
-                        <div className="board-log-head">
-                          <span className="board-log-author">
-                            {entry.author_session_id
-                              ? shortId(entry.author_session_id)
-                              : "—"}
-                          </span>
-                          <span className="board-log-time">
-                            {formatRelativeTime(entry.created_at)}
-                            {entry.edited_at ? (
-                              <span className="board-edited"> · edited</span>
-                            ) : null}
-                          </span>
-                        </div>
-                        {editingId === entry.id ? (
-                          <EntryEditor
-                            entry={entry}
-                            draft={editDraft}
-                            saving={savingEdit}
-                            onChange={setEditDraft}
-                            onSave={handleEditSave}
-                            onCancel={cancelEdit}
-                          />
-                        ) : (
-                          <p className="board-log-text">{entry.text}</p>
-                        )}
-                        <MetaChips metadata={entry.metadata} />
-                        {expandedId === entry.id && editingId !== entry.id ? (
-                          <EntryDetail
-                            entry={entry}
-                            confirmingDelete={confirmDeleteId === entry.id}
-                            onStartEdit={startEdit}
-                            onRequestDelete={requestDelete}
-                            onConfirmDelete={handleDeleteEntry}
-                            onCancelDelete={cancelDelete}
-                          />
-                        ) : null}
+                        <EntryExpansion entry={entry} controls={controls}>
+                          <div className="board-log-main">
+                            <p className="board-log-text">{entry.text}</p>
+                            <div className="board-log-meta">
+                              <span className="board-log-time">
+                                {formatRelativeTime(entry.created_at)}
+                                {entry.edited_at ? (
+                                  <span className="board-edited"> · edited</span>
+                                ) : null}
+                              </span>
+                              {logAuthor ? null : (
+                                <span className="board-log-author">
+                                  {entry.author_session_id
+                                    ? shortId(entry.author_session_id)
+                                    : "—"}
+                                </span>
+                              )}
+                              <MetaChips metadata={entry.metadata} />
+                            </div>
+                          </div>
+                        </EntryExpansion>
                       </div>
                     </li>
                   ))}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10571,10 +10571,78 @@ html[data-theme="light"]
 }
 
 /* Composer */
+/* Composer collapses to a slim bar so reading the board, not posting, owns the
+   top of the page. */
 .board-composer {
   display: flex;
   flex-direction: column;
+  gap: 12px;
+  padding: 0;
+  overflow: hidden;
+}
+
+.board-composer-toggle {
+  display: flex;
+  align-items: center;
   gap: 10px;
+  width: 100%;
+  padding: 12px 16px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+
+.board-composer-cue {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--accent-cool);
+}
+
+.board-composer-toggle-label {
+  flex-shrink: 0;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.board-composer-toggle:hover .board-composer-toggle-label {
+  color: var(--text);
+}
+
+.board-composer-target {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--accent-cool);
+}
+
+.board-composer-chevron {
+  margin-left: auto;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--muted-soft);
+  transition: transform 0.16s ease;
+}
+
+.board-composer.is-open .board-composer-chevron {
+  transform: rotate(90deg);
+}
+
+.board-composer-body {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 0 16px 14px;
 }
 
 .board-composer-fields {
@@ -10752,7 +10820,8 @@ html[data-theme="light"]
   font-size: 1.5rem;
   letter-spacing: 0.01em;
   color: var(--text-strong);
-  word-break: break-all;
+  /* Break at the channel's own separators (`:` `-`) before splitting a word. */
+  overflow-wrap: anywhere;
 }
 
 .board-actions {
@@ -10804,10 +10873,179 @@ html[data-theme="light"]
   color: var(--muted-soft);
 }
 
-/* Pinned keyed cells */
+/* Keyed cells, ranked by shape: a `plan` hero, a scalar state strip, then
+   long-form cards. */
+.board-cells {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.board-group-by {
+  color: var(--muted);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+/* The brief — promoted above the rest of the cells. */
+.board-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 16px 18px;
+  border-radius: var(--radius-md);
+  border: 1px solid color-mix(in srgb, var(--accent) 36%, var(--line));
+  border-left: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--accent) 7%, var(--bg-card));
+}
+
+.board-hero-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.board-hero-key {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.board-hero-value {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 1.02rem;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 5;
+  overflow: hidden;
+}
+
+.board-hero.is-expanded .board-hero-value {
+  display: block;
+  -webkit-line-clamp: unset;
+  overflow: visible;
+}
+
+/* Scalar cells render as a dense state strip instead of a grid of near-empty
+   cards. */
+.board-state-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.board-state-wrap:not(:last-child) {
+  border-bottom: 1px solid var(--line);
+}
+
+.board-state-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  padding: 8px 14px;
+  background: var(--bg-card);
+  cursor: pointer;
+  transition: background 0.14s ease;
+}
+
+.board-state-row:hover,
+.board-state-row.is-expanded {
+  background: color-mix(in srgb, var(--accent-cool) 8%, var(--bg-card));
+}
+
+.board-state-row:focus-visible {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: -2px;
+}
+
+.board-state-key {
+  flex-shrink: 0;
+  min-width: 96px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent-cool);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board-state-value {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-strong);
+  font-size: 0.9rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.board-state-row .board-meta {
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.board-state-author {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+}
+
+.board-state-time {
+  flex-shrink: 0;
+  margin-left: auto;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
+.board-state-wrap .board-edit,
+.board-state-wrap .board-detail {
+  padding: 12px 14px;
+  margin: 0;
+  background: color-mix(in srgb, var(--accent-cool) 6%, var(--bg-card));
+  border-top: 1px solid var(--line);
+}
+
+.board-state-wrap .board-detail {
+  border-top: 1px dashed var(--line);
+}
+
+/* A faint chevron signals a card expands; it rotates open. */
+.board-expand-cue {
+  display: inline-block;
+  margin-left: 6px;
+  color: var(--muted-soft);
+  transition: transform 0.14s ease;
+}
+
+.board-cell.is-expanded .board-expand-cue,
+.board-hero.is-expanded .board-expand-cue,
+.board-state-row.is-expanded .board-expand-cue {
+  transform: rotate(90deg);
+  color: var(--accent-cool);
+}
+
+/* Long-form cells */
 .board-cell-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 12px;
   /* Size each card to its own content so expanding one doesn't stretch the
      rest of its row to match. */
@@ -10922,13 +11160,25 @@ html[data-theme="light"]
   min-width: 0;
 }
 
-.board-log-head {
+/* Message-first: the post text leads, authorship trails as dim meta. */
+.board-log-main {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.board-log-meta {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 8px;
   font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--muted);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
+.board-log-meta .board-meta {
+  margin: 0;
 }
 
 .board-log-author,
@@ -10940,12 +11190,8 @@ html[data-theme="light"]
   color: var(--muted);
 }
 
-.board-log-time {
-  margin-left: auto;
-}
-
 .board-log-text {
-  margin: 4px 0 0;
+  margin: 0;
   color: var(--text);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -11024,6 +11270,11 @@ html[data-theme="light"]
   border: 1px solid var(--line);
   border-radius: var(--radius-pill);
   padding: 1px 8px;
+  /* A long value (e.g. a session id) ellipsizes instead of overflowing. */
+  max-width: 16rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Expandable entries + detail */
@@ -11203,5 +11454,17 @@ html[data-theme="light"]
   }
   .board-rail {
     position: static;
+  }
+  /* Stack the title above its actions so a long channel name doesn't collide
+     with the Clear/Delete buttons. */
+  .board-main-head {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .board-main-title {
+    font-size: 1.25rem;
+  }
+  .board-actions {
+    flex-wrap: wrap;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3725,6 +3725,10 @@ html[data-theme="light"] .task-dock-panel {
   bottom: 0;
   z-index: 6;
   display: grid;
+  /* Clamp the single column to the container so a wide child (e.g. the
+     no-wrap attachment strip) scrolls inside its own box instead of stretching
+     the composer and skewing the whole page. */
+  grid-template-columns: minmax(0, 1fr);
   gap: 7px;
   padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
   border: 1px solid var(--line-strong);
@@ -6443,6 +6447,10 @@ html[data-theme="light"] .composer-overflow-item.warn:hover:not(:disabled) {
  * vertically centres the auto-grown textarea, and it grows past 38px only when
  * the draft wraps to multiple lines. */
 .reply-textarea-wrap {
+  /* Right padding reserves room for the send button pinned inside the pill;
+   * the tray above the button reclaims the difference (see .attachment-tray-wrap). */
+  --pill-inset-left: 16px;
+  --pill-send-gutter: 46px;
   flex: 1 1 auto;
   min-width: 0;
   min-height: 40px;
@@ -6452,9 +6460,7 @@ html[data-theme="light"] .composer-overflow-item.warn:hover:not(:disabled) {
   border: 1px solid var(--line-strong);
   border-radius: 20px;
   background: rgba(6, 8, 13, 0.66);
-  /* Right padding reserves room for the send button, which is pinned inside
-   * the pill so the text field reads wider. */
-  padding: 5px 46px 5px 16px;
+  padding: 5px var(--pill-send-gutter) 5px var(--pill-inset-left);
   box-shadow: inset 0 1px 0 rgba(200, 169, 106, 0.1);
   transition:
     border-color 160ms ease,
@@ -7250,6 +7256,14 @@ html[data-theme="light"] .ask-question-note-input {
 
 .attachment-tray-wrap {
   margin-bottom: 8px;
+  /* Let the no-wrap scroll strip below clamp to the composer width. */
+  min-width: 0;
+  /* The pill reserves a right gutter for the send button, but the button only
+     sits on the bottom row — reclaim that gutter for the tray above it so the
+     chips align to the same inset as the left edge instead of being squeezed.
+     Derived from the pill padding so it tracks any send-button geometry change;
+     resolves to 0 outside a composer pill where the vars are undefined. */
+  margin-right: calc(var(--pill-inset-left) - var(--pill-send-gutter));
 }
 
 .attachment-tray-header {
@@ -7290,6 +7304,7 @@ html[data-theme="light"] .ask-question-note-input {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  min-width: 0;
 }
 
 .attachment-chip {
@@ -8496,6 +8511,9 @@ html[data-theme="light"] .term-compose-handle:hover {
 /* The text pill — owns the border, fill, gold hairline, focus ring, and the
  * send button pinned inside its bottom-right. */
 .term-compose-input {
+  /* Same pinned-send-button geometry as .reply-textarea-wrap. */
+  --pill-inset-left: 16px;
+  --pill-send-gutter: 46px;
   position: relative;
   flex: 1 1 auto;
   min-width: 0;
@@ -8506,7 +8524,7 @@ html[data-theme="light"] .term-compose-handle:hover {
   border: 1px solid var(--line-strong);
   border-radius: 20px;
   background: rgba(6, 8, 13, 0.66);
-  padding: 5px 46px 5px 16px;
+  padding: 5px var(--pill-send-gutter) 5px var(--pill-inset-left);
   box-shadow: inset 0 1px 0 rgba(200, 169, 106, 0.1);
   transition:
     border-color 160ms ease,


### PR DESCRIPTION
## Summary

Two changes ship together on this branch, both frontend-only UI work surfaced by reviewing the board and the message composer on a phone.

**1. The blackboard is re-ranked for density and hierarchy.** Every keyed cell rendered as an identical card and the composer docked as the heaviest element on the page, so a wall of near-empty `status:*` cards pushed the actual channel below the fold. Cells are now ranked by shape rather than rendered uniformly, and the composer steps out of the way until you need it.

User-visible outcomes:

1. **The composer is a slim, collapsed bar.** It shows the target channel and expands on click, so reading the board — the common case — owns the top of the page instead of ~200px of form.
2. **Cells are ranked by shape.** The `plan` brief leads as a full-width hero with an accent rule; short single-line scalars (`status:N`, `state=done`) collapse into a compact state strip instead of five big near-empty cards; long-form cells (`task:N`) stay as cards in a tighter grid that packs more columns and stops leaving dead cells.
3. **Authorship is stated once.** When every cell (or the fully-loaded log) shares an author it reads in the group label and drops off each entry; the per-entry author reappears only when authors differ.
4. **The log is message-first.** The post text leads and time + author + chips trail as dim meta, and each clamped card carries a chevron advertising the click-to-expand it always had.
5. **Mobile holds together.** Long channel names break at their own separators, the header actions stack below the title, the composer label stays one line, and long metadata chips ellipsize or wrap instead of overflowing.

**2. The composer attachment tray no longer skews the page.** Attaching several images blew the composer (and the whole page) wider on mobile, and the tray was squeezed against a gutter reserved for the send button.

User-visible outcomes:

1. **Multiple attachments stay within the composer width** — wrapping to rows on desktop and becoming a horizontal scroll strip on phones, with no page skew.
2. **The tray uses the full pill width.** The pinned send button reserves a right gutter across the pill's height even though it only sits on the bottom row; the tray above it now reclaims that gutter so chips align to the same inset as the left edge.

## Changes

### Frontend

- **`app/board/page.tsx`** — splits keyed cells into a `plan` hero, a scalar `board-state` strip, and long-form cards; adds a collapsible composer (`composerOpen`); makes the log message-first with trailing meta; de-duplicates authorship via `uniformAuthor` (the log only collapses once fully loaded, so "Load older" can't make the header flip); hoists the hero key to `HERO_CELL_KEY`; and factors the editor/detail expansion into a shared `EntryExpansion` used across hero, strip, cards, and log.
- **`app/globals.css`** — board styles for the hero, state strip, expand chevrons, and tighter card grid, plus the mobile wrap/ellipsize rules. For the composer: `.composer` gets `grid-template-columns: minmax(0, 1fr)` so a wide child can't stretch the track; `.attachment-tray-wrap` / `.attachment-tray` get `min-width: 0` to complete the overflow-clamp chain; and the tray reclaims the send-button gutter via a margin derived from shared `--pill-inset-left` / `--pill-send-gutter` vars on both composer pills. All new colors resolve through theme variables, so light mode adapts without separate overrides.

## Test Plan

- [x] `cd frontend && npm run lint` — clean.
- [x] `cd frontend && npx tsc --noEmit` — clean.
- [x] `cd frontend && npm run build` — compiled (`/board` route builds).
- [x] `waypointctl restart frontend` — came up healthy serving this branch; `/board` returns 200.
- [x] On-device (reporting screenshots): confirmed the board renders the hero / state strip / message-first log / collapsed composer, the mobile overflow fixes hold, and multiple attached images no longer skew the page.
- [ ] Not yet re-confirmed on device after the final tweak: the attachment tray reclaiming the send-button gutter (the derived-margin version).
- Note: the frontend has no automated test harness in this repo, so verification is lint + build + on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)