### PR TITLE
fix: scope claude_tty dialog detection to the active pane region

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -134,21 +134,12 @@ def _is_composer_line(line: str) -> bool:
 
 
 def _active_region(lines: list[str]) -> list[str]:
-    """The bottom-most interactive block of the pane — a live dialog or composer.
+    """The pane text at and below the bottom-most live composer prompt.
 
-    A modal dialog is always the lowest block on screen: it either replaces the
-    composer (approval/question/trust — no free-text prompt remains, so the whole
-    pane is its region), or renders as a popup just below the composer's
-    slash-command echo (``/model``, ``/effort`` — the popup lives below the
-    bottom-most composer line). Either way, scoping to the text at and below the
-    bottom-most composer line drops settled transcript above it. That is what
-    stops a dialog-signature string an agent merely quoted, discussed, or pasted
-    into the conversation from reading as a live dialog: the live composer sits
-    below such text, so the quoted markers fall outside the region. A real
-    dialog's interactive rows are options (``❯ 1.``), not a leading free-text
-    prompt, and no composer is drawn below or inside it — so the boundary only
-    ever lands at the dialog's own slash-command echo (or above the dialog) and
-    never slices an actual dialog between its question and footer.
+    Settled transcript sits above the live composer, so scoping here drops a
+    dialog-signature string an agent merely quoted or pasted into the
+    conversation. A real dialog's interactive rows are options (``❯ 1.``), never
+    a leading free-text prompt, so the boundary never slices an actual dialog.
     """
     last_composer = next(
         (i for i in range(len(lines) - 1, -1, -1) if _is_composer_line(lines[i])),
@@ -251,14 +242,16 @@ def parse_approval(screen: str) -> ApprovalDialog | None:
     screen = _strip_ansi(screen)
     if classify(screen) is not PaneScreen.APPROVAL:
         return None
-    lines = screen.splitlines()
+    # Scope to the active region and take the bottom-most question: the live
+    # dialog is the lowest block, so a "Do you want to …?" an agent quoted higher
+    # in the transcript must not be parsed in place of the real prompt.
+    lines = _active_region(screen.splitlines())
     question_idx: int | None = None
     question = ""
     for i, line in enumerate(lines):
         match = _QUESTION_RE.match(line)
         if match is not None:
             question_idx, question = i, match.group(1)
-            break
     if question_idx is None:
         return None
 
@@ -338,7 +331,14 @@ def parse_model_selector(screen: str) -> list[DialogOption] | None:
     screen = _strip_ansi(screen)
     if classify(screen) is not PaneScreen.MODEL_SELECTOR:
         return None
-    lines = screen.splitlines()
-    start = next((i for i, line in enumerate(lines) if "Select model" in line), 0)
-    end = next((i for i, line in enumerate(lines) if _MODEL_FOOTER in line), len(lines))
+    # Scope to the active region and anchor to the bottom-most "Select model" so
+    # the live popup's options win over any the transcript quoted above it.
+    lines = _active_region(screen.splitlines())
+    start = next(
+        (i for i in range(len(lines) - 1, -1, -1) if "Select model" in lines[i]), 0
+    )
+    end = next(
+        (i for i, line in enumerate(lines[start:], start) if _MODEL_FOOTER in line),
+        len(lines),
+    )
     return _parse_options(lines[start:end])

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -58,6 +58,13 @@ _TRUST_MARKER = "Is this a project you created or one you trust?"
 _OPTION_RE = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
 _QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
+# The live composer is a ``❯`` prompt at the start of the line (after any pad).
+# A ``❯`` embedded mid-line is content — a diff-preview row, a quoted glyph, a
+# command — not a prompt, and must not be read as one. A dialog's selected
+# option also leads with ``❯`` but as ``❯ 1.``; ``_OPTION_PROMPT_RE`` separates
+# those so option rows are not mistaken for the composer either.
+_COMPOSER_PROMPT_RE = re.compile(r"^\s*❯(?:\s|$)")
+_OPTION_PROMPT_RE = re.compile(r"^\s*❯\s*\d+\.")
 
 
 def _strip_ansi(text: str) -> str:
@@ -111,6 +118,45 @@ _COMPOSER_PROMPT = "❯"
 _COMPOSER_PLACEHOLDER_PREFIX = 'Try "'
 
 
+def _is_composer_line(line: str) -> bool:
+    """Whether a line is the live composer input prompt rather than a dialog row.
+
+    The composer is a leading ``❯`` prompt followed by free text — a typed
+    message, a slash command, the idle placeholder, or nothing. A ``❯`` embedded
+    mid-line is dialog body or transcript content and is not a prompt. A dialog's
+    selected option leads with the glyph but as ``❯ 1.`` (handled by
+    `_OPTION_PROMPT_RE`); option rows are excluded too.
+    """
+    return (
+        _COMPOSER_PROMPT_RE.match(line) is not None
+        and _OPTION_PROMPT_RE.match(line) is None
+    )
+
+
+def _active_region(lines: list[str]) -> list[str]:
+    """The bottom-most interactive block of the pane — a live dialog or composer.
+
+    A modal dialog is always the lowest block on screen: it either replaces the
+    composer (approval/question/trust — no free-text prompt remains, so the whole
+    pane is its region), or renders as a popup just below the composer's
+    slash-command echo (``/model``, ``/effort`` — the popup lives below the
+    bottom-most composer line). Either way, scoping to the text at and below the
+    bottom-most composer line drops settled transcript above it. That is what
+    stops a dialog-signature string an agent merely quoted, discussed, or pasted
+    into the conversation from reading as a live dialog: the live composer sits
+    below such text, so the quoted markers fall outside the region. A real
+    dialog's interactive rows are options (``❯ 1.``), not a leading free-text
+    prompt, and no composer is drawn below or inside it — so the boundary only
+    ever lands at the dialog's own slash-command echo (or above the dialog) and
+    never slices an actual dialog between its question and footer.
+    """
+    last_composer = next(
+        (i for i in range(len(lines) - 1, -1, -1) if _is_composer_line(lines[i])),
+        None,
+    )
+    return lines if last_composer is None else lines[last_composer:]
+
+
 def composer_ready(screen: str) -> bool:
     """Whether the Claude TUI composer prompt is drawn and able to take input.
 
@@ -144,22 +190,25 @@ def composer_is_empty(screen: str) -> bool:
 
 
 def classify(screen: str) -> PaneScreen:
-    screen = _strip_ansi(screen)
-    compact = _compact(screen)
-    if _contains(screen, compact, _APPROVAL_FOOTER) and _contains(
-        screen, compact, _APPROVAL_QUESTION_MARKER
+    # Match only within the active region (the bottom-most dialog/composer block),
+    # not the whole pane: substring/compact matching against scrollback would let
+    # a marker quoted in transcript content read as a live dialog.
+    region = "\n".join(_active_region(_strip_ansi(screen).splitlines()))
+    compact = _compact(region)
+    if _contains(region, compact, _APPROVAL_FOOTER) and _contains(
+        region, compact, _APPROVAL_QUESTION_MARKER
     ):
         return PaneScreen.APPROVAL
-    if all(_contains(screen, compact, marker) for marker in _QUESTION_MARKERS):
+    if all(_contains(region, compact, marker) for marker in _QUESTION_MARKERS):
         return PaneScreen.QUESTION
-    if _contains(screen, compact, _TRUST_MARKER):
+    if _contains(region, compact, _TRUST_MARKER):
         return PaneScreen.TRUST
-    if _contains(screen, compact, _MODEL_FOOTER) and _contains(
-        screen, compact, _MODEL_MARKER
+    if _contains(region, compact, _MODEL_FOOTER) and _contains(
+        region, compact, _MODEL_MARKER
     ):
         return PaneScreen.MODEL_SELECTOR
-    if _contains(screen, compact, _EFFORT_FOOTER) and _contains(
-        screen, compact, _EFFORT_MARKER
+    if _contains(region, compact, _EFFORT_FOOTER) and _contains(
+        region, compact, _EFFORT_MARKER
     ):
         return PaneScreen.EFFORT_POPUP
     return PaneScreen.OTHER

--- a/backend/tests/fixtures/claude_tty_pane/approval_quoted_in_transcript.txt
+++ b/backend/tests/fixtures/claude_tty_pane/approval_quoted_in_transcript.txt
@@ -1,0 +1,50 @@
+  [1mopen[0m. The composer is live with text typed in it ([38;5;153m❯ yes, implement the fix[39m, auto mode on). The classifier is matching
+  transcript content, not a real dialog.                                                                               
+                                                                                                                     
+  Specifically, the APPROVAL check requires two markers anywhere on the pane:                                       
+  - [38;5;153m_APPROVAL_QUESTION_MARKER = "Do you want to"[39m                                                                       
+  - [38;5;153m_APPROVAL_FOOTER = "Esc to cancel · Tab to amend"[39m                                                                  
+                                                                                                                       
+  This session's [3mown conversation text[0m happens to quote both strings — it was investigating this very pane-dialog code 
+  and printed the marker constants into its output. The footer is line-wrapped on the pane ([38;5;153m…Esc to cancel · Tab to[39m /   
+  [38;5;153mamend[39m), so the literal match fails — but [38;5;153mclassify()[39m also matches a [1mwhitespace-stripped "compact" form[0m                
+  ([38;5;153mpane_dialog.py:71-72[39m), and [38;5;153mEsctocancel·Tabtoamend[39m [3mis[0m present once wraps are collapsed. Both markers match → [38;5;153mAPPROVAL
+[39m  → blocking → send refused.                                                                                           
+                                                                                                                       
+  question marker literal:        True                                                                                 
+  footer literal in screen:       False                                                                                
+  footer compact in compact:      True   ← the wrap-collapsing match                                                   
+                                                                                                                       
+  [1mThe underlying flaw[0m                                                                                                  
+                                                                                                                       
+  [38;5;153mclassify()[39m scans the [1mentire pane[0m, including scrollback/transcript, with substring matching. Any dialog-signature    
+  string that appears in conversation content (an agent quoting these constants, pasting a captured dialog, discussing  
+  the markers) is indistinguishable from a live dialog. The [38;5;153m_compact[39m whitespace-stripping widens the false-positive    
+  surface further by matching strings that span line wraps in the transcript.                                          
+                                                                                                                       
+  This is an edge case here (a session reasoning about its own dialog parser), but the same class of failure hits any  
+  session that pastes or discusses an approval/trust/question dialog's text.                                            
+                                                                                                                       
+  [1mFixes (in order of robustness)[0m                                                                                      
+                                                                                                                      
+  1. [1mAnchor detection to the live dialog region, not the whole pane.[0m A real dialog/composer is always the bottom-most   
+  block. Restrict marker matching to the last N lines below the final [38;5;153m❯[39m prompt, or require the footer to be on (or near)
+  the bottom of the pane — a quoted marker buried mid-transcript then can't trigger it.                                
+  2. [1mRequire markers to be co-located[0m, e.g. the question and footer within a small line window of each other, rather   
+  than anywhere on screen.                                                                                             
+  3. [1mDrop or tighten the [38;5;153m_compact[39m cross-line match[0m for the footer so a marker split across a wrap in transcript text    
+  doesn't match — at minimum don't let compact-matching bridge unrelated lines.                                         
+                                                                                                                       
+  The right fix is #1 — scope [38;5;153mclassify()[39m to the active (bottom) region of the pane. Want me to implement it? It needs a
+  captured fixture of this exact pane plus classifier tests so the regression is pinned.                                
+                                                                                                                     
+  Note: pane [38;5;153m%272[39m is itself a Waypoint session that was independently investigating a [3mdifferent but adjacent[0m bug (the   
+  plan-mode [38;5;153m"Would you like to proceed?"[39m dialog not being recognized — the inverse false-negative). That's a separate   
+  issue from this send-blocking false-positive.                                                                         
+
+[38;5;246m✻[39m [38;5;246mCogitated for 2m 20s[39m                                                                                                  
+
+[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m❯ [2mimplement the fix with a captured fixture and tests
+[0m[38;5;244m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[39m  [38;5;220m⏵⏵ auto mode on[38;5;246m (shift+tab to cycle) · ← for agents[39m                   

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -130,6 +130,50 @@ def test_parse_approval_returns_none_for_non_approval() -> None:
     assert parse_approval(_load("model_selector.txt")) is None
 
 
+def test_parse_approval_ignores_quoted_question_above_live_dialog() -> None:
+    # A "Do you want to …?" quoted at line-start in the transcript, above a real
+    # approval. classify() is region-scoped, so the screen is APPROVAL; the parser
+    # must return the live dialog's question (the bottom-most), not the quote.
+    screen = "\n".join(
+        [
+            "Do you want to delete the_old_file.txt?",
+            "",
+            " Create file",
+            "   probe_out.txt",
+            " Do you want to create probe_out.txt?",
+            " ❯ 1. Yes",
+            "   2. No",
+            " Esc to cancel · Tab to amend",
+        ]
+    )
+    dialog = parse_approval(screen)
+    assert dialog is not None
+    assert dialog.question == "Do you want to create probe_out.txt?"
+    assert (dialog.tool_name, dialog.target) == ("Write", "probe_out.txt")
+
+
+def test_parse_model_selector_ignores_quoted_options_above_live_popup() -> None:
+    # A quoted "Select model" + option above the live /model popup must not pull
+    # spurious rows into the parse; anchor to the bottom-most "Select model".
+    screen = "\n".join(
+        [
+            "Select model",
+            "  ❯ 1. Fake Quoted Model    bogus",
+            "❯ /model",
+            "  Select model",
+            "  ❯ 1. Default (recommended) real",
+            "    2. Sonnet                real",
+            "  Enter to set as default · Esc to cancel",
+        ]
+    )
+    options = parse_model_selector(screen)
+    assert options is not None
+    assert [o.label for o in options] == [
+        "Default (recommended) real",
+        "Sonnet                real",
+    ]
+
+
 def test_parse_model_selector() -> None:
     options = parse_model_selector(_load("model_selector.txt"))
     assert options is not None
@@ -258,9 +302,12 @@ def test_glyph_in_dialog_body_does_not_truncate_region() -> None:
     # Treating a mid-line ❯ as a region boundary would slice the dialog between
     # its question and footer, dropping a real approval to OTHER — a false
     # negative that would let a send bulldoze a live prompt.
+    # The glyph is injected *below* the option rows so it would be the bottom-most
+    # ❯ under a naive "any ❯ is the composer" rule, slicing off the question above
+    # — the test fails without the leading-prompt anchor.
     screen = _load("approval_write.txt").replace(
-        " Do you want to create probe_out.txt?",
-        ' Do you want to create probe_out.txt?\n   1 print("❯ prompt")',
+        "   3. No",
+        '   3. No\n   1 print("❯ prompt")',
     )
     assert classify(screen) is PaneScreen.APPROVAL
     assert shows_blocking_dialog(screen) is True

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -193,6 +193,83 @@ def test_classify_robust_to_wrapped_footer() -> None:
     assert classify(screen) is PaneScreen.APPROVAL
 
 
+def test_quoted_dialog_markers_above_composer_do_not_block() -> None:
+    # Regression: a session reasoning about this very parser printed the approval
+    # markers into its transcript, then a live composer (with a typed reply) sat
+    # below them. Whole-pane matching read the quoted markers as a live dialog and
+    # refused every send, wedging the session. Detection must scope to the active
+    # region at/below the composer, so quoted markers above it are inert.
+    screen = _load("approval_quoted_in_transcript.txt")
+    assert "Do you want to" in screen and "Esc to cancel · Tab to amend" in screen
+    assert classify(screen) is PaneScreen.OTHER
+    assert shows_blocking_dialog(screen) is False
+    assert parse_approval(screen) is None
+
+
+def test_classify_scopes_to_region_below_live_composer() -> None:
+    # A constructed pane: approval markers quoted in the transcript, then the live
+    # composer below with the user's reply. The composer is the bottom-most prompt,
+    # so the quoted markers are settled transcript and must not classify.
+    screen = "\n".join(
+        [
+            "● Discussing the approval dialog parser:",
+            '  question marker is "Do you want to" and the footer is',
+            "  Esc to cancel · Tab to amend",
+            "────────────────────────────",
+            "❯ yes, go ahead and implement it",
+            "────────────────────────────",
+            "  ? for shortcuts",
+        ]
+    )
+    assert classify(screen) is PaneScreen.OTHER
+    assert shows_blocking_dialog(screen) is False
+
+
+def test_popup_below_slash_command_echo_still_classifies() -> None:
+    # The /model and /effort popups render below the composer's own slash-command
+    # echo (a free-text ❯ line). The active region must extend from that echo
+    # downward so the popup — which is below it — is still detected.
+    assert classify(_load("model_selector.txt")) is PaneScreen.MODEL_SELECTOR
+    assert classify(_load("effort_popup.txt")) is PaneScreen.EFFORT_POPUP
+
+
+def test_real_dialog_below_quoted_marker_still_classifies() -> None:
+    # A quoted marker on a composer-prompt line — and as the bottom-most such line
+    # above a genuine dialog that renders below it — must not suppress detection:
+    # the region runs from that line down and still contains the live dialog.
+    screen = "\n".join(
+        [
+            "● Earlier I explained the footer reads Esc to cancel · Tab to amend",
+            "❯ ok, now actually delete the file",
+            "",
+            " Do you want to delete probe_out.txt?",
+            " ❯ 1. Yes",
+            "   2. No",
+            "",
+            " Esc to cancel · Tab to amend",
+        ]
+    )
+    assert classify(screen) is PaneScreen.APPROVAL
+
+
+def test_glyph_in_dialog_body_does_not_truncate_region() -> None:
+    # Regression: a ❯ rendered *inside* the dialog (a diff-preview row, a command,
+    # an option label quoting the glyph) must not be read as a composer prompt.
+    # Treating a mid-line ❯ as a region boundary would slice the dialog between
+    # its question and footer, dropping a real approval to OTHER — a false
+    # negative that would let a send bulldoze a live prompt.
+    screen = _load("approval_write.txt").replace(
+        " Do you want to create probe_out.txt?",
+        ' Do you want to create probe_out.txt?\n   1 print("❯ prompt")',
+    )
+    assert classify(screen) is PaneScreen.APPROVAL
+    assert shows_blocking_dialog(screen) is True
+    dialog = parse_approval(screen)
+    assert (
+        dialog is not None and dialog.question == "Do you want to create probe_out.txt?"
+    )
+
+
 def test_composer_is_empty_for_bare_prompt() -> None:
     # After a real submit the composer clears to a bare ``❯`` above the footer.
     screen = "\n".join(


### PR DESCRIPTION
## Summary

A `claude_tty` session could wedge itself: every send was refused with "the pane has an open dialog; respond to it before sending" even though no dialog was open. The trigger was a session whose own transcript quoted an approval/trust/question dialog's marker strings — e.g. a session reasoning about this very parser, or one that pasted a captured dialog into the conversation.

Root cause: `classify()` substring-matched the dialog markers against the whole captured pane (`capture-pane -S -200`, which includes 200 lines of scrollback), so a marker sitting anywhere in transcript content was indistinguishable from a live modal. The tmux transport consults `classify()` before every paste/submit and refuses to send into a dialog, so a quoted marker blocked all sends until the scrollback rolled past it.

The fix scopes detection to the **active region** — the slice of the pane at and below the bottom-most live composer prompt. A real modal either replaces the composer (its block is the bottom of the pane) or renders as a popup just below the composer's slash-command echo (`/model`, `/effort`); settled transcript always sits *above* the live composer, so a quoted marker now falls outside the region. The composer is anchored to a *leading* `❯` prompt rather than any `❯` on the line, so a glyph inside a dialog body (a diff-preview row, a command, an option label) can't slice a real dialog between its question and footer and drop it to `OTHER` — which would be a worse, send-bulldozing false negative.

## Changes

### Backend

- **`backends/claude_tty/pane_dialog.py`** — add `_active_region()` / `_is_composer_line()` and match `classify()` against the region instead of the whole pane. `_COMPOSER_PROMPT_RE` anchors the composer to a leading prompt; `_OPTION_PROMPT_RE` keeps a dialog's `❯ 1.` option rows from being read as the composer. `shows_blocking_dialog` and the `parse_*` helpers inherit the fix through `classify()`.
- Regression tests and a real captured fixture (`approval_quoted_in_transcript.txt`) of the wedged pane, plus cases for a `❯` in a dialog body, a popup below a slash-command echo, and a tall dialog below long `❯`-echo scrollback.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_claude_tty_pane_dialog.py` — 42 passed.
- [x] `cd backend && uv run pytest -k "claude_tty or tmux or transport"` — 296 passed.
- [x] `cd backend && uv run pre-commit run --files <changed>` — isort, black, ruff, codespell, mypy all pass.
- [x] Ran the patched `classify()` against the live wedged pane (`%274`, session `claude_code-18fc911f`): now `other` / non-blocking, while all canonical dialog fixtures still classify correctly.

Related to #121 (the "a TUI dialog blocks it, the pane is wedged" send-robustness failure mode; this fixes the false detection, not that issue's event-rollback/frontend items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)