### PR TITLE
feat: surface per-model Claude rate-limit usage (Sonnet/Opus)

### DIFF
--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -24,6 +24,7 @@ from waypoint.schemas import SessionRateLimitUsage, UsageWindow
 log = logging.getLogger("waypoint.claude_code.rate_limits")
 
 _CLAUDE_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+_CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 _CLAUDE_MESSAGES_MODEL = "claude-haiku-4-5-20251001"
 _CLAUDE_MESSAGES_VERSION = "2023-06-01"
 _WINDOWS: tuple[tuple[str, str, int], ...] = (
@@ -33,6 +34,9 @@ _WINDOWS: tuple[tuple[str, str, int], ...] = (
     ("seven_day_sonnet", "Sonnet", 7 * 24 * 60),
     ("seven_day_fable", "Fable", 7 * 24 * 60),
 )
+# Windows the account-wide plan always carries; the per-model windows are
+# gated in parse_claude_usage_payload.
+_PRIMARY_WINDOW_KEYS = frozenset({"five_hour", "seven_day"})
 _CLAUDE_USER_AGENT: str | None = None
 _CLAUDE_USER_AGENT_RESOLVED = False
 
@@ -61,13 +65,19 @@ def parse_claude_usage_payload(
         percent = _parse_utilization(window.get("utilization"))
         if percent is None:
             continue
+        resets_at = _parse_iso_datetime(window.get("resets_at"))
+        # Skip a per-model scoped window (Opus/Sonnet/Fable) only while it is
+        # both un-armed (no reset) and at 0% — the API's "no usage yet this
+        # week" state. The 5h / weekly windows always surface.
+        if key not in _PRIMARY_WINDOW_KEYS and resets_at is None and percent <= 0.0:
+            continue
         windows.append(
             UsageWindow(
                 id=key,
                 label=label,
                 used_percent=percent,
                 window_minutes=minutes,
-                resets_at=_parse_iso_datetime(window.get("resets_at")),
+                resets_at=resets_at,
             )
         )
 
@@ -100,6 +110,22 @@ async def probe_claude_usage(
                 "skipping HTTP call and surfacing expiry"
             )
             return _expired_credentials_snapshot(credential_note, resolved_env)
+        account_notes = _read_oauth_account_notes(resolved_env)
+
+        # Prefer the OAuth usage endpoint: it carries per-model windows
+        # (Sonnet/Opus/Fable) that the Messages API rate-limit headers omit.
+        usage_response = await asyncio.wait_for(
+            asyncio.to_thread(_fetch_claude_oauth_usage, access_token),
+            timeout=timeout_seconds,
+        )
+        snapshot = _build_oauth_usage_snapshot(
+            usage_response, credential_note, account_notes
+        )
+        if snapshot is not None:
+            return snapshot
+
+        # Fall back to the Messages API rate-limit headers (5h + weekly only)
+        # when the usage endpoint is unavailable or returns no windows.
         response = await asyncio.wait_for(
             asyncio.to_thread(_fetch_claude_messages_usage, access_token),
             timeout=timeout_seconds,
@@ -112,7 +138,7 @@ async def probe_claude_usage(
             headers=response.headers,
             body=response.body,
             credential_note=credential_note,
-            account_notes=_read_oauth_account_notes(resolved_env),
+            account_notes=account_notes,
         )
 
 
@@ -147,6 +173,21 @@ async def probe_claude_usage_remote(
             f"claude remote rate-limit probe internal error: {payload.get('message')!r}"
         )
         return None
+    if "usage" in payload:
+        # The remote script emits the usage variant only when it carries a
+        # usable window; parse it and return whatever it yields rather than
+        # misrouting into the Messages-API header branch below.
+        usage = payload.get("usage")
+        snapshot = (
+            parse_claude_usage_payload(
+                usage, notes=_unique_notes([credential_note, *account_notes])
+            )
+            if isinstance(usage, dict)
+            else None
+        )
+        if snapshot is None:
+            log.info("claude remote usage payload carried no usable windows")
+        return snapshot
     status = payload.get("status")
     headers = payload.get("headers")
     body_preview = payload.get("body_preview", "")
@@ -370,6 +411,43 @@ async def _run_remote_probe_script(
     return decoded
 
 
+def _build_oauth_usage_snapshot(
+    response: _ClaudeHTTPResponse | None,
+    credential_note: str,
+    account_notes: list[str],
+) -> SessionRateLimitUsage | None:
+    """Build a snapshot from the OAuth usage endpoint, or ``None`` to fall back.
+
+    Returns ``None`` whenever the endpoint is unreachable, returns a non-200
+    (it has historically been disabled and answered 4xx), or yields no usable
+    windows — in every such case the caller drops back to the Messages API
+    rate-limit headers. A 401/expiry surfaces through that header path, which
+    already renders the "credentials expired" snapshot.
+    """
+    if response is None:
+        log.info(
+            "claude usage endpoint unreachable; falling back to rate-limit headers"
+        )
+        return None
+    if response.status != 200:
+        log.info(
+            "claude usage endpoint returned status %s; "
+            "falling back to rate-limit headers",
+            response.status,
+        )
+        return None
+    snapshot = parse_claude_usage_payload(
+        response.body,
+        notes=_unique_notes([credential_note, *account_notes]),
+    )
+    if snapshot is None:
+        log.info(
+            "claude usage endpoint returned no usable windows; "
+            "falling back to rate-limit headers"
+        )
+    return snapshot
+
+
 def _build_messages_snapshot(
     *,
     status: int,
@@ -527,6 +605,21 @@ def _claude_user_agent() -> str:
     )
     _CLAUDE_USER_AGENT = f"claude-code/{version}" if version else "claude-code/2.1.5"
     return _CLAUDE_USER_AGENT
+
+
+def _fetch_claude_oauth_usage(access_token: str) -> _ClaudeHTTPResponse | None:
+    request = Request(
+        _CLAUDE_USAGE_URL,
+        method="GET",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "User-Agent": _claude_user_agent(),
+            "anthropic-beta": "oauth-2025-04-20",
+            "Accept": "application/json",
+        },
+    )
+    return _fetch_url(request)
 
 
 def _fetch_claude_messages_usage(access_token: str) -> _ClaudeHTTPResponse | None:

--- a/backend/src/waypoint/backends/claude_code/remote_probe_script.py
+++ b/backend/src/waypoint/backends/claude_code/remote_probe_script.py
@@ -2,8 +2,9 @@
 
 Designed to be piped to ``python3 -`` over SSH on a remote launch
 target. Reads the locally-stored OAuth token (``~/.claude/.credentials.json``
-or the macOS keychain), calls the Anthropic Messages API, and prints a
-single JSON line to stdout describing the response (or an error
+or the macOS keychain), prefers the per-model OAuth usage endpoint, falls
+back to the Messages API rate-limit headers when it is unavailable, and
+prints a single JSON line to stdout describing the response (or an error
 sentinel) so the backend can build a ``SessionRateLimitUsage`` from it.
 
 Stdlib-only; targets Python 3.8+ so it runs on most pre-installed
@@ -11,6 +12,7 @@ remote interpreters without a virtualenv.
 
 Output schema (always one line of JSON on stdout, ``\\n``-terminated):
 
+    {"usage": {...}, "oauth_account_notes": [str], "expires_at": float | None}
     {"status": int, "headers": {str: str}, "body_preview": str,
      "oauth_account_notes": [str], "expires_at": float | None}
     {"error": "no_credentials" | "expired" | "network" | "internal", ...}
@@ -27,8 +29,16 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 CLAUDE_MESSAGES_URL = "https://api.anthropic.com/v1/messages"
+CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage"
 CLAUDE_MESSAGES_MODEL = "claude-haiku-4-5-20251001"
 CLAUDE_MESSAGES_VERSION = "2023-06-01"
+USAGE_WINDOW_KEYS = (
+    "five_hour",
+    "seven_day",
+    "seven_day_opus",
+    "seven_day_sonnet",
+    "seven_day_fable",
+)
 EXPIRY_SKEW_SECONDS = 60
 HTTP_TIMEOUT = 25
 BODY_PREVIEW_BYTES = 240
@@ -172,6 +182,34 @@ def read_credentials():
     return None
 
 
+def usage_has_windows(payload):
+    return isinstance(payload, dict) and any(
+        isinstance(payload.get(key), dict) for key in USAGE_WINDOW_KEYS
+    )
+
+
+def fetch_usage(token):
+    request = Request(
+        CLAUDE_USAGE_URL,
+        method="GET",
+        headers={
+            "Authorization": "Bearer " + token,
+            "Content-Type": "application/json",
+            "User-Agent": "claude-code/remote-probe",
+            "anthropic-beta": "oauth-2025-04-20",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urlopen(request, timeout=HTTP_TIMEOUT) as response:
+            status_code = getattr(response, "status", 200)
+            return status_code, response.read()
+    except HTTPError as exc:
+        return exc.code, None
+    except (URLError, OSError):
+        return None, None
+
+
 def fetch_messages(token):
     body = json.dumps(
         {
@@ -225,6 +263,24 @@ def main():
             }
         )
         return
+    # Prefer the OAuth usage endpoint (per-model windows incl. Sonnet/Opus);
+    # fall back to Messages API rate-limit headers when it is unavailable or
+    # answers with a body that carries no usable window.
+    usage_status, usage_body = fetch_usage(token)
+    if usage_status == 200 and usage_body:
+        try:
+            usage = json.loads(usage_body.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            usage = None
+        if usage_has_windows(usage):
+            emit(
+                {
+                    "usage": usage,
+                    "oauth_account_notes": notes,
+                    "expires_at": expires_at,
+                }
+            )
+            return
     status_code, headers, body = fetch_messages(token)
     if status_code is None:
         emit(

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -285,6 +286,10 @@ def test_probe_claude_usage_surfaces_rate_limit_state(
         lambda env: ["org: lumid", "user tier: default_claude_max_5x"],
     )
     monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_oauth_usage",
+        lambda token: None,
+    )
+    monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
         lambda request: _ClaudeHTTPResponse(
             status=429,
@@ -319,6 +324,10 @@ def test_probe_claude_usage_parses_messages_api_headers(
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
         lambda env: ["org: lumid", "user tier: default_claude_max_5x"],
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_oauth_usage",
+        lambda token: None,
     )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
@@ -368,6 +377,10 @@ def test_probe_claude_usage_bails_when_token_expired(
         raise AssertionError("HTTP call must not happen when token is expired")
 
     monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_oauth_usage",
+        _should_not_be_called,
+    )
+    monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
         _should_not_be_called,
     )
@@ -380,6 +393,132 @@ def test_probe_claude_usage_bails_when_token_expired(
         "credentials expired — run `claude` to refresh",
         "org: lumid",
     ]
+
+
+def test_probe_claude_usage_prefers_oauth_usage_endpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_cli_credentials_for_env",
+        lambda env: ("access-token", None, "CLI creds"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._claude_user_agent",
+        lambda: "claude-code/2.1.136",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
+        lambda env: ["org: lumid"],
+    )
+    body = json.dumps(
+        {
+            "five_hour": {"utilization": 11.0, "resets_at": "2026-06-21T09:20:00Z"},
+            "seven_day": {"utilization": 2.0, "resets_at": "2026-06-23T12:00:00Z"},
+            # Armed once Sonnet usage accrues this week.
+            "seven_day_sonnet": {
+                "utilization": 3.0,
+                "resets_at": "2026-06-23T12:00:00Z",
+            },
+            # No Opus weekly limit on this plan — null entry must be skipped.
+            "seven_day_opus": None,
+        }
+    ).encode("utf-8")
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_oauth_usage",
+        lambda token: _ClaudeHTTPResponse(status=200, headers={}, body=body),
+    )
+
+    def _messages_must_not_run(request: object) -> object:
+        raise AssertionError("Messages API must not be called when usage succeeds")
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
+        _messages_must_not_run,
+    )
+
+    snapshot = asyncio.run(probe_claude_usage(env={}))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly", "Sonnet"]
+    assert snapshot.windows[2].used_percent == 3.0
+    assert snapshot.notes == ["CLI creds", "org: lumid"]
+
+
+def test_probe_claude_usage_falls_back_when_usage_endpoint_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_cli_credentials_for_env",
+        lambda env: ("access-token", None, "CLI creds"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._claude_user_agent",
+        lambda: "claude-code/2.1.136",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
+        lambda env: [],
+    )
+    # The usage endpoint has historically been disabled and answers a 4xx.
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_oauth_usage",
+        lambda token: _ClaudeHTTPResponse(status=404, headers={}, body=b"not found"),
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
+        lambda request: _ClaudeHTTPResponse(
+            status=200,
+            headers={
+                "anthropic-ratelimit-unified-5h-utilization": "0.25",
+                "anthropic-ratelimit-unified-5h-reset": str(
+                    (datetime.now(UTC) + timedelta(hours=4)).timestamp()
+                ),
+                "anthropic-ratelimit-unified-7d-utilization": "0.5",
+                "anthropic-ratelimit-unified-7d-reset": str(
+                    (datetime.now(UTC) + timedelta(days=6)).timestamp()
+                ),
+            },
+            body=b"{}",
+        ),
+    )
+
+    snapshot = asyncio.run(probe_claude_usage(env={}))
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly"]
+    assert snapshot.windows[0].used_percent == 25.0
+
+
+def test_parse_claude_usage_payload_skips_unarmed_per_model_window() -> None:
+    snapshot = parse_claude_usage_payload(
+        {
+            "five_hour": {"utilization": 0.04, "resets_at": "2026-06-21T09:20:00Z"},
+            "seven_day": {"utilization": 0.02, "resets_at": "2026-06-23T12:00:00Z"},
+            # Before any Sonnet usage: 0% utilization and no reset → skipped.
+            "seven_day_sonnet": {"utilization": 0.0, "resets_at": None},
+        },
+        now=datetime(2026, 6, 21, 8, 0, tzinfo=UTC),
+    )
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly"]
+
+
+def test_parse_claude_usage_payload_shows_armed_zero_per_model_window() -> None:
+    snapshot = parse_claude_usage_payload(
+        {
+            "five_hour": {"utilization": 0.04, "resets_at": "2026-06-21T09:20:00Z"},
+            "seven_day": {"utilization": 0.02, "resets_at": "2026-06-23T12:00:00Z"},
+            # Armed once Sonnet usage accrues: 0% but a reset is set → surfaced,
+            # so the row appears before weekly usage rounds above 0%.
+            "seven_day_sonnet": {
+                "utilization": 0.0,
+                "resets_at": "2026-06-23T12:00:00Z",
+            },
+        },
+        now=datetime(2026, 6, 21, 8, 0, tzinfo=UTC),
+    )
+    assert snapshot is not None
+    assert [window.label for window in snapshot.windows] == ["5h", "Weekly", "Sonnet"]
+    assert snapshot.windows[2].used_percent == 0.0
 
 
 def test_probe_claude_usage_surfaces_401_as_expired(
@@ -396,6 +535,10 @@ def test_probe_claude_usage_surfaces_401_as_expired(
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._read_oauth_account_notes",
         lambda env: [],
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._fetch_claude_oauth_usage",
+        lambda token: None,
     )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.rate_limits._fetch_claude_messages_usage",
@@ -487,6 +630,53 @@ def test_probe_claude_usage_remote_parses_messages_headers(
         "org: lumid",
         "user tier: default_claude_max_5x",
     ]
+
+
+def test_probe_claude_usage_remote_parses_oauth_usage_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "usage": {
+            "five_hour": {"utilization": 11.0, "resets_at": "2026-06-21T09:20:00Z"},
+            "seven_day": {"utilization": 2.0, "resets_at": "2026-06-23T12:00:00Z"},
+            "seven_day_sonnet": {
+                "utilization": 3.0,
+                "resets_at": "2026-06-23T12:00:00Z",
+            },
+        },
+        "oauth_account_notes": ["org: lumid"],
+        "expires_at": None,
+    }
+
+    async def _fake_runner(launch_target, timeout_seconds):
+        return payload
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_claude_usage_remote(_ssh_target()))
+    assert snapshot is not None
+    assert snapshot.source == "claude_code"
+    assert [w.label for w in snapshot.windows] == ["5h", "Weekly", "Sonnet"]
+    assert snapshot.notes == ["remote CLI creds", "org: lumid"]
+
+
+def test_probe_claude_usage_remote_ignores_windowless_usage_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The remote script only emits the usage variant when it carries a window,
+    # but if a window-less usage payload ever arrives the backend returns None
+    # cleanly rather than misrouting into the malformed-payload branch.
+    async def _fake_runner(launch_target, timeout_seconds):
+        return {"usage": {}, "oauth_account_notes": ["org: lumid"], "expires_at": None}
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.rate_limits._run_remote_probe_script",
+        _fake_runner,
+    )
+    snapshot = asyncio.run(probe_claude_usage_remote(_ssh_target()))
+    assert snapshot is None
 
 
 def test_probe_claude_usage_remote_handles_expired_sentinel(


### PR DESCRIPTION
## Summary

The Claude rate-limit probe read only the Messages API `anthropic-ratelimit-unified-{5h,7d}` headers, which carry no per-model breakdown — so Sonnet/Opus/Fable weekly usage never surfaced on the session pages or the homepage usage dashboard. This switches the probe to prefer the OAuth usage endpoint (`/api/oauth/usage`), which returns per-model windows, and falls back to the existing header probe when that endpoint is unavailable. The frontend already renders windows generically, so the new windows appear with no UI change.

The OAuth usage endpoint has historically been flaky/disabled — the original reason the probe moved to the Messages-API headers. Keeping it as the *preferred* source with a header fallback recovers per-model data without regressing the 5h/weekly numbers whenever it is down.

## Changes

### Backend

- **`backends/claude_code/rate_limits.py`** — `probe_claude_usage` now fetches `/api/oauth/usage` first and only falls back to the `/v1/messages` rate-limit-header probe when that endpoint is unreachable, returns a non-200, or yields no windows. The previously-unused `parse_claude_usage_payload` is wired in and gates per-model scoped windows (`seven_day_opus/sonnet/fable`) until armed — a reset is set once usage accrues that week — while the 5h and weekly windows always surface.
- **`backends/claude_code/remote_probe_script.py`** — the SSH probe mirrors the same prefer-then-fall-back path, emitting the usage payload only when it carries a usable window and otherwise falling through to the header probe.

## Test Plan

- [x] `cd backend && uv run pytest` — 1039 passed (new tests cover the prefer/fallback paths, the unarmed-vs-armed per-model gating, and the remote usage payload).
- [x] `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- [x] Live, after `waypointctl restart backend`: `GET /api/usage` on a `claude_code` session returns a `Sonnet` window alongside `5h`/`Weekly`. Before any Sonnet usage the window is correctly omitted; once Sonnet has been used this week it appears (at 0% with a reset) and renders on both the session page and the homepage usage dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)