### PR TITLE
feat: syntax highlighting and refresh controls in workspace preview

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "lowlight": "^3.3.0",
         "next": "^16.2.9",
         "react": "^19.0.0",
         "react-dom": "^19.2.7",
@@ -1114,9 +1115,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1132,9 +1130,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1152,9 +1147,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1170,9 +1162,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3885,6 +3874,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4614,6 +4612,21 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowlight": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
+      "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.0.0",
+        "highlight.js": "~11.11.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/lru-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "lowlight": "^3.3.0",
     "next": "^16.2.9",
     "react": "^19.0.0",
     "react-dom": "^19.2.7",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12197,7 +12197,7 @@ html[data-theme="light"] .wp-code-toolbar {
 }
 
 html[data-theme="light"] .wp-code-pre {
-  --hl-comment: #9a8d78;
+  --hl-comment: #857a66;
   --hl-keyword: #9c3f6e;
   --hl-string: #2f7d4f;
   --hl-number: #8a5410;
@@ -12205,7 +12205,7 @@ html[data-theme="light"] .wp-code-pre {
   --hl-type: #1f7a82;
   --hl-attr: #6b4fa0;
   --hl-variable: #2a261f;
-  --hl-meta: #8a7d68;
+  --hl-meta: #7a6e59;
   --hl-symbol: #2f6f9e;
   --hl-punct: #6e6356;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12124,6 +12124,108 @@ html[data-theme="light"] .wp-code-toolbar {
   overflow-wrap: anywhere;
 }
 
+/* ─── Syntax highlighting (file preview) ─── */
+/* highlight.js token classes, recolored to the app's warm-gold / cool-blue
+   palette rather than a stock theme. Tokens are scoped to .wp-code-pre so the
+   highlighter never bleeds into the transcript. */
+.wp-code-pre {
+  --hl-comment: #6f7a8c;
+  --hl-keyword: #cf98b1;
+  --hl-string: #9cc7a6;
+  --hl-number: #d9a86a;
+  --hl-function: #8fb3d6;
+  --hl-type: #7fbac0;
+  --hl-attr: #bca7d4;
+  --hl-variable: #d7dde6;
+  --hl-meta: #7f8a9c;
+  --hl-symbol: #8fb3d6;
+  --hl-punct: #97a2b3;
+}
+
+html[data-theme="light"] .wp-code-pre {
+  --hl-comment: #9a8d78;
+  --hl-keyword: #9c3f6e;
+  --hl-string: #2f7d4f;
+  --hl-number: #8a5410;
+  --hl-function: #2f6f9e;
+  --hl-type: #1f7a82;
+  --hl-attr: #6b4fa0;
+  --hl-variable: #2a261f;
+  --hl-meta: #8a7d68;
+  --hl-symbol: #2f6f9e;
+  --hl-punct: #6e6356;
+}
+
+.wp-code-pre .hljs-comment,
+.wp-code-pre .hljs-quote {
+  color: var(--hl-comment);
+  font-style: italic;
+}
+.wp-code-pre .hljs-keyword,
+.wp-code-pre .hljs-selector-tag,
+.wp-code-pre .hljs-subst {
+  color: var(--hl-keyword);
+}
+.wp-code-pre .hljs-string,
+.wp-code-pre .hljs-regexp,
+.wp-code-pre .hljs-meta .hljs-string {
+  color: var(--hl-string);
+}
+.wp-code-pre .hljs-number,
+.wp-code-pre .hljs-literal,
+.wp-code-pre .hljs-bullet {
+  color: var(--hl-number);
+}
+.wp-code-pre .hljs-title,
+.wp-code-pre .hljs-title.function_,
+.wp-code-pre .hljs-section,
+.wp-code-pre .hljs-name {
+  color: var(--hl-function);
+}
+.wp-code-pre .hljs-type,
+.wp-code-pre .hljs-built_in,
+.wp-code-pre .hljs-title.class_ {
+  color: var(--hl-type);
+}
+.wp-code-pre .hljs-attr,
+.wp-code-pre .hljs-attribute,
+.wp-code-pre .hljs-property,
+.wp-code-pre .hljs-selector-attr,
+.wp-code-pre .hljs-selector-class,
+.wp-code-pre .hljs-selector-id {
+  color: var(--hl-attr);
+}
+.wp-code-pre .hljs-variable,
+.wp-code-pre .hljs-template-variable {
+  color: var(--hl-variable);
+}
+.wp-code-pre .hljs-meta,
+.wp-code-pre .hljs-doctag {
+  color: var(--hl-meta);
+}
+.wp-code-pre .hljs-symbol,
+.wp-code-pre .hljs-link,
+.wp-code-pre .hljs-params {
+  color: var(--hl-symbol);
+}
+.wp-code-pre .hljs-tag,
+.wp-code-pre .hljs-punctuation,
+.wp-code-pre .hljs-operator {
+  color: var(--hl-punct);
+}
+.wp-code-pre .hljs-emphasis {
+  font-style: italic;
+}
+.wp-code-pre .hljs-strong {
+  font-weight: 600;
+}
+.wp-code-pre .hljs-deletion {
+  color: var(--danger);
+}
+.wp-code-pre .hljs-addition {
+  color: var(--success);
+}
+
 .diff-file-path-btn {
   background: transparent;
   border: none;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11727,6 +11727,60 @@ html[data-theme="light"] .wp-panel-modal {
   text-overflow: ellipsis;
 }
 
+.wp-tree-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+
+.wp-tree-toolbar-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.wp-tree-toolbar .wp-refresh-btn {
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-pill);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.wp-tree-toolbar .wp-refresh-btn:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.wp-refresh-icon {
+  display: inline-block;
+  font-size: 0.92rem;
+  line-height: 1;
+}
+
+.wp-refresh-btn.spinning .wp-refresh-icon {
+  animation: wp-spin 0.6s linear infinite;
+}
+
+@keyframes wp-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .wp-tree-scroll {
   flex: 1;
   min-height: 0;

--- a/frontend/src/components/FilePreview.tsx
+++ b/frontend/src/components/FilePreview.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { type CSSProperties, useState } from "react";
+import { type CSSProperties, Fragment, useEffect, useMemo, useState } from "react";
 
 import { formatBytes } from "@/components/AttachmentTray";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 import type { WorkspaceFile } from "@/lib/api";
+import { highlightToLines, type HighlightToken } from "@/lib/highlight";
 
 const IMAGE_EXTS = new Set([
   ".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg",
@@ -140,7 +141,26 @@ function FileCodeView({
   softWrap: boolean;
   setSoftWrap: (v: boolean) => void;
 }) {
-  const lines = content.split("\n");
+  // Render raw lines synchronously, then upgrade to highlighted token lines once
+  // the lazy highlighter resolves. Each "line" is an array of tokens; a raw line
+  // is a single classless token (empty array for a blank line).
+  const plain = useMemo<HighlightToken[][]>(
+    () => content.split("\n").map((line) => (line ? [{ text: line, className: "" }] : [])),
+    [content],
+  );
+  const [lines, setLines] = useState<HighlightToken[][]>(plain);
+
+  useEffect(() => {
+    setLines(plain);
+    let cancelled = false;
+    void highlightToLines(content, path).then((highlighted) => {
+      if (!cancelled && highlighted) setLines(highlighted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [content, path, plain]);
+
   const lnw = `${String(lines.length).length}ch`;
   return (
     <div className="wp-code-wrap">
@@ -160,10 +180,22 @@ function FileCodeView({
         style={{ "--lnw": lnw } as CSSProperties}
         aria-label={`Contents of ${path}`}
       >
-        {lines.map((line, idx) => (
+        {lines.map((tokens, idx) => (
           <span key={idx} className="wp-code-line">
             <span className="wp-line-num">{idx + 1}</span>
-            <span className="wp-line-text">{line || " "}</span>
+            <span className="wp-line-text">
+              {tokens.length === 0
+                ? " "
+                : tokens.map((token, i) =>
+                    token.className ? (
+                      <span key={i} className={token.className}>
+                        {token.text}
+                      </span>
+                    ) : (
+                      <Fragment key={i}>{token.text}</Fragment>
+                    ),
+                  )}
+            </span>
           </span>
         ))}
       </pre>

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -58,6 +58,23 @@ function useWorkspacePreview(host: string, token: string, sessionId: string) {
     [host, token, sessionId],
   );
 
+  // Background re-fetch of the open file with no loading flash; swaps content
+  // only when mtime/size actually changed, so an auto-refresh that finds nothing
+  // new never disturbs the reader's scroll position.
+  const silentRefreshFile = useCallback(async () => {
+    const path = latestRequest.current;
+    if (!path) return;
+    try {
+      const data = await fetchWorkspaceFile(host, token, sessionId, path);
+      if (latestRequest.current !== path) return;
+      setFileData((prev) =>
+        prev && prev.mtime === data.mtime && prev.size === data.size ? prev : data,
+      );
+    } catch {
+      // Silent: leave the current content in place on a transient failure.
+    }
+  }, [host, token, sessionId]);
+
   const reset = useCallback(() => {
     latestRequest.current = null;
     setOpenPathState(null);
@@ -66,7 +83,17 @@ function useWorkspacePreview(host: string, token: string, sessionId: string) {
     setFileLoading(false);
   }, []);
 
-  return { openPath, openFile, fileData, fileLoading, fileError, root, setRoot, reset };
+  return {
+    openPath,
+    openFile,
+    silentRefreshFile,
+    fileData,
+    fileLoading,
+    fileError,
+    root,
+    setRoot,
+    reset,
+  };
 }
 
 export function WorkspaceFilesPanel({
@@ -82,8 +109,19 @@ export function WorkspaceFilesPanel({
 }: WorkspaceFilesPanelProps) {
   const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
   const [revealDir, setRevealDir] = useState<string | null>(null);
-  const { openPath, openFile, fileData, fileLoading, fileError, root, setRoot, reset } =
-    useWorkspacePreview(host, token, sessionId);
+  const [treeRefreshSeq, setTreeRefreshSeq] = useState(0);
+  const [treeRefreshing, setTreeRefreshing] = useState(false);
+  const {
+    openPath,
+    openFile,
+    silentRefreshFile,
+    fileData,
+    fileLoading,
+    fileError,
+    root,
+    setRoot,
+    reset,
+  } = useWorkspacePreview(host, token, sessionId);
 
   useEffect(() => {
     if (!open) return;
@@ -112,6 +150,37 @@ export function WorkspaceFilesPanel({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [open, onClose]);
+
+  const refreshTree = useCallback(() => {
+    setTreeRefreshSeq((s) => s + 1);
+    setTreeRefreshing(true);
+    window.setTimeout(() => setTreeRefreshing(false), 600);
+  }, []);
+  const refreshFile = useCallback(() => {
+    if (openPath) void openFile(openPath);
+  }, [openPath, openFile]);
+
+  // Auto-refresh when the tab regains focus — the common case is the user
+  // switching to the terminal, the agent editing files, then switching back.
+  // Throttled so visibilitychange + focus firing together only refresh once.
+  const lastFocusRefresh = useRef(0);
+  useEffect(() => {
+    if (!open) return;
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      const now = Date.now();
+      if (now - lastFocusRefresh.current < 1000) return;
+      lastFocusRefresh.current = now;
+      void silentRefreshFile();
+      setTreeRefreshSeq((s) => s + 1);
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [open, silentRefreshFile]);
 
   const handleSelectFile = useCallback(
     async (path: string) => {
@@ -187,6 +256,18 @@ export function WorkspaceFilesPanel({
 
         <div className="wp-panel-body">
           <div className={`wp-tree-pane${mobileView === "preview" ? " wp-mobile-hidden" : ""}`}>
+            <div className="wp-tree-toolbar">
+              <span className="wp-tree-toolbar-label">Files</span>
+              <button
+                type="button"
+                className={`wp-refresh-btn${treeRefreshing ? " spinning" : ""}`}
+                onClick={refreshTree}
+                title="Refresh files"
+                aria-label="Refresh files"
+              >
+                <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
+              </button>
+            </div>
             {recentPaths.length > 0 ? (
               <div className="wp-recent">
                 <p className="wp-recent-label">Recently written</p>
@@ -215,6 +296,7 @@ export function WorkspaceFilesPanel({
                 selectedPath={openPath}
                 revealPath={revealDir}
                 revealSeq={revealSeq}
+                refreshSeq={treeRefreshSeq}
                 onSelectFile={handleSelectFile}
                 onRootLoaded={setRoot}
               />
@@ -234,6 +316,15 @@ export function WorkspaceFilesPanel({
                         {formatBytes(fileData.size)} · {mtime}
                       </span>
                     ) : null}
+                    <button
+                      type="button"
+                      className={`wp-preview-btn wp-refresh-btn${fileLoading ? " spinning" : ""}`}
+                      onClick={refreshFile}
+                      title="Refresh file"
+                      aria-label="Refresh file"
+                    >
+                      <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
+                    </button>
                     <button
                       type="button"
                       className="wp-preview-btn"

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -111,6 +111,7 @@ export function WorkspaceFilesPanel({
   const [revealDir, setRevealDir] = useState<string | null>(null);
   const [treeRefreshSeq, setTreeRefreshSeq] = useState(0);
   const [treeRefreshing, setTreeRefreshing] = useState(false);
+  const [fileRefreshing, setFileRefreshing] = useState(false);
   const {
     openPath,
     openFile,
@@ -157,8 +158,11 @@ export function WorkspaceFilesPanel({
     window.setTimeout(() => setTreeRefreshing(false), 600);
   }, []);
   const refreshFile = useCallback(() => {
-    if (openPath) void openFile(openPath);
-  }, [openPath, openFile]);
+    if (!openPath) return;
+    void silentRefreshFile();
+    setFileRefreshing(true);
+    window.setTimeout(() => setFileRefreshing(false), 600);
+  }, [openPath, silentRefreshFile]);
 
   // Auto-refresh when the tab regains focus — the common case is the user
   // switching to the terminal, the agent editing files, then switching back.
@@ -318,7 +322,7 @@ export function WorkspaceFilesPanel({
                     ) : null}
                     <button
                       type="button"
-                      className={`wp-preview-btn wp-refresh-btn${fileLoading ? " spinning" : ""}`}
+                      className={`wp-preview-btn wp-refresh-btn${fileLoading || fileRefreshing ? " spinning" : ""}`}
                       onClick={refreshFile}
                       title="Refresh file"
                       aria-label="Refresh file"

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -31,6 +31,7 @@ interface WorkspaceTreeProps {
   selectedPath: string | null;
   revealPath?: string | null;
   revealSeq?: number;
+  refreshSeq?: number;
   onSelectFile: (path: string) => void;
   onRootLoaded?: (root: WorkspaceTreePage["root"]) => void;
 }
@@ -42,6 +43,7 @@ export function WorkspaceTree({
   selectedPath,
   revealPath,
   revealSeq,
+  refreshSeq,
   onSelectFile,
   onRootLoaded,
 }: WorkspaceTreeProps) {
@@ -65,7 +67,15 @@ export function WorkspaceTree({
     async (dirPath: string) => {
       setDirCache((prev) => {
         const next = new Map(prev);
-        next.set(dirPath, { entries: [], overflow: null, loading: true, error: null });
+        // Preserve any already-loaded entries while reloading so a refresh
+        // updates in place instead of blanking the tree to "Loading…".
+        const existing = prev.get(dirPath);
+        next.set(dirPath, {
+          entries: existing?.entries ?? [],
+          overflow: existing?.overflow ?? null,
+          loading: true,
+          error: null,
+        });
         return next;
       });
       try {
@@ -136,6 +146,15 @@ export function WorkspaceTree({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [revealPath, revealSeq]);
 
+  // Refresh: re-fetch every currently-expanded directory (root included),
+  // preserving the expansion set and selection. Skipped on first mount
+  // (refreshSeq starts undefined/0) so it only fires on an explicit bump.
+  useEffect(() => {
+    if (!refreshSeq) return;
+    for (const dir of expanded) void fetchDir(dir);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refreshSeq]);
+
   const toggleDir = useCallback(
     (dirPath: string) => {
       setActiveReveal(null);
@@ -156,7 +175,7 @@ export function WorkspaceTree({
   );
 
   const rootState = dirCache.get("");
-  if (!rootState || rootState.loading) {
+  if (!rootState || (rootState.loading && rootState.entries.length === 0)) {
     return <div className="wp-tree-loading">Loading…</div>;
   }
   if (rootState.error) {
@@ -256,21 +275,7 @@ function TreeNode({
       </button>
       {isDir && isExpanded ? (
         <ul role="group">
-          {dirState?.loading ? (
-            <li
-              className="wp-tree-loading-child"
-              style={{ "--depth": depth + 1 } as CSSProperties}
-            >
-              Loading…
-            </li>
-          ) : dirState?.error ? (
-            <li
-              className="wp-tree-error-child"
-              style={{ "--depth": depth + 1 } as CSSProperties}
-            >
-              {dirState.error}
-            </li>
-          ) : dirState ? (
+          {dirState && dirState.entries.length > 0 ? (
             <>
               {dirState.entries.map((child) => (
                 <TreeNode
@@ -296,6 +301,20 @@ function TreeNode({
                 </li>
               ) : null}
             </>
+          ) : dirState?.loading ? (
+            <li
+              className="wp-tree-loading-child"
+              style={{ "--depth": depth + 1 } as CSSProperties}
+            >
+              Loading…
+            </li>
+          ) : dirState?.error ? (
+            <li
+              className="wp-tree-error-child"
+              style={{ "--depth": depth + 1 } as CSSProperties}
+            >
+              {dirState.error}
+            </li>
           ) : null}
         </ul>
       ) : null}

--- a/frontend/src/lib/highlight.ts
+++ b/frontend/src/lib/highlight.ts
@@ -1,0 +1,145 @@
+// Lazy syntax highlighting for the workspace file preview. lowlight (the hast
+// interface to highlight.js) is dynamically imported so its language grammars
+// stay out of the initial bundle — the file preview is a modal opened on
+// demand. We tokenize to a hast tree and split it into per-line token arrays so
+// the preview keeps its custom line-number gutter and soft-wrap behavior.
+
+export interface HighlightToken {
+  text: string;
+  className: string;
+}
+
+// Skip highlighting past this size: content is already backend-capped at
+// ~200 KB, but minified blobs can still jank the tokenizer.
+const MAX_HIGHLIGHT_CHARS = 120_000;
+
+const EXTENSION_LANGUAGE: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+  java: "java",
+  c: "c",
+  h: "c",
+  cc: "cpp",
+  cpp: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  swift: "swift",
+  kt: "kotlin",
+  scala: "scala",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  json: "json",
+  jsonc: "json",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "ini",
+  ini: "ini",
+  xml: "xml",
+  html: "xml",
+  htm: "xml",
+  svg: "xml",
+  vue: "xml",
+  css: "css",
+  scss: "scss",
+  sass: "scss",
+  less: "less",
+  md: "markdown",
+  markdown: "markdown",
+  sql: "sql",
+  diff: "diff",
+  patch: "diff",
+  graphql: "graphql",
+  gql: "graphql",
+  lua: "lua",
+  r: "r",
+  pl: "perl",
+};
+
+function languageForPath(path: string): string | null {
+  const name = path.split("/").pop() ?? path;
+  const dot = name.lastIndexOf(".");
+  if (dot < 0) return null;
+  return EXTENSION_LANGUAGE[name.slice(dot + 1).toLowerCase()] ?? null;
+}
+
+interface HastNode {
+  type: string;
+  value?: string;
+  tagName?: string;
+  properties?: { className?: string[] };
+  children?: HastNode[];
+}
+
+interface LowlightLike {
+  registered(name: string): boolean;
+  highlight(language: string, value: string): HastNode;
+}
+
+let lowlightPromise: Promise<LowlightLike> | null = null;
+
+function getLowlight(): Promise<LowlightLike> {
+  if (!lowlightPromise) {
+    lowlightPromise = import("lowlight").then(({ createLowlight, common }) =>
+      createLowlight(common),
+    ) as Promise<LowlightLike>;
+  }
+  return lowlightPromise;
+}
+
+function flatten(nodes: HastNode[], inherited: string, out: HighlightToken[]): void {
+  for (const node of nodes) {
+    if (node.type === "text") {
+      out.push({ text: node.value ?? "", className: inherited });
+    } else if (node.type === "element" && node.children) {
+      const own = (node.properties?.className ?? []).join(" ");
+      const combined = own ? (inherited ? `${inherited} ${own}` : own) : inherited;
+      flatten(node.children, combined, out);
+    }
+  }
+}
+
+function splitIntoLines(tokens: HighlightToken[]): HighlightToken[][] {
+  const lines: HighlightToken[][] = [[]];
+  for (const token of tokens) {
+    const parts = token.text.split("\n");
+    parts.forEach((part, index) => {
+      if (index > 0) lines.push([]);
+      if (part) lines[lines.length - 1].push({ text: part, className: token.className });
+    });
+  }
+  return lines;
+}
+
+// Returns per-line token arrays, or null when highlighting is unavailable
+// (unknown language, oversized content, unregistered grammar, or a parse
+// error) — callers fall back to rendering the raw lines.
+export async function highlightToLines(
+  code: string,
+  path: string,
+): Promise<HighlightToken[][] | null> {
+  const language = languageForPath(path);
+  if (!language || code.length > MAX_HIGHLIGHT_CHARS) return null;
+  const lowlight = await getLowlight();
+  if (!lowlight.registered(language)) return null;
+  try {
+    const tree = lowlight.highlight(language, code);
+    const tokens: HighlightToken[] = [];
+    flatten(tree.children ?? [], "", tokens);
+    return splitIntoLines(tokens);
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/highlight.ts
+++ b/frontend/src/lib/highlight.ts
@@ -37,7 +37,6 @@ const EXTENSION_LANGUAGE: Record<string, string> = {
   php: "php",
   swift: "swift",
   kt: "kotlin",
-  scala: "scala",
   sh: "bash",
   bash: "bash",
   zsh: "bash",


### PR DESCRIPTION
## Summary

Two enhancements to the workspace file-preview panel: syntax highlighting in the code view, and refresh controls (manual per-pane buttons plus auto-refresh on tab focus) so the preview and tree don't go stale while the panel is open.

## Changes

- **Syntax highlighting** — adds `lowlight` (highlight.js), dynamically imported so its grammars stay out of the initial bundle. The code view tokenizes content and splits it into per-line token arrays, preserving the existing line-number gutter and soft-wrap. Tokens are recolored to the app's warm-gold/cool-blue palette via `.wp-code-pre`-scoped `--hl-*` variables with full dark/light parity, rather than shipping a stock theme. Unknown languages and oversized content fall back to plain text. Scoped to the preview code view (and the markdown Source view) — the transcript is untouched.
- **Refresh controls** — a refresh button on each pane: the preview re-fetches the open file, the tree refetches its currently-expanded directories while preserving expansion and selection. On tab focus regain, a throttled silent refresh runs; the file refetch is mtime-gated so it only swaps content when something actually changed (no scroll disruption), and tree refetches keep prior entries in place instead of blanking to a loading state.

## Testing

- `cd frontend && npx tsc --noEmit && npm run lint && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)