### PR TITLE
feat: open transcript filesystem paths in the workspace panel

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -497,6 +497,41 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "content": content,
         }
 
+    @app.get("/api/sessions/{session_id}/workspace/resolve")
+    async def workspace_resolve(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        path: Annotated[str, Query()] = "",
+    ) -> Any:
+        # ``path`` may be absolute or base-relative; both must resolve inside the
+        # workspace. Used by the transcript to turn an agent-printed filesystem
+        # path into a canonical relative path plus its kind, so the frontend can
+        # open a file preview or reveal a directory in the tree.
+        session = _workspace_session(session_id)
+        base = Path(session.worktree_path or session.cwd)
+        try:
+            if is_denied(path, context.settings.workspace_denylist):
+                raise WorkspacePathError("path is denied")
+            resolved = resolve_in_base(
+                base,
+                path,
+                follow_symlinks=context.settings.workspace_follow_symlinks,
+            )
+            if not resolved.exists():
+                raise FileNotFoundError(resolved)
+        except WorkspacePathError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="workspace path denied"
+            ) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="workspace path not found"
+            ) from exc
+        return {
+            "path": relative_to_base(base, resolved),
+            "kind": "dir" if resolved.is_dir() else "file",
+        }
+
     @app.delete("/api/sessions/{session_id}/attachments/{attachment_id}")
     async def delete_attachment(
         session_id: str,

--- a/backend/tests/test_workspace_api.py
+++ b/backend/tests/test_workspace_api.py
@@ -159,6 +159,88 @@ async def test_raw_validates_query_token(tmp_path: Path) -> None:
     assert good.text == "hello"
 
 
+async def test_resolve_relative_file(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": "notes.md"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"path": "notes.md", "kind": "file"}
+
+
+async def test_resolve_absolute_path_within_base(tmp_path: Path) -> None:
+    # The transcript hands the backend the agent-printed absolute path verbatim;
+    # it must resolve to the same canonical relative path as the bare name.
+    app, token = _build(tmp_path)
+    absolute = str(tmp_path / "ws" / "notes.md")
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": absolute},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"path": "notes.md", "kind": "file"}
+
+
+async def test_resolve_directory(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    (tmp_path / "ws" / "docs").mkdir()
+    headers = {"Authorization": f"Bearer {token}"}
+    async with _client(app) as client:
+        rel = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": "docs"},
+            headers=headers,
+        )
+        absolute = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": str(tmp_path / "ws" / "docs")},
+            headers=headers,
+        )
+    assert rel.json() == {"path": "docs", "kind": "dir"}
+    assert absolute.json() == {"path": "docs", "kind": "dir"}
+
+
+async def test_resolve_outside_base_is_rejected(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    headers = {"Authorization": f"Bearer {token}"}
+    async with _client(app) as client:
+        absolute = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": "/etc/passwd"},
+            headers=headers,
+        )
+        relative = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": "../../../../etc/passwd"},
+            headers=headers,
+        )
+        denied = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": ".git/config"},
+            headers=headers,
+        )
+        denied_absolute = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": str(tmp_path / "ws" / ".git" / "config")},
+            headers=headers,
+        )
+        missing = await client.get(
+            "/api/sessions/s1/workspace/resolve",
+            params={"path": "nope.txt"},
+            headers=headers,
+        )
+    assert absolute.status_code == 403
+    assert relative.status_code == 403
+    assert denied.status_code == 403
+    assert denied_absolute.status_code == 403  # denylist runs on the raw absolute path
+    assert missing.status_code == 404
+
+
 async def test_empty_denylist_disables_filtering(tmp_path: Path) -> None:
     app, token = _build(tmp_path, settings_kw={"workspace_denylist": []})
     async with _client(app) as client:

--- a/frontend/src/components/MarkdownMessage.tsx
+++ b/frontend/src/components/MarkdownMessage.tsx
@@ -4,6 +4,9 @@ import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
+import { useWorkspaceFileLink } from "@/components/WorkspaceFileLinkContext";
+import { isWorkspacePathHref, remarkLinkifyPaths } from "@/lib/workspacePaths";
+
 interface MarkdownMessageProps {
   text: string;
 }
@@ -11,16 +14,48 @@ interface MarkdownMessageProps {
 // Hoisted to module scope so the plugin array and component overrides keep a
 // stable identity across renders — combined with the memo() below, an
 // unchanged `text` skips the remark parse entirely during streaming.
-const REMARK_PLUGINS = [remarkGfm, remarkBreaks];
+const REMARK_PLUGINS = [remarkGfm, remarkBreaks, remarkLinkifyPaths];
 
-const COMPONENTS: Components = {
-  a({ href, children, ...props }) {
+function MarkdownAnchor({
+  href,
+  children,
+  ...props
+}: ComponentPropsWithoutRef<"a">) {
+  const link = useWorkspaceFileLink();
+  const fromBareText = props["data-wp-bare" as keyof typeof props] === "true";
+  if (link && isWorkspacePathHref(href)) {
     return (
-      <a href={href} rel="noreferrer" target="_blank" {...props}>
+      <a
+        href={href}
+        onClick={(e) => {
+          // Leave modified clicks (new tab/window) and non-primary buttons to
+          // the browser; intercept only a plain left click.
+          if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+            return;
+          }
+          e.preventDefault();
+          link.openWorkspacePath(href as string, { fromBareText });
+        }}
+        {...props}
+      >
         {children}
       </a>
     );
-  },
+  }
+  // A path we synthesized from prose but have nowhere to open (no session
+  // context): render plain text rather than a dead navigation.
+  if (fromBareText && isWorkspacePathHref(href)) {
+    return <span>{children}</span>;
+  }
+  return (
+    <a href={href} rel="noreferrer" target="_blank" {...props}>
+      {children}
+    </a>
+  );
+}
+
+const COMPONENTS: Components = {
+  a: MarkdownAnchor,
   code({
     inline,
     className,

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -31,6 +31,7 @@ import {
   isAuthError,
   postAction,
   refreshSessionRateLimitUsage,
+  resolveWorkspacePath,
   sendInput,
   setSessionEffort,
   setSessionModel,
@@ -85,6 +86,10 @@ import {
 } from "@/components/AttachmentTray";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { WorkspaceFilesPanel } from "@/components/WorkspaceFilesPanel";
+import {
+  WorkspaceFileLinkProvider,
+  type WorkspaceLinkHandler,
+} from "@/components/WorkspaceFileLinkContext";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -311,6 +316,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [events, setEvents] = useState<EventRecord[]>([]);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | undefined>(undefined);
+  const [workspaceInitialDir, setWorkspaceInitialDir] = useState<string | undefined>(undefined);
+  // Bumped on every open request so the panel re-reveals even when the target
+  // path is unchanged; the ref is the source of truth for discarding the
+  // results of out-of-order resolve() calls.
+  const [workspaceRevealSeq, setWorkspaceRevealSeq] = useState(0);
+  const workspaceRequestRef = useRef(0);
   // The todo-event sequence the user last dismissed from the progress dock.
   // `undefined` means we haven't read the persisted value yet — the dock stays
   // hidden until then so a dismissed dock doesn't flash on load (and to avoid
@@ -1641,11 +1652,47 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     void runAction("resume");
   }, [runAction]);
   const handleOpenWorkspaceFile = useCallback((path: string) => {
+    const seq = ++workspaceRequestRef.current;
+    setWorkspaceInitialDir(undefined);
     setWorkspaceInitialPath(path);
+    setWorkspaceRevealSeq(seq);
     setWorkspaceOpen(true);
   }, []);
+  // Route a clicked transcript path (absolute or ~/-relative) through the
+  // backend resolver: files open the preview, directories reveal the tree. If
+  // it resolves to nothing in the workspace, explicit links degrade to opening
+  // in a new tab while synthesized bare-path links stay inert.
+  const openWorkspacePath = useCallback(
+    async (href: string, opts?: { fromBareText?: boolean }) => {
+      const seq = ++workspaceRequestRef.current;
+      try {
+        const resolved = await resolveWorkspacePath(host, token, sessionId, href);
+        if (workspaceRequestRef.current !== seq) return; // superseded by a newer click
+        if (resolved.kind === "dir") {
+          setWorkspaceInitialPath(undefined);
+          setWorkspaceInitialDir(resolved.path);
+        } else {
+          setWorkspaceInitialDir(undefined);
+          setWorkspaceInitialPath(resolved.path);
+        }
+        setWorkspaceRevealSeq(seq);
+        setWorkspaceOpen(true);
+      } catch {
+        if (workspaceRequestRef.current !== seq) return;
+        if (!opts?.fromBareText) {
+          window.open(href, "_blank", "noopener,noreferrer");
+        }
+      }
+    },
+    [host, token, sessionId],
+  );
+  const workspaceLink = useMemo<WorkspaceLinkHandler | null>(
+    () => (workspacePreviewEnabled ? { openWorkspacePath } : null),
+    [workspacePreviewEnabled, openWorkspacePath],
+  );
 
   return (
+    <WorkspaceFileLinkProvider value={workspaceLink}>
     <section className="stack" ref={sectionRef}>
       {!terminalOnly && activeView === "chat" && showScrollToTop ? (
         <div className="scroll-top-floater" aria-hidden={false}>
@@ -2173,6 +2220,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           workspacePreviewEnabled={workspacePreviewEnabled}
           onBrowseWorkspace={() => {
             setWorkspaceInitialPath(undefined);
+            setWorkspaceInitialDir(undefined);
+            setWorkspaceRevealSeq(++workspaceRequestRef.current);
             setWorkspaceOpen(true);
           }}
         />
@@ -2184,11 +2233,14 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           sessionId={sessionId}
           open={workspaceOpen}
           initialPath={workspaceInitialPath}
+          initialDir={workspaceInitialDir}
+          revealSeq={workspaceRevealSeq}
           recentPaths={recentPaths}
           onClose={() => setWorkspaceOpen(false)}
         />
       ) : null}
     </section>
+    </WorkspaceFileLinkProvider>
   );
 }
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1677,14 +1677,18 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         }
         setWorkspaceRevealSeq(seq);
         setWorkspaceOpen(true);
-      } catch {
+      } catch (e) {
         if (workspaceRequestRef.current !== seq) return;
+        if (isAuthError(e)) {
+          handleAuthFailure();
+          return;
+        }
         if (!opts?.fromBareText) {
           window.open(href, "_blank", "noopener,noreferrer");
         }
       }
     },
-    [host, token, sessionId],
+    [host, token, sessionId, handleAuthFailure],
   );
   const workspaceLink = useMemo<WorkspaceLinkHandler | null>(
     () => (workspacePreviewEnabled ? { openWorkspacePath } : null),

--- a/frontend/src/components/WorkspaceFileLinkContext.tsx
+++ b/frontend/src/components/WorkspaceFileLinkContext.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+export interface WorkspaceLinkHandler {
+  // `fromBareText` marks a link the transcript synthesized from a bare path in
+  // prose (vs. an explicit markdown link). It controls the fallback when the
+  // path can't be resolved: explicit links open in a new tab, synthesized ones
+  // stay inert so a false-positive match never spawns a junk navigation.
+  openWorkspacePath: (href: string, opts?: { fromBareText?: boolean }) => void;
+}
+
+const WorkspaceFileLinkContext = createContext<WorkspaceLinkHandler | null>(null);
+
+export const WorkspaceFileLinkProvider = WorkspaceFileLinkContext.Provider;
+
+export function useWorkspaceFileLink(): WorkspaceLinkHandler | null {
+  return useContext(WorkspaceFileLinkContext);
+}

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -20,6 +20,8 @@ interface WorkspaceFilesPanelProps {
   sessionId: string;
   open: boolean;
   initialPath?: string;
+  initialDir?: string;
+  revealSeq?: number;
   recentPaths: string[];
   onClose: () => void;
 }
@@ -73,10 +75,13 @@ export function WorkspaceFilesPanel({
   sessionId,
   open,
   initialPath,
+  initialDir,
+  revealSeq,
   recentPaths,
   onClose,
 }: WorkspaceFilesPanelProps) {
   const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
+  const [revealDir, setRevealDir] = useState<string | null>(null);
   const { openPath, openFile, fileData, fileLoading, fileError, root, setRoot, reset } =
     useWorkspacePreview(host, token, sessionId);
 
@@ -85,12 +90,19 @@ export function WorkspaceFilesPanel({
     reset();
     if (initialPath) {
       void openFile(initialPath);
+      setRevealDir(null);
       setMobileView("preview");
+    } else if (initialDir != null) {
+      setRevealDir(initialDir);
+      setMobileView("tree");
     } else {
+      setRevealDir(null);
       setMobileView("tree");
     }
+    // revealSeq is the retrigger knob: it bumps on every open request so an
+    // identical path still re-reveals.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, initialPath]);
+  }, [open, initialPath, initialDir, revealSeq]);
 
   useEffect(() => {
     if (!open) return;
@@ -201,6 +213,8 @@ export function WorkspaceFilesPanel({
                 token={token}
                 sessionId={sessionId}
                 selectedPath={openPath}
+                revealPath={revealDir}
+                revealSeq={revealSeq}
                 onSelectFile={handleSelectFile}
                 onRootLoaded={setRoot}
               />

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -29,6 +29,8 @@ interface WorkspaceTreeProps {
   token: string;
   sessionId: string;
   selectedPath: string | null;
+  revealPath?: string | null;
+  revealSeq?: number;
   onSelectFile: (path: string) => void;
   onRootLoaded?: (root: WorkspaceTreePage["root"]) => void;
 }
@@ -38,13 +40,26 @@ export function WorkspaceTree({
   token,
   sessionId,
   selectedPath,
+  revealPath,
+  revealSeq,
   onSelectFile,
   onRootLoaded,
 }: WorkspaceTreeProps) {
   const [dirCache, setDirCache] = useState<Map<string, DirState>>(new Map());
   const [expanded, setExpanded] = useState<Set<string>>(new Set([""]));
+  // The directory currently highlighted by a reveal. Cleared on the next user
+  // interaction so the highlight doesn't outlive its purpose.
+  const [activeReveal, setActiveReveal] = useState<string | null>(null);
   const onRootLoadedRef = useRef(onRootLoaded);
   onRootLoadedRef.current = onRootLoaded;
+
+  const selectFile = useCallback(
+    (path: string) => {
+      setActiveReveal(null);
+      onSelectFile(path);
+    },
+    [onSelectFile],
+  );
 
   const fetchDir = useCallback(
     async (dirPath: string) => {
@@ -91,8 +106,39 @@ export function WorkspaceTree({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [host, token, sessionId]);
 
+  // Reveal a directory: expand its full ancestor chain (lazy-fetching any dir
+  // not yet cached) so the target node renders, then it scrolls itself into
+  // view (see TreeNode).
+  useEffect(() => {
+    if (revealPath == null || revealPath === "") {
+      setActiveReveal(null);
+      return;
+    }
+    const parts = revealPath.split("/").filter(Boolean);
+    // Ancestor dirs to expand, plus the target itself. The root ("") is always
+    // fetched by the session-reset effect, so it's excluded from the chain.
+    const chain: string[] = [];
+    let acc = "";
+    for (const part of parts) {
+      acc = acc ? `${acc}/${part}` : part;
+      chain.push(acc);
+    }
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      for (const dir of chain) next.add(dir);
+      return next;
+    });
+    for (const dir of chain) {
+      if (!dirCache.has(dir)) void fetchDir(dir);
+    }
+    setActiveReveal(revealPath);
+    // revealSeq lets an unchanged revealPath re-trigger a reveal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [revealPath, revealSeq]);
+
   const toggleDir = useCallback(
     (dirPath: string) => {
+      setActiveReveal(null);
       setExpanded((prev) => {
         const next = new Set(prev);
         if (next.has(dirPath)) {
@@ -128,7 +174,8 @@ export function WorkspaceTree({
           dirCache={dirCache}
           expanded={expanded}
           selectedPath={selectedPath}
-          onSelectFile={onSelectFile}
+          revealTarget={activeReveal}
+          onSelectFile={selectFile}
           onToggleDir={toggleDir}
         />
       ))}
@@ -146,6 +193,7 @@ function TreeNode({
   dirCache,
   expanded,
   selectedPath,
+  revealTarget,
   onSelectFile,
   onToggleDir,
 }: {
@@ -155,6 +203,7 @@ function TreeNode({
   dirCache: Map<string, DirState>;
   expanded: Set<string>;
   selectedPath: string | null;
+  revealTarget: string | null;
   onSelectFile: (path: string) => void;
   onToggleDir: (dirPath: string) => void;
 }) {
@@ -163,6 +212,14 @@ function TreeNode({
   const isExpanded = expanded.has(fullPath);
   const dirState = isDir ? dirCache.get(fullPath) : undefined;
   const isSelected = !isDir && selectedPath === fullPath;
+  const isRevealed = revealTarget != null && revealTarget === fullPath;
+  const nodeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isRevealed) {
+      nodeRef.current?.scrollIntoView({ block: "center" });
+    }
+  }, [isRevealed]);
 
   return (
     <li
@@ -172,8 +229,9 @@ function TreeNode({
       style={{ "--depth": depth } as CSSProperties}
     >
       <button
+        ref={nodeRef}
         type="button"
-        className={`wp-tree-node${isSelected ? " selected" : ""}${isDir ? " is-dir" : ""}`}
+        className={`wp-tree-node${isSelected || isRevealed ? " selected" : ""}${isDir ? " is-dir" : ""}`}
         onClick={() => {
           if (isDir) {
             onToggleDir(fullPath);
@@ -218,6 +276,7 @@ function TreeNode({
                   dirCache={dirCache}
                   expanded={expanded}
                   selectedPath={selectedPath}
+                  revealTarget={revealTarget}
                   onSelectFile={onSelectFile}
                   onToggleDir={onToggleDir}
                 />

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -175,6 +175,7 @@ export function WorkspaceTree({
           expanded={expanded}
           selectedPath={selectedPath}
           revealTarget={activeReveal}
+          revealSeq={revealSeq}
           onSelectFile={selectFile}
           onToggleDir={toggleDir}
         />
@@ -194,6 +195,7 @@ function TreeNode({
   expanded,
   selectedPath,
   revealTarget,
+  revealSeq,
   onSelectFile,
   onToggleDir,
 }: {
@@ -204,6 +206,7 @@ function TreeNode({
   expanded: Set<string>;
   selectedPath: string | null;
   revealTarget: string | null;
+  revealSeq?: number;
   onSelectFile: (path: string) => void;
   onToggleDir: (dirPath: string) => void;
 }) {
@@ -215,11 +218,13 @@ function TreeNode({
   const isRevealed = revealTarget != null && revealTarget === fullPath;
   const nodeRef = useRef<HTMLButtonElement>(null);
 
+  // revealSeq is in the deps so a repeat reveal of the same (already-revealed)
+  // node re-scrolls it into view even though `isRevealed` stays true.
   useEffect(() => {
     if (isRevealed) {
       nodeRef.current?.scrollIntoView({ block: "center" });
     }
-  }, [isRevealed]);
+  }, [isRevealed, revealSeq]);
 
   return (
     <li
@@ -277,6 +282,7 @@ function TreeNode({
                   expanded={expanded}
                   selectedPath={selectedPath}
                   revealTarget={revealTarget}
+                  revealSeq={revealSeq}
                   onSelectFile={onSelectFile}
                   onToggleDir={onToggleDir}
                 />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -911,6 +911,37 @@ export async function fetchWorkspaceTree(
   };
 }
 
+export interface WorkspaceResolve {
+  path: string;
+  kind: "file" | "dir";
+}
+
+// Resolve an absolute or base-relative path to its canonical workspace-relative
+// path and kind. Used to turn an agent-printed filesystem path in the transcript
+// into something the preview/tree can open. Rejects (throws) paths outside the
+// workspace or on the denylist.
+export async function resolveWorkspacePath(
+  host: string,
+  token: string,
+  sessionId: string,
+  path: string,
+): Promise<WorkspaceResolve> {
+  const params = new URLSearchParams({ path });
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/workspace/resolve?${params.toString()}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to resolve workspace path");
+  const payload = await response.json();
+  return {
+    path: typeof payload.path === "string" ? payload.path : "",
+    kind: payload.kind === "dir" ? "dir" : "file",
+  };
+}
+
 export async function fetchWorkspaceFile(
   host: string,
   token: string,

--- a/frontend/src/lib/workspacePaths.ts
+++ b/frontend/src/lib/workspacePaths.ts
@@ -1,0 +1,94 @@
+import type { Plugin } from "unified";
+import type { Node } from "unist";
+
+// Filesystem paths we linkify in prose: explicit-relative (./a, ../a),
+// home-relative (~/a), or absolute with at least two segments (/a/b…). The
+// leading lookbehind keeps us from starting mid-token — so the "/b" inside
+// "a/b" and the "//" of a protocol-relative URL are both skipped.
+const WORKSPACE_PATH_RE =
+  /(?<![\w~/.])(?:\.\.?\/[^\s)\]}>"'`,;]+(?:\/[^\s)\]}>"'`,;]+)*|~\/[^\s)\]}>"'`,;]+|\/[^\s/)\]}>"'`,;]+(?:\/[^\s)\]}>"'`,;]+)+)/g;
+
+export function isWorkspacePathHref(href: string | undefined | null): boolean {
+  if (!href) return false;
+  if (href.startsWith("#")) return false;
+  if (href.startsWith("//")) return false; // protocol-relative URL
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(href)) return false; // http:, mailto:, data:, …
+  return (
+    href.startsWith("/") ||
+    href.startsWith("~/") ||
+    href.startsWith("./") ||
+    href.startsWith("../")
+  );
+}
+
+export interface WorkspacePathSpan {
+  start: number;
+  end: number;
+  value: string;
+}
+
+export function findWorkspacePaths(text: string): WorkspacePathSpan[] {
+  const spans: WorkspacePathSpan[] = [];
+  const re = new RegExp(WORKSPACE_PATH_RE.source, "g");
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    // Trailing sentence punctuation almost never belongs to a filename.
+    const value = match[0].replace(/[.,;:!?]+$/, "");
+    if (!value) continue;
+    spans.push({ start: match.index, end: match.index + value.length, value });
+  }
+  return spans;
+}
+
+interface MdastNode {
+  type: string;
+  value?: string;
+  url?: string;
+  children?: MdastNode[];
+  data?: { hProperties?: Record<string, string> };
+}
+
+// Linkify bare filesystem paths in prose so the transcript can route a click to
+// the workspace panel. Operating on the mdast (not the raw string) is what lets
+// us leave code spans, fenced code, and already-linked text untouched.
+export const remarkLinkifyPaths: Plugin<[], Node> = () => (tree) => {
+  linkify(tree as unknown as MdastNode);
+};
+
+function linkify(node: MdastNode): void {
+  if (!node.children || node.children.length === 0) return;
+  if (node.type === "link") return; // never linkify inside an existing link
+  const next: MdastNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      next.push(...splitTextNode(child.value));
+    } else {
+      linkify(child);
+      next.push(child);
+    }
+  }
+  node.children = next;
+}
+
+function splitTextNode(text: string): MdastNode[] {
+  const spans = findWorkspacePaths(text);
+  if (spans.length === 0) return [{ type: "text", value: text }];
+  const out: MdastNode[] = [];
+  let cursor = 0;
+  for (const span of spans) {
+    if (span.start > cursor) {
+      out.push({ type: "text", value: text.slice(cursor, span.start) });
+    }
+    out.push({
+      type: "link",
+      url: span.value,
+      data: { hProperties: { "data-wp-bare": "true" } },
+      children: [{ type: "text", value: span.value }],
+    });
+    cursor = span.end;
+  }
+  if (cursor < text.length) {
+    out.push({ type: "text", value: text.slice(cursor) });
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

Clicking a filesystem path in the session transcript now opens the workspace file panel instead of dead-navigating to the raw path. It detects both explicit markdown links (e.g. the absolute paths Claude Code prints) and bare absolute/relative paths in prose; files open the preview and directories reveal in the tree.

## Changes

- Backend: new `GET /api/sessions/{id}/workspace/resolve` returning `{path, kind}` for an absolute-or-base-relative path, reusing the existing `/workspace/file` containment and denylist guards.
- Frontend: path detection plus an mdast linkifier for bare paths (which leaves code spans and existing links untouched), a React context so the shared `MarkdownMessage` renderer can intercept clicks without prop-drilling, and ancestor-expanding directory reveal in the workspace tree. Paths outside the workspace fall back to opening in a new tab for explicit links, or stay inert for synthesized bare-path links.

## Testing

- `cd backend && uv run pytest` (full suite, including new resolve endpoint tests)
- `cd backend && uv run pre-commit run --all-files`
- `cd frontend && npx tsc --noEmit && npm run lint && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)