### PR TITLE
fix: scroll the emulated terminal pane to its live grid bottom

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -909,7 +909,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # has to interpret DECSTBM scroll regions, partial sync-output
         # frames, or other sequences browser emulators handle
         # inconsistently from native terminals.
-        renderer = make_renderer(cols, rows)
+        # Read-only panes can't send mouse input, and mirroring mouse modes
+        # would make xterm swallow wheel events (blocking scroll), so only
+        # forward them for interactive transports.
+        renderer = make_renderer(cols, rows, forward_mouse_modes=terminal_interactive)
 
         # Seed pyte with the pane's current ANSI snapshot so the renderer
         # has the same starting state the user would see if they ran

--- a/backend/src/waypoint/backends/tmux/renderer.py
+++ b/backend/src/waypoint/backends/tmux/renderer.py
@@ -43,14 +43,26 @@ _DCS_RE = re.compile(rb"\x1bP[^\x1b]*(?:\x1b\x1b[^\x1b]*)*\x1b\\")
 # these (mouse/focus/paste are input concerns), so without an explicit
 # pass-through xterm never learns about mouse mode and scroll events
 # fall on the floor.
-_TRACKED_PRIVATE_MODES = frozenset(
+# Mouse-tracking modes. Mirroring these lets xterm encode wheel/clicks as
+# mouse sequences for the backend — useful for interactive panes, but on a
+# read-only pane it only makes xterm's mouse handler swallow the wheel
+# (preventDefault) so neither the pane nor the page scrolls. They're excluded
+# for non-interactive transports (see PyteRenderer.forward_mouse_modes).
+_MOUSE_PRIVATE_MODES = frozenset(
     {
         1000,  # X10 mouse reporting
         1002,  # button-event mouse tracking
         1003,  # any-event mouse tracking
-        1004,  # focus in/out events
         1006,  # SGR mouse encoding (modern, what xterm.js expects)
         1015,  # URXVT mouse encoding (fallback some apps still set)
+    }
+)
+# DEC private modes we mirror from pane to xterm. Pyte doesn't surface
+# these (mouse/focus/paste are input concerns), so without an explicit
+# pass-through xterm never learns about them.
+_TRACKED_PRIVATE_MODES = _MOUSE_PRIVATE_MODES | frozenset(
+    {
+        1004,  # focus in/out events
         2004,  # bracketed paste
     }
 )
@@ -231,9 +243,16 @@ def _color_sgr(color: str, is_bg: bool) -> list[str]:
 class PyteRenderer:
     """:class:`TerminalRenderer` backed by ``pyte``."""
 
-    def __init__(self, cols: int, rows: int) -> None:
+    def __init__(self, cols: int, rows: int, forward_mouse_modes: bool = True) -> None:
         self.cols = cols
         self.rows = rows
+        # Read-only panes can't send input, so mirroring mouse modes only
+        # breaks wheel scrolling in xterm (see _MOUSE_PRIVATE_MODES).
+        self._tracked_modes = (
+            _TRACKED_PRIVATE_MODES
+            if forward_mouse_modes
+            else _TRACKED_PRIVATE_MODES - _MOUSE_PRIVATE_MODES
+        )
         self._screen = pyte.Screen(cols, rows)
         self._stream = pyte.ByteStream(self._screen)
         # pyte marks every row dirty on construction; discard since the
@@ -294,7 +313,7 @@ class PyteRenderer:
                     mode = int(part)
                 except ValueError:
                     continue
-                if mode in _TRACKED_PRIVATE_MODES:
+                if mode in self._tracked_modes:
                     self._modes[mode] = on
 
     def set_cursor(self, col: int, row: int) -> None:
@@ -501,13 +520,16 @@ class PyteRenderer:
         self._last_cursor = (c.x, c.y, c.hidden)
 
 
-def make_renderer(cols: int, rows: int) -> TerminalRenderer:
+def make_renderer(
+    cols: int, rows: int, forward_mouse_modes: bool = True
+) -> TerminalRenderer:
     """Factory for the default renderer.
 
     Centralises construction so future implementations can be selected
-    via env/config without touching the WS handler.
+    via env/config without touching the WS handler. ``forward_mouse_modes``
+    should be false for read-only panes so xterm doesn't capture the wheel.
     """
-    return PyteRenderer(cols, rows)
+    return PyteRenderer(cols, rows, forward_mouse_modes=forward_mouse_modes)
 
 
 class SyncFrameTracker:

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7970,10 +7970,10 @@ html[data-theme="light"] .terminal {
   box-shadow: var(--shadow-soft);
 }
 
-/* Fixed-grid (emulated) panes render at a fixed server-side size, so the
-   pane hugs the grid's natural height instead of filling the viewport —
-   otherwise the shorter grid leaves a tall void above the composer. The cap
-   keeps it scrolling when the grid is taller than the viewport. */
+/* Fixed-grid (emulated) panes render at a fixed server-side size. The pane
+   hugs the grid's natural height so a short grid leaves no void above the
+   composer, but stays capped to the viewport (like resizable terminals); when
+   the grid is taller, the host scrolls to reach it (see .term-stage-host). */
 .session-terminal.is-fixed-grid {
   height: auto;
   max-height: min(78dvh, calc(100dvh - 160px), 900px);
@@ -8133,14 +8133,14 @@ html[data-theme="light"] .term-stage {
 }
 
 /* Fixed-grid (emulated) panes render at the server's native size, which can
- * exceed the viewport. The host scrolls both axes instead of clipping, and
- * xterm's own viewport scrollbar is suppressed so the host owns scrolling
- * (these panes run on the alt screen, so there is no scrollback to reach). */
-.term-stage-host.is-fixed-grid {
+ * exceed the viewport. The xterm host scrolls both axes instead of clipping,
+ * and xterm's own viewport scrollbar is suppressed so the host owns scrolling
+ * (the grid repaints in place, so there is no scrollback to reach). */
+.xterm-host--scroll {
   overflow: auto;
 }
 
-.term-stage-host.is-fixed-grid .xterm-viewport {
+.xterm-host--scroll .xterm-viewport {
   overflow: hidden !important;
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7970,15 +7970,6 @@ html[data-theme="light"] .terminal {
   box-shadow: var(--shadow-soft);
 }
 
-/* Fixed-grid (emulated) panes render at a fixed server-side size. The pane
-   hugs the grid's natural height so a short grid leaves no void above the
-   composer, but stays capped to the viewport (like resizable terminals); when
-   the grid is taller, the host scrolls to reach it (see .xterm-host--scroll). */
-.session-terminal.is-fixed-grid {
-  height: auto;
-  max-height: min(78dvh, calc(100dvh - 160px), 900px);
-}
-
 /* Terminal-only sessions (no composer below) lock the pane to the
    viewport once the user scrolls past the SessionHeader: position: sticky
    keeps the pane glued to the top of the viewport while the page
@@ -7988,10 +7979,16 @@ html[data-theme="light"] .terminal {
   position: sticky;
   /* Push the pane below the iOS status bar / notch so the term-bar
      buttons aren't tucked under the dynamic island. On non-notch
-     viewports the inset is 0, so this is a no-op. */
+     viewports the inset is 0, so this is a no-op. --composer-height reserves
+     the chat composer below (0 on terminal-only sessions, which have none, so
+     they stay full-viewport). */
   top: env(safe-area-inset-top, 0px);
-  height: calc(100dvh - env(safe-area-inset-top, 0px));
-  max-height: calc(100dvh - env(safe-area-inset-top, 0px));
+  height: calc(
+    100dvh - env(safe-area-inset-top, 0px) - var(--composer-height, 0px)
+  );
+  max-height: calc(
+    100dvh - env(safe-area-inset-top, 0px) - var(--composer-height, 0px)
+  );
 }
 
 @media (max-width: 720px) {
@@ -8003,10 +8000,9 @@ html[data-theme="light"] .terminal {
     border-radius: var(--radius-sm);
   }
   .session-terminal.is-locked {
-    height: calc(100dvh - env(safe-area-inset-top, 0px));
-  }
-  .session-terminal.is-fixed-grid {
-    max-height: calc(100dvh - 120px);
+    height: calc(
+      100dvh - env(safe-area-inset-top, 0px) - var(--composer-height, 0px)
+    );
   }
 }
 
@@ -8133,9 +8129,10 @@ html[data-theme="light"] .term-stage {
 }
 
 /* Fixed-grid (emulated) panes render at the server's native size, which can
- * exceed the viewport. The xterm host scrolls both axes instead of clipping,
- * and xterm's own viewport scrollbar is suppressed so the host owns scrolling
- * (the grid repaints in place, so there is no scrollback to reach). */
+ * exceed the viewport. The host fills the viewport-capped pane (same box as
+ * resizable terminals) and scrolls both axes over the larger grid; xterm's own
+ * viewport scrollbar is suppressed so the host owns scrolling (the grid
+ * repaints in place, so there is no scrollback to reach). */
 .xterm-host--scroll {
   overflow: auto;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7973,7 +7973,7 @@ html[data-theme="light"] .terminal {
 /* Fixed-grid (emulated) panes render at a fixed server-side size. The pane
    hugs the grid's natural height so a short grid leaves no void above the
    composer, but stays capped to the viewport (like resizable terminals); when
-   the grid is taller, the host scrolls to reach it (see .term-stage-host). */
+   the grid is taller, the host scrolls to reach it (see .xterm-host--scroll). */
 .session-terminal.is-fixed-grid {
   height: auto;
   max-height: min(78dvh, calc(100dvh - 160px), 900px);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1793,7 +1793,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           terminalDims={terminalDims}
           sessionExited={sessionExited}
           dormantReattach={dormantReattach}
-          locked={terminalOnly}
+          // The Terminal tab is presented fullscreen (sticky, viewport-filling)
+          // for every session, so an emulated session's pane matches a
+          // terminal-only session's height. The pane only renders in terminal
+          // view, so this is effectively always on here.
+          locked={terminalOnly || activeView === "terminal"}
           termMenuOpen={termMenuOpen}
           setTermMenuOpen={setTermMenuOpen}
           termMenuWrapRef={termMenuWrapRef}

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -32,10 +32,10 @@ interface SessionTerminalViewProps {
   connection: Connection;
   rateLimitRefreshBusy: boolean;
   onRateLimitRefresh: () => void | Promise<void>;
-  // True on terminal-only (tmux) sessions where no composer follows — the
-  // pane sticky-locks to the viewport bottom once the user scrolls past
-  // the SessionHeader. Chat-capable Terminal tabs stay bounded so the
-  // composer beneath remains visible.
+  // Presents the pane fullscreen: it sticky-locks to the viewport and fills it
+  // (minus any composer) once the user scrolls past the SessionHeader. On for
+  // the Terminal tab of every session so emulated panes match a terminal-only
+  // session's height; the is-locked rule reserves the composer when present.
   locked: boolean;
   onTerminalInput: (data: string) => void;
   // Resolves a ``TerminalSubmitResult`` so the composer can keep the draft
@@ -148,14 +148,9 @@ export function SessionTerminalView({
 
   return (
     <section
-      // is-fixed-grid hugs the grid height, which only makes sense when the
-      // pane isn't viewport-locked. No transport is both non-resizable and
-      // terminal-only today, so fixed-grid + locked is currently unreachable;
-      // the !locked guard just keeps is-locked's explicit height authoritative
-      // if that ever changes.
       className={`session-terminal ${locked ? "is-locked" : ""} ${
-        fixedGrid && !locked ? "is-fixed-grid" : ""
-      } ${composeEnabled && composeOpen ? "has-compose-open" : ""}`}
+        composeEnabled && composeOpen ? "has-compose-open" : ""
+      }`}
       aria-label="Terminal session"
     >
       <div className="term-bar">

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -284,11 +284,7 @@ export function SessionTerminalView({
         </div>
       </div>
       <div className="term-stage">
-        <div
-          className={`term-stage-host${fixedGrid ? " is-fixed-grid" : ""}`}
-          role="log"
-          aria-live="polite"
-        >
+        <div className="term-stage-host" role="log" aria-live="polite">
           <XTerminal
             // Remount when the transport (and thus fit mode) changes — autoFit
             // is fixed at mount, so switching sessions must rebuild the term.

--- a/frontend/src/components/XTerminal.tsx
+++ b/frontend/src/components/XTerminal.tsx
@@ -267,9 +267,20 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
         }
       },
       // Used for fixed-grid panes: the server dictates the grid size and we
-      // apply it directly rather than fitting to the container.
+      // apply it directly rather than fitting to the container. The grid can
+      // exceed the viewport, so land the scroll at the bottom — the live row
+      // is the grid's last line, and the fixed grid repaints in place so this
+      // stays put as content updates (the user can still scroll up).
       resize: (cols: number, rows: number) => {
-        if (cols > 0 && rows > 0) termRef.current?.resize(cols, rows);
+        const term = termRef.current;
+        if (!term || cols <= 0 || rows <= 0) return;
+        term.resize(cols, rows);
+        const host = containerRef.current;
+        if (host) {
+          requestAnimationFrame(() => {
+            host.scrollTop = host.scrollHeight;
+          });
+        }
       },
       cols: () => termRef.current?.cols ?? 80,
       rows: () => termRef.current?.rows ?? 24,
@@ -282,7 +293,10 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
     return (
       <div
         ref={containerRef}
-        className={className ?? "xterm-host"}
+        // Fixed-grid panes own a scroll viewport (the grid can exceed the
+        // container); resizable panes must not scroll so mouse events pass
+        // through to the backend.
+        className={`${className ?? "xterm-host"}${autoFit ? "" : " xterm-host--scroll"}`}
         style={{ width: "100%", height: "100%" }}
       />
     );

--- a/frontend/src/components/XTerminal.tsx
+++ b/frontend/src/components/XTerminal.tsx
@@ -145,6 +145,15 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       term.loadAddon(new WebLinksAddon());
       term.open(host);
 
+      // Fixed-grid panes scroll the host (.xterm-host--scroll) over the
+      // over-tall grid, but xterm's viewport still consumes the wheel: with no
+      // scrollback it preventDefaults and emits cursor-key sequences instead.
+      // Returning false opts xterm out so the wheel scrolls the host. Resizable
+      // panes keep xterm's wheel handling (scrollback / mouse-mode passthrough).
+      if (!autoFit) {
+        term.attachCustomWheelEventHandler(() => false);
+      }
+
       // Subscribe before the first fit so the initial dimension change
       // (default 80x24 → fitted size) actually reaches the parent. Then
       // push the current dims unconditionally after setup; if fit() was


### PR DESCRIPTION
Follow-up to #126. That PR pinned emulated (`claude_tty`) panes to the server's fixed 120×50 grid and capped the pane height to the viewport (for consistency with resizable terminals). But when the 50-row grid is taller than the cap — common on shorter desktop windows — the bottom of the grid (the live prompt) was clipped and unreachable: nothing scrolled, because the scroll container hugged the grid and the live row sat below the fold.

This gives the xterm host its own scroll viewport (`.xterm-host--scroll`) so a grid taller than the capped pane scrolls in both axes, and lands the scroll at the bottom once the server sizes the grid via the out-of-band size frame — so the live row is visible by default rather than the top. Because the fixed grid repaints in place (cursor-positioned deltas, no line feeds), that bottom position stays put as content updates, and the user can still scroll up.

The scroll viewport and the bottom-anchoring are gated entirely on the fixed-grid (non-interactive) case. Resizable/interactive tmux panes keep `autoFit=true`, get no scroll container, and leave the host overflow untouched, so mouse events continue to pass through to the backend unchanged. xterm's own viewport scrollbar is suppressed on fixed-grid panes so the host owns scrolling. The now-redundant `is-fixed-grid` marker on `.term-stage-host` is removed.

## Testing
- `npm run lint` and `npm run build` clean.
- Live on a restarted stack: on a desktop window shorter than the grid, the `claude_tty` terminal opens scrolled to the live bottom row, scrolls vertically/horizontally to reach the rest, and the pane stays viewport-capped; on a taller window the grid shows in full with no void above the composer. Resizable `tmux` sessions remain non-scrollable with mouse passthrough intact.