### PR TITLE
fix: wrap diff lines on mobile to stop iOS font inflation

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2916,6 +2916,19 @@ html[data-theme="light"] .diff-code {
   white-space: pre;
 }
 
+/* On phones, a per-line min-width: max-content makes each long line a block
+ * wider than the viewport, which iOS WebKit's text-autosizer then inflates
+ * (text-size-adjust does not suppress it here). Wrapping keeps every line
+ * within the viewport so no block is wide enough to boost, and the full-width
+ * line background falls out naturally without horizontal scroll. */
+@media (max-width: 720px) {
+  .diff-line {
+    min-width: 0;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+}
+
 .diff-line.add {
   background: rgba(108, 201, 154, 0.13);
   color: #a8e6c5;


### PR DESCRIPTION
On iOS (Safari and other WebKit browsers, including the standalone PWA), file diffs in the session transcript rendered with wildly inflated text — long lines blew up to several times their intended size while short lines stayed normal — even though the same diff rendered correctly on desktop. The CSS is identical across viewports, so the difference came from a browser behavior, not the stylesheet.

The cause is WebKit's width-based text autosizer. `.diff-code` lines use `min-width: max-content` so per-line backgrounds extend the full width during horizontal scroll, which makes each long line its own block far wider than the phone viewport — exactly the condition the autosizer inflates. Only long lines were boosted, which is the tell. `-webkit-text-size-adjust: none`/`100%` does **not** suppress this in iOS WebKit (verified across fresh loads in multiple browsers), so the property is not a usable lever here.

The fix is geometric rather than relying on the autosizer honoring any property: at `≤720px`, diff lines wrap (`white-space: pre-wrap; overflow-wrap: anywhere; min-width: 0`) instead of scrolling horizontally, so no line forms a block wider than the viewport and there is nothing for the autosizer to boost. The full-width line background falls out naturally. Desktop keeps its existing horizontal-scroll behavior unchanged.

## Testing
- `npm run lint` and `npm run build` clean.
- Live on an iOS PWA after a frontend redeploy: diffs render at the correct monospace size, long lines soft-wrap within the viewport, no inflation. Confirmed across a full reload and multiple browsers. Desktop horizontal scroll unaffected.