### PR TITLE
fix: render emulated terminal panes at their fixed server-side grid

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -958,6 +958,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 if prefix_bytes:
                     renderer.snoop_modes(prefix_bytes)
 
+        # Non-resizable panes own their geometry server-side, so the client
+        # must size its grid to ours rather than fitting to the viewport —
+        # otherwise the CUP-positioned deltas below land in the wrong cells.
+        # xterm ignores in-band resize ops (CSI 8 t), so announce the size as
+        # an out-of-band JSON frame the client applies via term.resize(). It
+        # precedes the repaint so the seed lands in the matching grid.
+        # Resizable transports drive their own size, so we don't fight them.
+        if not terminal_resizable:
+            with suppress(Exception):
+                await websocket.send_text(
+                    json.dumps({"type": "size", "cols": cols, "rows": rows})
+                )
         initial_frame = renderer.render_full()
         if initial_frame:
             with suppress(Exception):

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7970,6 +7970,15 @@ html[data-theme="light"] .terminal {
   box-shadow: var(--shadow-soft);
 }
 
+/* Fixed-grid (emulated) panes render at a fixed server-side size, so the
+   pane hugs the grid's natural height instead of filling the viewport —
+   otherwise the shorter grid leaves a tall void above the composer. The cap
+   keeps it scrolling when the grid is taller than the viewport. */
+.session-terminal.is-fixed-grid {
+  height: auto;
+  max-height: min(78dvh, calc(100dvh - 160px), 900px);
+}
+
 /* Terminal-only sessions (no composer below) lock the pane to the
    viewport once the user scrolls past the SessionHeader: position: sticky
    keeps the pane glued to the top of the viewport while the page
@@ -7995,6 +8004,9 @@ html[data-theme="light"] .terminal {
   }
   .session-terminal.is-locked {
     height: calc(100dvh - env(safe-area-inset-top, 0px));
+  }
+  .session-terminal.is-fixed-grid {
+    max-height: calc(100dvh - 120px);
   }
 }
 
@@ -8118,6 +8130,18 @@ html[data-theme="light"] .term-stage {
   padding: 10px 12px;
   overflow: hidden;
   position: relative;
+}
+
+/* Fixed-grid (emulated) panes render at the server's native size, which can
+ * exceed the viewport. The host scrolls both axes instead of clipping, and
+ * xterm's own viewport scrollbar is suppressed so the host owns scrolling
+ * (these panes run on the alt screen, so there is no scrollback to reach). */
+.term-stage-host.is-fixed-grid {
+  overflow: auto;
+}
+
+.term-stage-host.is-fixed-grid .xterm-viewport {
+  overflow: hidden !important;
 }
 
 .term-stage-host .xterm,

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1406,6 +1406,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         onChunk: (text) => {
           terminalRef.current?.write(text);
         },
+        onResize: (cols, rows) => {
+          // Fixed-grid panes (claude_tty) are pinned server-side; match our
+          // grid so the cell-positioned stream aligns instead of rewrapping.
+          terminalRef.current?.resize(cols, rows);
+        },
         onAuthFailure: () => {
           handleAuthFailure();
         },

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -7,7 +7,7 @@ import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { TerminalCompose } from "@/components/TerminalCompose";
 import { TerminalScrollChips } from "@/components/TerminalScrollChips";
 import { XTerminal, type XTerminalHandle } from "@/components/XTerminal";
-import { useBackendCatalog } from "@/lib/backends";
+import { terminalResizable, useBackendCatalog } from "@/lib/backends";
 import type { TerminalSubmitResult } from "@/lib/composer";
 import { SessionRecord } from "@/lib/types";
 import { usePopoverAnchor } from "@/lib/use-popover-anchor";
@@ -102,6 +102,10 @@ export function SessionTerminalView({
   onError,
 }: SessionTerminalViewProps) {
   const catalog = useBackendCatalog(host || null, token || null, null);
+  // Emulated panes (claude_tty) are pinned to a fixed server-side grid. The
+  // terminal must mirror that grid exactly rather than fit to the viewport,
+  // or the cell-positioned stream misaligns; the host scrolls at native size.
+  const fixedGrid = session ? !terminalResizable(session.transport, catalog) : false;
   // Primary action shown as a pill button next to the overflow trigger.
   // Only states the user can't trivially reach inside the pane — Reconnect
   // when exited (the pane is gone). We deliberately do NOT surface "Interrupt"
@@ -145,8 +149,8 @@ export function SessionTerminalView({
   return (
     <section
       className={`session-terminal ${locked ? "is-locked" : ""} ${
-        composeEnabled && composeOpen ? "has-compose-open" : ""
-      }`}
+        fixedGrid && !locked ? "is-fixed-grid" : ""
+      } ${composeEnabled && composeOpen ? "has-compose-open" : ""}`}
       aria-label="Terminal session"
     >
       <div className="term-bar">
@@ -275,11 +279,19 @@ export function SessionTerminalView({
         </div>
       </div>
       <div className="term-stage">
-        <div className="term-stage-host" role="log" aria-live="polite">
+        <div
+          className={`term-stage-host${fixedGrid ? " is-fixed-grid" : ""}`}
+          role="log"
+          aria-live="polite"
+        >
           <XTerminal
+            // Remount when the transport (and thus fit mode) changes — autoFit
+            // is fixed at mount, so switching sessions must rebuild the term.
+            key={session?.transport ?? "none"}
             ref={terminalRef}
             theme={theme}
             readOnly={!interactive}
+            autoFit={!fixedGrid}
             onData={interactive ? onTerminalInput : undefined}
             onResize={onTerminalResize}
             onScrollChange={interactive ? onTerminalScrollChange : undefined}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -148,6 +148,11 @@ export function SessionTerminalView({
 
   return (
     <section
+      // is-fixed-grid hugs the grid height, which only makes sense when the
+      // pane isn't viewport-locked. No transport is both non-resizable and
+      // terminal-only today, so fixed-grid + locked is currently unreachable;
+      // the !locked guard just keeps is-locked's explicit height authoritative
+      // if that ever changes.
       className={`session-terminal ${locked ? "is-locked" : ""} ${
         fixedGrid && !locked ? "is-fixed-grid" : ""
       } ${composeEnabled && composeOpen ? "has-compose-open" : ""}`}

--- a/frontend/src/components/XTerminal.tsx
+++ b/frontend/src/components/XTerminal.tsx
@@ -11,6 +11,7 @@ export interface XTerminalHandle {
   write(data: string): void;
   reset(): void;
   fit(): void;
+  resize(cols: number, rows: number): void;
   cols(): number;
   rows(): number;
   focus(): void;
@@ -20,6 +21,12 @@ export interface XTerminalHandle {
 interface XTerminalProps {
   theme?: "dark" | "light";
   readOnly?: boolean;
+  // When false, the terminal does not fit its grid to the container. The
+  // server owns the geometry (emulated panes like claude_tty are pinned to a
+  // fixed size) and drives the grid via a ``CSI 8 ; rows ; cols t`` resize, so
+  // fitting here would override it and misalign the cell-positioned stream.
+  // The host scrolls instead. Defaults to true (resizable tmux behavior).
+  autoFit?: boolean;
   onData?: (data: string) => void;
   onResize?: (size: { cols: number; rows: number }) => void;
   // Fires whenever the user's distance from the live cursor changes. Used
@@ -83,7 +90,15 @@ function themeFor(mode: "dark" | "light"): ITheme {
 
 export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
   function XTerminal(
-    { theme = "dark", readOnly = false, onData, onResize, onScrollChange, className },
+    {
+      theme = "dark",
+      readOnly = false,
+      autoFit = true,
+      onData,
+      onResize,
+      onScrollChange,
+      className,
+    },
     ref,
   ) {
     const containerRef = useRef<HTMLDivElement | null>(null);
@@ -124,8 +139,8 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
         disableStdin: readOnly,
         theme: themeFor(theme),
       });
-      const fit = new FitAddon();
-      term.loadAddon(fit);
+      const fit = autoFit ? new FitAddon() : null;
+      if (fit) term.loadAddon(fit);
       term.loadAddon(new WebLinksAddon());
       term.open(host);
 
@@ -190,7 +205,7 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       // Initial fit can throw if the container is still 0-sized (animation,
       // hidden tab, etc.) — guard so we don't crash the React tree.
       try {
-        fit.fit();
+        fit?.fit();
       } catch {
         // ResizeObserver below will retry once the container has a size.
       }
@@ -198,21 +213,25 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       fitRef.current = fit;
       onResizeRef.current?.({ cols: term.cols, rows: term.rows });
 
-      const ro = new ResizeObserver(() => {
-        try {
-          fit.fit();
-        } catch {
-          // Container detached mid-resize; ignore until next tick.
-        }
-      });
-      ro.observe(host);
+      // Only resizable panes refit on container changes. Fixed-grid panes
+      // keep the server-driven grid and let the host scroll instead.
+      const ro = fit
+        ? new ResizeObserver(() => {
+            try {
+              fit.fit();
+            } catch {
+              // Container detached mid-resize; ignore until next tick.
+            }
+          })
+        : null;
+      ro?.observe(host);
 
       return () => {
         onDataSub.dispose();
         onResizeSub.dispose();
         onScrollSub.dispose();
         osc52Sub.dispose();
-        ro.disconnect();
+        ro?.disconnect();
         term.dispose();
         termRef.current = null;
         fitRef.current = null;
@@ -245,6 +264,11 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
         } catch {
           // see above
         }
+      },
+      // Used for fixed-grid panes: the server dictates the grid size and we
+      // apply it directly rather than fitting to the container.
+      resize: (cols: number, rows: number) => {
+        if (cols > 0 && rows > 0) termRef.current?.resize(cols, rows);
       },
       cols: () => termRef.current?.cols ?? 80,
       rows: () => termRef.current?.rows ?? 24,

--- a/frontend/src/components/XTerminal.tsx
+++ b/frontend/src/components/XTerminal.tsx
@@ -23,9 +23,10 @@ interface XTerminalProps {
   readOnly?: boolean;
   // When false, the terminal does not fit its grid to the container. The
   // server owns the geometry (emulated panes like claude_tty are pinned to a
-  // fixed size) and drives the grid via a ``CSI 8 ; rows ; cols t`` resize, so
-  // fitting here would override it and misalign the cell-positioned stream.
-  // The host scrolls instead. Defaults to true (resizable tmux behavior).
+  // fixed size) and announces it out of band; the parent applies it via the
+  // imperative ``resize()`` handle. Fitting here would override that and
+  // misalign the cell-positioned stream, so the host scrolls instead.
+  // Defaults to true (resizable tmux behavior).
   autoFit?: boolean;
   onData?: (data: string) => void;
   onResize?: (size: { cols: number; rows: number }) => void;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -916,6 +916,11 @@ export function connectSessionSocket(
 
 interface TerminalSocketHandlers {
   onChunk: (text: string) => void;
+  // Fixed-grid (emulated) panes own their geometry server-side and announce
+  // it out of band as a ``{type:"size"}`` JSON frame, since xterm ignores
+  // in-band resize ops. The client applies it via term.resize() so its grid
+  // matches the cell-positioned stream.
+  onResize?: (cols: number, rows: number) => void;
   onAuthFailure?: () => void;
   // Backend sends 4410 when the underlying tmux pane has exited. The
   // user has to click Reconnect explicitly; we don't auto-retry.
@@ -933,9 +938,21 @@ export function connectTerminalSocket(
   const url = `${host.replace(/^http/, "ws")}/ws/sessions/${sessionId}/terminal?token=${encodeURIComponent(token)}`;
   const socket = new WebSocket(url);
   socket.onmessage = (event) => {
-    if (typeof event.data === "string") {
-      handlers.onChunk(event.data);
+    if (typeof event.data !== "string") return;
+    // Terminal output is always wrapped in a sync-update escape, so it begins
+    // with ESC; a leading "{" marks an out-of-band control frame (e.g. size).
+    if (event.data.charCodeAt(0) === 0x7b) {
+      try {
+        const msg = JSON.parse(event.data);
+        if (msg?.type === "size" && typeof msg.cols === "number" && typeof msg.rows === "number") {
+          handlers.onResize?.(msg.cols, msg.rows);
+          return;
+        }
+      } catch {
+        // Not a control frame after all — fall through and treat as output.
+      }
     }
+    handlers.onChunk(event.data);
   };
   socket.onopen = () => {
     handlers.onOpen?.();


### PR DESCRIPTION
Emulated panes (`claude_tty`) pin their tmux pane to a fixed 120×50 grid and the server streams cell-positioned deltas (absolute CUP coordinates) for that grid. The client xterm, however, fit its grid to the container/viewport, so the grid sizes disagreed: the server's coordinates landed in the wrong cells and long lines rewrapped with stale leftover characters. It looked plausible on a narrow phone only because clipping hid the rewrap; on desktop it was visibly garbled.

The terminal must mirror the server's grid exactly rather than reflow. The first attempt — emitting `CSI 8 ; rows ; cols t` with xterm's `setWinSizeChars` window option — turned out to be a dead end: xterm v6's window-ops handler implements only cases 14/16/18/22/23, so `CSI 8 t` is a no-op (it's a sequence xterm *emits* as a size report, not one it acts on), and the grid stayed at the default 80×24. Instead the server now announces its authoritative grid out of band as a `{"type":"size","cols","rows"}` JSON frame sent before the seed repaint. The client distinguishes it from terminal output (which is always wrapped in a sync-update escape, so it begins with ESC — a leading `{` is unambiguously a control frame) and applies it through xterm's real `term.resize()` API. Reconnects re-announce it.

On the client, fixed-grid panes (derived from the `terminal_resizable=false` capability) no longer load the fit addon or refit on container resize; the host scrolls at native size instead, and the pane hugs the grid's natural height so a grid shorter than the viewport no longer leaves a tall void above the composer. Resizable `tmux` terminals are untouched — they still fit to the viewport and drive their own size via client `resize` frames.

## Testing
- `npm run lint` and `npm run build` clean; backend `uv run pre-commit run --files src/waypoint/api.py` clean (black, isort, ruff, codespell, mypy).
- Verified on the wire: the terminal WS's first frame for a `claude_tty` session is now `{"type": "size", "cols": 120, "rows": 50}`.
- Live on a restarted stack: `claude_tty` renders aligned at the true 120-column grid (no rewrapping/stray cells) on both desktop and mobile, scrolling where the grid exceeds the viewport, with the composer flush below the grid; resizable `tmux` sessions still fit-to-viewport as before.