### PR TITLE
fix: force a live rate-limit probe on user-driven usage refresh

### DIFF
--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -317,6 +317,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         launch_target: SshLaunchTargetConfig | None,
         *,
         cwd: str | None = None,
+        force: bool = False,
     ) -> SessionRateLimitUsage | None:
         """Fetch the account's current rate-limit snapshot without a session.
 
@@ -326,12 +327,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         populate ``rate_limit_usage`` for wrapped-claude sessions without
         wiring them through the structured adapter. ``cwd`` is accepted for
         a uniform probe signature across agents but unused — Claude's probe
-        is independent of the working directory.
+        is independent of the working directory. ``force`` bypasses the shared
+        TTL cache for a user-driven refresh so the click makes a live call.
         """
         _ = cwd
         if launch_target is None:
-            return await probe_claude_usage_shared()
-        return await probe_claude_usage_remote_shared(launch_target)
+            return await probe_claude_usage_shared(force=force)
+        return await probe_claude_usage_remote_shared(launch_target, force=force)
 
     def rate_limit_account(
         self, snapshot: SessionRateLimitUsage

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -238,7 +238,7 @@ class ClaudeTtyPlugin:
     async def refresh_rate_limit_usage(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        await self._tmux.refresh_rate_limit_usage(runtime, session)
+        await self._tmux.refresh_rate_limit_usage(runtime, session, force=True)
 
     # ── Composed agent knowledge (claude_code) ───────────────────────────────
 
@@ -254,9 +254,10 @@ class ClaudeTtyPlugin:
         launch_target: SshLaunchTargetConfig | None,
         *,
         cwd: str | None = None,
+        force: bool = False,
     ) -> SessionRateLimitUsage | None:
         return await self._claude.probe_account_rate_limit(
-            runtime, launch_target, cwd=cwd
+            runtime, launch_target, cwd=cwd, force=force
         )
 
     def validate_permission_mode(self, mode: str | None) -> str | None:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -287,14 +287,18 @@ class CodexPlugin(DefaultLaunchContract):
         launch_target: SshLaunchTargetConfig | None,
         *,
         cwd: str,
+        force: bool = False,
     ) -> SessionRateLimitUsage | None:
         """Fetch the account's current rate-limit snapshot without a session.
 
         Exposed so the tmux fallback can populate ``rate_limit_usage`` for
         wrapped-codex sessions without wiring them through the structured
         adapter. ``cwd`` is forwarded to the local probe because codex's
-        ``/status`` PTY fallback needs a working directory.
+        ``/status`` PTY fallback needs a working directory. ``force`` is
+        accepted for a uniform probe signature; codex always makes a live
+        call (it has no shared TTL cache), so it has no effect here.
         """
+        _ = force
         if launch_target is None:
             binary = (
                 self._config(runtime).local_bin

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -286,7 +286,7 @@ class TmuxPlugin:
         return None
 
     async def refresh_rate_limit_usage(
-        self, runtime: "SessionRuntime", session: SessionRecord
+        self, runtime: "SessionRuntime", session: SessionRecord, *, force: bool = True
     ) -> None:
         """Populate ``rate_limit_usage`` on tmux-wrapped sessions.
 
@@ -295,6 +295,10 @@ class TmuxPlugin:
         fires. Delegate to the inner plugin's account-level probe (same
         upstream API call the structured adapter makes) and persist +
         broadcast the snapshot via ``update_session_fields``.
+
+        ``force`` defaults to True because the user-driven refresh contract
+        reaches here directly; the background watcher passes ``force=False``
+        so its periodic ticks coalesce through the shared probe cache.
         """
         inner = runtime.registry.get(session.backend)
         probe = getattr(inner, "probe_account_rate_limit", None)
@@ -309,7 +313,7 @@ class TmuxPlugin:
         # always supplied (codex's ``/status`` PTY fallback needs it, the
         # others ignore it) so no per-backend call shape is needed here.
         try:
-            snapshot = await probe(runtime, launch_target, cwd=session.cwd)
+            snapshot = await probe(runtime, launch_target, cwd=session.cwd, force=force)
         except Exception:  # noqa: BLE001
             log.exception(
                 "tmux rate-limit probe failed",
@@ -641,7 +645,7 @@ class TmuxPlugin:
                 if session.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
                     return
                 try:
-                    await self.refresh_rate_limit_usage(runtime, session)
+                    await self.refresh_rate_limit_usage(runtime, session, force=False)
                 except Exception:  # noqa: BLE001
                     log.exception(
                         "tmux rate-limit refresh loop probe failed",

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -737,11 +737,18 @@ class _InnerPluginStub:
 
     def __init__(self) -> None:
         self.calls = 0
+        self.forces: list[bool] = []
 
     async def probe_account_rate_limit(
-        self, _runtime: Any, _launch_target: Any, *, cwd: str | None = None
+        self,
+        _runtime: Any,
+        _launch_target: Any,
+        *,
+        cwd: str | None = None,
+        force: bool = False,
     ) -> Any:
         self.calls += 1
+        self.forces.append(force)
         from waypoint.schemas import SessionRateLimitUsage
 
         return SessionRateLimitUsage(
@@ -835,6 +842,8 @@ async def test_rate_limit_watcher_stops_on_natural_exit(
     for _ in range(5):
         await asyncio.sleep(0)
     assert inner.calls >= 1, "probe should have fired at least once"
+    # Background ticks coalesce through the shared cache, never forcing.
+    assert all(force is False for force in inner.forces)
 
     # Flip status to EXITED without invoking terminate_session.
     runtime.sessions_by_id[session.id] = _watcher_session(
@@ -843,6 +852,20 @@ async def test_rate_limit_watcher_stops_on_natural_exit(
     # The loop's next iteration should observe the EXITED status and exit.
     await asyncio.wait_for(task, timeout=1.0)
     assert session.id not in runtime._rate_limit_watchers
+
+
+async def test_user_refresh_forces_live_probe(plugin: TmuxPlugin) -> None:
+    """The user-driven refresh contract must bypass the shared probe cache so
+    a click makes a live call, unlike the background watcher's coalesced ticks.
+    """
+    inner = _InnerPluginStub()
+    runtime = _FakeRuntime(inner_plugin=inner)
+    session = _watcher_session("sess-user-refresh")
+    runtime.sessions_by_id[session.id] = session
+
+    await plugin.refresh_rate_limit_usage(cast(Any, runtime), session)
+
+    assert inner.forces == [True]
 
 
 def _ctx_session(backend: str) -> SessionRecord:


### PR DESCRIPTION
## Summary

Regression from #128. The shared rate-limit probe cache landed there made the usage-refresh buttons no-ops for tmux-wrapped sessions — clicking refresh on the session page or the homepage usage dashboard replayed the cached snapshot (its `updated_at` never advanced) instead of making a live call. Since `claude_code` defaults to the Emulated (`claude_tty`) transport, this affected most sessions.

Root cause: `ClaudeCodePlugin.probe_account_rate_limit` was switched to read through the shared TTL cache (`probe_claude_usage_shared`) without forcing or invalidating, and that method is the user-driven refresh entrypoint for every tmux-wrapped session (`TmuxPlugin.refresh_rate_limit_usage`). The structured (`claude_cli` / codex) path was unaffected because it already invalidates and force-refreshes through the adapter, which is why the regression slipped through.

The `force` parameter the #128 review flagged as unused was exactly the missing wiring — it just never reached this path.

## Changes

### Backend

- **`backends/tmux/plugin.py`** — `refresh_rate_limit_usage` gains `force` (default `True`, since the user-driven refresh contract reaches it directly) and forwards it to the inner plugin's probe; the background `_rate_limit_refresh_loop` now calls it with `force=False` so its periodic ticks keep coalescing through the shared cache.
- **`backends/claude_code/plugin.py`** — `probe_account_rate_limit` accepts `force` and passes it to `probe_claude_usage_shared` / `probe_claude_usage_remote_shared`, so a user refresh bypasses the TTL window.
- **`backends/claude_tty/plugin.py`** — forwards `force=True` from `refresh_rate_limit_usage` and threads `force` through its `probe_account_rate_limit` wrapper.
- **`backends/codex/plugin.py`** — `probe_account_rate_limit` accepts `force` for a uniform signature; it's a no-op since codex has no shared cache and always probes live.

## Test Plan

- [x] `cd backend && uv run pytest` — 1021 passed (new tests assert the watcher probes with `force=False` and the user refresh with `force=True`).
- [x] `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- [x] Live, after `waypointctl restart backend`: on a `claude_tty` session, `POST /api/sessions/{id}/rate-limit-usage/refresh` three times now returns a strictly advancing `updated_at` (06:17:52 → 55 → 58); `POST /api/usage/refresh` advances the Claude bucket's snapshot on each call. Before the fix both were byte-identical across calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)