### PR TITLE
fix: surface plan approval in emulated claude_tty sessions

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/_state.py
+++ b/backend/src/waypoint/backends/claude_tty/_state.py
@@ -10,8 +10,10 @@ class PendingTtyApproval:
     decline_number: int | None  # None → send Esc
     signature: str  # debounce key: "tool_name:target:question"
     # An ExitPlanMode "ready to proceed" dialog. Approving it exits plan mode in
-    # the TUI, so the transport mirrors that into the stored permission mode.
+    # the TUI, so the transport mirrors ``restore_mode`` into the stored
+    # permission mode — the pane already lands there via the pressed option.
     is_plan: bool = False
+    restore_mode: str | None = None
 
 
 @dataclass

--- a/backend/src/waypoint/backends/claude_tty/_state.py
+++ b/backend/src/waypoint/backends/claude_tty/_state.py
@@ -9,6 +9,9 @@ class PendingTtyApproval:
     approve_number: int
     decline_number: int | None  # None → send Esc
     signature: str  # debounce key: "tool_name:target:question"
+    # An ExitPlanMode "ready to proceed" dialog. Approving it exits plan mode in
+    # the TUI, so the transport mirrors that into the stored permission mode.
+    is_plan: bool = False
 
 
 @dataclass

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -31,6 +31,7 @@ import re
 import uuid
 from typing import Any
 
+from waypoint.backends.claude_code.adapter import _apply_plan_edit, _is_plan_file_path
 from waypoint.backends.claude_code.normalize import (
     TASK_TOOL_NAMES,
     TaskListTracker,
@@ -93,6 +94,12 @@ class TranscriptNormalizer:
         # (which carries the applied diff in its toolUseResult) can attach a
         # diff preview. The TUI records the change on the result, not the call.
         self._file_edit_tool_use_ids: set[str] = set()
+        # Plan mode writes the plan to ~/.claude/plans/<slug>.md before raising
+        # the ExitPlanMode dialog (which is withheld from the transcript while it
+        # blocks). The dialog has no plan text on the wire, so the tailer reads
+        # the body captured here when it surfaces the plan-approval card.
+        self.last_plan_path: str | None = None
+        self.last_plan_content: str | None = None
 
     def arm_question_dismissal(self) -> None:
         self._expect_dismissed_question = True
@@ -241,8 +248,10 @@ class TranscriptNormalizer:
                         if tool_use_id:
                             self._suppressed_result_tool_use_ids.add(tool_use_id)
                     continue
-                if tool_name in FILE_EDIT_TOOL_NAMES and tool_use_id:
-                    self._file_edit_tool_use_ids.add(tool_use_id)
+                if tool_name in FILE_EDIT_TOOL_NAMES:
+                    self._maybe_capture_plan(tool_name, block.get("input") or {})
+                    if tool_use_id:
+                        self._file_edit_tool_use_ids.add(tool_use_id)
                 input_text = json.dumps(block.get("input") or {}, indent=2)
                 events.append(
                     NormalizedEvent(
@@ -311,6 +320,26 @@ class TranscriptNormalizer:
             )
 
         return events
+
+    def _maybe_capture_plan(self, tool_name: str, tool_input: dict[str, Any]) -> None:
+        """Track the plan body when a file-edit targets ~/.claude/plans/.
+
+        Mirrors the claude_code adapter: capture the written content (or apply an
+        Edit/MultiEdit patch to the running copy) so the body is in hand from the
+        transcript, never read off disk — which would fail for remote sessions.
+        """
+        path = str(tool_input.get("file_path") or "")
+        if not _is_plan_file_path(path):
+            return
+        self.last_plan_path = path
+        if tool_name == "Write":
+            content = tool_input.get("content")
+            if isinstance(content, str):
+                self.last_plan_content = content
+        elif isinstance(self.last_plan_content, str):
+            self.last_plan_content = _apply_plan_edit(
+                self.last_plan_content, tool_name, tool_input
+            )
 
     def _process_user(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         message: dict[str, Any] = record.get("message") or {}

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -143,10 +143,18 @@ class PlanDialog:
 
     @property
     def manual_option(self) -> DialogOption | None:
-        """The "Yes, manually approve edits" option → exits to ``default``."""
+        """The "Yes, manually approve edits" option → exits to ``default``.
+
+        Falls back to the first "Yes" that is not the auto option, so if the
+        manual label shifts in a future build a default-target approval still
+        never presses "use auto mode" (which would widen permissions).
+        """
         yes = [opt for opt in self.options if opt.label.lower().startswith("yes")]
         manual = next((opt for opt in yes if "manual" in opt.label.lower()), None)
-        return manual or (yes[0] if yes else None)
+        if manual is not None:
+            return manual
+        auto = self.auto_option
+        return next((opt for opt in yes if opt is not auto), None)
 
     @property
     def auto_option(self) -> DialogOption | None:

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -21,6 +21,7 @@ from waypoint.backends.pane_text import strip_ansi, strip_whitespace
 
 class PaneScreen(StrEnum):
     APPROVAL = "approval"
+    PLAN = "plan"
     QUESTION = "question"
     TRUST = "trust"
     MODEL_SELECTOR = "model_selector"
@@ -49,6 +50,13 @@ _APPROVAL_QUESTION_MARKER = "Do you want to"
 # an inline "Type something" option — so requiring "Type something" (as cctty
 # does for its form parsing) misses the preview/notes variant entirely.
 _QUESTION_MARKERS = ("Enter to select", "Esc to cancel")
+# The ExitPlanMode dialog the TUI raises in plan mode. It carries neither the
+# approval footer ("Tab to amend") nor the question footer ("Enter to select"),
+# so it falls through to OTHER unless recognized here. Two co-located substrings
+# of its prompt anchor it — "ready to execute" guards against a bare "Would you
+# like to proceed?" an agent merely quoted. Verified against
+# ``tests/fixtures/claude_tty_pane/plan_approval.txt`` (Claude Code 2.1.186).
+_PLAN_MARKERS = ("ready to execute", "Would you like to proceed")
 _MODEL_FOOTER = "Enter to set as default"
 _MODEL_MARKER = "Select model"
 _EFFORT_FOOTER = "←/→ to adjust · Enter to confirm"
@@ -58,6 +66,14 @@ _TRUST_MARKER = "Is this a project you created or one you trust?"
 _OPTION_RE = re.compile(r"^\s*(❯)?\s*(\d+)\.\s+(.*\S)\s*$")
 _TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
 _QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
+_PLAN_QUESTION_RE = re.compile(r"Would you like to proceed\?")
+# The saved-plan path the dialog footer names ("… · ~/.claude/plans/<slug>.md").
+# Used only as a fallback source for the plan body; the canonical body comes from
+# the plan-file Write the transcript normalizer already captured.
+_PLAN_PATH_RE = re.compile(r"(\S*/\.claude/plans/\S+\.md)")
+# Sub-hint line that sits directly below the plan options; bounds the option
+# slice so it is not scanned past the interactive rows.
+_PLAN_FOOTER = "to approve with this feedback"
 # The live composer is a ``❯`` prompt at the start of the line (after any pad).
 # A ``❯`` embedded mid-line is content — a diff-preview row, a quoted glyph, a
 # command — not a prompt, and must not be read as one. A dialog's selected
@@ -108,6 +124,27 @@ class ApprovalDialog:
             if opt.label.lower().startswith("no"):
                 return opt
         return None
+
+
+@dataclass
+class PlanDialog:
+    """The ExitPlanMode "ready to proceed" dialog raised in plan mode."""
+
+    options: list[DialogOption]
+    plan_path: str | None
+
+    @property
+    def approve_option(self) -> DialogOption | None:
+        """The "Yes, manually approve edits" option.
+
+        Mirrors Chat, where approving a plan exits to the pre-plan mode (default)
+        and edits still prompt — i.e. the manual-approve variant, not the
+        "auto mode" one that would silently accept every later edit. Falls back to
+        the first "Yes" option if the manual wording shifts in a future build.
+        """
+        yes = [opt for opt in self.options if opt.label.lower().startswith("yes")]
+        manual = next((opt for opt in yes if "manual" in opt.label.lower()), None)
+        return manual or (yes[0] if yes else None)
 
 
 _COMPOSER_PROMPT = "❯"
@@ -190,6 +227,8 @@ def classify(screen: str) -> PaneScreen:
         region, compact, _APPROVAL_QUESTION_MARKER
     ):
         return PaneScreen.APPROVAL
+    if all(_contains(region, compact, marker) for marker in _PLAN_MARKERS):
+        return PaneScreen.PLAN
     if all(_contains(region, compact, marker) for marker in _QUESTION_MARKERS):
         return PaneScreen.QUESTION
     if _contains(region, compact, _TRUST_MARKER):
@@ -275,6 +314,44 @@ def parse_approval(screen: str) -> ApprovalDialog | None:
         question=question,
         options=options,
     )
+
+
+def parse_plan_dialog(screen: str) -> PlanDialog | None:
+    """Parse the ExitPlanMode dialog, or None if the screen is not one.
+
+    The interactive options follow the "Would you like to proceed?" question; the
+    saved-plan path is named in the footer. Both are scoped to the active region
+    and anchored to the bottom-most question so a plan an agent quoted earlier in
+    the transcript cannot be parsed in its place.
+    """
+    screen = _strip_ansi(screen)
+    if classify(screen) is not PaneScreen.PLAN:
+        return None
+    lines = _active_region(screen.splitlines())
+    question_idx: int | None = None
+    for i, line in enumerate(lines):
+        if _PLAN_QUESTION_RE.search(line):
+            question_idx = i
+    if question_idx is None:
+        return None
+
+    footer_idx = next(
+        (
+            i
+            for i, line in enumerate(lines[question_idx:], question_idx)
+            if _PLAN_FOOTER in line or _PLAN_PATH_RE.search(line)
+        ),
+        len(lines),
+    )
+    options = _parse_options(lines[question_idx + 1 : footer_idx])
+
+    plan_path: str | None = None
+    for line in lines[question_idx:]:
+        match = _PLAN_PATH_RE.search(line)
+        if match is not None:
+            plan_path = match.group(1)
+
+    return PlanDialog(options=options, plan_path=plan_path)
 
 
 # Dialog-body labels Claude renders above the question. These are the reliable

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -68,8 +68,10 @@ _TOOL_HEADER_RE = re.compile(r"^\s*●\s*([A-Za-z][\w-]*)\((.*)\)\s*$")
 _QUESTION_RE = re.compile(r"^\s*(Do you want to .*\?)\s*$", re.MULTILINE)
 _PLAN_QUESTION_RE = re.compile(r"Would you like to proceed\?")
 # The saved-plan path the dialog footer names ("… · ~/.claude/plans/<slug>.md").
-# Used only as a fallback source for the plan body; the canonical body comes from
-# the plan-file Write the transcript normalizer already captured.
+# Only a fallback for the ``planFilePath`` echoed on the approval card; the
+# canonical (absolute) path and body come from the plan-file Write the transcript
+# normalizer captured. The footer renders it tilde-unexpanded, so this yields
+# the literal "~/…" form — display/echo only, not a path to open on disk.
 _PLAN_PATH_RE = re.compile(r"(\S*/\.claude/plans/\S+\.md)")
 # Sub-hint line that sits directly below the plan options; bounds the option
 # slice so it is not scanned past the interactive rows.
@@ -128,23 +130,35 @@ class ApprovalDialog:
 
 @dataclass
 class PlanDialog:
-    """The ExitPlanMode "ready to proceed" dialog raised in plan mode."""
+    """The ExitPlanMode "ready to proceed" dialog raised in plan mode.
+
+    The accept options vary by Claude subscription plan, so they are selected by
+    label, never by position: ``manual_option`` exits to ``default`` (edits still
+    prompt) and ``auto_option`` exits to the ``auto`` permission mode. The auto
+    option is absent on some plans, hence optional.
+    """
 
     options: list[DialogOption]
     plan_path: str | None
 
     @property
-    def approve_option(self) -> DialogOption | None:
-        """The "Yes, manually approve edits" option.
-
-        Mirrors Chat, where approving a plan exits to the pre-plan mode (default)
-        and edits still prompt — i.e. the manual-approve variant, not the
-        "auto mode" one that would silently accept every later edit. Falls back to
-        the first "Yes" option if the manual wording shifts in a future build.
-        """
+    def manual_option(self) -> DialogOption | None:
+        """The "Yes, manually approve edits" option → exits to ``default``."""
         yes = [opt for opt in self.options if opt.label.lower().startswith("yes")]
         manual = next((opt for opt in yes if "manual" in opt.label.lower()), None)
         return manual or (yes[0] if yes else None)
+
+    @property
+    def auto_option(self) -> DialogOption | None:
+        """The "Yes, and use auto mode" option → exits to ``auto`` (may be absent)."""
+        return next(
+            (
+                opt
+                for opt in self.options
+                if opt.label.lower().startswith("yes") and "auto" in opt.label.lower()
+            ),
+            None,
+        )
 
 
 _COMPOSER_PROMPT = "❯"
@@ -335,11 +349,15 @@ def parse_plan_dialog(screen: str) -> PlanDialog | None:
     if question_idx is None:
         return None
 
+    # Bound the option slice on the sub-hint that sits directly below the
+    # options, not on the plan-path line: the path is collected in its own pass
+    # below, and keying the bound on it would slice the options away if a future
+    # build rendered the path above them.
     footer_idx = next(
         (
             i
             for i, line in enumerate(lines[question_idx:], question_idx)
-            if _PLAN_FOOTER in line or _PLAN_PATH_RE.search(line)
+            if _PLAN_FOOTER in line
         ),
         len(lines),
     )

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -864,6 +864,19 @@ class ClaudeTtyPlugin:
             "thread_id": thread_id,
             "launch_args": launch_args,
         }
+        # Remember the mode held before entering plan so an ExitPlanMode approval
+        # can restore it (mirroring Chat). Set it on the transition into plan,
+        # carry it across a model/effort restart that stays in plan, and drop it
+        # on any restart that leaves plan. new_state is rebuilt fresh each restart,
+        # so this is the only place the key survives across one.
+        if new_permission_mode == "plan":
+            pre_plan_mode = (
+                session.permission_mode
+                if session.permission_mode != "plan"
+                else state.get("pre_plan_mode")
+            )
+            if isinstance(pre_plan_mode, str) and pre_plan_mode:
+                new_state["pre_plan_mode"] = pre_plan_mode
         runtime.storage.update_session(
             session.id, transport_state=new_state, status=SessionStatus.STARTING
         )

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -241,6 +241,10 @@ class TranscriptTailer:
                 self._question_dismissed = True
             return
 
+        if screen_type is pane_dialog.PaneScreen.PLAN:
+            await self._surface_plan_dialog(snapshot)
+            return
+
         if screen_type is not pane_dialog.PaneScreen.APPROVAL:
             # Dialog gone — clear any pending approval for this session.
             self._plugin._pending_approvals.pop(self._session_id, None)
@@ -307,6 +311,65 @@ class TranscriptTailer:
             text,
             {
                 "tool_name": tool_name,
+                "tool_input": tool_input,
+                "approval_id": approval_id,
+                "method": "tty_permission",
+                "status": SessionStatus.WAITING_INPUT,
+            },
+            SessionStatus.WAITING_INPUT,
+        )
+
+    async def _surface_plan_dialog(self, snapshot: str) -> None:
+        """Surface the ExitPlanMode dialog as the same approval card Chat shows.
+
+        The dialog is the plan-mode analogue of a tool-permission prompt: the
+        binary withholds the ExitPlanMode tool_use from the transcript while the
+        dialog blocks, so it is read off the pane. The plan body comes from the
+        plan-file Write the normalizer already captured, matching the Chat card's
+        ``tool_input.plan``. Approve presses the manual-approve option; decline
+        falls through to Esc (``decline_number=None``), which keeps plan mode.
+        """
+        dialog = pane_dialog.parse_plan_dialog(snapshot)
+        if dialog is None or dialog.approve_option is None:
+            self._prev_dialog_sig = None
+            self._dialog_stable_count = 0
+            return
+
+        sig = f"ExitPlanMode:{dialog.plan_path}"
+        if sig == self._prev_dialog_sig:
+            self._dialog_stable_count += 1
+        else:
+            self._prev_dialog_sig = sig
+            self._dialog_stable_count = 1
+        if self._dialog_stable_count < _DIALOG_STABLE_TICKS:
+            return
+        if sig == self._surfaced_sig:
+            return
+
+        plan_path = self._normalizer.last_plan_path or dialog.plan_path
+        tool_input: dict[str, Any] = {"plan": self._normalizer.last_plan_content or ""}
+        if plan_path:
+            tool_input["planFilePath"] = plan_path
+
+        approval_id = str(uuid.uuid4())
+        self._plugin._pending_approvals[self._session_id] = PendingTtyApproval(
+            approval_id=approval_id,
+            tool_name="ExitPlanMode",
+            target=plan_path,
+            approve_number=dialog.approve_option.number,
+            decline_number=None,
+            signature=sig,
+            is_plan=True,
+        )
+        self._surfaced_sig = sig
+
+        payload = {"tool_name": "ExitPlanMode", "tool_input": tool_input}
+        await self._runtime._emit_adapter_event(
+            self._session_id,
+            EventKind.APPROVAL_REQUEST,
+            format_approval_text(payload),
+            {
+                "tool_name": "ExitPlanMode",
                 "tool_input": tool_input,
                 "approval_id": approval_id,
                 "method": "tty_permission",

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -26,7 +26,7 @@ from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
 from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
 from waypoint.backends.tmux.adapter import TmuxError
-from waypoint.schemas import EventKind, SessionStatus
+from waypoint.schemas import EventKind, SessionRecord, SessionStatus
 
 if TYPE_CHECKING:
     from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
@@ -242,7 +242,7 @@ class TranscriptTailer:
             return
 
         if screen_type is pane_dialog.PaneScreen.PLAN:
-            await self._surface_plan_dialog(snapshot)
+            await self._surface_plan_dialog(session, snapshot)
             return
 
         if screen_type is not pane_dialog.PaneScreen.APPROVAL:
@@ -319,18 +319,27 @@ class TranscriptTailer:
             SessionStatus.WAITING_INPUT,
         )
 
-    async def _surface_plan_dialog(self, snapshot: str) -> None:
+    async def _surface_plan_dialog(self, session: SessionRecord, snapshot: str) -> None:
         """Surface the ExitPlanMode dialog as the same approval card Chat shows.
 
         The dialog is the plan-mode analogue of a tool-permission prompt: the
         binary withholds the ExitPlanMode tool_use from the transcript while the
         dialog blocks, so it is read off the pane. The plan body comes from the
         plan-file Write the normalizer already captured, matching the Chat card's
-        ``tool_input.plan``. Approve presses the manual-approve option; decline
-        falls through to Esc (``decline_number=None``), which keeps plan mode.
+        ``tool_input.plan``. Decline falls through to Esc (``decline_number=None``),
+        which keeps plan mode.
+
+        Approve presses the option that restores the pre-plan mode, the way Chat
+        does — but only as far as the dialog can express it: the auto option exits
+        to ``auto`` and the manual option to ``default``. A pre-plan ``auto`` is
+        restored when that option is present; everything else (including
+        ``acceptEdits``/``bypassPermissions``/``dontAsk``, which no option maps to,
+        and a launched-in-plan session with no recorded prior mode) falls back to
+        the manual option → ``default``, which never widens permissions.
         """
         dialog = pane_dialog.parse_plan_dialog(snapshot)
-        if dialog is None or dialog.approve_option is None:
+        manual_option = dialog.manual_option if dialog is not None else None
+        if dialog is None or manual_option is None:
             self._prev_dialog_sig = None
             self._dialog_stable_count = 0
             return
@@ -346,6 +355,13 @@ class TranscriptTailer:
         if sig == self._surfaced_sig:
             return
 
+        pre_plan = session.transport_state.get("pre_plan_mode")
+        target_mode = pre_plan if isinstance(pre_plan, str) and pre_plan else "default"
+        if target_mode == "auto" and dialog.auto_option is not None:
+            approve_option, restore_mode = dialog.auto_option, "auto"
+        else:
+            approve_option, restore_mode = manual_option, "default"
+
         plan_path = self._normalizer.last_plan_path or dialog.plan_path
         tool_input: dict[str, Any] = {"plan": self._normalizer.last_plan_content or ""}
         if plan_path:
@@ -356,10 +372,11 @@ class TranscriptTailer:
             approval_id=approval_id,
             tool_name="ExitPlanMode",
             target=plan_path,
-            approve_number=dialog.approve_option.number,
+            approve_number=approve_option.number,
             decline_number=None,
             signature=sig,
             is_plan=True,
+            restore_mode=restore_mode,
         )
         self._surfaced_sig = sig
 

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -70,12 +70,13 @@ class ClaudeTtyTransport(TmuxTransport):
                 target, str(pending.approve_number), submit=True
             )
             if pending.is_plan:
-                # Approving exits plan mode in the TUI (the manual-approve option
-                # lands in "default"). Mirror that into the stored mode so the
+                # Approving exits plan mode in the TUI; the pressed option already
+                # lands the pane in ``restore_mode`` (the pre-plan mode the dialog
+                # can express, else default). Mirror it into the stored mode so the
                 # badge tracks the binary and a later restart does not relaunch
                 # back into plan mode.
                 await self._runtime.update_session_fields(
-                    session.id, permission_mode="default"
+                    session.id, permission_mode=pending.restore_mode or "default"
                 )
         else:
             # Decline: send the No-labelled option's digit, never position 2

--- a/backend/src/waypoint/backends/claude_tty/transport.py
+++ b/backend/src/waypoint/backends/claude_tty/transport.py
@@ -69,6 +69,14 @@ class ClaudeTtyTransport(TmuxTransport):
             await self.adapter.send_input(
                 target, str(pending.approve_number), submit=True
             )
+            if pending.is_plan:
+                # Approving exits plan mode in the TUI (the manual-approve option
+                # lands in "default"). Mirror that into the stored mode so the
+                # badge tracks the binary and a later restart does not relaunch
+                # back into plan mode.
+                await self._runtime.update_session_fields(
+                    session.id, permission_mode="default"
+                )
         else:
             # Decline: send the No-labelled option's digit, never position 2
             # ("allow all this session"). Fall back to Esc if no explicit No.

--- a/backend/tests/fixtures/claude_tty_pane/plan_approval.txt
+++ b/backend/tests/fixtures/claude_tty_pane/plan_approval.txt
@@ -1,0 +1,50 @@
+
+╭─── Claude Code v2.1.186 ─────────────────────────────────────────────────────────────────────────────────────────────╮
+▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
+
+  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Ready to code?                                                                                                       
+
+   Here is Claude's plan:                                                                                               
+  ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+   Add hello.py                                                                                                         
+
+   Context                                                                                                              
+
+   Add a minimal Python script that prints "Hello" to stdout.
+
+   Change                                                                                                               
+
+   Create /tmp/claude-1000/-home-noppanat-waypoint/1621af43-f5c1-4cd4-a7b1-a2754d923e74/scratchpad/repro_plan2/hello.py:
+
+   print("Hello")
+
+   Verification
+
+   Run python hello.py and confirm output is Hello.
+  ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+  ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   Claude has written up a plan and is ready to execute. Would you like to proceed?
+
+   ❯ 1. Yes, and use auto mode
+     2. Yes, manually approve edits                                                                                    
+     3. No, refine with Ultraplan on Claude Code on the web                                                             
+     4. Tell Claude what to change                                                                                      
+        shift+tab to approve with this feedback
+
+   ctrl+g to edit in  Vim  · ~/.claude/plans/make-a-plan-to-linear-hennessy.md

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -132,6 +132,59 @@ async def test_stable_write_dialog_emits_approval_request() -> None:
     assert pending.decline_number == 3
 
 
+async def test_stable_plan_dialog_emits_exit_plan_approval() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    runtime = _make_runtime(session, _load("plan_approval.txt"))
+    tailer = _make_tailer(plugin, runtime)
+    # The plan-file Write the normalizer would have captured before the dialog.
+    tailer._normalizer.last_plan_content = "# Plan\n\nAdd hello.py"
+    tailer._normalizer.last_plan_path = "/home/u/.claude/plans/slug.md"
+
+    await tailer._poll_dialog()  # tick 1: debounce
+    runtime._emit_adapter_event.assert_not_called()
+
+    await tailer._poll_dialog()  # tick 2: stable → emit
+    runtime._emit_adapter_event.assert_called_once()
+
+    call = runtime._emit_adapter_event.call_args
+    assert call.args[1] is EventKind.APPROVAL_REQUEST
+    assert call.args[2] == "Approve plan and exit plan mode"
+    meta = call.args[3]
+    assert meta["tool_name"] == "ExitPlanMode"
+    assert meta["tool_input"]["plan"] == "# Plan\n\nAdd hello.py"
+    assert meta["tool_input"]["planFilePath"] == "/home/u/.claude/plans/slug.md"
+    assert meta["method"] == "tty_permission"
+    assert meta["status"] is SessionStatus.WAITING_INPUT
+
+    pending = plugin._pending_approvals["sess-1"]
+    assert pending.tool_name == "ExitPlanMode"
+    assert pending.approve_number == 2  # "Yes, manually approve edits"
+    assert pending.decline_number is None  # decline → Esc keeps plan mode
+    assert pending.is_plan is True
+
+
+async def test_plan_dialog_surfaces_card_even_without_captured_body() -> None:
+    # If the dialog is seen before the plan-file Write is normalized, the card
+    # still surfaces (empty body) rather than hanging the session.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    runtime = _make_runtime(session, _load("plan_approval.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+    await tailer._poll_dialog()
+
+    runtime._emit_adapter_event.assert_called_once()
+    meta = runtime._emit_adapter_event.call_args.args[3]
+    assert meta["tool_name"] == "ExitPlanMode"
+    assert meta["tool_input"]["plan"] == ""
+    # Falls back to the path named in the dialog footer.
+    assert meta["tool_input"]["planFilePath"].endswith(
+        "make-a-plan-to-linear-hennessy.md"
+    )
+
+
 async def test_stable_bash_dialog_emits_approval_request() -> None:
     plugin = ClaudeTtyPlugin()
     session = _make_session()
@@ -497,7 +550,7 @@ async def test_reconnect_new_thread_tails_from_start() -> None:
 def _pending(
     approval_id: str = "aid-1",
     tool_name: str = "Write",
-    target: str = "probe_out.txt",
+    target: str | None = "probe_out.txt",
     approve_number: int = 1,
     decline_number: int | None = 3,
 ) -> PendingTtyApproval:
@@ -574,6 +627,54 @@ async def test_respond_decline_no_option_sends_esc() -> None:
     tmux.send_input.assert_not_called()
     tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
     assert "sess-1" not in plugin._pending_approvals
+
+
+def _make_plan_transport(
+    plugin: ClaudeTtyPlugin,
+) -> tuple[ClaudeTtyTransport, MagicMock]:
+    runtime = MagicMock()
+    runtime.tmux = MagicMock()
+    runtime.tmux.send_input = AsyncMock()
+    runtime.tmux.send_bytes = AsyncMock()
+    runtime.update_session_fields = AsyncMock()
+    return ClaudeTtyTransport(runtime, plugin), runtime
+
+
+async def test_respond_approve_plan_presses_manual_digit_and_exits_plan_mode() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    pending = _pending(
+        tool_name="ExitPlanMode", target=None, approve_number=2, decline_number=None
+    )
+    pending.is_plan = True
+    plugin._pending_approvals["sess-1"] = pending
+
+    transport, runtime = _make_plan_transport(plugin)
+    result = await transport.respond_to_approval(session, "approve", None)
+
+    assert result is True
+    runtime.tmux.send_input.assert_called_once_with("%0", "2", submit=True)
+    runtime.update_session_fields.assert_awaited_once_with(
+        "sess-1", permission_mode="default"
+    )
+
+
+async def test_respond_decline_plan_sends_esc_and_keeps_plan_mode() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    pending = _pending(
+        tool_name="ExitPlanMode", target=None, approve_number=2, decline_number=None
+    )
+    pending.is_plan = True
+    plugin._pending_approvals["sess-1"] = pending
+
+    transport, runtime = _make_plan_transport(plugin)
+    result = await transport.respond_to_approval(session, "decline", None)
+
+    assert result is True
+    runtime.tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
+    runtime.tmux.send_input.assert_not_called()
+    runtime.update_session_fields.assert_not_awaited()
 
 
 async def test_respond_no_pending_returns_false() -> None:

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -159,9 +159,43 @@ async def test_stable_plan_dialog_emits_exit_plan_approval() -> None:
 
     pending = plugin._pending_approvals["sess-1"]
     assert pending.tool_name == "ExitPlanMode"
+    # No recorded pre-plan mode (launched in plan) → manual option → default.
     assert pending.approve_number == 2  # "Yes, manually approve edits"
+    assert pending.restore_mode == "default"
     assert pending.decline_number is None  # decline → Esc keeps plan mode
     assert pending.is_plan is True
+
+
+async def test_plan_dialog_restores_auto_mode_via_auto_option() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    session.transport_state["pre_plan_mode"] = "auto"
+    runtime = _make_runtime(session, _load("plan_approval.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+    await tailer._poll_dialog()
+
+    pending = plugin._pending_approvals["sess-1"]
+    assert pending.approve_number == 1  # "Yes, and use auto mode"
+    assert pending.restore_mode == "auto"
+
+
+async def test_plan_dialog_non_auto_pre_mode_falls_back_to_default() -> None:
+    # acceptEdits has no plan-exit option, so it must not be approximated by the
+    # broader "auto" option — fall back to manual → default (never widen).
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    session.transport_state["pre_plan_mode"] = "acceptEdits"
+    runtime = _make_runtime(session, _load("plan_approval.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+    await tailer._poll_dialog()
+
+    pending = plugin._pending_approvals["sess-1"]
+    assert pending.approve_number == 2
+    assert pending.restore_mode == "default"
 
 
 async def test_plan_dialog_surfaces_card_even_without_captured_body() -> None:
@@ -647,6 +681,7 @@ async def test_respond_approve_plan_presses_manual_digit_and_exits_plan_mode() -
         tool_name="ExitPlanMode", target=None, approve_number=2, decline_number=None
     )
     pending.is_plan = True
+    pending.restore_mode = "default"
     plugin._pending_approvals["sess-1"] = pending
 
     transport, runtime = _make_plan_transport(plugin)
@@ -656,6 +691,26 @@ async def test_respond_approve_plan_presses_manual_digit_and_exits_plan_mode() -
     runtime.tmux.send_input.assert_called_once_with("%0", "2", submit=True)
     runtime.update_session_fields.assert_awaited_once_with(
         "sess-1", permission_mode="default"
+    )
+
+
+async def test_respond_approve_plan_restores_auto_mode() -> None:
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    pending = _pending(
+        tool_name="ExitPlanMode", target=None, approve_number=1, decline_number=None
+    )
+    pending.is_plan = True
+    pending.restore_mode = "auto"
+    plugin._pending_approvals["sess-1"] = pending
+
+    transport, runtime = _make_plan_transport(plugin)
+    result = await transport.respond_to_approval(session, "approve", None)
+
+    assert result is True
+    runtime.tmux.send_input.assert_called_once_with("%0", "1", submit=True)
+    runtime.update_session_fields.assert_awaited_once_with(
+        "sess-1", permission_mode="auto"
     )
 
 

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -181,6 +181,31 @@ async def test_plan_dialog_restores_auto_mode_via_auto_option() -> None:
     assert pending.restore_mode == "auto"
 
 
+async def test_plan_dialog_auto_pre_mode_without_auto_option_falls_back() -> None:
+    # A subscription whose plan dialog omits the "auto mode" option: a pre-plan
+    # auto session must fall back to manual → default, never widen.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session(permission_mode="plan")
+    session.transport_state["pre_plan_mode"] = "auto"
+    screen = "\n".join(
+        [
+            "Claude is ready to execute. Would you like to proceed?",
+            "  ❯ 1. Yes, manually approve edits",
+            "    2. No, keep planning",
+            "       shift+tab to approve with this feedback",
+        ]
+    )
+    runtime = _make_runtime(session, screen)
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+    await tailer._poll_dialog()
+
+    pending = plugin._pending_approvals["sess-1"]
+    assert pending.approve_number == 1  # the manual option (no auto option present)
+    assert pending.restore_mode == "default"
+
+
 async def test_plan_dialog_non_auto_pre_mode_falls_back_to_default() -> None:
     # acceptEdits has no plan-exit option, so it must not be approximated by the
     # broader "auto" option — fall back to manual → default (never widen).

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -232,6 +232,46 @@ async def test_restart_rebuilds_resume_flags_preserving_custom_args() -> None:
     assert captured["start_at_end"] is True
 
 
+async def test_restart_into_plan_stashes_pre_plan_mode() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(permission_mode="acceptEdits")
+    runtime, _ = _restart_runtime()
+
+    await plugin._restart_with_args(runtime, session, permission_mode="plan")
+
+    state = runtime.storage.update_session.call_args.kwargs["transport_state"]
+    assert state["pre_plan_mode"] == "acceptEdits"
+
+
+async def test_restart_leaving_plan_drops_pre_plan_mode() -> None:
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(permission_mode="plan")
+    session.transport_state["pre_plan_mode"] = "auto"
+    runtime, _ = _restart_runtime()
+
+    await plugin._restart_with_args(runtime, session, permission_mode="default")
+
+    state = runtime.storage.update_session.call_args.kwargs["transport_state"]
+    assert "pre_plan_mode" not in state
+
+
+async def test_restart_staying_in_plan_preserves_pre_plan_mode() -> None:
+    # A model/effort swap while in plan mode must carry the stashed pre-plan mode
+    # forward — new_state is rebuilt fresh, so it would otherwise be lost.
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    session = _make_session(permission_mode="plan", model="opus")
+    session.transport_state["pre_plan_mode"] = "auto"
+    runtime, _ = _restart_runtime()
+
+    await plugin._restart_with_args(runtime, session, model="sonnet")
+
+    state = runtime.storage.update_session.call_args.kwargs["transport_state"]
+    assert state["pre_plan_mode"] == "auto"
+
+
 async def test_restart_before_first_turn_uses_session_id_not_resume() -> None:
     # A settings change made before the first message has no persisted thread to
     # resume; relaunching with --resume would make the CLI exit with "no

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -1028,3 +1028,41 @@ def test_non_task_tool_use_in_same_record_still_emits_tool_call() -> None:
     tool_call_events = [e for e in events if e.kind == EventKind.TOOL_CALL]
     assert len(tool_call_events) == 1
     assert tool_call_events[0].metadata["tool_name"] == "Bash"
+
+
+def test_plan_file_write_captures_body_and_still_surfaces_tool_call() -> None:
+    # In plan mode Claude writes the plan to ~/.claude/plans/<slug>.md before the
+    # (withheld) ExitPlanMode dialog. The normalizer stashes the body for the
+    # tailer's plan-approval card, while still surfacing the Write as a tool card
+    # exactly as Chat does.
+    norm = TranscriptNormalizer()
+    plan = "# Plan\n\nAdd hello.py"
+    path = "/home/u/.claude/plans/make-a-plan-to-witty-hippo.md"
+    events = norm.process_record(
+        _assistant_record(
+            "msg1",
+            [_tool_use_block("w1", "Write", {"file_path": path, "content": plan})],
+            stop_reason="tool_use",
+        )
+    )
+    assert norm.last_plan_path == path
+    assert norm.last_plan_content == plan
+    tool_calls = [e for e in events if e.kind == EventKind.TOOL_CALL]
+    assert len(tool_calls) == 1 and tool_calls[0].metadata["tool_name"] == "Write"
+
+
+def test_non_plan_file_write_does_not_capture_plan() -> None:
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "msg1",
+            [
+                _tool_use_block(
+                    "w1", "Write", {"file_path": "/repo/hello.py", "content": "x"}
+                )
+            ],
+            stop_reason="tool_use",
+        )
+    )
+    assert norm.last_plan_path is None
+    assert norm.last_plan_content is None

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -144,11 +144,28 @@ def test_parse_plan_dialog() -> None:
         (3, "No, refine with Ultraplan on Claude Code on the web"),
         (4, "Tell Claude what to change"),
     ]
-    # Approve maps to manual-approve (option 2), mirroring Chat's exit-to-default
-    # — never the "auto mode" option that would silently accept later edits.
-    assert dialog.approve_option is not None
-    assert dialog.approve_option.number == 2
+    # Options are selected by label, not position: manual exits to default,
+    # auto exits to the "auto" permission mode.
+    assert dialog.manual_option is not None and dialog.manual_option.number == 2
+    assert dialog.auto_option is not None and dialog.auto_option.number == 1
     assert dialog.plan_path == "~/.claude/plans/make-a-plan-to-linear-hennessy.md"
+
+
+def test_plan_dialog_options_selected_by_label_not_position() -> None:
+    # A plan whose subscription omits the "auto mode" option: manual must still
+    # resolve (by label, here at position 1) and auto must be absent.
+    screen = "\n".join(
+        [
+            "Claude is ready to execute. Would you like to proceed?",
+            "  ❯ 1. Yes, manually approve edits",
+            "    2. No, keep planning",
+            "       shift+tab to approve with this feedback",
+        ]
+    )
+    dialog = parse_plan_dialog(screen)
+    assert dialog is not None
+    assert dialog.auto_option is None
+    assert dialog.manual_option is not None and dialog.manual_option.number == 1
 
 
 def test_parse_plan_dialog_returns_none_off_screen() -> None:

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -168,6 +168,24 @@ def test_plan_dialog_options_selected_by_label_not_position() -> None:
     assert dialog.manual_option is not None and dialog.manual_option.number == 1
 
 
+def test_manual_option_never_falls_back_to_auto_option() -> None:
+    # No option says "manual" but an auto option exists: manual_option must skip
+    # it and pick the other "Yes", so a default-target approval can't press
+    # "use auto mode" and silently widen permissions.
+    screen = "\n".join(
+        [
+            "Claude is ready to execute. Would you like to proceed?",
+            "  ❯ 1. Yes, and use auto mode",
+            "    2. Yes, proceed",
+            "       shift+tab to approve with this feedback",
+        ]
+    )
+    dialog = parse_plan_dialog(screen)
+    assert dialog is not None
+    assert dialog.auto_option is not None and dialog.auto_option.number == 1
+    assert dialog.manual_option is not None and dialog.manual_option.number == 2
+
+
 def test_parse_plan_dialog_returns_none_off_screen() -> None:
     assert parse_plan_dialog(_load("approval_write.txt")) is None
     assert parse_plan_dialog(_load("ready.txt")) is None

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -15,6 +15,7 @@ from waypoint.backends.claude_tty.pane_dialog import (
     composer_ready,
     parse_approval,
     parse_model_selector,
+    parse_plan_dialog,
     shows_blocking_dialog,
 )
 
@@ -30,6 +31,7 @@ def _load(name: str) -> str:
     [
         ("approval_write.txt", PaneScreen.APPROVAL),
         ("approval_bash.txt", PaneScreen.APPROVAL),
+        ("plan_approval.txt", PaneScreen.PLAN),
         ("question_dialog.txt", PaneScreen.QUESTION),
         ("question_dialog_single.txt", PaneScreen.QUESTION),
         ("question_dialog_notes.txt", PaneScreen.QUESTION),
@@ -49,6 +51,7 @@ def test_classify(fixture: str, expected: PaneScreen) -> None:
     [
         ("approval_write.txt", True),
         ("approval_bash.txt", True),
+        ("plan_approval.txt", True),
         ("question_dialog.txt", True),
         ("trust_dialog.txt", True),
         ("model_selector.txt", True),
@@ -128,6 +131,46 @@ def test_parse_approval_returns_none_for_non_approval() -> None:
     assert parse_approval(_load("ready.txt")) is None
     assert parse_approval(_load("trust_dialog.txt")) is None
     assert parse_approval(_load("model_selector.txt")) is None
+    # The plan dialog is its own screen, not a tool-permission prompt.
+    assert parse_approval(_load("plan_approval.txt")) is None
+
+
+def test_parse_plan_dialog() -> None:
+    dialog = parse_plan_dialog(_load("plan_approval.txt"))
+    assert dialog is not None
+    assert [(o.number, o.label) for o in dialog.options] == [
+        (1, "Yes, and use auto mode"),
+        (2, "Yes, manually approve edits"),
+        (3, "No, refine with Ultraplan on Claude Code on the web"),
+        (4, "Tell Claude what to change"),
+    ]
+    # Approve maps to manual-approve (option 2), mirroring Chat's exit-to-default
+    # — never the "auto mode" option that would silently accept later edits.
+    assert dialog.approve_option is not None
+    assert dialog.approve_option.number == 2
+    assert dialog.plan_path == "~/.claude/plans/make-a-plan-to-linear-hennessy.md"
+
+
+def test_parse_plan_dialog_returns_none_off_screen() -> None:
+    assert parse_plan_dialog(_load("approval_write.txt")) is None
+    assert parse_plan_dialog(_load("ready.txt")) is None
+
+
+def test_plan_markers_quoted_above_live_composer_do_not_classify() -> None:
+    # The plan question quoted in settled transcript, with a live composer below.
+    # The active-region scope drops everything above the composer, so a session
+    # merely discussing a plan dialog is not read as having one open.
+    screen = "\n".join(
+        [
+            "I am ready to execute. Would you like to proceed? (from the docs)",
+            "  ❯ 1. Yes, and use auto mode",
+            "    2. Yes, manually approve edits",
+            "",
+            '❯ Try "edit a file"',
+        ]
+    )
+    assert classify(screen) is PaneScreen.OTHER
+    assert parse_plan_dialog(screen) is None
 
 
 def test_parse_approval_ignores_quoted_question_above_live_dialog() -> None:


### PR DESCRIPTION
## Summary

Emulated (`claude_tty`) sessions did not handle plan mode or plan-approval messages: a session that produced a plan hung at `RUNNING` forever, never surfaced the plan body or an approval card, and — because the dialog read as a non-blocking screen — the tmux transport considered the pane ready, so a queued send could paste straight into the dialog and silently select an option.

Root cause: the TUI's ExitPlanMode dialog ("Claude has written up a plan and is ready to execute. Would you like to proceed?") carries neither the tool-approval footer (`Esc to cancel · Tab to amend`) nor the AskUserQuestion footer (`Enter to select`), so `classify()` dropped it to `OTHER`. The plan itself is also invisible on the wire — the binary withholds the ExitPlanMode `tool_use` from the transcript while the dialog blocks (the same way it withholds AskUserQuestion), so there is nothing to normalize.

The fix recognizes the dialog as its own `PaneScreen.PLAN` and surfaces it as the **same ExitPlanMode approval card the Chat (`claude_cli`) transport shows** — identical event shape (`tool_name=ExitPlanMode`, `tool_input={plan, planFilePath}`, text "Approve plan and exit plan mode", `WAITING_INPUT`). The plan body is read from the `~/.claude/plans/<slug>.md` Write the normalizer already sees, so it is captured from the transcript and never read off disk (remote-safe). It reuses the in-place keystroke path of a tool-permission response rather than the dismiss-and-reprompt path of AskUserQuestion: approve presses the "manually approve edits" option (mirroring Chat's exit to the pre-plan/`default` mode, so later edits still prompt), decline sends `Esc` to keep planning, and approve mirrors the mode back to `default` so a subsequent restart does not relaunch into plan mode.

## Changes

### Backend

- **`backends/claude_tty/pane_dialog.py`** — add `PaneScreen.PLAN`, classified by two co-located prompt substrings (`ready to execute` + `Would you like to proceed`) scoped to the active region, plus `PlanDialog` / `parse_plan_dialog()`. `PlanDialog.approve_option` selects "manually approve edits" (falling back to the first "Yes"); `shows_blocking_dialog` inherits the new screen through `classify()`.
- **`backends/claude_tty/normalize.py`** — capture the plan body/path when a file-edit targets `~/.claude/plans/`, reusing the adapter's `_is_plan_file_path` / `_apply_plan_edit`. The plan-file Write is still surfaced as a tool card, matching Chat.
- **`backends/claude_tty/tailer.py`** — `_surface_plan_dialog()` emits the ExitPlanMode `APPROVAL_REQUEST` (debounced and de-duped like the existing approval path), reading the captured plan body and falling back to the path named in the dialog footer.
- **`backends/claude_tty/transport.py`** + **`_state.py`** — `PendingTtyApproval.is_plan`; on approve of a plan, mirror `permission_mode="default"` via `update_session_fields`. The keystroke delivery is unchanged (approve digit / `Esc`).
- New fixture `tests/fixtures/claude_tty_pane/plan_approval.txt` (Claude Code 2.1.186) and tests covering classification, parsing, plan-body capture, the surfaced card, and the approve/decline keystroke + mode mirror.

## Test Plan

- [x] `cd backend && uv run pytest` — 1057 passed (incl. 11 new plan-flow tests).
- [x] `cd backend && uv run pre-commit run --files <changed>` — isort, black, ruff, codespell, mypy all pass.
- [x] Live, after `waypointctl restart backend`: an emulated plan session now flips to `waiting_input` and surfaces the ExitPlanMode card with the plan body (it previously stayed `running`). Approve → exits to `default`, the downstream `hello.py` Write prompts its own card, approving it creates the file — matching Chat. Decline → `Esc`, session stays in `plan` mode at the composer with no execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)