### PR TITLE
fix: widen the tmux submit-confirm budget for image ingestion

### DIFF
--- a/backend/src/waypoint/backends/tmux/transport.py
+++ b/backend/src/waypoint/backends/tmux/transport.py
@@ -107,7 +107,7 @@ class TmuxTransport(TransportAdapter):
         confirmer: PaneSubmitConfirming,
         sent_text: str,
         *,
-        attempts: int = 8,
+        attempts: int = 30,
         poll_seconds: float = 0.4,
     ) -> None:
         # Re-send Enter until the composer reports cleared. Submit before
@@ -119,6 +119,17 @@ class TmuxTransport(TransportAdapter):
         # message already submitted and opened one (or one raced in), and an
         # Enter would select an option (e.g. approve a tool). Bounded; if the TUI
         # never confirms, leave the input rather than spamming keystrokes.
+        #
+        # The budget (attempts × poll) must outlast the wrapped TUI's paste
+        # ingestion: the Claude TUI converts pasted image paths into ``[Image
+        # #N]`` chips asynchronously and *drops* the submit Enter for the whole
+        # window (the keystrokes are discarded, not queued), which on a
+        # cold-booting session with several large images can run well past the
+        # first few seconds. A budget too short here gives up mid-ingestion and
+        # strands the message in the composer until the next send re-triggers it
+        # — the original "first message with attachments never sends" bug. ~12s
+        # comfortably covers observed ingestion; the loop still exits the instant
+        # the composer clears, so the common (fast) case is unchanged.
         for _ in range(attempts):
             if confirmer.pane_shows_blocking_dialog(
                 await self.adapter.capture_snapshot(target)

--- a/backend/tests/test_tmux.py
+++ b/backend/tests/test_tmux.py
@@ -368,6 +368,21 @@ def test_submit_confirmed_is_bounded_when_never_confirmed() -> None:
     assert adapter.submits == 4
 
 
+def test_submit_confirmed_default_budget_outlasts_image_ingestion() -> None:
+    # The Claude TUI drops the submit Enter while it ingests pasted image paths
+    # into chips; the default retry budget must keep firing through that window
+    # so the first message with attachments is not stranded. Model a long
+    # ingestion as many absorbed Enters before the composer clears.
+    adapter = _FakeAdapter(clear_after=20)
+    transport = _transport(adapter)
+
+    asyncio.run(
+        transport._submit_confirmed("%1", _Confirmer(), "msg", poll_seconds=0.0)
+    )
+
+    assert adapter.submits == 20
+
+
 def test_submit_confirmed_stops_when_dialog_appears() -> None:
     # The message submits (one Enter) and opens a dialog; the loop must stop
     # rather than drive a second Enter into it — which would select an option


### PR DESCRIPTION
Follow-up to #120. Attaching one or more images and hitting send as the **first** message in a tmux-wrapped session could still leave the message typed in the composer but unsent — the agent only picked it up after a second send re-triggered the submit.

#120 made the tmux transport paste without submitting, then send `Enter` and retry the swallowed keystroke until the composer cleared. The mechanism is right, but the retry budget was only ~3.2s (8 attempts × 0.4s). The Claude TUI converts pasted image paths into `[Image #N]` chips asynchronously and *drops* the submit `Enter` for the whole ingestion window (the keystrokes are discarded, not queued). On a cold-booting Opus session with several large images, ingestion outran the budget, so the loop gave up mid-ingestion and stranded the first message until the next send landed an `Enter` after ingestion had finished.

This widens the confirm-loop budget to ~12s (30 attempts × 0.4s) so a retried `Enter` follows ingestion to completion. The loop still exits the instant the composer reports cleared, so the common (fast) case is unchanged, and it remains bounded and dialog-guarded. This is a generous fixed ceiling rather than an adaptive one — a pathological ingestion beyond ~12s could still lose the race, but it comfortably covers observed ingestion across repeated trials.

## Testing
- `uv run pytest tests/test_tmux.py tests/test_runtime.py tests/test_claude_tty_pane_dialog.py tests/test_codex_pane.py tests/test_opencode_pane.py` (221 passed; new case pins that the default budget survives a long ingestion window of 20 absorbed `Enter`s)
- `uv run pre-commit run --files src/waypoint/backends/tmux/transport.py tests/test_tmux.py` (black, isort, ruff, codespell, mypy clean)
- Live, on a stack restarted onto this branch: first message with two large images (~0.9MB + ~1.9MB) to a cold Opus/high-effort `claude_tty` session submits on the first send and the agent processes both images — no strand, no regression on the fast path.