### PR TITLE
feat: preview local workspace files from the chat window

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import mimetypes
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -58,6 +59,13 @@ from waypoint.settings import Settings, load_settings
 from waypoint.storage import Storage
 from waypoint.tailnet import fetch_snapshot
 from waypoint.usage_dashboard import build_dashboard
+from waypoint.workspace_preview import (
+    WorkspacePathError,
+    is_denied,
+    list_dir,
+    read_text_capped,
+    resolve_in_base,
+)
 
 log = logging.getLogger("waypoint.api")
 
@@ -381,6 +389,126 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             filename=spec.filename,
             content_disposition_type="inline",
         )
+
+    @app.get("/api/sessions/{session_id}/workspace/tree")
+    async def workspace_tree(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        path: Annotated[str, Query()] = "",
+    ) -> Any:
+        if not context.settings.workspace_preview_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="disabled"
+            )
+        session = context.runtime.get_session(session_id)
+        if session.launch_target_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="workspace preview unavailable for remote sessions",
+            )
+        base = Path(session.worktree_path or session.cwd)
+        try:
+            entries, truncated, overflow = list_dir(
+                base,
+                path,
+                500,
+                denylist=context.settings.workspace_denylist,
+                follow_symlinks=context.settings.workspace_follow_symlinks,
+            )
+            normalized_path = _workspace_rel(base, path)
+        except WorkspacePathError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="workspace path denied"
+            ) from exc
+        except (FileNotFoundError, NotADirectoryError) as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="workspace path not found"
+            ) from exc
+        return {
+            "root": {"cwd": session.cwd, "worktree_path": session.worktree_path},
+            "path": normalized_path,
+            "entries": entries,
+            "truncated": truncated,
+            "overflow": overflow,
+        }
+
+    @app.get("/api/sessions/{session_id}/workspace/file")
+    async def workspace_file(
+        session_id: str,
+        authorization: Annotated[str | None, Header()] = None,
+        path: Annotated[str, Query()] = "",
+        raw: Annotated[bool, Query()] = False,
+        token: Annotated[str, Query()] = "",
+    ) -> Any:
+        if raw:
+            # ``<img>`` tags cannot send an Authorization header.
+            if not context.tokens.validate(token):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED, detail="invalid token"
+                )
+        else:
+            require_token(authorization, context.tokens)
+        if not context.settings.workspace_preview_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="disabled"
+            )
+        session = context.runtime.get_session(session_id)
+        if session.launch_target_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="workspace preview unavailable for remote sessions",
+            )
+        base = Path(session.worktree_path or session.cwd)
+        try:
+            resolved = resolve_in_base(
+                base,
+                path,
+                follow_symlinks=context.settings.workspace_follow_symlinks,
+            )
+            if is_denied(path, context.settings.workspace_denylist):
+                raise WorkspacePathError("path is denied")
+            if not resolved.exists() or not resolved.is_file():
+                raise FileNotFoundError(resolved)
+            normalized_path = _workspace_rel(base, path)
+            if raw:
+                media_type = (
+                    mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
+                )
+                return FileResponse(
+                    resolved,
+                    media_type=media_type,
+                    filename=resolved.name,
+                    content_disposition_type="inline",
+                )
+            content, truncated, binary, encoding = read_text_capped(
+                resolved, context.settings.workspace_max_file_bytes
+            )
+        except WorkspacePathError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="workspace path denied"
+            ) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="workspace path not found"
+            ) from exc
+        return {
+            "path": normalized_path,
+            "size": resolved.stat().st_size,
+            "mtime": resolved.stat().st_mtime,
+            "encoding": encoding,
+            "truncated": truncated,
+            "binary": binary,
+            "content": content,
+        }
+
+    def _workspace_rel(base: Path, rel: str) -> str:
+        resolved = resolve_in_base(
+            base,
+            rel,
+            follow_symlinks=context.settings.workspace_follow_symlinks,
+        )
+        relative = resolved.relative_to(base.expanduser().resolve())
+        return "" if relative == Path(".") else relative.as_posix()
 
     @app.delete("/api/sessions/{session_id}/attachments/{attachment_id}")
     async def delete_attachment(

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -52,6 +52,7 @@ from waypoint.schemas import (
     SessionModelRequest,
     SessionPermissionModeRequest,
     SessionPlanApprovalRequest,
+    SessionRecord,
     SessionStatus,
     SessionTitleRequest,
 )
@@ -64,6 +65,7 @@ from waypoint.workspace_preview import (
     is_denied,
     list_dir,
     read_text_capped,
+    relative_to_base,
     resolve_in_base,
 )
 
@@ -390,12 +392,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             content_disposition_type="inline",
         )
 
-    @app.get("/api/sessions/{session_id}/workspace/tree")
-    async def workspace_tree(
-        session_id: str,
-        _: Annotated[str, Depends(token_dependency())],
-        path: Annotated[str, Query()] = "",
-    ) -> Any:
+    def _workspace_session(session_id: str) -> SessionRecord:
         if not context.settings.workspace_preview_enabled:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="disabled"
@@ -406,16 +403,24 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="workspace preview unavailable for remote sessions",
             )
+        return session
+
+    @app.get("/api/sessions/{session_id}/workspace/tree")
+    async def workspace_tree(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        path: Annotated[str, Query()] = "",
+    ) -> Any:
+        session = _workspace_session(session_id)
         base = Path(session.worktree_path or session.cwd)
         try:
-            entries, truncated, overflow = list_dir(
+            entries, truncated, overflow, resolved_dir = list_dir(
                 base,
                 path,
                 500,
                 denylist=context.settings.workspace_denylist,
                 follow_symlinks=context.settings.workspace_follow_symlinks,
             )
-            normalized_path = _workspace_rel(base, path)
         except WorkspacePathError as exc:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN, detail="workspace path denied"
@@ -426,7 +431,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             ) from exc
         return {
             "root": {"cwd": session.cwd, "worktree_path": session.worktree_path},
-            "path": normalized_path,
+            "path": relative_to_base(base, resolved_dir),
             "entries": entries,
             "truncated": truncated,
             "overflow": overflow,
@@ -448,28 +453,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 )
         else:
             require_token(authorization, context.tokens)
-        if not context.settings.workspace_preview_enabled:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND, detail="disabled"
-            )
-        session = context.runtime.get_session(session_id)
-        if session.launch_target_id is not None:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="workspace preview unavailable for remote sessions",
-            )
+        session = _workspace_session(session_id)
         base = Path(session.worktree_path or session.cwd)
         try:
+            if is_denied(path, context.settings.workspace_denylist):
+                raise WorkspacePathError("path is denied")
             resolved = resolve_in_base(
                 base,
                 path,
                 follow_symlinks=context.settings.workspace_follow_symlinks,
             )
-            if is_denied(path, context.settings.workspace_denylist):
-                raise WorkspacePathError("path is denied")
             if not resolved.exists() or not resolved.is_file():
                 raise FileNotFoundError(resolved)
-            normalized_path = _workspace_rel(base, path)
             if raw:
                 media_type = (
                     mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
@@ -480,6 +475,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     filename=resolved.name,
                     content_disposition_type="inline",
                 )
+            stat = resolved.stat()
             content, truncated, binary, encoding = read_text_capped(
                 resolved, context.settings.workspace_max_file_bytes
             )
@@ -492,23 +488,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND, detail="workspace path not found"
             ) from exc
         return {
-            "path": normalized_path,
-            "size": resolved.stat().st_size,
-            "mtime": resolved.stat().st_mtime,
+            "path": relative_to_base(base, resolved),
+            "size": stat.st_size,
+            "mtime": stat.st_mtime,
             "encoding": encoding,
             "truncated": truncated,
             "binary": binary,
             "content": content,
         }
-
-    def _workspace_rel(base: Path, rel: str) -> str:
-        resolved = resolve_in_base(
-            base,
-            rel,
-            follow_symlinks=context.settings.workspace_follow_symlinks,
-        )
-        relative = resolved.relative_to(base.expanduser().resolve())
-        return "" if relative == Path(".") else relative.as_posix()
 
     @app.delete("/api/sessions/{session_id}/attachments/{attachment_id}")
     async def delete_attachment(

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -9,6 +9,7 @@ from waypoint.backends.plugin_config import PluginConfig
 from waypoint.backends.registry import get_registry
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import BackendId, SessionTransportId
+from waypoint.workspace_preview import DEFAULT_WORKSPACE_DENYLIST
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
@@ -116,7 +117,7 @@ class Settings(BaseModel):
     workspace_preview_enabled: bool = True
     workspace_max_file_bytes: int = 200_000
     workspace_denylist: list[str] = Field(
-        default_factory=lambda: [".git", ".claude", ".env", ".ssh"]
+        default_factory=lambda: list(DEFAULT_WORKSPACE_DENYLIST)
     )
     workspace_follow_symlinks: bool = False
     database_name: str = "waypoint.db"

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -113,6 +113,12 @@ class Settings(BaseModel):
     # message references them. Defaults to 24h; override with
     # ``WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS``.
     attachment_orphan_ttl_seconds: int = 60 * 60 * 24
+    workspace_preview_enabled: bool = True
+    workspace_max_file_bytes: int = 200_000
+    workspace_denylist: list[str] = Field(
+        default_factory=lambda: [".git", ".claude", ".env", ".ssh"]
+    )
+    workspace_follow_symlinks: bool = False
     database_name: str = "waypoint.db"
     token_ttl_seconds: int = 60 * 60 * 24 * 30
     stream_poll_interval: float = 1.0
@@ -260,6 +266,24 @@ def _env_overrides() -> dict[str, Any]:
         overrides["attachment_orphan_ttl_seconds"] = int(
             os.environ["WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS"]
         )
+    if "WAYPOINT_WORKSPACE_PREVIEW_ENABLED" in os.environ:
+        overrides["workspace_preview_enabled"] = os.environ[
+            "WAYPOINT_WORKSPACE_PREVIEW_ENABLED"
+        ].lower() not in {"0", "false", "no", ""}
+    if "WAYPOINT_WORKSPACE_MAX_FILE_BYTES" in os.environ:
+        overrides["workspace_max_file_bytes"] = int(
+            os.environ["WAYPOINT_WORKSPACE_MAX_FILE_BYTES"]
+        )
+    if "WAYPOINT_WORKSPACE_DENYLIST" in os.environ:
+        overrides["workspace_denylist"] = [
+            item.strip()
+            for item in os.environ["WAYPOINT_WORKSPACE_DENYLIST"].split(",")
+            if item.strip()
+        ]
+    if "WAYPOINT_WORKSPACE_FOLLOW_SYMLINKS" in os.environ:
+        overrides["workspace_follow_symlinks"] = os.environ[
+            "WAYPOINT_WORKSPACE_FOLLOW_SYMLINKS"
+        ].lower() not in {"0", "false", "no", ""}
     if "WAYPOINT_CORS_ORIGINS" in os.environ:
         overrides["cors_origins"] = parse_cors_origins(
             os.environ["WAYPOINT_CORS_ORIGINS"]

--- a/backend/src/waypoint/workspace_preview.py
+++ b/backend/src/waypoint/workspace_preview.py
@@ -3,7 +3,11 @@ import os
 from pathlib import Path
 from typing import Literal, TypedDict
 
-DEFAULT_WORKSPACE_DENYLIST = [".git", ".claude", ".env", ".ssh"]
+# The denylist is the single filter knob. By default only VCS internals and
+# SSH key material are hidden; ordinary dotfiles (.env, .gitignore, …) preview
+# fine. Add globs like ".*" to hide all dotfiles, or set the denylist to an
+# explicit empty list to disable filtering entirely.
+DEFAULT_WORKSPACE_DENYLIST = [".git", ".ssh"]
 
 WorkspaceEntryKind = Literal["file", "dir", "symlink"]
 
@@ -36,15 +40,18 @@ def is_denied(
     name_or_path: str | Path,
     denylist: list[str] | None = None,
 ) -> bool:
-    deny_patterns = denylist or DEFAULT_WORKSPACE_DENYLIST
+    patterns = DEFAULT_WORKSPACE_DENYLIST if denylist is None else denylist
+    deny_patterns = [pattern.lower() for pattern in patterns]
+    if not deny_patterns:
+        return False
     path = Path(name_or_path)
     parts = [part for part in path.parts if part not in {"", "."}]
+    if not parts:
+        return False
     for part in parts:
-        if part.startswith("."):
+        if any(fnmatch.fnmatch(part.lower(), pattern) for pattern in deny_patterns):
             return True
-        if any(fnmatch.fnmatch(part, pattern) for pattern in deny_patterns):
-            return True
-    normalized = path.as_posix()
+    normalized = path.as_posix().lower()
     return any(fnmatch.fnmatch(normalized, pattern) for pattern in deny_patterns)
 
 

--- a/backend/src/waypoint/workspace_preview.py
+++ b/backend/src/waypoint/workspace_preview.py
@@ -48,6 +48,11 @@ def is_denied(
     return any(fnmatch.fnmatch(normalized, pattern) for pattern in deny_patterns)
 
 
+def relative_to_base(base: Path, resolved: Path) -> str:
+    relative = resolved.relative_to(base.expanduser().resolve())
+    return "" if relative == Path(".") else relative.as_posix()
+
+
 def sniff_text(data: bytes) -> bool:
     if b"\x00" in data:
         return False
@@ -74,18 +79,19 @@ def list_dir(
     cap: int,
     denylist: list[str] | None = None,
     follow_symlinks: bool = False,
-) -> tuple[list[WorkspaceEntry], bool, int | None]:
-    directory = resolve_in_base(base, rel, follow_symlinks=follow_symlinks)
+) -> tuple[list[WorkspaceEntry], bool, int | None, Path]:
     if is_denied(rel, denylist):
         raise WorkspacePathError("path is denied")
+    directory = resolve_in_base(base, rel, follow_symlinks=follow_symlinks)
     if not directory.exists():
         raise FileNotFoundError(directory)
     if not directory.is_dir():
         raise NotADirectoryError(directory)
 
+    base_resolved = base.expanduser().resolve()
     allowed: list[WorkspaceEntry] = []
     for child in directory.iterdir():
-        child_rel = child.relative_to(base.expanduser().resolve())
+        child_rel = child.relative_to(base_resolved)
         if is_denied(child_rel, denylist):
             continue
         stat = child.lstat()
@@ -101,7 +107,7 @@ def list_dir(
     if cap < 0:
         cap = 0
     overflow = max(len(allowed) - cap, 0)
-    return allowed[:cap], overflow > 0, overflow or None
+    return allowed[:cap], overflow > 0, overflow or None, directory
 
 
 def _entry_kind(path: Path) -> WorkspaceEntryKind:

--- a/backend/src/waypoint/workspace_preview.py
+++ b/backend/src/waypoint/workspace_preview.py
@@ -1,0 +1,125 @@
+import fnmatch
+import os
+from pathlib import Path
+from typing import Literal, TypedDict
+
+DEFAULT_WORKSPACE_DENYLIST = [".git", ".claude", ".env", ".ssh"]
+
+WorkspaceEntryKind = Literal["file", "dir", "symlink"]
+
+
+class WorkspacePathError(ValueError):
+    pass
+
+
+class WorkspaceEntry(TypedDict):
+    name: str
+    kind: WorkspaceEntryKind
+    size: int
+    mtime: float
+
+
+def resolve_in_base(base: Path, rel: str, follow_symlinks: bool = False) -> Path:
+    base_expanded = base.expanduser()
+    base_resolved = base_expanded.resolve()
+    target = base_expanded / rel
+    lexical_target = Path(os.path.normpath(base_resolved / rel))
+    resolved = Path(os.path.realpath(os.path.normpath(target)))
+    if not resolved.is_relative_to(base_resolved):
+        raise WorkspacePathError("path escapes workspace")
+    if not follow_symlinks and _has_symlink_component(base_resolved, lexical_target):
+        raise WorkspacePathError("symlink paths are not allowed")
+    return resolved
+
+
+def is_denied(
+    name_or_path: str | Path,
+    denylist: list[str] | None = None,
+) -> bool:
+    deny_patterns = denylist or DEFAULT_WORKSPACE_DENYLIST
+    path = Path(name_or_path)
+    parts = [part for part in path.parts if part not in {"", "."}]
+    for part in parts:
+        if part.startswith("."):
+            return True
+        if any(fnmatch.fnmatch(part, pattern) for pattern in deny_patterns):
+            return True
+    normalized = path.as_posix()
+    return any(fnmatch.fnmatch(normalized, pattern) for pattern in deny_patterns)
+
+
+def sniff_text(data: bytes) -> bool:
+    if b"\x00" in data:
+        return False
+    try:
+        data.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def read_text_capped(path: Path, max_bytes: int) -> tuple[str | None, bool, bool, str]:
+    size = path.stat().st_size
+    if size > max_bytes:
+        return None, True, False, "utf-8"
+    data = path.read_bytes()
+    if not sniff_text(data):
+        return None, False, True, "utf-8"
+    return data.decode("utf-8"), False, False, "utf-8"
+
+
+def list_dir(
+    base: Path,
+    rel: str,
+    cap: int,
+    denylist: list[str] | None = None,
+    follow_symlinks: bool = False,
+) -> tuple[list[WorkspaceEntry], bool, int | None]:
+    directory = resolve_in_base(base, rel, follow_symlinks=follow_symlinks)
+    if is_denied(rel, denylist):
+        raise WorkspacePathError("path is denied")
+    if not directory.exists():
+        raise FileNotFoundError(directory)
+    if not directory.is_dir():
+        raise NotADirectoryError(directory)
+
+    allowed: list[WorkspaceEntry] = []
+    for child in directory.iterdir():
+        child_rel = child.relative_to(base.expanduser().resolve())
+        if is_denied(child_rel, denylist):
+            continue
+        stat = child.lstat()
+        allowed.append(
+            {
+                "name": child.name,
+                "kind": _entry_kind(child),
+                "size": stat.st_size,
+                "mtime": stat.st_mtime,
+            }
+        )
+    allowed.sort(key=lambda entry: (entry["kind"] != "dir", entry["name"].lower()))
+    if cap < 0:
+        cap = 0
+    overflow = max(len(allowed) - cap, 0)
+    return allowed[:cap], overflow > 0, overflow or None
+
+
+def _entry_kind(path: Path) -> WorkspaceEntryKind:
+    if path.is_symlink():
+        return "symlink"
+    if path.is_dir():
+        return "dir"
+    return "file"
+
+
+def _has_symlink_component(base_resolved: Path, target: Path) -> bool:
+    try:
+        relative = target.relative_to(base_resolved)
+    except ValueError:
+        return False
+    current = base_resolved
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False

--- a/backend/tests/test_workspace_api.py
+++ b/backend/tests/test_workspace_api.py
@@ -140,6 +140,7 @@ async def test_disabled_returns_404(tmp_path: Path) -> None:
             headers={"Authorization": f"Bearer {token}"},
         )
     assert resp.status_code == 404
+    assert resp.json()["detail"] == "disabled"  # the gated branch, not a routing miss
 
 
 async def test_raw_validates_query_token(tmp_path: Path) -> None:

--- a/backend/tests/test_workspace_api.py
+++ b/backend/tests/test_workspace_api.py
@@ -1,0 +1,170 @@
+"""Route-level tests for the workspace preview endpoints.
+
+These exercise the auth, gating, and denylist behavior through the real
+FastAPI app (over an in-process ASGI transport) rather than the helper layer.
+The routes only read storage/tokens, so the runtime lifespan is not started.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from waypoint.api import create_app
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+from waypoint.settings import Settings
+
+
+def _build(
+    tmp_path: Path,
+    settings_kw: dict[str, Any] | None = None,
+    session_kw: dict[str, Any] | None = None,
+) -> tuple[Any, str]:
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    (workspace / "notes.md").write_text("hello", encoding="utf-8")
+    (workspace / ".env").write_text("SECRET=1", encoding="utf-8")
+    git_dir = workspace / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text("[core]\n", encoding="utf-8")
+
+    settings = Settings(data_dir=tmp_path / "data", **(settings_kw or {}))
+    app = create_app(settings)
+    context = app.state.context
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="s1",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title="t",
+        cwd=str(workspace),
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(tmp_path / "raw.log"),
+        structured_log_path=str(tmp_path / "events.jsonl"),
+        **(session_kw or {}),
+    )
+    context.storage.create_session(session)
+    token = context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def test_tree_lists_dotfiles_but_hides_git(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/tree",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    names = [entry["name"] for entry in resp.json()["entries"]]
+    assert "notes.md" in names
+    assert ".env" in names  # ordinary dotfiles preview by default
+    assert ".git" not in names  # VCS internals stay hidden
+
+
+async def test_file_reads_text(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": "notes.md"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["content"] == "hello"
+    assert body["binary"] is False
+
+
+async def test_dotdir_is_denied(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": ".git/config"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 403
+
+
+async def test_traversal_and_missing(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    headers = {"Authorization": f"Bearer {token}"}
+    async with _client(app) as client:
+        escape = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": "../../../../etc/passwd"},
+            headers=headers,
+        )
+        missing = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": "nope.txt"},
+            headers=headers,
+        )
+    assert escape.status_code == 403
+    assert missing.status_code == 404
+
+
+async def test_requires_token(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/sessions/s1/workspace/tree")
+    assert resp.status_code == 401
+
+
+async def test_remote_session_rejected(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, session_kw={"launch_target_id": "devbox"})
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/tree",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 400
+
+
+async def test_disabled_returns_404(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, settings_kw={"workspace_preview_enabled": False})
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/tree",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 404
+
+
+async def test_raw_validates_query_token(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        bad = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": "notes.md", "raw": "1", "token": "bogus"},
+        )
+        good = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": "notes.md", "raw": "1", "token": token},
+        )
+    assert bad.status_code == 401
+    assert good.status_code == 200
+    assert good.text == "hello"
+
+
+async def test_empty_denylist_disables_filtering(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, settings_kw={"workspace_denylist": []})
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/file",
+            params={"path": ".git/config"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["content"] == "[core]\n"

--- a/backend/tests/test_workspace_preview.py
+++ b/backend/tests/test_workspace_preview.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from waypoint.settings import Settings
+from waypoint.settings import Settings, _env_overrides
 from waypoint.workspace_preview import (
     WorkspacePathError,
     is_denied,
@@ -116,3 +116,19 @@ def test_read_text_capped_returns_placeholder_for_binary(tmp_path: Path) -> None
 def test_sniff_text_rejects_invalid_utf8() -> None:
     assert sniff_text(b"hello") is True
     assert sniff_text(b"\xff") is False
+
+
+def test_env_overrides_parse_workspace_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("WAYPOINT_WORKSPACE_PREVIEW_ENABLED", "false")
+    monkeypatch.setenv("WAYPOINT_WORKSPACE_MAX_FILE_BYTES", "1024")
+    monkeypatch.setenv("WAYPOINT_WORKSPACE_DENYLIST", ".git, *.pem ,")
+    monkeypatch.setenv("WAYPOINT_WORKSPACE_FOLLOW_SYMLINKS", "1")
+
+    overrides = _env_overrides()
+
+    assert overrides["workspace_preview_enabled"] is False
+    assert overrides["workspace_max_file_bytes"] == 1024
+    assert overrides["workspace_denylist"] == [".git", "*.pem"]
+    assert overrides["workspace_follow_symlinks"] is True

--- a/backend/tests/test_workspace_preview.py
+++ b/backend/tests/test_workspace_preview.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+import pytest
+
+from waypoint.settings import Settings
+from waypoint.workspace_preview import (
+    WorkspacePathError,
+    is_denied,
+    list_dir,
+    read_text_capped,
+    resolve_in_base,
+    sniff_text,
+)
+
+
+def test_list_dir_orders_dirs_first_and_skips_denied(tmp_path: Path) -> None:
+    settings = Settings(data_dir=tmp_path)
+    (tmp_path / "zeta.txt").write_text("z", encoding="utf-8")
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "beta.txt").write_text("b", encoding="utf-8")
+    (tmp_path / ".env").write_text("secret", encoding="utf-8")
+
+    entries, truncated, overflow = list_dir(
+        tmp_path,
+        "",
+        10,
+        denylist=settings.workspace_denylist,
+        follow_symlinks=settings.workspace_follow_symlinks,
+    )
+
+    assert [entry["name"] for entry in entries] == ["alpha", "beta.txt", "zeta.txt"]
+    assert [entry["kind"] for entry in entries] == ["dir", "file", "file"]
+    assert all(entry["size"] >= 0 for entry in entries)
+    assert all(entry["mtime"] > 0 for entry in entries)
+    assert truncated is False
+    assert overflow is None
+
+
+def test_list_dir_reports_overflow(tmp_path: Path) -> None:
+    for index in range(4):
+        (tmp_path / f"file-{index}.txt").write_text(str(index), encoding="utf-8")
+
+    entries, truncated, overflow = list_dir(tmp_path, "", 2)
+
+    assert [entry["name"] for entry in entries] == ["file-0.txt", "file-1.txt"]
+    assert truncated is True
+    assert overflow == 2
+
+
+def test_resolve_in_base_rejects_parent_traversal(tmp_path: Path) -> None:
+    with pytest.raises(WorkspacePathError):
+        resolve_in_base(tmp_path, "../outside.txt")
+
+
+def test_resolve_in_base_rejects_symlink_escape(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside.txt"
+    outside.write_text("outside", encoding="utf-8")
+    link = tmp_path / "outside-link"
+    link.symlink_to(outside)
+
+    with pytest.raises(WorkspacePathError):
+        resolve_in_base(tmp_path, link.name)
+
+
+def test_denied_dotfile_and_custom_glob(tmp_path: Path) -> None:
+    assert is_denied(".ssh/config", ["*.pem"])
+    assert is_denied("certs/private.pem", ["*.pem"])
+
+    (tmp_path / "visible.txt").write_text("ok", encoding="utf-8")
+    (tmp_path / "private.pem").write_text("secret", encoding="utf-8")
+
+    entries, _, _ = list_dir(tmp_path, "", 10, denylist=["*.pem"])
+
+    assert [entry["name"] for entry in entries] == ["visible.txt"]
+
+
+def test_read_text_capped_returns_placeholder_over_limit(tmp_path: Path) -> None:
+    settings = Settings(data_dir=tmp_path, workspace_max_file_bytes=3)
+    path = tmp_path / "large.txt"
+    path.write_text("hello", encoding="utf-8")
+
+    content, truncated, binary, encoding = read_text_capped(
+        path, settings.workspace_max_file_bytes
+    )
+
+    assert content is None
+    assert truncated is True
+    assert binary is False
+    assert encoding == "utf-8"
+
+
+def test_read_text_capped_returns_placeholder_for_binary(tmp_path: Path) -> None:
+    path = tmp_path / "binary.bin"
+    path.write_bytes(b"abc\x00def")
+
+    content, truncated, binary, encoding = read_text_capped(path, 100)
+
+    assert content is None
+    assert truncated is False
+    assert binary is True
+    assert encoding == "utf-8"
+
+
+def test_sniff_text_rejects_invalid_utf8() -> None:
+    assert sniff_text(b"hello") is True
+    assert sniff_text(b"\xff") is False

--- a/backend/tests/test_workspace_preview.py
+++ b/backend/tests/test_workspace_preview.py
@@ -18,7 +18,7 @@ def test_list_dir_orders_dirs_first_and_skips_denied(tmp_path: Path) -> None:
     (tmp_path / "zeta.txt").write_text("z", encoding="utf-8")
     (tmp_path / "alpha").mkdir()
     (tmp_path / "beta.txt").write_text("b", encoding="utf-8")
-    (tmp_path / ".env").write_text("secret", encoding="utf-8")
+    (tmp_path / ".git").mkdir()  # denied by the default denylist
 
     entries, truncated, overflow, resolved_dir = list_dir(
         tmp_path,
@@ -64,8 +64,19 @@ def test_resolve_in_base_rejects_symlink_escape(tmp_path: Path) -> None:
 
 
 def test_denied_dotfile_and_custom_glob(tmp_path: Path) -> None:
-    assert is_denied(".ssh/config", ["*.pem"])
+    # The default denylist hides .git and .ssh but leaves other dotfiles
+    # (e.g. .env) previewable.
+    assert is_denied(".git/config")
+    assert is_denied("nested/.ssh/id_rsa")
+    assert not is_denied(".env")
+    assert not is_denied("nested/.env")
+    # Custom globs match case-insensitively; ".*" hides every dotfile.
     assert is_denied("certs/private.pem", ["*.pem"])
+    assert is_denied("certs/PRIVATE.PEM", ["*.pem"])
+    assert is_denied(".env", [".*"])
+    # An explicit empty denylist disables all filtering.
+    assert not is_denied(".git/config", [])
+    assert not is_denied(".env", [])
 
     (tmp_path / "visible.txt").write_text("ok", encoding="utf-8")
     (tmp_path / "private.pem").write_text("secret", encoding="utf-8")

--- a/backend/tests/test_workspace_preview.py
+++ b/backend/tests/test_workspace_preview.py
@@ -20,7 +20,7 @@ def test_list_dir_orders_dirs_first_and_skips_denied(tmp_path: Path) -> None:
     (tmp_path / "beta.txt").write_text("b", encoding="utf-8")
     (tmp_path / ".env").write_text("secret", encoding="utf-8")
 
-    entries, truncated, overflow = list_dir(
+    entries, truncated, overflow, resolved_dir = list_dir(
         tmp_path,
         "",
         10,
@@ -28,6 +28,7 @@ def test_list_dir_orders_dirs_first_and_skips_denied(tmp_path: Path) -> None:
         follow_symlinks=settings.workspace_follow_symlinks,
     )
 
+    assert resolved_dir == tmp_path.resolve()
     assert [entry["name"] for entry in entries] == ["alpha", "beta.txt", "zeta.txt"]
     assert [entry["kind"] for entry in entries] == ["dir", "file", "file"]
     assert all(entry["size"] >= 0 for entry in entries)
@@ -40,7 +41,7 @@ def test_list_dir_reports_overflow(tmp_path: Path) -> None:
     for index in range(4):
         (tmp_path / f"file-{index}.txt").write_text(str(index), encoding="utf-8")
 
-    entries, truncated, overflow = list_dir(tmp_path, "", 2)
+    entries, truncated, overflow, _ = list_dir(tmp_path, "", 2)
 
     assert [entry["name"] for entry in entries] == ["file-0.txt", "file-1.txt"]
     assert truncated is True
@@ -69,7 +70,7 @@ def test_denied_dotfile_and_custom_glob(tmp_path: Path) -> None:
     (tmp_path / "visible.txt").write_text("ok", encoding="utf-8")
     (tmp_path / "private.pem").write_text("secret", encoding="utf-8")
 
-    entries, _, _ = list_dir(tmp_path, "", 10, denylist=["*.pem"])
+    entries, _, _, _ = list_dir(tmp_path, "", 10, denylist=["*.pem"])
 
     assert [entry["name"] for entry in entries] == ["visible.txt"]
 

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -13,6 +13,20 @@ cors_origins: []
                           # tool_call+tool_result pair) into one unit so
                           # a page of N reliably surfaces N bubbles.
 
+# Workspace file preview (the file explorer in the chat window). Reads files
+# under each *local* session's working dir; remote (SSH) sessions are excluded.
+# workspace_preview_enabled: true
+# workspace_denylist:            # globs hidden from the tree/preview, matched
+#   - .git                       #   per path component, case-insensitively.
+#   - .ssh                       # Default hides VCS internals and SSH keys only,
+#                                #   so ordinary dotfiles like .env preview. Use
+#                                #   [".*"] to hide all dotfiles, or [] to disable
+#                                #   filtering entirely. Env: WAYPOINT_WORKSPACE_DENYLIST
+#                                #   (comma-separated).
+# workspace_max_file_bytes: 200000   # larger files preview as a placeholder
+# workspace_follow_symlinks: false   # if true, allow paths through symlinks that
+#                                    #   still resolve inside the working dir
+
 # Per-plugin config blocks keyed by plugin id. Each block is validated
 # against the plugin's `config_schema` (see `backends/<id>/plugin.py`).
 # Keys here must match a registered plugin; unknown ids fail

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2732,6 +2732,11 @@ html[data-theme="light"] .transcript.codex.tool_pair {
   overflow-wrap: anywhere;
 }
 
+.todo-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .todo-detail {
   min-width: 0;
   font-size: 0.85em;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12159,9 +12159,10 @@ html[data-theme="light"] .wp-code-toolbar {
 
   .wp-tree-pane {
     width: 100%;
+    flex: 1;
+    min-height: 0;
+    max-height: none;
     border-right: none;
-    border-bottom: 1px solid var(--line);
-    max-height: 45dvh;
   }
 
   .wp-mobile-hidden {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11521,3 +11521,643 @@ html[data-theme="light"]
     flex-wrap: wrap;
   }
 }
+
+/* ─── Workspace preview ─── */
+.wp-panel-backdrop {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  padding: 16px;
+}
+
+.wp-panel-modal {
+  width: 100%;
+  max-width: min(960px, calc(100vw - 32px));
+  height: calc(100dvh - 64px);
+  min-height: 0;
+  background: rgba(14, 17, 24, 0.96);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: session-files-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+html[data-theme="light"] .wp-panel-modal {
+  background: rgba(252, 249, 242, 0.98);
+  box-shadow: 0 16px 48px rgba(60, 45, 20, 0.2);
+}
+
+.wp-panel-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+
+.wp-panel-title {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.wp-panel-title > span:first-child {
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+  color: var(--text-strong);
+}
+
+.wp-panel-cwd {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wp-panel-mobile-toggle {
+  display: none;
+  gap: 4px;
+}
+
+.wp-toggle-btn {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 5px 10px;
+  border-radius: var(--radius-pill);
+  transition:
+    border-color 120ms ease,
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.wp-toggle-btn.active {
+  border-color: var(--line-strong);
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.wp-panel-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.2rem;
+  line-height: 1;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.wp-panel-close:hover {
+  background: color-mix(in srgb, var(--text) 12%, transparent);
+  color: var(--text-strong);
+}
+
+.wp-panel-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.wp-tree-pane {
+  width: 280px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.wp-recent {
+  border-bottom: 1px solid var(--line);
+  padding: 8px;
+  flex-shrink: 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.wp-recent-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0 4px 4px;
+  margin: 0;
+}
+
+.wp-recent-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.wp-recent-item {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 5px 8px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 0.82rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background-color 120ms ease;
+}
+
+.wp-recent-item:hover,
+.wp-recent-item.selected {
+  background: color-mix(in srgb, var(--accent-cool) 12%, transparent);
+}
+
+.wp-recent-full {
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wp-tree-scroll {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px;
+}
+
+.wp-tree-root {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.wp-tree-root ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.wp-tree-loading,
+.wp-tree-error {
+  padding: 16px;
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-align: center;
+}
+
+.wp-tree-error {
+  color: var(--danger);
+}
+
+.wp-tree-node {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 0.82rem;
+  transition: background-color 100ms ease;
+}
+
+.wp-tree-node:hover {
+  background: var(--bg-card-soft);
+}
+
+.wp-tree-node.selected {
+  background: color-mix(in srgb, var(--accent-cool) 14%, transparent);
+  color: var(--accent-cool);
+}
+
+.wp-tree-node.is-dir {
+  color: var(--text-strong);
+}
+
+.wp-tree-indent {
+  flex-shrink: 0;
+}
+
+.wp-tree-toggle {
+  flex-shrink: 0;
+  width: 12px;
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.wp-tree-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+}
+
+.wp-tree-node.is-dir .wp-tree-icon {
+  color: var(--accent);
+}
+
+.wp-tree-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wp-tree-overflow,
+.wp-tree-loading-child,
+.wp-tree-error-child {
+  padding: 3px 6px 3px calc(var(--depth, 0) * 16px + 24px);
+  font-size: 0.72rem;
+  color: var(--muted);
+  list-style: none;
+}
+
+.wp-tree-error-child {
+  color: var(--danger);
+}
+
+.wp-preview-pane {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.wp-preview-header {
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex-shrink: 0;
+  background: rgba(8, 11, 16, 0.2);
+}
+
+html[data-theme="light"] .wp-preview-header {
+  background: rgba(200, 190, 170, 0.08);
+}
+
+.wp-preview-path {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wp-preview-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.wp-preview-meta {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  color: var(--muted);
+  letter-spacing: 0.03em;
+}
+
+.wp-preview-btn {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.wp-preview-btn:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.wp-preview-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.wp-preview-loading,
+.wp-preview-error,
+.wp-preview-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 0.84rem;
+  padding: 32px;
+}
+
+.wp-preview-error {
+  color: var(--danger);
+}
+
+.wp-file-binary {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 32px;
+}
+
+.wp-file-binary-icon {
+  font-size: 2rem;
+  color: var(--muted-soft);
+}
+
+.wp-file-binary-label {
+  color: var(--text);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.wp-file-binary-size {
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  margin: 0;
+}
+
+.wp-file-binary-open {
+  margin-top: 4px;
+  font-size: 0.82rem;
+}
+
+.wp-file-image {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  overflow: auto;
+}
+
+.wp-file-img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  border-radius: var(--radius-sm);
+}
+
+.wp-file-markdown {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.wp-md-toggle {
+  display: flex;
+  gap: 4px;
+  padding: 8px;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+  background: rgba(8, 11, 16, 0.12);
+}
+
+html[data-theme="light"] .wp-md-toggle {
+  background: rgba(200, 190, 170, 0.06);
+}
+
+.wp-md-btn {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 8px;
+  border-radius: var(--radius-pill);
+  transition:
+    border-color 120ms ease,
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.wp-md-btn.active {
+  border-color: var(--line-strong);
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+
+.wp-md-rendered {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+}
+
+.wp-code-wrap {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.wp-code-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line);
+  background: rgba(5, 7, 10, 0.3);
+  flex-shrink: 0;
+}
+
+html[data-theme="light"] .wp-code-toolbar {
+  background: rgba(200, 190, 170, 0.08);
+}
+
+.wp-code-lang {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+}
+
+.wp-wrap-toggle {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 7px;
+  border-radius: var(--radius-pill);
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.wp-wrap-toggle.active,
+.wp-wrap-toggle:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.wp-code-pre {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  margin: 0;
+  max-height: none;
+  padding: 0;
+  white-space: normal;
+}
+
+.wp-code-line {
+  display: flex;
+  align-items: baseline;
+  padding: 0 6px 0 0;
+}
+
+.wp-code-pre.soft-wrap .wp-code-line {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.wp-line-num {
+  flex: 0 0 calc(var(--lnw, 3ch) + 16px);
+  text-align: right;
+  padding: 0 8px;
+  border-right: 1px solid var(--line);
+  margin-right: 8px;
+  color: var(--muted-soft);
+  user-select: none;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.wp-line-text {
+  flex: 1;
+  min-width: 0;
+  white-space: pre;
+}
+
+.wp-code-pre.soft-wrap .wp-line-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.diff-file-path-btn {
+  background: transparent;
+  border: none;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  border-radius: 3px;
+  transition:
+    background-color 100ms ease,
+    color 100ms ease;
+  text-align: left;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.diff-file-path-btn:hover {
+  background: color-mix(in srgb, var(--accent-cool) 14%, transparent);
+  color: var(--accent-cool);
+}
+
+@media (max-width: 640px) {
+  .wp-panel-mobile-toggle {
+    display: flex;
+  }
+
+  .wp-panel-body {
+    flex-direction: column;
+  }
+
+  .wp-tree-pane {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--line);
+    max-height: 45dvh;
+  }
+
+  .wp-mobile-hidden {
+    display: none;
+  }
+
+  .wp-panel-close {
+    width: 38px;
+    height: 38px;
+  }
+}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11534,13 +11534,17 @@ html[data-theme="light"]
   background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(2px);
   -webkit-backdrop-filter: blur(2px);
-  padding: 16px;
+  /* Keep the modal clear of the notch/home indicator on mobile; the panel is
+     near-full-height, so without this the header slides under the status bar. */
+  padding: max(16px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
+    max(16px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
 }
 
 .wp-panel-modal {
   width: 100%;
   max-width: min(960px, calc(100vw - 32px));
-  height: calc(100dvh - 64px);
+  height: 100%;
+  max-height: 100%;
   min-height: 0;
   background: rgba(14, 17, 24, 0.96);
   border: 1px solid var(--line-strong);
@@ -11833,9 +11837,9 @@ html[data-theme="light"] .wp-panel-modal {
   padding: 10px 14px;
   border-bottom: 1px solid var(--line);
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 8px 12px;
   flex-shrink: 0;
   background: rgba(8, 11, 16, 0.2);
 }
@@ -11867,6 +11871,8 @@ html[data-theme="light"] .wp-preview-header {
   font-size: 0.64rem;
   color: var(--muted);
   letter-spacing: 0.03em;
+  white-space: nowrap;
+  margin-right: 4px;
 }
 
 .wp-preview-btn {
@@ -12099,6 +12105,7 @@ html[data-theme="light"] .wp-code-toolbar {
   user-select: none;
   font-family: inherit;
   font-size: inherit;
+  white-space: nowrap;
 }
 
 .wp-line-text {

--- a/frontend/src/components/AttachmentTray.tsx
+++ b/frontend/src/components/AttachmentTray.tsx
@@ -355,6 +355,26 @@ export function FileIcon() {
   );
 }
 
+// Folder glyph for the workspace file-explorer button in the composer.
+export function FolderIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 9a2 2 0 0 1 2-2h5l2 2h9a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2z" />
+      <path d="M2 12h20" />
+    </svg>
+  );
+}
+
 // Folder glyph for the "session files" manager entry point.
 export function FilesIcon() {
   return (

--- a/frontend/src/components/DiffPreview.tsx
+++ b/frontend/src/components/DiffPreview.tsx
@@ -6,7 +6,13 @@ const PHASE_LABEL: Record<EventDiffPreview["phase"], string> = {
   aggregate: "Turn changes",
 };
 
-export function DiffPreview({ preview }: { preview: EventDiffPreview }) {
+export function DiffPreview({
+  preview,
+  onOpenWorkspaceFile,
+}: {
+  preview: EventDiffPreview;
+  onOpenWorkspaceFile?: (path: string) => void;
+}) {
   return (
     <div className="diff-preview">
       <div className="diff-preview-header">
@@ -17,24 +23,49 @@ export function DiffPreview({ preview }: { preview: EventDiffPreview }) {
       </div>
       <div className="diff-preview-files">
         {preview.files.map((file, index) => (
-          <DiffPreviewFileView file={file} key={`${file.path}-${index}`} />
+          <DiffPreviewFileView
+            file={file}
+            key={`${file.path}-${index}`}
+            onOpenWorkspaceFile={onOpenWorkspaceFile}
+          />
         ))}
       </div>
     </div>
   );
 }
 
-function DiffPreviewFileView({ file }: { file: EventDiffPreviewFile }) {
+function DiffPreviewFileView({
+  file,
+  onOpenWorkspaceFile,
+}: {
+  file: EventDiffPreviewFile;
+  onOpenWorkspaceFile?: (path: string) => void;
+}) {
   const changeType = displayChangeType(file);
+  const pathLabel =
+    file.oldPath && file.oldPath !== file.path
+      ? `${file.oldPath} -> ${file.path}`
+      : file.path;
   return (
     <section className="diff-preview-file">
       <div className="diff-file-header">
         <span className={`diff-change-type ${changeType.className}`}>
           {changeType.label}
         </span>
-        <span className="diff-file-path" title={file.path}>
-          {file.oldPath && file.oldPath !== file.path ? `${file.oldPath} -> ${file.path}` : file.path}
-        </span>
+        {onOpenWorkspaceFile ? (
+          <button
+            type="button"
+            className="diff-file-path diff-file-path-btn"
+            title={`Open ${file.path}`}
+            onClick={() => onOpenWorkspaceFile(file.path)}
+          >
+            {pathLabel}
+          </button>
+        ) : (
+          <span className="diff-file-path" title={file.path}>
+            {pathLabel}
+          </span>
+        )}
         <span className="diff-file-stats">
           +{file.additions} -{file.deletions}
         </span>

--- a/frontend/src/components/FilePreview.tsx
+++ b/frontend/src/components/FilePreview.tsx
@@ -30,6 +30,7 @@ interface FilePreviewProps {
 export function FilePreview({ file, rawUrl }: FilePreviewProps) {
   const [softWrap, setSoftWrap] = useState(false);
   const [mdView, setMdView] = useState<"rendered" | "source">("rendered");
+  const [imageError, setImageError] = useState(false);
 
   if (file.binary || file.content === null) {
     return (
@@ -51,11 +52,34 @@ export function FilePreview({ file, rawUrl }: FilePreviewProps) {
     );
   }
 
-  if (isImagePath(file.path)) {
+  if (isImagePath(file.path) && !imageError) {
     return (
       <div className="wp-file-image">
         {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src={rawUrl} alt={file.path} className="wp-file-img" />
+        <img
+          src={rawUrl}
+          alt={file.path}
+          className="wp-file-img"
+          onError={() => setImageError(true)}
+        />
+      </div>
+    );
+  }
+
+  if (isImagePath(file.path)) {
+    return (
+      <div className="wp-file-binary">
+        <span className="wp-file-binary-icon" aria-hidden="true">⬜</span>
+        <p className="wp-file-binary-label">Could not load image</p>
+        <p className="wp-file-binary-size">{formatBytes(file.size)}</p>
+        <a
+          href={rawUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="secondary wp-file-binary-open"
+        >
+          Open raw ↗
+        </a>
       </div>
     );
   }

--- a/frontend/src/components/FilePreview.tsx
+++ b/frontend/src/components/FilePreview.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { type CSSProperties, useState } from "react";
+
+import { formatBytes } from "@/components/AttachmentTray";
+import { MarkdownMessage } from "@/components/MarkdownMessage";
+import type { WorkspaceFile } from "@/lib/api";
+
+const IMAGE_EXTS = new Set([
+  ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
+  ".ico", ".bmp", ".avif",
+]);
+
+function isImagePath(path: string): boolean {
+  const dot = path.lastIndexOf(".");
+  if (dot < 0) return false;
+  return IMAGE_EXTS.has(path.slice(dot).toLowerCase());
+}
+
+function isMarkdownPath(path: string): boolean {
+  const lower = path.toLowerCase();
+  return lower.endsWith(".md") || lower.endsWith(".markdown");
+}
+
+interface FilePreviewProps {
+  file: WorkspaceFile;
+  rawUrl: string;
+}
+
+export function FilePreview({ file, rawUrl }: FilePreviewProps) {
+  const [softWrap, setSoftWrap] = useState(false);
+  const [mdView, setMdView] = useState<"rendered" | "source">("rendered");
+
+  if (file.binary || file.content === null) {
+    return (
+      <div className="wp-file-binary">
+        <span className="wp-file-binary-icon" aria-hidden="true">⬜</span>
+        <p className="wp-file-binary-label">
+          {file.binary ? "Binary file" : "File too large to preview"}
+        </p>
+        <p className="wp-file-binary-size">{formatBytes(file.size)}</p>
+        <a
+          href={rawUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="secondary wp-file-binary-open"
+        >
+          Open raw ↗
+        </a>
+      </div>
+    );
+  }
+
+  if (isImagePath(file.path)) {
+    return (
+      <div className="wp-file-image">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src={rawUrl} alt={file.path} className="wp-file-img" />
+      </div>
+    );
+  }
+
+  if (isMarkdownPath(file.path) && file.content) {
+    return (
+      <div className="wp-file-markdown">
+        <div className="wp-md-toggle">
+          <button
+            type="button"
+            className={`wp-md-btn${mdView === "rendered" ? " active" : ""}`}
+            onClick={() => setMdView("rendered")}
+          >
+            Rendered
+          </button>
+          <button
+            type="button"
+            className={`wp-md-btn${mdView === "source" ? " active" : ""}`}
+            onClick={() => setMdView("source")}
+          >
+            Source
+          </button>
+        </div>
+        {mdView === "rendered" ? (
+          <div className="wp-md-rendered">
+            <MarkdownMessage text={file.content} />
+          </div>
+        ) : (
+          <FileCodeView
+            content={file.content}
+            path={file.path}
+            softWrap={softWrap}
+            setSoftWrap={setSoftWrap}
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <FileCodeView
+      content={file.content ?? ""}
+      path={file.path}
+      softWrap={softWrap}
+      setSoftWrap={setSoftWrap}
+    />
+  );
+}
+
+function FileCodeView({
+  content,
+  path,
+  softWrap,
+  setSoftWrap,
+}: {
+  content: string;
+  path: string;
+  softWrap: boolean;
+  setSoftWrap: (v: boolean) => void;
+}) {
+  const lines = content.split("\n");
+  const lnw = `${String(lines.length).length}ch`;
+  return (
+    <div className="wp-code-wrap">
+      <div className="wp-code-toolbar">
+        <span className="wp-code-lang">{path.split("/").pop()}</span>
+        <button
+          type="button"
+          className={`wp-wrap-toggle${softWrap ? " active" : ""}`}
+          onClick={() => setSoftWrap(!softWrap)}
+          title={softWrap ? "Disable soft wrap" : "Enable soft wrap"}
+        >
+          wrap
+        </button>
+      </div>
+      <pre
+        className={`diff-code wp-code-pre${softWrap ? " soft-wrap" : ""}`}
+        style={{ "--lnw": lnw } as CSSProperties}
+        aria-label={`Contents of ${path}`}
+      >
+        {lines.map((line, idx) => (
+          <span key={idx} className="wp-code-line">
+            <span className="wp-line-num">{idx + 1}</span>
+            <span className="wp-line-text">{line || " "}</span>
+          </span>
+        ))}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -80,7 +80,6 @@ import {
   AttachmentContextProvider,
   AttachmentTray,
   filesFromDataTransfer,
-  FolderIcon,
   PaperclipIcon,
   useAttachments,
 } from "@/components/AttachmentTray";
@@ -3161,20 +3160,6 @@ const ReplyComposer = memo(function ReplyComposer({
             aria-hidden="true"
             tabIndex={-1}
           />
-        ) : null}
-        {workspacePreviewEnabled ? (
-          <button
-            type="button"
-            className="composer-attach-btn"
-            onClick={onBrowseWorkspace}
-            disabled={disabled}
-            aria-label="Browse workspace files"
-            title="Browse workspace files"
-          >
-            <span className="glyph" aria-hidden>
-              <FolderIcon />
-            </span>
-          </button>
         ) : null}
         {attachmentsEnabled ? (
           <button

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -69,6 +69,7 @@ import { useFileMentions } from "@/lib/use-file-mentions";
 import {
   isPlanEvent,
   itemIdForEvent,
+  parseEvent,
   planForEvent,
   type PlanDecision,
   type PlanViewModel,
@@ -79,10 +80,12 @@ import {
   AttachmentContextProvider,
   AttachmentTray,
   filesFromDataTransfer,
+  FolderIcon,
   PaperclipIcon,
   useAttachments,
 } from "@/components/AttachmentTray";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
+import { WorkspaceFilesPanel } from "@/components/WorkspaceFilesPanel";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -307,6 +310,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   );
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
+  const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | undefined>(undefined);
   // The todo-event sequence the user last dismissed from the progress dock.
   // `undefined` means we haven't read the persisted value yet — the dock stays
   // hidden until then so a dismissed dock doesn't flash on load (and to avoid
@@ -1301,6 +1306,27 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => transcriptItems.some((item) => item.kind === "tool_run"),
     [transcriptItems],
   );
+  // Workspace preview: collect recently written file paths from applied diff
+  // previews, newest-first and deduplicated. Backend-agnostic: keyed off the
+  // diff_preview phase, not tool names.
+  const recentPaths = useMemo(() => {
+    const seen = new Set<string>();
+    const paths: string[] = [];
+    for (let i = events.length - 1; i >= 0; i--) {
+      const diff = parseEvent(events[i]).diffPreview;
+      if (!diff || diff.phase !== "applied") continue;
+      for (const file of diff.files) {
+        if (!seen.has(file.path)) {
+          seen.add(file.path);
+          paths.push(file.path);
+        }
+      }
+    }
+    return paths;
+  }, [events]);
+  // True for local sessions only; remote sessions return 400 from the workspace
+  // endpoints.
+  const workspacePreviewEnabled = Boolean(session && !session.launch_target_id);
   // Latest task group, read off the raw event stream so the dock reflects the
   // true current state regardless of the transcript's event filter.
   const currentTaskEvent = useMemo(() => {
@@ -1615,6 +1641,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const resumeSession = useCallback(() => {
     void runAction("resume");
   }, [runAction]);
+  const handleOpenWorkspaceFile = useCallback((path: string) => {
+    setWorkspaceInitialPath(path);
+    setWorkspaceOpen(true);
+  }, []);
 
   return (
     <section className="stack" ref={sectionRef}>
@@ -1751,6 +1781,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                             transport={session.transport}
                             catalog={catalog}
                             onAnswerAskQuestion={submitAskAnswer}
+                            onOpenWorkspaceFile={workspacePreviewEnabled ? handleOpenWorkspaceFile : undefined}
                             key={`pair-${child.pair.itemId}`}
                           />
                         ) : (
@@ -1759,6 +1790,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                             transport={session.transport}
                             catalog={catalog}
                             onAnswerAskQuestion={submitAskAnswer}
+                            onOpenWorkspaceFile={workspacePreviewEnabled ? handleOpenWorkspaceFile : undefined}
                             key={`${child.event.sequence}-${child.event.id ?? "local"}`}
                           />
                         ),
@@ -1773,6 +1805,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                     transport={session.transport}
                     catalog={catalog}
                     onAnswerAskQuestion={submitAskAnswer}
+                    onOpenWorkspaceFile={workspacePreviewEnabled ? handleOpenWorkspaceFile : undefined}
                     key={`pair-${item.pair.itemId}`}
                   />
                 ) : (
@@ -1781,6 +1814,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                     transport={session.transport}
                     catalog={catalog}
                     onAnswerAskQuestion={submitAskAnswer}
+                    onOpenWorkspaceFile={workspacePreviewEnabled ? handleOpenWorkspaceFile : undefined}
                     key={`${item.event.sequence}-${item.event.id ?? "local"}`}
                   />
                 );
@@ -2137,6 +2171,22 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onError={setError}
           assistant={assistant}
           assistantControls={assistantControls}
+          workspacePreviewEnabled={workspacePreviewEnabled}
+          onBrowseWorkspace={() => {
+            setWorkspaceInitialPath(undefined);
+            setWorkspaceOpen(true);
+          }}
+        />
+      ) : null}
+      {workspacePreviewEnabled ? (
+        <WorkspaceFilesPanel
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          open={workspaceOpen}
+          initialPath={workspaceInitialPath}
+          recentPaths={recentPaths}
+          onClose={() => setWorkspaceOpen(false)}
         />
       ) : null}
     </section>
@@ -2196,6 +2246,8 @@ interface ReplyComposerProps {
   onError: (message: string) => void;
   assistant: boolean;
   assistantControls: AssistantControls | null;
+  workspacePreviewEnabled: boolean;
+  onBrowseWorkspace: () => void;
 }
 
 const ReplyComposer = memo(function ReplyComposer({
@@ -2243,6 +2295,8 @@ const ReplyComposer = memo(function ReplyComposer({
   onError,
   assistant,
   assistantControls,
+  workspacePreviewEnabled,
+  onBrowseWorkspace,
 }: ReplyComposerProps) {
   const [draft, setDraft] = useState("");
   const [dragActive, setDragActive] = useState(false);
@@ -3108,6 +3162,20 @@ const ReplyComposer = memo(function ReplyComposer({
             tabIndex={-1}
           />
         ) : null}
+        {workspacePreviewEnabled ? (
+          <button
+            type="button"
+            className="composer-attach-btn"
+            onClick={onBrowseWorkspace}
+            disabled={disabled}
+            aria-label="Browse workspace files"
+            title="Browse workspace files"
+          >
+            <span className="glyph" aria-hidden>
+              <FolderIcon />
+            </span>
+          </button>
+        ) : null}
         {attachmentsEnabled ? (
           <button
             type="button"
@@ -3180,6 +3248,20 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">⇄</span>
                     Switch session…
                   </button>
+                  {workspacePreviewEnabled ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="composer-overflow-item"
+                      onClick={() => {
+                        setOverflowOpen(false);
+                        onBrowseWorkspace();
+                      }}
+                    >
+                      <span className="glyph">◫</span>
+                      Browse workspace…
+                    </button>
+                  ) : null}
                   {attachmentsEnabled ? (
                     <button
                       type="button"

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -119,6 +119,7 @@ interface TranscriptCardProps {
     toolUseId?: string,
     answers?: AskAnswerEntry[],
   ) => Promise<boolean> | void;
+  onOpenWorkspaceFile?: (path: string) => void;
 }
 
 export const TranscriptCard = memo(function TranscriptCard({
@@ -127,11 +128,16 @@ export const TranscriptCard = memo(function TranscriptCard({
   catalog,
   pair,
   onAnswerAskQuestion,
+  onOpenWorkspaceFile,
 }: TranscriptCardProps) {
   if (fidelityFor(transport, catalog) === "structured") {
     if (pair) {
       return (
-        <ToolPairCard pair={pair} onAnswerAskQuestion={onAnswerAskQuestion} />
+        <ToolPairCard
+          pair={pair}
+          onAnswerAskQuestion={onAnswerAskQuestion}
+          onOpenWorkspaceFile={onOpenWorkspaceFile}
+        />
       );
     }
     return (
@@ -140,6 +146,7 @@ export const TranscriptCard = memo(function TranscriptCard({
         transport={transport}
         catalog={catalog}
         onAnswerAskQuestion={onAnswerAskQuestion}
+        onOpenWorkspaceFile={onOpenWorkspaceFile}
       />
     );
   }
@@ -151,6 +158,7 @@ function StructuredCard({
   transport,
   catalog,
   onAnswerAskQuestion,
+  onOpenWorkspaceFile,
 }: {
   event: EventRecord;
   transport: SessionTransport;
@@ -159,6 +167,7 @@ function StructuredCard({
     text: string,
     toolUseId?: string,
   ) => Promise<boolean> | void;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   // Convention: the chat-bubble agent label is the first word of the agent
   // that owns this transport, lowercased ("Claude Code" → "claude", "Codex"
@@ -173,6 +182,7 @@ function StructuredCard({
       event={event}
       agentLabel={agentLabel}
       onAnswerAskQuestion={onAnswerAskQuestion}
+      onOpenWorkspaceFile={onOpenWorkspaceFile}
     />
   );
 }
@@ -181,6 +191,7 @@ function CodexCard({
   event,
   agentLabel = "codex",
   onAnswerAskQuestion,
+  onOpenWorkspaceFile,
 }: {
   event: EventRecord;
   agentLabel?: string;
@@ -188,6 +199,7 @@ function CodexCard({
     text: string,
     toolUseId?: string,
   ) => Promise<boolean> | void;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   switch (event.kind) {
     case "user_input": {
@@ -223,13 +235,25 @@ function CodexCard({
       if (isTodoToolEvent(event)) {
         return <TodoToolCard event={event} />;
       }
-      return <ToolDisclosure event={event} bodyClassName="shell" />;
+      return (
+        <ToolDisclosure
+          event={event}
+          bodyClassName="shell"
+          onOpenWorkspaceFile={onOpenWorkspaceFile}
+        />
+      );
     }
     case "tool_result":
       if (isTodoToolEvent(event)) {
         return <TodoToolCard event={event} />;
       }
-      return <ToolDisclosure event={event} bodyClassName="output" />;
+      return (
+        <ToolDisclosure
+          event={event}
+          bodyClassName="output"
+          onOpenWorkspaceFile={onOpenWorkspaceFile}
+        />
+      );
     case "approval_request":
       // The interactive ApprovalCard sits above the composer with the same
       // text and Approve/Decline buttons; rendering the event here too would
@@ -253,7 +277,7 @@ function CodexCard({
       if (event.metadata?.builtin_command === "/status") {
         return <CommandStatusCard event={event} agentLabel={agentLabel} />;
       }
-      return <SystemRule event={event} />;
+      return <SystemRule event={event} onOpenWorkspaceFile={onOpenWorkspaceFile} />;
     }
     default:
       return <HeuristicCard event={event} />;
@@ -323,7 +347,13 @@ function CommandStatusCard({
   );
 }
 
-function SystemRule({ event }: { event: EventRecord }) {
+function SystemRule({
+  event,
+  onOpenWorkspaceFile,
+}: {
+  event: EventRecord;
+  onOpenWorkspaceFile?: (path: string) => void;
+}) {
   const diffPreview = parseEvent(event).diffPreview;
   if (diffPreview) {
     return (
@@ -335,7 +365,7 @@ function SystemRule({ event }: { event: EventRecord }) {
           </div>
           <p className="transcript-preview">{event.text}</p>
         </summary>
-        <DiffPreview preview={diffPreview} />
+        <DiffPreview preview={diffPreview} onOpenWorkspaceFile={onOpenWorkspaceFile} />
       </details>
     );
   }
@@ -570,9 +600,11 @@ export function ToolCallRunGroup({
 function ToolDisclosure({
   event,
   bodyClassName,
+  onOpenWorkspaceFile,
 }: {
   event: EventRecord;
   bodyClassName: string;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const tool = toolBadgeFor(readToolName(event));
   const preview = previewForToolEvent(event, tool.label);
@@ -597,7 +629,7 @@ function ToolDisclosure({
         {preview ? <p className="transcript-preview">{preview}</p> : null}
       </summary>
       {diffPreview ? (
-        <DiffPreview preview={diffPreview} />
+        <DiffPreview preview={diffPreview} onOpenWorkspaceFile={onOpenWorkspaceFile} />
       ) : (
         <pre className={bodyClassName}>{event.text}</pre>
       )}
@@ -608,12 +640,14 @@ function ToolDisclosure({
 function ToolPairCard({
   pair,
   onAnswerAskQuestion,
+  onOpenWorkspaceFile,
 }: {
   pair: ToolPair;
   onAnswerAskQuestion?: (
     text: string,
     toolUseId?: string,
   ) => Promise<boolean> | void;
+  onOpenWorkspaceFile?: (path: string) => void;
 }) {
   const { call, result } = pair;
   if (call) {
@@ -657,7 +691,7 @@ function ToolPairCard({
       </summary>
       <div className="tool-pair-body">
         {diffPreview ? (
-          <DiffPreview preview={diffPreview} />
+          <DiffPreview preview={diffPreview} onOpenWorkspaceFile={onOpenWorkspaceFile} />
         ) : (
           <>
             {call ? (

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import {
@@ -31,25 +31,33 @@ function useWorkspacePreview(host: string, token: string, sessionId: string) {
   const [fileError, setFileError] = useState<string | null>(null);
   const [root, setRoot] = useState<WorkspaceTreePage["root"] | null>(null);
 
+  // Tracks the most recent request so a slow fetch for a previously-selected
+  // file can't overwrite the content of the file the user switched to.
+  const latestRequest = useRef<string | null>(null);
+
   const openFile = useCallback(
     async (path: string) => {
+      latestRequest.current = path;
       setOpenPathState(path);
       setFileData(null);
       setFileError(null);
       setFileLoading(true);
       try {
         const data = await fetchWorkspaceFile(host, token, sessionId, path);
+        if (latestRequest.current !== path) return;
         setFileData(data);
       } catch (e) {
+        if (latestRequest.current !== path) return;
         setFileError(e instanceof Error ? e.message : "Failed to load file");
       } finally {
-        setFileLoading(false);
+        if (latestRequest.current === path) setFileLoading(false);
       }
     },
     [host, token, sessionId],
   );
 
   const reset = useCallback(() => {
+    latestRequest.current = null;
     setOpenPathState(null);
     setFileData(null);
     setFileError(null);
@@ -249,7 +257,11 @@ export function WorkspaceFilesPanel({
                   ) : fileError ? (
                     <div className="wp-preview-error">{fileError}</div>
                   ) : fileData ? (
-                    <FilePreview file={fileData} rawUrl={rawUrl ?? ""} />
+                    <FilePreview
+                      key={fileData.path}
+                      file={fileData}
+                      rawUrl={rawUrl ?? ""}
+                    />
                   ) : null}
                 </div>
               </>

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  fetchWorkspaceFile,
+  workspaceRawUrl,
+  type WorkspaceFile,
+  type WorkspaceTreePage,
+} from "@/lib/api";
+import { formatBytes } from "@/components/AttachmentTray";
+import { FilePreview } from "@/components/FilePreview";
+import { WorkspaceTree } from "@/components/WorkspaceTree";
+
+interface WorkspaceFilesPanelProps {
+  host: string;
+  token: string;
+  sessionId: string;
+  open: boolean;
+  initialPath?: string;
+  recentPaths: string[];
+  onClose: () => void;
+}
+
+function useWorkspacePreview(host: string, token: string, sessionId: string) {
+  const [openPath, setOpenPathState] = useState<string | null>(null);
+  const [fileData, setFileData] = useState<WorkspaceFile | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [root, setRoot] = useState<WorkspaceTreePage["root"] | null>(null);
+
+  const openFile = useCallback(
+    async (path: string) => {
+      setOpenPathState(path);
+      setFileData(null);
+      setFileError(null);
+      setFileLoading(true);
+      try {
+        const data = await fetchWorkspaceFile(host, token, sessionId, path);
+        setFileData(data);
+      } catch (e) {
+        setFileError(e instanceof Error ? e.message : "Failed to load file");
+      } finally {
+        setFileLoading(false);
+      }
+    },
+    [host, token, sessionId],
+  );
+
+  const reset = useCallback(() => {
+    setOpenPathState(null);
+    setFileData(null);
+    setFileError(null);
+    setFileLoading(false);
+  }, []);
+
+  return { openPath, openFile, fileData, fileLoading, fileError, root, setRoot, reset };
+}
+
+export function WorkspaceFilesPanel({
+  host,
+  token,
+  sessionId,
+  open,
+  initialPath,
+  recentPaths,
+  onClose,
+}: WorkspaceFilesPanelProps) {
+  const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
+  const { openPath, openFile, fileData, fileLoading, fileError, root, setRoot, reset } =
+    useWorkspacePreview(host, token, sessionId);
+
+  useEffect(() => {
+    if (!open) return;
+    reset();
+    if (initialPath) {
+      void openFile(initialPath);
+      setMobileView("preview");
+    } else {
+      setMobileView("tree");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, initialPath]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  const handleSelectFile = useCallback(
+    async (path: string) => {
+      await openFile(path);
+      setMobileView("preview");
+    },
+    [openFile],
+  );
+
+  const copyPath = useCallback(() => {
+    if (!openPath) return;
+    navigator.clipboard.writeText(openPath).catch(() => {});
+  }, [openPath]);
+
+  const copyContents = useCallback(() => {
+    if (fileData?.content) {
+      navigator.clipboard.writeText(fileData.content).catch(() => {});
+    }
+  }, [fileData]);
+
+  const rawUrl = openPath ? workspaceRawUrl(host, token, sessionId, openPath) : null;
+  const mtime = fileData ? new Date(fileData.mtime * 1000).toLocaleString() : null;
+
+  if (!open || typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="wp-panel-backdrop"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="wp-panel-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Workspace files"
+      >
+        <div className="wp-panel-header">
+          <div className="wp-panel-title">
+            <span>Workspace files</span>
+            {root ? (
+              <span className="wp-panel-cwd" title={root.worktreePath ?? root.cwd}>
+                {root.worktreePath ?? root.cwd}
+              </span>
+            ) : null}
+          </div>
+          <div className="wp-panel-mobile-toggle">
+            <button
+              type="button"
+              className={`wp-toggle-btn${mobileView === "tree" ? " active" : ""}`}
+              onClick={() => setMobileView("tree")}
+            >
+              Tree
+            </button>
+            <button
+              type="button"
+              className={`wp-toggle-btn${mobileView === "preview" ? " active" : ""}`}
+              onClick={() => setMobileView("preview")}
+            >
+              Preview
+            </button>
+          </div>
+          <button
+            type="button"
+            className="wp-panel-close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="wp-panel-body">
+          <div className={`wp-tree-pane${mobileView === "preview" ? " wp-mobile-hidden" : ""}`}>
+            {recentPaths.length > 0 ? (
+              <div className="wp-recent">
+                <p className="wp-recent-label">Recently written</p>
+                <ul className="wp-recent-list">
+                  {recentPaths.slice(0, 10).map((p) => (
+                    <li key={p}>
+                      <button
+                        type="button"
+                        className={`wp-recent-item${openPath === p ? " selected" : ""}`}
+                        title={p}
+                        onClick={() => void handleSelectFile(p)}
+                      >
+                        {p.split("/").pop() ?? p}
+                        <span className="wp-recent-full">{p}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ) : null}
+            <div className="wp-tree-scroll">
+              <WorkspaceTree
+                host={host}
+                token={token}
+                sessionId={sessionId}
+                selectedPath={openPath}
+                onSelectFile={handleSelectFile}
+                onRootLoaded={setRoot}
+              />
+            </div>
+          </div>
+
+          <div className={`wp-preview-pane${mobileView === "tree" ? " wp-mobile-hidden" : ""}`}>
+            {openPath ? (
+              <>
+                <div className="wp-preview-header">
+                  <span className="wp-preview-path" title={openPath}>
+                    {openPath}
+                  </span>
+                  <div className="wp-preview-actions">
+                    {fileData ? (
+                      <span className="wp-preview-meta">
+                        {formatBytes(fileData.size)} · {mtime}
+                      </span>
+                    ) : null}
+                    <button
+                      type="button"
+                      className="wp-preview-btn"
+                      onClick={copyPath}
+                      title="Copy path"
+                    >
+                      Copy path
+                    </button>
+                    {fileData?.content ? (
+                      <button
+                        type="button"
+                        className="wp-preview-btn"
+                        onClick={copyContents}
+                        title="Copy contents"
+                      >
+                        Copy contents
+                      </button>
+                    ) : null}
+                    {rawUrl ? (
+                      <a
+                        href={rawUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="wp-preview-btn"
+                        title="Open raw"
+                      >
+                        Open raw ↗
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+                <div className="wp-preview-body">
+                  {fileLoading ? (
+                    <div className="wp-preview-loading">Loading…</div>
+                  ) : fileError ? (
+                    <div className="wp-preview-error">{fileError}</div>
+                  ) : fileData ? (
+                    <FilePreview file={fileData} rawUrl={rawUrl ?? ""} />
+                  ) : null}
+                </div>
+              </>
+            ) : (
+              <div className="wp-preview-empty">Select a file to preview</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -12,6 +12,7 @@ import {
 import { formatBytes } from "@/components/AttachmentTray";
 import { FilePreview } from "@/components/FilePreview";
 import { WorkspaceTree } from "@/components/WorkspaceTree";
+import { copyText } from "@/lib/clipboard";
 
 interface WorkspaceFilesPanelProps {
   host: string;
@@ -102,12 +103,12 @@ export function WorkspaceFilesPanel({
 
   const copyPath = useCallback(() => {
     if (!openPath) return;
-    navigator.clipboard.writeText(openPath).catch(() => {});
+    void copyText(openPath);
   }, [openPath]);
 
   const copyContents = useCallback(() => {
     if (fileData?.content) {
-      navigator.clipboard.writeText(fileData.content).catch(() => {});
+      void copyText(fileData.content);
     }
   }, [fileData]);
 

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  fetchWorkspaceTree,
+  type WorkspaceTreeEntry,
+  type WorkspaceTreePage,
+} from "@/lib/api";
+import { FileIcon, FolderIcon } from "@/components/AttachmentTray";
+
+interface DirState {
+  entries: WorkspaceTreeEntry[];
+  overflow: number | null;
+  loading: boolean;
+  error: string | null;
+}
+
+function sortEntries(entries: WorkspaceTreeEntry[]): WorkspaceTreeEntry[] {
+  return [...entries].sort((a, b) => {
+    if (a.kind === "dir" && b.kind !== "dir") return -1;
+    if (a.kind !== "dir" && b.kind === "dir") return 1;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+interface WorkspaceTreeProps {
+  host: string;
+  token: string;
+  sessionId: string;
+  selectedPath: string | null;
+  onSelectFile: (path: string) => void;
+  onRootLoaded?: (root: WorkspaceTreePage["root"]) => void;
+}
+
+export function WorkspaceTree({
+  host,
+  token,
+  sessionId,
+  selectedPath,
+  onSelectFile,
+  onRootLoaded,
+}: WorkspaceTreeProps) {
+  const [dirCache, setDirCache] = useState<Map<string, DirState>>(new Map());
+  const [expanded, setExpanded] = useState<Set<string>>(new Set([""]));
+  const onRootLoadedRef = useRef(onRootLoaded);
+  onRootLoadedRef.current = onRootLoaded;
+
+  const fetchDir = useCallback(
+    async (dirPath: string) => {
+      setDirCache((prev) => {
+        const next = new Map(prev);
+        next.set(dirPath, { entries: [], overflow: null, loading: true, error: null });
+        return next;
+      });
+      try {
+        const page = await fetchWorkspaceTree(host, token, sessionId, dirPath);
+        if (dirPath === "") {
+          onRootLoadedRef.current?.(page.root);
+        }
+        setDirCache((prev) => {
+          const next = new Map(prev);
+          next.set(dirPath, {
+            entries: sortEntries(page.entries),
+            overflow: page.overflow,
+            loading: false,
+            error: null,
+          });
+          return next;
+        });
+      } catch (e) {
+        setDirCache((prev) => {
+          const next = new Map(prev);
+          next.set(dirPath, {
+            entries: [],
+            overflow: null,
+            loading: false,
+            error: e instanceof Error ? e.message : "Failed to load",
+          });
+          return next;
+        });
+      }
+    },
+    [host, token, sessionId],
+  );
+
+  useEffect(() => {
+    setDirCache(new Map());
+    setExpanded(new Set([""]));
+    void fetchDir("");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [host, token, sessionId]);
+
+  const toggleDir = useCallback(
+    (dirPath: string) => {
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(dirPath)) {
+          next.delete(dirPath);
+        } else {
+          next.add(dirPath);
+          if (!dirCache.has(dirPath)) {
+            void fetchDir(dirPath);
+          }
+        }
+        return next;
+      });
+    },
+    [dirCache, fetchDir],
+  );
+
+  const rootState = dirCache.get("");
+  if (!rootState || rootState.loading) {
+    return <div className="wp-tree-loading">Loading…</div>;
+  }
+  if (rootState.error) {
+    return <div className="wp-tree-error">{rootState.error}</div>;
+  }
+
+  return (
+    <ul className="wp-tree-root" role="tree">
+      {rootState.entries.map((entry) => (
+        <TreeNode
+          key={entry.name}
+          entry={entry}
+          parentPath=""
+          depth={0}
+          dirCache={dirCache}
+          expanded={expanded}
+          selectedPath={selectedPath}
+          onSelectFile={onSelectFile}
+          onToggleDir={toggleDir}
+          onFetchDir={fetchDir}
+        />
+      ))}
+      {rootState.overflow ? (
+        <li className="wp-tree-overflow">+{rootState.overflow} more</li>
+      ) : null}
+    </ul>
+  );
+}
+
+function TreeNode({
+  entry,
+  parentPath,
+  depth,
+  dirCache,
+  expanded,
+  selectedPath,
+  onSelectFile,
+  onToggleDir,
+}: {
+  entry: WorkspaceTreeEntry;
+  parentPath: string;
+  depth: number;
+  dirCache: Map<string, DirState>;
+  expanded: Set<string>;
+  selectedPath: string | null;
+  onSelectFile: (path: string) => void;
+  onToggleDir: (dirPath: string) => void;
+  onFetchDir: (dirPath: string) => void;
+}) {
+  const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
+  const isDir = entry.kind === "dir";
+  const isExpanded = expanded.has(fullPath);
+  const dirState = isDir ? dirCache.get(fullPath) : undefined;
+  const isSelected = !isDir && selectedPath === fullPath;
+
+  return (
+    <li
+      role="treeitem"
+      aria-expanded={isDir ? isExpanded : undefined}
+      aria-selected={isSelected}
+      style={{ "--depth": depth } as CSSProperties}
+    >
+      <button
+        type="button"
+        className={`wp-tree-node${isSelected ? " selected" : ""}${isDir ? " is-dir" : ""}`}
+        onClick={() => {
+          if (isDir) {
+            onToggleDir(fullPath);
+          } else {
+            onSelectFile(fullPath);
+          }
+        }}
+      >
+        <span className="wp-tree-indent" style={{ width: `${depth * 16}px` }} />
+        <span className="wp-tree-toggle" aria-hidden="true">
+          {isDir ? (isExpanded ? "▾" : "▸") : ""}
+        </span>
+        <span className="wp-tree-icon" aria-hidden="true">
+          {isDir ? <FolderIcon /> : <FileIcon />}
+        </span>
+        <span className="wp-tree-name">{entry.name}</span>
+      </button>
+      {isDir && isExpanded ? (
+        <ul role="group">
+          {dirState?.loading ? (
+            <li
+              className="wp-tree-loading-child"
+              style={{ "--depth": depth + 1 } as CSSProperties}
+            >
+              Loading…
+            </li>
+          ) : dirState?.error ? (
+            <li
+              className="wp-tree-error-child"
+              style={{ "--depth": depth + 1 } as CSSProperties}
+            >
+              {dirState.error}
+            </li>
+          ) : dirState ? (
+            <>
+              {dirState.entries.map((child) => (
+                <TreeNode
+                  key={child.name}
+                  entry={child}
+                  parentPath={fullPath}
+                  depth={depth + 1}
+                  dirCache={dirCache}
+                  expanded={expanded}
+                  selectedPath={selectedPath}
+                  onSelectFile={onSelectFile}
+                  onToggleDir={onToggleDir}
+                  onFetchDir={() => {}}
+                />
+              ))}
+              {dirState.overflow ? (
+                <li
+                  className="wp-tree-overflow"
+                  style={{ "--depth": depth + 1 } as CSSProperties}
+                >
+                  +{dirState.overflow} more
+                </li>
+              ) : null}
+            </>
+          ) : null}
+        </ul>
+      ) : null}
+    </li>
+  );
+}

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -130,7 +130,6 @@ export function WorkspaceTree({
           selectedPath={selectedPath}
           onSelectFile={onSelectFile}
           onToggleDir={toggleDir}
-          onFetchDir={fetchDir}
         />
       ))}
       {rootState.overflow ? (
@@ -158,7 +157,6 @@ function TreeNode({
   selectedPath: string | null;
   onSelectFile: (path: string) => void;
   onToggleDir: (dirPath: string) => void;
-  onFetchDir: (dirPath: string) => void;
 }) {
   const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
   const isDir = entry.kind === "dir";
@@ -222,7 +220,6 @@ function TreeNode({
                   selectedPath={selectedPath}
                   onSelectFile={onSelectFile}
                   onToggleDir={onToggleDir}
-                  onFetchDir={() => {}}
                 />
               ))}
               {dirState.overflow ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -855,6 +855,92 @@ export async function deleteAttachment(
   }
 }
 
+export interface WorkspaceTreeEntry {
+  name: string;
+  kind: "file" | "dir" | "symlink";
+  size: number;
+  mtime: number;
+}
+
+export interface WorkspaceTreePage {
+  root: { cwd: string; worktreePath: string | null };
+  path: string;
+  entries: WorkspaceTreeEntry[];
+  truncated: boolean;
+  overflow: number | null;
+}
+
+export interface WorkspaceFile {
+  path: string;
+  size: number;
+  mtime: number;
+  truncated: boolean;
+  binary: boolean;
+  content: string | null;
+  encoding?: string;
+}
+
+export async function fetchWorkspaceTree(
+  host: string,
+  token: string,
+  sessionId: string,
+  relPath = "",
+): Promise<WorkspaceTreePage> {
+  const params = new URLSearchParams();
+  if (relPath) params.set("path", relPath);
+  const suffix = params.size ? `?${params.toString()}` : "";
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/workspace/tree${suffix}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch workspace tree");
+  const payload = await response.json();
+  const rootRaw = payload.root ?? {};
+  return {
+    root: {
+      cwd: typeof rootRaw.cwd === "string" ? rootRaw.cwd : "",
+      worktreePath: typeof rootRaw.worktree_path === "string" ? rootRaw.worktree_path : null,
+    },
+    path: typeof payload.path === "string" ? payload.path : "",
+    entries: Array.isArray(payload.entries) ? (payload.entries as WorkspaceTreeEntry[]) : [],
+    truncated: Boolean(payload.truncated),
+    overflow: typeof payload.overflow === "number" ? payload.overflow : null,
+  };
+}
+
+export async function fetchWorkspaceFile(
+  host: string,
+  token: string,
+  sessionId: string,
+  relPath: string,
+): Promise<WorkspaceFile> {
+  const params = new URLSearchParams({ path: relPath });
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/workspace/file?${params.toString()}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch workspace file");
+  return (await response.json()) as WorkspaceFile;
+}
+
+// Authenticated URL for a workspace file served inline (used by <img> and
+// "Open raw" links). Token rides as a query param — same pattern as
+// attachmentUrl — because <img>/<a> cannot send an Authorization header.
+export function workspaceRawUrl(
+  host: string,
+  token: string,
+  sessionId: string,
+  relPath: string,
+): string {
+  return `${host}/api/sessions/${sessionId}/workspace/file?path=${encodeURIComponent(relPath)}&raw=1&token=${encodeURIComponent(token)}`;
+}
+
 // Authenticated URL for an uploaded attachment. The token rides as a query
 // param because <img>/<a> can't send an Authorization header (mirrors the
 // WebSocket endpoints).


### PR DESCRIPTION
## Summary

The chat window could only ever preview a file the agent had explicitly surfaced — a plan file, or the inline diff of an edit. There was no way to look at an arbitrary file the agent wrote somewhere under its working directory, even though that is a common need: dropping a note or document outside `~/.claude` for a *different* agent to pick up, and then wanting to read it back without SSHing in. This adds a workspace file preview — a lazy directory explorer plus a file viewer — rooted at the session's working tree, reachable from a dedicated button in the composer and from any file path shown in a tool call or diff.

This is the last open item on #31 (Local File Preview/Explorer).

The backend reads from its own filesystem the same way the diff-preview pipeline already does, so it is gated to **local sessions only** — remote (SSH launch-target) sessions return a 400 and the UI hides the entry points. All reads are confined to the session's `cwd`/`worktree_path` by a path guard that blocks `..` traversal and symlink escapes, denies dotfiles/dot-dirs (`.git`, `.claude`, `.env`, `.ssh`, …) by default, caps file size, and refuses to inline binary content.

User-visible outcomes:

1. **A "Browse workspace" button opens a file explorer.** A folder button sits beside the paperclip in the composer (plus a "Browse workspace…" overflow item), opening a panel with a lazy directory tree on the left and a file preview on the right. It is gated to local sessions and is independent of the attachments feature.
2. **Recently written files are one click away.** The panel leads with a "Recently written in this session" list, derived from the applied file-diffs already in the transcript — so the document the agent just wrote for the next agent is immediately reachable.
3. **File paths in the transcript are clickable.** Paths shown in tool-call and diff blocks open the preview focused on that file.
4. **The preview renders by type.** Text/code shows in a monospace view with line numbers and a soft-wrap toggle; Markdown gets a Rendered/Source toggle; images render inline; binary or over-cap files show a placeholder with an "Open raw" link.

## Changes

### Backend

- **`workspace_preview.py`** (new) — pure, FastAPI-free helpers: `resolve_in_base` (realpath + `is_relative_to` containment check, plus per-component symlink rejection when `workspace_follow_symlinks` is off), `is_denied` (leading-dot rule + glob denylist), `sniff_text`, `read_text_capped` (returns a `content=None` placeholder for over-cap/binary), and `list_dir` (one level, dirs-first, denylist-filtered, capped with an overflow count).
- **`api.py`** — `GET /api/sessions/{id}/workspace/tree` and `/workspace/file`, both behind `token_dependency()`, plus a `?raw=1&token=` variant that streams the file inline via `FileResponse` for `<img>` (a faithful copy of `serve_attachment`'s query-token auth). Each route resolves the base from `session.worktree_path or session.cwd`, returns 400 for remote sessions, 404 when the feature is disabled, and maps the guard's errors to 403/404.
- **`settings.py`** — `workspace_preview_enabled`, `workspace_max_file_bytes` (200 KB), `workspace_denylist`, and `workspace_follow_symlinks`, each wired into `_env_overrides()` under `WAYPOINT_WORKSPACE_*`.
- **`tests/test_workspace_preview.py`** (new) — unit tests over the helpers: dirs-first ordering, overflow cap, `..` traversal and symlink-escape rejection, dotfile/denylist denial, size-cap and binary placeholders.

### Frontend

- **`components/WorkspaceFilesPanel.tsx`**, **`WorkspaceTree.tsx`**, **`FilePreview.tsx`** (new) — the panel reuses the `SessionFilesPanel` portal shell (backdrop `onPointerDown`, Escape, `role="dialog"`) at a wider size with a responsive tree↔preview toggle for phones; the tree fetches one level per expand; the preview switches on type (code with line numbers + wrap toggle, Markdown via `MarkdownMessage`, inline image, binary/over-cap placeholder).
- **`components/SessionDetail.tsx`** — owns `workspaceOpen`/`workspaceInitialPath`; adds the folder button and overflow item gated on a local-only `workspacePreviewEnabled` flag (`!session.launch_target_id`); computes the "recently written" list from `diff_preview` events whose phase is `applied` (backend-agnostic — not keyed on tool names); threads an open-file callback into the transcript.
- **`components/DiffPreview.tsx`**, **`TranscriptCard.tsx`** — file paths become clickable buttons that open the preview at that path.
- **`components/AttachmentTray.tsx`** — adds a `FolderIcon`; the new UI reuses the existing `formatBytes`/`FileIcon` helpers.
- **`lib/api.ts`** — `fetchWorkspaceTree`, `fetchWorkspaceFile`, and `workspaceRawUrl` (query-token URL for images), with matching types.
- **`app/globals.css`** — a `Workspace preview` section built on the existing theme variables, with co-located `html[data-theme="light"]` overrides for the hardcoded dark surfaces.

## Test Plan

- [x] `cd backend && uv run pytest tests/test_workspace_preview.py` — 8 passed.
- [x] `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- [x] `cd frontend && npm run lint && npm run build` — clean, `/session/[id]` builds.
- [x] Live, after restarting the stack: against a local session, `tree` lists the root dirs-first with dotdirs excluded and navigates into subdirs; `file` returns text with metadata. `..` traversal, a dotfile, and a dotdir all return **403**; a missing file **404**; an unauthenticated request **401**; an absolute path *inside* the workspace resolves correctly. A 268 KB file returns `truncated` with `content: null`; a `.ico` returns `binary` with `content: null`; `?raw=1&token=` streams it with the right content-type and rejects a bad token with **401**.
- Note: the frontend has no automated test harness in this repo, so UI verification is lint + build + the live endpoint checks above.

Addresses #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)