### PR TITLE
perf: cut hot-path overhead and share Claude rate-limit probes

### DIFF
--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -298,6 +298,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         await self._register_rate_limit_probe(runtime, session.id, launch_target)
         # User asked for fresh data: drop any cached shared snapshot so the
         # forced probe below makes a real call instead of replaying the window.
+        # Best-effort — a concurrent periodic probe for the same account can
+        # repopulate the cache between here and the forced refresh, but that
+        # snapshot is itself just-fetched, so the served data is still fresh.
         if launch_target is None:
             invalidate_shared_probe_local()
         else:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -40,8 +40,10 @@ from waypoint.backends.claude_code.permission_modes import (
     claude_permission_mode_label,
 )
 from waypoint.backends.claude_code.rate_limits import (
-    probe_claude_usage,
-    probe_claude_usage_remote,
+    invalidate_shared_probe_local,
+    invalidate_shared_probe_remote,
+    probe_claude_usage_remote_shared,
+    probe_claude_usage_shared,
 )
 from waypoint.backends.claude_code.remote import build_remote_claude_launch_factory
 from waypoint.backends.claude_code.schemas import (
@@ -252,7 +254,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return
 
         async def _probe() -> SessionRateLimitUsage | None:
-            return await probe_claude_usage()
+            return await probe_claude_usage_shared()
 
         await self.adapter.register_rate_limit_probe(
             session_id, _probe, refresh_interval_seconds=300.0
@@ -268,7 +270,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return
 
         async def _probe() -> SessionRateLimitUsage | None:
-            return await probe_claude_usage_remote(launch_target)
+            return await probe_claude_usage_remote_shared(launch_target)
 
         await self.adapter.register_rate_limit_probe(
             session_id, _probe, refresh_interval_seconds=300.0
@@ -294,6 +296,12 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             else None
         )
         await self._register_rate_limit_probe(runtime, session.id, launch_target)
+        # User asked for fresh data: drop any cached shared snapshot so the
+        # forced probe below makes a real call instead of replaying the window.
+        if launch_target is None:
+            invalidate_shared_probe_local()
+        else:
+            invalidate_shared_probe_remote(launch_target)
         # Run the probe inline so the caller's HTTP response carries the
         # post-refresh snapshot — otherwise the response races the WS push
         # from the periodic loop and the UI sees stale data.
@@ -319,8 +327,8 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         """
         _ = cwd
         if launch_target is None:
-            return await probe_claude_usage()
-        return await probe_claude_usage_remote(launch_target)
+            return await probe_claude_usage_shared()
+        return await probe_claude_usage_remote_shared(launch_target)
 
     def rate_limit_account(
         self, snapshot: SessionRateLimitUsage

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -8,6 +8,8 @@ import os
 import platform
 import re
 import subprocess
+import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -16,6 +18,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.perf import debug_timer
 from waypoint.schemas import SessionRateLimitUsage, UsageWindow
 
 log = logging.getLogger("waypoint.claude_code.rate_limits")
@@ -84,32 +87,33 @@ async def probe_claude_usage(
     env: dict[str, str] | None = None,
     timeout_seconds: float = 30.0,
 ) -> SessionRateLimitUsage | None:
-    resolved_env = env if env is not None else dict(os.environ)
-    credentials = _read_cli_credentials_for_env(resolved_env)
-    if credentials is None:
-        log.warning("claude rate-limit probe found no CLI credentials")
-        return None
-    access_token, expires_at, credential_note = credentials
-    if _is_access_token_expired(expires_at):
-        log.info(
-            "claude rate-limit probe: cached access token is expired; "
-            "skipping HTTP call and surfacing expiry"
+    with debug_timer(log, "probe_claude_usage"):
+        resolved_env = env if env is not None else dict(os.environ)
+        credentials = _read_cli_credentials_for_env(resolved_env)
+        if credentials is None:
+            log.warning("claude rate-limit probe found no CLI credentials")
+            return None
+        access_token, expires_at, credential_note = credentials
+        if _is_access_token_expired(expires_at):
+            log.info(
+                "claude rate-limit probe: cached access token is expired; "
+                "skipping HTTP call and surfacing expiry"
+            )
+            return _expired_credentials_snapshot(credential_note, resolved_env)
+        response = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_claude_messages_usage, access_token),
+            timeout=timeout_seconds,
         )
-        return _expired_credentials_snapshot(credential_note, resolved_env)
-    response = await asyncio.wait_for(
-        asyncio.to_thread(_fetch_claude_messages_usage, access_token),
-        timeout=timeout_seconds,
-    )
-    if response is None:
-        log.warning("claude rate-limit request failed before receiving a response")
-        return None
-    return _build_messages_snapshot(
-        status=response.status,
-        headers=response.headers,
-        body=response.body,
-        credential_note=credential_note,
-        account_notes=_read_oauth_account_notes(resolved_env),
-    )
+        if response is None:
+            log.warning("claude rate-limit request failed before receiving a response")
+            return None
+        return _build_messages_snapshot(
+            status=response.status,
+            headers=response.headers,
+            body=response.body,
+            credential_note=credential_note,
+            account_notes=_read_oauth_account_notes(resolved_env),
+        )
 
 
 async def probe_claude_usage_remote(
@@ -156,6 +160,147 @@ async def probe_claude_usage_remote(
         credential_note=credential_note,
         account_notes=account_notes,
     )
+
+
+# Matched to the 300s per-session refresh cadence in plugin.py. The rate-limit
+# snapshot is account-wide, so one real probe per account per refresh window is
+# enough; every other session reuses the cached snapshot. A lone session still
+# refreshes each cycle (its probe age exceeds the TTL by the loop's sleep), so
+# liveness is unchanged while N concurrent sessions collapse to ~1 HTTP probe.
+_SHARED_PROBE_TTL_SECONDS = 300.0
+
+
+@dataclass
+class _ProbeCacheEntry:
+    stored_at: float
+    result: SessionRateLimitUsage | None
+
+
+class SharedRateLimitProbeCache:
+    """Process-wide TTL cache that coalesces account-wide rate-limit probes.
+
+    Claude rate limits are scoped to an account, not a session, yet every
+    Claude session runs its own refresh loop. Without sharing, N sessions make
+    N identical Anthropic probes per window. This cache serves one probe's
+    result to every session in the same account/TTL window and de-duplicates
+    concurrent in-flight probes behind a per-key lock. Only successful (non
+    ``None``) snapshots are cached, so a transient probe failure does not blank
+    the rate-limit UI for the whole window — the next session retries.
+    """
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: float = _SHARED_PROBE_TTL_SECONDS,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._clock = clock
+        self._entries: dict[str, _ProbeCacheEntry] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._guard = asyncio.Lock()
+
+    def _fresh(self, key: str) -> _ProbeCacheEntry | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        if self._clock() - entry.stored_at >= self._ttl:
+            return None
+        return entry
+
+    async def _lock_for(self, key: str) -> asyncio.Lock:
+        async with self._guard:
+            lock = self._locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._locks[key] = lock
+            return lock
+
+    def invalidate(self, key: str) -> None:
+        self._entries.pop(key, None)
+
+    async def get_or_probe(
+        self,
+        key: str,
+        fetch: Callable[[], Awaitable[SessionRateLimitUsage | None]],
+        *,
+        force: bool = False,
+    ) -> SessionRateLimitUsage | None:
+        if not force:
+            entry = self._fresh(key)
+            if entry is not None:
+                return entry.result
+        lock = await self._lock_for(key)
+        async with lock:
+            # Re-check inside the lock: a concurrent probe for the same key may
+            # have populated the cache while we waited.
+            if not force:
+                entry = self._fresh(key)
+                if entry is not None:
+                    return entry.result
+            result = await fetch()
+            if result is not None:
+                self._entries[key] = _ProbeCacheEntry(
+                    stored_at=self._clock(), result=result
+                )
+            return result
+
+
+_SHARED_PROBE_CACHE = SharedRateLimitProbeCache()
+
+
+def _local_probe_cache_key(env: dict[str, str]) -> str:
+    return f"local:{env.get('CLAUDE_CONFIG_DIR') or '~'}"
+
+
+def _remote_probe_cache_key(launch_target: SshLaunchTargetConfig) -> str:
+    return f"remote:{launch_target.id}"
+
+
+async def probe_claude_usage_shared(
+    *,
+    env: dict[str, str] | None = None,
+    timeout_seconds: float = 30.0,
+    force: bool = False,
+) -> SessionRateLimitUsage | None:
+    """Account-shared variant of :func:`probe_claude_usage`.
+
+    Sessions sharing the same credentials (keyed by ``CLAUDE_CONFIG_DIR``)
+    reuse one probe per TTL window. Pass ``force=True`` to bypass a cache hit
+    for a user-driven refresh.
+    """
+    resolved_env = env if env is not None else dict(os.environ)
+    return await _SHARED_PROBE_CACHE.get_or_probe(
+        _local_probe_cache_key(resolved_env),
+        lambda: probe_claude_usage(env=resolved_env, timeout_seconds=timeout_seconds),
+        force=force,
+    )
+
+
+async def probe_claude_usage_remote_shared(
+    launch_target: SshLaunchTargetConfig,
+    *,
+    timeout_seconds: float = 30.0,
+    force: bool = False,
+) -> SessionRateLimitUsage | None:
+    """Account-shared variant of :func:`probe_claude_usage_remote`, keyed by
+    launch-target id."""
+    return await _SHARED_PROBE_CACHE.get_or_probe(
+        _remote_probe_cache_key(launch_target),
+        lambda: probe_claude_usage_remote(
+            launch_target, timeout_seconds=timeout_seconds
+        ),
+        force=force,
+    )
+
+
+def invalidate_shared_probe_local(env: dict[str, str] | None = None) -> None:
+    resolved_env = env if env is not None else dict(os.environ)
+    _SHARED_PROBE_CACHE.invalidate(_local_probe_cache_key(resolved_env))
+
+
+def invalidate_shared_probe_remote(launch_target: SshLaunchTargetConfig) -> None:
+    _SHARED_PROBE_CACHE.invalidate(_remote_probe_cache_key(launch_target))
 
 
 def _string_list(value: Any) -> list[str]:

--- a/backend/src/waypoint/perf.py
+++ b/backend/src/waypoint/perf.py
@@ -1,0 +1,29 @@
+"""Low-overhead timing helpers for hot paths.
+
+``debug_timer`` is a context manager that records how long a block took and
+emits a single DEBUG log line. When the target logger has DEBUG disabled it
+short-circuits before reading the clock or formatting anything, so the common
+(non-DEBUG) case on streaming paths pays effectively nothing.
+"""
+
+import logging
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def debug_timer(logger: logging.Logger, label: str, **fields: Any) -> Iterator[None]:
+    if not logger.isEnabledFor(logging.DEBUG):
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        if fields:
+            logger.debug("%s took %.2fms %r", label, elapsed_ms, fields)
+        else:
+            logger.debug("%s took %.2fms", label, elapsed_ms)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -9,6 +9,7 @@ import subprocess
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
@@ -25,6 +26,7 @@ from waypoint.backends.tmux.normalize import NormalizedChunk, TerminalNormalizer
 from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.perf import debug_timer
 from waypoint.scheduler import Scheduler
 from waypoint.schemas import (
     AssistantSummary,
@@ -61,9 +63,26 @@ COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
 # immediately, so this only adds at most this much latency to the live
 # list/status updates a fast stream produces.
 SESSION_BROADCAST_DEBOUNCE_SECONDS = 0.25
+# The per-session structured log (events.jsonl) is a write-only audit/debug
+# artifact; the SQLite store is the source of truth for replay. Flushing every
+# write turns the streaming path into a syscall per event, so we let the buffer
+# absorb a short run and flush once it crosses this many writes (and always on
+# close). A crash can lose at most the last few un-flushed lines, all of which
+# are still durable in SQLite.
+STRUCTURED_LOG_FLUSH_EVERY = 16
 
 
 log = logging.getLogger("waypoint.runtime")
+
+
+@dataclass
+class _StructuredLogHandle:
+    """Open append handle for a session's structured log plus its write count
+    since the last flush, so the streaming path can batch flushes."""
+
+    handle: TextIO
+    pending: int = 0
+
 
 SAFE_NAME = re.compile(r"[^a-zA-Z0-9_-]+")
 CompletionCacheKey = tuple[str, str]
@@ -176,7 +195,7 @@ class SessionRuntime:
         # Open append handles for per-session structured logs, kept around
         # so the streaming path doesn't reopen (and re-stat via get_session)
         # the file on every event. Closed on terminate/delete and at stop().
-        self._structured_log_handles: dict[str, TextIO] = {}
+        self._structured_log_handles: dict[str, _StructuredLogHandle] = {}
         # Coalesced session_state / session_list broadcasting. The
         # streaming event path marks sessions dirty and wakes the flusher
         # instead of re-serializing every session per event; the flusher
@@ -263,9 +282,9 @@ class SessionRuntime:
             with suppress(asyncio.CancelledError):
                 await self._broadcast_flusher
             self._broadcast_flusher = None
-        for handle in self._structured_log_handles.values():
+        for entry in self._structured_log_handles.values():
             with suppress(Exception):
-                handle.close()
+                entry.handle.close()
         self._structured_log_handles.clear()
         for plugin in self.registry.all():
             await plugin.shutdown(self)
@@ -1786,14 +1805,12 @@ class SessionRuntime:
         self._broadcast_wake.set()
 
     async def _broadcast_session_list(self) -> None:
+        with debug_timer(log, "_broadcast_session_list"):
+            sessions = [item.model_dump(mode="json") for item in self.list_sessions()]
         await self.broadcast.publish(
             SessionEnvelope(
                 type="session_list_update",
-                payload={
-                    "sessions": [
-                        item.model_dump(mode="json") for item in self.list_sessions()
-                    ]
-                },
+                payload={"sessions": sessions},
             )
         )
 
@@ -1829,19 +1846,24 @@ class SessionRuntime:
                 await self._broadcast_session_list()
 
     def _append_structured_log(self, session_id: str, event: EventRecord) -> None:
-        handle = self._structured_log_handles.get(session_id)
-        if handle is None:
-            session = self.get_session(session_id)
-            handle = Path(session.structured_log_path).open("a", encoding="utf-8")
-            self._structured_log_handles[session_id] = handle
-        handle.write(json.dumps(event.model_dump(mode="json")) + "\n")
-        handle.flush()
+        with debug_timer(log, "_append_structured_log", session=session_id):
+            entry = self._structured_log_handles.get(session_id)
+            if entry is None:
+                session = self.get_session(session_id)
+                handle = Path(session.structured_log_path).open("a", encoding="utf-8")
+                entry = _StructuredLogHandle(handle=handle)
+                self._structured_log_handles[session_id] = entry
+            entry.handle.write(json.dumps(event.model_dump(mode="json")) + "\n")
+            entry.pending += 1
+            if entry.pending >= STRUCTURED_LOG_FLUSH_EVERY:
+                entry.handle.flush()
+                entry.pending = 0
 
     def _close_structured_log(self, session_id: str) -> None:
-        handle = self._structured_log_handles.pop(session_id, None)
-        if handle is not None:
+        entry = self._structured_log_handles.pop(session_id, None)
+        if entry is not None:
             with suppress(Exception):
-                handle.close()
+                entry.handle.close()
 
     def _generate_session_id(self, backend: str) -> str:
         token = secrets.token_hex(4)

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -329,8 +329,8 @@ class Storage:
 
     @_synchronized
     def update_session(self, session_id: str, **fields: Any) -> SessionRecord:
+        fields.setdefault("updated_at", datetime.now(UTC))
         with debug_timer(log, "Storage.update_session", fields=sorted(fields)):
-            fields.setdefault("updated_at", datetime.now(UTC))
             assignments = ", ".join(f"{name} = ?" for name in fields)
             values = [self._serialize_field(value) for value in fields.values()]
             values.append(session_id)

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1,5 +1,6 @@
 import functools
 import json
+import logging
 import sqlite3
 import threading
 from collections.abc import Callable
@@ -9,6 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from waypoint.perf import debug_timer
 from waypoint.schemas import (
     BoardChannel,
     BoardEntry,
@@ -19,6 +21,13 @@ from waypoint.schemas import (
     SessionRecord,
     SessionStatus,
 )
+
+log = logging.getLogger("waypoint.storage")
+
+# ``UPDATE ... RETURNING`` landed in SQLite 3.35 (2021). When present it lets
+# ``update_session`` fetch the post-update row in the same statement, avoiding
+# the extra existence-check and re-read round-trips on a hot path.
+_SUPPORTS_RETURNING = sqlite3.sqlite_version_info >= (3, 35, 0)
 
 # Event kinds that the chat view always renders as their own bubble. These
 # drive the page-size budget so a page of N reliably surfaces ~N visible
@@ -231,6 +240,17 @@ class Storage:
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
+        # Indexes for columns filtered on by the runtime/scheduler. Created
+        # after the ALTER TABLE block above so ``spawner_session_id`` exists on
+        # databases that predate it.
+        self.connection.executescript("""
+            CREATE INDEX IF NOT EXISTS idx_sessions_spawner
+                ON sessions(spawner_session_id);
+            CREATE INDEX IF NOT EXISTS idx_board_author
+                ON board_entries(author_session_id);
+            CREATE INDEX IF NOT EXISTS idx_scheduled_status
+                ON scheduled_sessions(status);
+            """)
         self.connection.commit()
 
     @_synchronized
@@ -309,21 +329,30 @@ class Storage:
 
     @_synchronized
     def update_session(self, session_id: str, **fields: Any) -> SessionRecord:
-        current = self.get_session(session_id)
-        if current is None:
-            raise KeyError(session_id)
-        fields.setdefault("updated_at", datetime.now(UTC))
-        assignments = ", ".join(f"{name} = ?" for name in fields)
-        values = [self._serialize_field(value) for value in fields.values()]
-        values.append(session_id)
-        self.connection.execute(
-            f"UPDATE sessions SET {assignments} WHERE id = ?",
-            values,
-        )
-        self.connection.commit()
-        updated = self.get_session(session_id)
-        assert updated is not None
-        return updated
+        with debug_timer(log, "Storage.update_session", fields=sorted(fields)):
+            fields.setdefault("updated_at", datetime.now(UTC))
+            assignments = ", ".join(f"{name} = ?" for name in fields)
+            values = [self._serialize_field(value) for value in fields.values()]
+            values.append(session_id)
+            if _SUPPORTS_RETURNING:
+                row = self.connection.execute(
+                    f"UPDATE sessions SET {assignments} WHERE id = ? RETURNING *",
+                    values,
+                ).fetchone()
+                self.connection.commit()
+                if row is None:
+                    raise KeyError(session_id)
+                return self._session_from_row(row)
+            if self.get_session(session_id) is None:
+                raise KeyError(session_id)
+            self.connection.execute(
+                f"UPDATE sessions SET {assignments} WHERE id = ?",
+                values,
+            )
+            self.connection.commit()
+            updated = self.get_session(session_id)
+            assert updated is not None
+            return updated
 
     @_synchronized
     def delete_session(self, session_id: str) -> bool:
@@ -615,38 +644,42 @@ class Storage:
             event = event.model_copy(
                 update={"metadata": {**event.metadata, "version": 1}}
             )
-        cursor = self.connection.execute(
-            """
-            INSERT INTO events (session_id, ts, kind, text, metadata, sequence)
-            VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                event.session_id,
-                event.ts.isoformat(),
-                event.kind,
-                event.text,
-                json.dumps(event.metadata),
-                event.sequence,
-            ),
-        )
-        self.connection.execute(
-            """
-            UPDATE sessions
-            SET last_event_at = ?, updated_at = ?, status = COALESCE(?, status)
-            WHERE id = ?
-            """,
-            (
-                event.ts.isoformat(),
-                event.ts.isoformat(),
-                event.metadata.get("status"),
-                event.session_id,
-            ),
-        )
-        self.connection.commit()
-        last_id = cursor.lastrowid
-        if last_id is None:
-            raise RuntimeError("sqlite did not assign a row id for the inserted event")
-        return event.model_copy(update={"id": int(last_id)})
+        with debug_timer(log, "Storage.append_event", session=event.session_id):
+            ts_iso = event.ts.isoformat()
+            cursor = self.connection.execute(
+                """
+                INSERT INTO events (session_id, ts, kind, text, metadata, sequence)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    event.session_id,
+                    ts_iso,
+                    event.kind,
+                    event.text,
+                    json.dumps(event.metadata),
+                    event.sequence,
+                ),
+            )
+            self.connection.execute(
+                """
+                UPDATE sessions
+                SET last_event_at = ?, updated_at = ?, status = COALESCE(?, status)
+                WHERE id = ?
+                """,
+                (
+                    ts_iso,
+                    ts_iso,
+                    event.metadata.get("status"),
+                    event.session_id,
+                ),
+            )
+            self.connection.commit()
+            last_id = cursor.lastrowid
+            if last_id is None:
+                raise RuntimeError(
+                    "sqlite did not assign a row id for the inserted event"
+                )
+            return event.model_copy(update={"id": int(last_id)})
 
     @_synchronized
     def clone_events(self, source_session_id: str, target_session_id: str) -> int:

--- a/backend/tests/test_perf.py
+++ b/backend/tests/test_perf.py
@@ -1,0 +1,45 @@
+import logging
+
+from waypoint.perf import debug_timer
+
+
+class _ListHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__()
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+
+def _capture(logger: logging.Logger) -> list[logging.LogRecord]:
+    handler = _ListHandler()
+    logger.addHandler(handler)
+    return handler.records
+
+
+def test_debug_timer_emits_one_record_when_debug_enabled() -> None:
+    logger = logging.getLogger("waypoint.test.perf.enabled")
+    logger.setLevel(logging.DEBUG)
+    records = _capture(logger)
+    try:
+        with debug_timer(logger, "do_thing", session="abc"):
+            pass
+    finally:
+        logger.handlers.clear()
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert "do_thing" in message
+    assert "session" in message
+
+
+def test_debug_timer_is_silent_when_debug_disabled() -> None:
+    logger = logging.getLogger("waypoint.test.perf.disabled")
+    logger.setLevel(logging.INFO)
+    records = _capture(logger)
+    try:
+        with debug_timer(logger, "do_thing"):
+            pass
+    finally:
+        logger.handlers.clear()
+    assert records == []

--- a/backend/tests/test_rate_limit_probe_cache.py
+++ b/backend/tests/test_rate_limit_probe_cache.py
@@ -1,0 +1,149 @@
+import asyncio
+from datetime import UTC, datetime
+
+from waypoint.backends.claude_code.rate_limits import SharedRateLimitProbeCache
+from waypoint.schemas import SessionRateLimitUsage, UsageWindow
+
+
+def _snapshot(used: float = 10.0) -> SessionRateLimitUsage:
+    return SessionRateLimitUsage(
+        source="claude_code",
+        updated_at=datetime.now(UTC),
+        windows=[
+            UsageWindow(
+                id="five_hour",
+                label="5h",
+                used_percent=used,
+                window_minutes=300,
+                resets_at=None,
+            )
+        ],
+        notes=["CLI creds"],
+    )
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+async def test_serves_cached_snapshot_within_ttl() -> None:
+    clock = _Clock()
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=clock)
+    calls = 0
+
+    async def fetch() -> SessionRateLimitUsage:
+        nonlocal calls
+        calls += 1
+        return _snapshot()
+
+    first = await cache.get_or_probe("acct", fetch)
+    clock.now = 299.0
+    second = await cache.get_or_probe("acct", fetch)
+
+    assert calls == 1
+    assert first is second
+
+
+async def test_refetches_after_ttl_expires() -> None:
+    clock = _Clock()
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=clock)
+    calls = 0
+
+    async def fetch() -> SessionRateLimitUsage:
+        nonlocal calls
+        calls += 1
+        return _snapshot()
+
+    await cache.get_or_probe("acct", fetch)
+    clock.now = 300.0
+    await cache.get_or_probe("acct", fetch)
+
+    assert calls == 2
+
+
+async def test_coalesces_concurrent_probes() -> None:
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=_Clock())
+    calls = 0
+    release = asyncio.Event()
+
+    async def fetch() -> SessionRateLimitUsage:
+        nonlocal calls
+        calls += 1
+        await release.wait()
+        return _snapshot()
+
+    waiters = [asyncio.create_task(cache.get_or_probe("acct", fetch)) for _ in range(5)]
+    await asyncio.sleep(0)  # let all tasks reach the lock
+    release.set()
+    results = await asyncio.gather(*waiters)
+
+    assert calls == 1
+    assert all(r is results[0] for r in results)
+
+
+async def test_separate_keys_do_not_share() -> None:
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=_Clock())
+    calls = 0
+
+    async def fetch() -> SessionRateLimitUsage:
+        nonlocal calls
+        calls += 1
+        return _snapshot()
+
+    await cache.get_or_probe("local:~", fetch)
+    await cache.get_or_probe("remote:devbox", fetch)
+
+    assert calls == 2
+
+
+async def test_none_results_are_not_cached() -> None:
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=_Clock())
+    calls = 0
+
+    async def fetch() -> SessionRateLimitUsage | None:
+        nonlocal calls
+        calls += 1
+        return None
+
+    await cache.get_or_probe("acct", fetch)
+    await cache.get_or_probe("acct", fetch)
+
+    assert calls == 2
+
+
+async def test_force_bypasses_cache_hit() -> None:
+    clock = _Clock()
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=clock)
+    calls = 0
+
+    async def fetch() -> SessionRateLimitUsage:
+        nonlocal calls
+        calls += 1
+        return _snapshot(used=float(calls))
+
+    await cache.get_or_probe("acct", fetch)
+    forced = await cache.get_or_probe("acct", fetch, force=True)
+
+    assert calls == 2
+    assert forced is not None
+    assert forced.windows[0].used_percent == 2.0
+
+
+async def test_invalidate_drops_cached_entry() -> None:
+    cache = SharedRateLimitProbeCache(ttl_seconds=300.0, clock=_Clock())
+    calls = 0
+
+    async def fetch() -> SessionRateLimitUsage:
+        nonlocal calls
+        calls += 1
+        return _snapshot()
+
+    await cache.get_or_probe("acct", fetch)
+    cache.invalidate("acct")
+    await cache.get_or_probe("acct", fetch)
+
+    assert calls == 2

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -5,12 +5,16 @@ import pytest
 
 from waypoint.backends.claude_code.rate_limits import (
     _ClaudeHTTPResponse,
+    _local_probe_cache_key,
     _read_cli_credentials_for_env,
     _read_oauth_account_notes,
+    _remote_probe_cache_key,
+    invalidate_shared_probe_local,
     parse_claude_rate_limit_headers,
     parse_claude_usage_payload,
     probe_claude_usage,
     probe_claude_usage_remote,
+    probe_claude_usage_shared,
 )
 from waypoint.backends.codex.rate_limits import (
     _load_oauth_credentials,
@@ -661,3 +665,56 @@ def test_probe_codex_usage_remote_falls_back_when_oauth_payload_is_empty(
     assert snapshot is not None
     assert [w.label for w in snapshot.windows] == ["5h", "Weekly"]
     assert "remote /status" in snapshot.notes
+
+
+def test_probe_cache_keys_distinguish_local_and_remote() -> None:
+    local_default = _local_probe_cache_key({})
+    local_scoped = _local_probe_cache_key({"CLAUDE_CONFIG_DIR": "/tmp/acct-a"})
+    remote = _remote_probe_cache_key(_ssh_target())
+
+    assert local_default != local_scoped
+    assert local_scoped == "local:/tmp/acct-a"
+    assert remote == "remote:rover"
+    assert remote != local_default and remote != local_scoped
+
+
+def _usage_snapshot(used: float) -> SessionRateLimitUsage:
+    return SessionRateLimitUsage(
+        source="claude_code",
+        updated_at=datetime.now(UTC),
+        windows=[UsageWindow(id="five_hour", label="5h", used_percent=used)],
+        notes=["CLI creds"],
+    )
+
+
+def test_probe_claude_usage_shared_round_trips_force_and_invalidate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    env = {"CLAUDE_CONFIG_DIR": "/tmp/shared-wrapper-test"}
+    invalidate_shared_probe_local(env)
+    calls = 0
+
+    async def _fake_probe(*, env, timeout_seconds):
+        nonlocal calls
+        calls += 1
+        return _usage_snapshot(float(calls))
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits.probe_claude_usage",
+        _fake_probe,
+    )
+
+    first = asyncio.run(probe_claude_usage_shared(env=env))
+    cached = asyncio.run(probe_claude_usage_shared(env=env))
+    assert calls == 1
+    assert first is cached
+
+    forced = asyncio.run(probe_claude_usage_shared(env=env, force=True))
+    assert calls == 2
+    assert forced is not None and forced.windows[0].used_percent == 2.0
+
+    invalidate_shared_probe_local(env)
+    asyncio.run(probe_claude_usage_shared(env=env))
+    assert calls == 3
+
+    invalidate_shared_probe_local(env)

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -17,7 +17,7 @@ from waypoint.backends.codex.permission_modes import (
 )
 from waypoint.backends.codex.schemas import CodexThreadImportRequest
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.runtime import SessionRuntime
+from waypoint.runtime import STRUCTURED_LOG_FLUSH_EVERY, SessionRuntime
 from waypoint.schemas import (
     BoardEntryUpdateRequest,
     BoardPostRequest,
@@ -4756,3 +4756,64 @@ async def test_attach_assistant_disabled_409(tmp_path) -> None:
     with pytest.raises(HTTPException) as exc:
         await runtime.attach_assistant(backend="codex", thread_id="x")
     assert exc.value.status_code == 409
+
+
+def _seed_running_session(storage: Storage, session_id: str, log_path: Path) -> None:
+    now = datetime.now(UTC)
+    storage.create_session(
+        SessionRecord(
+            id=session_id,
+            backend="codex",
+            source=SessionSource.MANAGED,
+            title="streamer",
+            cwd="/tmp",
+            status=SessionStatus.RUNNING,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/tmp/raw.log",
+            structured_log_path=str(log_path),
+        )
+    )
+
+
+def _structured_event(session_id: str, sequence: int) -> EventRecord:
+    return EventRecord(
+        session_id=session_id,
+        ts=datetime.now(UTC),
+        kind=EventKind.AGENT_OUTPUT,
+        text=f"chunk-{sequence}",
+        metadata={},
+        sequence=sequence,
+    )
+
+
+def test_append_structured_log_batches_flush(tmp_path) -> None:
+    runtime, storage, _ = make_runtime(tmp_path)
+    log_path = tmp_path / "events.jsonl"
+    _seed_running_session(storage, "streamer", log_path)
+
+    for seq in range(STRUCTURED_LOG_FLUSH_EVERY - 1):
+        runtime._append_structured_log("streamer", _structured_event("streamer", seq))
+    # Buffered, not yet flushed: fewer than a full batch are visible on disk.
+    on_disk = log_path.read_text().splitlines() if log_path.exists() else []
+    assert len(on_disk) < STRUCTURED_LOG_FLUSH_EVERY
+
+    runtime._append_structured_log(
+        "streamer", _structured_event("streamer", STRUCTURED_LOG_FLUSH_EVERY - 1)
+    )
+    # Crossing the batch threshold flushes the whole run.
+    assert len(log_path.read_text().splitlines()) == STRUCTURED_LOG_FLUSH_EVERY
+
+    runtime._close_structured_log("streamer")
+
+
+def test_close_structured_log_flushes_pending_writes(tmp_path) -> None:
+    runtime, storage, _ = make_runtime(tmp_path)
+    log_path = tmp_path / "events.jsonl"
+    _seed_running_session(storage, "streamer", log_path)
+
+    runtime._append_structured_log("streamer", _structured_event("streamer", 0))
+    runtime._close_structured_log("streamer")
+
+    assert len(log_path.read_text().splitlines()) == 1

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1119,3 +1119,21 @@ def test_update_session_raises_keyerror_for_missing(tmp_path) -> None:
     storage = Storage(tmp_path / "waypoint.db")
     with pytest.raises(KeyError):
         storage.update_session("does-not-exist", title="x")
+
+
+def test_update_session_legacy_path_without_returning(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Exercise the fallback for SQLite < 3.35 that lacks UPDATE ... RETURNING.
+    monkeypatch.setattr("waypoint.storage._SUPPORTS_RETURNING", False)
+    storage = Storage(tmp_path / "waypoint.db")
+    _make_session(storage, "session-legacy", "before")
+
+    updated = storage.update_session("session-legacy", title="after")
+    assert updated.title == "after"
+    reloaded = storage.get_session("session-legacy")
+    assert reloaded is not None
+    assert reloaded.title == "after"
+
+    with pytest.raises(KeyError):
+        storage.update_session("missing-legacy", title="x")

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,6 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 
+import pytest
+
 from waypoint.schemas import (
     EventKind,
     EventRecord,
@@ -1086,3 +1088,34 @@ def test_board_regression_log_post_survives_session_delete_and_list(tmp_path) ->
     log_entries = [e for e in entries if e.key is None]
     assert len(log_entries) == 1
     assert log_entries[0].text == "task 1 done"
+
+
+def test_init_creates_performance_indexes(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    names = {
+        row["name"]
+        for row in storage.connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'index'"
+        ).fetchall()
+    }
+    assert {
+        "idx_sessions_spawner",
+        "idx_board_author",
+        "idx_scheduled_status",
+    } <= names
+
+
+def test_update_session_returns_updated_record(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    _make_session(storage, "session-upd", "before")
+    updated = storage.update_session("session-upd", title="after")
+    assert updated.title == "after"
+    reloaded = storage.get_session("session-upd")
+    assert reloaded is not None
+    assert reloaded.title == "after"
+
+
+def test_update_session_raises_keyerror_for_missing(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    with pytest.raises(KeyError):
+        storage.update_session("does-not-exist", title="x")

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -31,6 +31,7 @@ import { formatRelativeTime } from "@/lib/usage";
 
 const RECONNECT_BASE_MS = 500;
 const RECONNECT_MAX_MS = 15000;
+const BOARD_REFRESH_DEBOUNCE_MS = 300;
 const LOG_LIMIT = 100;
 
 type LoadState = "loading" | "ready" | "error";
@@ -467,6 +468,26 @@ export default function BoardPage() {
     let socket: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let attempt = 0;
+    // Coalesce bursts of board_update notifications into a single trailing
+    // refresh. `entriesDirty` records whether any update in the burst targeted
+    // the channel currently in view, so we only refetch entries when needed.
+    let boardRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+    let entriesDirty = false;
+    const scheduleBoardRefresh = () => {
+      if (boardRefreshTimer !== null) {
+        clearTimeout(boardRefreshTimer);
+      }
+      boardRefreshTimer = setTimeout(() => {
+        boardRefreshTimer = null;
+        if (!active) return;
+        void refreshChannels();
+        if (entriesDirty) {
+          entriesDirty = false;
+          const current = activeChannelRef.current;
+          if (current) void refreshEntries(current);
+        }
+      }, BOARD_REFRESH_DEBOUNCE_MS);
+    };
 
     function connect() {
       socket = connectSessionsSocket(
@@ -474,12 +495,12 @@ export default function BoardPage() {
         token,
         (message: SessionEnvelope) => {
           if (message.type === "board_update") {
-            void refreshChannels();
             const channel = message.payload.channel as string | null;
             const current = activeChannelRef.current;
             if (current && (channel === null || channel === current)) {
-              void refreshEntries(current);
+              entriesDirty = true;
             }
+            scheduleBoardRefresh();
           }
           if (message.type === "auth_revoked") {
             handleAuthFailure();
@@ -509,6 +530,7 @@ export default function BoardPage() {
     return () => {
       active = false;
       if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+      if (boardRefreshTimer !== null) clearTimeout(boardRefreshTimer);
       socket?.close();
     };
   }, [host, token, refreshChannels, refreshEntries, handleAuthFailure]);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -61,13 +61,22 @@ html[data-theme="light"] {
 }
 
 html {
-  /* Painted under the page so iOS Safari's rubber-band area renders the
-   * dark slate instead of revealing a white default background. Keep all
+  /* The gradient lives on the root element so it propagates to the viewport
+   * canvas: it spans the whole viewport and stays put while content scrolls,
+   * matching the old `background-attachment: fixed` look without forcing a
+   * full-screen repaint on every scroll frame. The solid `background-color`
+   * stays as a fallback and paints iOS Safari's rubber-band area. Keep all
    * other layout / scroll properties off the html element so the browser
    * uses it as the natural scroll root and trackpad wheel events reach it. */
+  background: linear-gradient(180deg, #0b0f15 0%, #0a0d12 60%, #08090d 100%);
   background-color: var(--bg-deep);
   -webkit-text-size-adjust: 100%;
   text-size-adjust: 100%;
+}
+
+html[data-theme="light"] {
+  background: linear-gradient(180deg, #f7f4ee 0%, #f4f0e8 60%, #efe9d8 100%);
+  background-color: var(--bg-deep);
 }
 
 body {
@@ -79,18 +88,10 @@ body {
    * the white flash at the top/bottom on macOS rubber-band). */
   overscroll-behavior-y: none;
   position: relative;
-  background: linear-gradient(180deg, #0b0f15 0%, #0a0d12 60%, #08090d 100%);
-  background-color: var(--bg-deep);
-  background-attachment: fixed;
   color: var(--text);
   font-family: var(--font-sans);
   font-feature-settings: "ss01", "cv11";
   -webkit-font-smoothing: antialiased;
-}
-
-html[data-theme="light"] body {
-  background: linear-gradient(180deg, #f7f4ee 0%, #f4f0e8 60%, #efe9d8 100%);
-  background-color: var(--bg-deep);
 }
 
 body::before {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -75,6 +75,7 @@ type ConnectionState = "idle" | "connecting" | "open" | "reconnecting";
 
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 15000;
+const BOARD_REFRESH_DEBOUNCE_MS = 300;
 
 function seedRecentCwdsFromHistory(
   host: string,
@@ -242,6 +243,25 @@ export default function HomePage() {
     let socket: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
     let attempt = 0;
+    // Coalesce bursts of board_update notifications into a single trailing
+    // refetch; the board channel list is small but each update otherwise
+    // triggers a full round-trip.
+    let boardRefreshTimer: ReturnType<typeof setTimeout> | null = null;
+    const scheduleBoardRefresh = () => {
+      if (boardRefreshTimer !== null) {
+        clearTimeout(boardRefreshTimer);
+      }
+      boardRefreshTimer = setTimeout(() => {
+        boardRefreshTimer = null;
+        fetchBoardChannels(host, token)
+          .then((list) => {
+            if (active) {
+              setBoardChannels(list);
+            }
+          })
+          .catch(() => {});
+      }, BOARD_REFRESH_DEBOUNCE_MS);
+    };
 
     function connect() {
       setConnection(attempt === 0 ? "connecting" : "reconnecting");
@@ -256,9 +276,7 @@ export default function HomePage() {
             setSchedules(message.payload.schedules as ScheduledSession[]);
           }
           if (message.type === "board_update") {
-            fetchBoardChannels(host, token)
-              .then((list) => setBoardChannels(list))
-              .catch(() => {});
+            scheduleBoardRefresh();
           }
           if (message.type === "auth_revoked") {
             resetAuthState("Session expired. Log in again.");
@@ -293,6 +311,9 @@ export default function HomePage() {
       active = false;
       if (reconnectTimer !== null) {
         clearTimeout(reconnectTimer);
+      }
+      if (boardRefreshTimer !== null) {
+        clearTimeout(boardRefreshTimer);
       }
       socket?.close();
     };

--- a/frontend/src/components/MarkdownMessage.tsx
+++ b/frontend/src/components/MarkdownMessage.tsx
@@ -1,6 +1,6 @@
-import type { ComponentPropsWithoutRef } from "react";
+import { memo, type ComponentPropsWithoutRef } from "react";
 
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
@@ -8,45 +8,51 @@ interface MarkdownMessageProps {
   text: string;
 }
 
-export function MarkdownMessage({ text }: MarkdownMessageProps) {
+// Hoisted to module scope so the plugin array and component overrides keep a
+// stable identity across renders — combined with the memo() below, an
+// unchanged `text` skips the remark parse entirely during streaming.
+const REMARK_PLUGINS = [remarkGfm, remarkBreaks];
+
+const COMPONENTS: Components = {
+  a({ href, children, ...props }) {
+    return (
+      <a href={href} rel="noreferrer" target="_blank" {...props}>
+        {children}
+      </a>
+    );
+  },
+  code({
+    inline,
+    className,
+    children,
+    ...props
+  }: ComponentPropsWithoutRef<"code"> & { inline?: boolean }) {
+    if (inline) {
+      return (
+        <code className={`inline-code ${className ?? ""}`.trim()} {...props}>
+          {children}
+        </code>
+      );
+    }
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  },
+  pre({ children }) {
+    return <pre className="markdown-pre">{children}</pre>;
+  },
+};
+
+export const MarkdownMessage = memo(function MarkdownMessage({
+  text,
+}: MarkdownMessageProps) {
   return (
     <div className="markdown-message">
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm, remarkBreaks]}
-        components={{
-          a({ href, children, ...props }) {
-            return (
-              <a href={href} rel="noreferrer" target="_blank" {...props}>
-                {children}
-              </a>
-            );
-          },
-          code({
-            inline,
-            className,
-            children,
-            ...props
-          }: ComponentPropsWithoutRef<"code"> & { inline?: boolean }) {
-            if (inline) {
-              return (
-                <code className={`inline-code ${className ?? ""}`.trim()} {...props}>
-                  {children}
-                </code>
-              );
-            }
-            return (
-              <code className={className} {...props}>
-                {children}
-              </code>
-            );
-          },
-          pre({ children }) {
-            return <pre className="markdown-pre">{children}</pre>;
-          },
-        }}
-      >
+      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={COMPONENTS}>
         {text}
       </ReactMarkdown>
     </div>
   );
-}
+});

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1244,34 +1244,63 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     }
   }
 
-  const pendingApprovals =
-    session && supportsStructuredApproval(session.transport, catalog)
-      ? findPendingApprovals(events)
-      : [];
+  const pendingApprovals = useMemo(
+    () =>
+      session && supportsStructuredApproval(session.transport, catalog)
+        ? findPendingApprovals(events)
+        : [],
+    [session, catalog, events],
+  );
   const approvalCount = pendingApprovals.length;
   const safeApprovalPage = approvalCount > 0 ? Math.min(approvalPageIndex, approvalCount - 1) : 0;
   const pendingApproval = pendingApprovals[safeApprovalPage] ?? null;
   const agentBusy = session ? isAgentBusy(session, connection) : false;
-  const displayEvents = collapseSupersededPlanEvents(renderedEvents);
-  const visibleEvents = filterMode === "all" ? displayEvents : displayEvents.filter(isImportantEvent);
+  const displayEvents = useMemo(
+    () => collapseSupersededPlanEvents(renderedEvents),
+    [renderedEvents],
+  );
+  const visibleEvents = useMemo(
+    () =>
+      filterMode === "all"
+        ? displayEvents
+        : displayEvents.filter(isImportantEvent),
+    [filterMode, displayEvents],
+  );
   const hiddenEventCount = displayEvents.length - visibleEvents.length;
-  const transcriptEvents =
-    optimisticMessages.length > 0
-      ? filterOptimisticTranscriptEvents(visibleEvents, optimisticMessages)
-      : visibleEvents;
-  const pendingPlanApprovalEvent =
-    session?.permission_mode === "plan" &&
-    supportsPlanApproval(session.backend, catalog)
-      ? latestActionablePlanEvent(displayEvents)
-      : null;
-  const pendingPlanApprovalView: PlanViewModel | null = pendingPlanApprovalEvent
-    ? planForEvent(pendingPlanApprovalEvent)
-    : null;
-  const transcriptEventsForDisplay = pendingPlanApprovalEvent
-    ? transcriptEvents.filter((event) => event !== pendingPlanApprovalEvent)
-    : transcriptEvents;
-  const transcriptItems = buildTranscriptItems(transcriptEventsForDisplay);
-  const hasToolRuns = transcriptItems.some((item) => item.kind === "tool_run");
+  const transcriptEvents = useMemo(
+    () =>
+      optimisticMessages.length > 0
+        ? filterOptimisticTranscriptEvents(visibleEvents, optimisticMessages)
+        : visibleEvents,
+    [visibleEvents, optimisticMessages],
+  );
+  const pendingPlanApprovalEvent = useMemo(
+    () =>
+      session?.permission_mode === "plan" &&
+      supportsPlanApproval(session.backend, catalog)
+        ? latestActionablePlanEvent(displayEvents)
+        : null,
+    [session, catalog, displayEvents],
+  );
+  const pendingPlanApprovalView: PlanViewModel | null = useMemo(
+    () => (pendingPlanApprovalEvent ? planForEvent(pendingPlanApprovalEvent) : null),
+    [pendingPlanApprovalEvent],
+  );
+  const transcriptEventsForDisplay = useMemo(
+    () =>
+      pendingPlanApprovalEvent
+        ? transcriptEvents.filter((event) => event !== pendingPlanApprovalEvent)
+        : transcriptEvents,
+    [pendingPlanApprovalEvent, transcriptEvents],
+  );
+  const transcriptItems = useMemo(
+    () => buildTranscriptItems(transcriptEventsForDisplay),
+    [transcriptEventsForDisplay],
+  );
+  const hasToolRuns = useMemo(
+    () => transcriptItems.some((item) => item.kind === "tool_run"),
+    [transcriptItems],
+  );
   // Latest task group, read off the raw event stream so the dock reflects the
   // true current state regardless of the transcript's event filter.
   const currentTaskEvent = useMemo(() => {


### PR DESCRIPTION
## Summary

Performance work on the backend hot paths and the frontend render/refetch loops, found by profiling the streaming and board paths under multiple concurrent sessions. No behavior changes — same contracts, fewer syscalls, network calls, and re-renders. A code review of the branch added test coverage and a couple of clarity fixes.

## Changes

### Backend

- **Shared rate-limit probe cache** (`backends/claude_code/rate_limits.py`, `plugin.py`) — every Claude session previously fired its own Anthropic rate-limit probe per window. They now coalesce behind a process-wide, account-keyed TTL cache (`SharedRateLimitProbeCache`), so sessions sharing credentials make one call per window instead of N. User-driven refresh invalidates the cached snapshot to force a live probe; the invalidate is best-effort against a concurrent periodic probe, but the served snapshot is still fresh either way.
- **Single-statement `update_session`** (`storage.py`) — collapses the read-modify-write into one `UPDATE ... RETURNING *` where SQLite ≥ 3.35 supports it, falling back to the legacy two-statement path on older SQLite.
- **Batched `events.jsonl` flush** (`storage.py`, `runtime.py`) — the SQLite store is the source of truth, so the streaming path no longer issues a flush syscall per event.
- **New indexes** — `sessions.spawner_session_id`, `board_entries.author_session_id`, and `scheduled_sessions.status`.
- **DEBUG perf timer** (`perf.py`) — a low-overhead `debug_timer` instrumenting `append_event` / `update_session`, the runtime session-list broadcast and structured-log append, and the rate-limit probe.

### Frontend

- **Memoized render path** (`MarkdownMessage.tsx`, `SessionDetail.tsx`) — memoizes the markdown render and `SessionDetail`'s per-render event derivations so unrelated state changes don't re-walk the transcript.
- **Debounced board refetches** (`board/page.tsx`) — collapses bursts of `board_update` events into a single trailing round-trip; the debounce reads the active channel at fire time and clears on unmount.
- **Gradient on the root element** (`globals.css`, `page.tsx`) — moves the page gradient onto `html` so it paints the viewport canvas without `background-attachment: fixed` repaints, keeping the solid `background-color` fallback for the iOS rubber-band area.

### Review follow-ups

- Tests for the shared probe wrappers (`probe_claude_usage_shared`) and cache-key builders, and for the SQLite pre-3.35 `update_session` fallback path.
- Moved the `update_session` `updated_at` default above the DEBUG timer so the logged field list is accurate.

## Test Plan

- [x] `cd backend && uv run pytest` — 1020 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- [x] `cd frontend && npm run lint` — clean (per the integrating session's run).
- [x] `cd frontend && npm run build` — clean (per the integrating session's run).
- Note: the frontend has no automated test harness in this repo, so frontend verification is lint + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)