### PR TITLE
perf: shrink backend-data footprint and add a maintenance CLI

### DIFF
--- a/backend/src/waypoint/backends/tmux/normalize.py
+++ b/backend/src/waypoint/backends/tmux/normalize.py
@@ -4,6 +4,13 @@ from datetime import UTC, datetime
 
 from waypoint.schemas import EventKind, EventRecord, SessionStatus
 
+# Event kinds emitted by the tmux normalizer that carry only raw terminal
+# content and are never rendered by the frontend. These are filtered out of
+# the DB for tmux-transport sessions to avoid storing 99% waste.
+TMUX_CONTENT_KINDS: frozenset[EventKind] = frozenset(
+    {EventKind.AGENT_OUTPUT, EventKind.RAW_TERMINAL_CHUNK}
+)
+
 ANSI_CSI_PATTERN = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 ANSI_OSC_PATTERN = re.compile(r"\x1b\].*?(?:\x07|\x1b\\)", re.DOTALL)
 ANSI_SINGLE_PATTERN = re.compile(r"\x1b[@-_]")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any, cast
 
@@ -29,6 +30,7 @@ from waypoint.schemas import (
     SessionStatus,
 )
 from waypoint.settings import Settings, load_settings
+from waypoint.storage import Storage
 
 # Statuses that, by default, end a `sessions wait`: the session is idle,
 # blocked on the user, or finished. `starting`/`running`/`interrupted` are
@@ -121,11 +123,16 @@ schedule_app = typer.Typer(
     help="Manage scheduled session launches on a running Waypoint server.",
     no_args_is_help=True,
 )
+maintenance_app = typer.Typer(
+    help="Maintenance commands for the Waypoint server data.",
+    no_args_is_help=True,
+)
 app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(board_app, name="board")
 app.add_typer(schedule_app, name="schedule")
+app.add_typer(maintenance_app, name="maintenance")
 
 
 @app.callback()
@@ -1772,6 +1779,115 @@ def schedule_delete(
 def schedule_clear_history(ctx: typer.Context) -> None:
     """Remove completed/cancelled schedule records."""
     _emit(_settings_from_ctx(ctx), lambda c: c.clear_schedule_history())
+
+
+@maintenance_app.command("stats")
+def maintenance_stats(ctx: typer.Context) -> None:
+    """Print DB table sizes and FS footprint."""
+    settings = _settings_from_ctx(ctx)
+    storage = Storage(settings.database_path)
+    try:
+        stats = storage.db_stats()
+        orphans = storage.scan_orphan_session_dirs(settings.sessions_dir)
+        stats["orphan_session_dirs"] = len(orphans)
+        typer.echo(json.dumps(stats, indent=2))
+    finally:
+        storage.close()
+
+
+@maintenance_app.command("prune-orphans")
+def maintenance_prune_orphans(
+    ctx: typer.Context,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            help="Confirm deletion. Without this flag the command is a dry run.",
+        ),
+    ] = False,
+) -> None:
+    """Delete orphaned session directories."""
+    settings = _settings_from_ctx(ctx)
+    storage = Storage(settings.database_path)
+    try:
+        orphans = storage.scan_orphan_session_dirs(settings.sessions_dir)
+        if not orphans:
+            typer.echo("No orphaned session directories found.")
+            return
+
+        if not yes:
+            typer.echo(f"Found {len(orphans)} orphaned session directories (dry run):")
+            for o in orphans:
+                typer.echo(f"  - {o}")
+            typer.echo("Run with --yes to remove them.")
+            return
+
+        for o in orphans:
+            shutil.rmtree(o, ignore_errors=True)
+            typer.echo(f"removed {o}")
+    finally:
+        storage.close()
+
+
+@maintenance_app.command("trim-events")
+def maintenance_trim_events(
+    ctx: typer.Context,
+    transport: Annotated[
+        list[str] | None,
+        typer.Option("--transport", help="Filter by transport. Repeatable."),
+    ] = None,
+    status: Annotated[
+        list[str] | None,
+        typer.Option("--status", help="Filter by session status. Repeatable."),
+    ] = None,
+    older_than: Annotated[
+        int | None,
+        typer.Option("--older-than", help="Filter by sessions older than X days."),
+    ] = None,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            help="Confirm deletion. Without this flag the command is a dry run.",
+        ),
+    ] = False,
+) -> None:
+    """Delete content events."""
+    settings = _settings_from_ctx(ctx)
+    cutoff = (
+        datetime.now(UTC) - timedelta(days=older_than)
+        if older_than is not None
+        else None
+    )
+
+    storage = Storage(settings.database_path)
+    try:
+        count = storage.delete_events_for(
+            transports=transport,
+            statuses=status,
+            older_than=cutoff,
+            dry_run=not yes,
+        )
+        if not yes:
+            typer.echo(
+                f"Would delete {count} events (dry run). Run with --yes to confirm."
+            )
+        else:
+            typer.echo(f"Deleted {count} events.")
+    finally:
+        storage.close()
+
+
+@maintenance_app.command("vacuum")
+def maintenance_vacuum(ctx: typer.Context) -> None:
+    """Run SQLite VACUUM."""
+    settings = _settings_from_ctx(ctx)
+    storage = Storage(settings.database_path)
+    try:
+        storage.vacuum()
+        typer.echo("Database vacuumed.")
+    finally:
+        storage.close()
 
 
 def run_reset(settings: Settings | None = None, *, confirmed: bool) -> None:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1890,6 +1890,44 @@ def maintenance_vacuum(ctx: typer.Context) -> None:
         storage.close()
 
 
+@maintenance_app.command("clear-structured-logs")
+def maintenance_clear_structured_logs(
+    ctx: typer.Context,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            help="Confirm deletion. Without this flag the command is a dry run.",
+        ),
+    ] = False,
+) -> None:
+    """Delete per-session events.jsonl audit logs (redundant with the DB)."""
+    settings = _settings_from_ctx(ctx)
+    storage = Storage(settings.database_path)
+    try:
+        logs = storage.scan_structured_logs(settings.sessions_dir)
+        if not logs:
+            typer.echo("No structured logs found.")
+            return
+        total = sum(p.stat().st_size for p in logs if p.exists())
+        if not yes:
+            typer.echo(
+                f"Found {len(logs)} events.jsonl files "
+                f"({total / 1e6:.1f} MB) (dry run). Run with --yes to delete."
+            )
+            return
+        removed = 0
+        for log_path in logs:
+            try:
+                log_path.unlink()
+                removed += 1
+            except OSError as exc:
+                typer.echo(f"skipped {log_path}: {exc}")
+        typer.echo(f"Deleted {removed} events.jsonl files ({total / 1e6:.1f} MB).")
+    finally:
+        storage.close()
+
+
 def run_reset(settings: Settings | None = None, *, confirmed: bool) -> None:
     settings = settings or load_settings()
     db_path = settings.database_path

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1852,7 +1852,14 @@ def maintenance_trim_events(
         ),
     ] = False,
 ) -> None:
-    """Delete content events."""
+    """Delete content events for the given transport(s)."""
+    if not transport:
+        raise typer.BadParameter(
+            "trim-events requires --transport (e.g. --transport tmux). "
+            "Refusing to delete content events across all transports: structured "
+            "sessions render their agent_output in the transcript, so an unscoped "
+            "delete would destroy real history."
+        )
     settings = _settings_from_ctx(ctx)
     cutoff = (
         datetime.now(UTC) - timedelta(days=older_than)
@@ -1905,9 +1912,19 @@ def maintenance_clear_structured_logs(
     settings = _settings_from_ctx(ctx)
     storage = Storage(settings.database_path)
     try:
-        logs = storage.scan_structured_logs(settings.sessions_dir)
+        # Skip RUNNING sessions: if structured logging is enabled the runtime
+        # holds an open append handle, and unlinking it would silently orphan
+        # the inode the runtime keeps writing to.
+        running = {
+            s.id for s in storage.list_sessions() if s.status == SessionStatus.RUNNING
+        }
+        logs = [
+            p
+            for p in storage.scan_structured_logs(settings.sessions_dir)
+            if p.parent.name not in running
+        ]
         if not logs:
-            typer.echo("No structured logs found.")
+            typer.echo("No structured logs to clear (RUNNING sessions skipped).")
             return
         total = sum(p.stat().st_size for p in logs if p.exists())
         if not yes:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1846,6 +1846,8 @@ class SessionRuntime:
                 await self._broadcast_session_list()
 
     def _append_structured_log(self, session_id: str, event: EventRecord) -> None:
+        if not self.settings.write_structured_log:
+            return
         with debug_timer(log, "_append_structured_log", session=session_id):
             entry = self._structured_log_handles.get(session_id)
             if entry is None:
@@ -1860,6 +1862,8 @@ class SessionRuntime:
                 entry.pending = 0
 
     def _close_structured_log(self, session_id: str) -> None:
+        if not self.settings.write_structured_log:
+            return
         entry = self._structured_log_handles.pop(session_id, None)
         if entry is not None:
             with suppress(Exception):

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -2078,20 +2078,26 @@ class SessionRuntime:
         self.file_offsets[session_id] = new_offset
         if normalized is None:
             return
-        is_tmux = session.transport == TMUX_TRANSPORT_ID
+        # Heuristic (non-structured) transports — the generic tmux pane — emit
+        # raw terminal frames the UI never renders (it shows the live xterm, not
+        # a transcript), so persisting them is pure DB bloat. Gate on the
+        # transport capability, not a hardcoded id, per the dispatch-by-capability
+        # rule. _ingest_raw_output only runs for raw-log transports today, but the
+        # capability check keeps a future heuristic transport from regressing.
+        is_heuristic = not self.transport_for(session).is_structured
         for event in normalized.events:
-            if is_tmux and event.kind in TMUX_CONTENT_KINDS:
+            if is_heuristic and event.kind in TMUX_CONTENT_KINDS:
                 continue
             persisted = self.storage.append_event(event)
             self._append_structured_log(session_id, persisted)
             await self._publish_event(persisted)
-        # For tmux sessions, content events (agent_output / raw_terminal_chunk)
-        # are not persisted but their two side-effects must still be applied:
-        # (1) bump last_event_at, (2) advance the heuristic status. Use
-        # update_session when the last event in the chunk was a content event —
-        # if a non-content event came last, append_event already handled both.
+        # Content events (agent_output / raw_terminal_chunk) were not persisted
+        # but their two side-effects must still be applied: (1) bump
+        # last_event_at, (2) advance the heuristic status. Use update_session
+        # when the last event in the chunk was a content event — if a
+        # non-content event came last, append_event already handled both.
         if (
-            is_tmux
+            is_heuristic
             and normalized.events
             and normalized.events[-1].kind in TMUX_CONTENT_KINDS
         ):

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -22,7 +22,11 @@ from waypoint.attachments import AttachmentStore, ResolvedAttachment
 from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
-from waypoint.backends.tmux.normalize import NormalizedChunk, TerminalNormalizer
+from waypoint.backends.tmux.normalize import (
+    TMUX_CONTENT_KINDS,
+    NormalizedChunk,
+    TerminalNormalizer,
+)
 from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -2074,10 +2078,29 @@ class SessionRuntime:
         self.file_offsets[session_id] = new_offset
         if normalized is None:
             return
+        is_tmux = session.transport == TMUX_TRANSPORT_ID
         for event in normalized.events:
+            if is_tmux and event.kind in TMUX_CONTENT_KINDS:
+                continue
             persisted = self.storage.append_event(event)
             self._append_structured_log(session_id, persisted)
             await self._publish_event(persisted)
+        # For tmux sessions, content events (agent_output / raw_terminal_chunk)
+        # are not persisted but their two side-effects must still be applied:
+        # (1) bump last_event_at, (2) advance the heuristic status. Use
+        # update_session when the last event in the chunk was a content event —
+        # if a non-content event came last, append_event already handled both.
+        if (
+            is_tmux
+            and normalized.events
+            and normalized.events[-1].kind in TMUX_CONTENT_KINDS
+        ):
+            self.storage.update_session(
+                session_id,
+                last_event_at=normalized.events[-1].ts,
+                status=normalized.status,
+            )
+            self._publish_session_state(session_id)
 
     async def _refresh_state(self, session_id: str) -> None:
         session = self.get_session(session_id)

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -140,6 +140,11 @@ class Settings(BaseModel):
     # surfaces N visible bubbles regardless of how many raw events the
     # backend emitted per message.
     chat_page_messages: int = Field(default=20, ge=1, le=200)
+    # When True, each session gets a per-session events.jsonl written
+    # alongside the SQLite events table. Disabled by default because the
+    # JSONL is a write-only audit/debug artifact (~290 MB in production) and
+    # SQLite is the source of truth. Override with WAYPOINT_WRITE_STRUCTURED_LOG.
+    write_structured_log: bool = False
     # Personal-assistant singleton. ``None`` (the default) means no
     # assistant is created. A present block is enabled unless it sets
     # ``enabled: false``.
@@ -263,6 +268,10 @@ def _env_overrides() -> dict[str, Any]:
         overrides["cors_allow_origin_regex"] = parse_cors_origin_regex(
             os.environ["WAYPOINT_CORS_ORIGIN_REGEX"]
         )
+    if "WAYPOINT_WRITE_STRUCTURED_LOG" in os.environ:
+        overrides["write_structured_log"] = os.environ[
+            "WAYPOINT_WRITE_STRUCTURED_LOG"
+        ].lower() not in {"0", "false", "no", ""}
     return overrides
 
 

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -954,6 +954,100 @@ class Storage:
         ).fetchone()
         return int(row["max_sequence"]) + 1
 
+    @_synchronized
+    def db_stats(self) -> dict[str, Any]:
+        stats: dict[str, Any] = {}
+        for row in self.connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ):
+            table = row["name"]
+            count = self.connection.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[
+                0
+            ]
+            stats[table] = {"row_count": count}
+
+        events_by_kind = {}
+        for row in self.connection.execute(
+            "SELECT kind, COUNT(*) as count FROM events GROUP BY kind"
+        ):
+            events_by_kind[row["kind"]] = row["count"]
+        stats["events_by_kind"] = events_by_kind
+
+        events_by_session = {}
+        for row in self.connection.execute(
+            "SELECT session_id, COUNT(*) as count FROM events GROUP BY session_id"
+        ):
+            events_by_session[row["session_id"]] = row["count"]
+        stats["events_by_session"] = events_by_session
+
+        db_size = (
+            self.database_path.stat().st_size if self.database_path.exists() else 0
+        )
+        wal_path = self.database_path.parent / (self.database_path.name + "-wal")
+        wal_size = wal_path.stat().st_size if wal_path.exists() else 0
+        stats["fs_footprint"] = {
+            "db_size_bytes": db_size,
+            "wal_size_bytes": wal_size,
+        }
+
+        return stats
+
+    @_synchronized
+    def scan_orphan_session_dirs(self, sessions_dir: Path) -> list[Path]:
+        orphans: list[Path] = []
+        if not sessions_dir.exists():
+            return orphans
+
+        valid_ids = {
+            row["id"] for row in self.connection.execute("SELECT id FROM sessions")
+        }
+
+        for session_dir in sessions_dir.iterdir():
+            if session_dir.is_dir() and session_dir.name not in valid_ids:
+                orphans.append(session_dir)
+        return orphans
+
+    @_synchronized
+    def delete_events_for(
+        self,
+        transports: list[str] | None = None,
+        statuses: list[str] | None = None,
+        older_than: datetime | None = None,
+        dry_run: bool = False,
+    ) -> int:
+        action = "SELECT COUNT(*)" if dry_run else "DELETE"
+        query = f"""
+            {action} FROM events
+            WHERE kind IN ('agent_output', 'raw_terminal_chunk')
+        """
+        params: list[Any] = []
+
+        if transports or statuses or older_than:
+            query += " AND session_id IN (SELECT id FROM sessions WHERE 1=1"
+            if transports:
+                placeholders = ",".join(["?"] * len(transports))
+                query += f" AND transport IN ({placeholders})"
+                params.extend(transports)
+            if statuses:
+                placeholders = ",".join(["?"] * len(statuses))
+                query += f" AND status IN ({placeholders})"
+                params.extend(statuses)
+            if older_than:
+                query += " AND last_event_at < ?"
+                params.append(older_than.isoformat())
+            query += ")"
+
+        cursor = self.connection.execute(query, params)
+        if dry_run:
+            return cursor.fetchone()[0]
+        self.connection.commit()
+        return cursor.rowcount or 0
+
+    @_synchronized
+    def vacuum(self) -> None:
+        self.connection.execute("VACUUM")
+        self.connection.commit()
+
     def _session_from_row(self, row: sqlite3.Row) -> SessionRecord:
         payload = dict(row)
         for field_name in ("created_at", "updated_at", "last_event_at"):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1012,6 +1012,9 @@ class Storage:
 
         These mirror the SQLite events table (the source of truth) and are
         write-only, so they are safe to delete to reclaim space.
+
+        Filesystem-only — no ``@_synchronized`` because it never touches the
+        connection (the decorator only serializes DB access).
         """
         logs: list[Path] = []
         if not sessions_dir.exists():
@@ -1062,6 +1065,9 @@ class Storage:
 
     @_synchronized
     def vacuum(self) -> None:
+        # VACUUM cannot run inside a transaction; with isolation_level='' a
+        # pending DML would have opened one, so commit first to be safe.
+        self.connection.commit()
         self.connection.execute("VACUUM")
         self.connection.commit()
 

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1007,6 +1007,23 @@ class Storage:
                 orphans.append(session_dir)
         return orphans
 
+    def scan_structured_logs(self, sessions_dir: Path) -> list[Path]:
+        """Per-session ``events.jsonl`` audit logs present on disk.
+
+        These mirror the SQLite events table (the source of truth) and are
+        write-only, so they are safe to delete to reclaim space.
+        """
+        logs: list[Path] = []
+        if not sessions_dir.exists():
+            return logs
+        for session_dir in sessions_dir.iterdir():
+            if not session_dir.is_dir():
+                continue
+            log_path = session_dir / "events.jsonl"
+            if log_path.is_file():
+                logs.append(log_path)
+        return logs
+
     @_synchronized
     def delete_events_for(
         self,

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -4788,8 +4788,17 @@ def _structured_event(session_id: str, sequence: int) -> EventRecord:
     )
 
 
+def _make_runtime_with_structured_log(
+    tmp_path: Path,
+) -> tuple[SessionRuntime, Storage, Settings]:
+    settings = Settings(data_dir=tmp_path / "data", write_structured_log=True)
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    return SessionRuntime(settings, storage), storage, settings
+
+
 def test_append_structured_log_batches_flush(tmp_path) -> None:
-    runtime, storage, _ = make_runtime(tmp_path)
+    runtime, storage, _ = _make_runtime_with_structured_log(tmp_path)
     log_path = tmp_path / "events.jsonl"
     _seed_running_session(storage, "streamer", log_path)
 
@@ -4809,11 +4818,40 @@ def test_append_structured_log_batches_flush(tmp_path) -> None:
 
 
 def test_close_structured_log_flushes_pending_writes(tmp_path) -> None:
-    runtime, storage, _ = make_runtime(tmp_path)
+    runtime, storage, _ = _make_runtime_with_structured_log(tmp_path)
     log_path = tmp_path / "events.jsonl"
     _seed_running_session(storage, "streamer", log_path)
 
     runtime._append_structured_log("streamer", _structured_event("streamer", 0))
     runtime._close_structured_log("streamer")
 
+    assert len(log_path.read_text().splitlines()) == 1
+
+
+def test_structured_log_off_skips_file_and_db_intact(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    assert not settings.write_structured_log
+    log_path = tmp_path / "events.jsonl"
+    _seed_running_session(storage, "streamer", log_path)
+
+    event = _structured_event("streamer", 0)
+    stored = storage.append_event(event)
+    runtime._append_structured_log("streamer", stored)
+    runtime._close_structured_log("streamer")
+
+    assert not log_path.exists()
+    assert len(storage.list_events("streamer")) == 1
+
+
+def test_structured_log_on_writes_file(tmp_path) -> None:
+    runtime, storage, _ = _make_runtime_with_structured_log(tmp_path)
+    log_path = tmp_path / "events.jsonl"
+    _seed_running_session(storage, "streamer", log_path)
+
+    event = _structured_event("streamer", 0)
+    stored = storage.append_event(event)
+    runtime._append_structured_log("streamer", stored)
+    runtime._close_structured_log("streamer")
+
+    assert log_path.exists()
     assert len(log_path.read_text().splitlines()) == 1

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -4913,6 +4913,9 @@ async def test_ingest_raw_output_tmux_skips_content_events_updates_session(
     assert (
         refreshed.last_event_at > original_last_event_at
     ), "last_event_at must be bumped even when content events are skipped"
+    # The second preserved side-effect: heuristic status advances (IDLE ->
+    # RUNNING here) via update_session even though no content row was written.
+    assert refreshed.status == SessionStatus.RUNNING
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -4855,3 +4855,116 @@ def test_structured_log_on_writes_file(tmp_path) -> None:
 
     assert log_path.exists()
     assert len(log_path.read_text().splitlines()) == 1
+
+
+# ---------------------------------------------------------------------------
+# _ingest_raw_output — tmux content-event filtering
+# ---------------------------------------------------------------------------
+
+
+def _make_tmux_session(
+    settings: Settings, tmp_path: Path, session_id: str = "tmux-1"
+) -> SessionRecord:
+    session_dir = settings.sessions_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    raw_log = session_dir / "raw.log"
+    structured_log = session_dir / "events.jsonl"
+    session = SessionRecord(
+        id=session_id,
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="tmux session",
+        cwd="/tmp/project",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(raw_log),
+        structured_log_path=str(structured_log),
+    )
+    return session
+
+
+@pytest.mark.asyncio
+async def test_ingest_raw_output_tmux_skips_content_events_updates_session(
+    tmp_path,
+) -> None:
+    """Tmux ingest must bump last_event_at / status WITHOUT inserting agent_output rows."""
+    runtime, storage, settings = make_runtime(tmp_path)
+    session = _make_tmux_session(settings, tmp_path)
+    storage.create_session(session)
+    raw_log = Path(session.raw_log_path)
+    raw_log.write_text("Agent is working on the task...\n", encoding="utf-8")
+    runtime.file_offsets[session.id] = 0
+
+    original_last_event_at = storage.get_session(session.id).last_event_at  # type: ignore[union-attr]
+
+    await runtime._ingest_raw_output(session.id)
+
+    events = storage.list_events(session.id)
+    assert all(
+        e.kind not in {EventKind.AGENT_OUTPUT, EventKind.RAW_TERMINAL_CHUNK}
+        for e in events
+    ), "tmux content events must not be persisted to the DB"
+    refreshed = storage.get_session(session.id)
+    assert refreshed is not None
+    assert (
+        refreshed.last_event_at > original_last_event_at
+    ), "last_event_at must be bumped even when content events are skipped"
+
+
+@pytest.mark.asyncio
+async def test_ingest_raw_output_tmux_still_persists_approval_request(
+    tmp_path,
+) -> None:
+    """Approval-request events in tmux output must still be persisted."""
+    runtime, storage, settings = make_runtime(tmp_path)
+    session = _make_tmux_session(settings, tmp_path)
+    storage.create_session(session)
+    raw_log = Path(session.raw_log_path)
+    raw_log.write_text("Approve this command? y/n\n", encoding="utf-8")
+    runtime.file_offsets[session.id] = 0
+
+    await runtime._ingest_raw_output(session.id)
+
+    events = storage.list_events(session.id)
+    assert any(
+        e.kind == EventKind.APPROVAL_REQUEST for e in events
+    ), "approval_request events must still be persisted for tmux sessions"
+
+
+@pytest.mark.asyncio
+async def test_ingest_raw_output_structured_session_unchanged(tmp_path) -> None:
+    """Structured-transport sessions must persist all event kinds normally."""
+    runtime, storage, settings = make_runtime(tmp_path)
+    session_dir = settings.sessions_dir / "cli-1"
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    raw_log = session_dir / "raw.log"
+    structured_log = session_dir / "events.jsonl"
+    session = SessionRecord(
+        id="cli-1",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="claude_cli",
+        title="structured session",
+        cwd="/tmp/project",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(raw_log),
+        structured_log_path=str(structured_log),
+    )
+    storage.create_session(session)
+    raw_log.write_text("Agent is working on the task...\n", encoding="utf-8")
+    runtime.file_offsets[session.id] = 0
+
+    await runtime._ingest_raw_output(session.id)
+
+    events = storage.list_events(session.id)
+    assert any(
+        e.kind in {EventKind.AGENT_OUTPUT, EventKind.RAW_TERMINAL_CHUNK} for e in events
+    ), "structured sessions must still persist content events"

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1279,10 +1279,10 @@ def test_delete_events_for_older_than(tmp_path) -> None:
     assert storage.list_events("stale") == []
     assert [e.text for e in storage.list_events("fresh")] == ["y"]
 
-    # Actual run should delete
+    # A non-dry-run trim with no older_than now removes fresh's remaining event.
     count2 = storage.delete_events_for(transports=["tmux"], dry_run=False)
     assert count2 == 1
-    assert len(storage.list_events("sess-1")) == 0
+    assert storage.list_events("fresh") == []
 
 
 def test_vacuum_runs_without_error(tmp_path) -> None:

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1258,6 +1258,27 @@ def test_delete_events_for_dry_run(tmp_path) -> None:
     assert count == 1
     assert len(storage.list_events("sess-1")) == 1
 
+
+def test_delete_events_for_older_than(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+
+    _make_session(storage, "stale", "Stale")
+    _append(storage, "stale", sequence=1, kind=EventKind.AGENT_OUTPUT, text="x", ts=now)
+    storage.update_session(
+        "stale", transport="tmux", last_event_at=now - timedelta(days=10)
+    )
+    _make_session(storage, "fresh", "Fresh")
+    _append(storage, "fresh", sequence=1, kind=EventKind.AGENT_OUTPUT, text="y", ts=now)
+    storage.update_session("fresh", transport="tmux", last_event_at=now)
+
+    count = storage.delete_events_for(
+        transports=["tmux"], older_than=now - timedelta(days=1)
+    )
+    assert count == 1
+    assert storage.list_events("stale") == []
+    assert [e.text for e in storage.list_events("fresh")] == ["y"]
+
     # Actual run should delete
     count2 = storage.delete_events_for(transports=["tmux"], dry_run=False)
     assert count2 == 1

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1137,3 +1137,119 @@ def test_update_session_legacy_path_without_returning(
 
     with pytest.raises(KeyError):
         storage.update_session("missing-legacy", title="x")
+
+
+# ── maintenance tests ───────────────────────────────────────────────────────
+
+
+def test_db_stats(tmp_path) -> None:
+    storage, now = _seed_session(tmp_path)
+    _append(
+        storage, "sess", sequence=1, kind=EventKind.AGENT_OUTPUT, text="hello", ts=now
+    )
+
+    stats = storage.db_stats()
+    assert "events" in stats
+    assert stats["events"]["row_count"] == 1
+    assert stats["events_by_kind"] == {EventKind.AGENT_OUTPUT: 1}
+    assert stats["events_by_session"] == {"sess": 1}
+    assert "fs_footprint" in stats
+    assert "db_size_bytes" in stats["fs_footprint"]
+
+
+def test_scan_orphan_session_dirs(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+
+    # Live session
+    _make_session(storage, "live-1", "Live")
+    (sessions_dir / "live-1").mkdir()
+
+    # Orphan session
+    (sessions_dir / "orphan-1").mkdir()
+    (sessions_dir / "orphan-2").mkdir()
+
+    orphans = storage.scan_orphan_session_dirs(sessions_dir)
+    orphan_names = {p.name for p in orphans}
+    assert orphan_names == {"orphan-1", "orphan-2"}
+
+
+def test_delete_events_for_filters(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+
+    # Create two sessions with different transports/statuses
+    _make_session(storage, "sess-1", "Target")
+    storage.update_session("sess-1", transport="tmux", status=SessionStatus.EXITED)
+    _make_session(storage, "sess-2", "Keep")
+    storage.update_session(
+        "sess-2", transport="claude_tty", status=SessionStatus.RUNNING
+    )
+
+    # Append events
+    _append(
+        storage,
+        "sess-1",
+        sequence=1,
+        kind=EventKind.AGENT_OUTPUT,
+        text="delete-this",
+        ts=now,
+    )
+    _append(
+        storage,
+        "sess-1",
+        sequence=2,
+        kind=EventKind.USER_INPUT,
+        text="keep-this",
+        ts=now,
+    )
+    _append(
+        storage,
+        "sess-2",
+        sequence=1,
+        kind=EventKind.AGENT_OUTPUT,
+        text="keep-this-too",
+        ts=now,
+    )
+
+    count = storage.delete_events_for(
+        transports=["tmux"],
+        statuses=[SessionStatus.EXITED],
+    )
+    assert count == 1
+
+    remaining = [e.text for e in storage.list_events("sess-1")] + [
+        e.text for e in storage.list_events("sess-2")
+    ]
+    assert set(remaining) == {"keep-this", "keep-this-too"}
+
+
+def test_delete_events_for_dry_run(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    _make_session(storage, "sess-1", "Target")
+    storage.update_session("sess-1", transport="tmux", status=SessionStatus.EXITED)
+    _append(
+        storage,
+        "sess-1",
+        sequence=1,
+        kind=EventKind.AGENT_OUTPUT,
+        text="target",
+        ts=now,
+    )
+
+    # Dry run should return count but not delete
+    count = storage.delete_events_for(transports=["tmux"], dry_run=True)
+    assert count == 1
+    assert len(storage.list_events("sess-1")) == 1
+
+    # Actual run should delete
+    count2 = storage.delete_events_for(transports=["tmux"], dry_run=False)
+    assert count2 == 1
+    assert len(storage.list_events("sess-1")) == 0
+
+
+def test_vacuum_runs_without_error(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    storage.vacuum()  # Should not raise

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1175,6 +1175,20 @@ def test_scan_orphan_session_dirs(tmp_path) -> None:
     assert orphan_names == {"orphan-1", "orphan-2"}
 
 
+def test_scan_structured_logs(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    sessions_dir = tmp_path / "sessions"
+    (sessions_dir / "s1").mkdir(parents=True)
+    (sessions_dir / "s1" / "events.jsonl").write_text("{}\n")
+    (sessions_dir / "s1" / "raw.log").write_text("ignored")
+    (sessions_dir / "s2").mkdir()  # no events.jsonl
+
+    logs = storage.scan_structured_logs(sessions_dir)
+    assert [p.name for p in logs] == ["events.jsonl"]
+    assert logs[0].parent.name == "s1"
+    assert storage.scan_structured_logs(tmp_path / "missing") == []
+
+
 def test_delete_events_for_filters(tmp_path) -> None:
     storage = Storage(tmp_path / "waypoint.db")
     now = datetime.now(UTC)


### PR DESCRIPTION
## Summary

The SQLite store (`waypoint.db`) had grown to ~676MB, of which **99% was heuristic `agent_output`/`raw_terminal_chunk` frames emitted by the generic tmux transport** — which is terminal-only in the UI, so those frames render nowhere (the live xterm is driven by `raw.log`, not the DB; an exited tmux session shows the terminal, never a transcript). A second ~290MB came from per-session `events.jsonl` files, a write-only audit mirror of the DB. This branch stops both at the source and adds a maintenance CLI to reclaim what already accumulated.

Verified live on a real tmux session: it renders and processes a prompt while persisting **zero** content events (only genuine `user_input`/`system_note`), with `last_event_at` and the heuristic status still advancing and no `events.jsonl` written. One-time reclaim via the new CLI took `waypoint.db` from 687MB to 212MB and `backend-data` from 1.1GB to 523MB.

## Changes

### Backend

- **Stop persisting heuristic terminal frames** (`runtime.py` `_ingest_raw_output`, `backends/tmux/normalize.py`) — for non-structured transports (gated on the `is_structured` capability, not a hardcoded id), `agent_output`/`raw_terminal_chunk` content events are no longer inserted. Their two live side-effects are preserved: `last_event_at` is bumped and the heuristic session status is advanced via a single `update_session` call when a polled chunk ends on a content event. Structured transports and the live terminal (raw.log WS) are unchanged.
- **Gate the `events.jsonl` structured log** (`settings.py`, `runtime.py`) — new `write_structured_log` setting, **default off** (override `WAYPOINT_WRITE_STRUCTURED_LOG`). When off, no per-session `events.jsonl` is opened or written; the SQLite events table remains the source of truth.
- **`waypoint maintenance` CLI** (`cli.py`, additive methods on `storage.py`) — `stats`, `prune-orphans`, `trim-events`, `vacuum`, and `clear-structured-logs` (delete the redundant write-only `events.jsonl` files). Mirrors the existing `reset` convention: dry-run by default, `--yes` to mutate. `trim-events` requires an explicit `--transport` so it can't delete structured sessions' transcripts unscoped; `vacuum` commits before running; `clear-structured-logs` skips RUNNING sessions.

## Test Plan

- [x] `cd backend && uv run pytest` — 1033 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- [x] Live on a redeployed backend: a real `tmux` session persisted 0 content events while `last_event_at`/status advanced and no `events.jsonl` was written; opening an old (trimmed) tmux session's transcript returns cleanly; no errors in the backend log.
- [x] Maintenance CLI exercised against the live DB: `waypoint.db` 687MB → 212MB, `backend-data` 1.1GB → 523MB; `trim-events` without `--transport` errors as intended.

### Reviewer note

`WAYPOINT_WRITE_STRUCTURED_LOG` defaults off, so `events.jsonl` files are no longer produced for new sessions; `clear-structured-logs` removes the ~225MB of existing ones. VACUUM and `clear-structured-logs` want the backend stopped (exclusive DB access / open-handle safety).

🤖 Generated with [Claude Code](https://claude.com/claude-code)