### PR TITLE
feat: add CLI to upload session attachments

### DIFF
--- a/.agents/skills/waypoint/references/sessions-steer.md
+++ b/.agents/skills/waypoint/references/sessions-steer.md
@@ -6,6 +6,28 @@ Send input:
 waypoint sessions send <session-id> <text>
 ```
 
+Attach files to a message with `--attach` (upload-and-send in one step):
+
+```bash
+waypoint sessions send <session-id> "here are the files" --attach path/to/a.png --attach path/to/b.txt
+```
+
+Pre-upload files and reuse the returned IDs with `--attachment-id` (useful when
+the same attachment will be sent to multiple sessions, or when upload and send
+happen in separate steps):
+
+```bash
+# Upload first — prints {"attachments": [{id, filename, mime, size, kind}, ...]}
+waypoint sessions upload <session-id> path/to/a.png path/to/b.txt
+
+# Send later, referencing the IDs
+waypoint sessions send <session-id> "here are the files" --attachment-id <id1> --attachment-id <id2>
+```
+
+When both `--attach` and `--attachment-id` are present on `sessions send`,
+uploaded files come first in the attachment list, followed by the explicit IDs
+in the order they were given.
+
 Interrupt only when the user asks, or when a session is clearly stuck and the
 user confirms:
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1157,6 +1157,15 @@ def sessions_send(
             "by host path or inline depending on the backend.",
         ),
     ] = None,
+    attachment_id: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--attachment-id",
+            help="ID of an already-uploaded attachment to include (repeatable). "
+            "Use `sessions upload` to obtain IDs. Files from --attach are "
+            "uploaded first; --attachment-id values follow in order.",
+        ),
+    ] = None,
 ) -> None:
     """Send a message to a session.
 
@@ -1167,13 +1176,39 @@ def sessions_send(
     """
 
     def _run(c: WaypointClient) -> dict[str, Any]:
-        ids = [c.upload_attachment(session_id, path)["id"] for path in attach or []]
-        return {"session": c.send_input(session_id, text, attachments=ids or None)}
+        uploaded = [
+            c.upload_attachment(session_id, path)["id"] for path in attach or []
+        ]
+        combined = uploaded + list(attachment_id or [])
+        return {"session": c.send_input(session_id, text, attachments=combined or None)}
 
     result = _run_client(_settings_from_ctx(ctx), _run)
     typer.echo(json.dumps(result, indent=2))
     if result.get("session", {}).get("send") == "unknown":
         raise typer.Exit(code=1)
+
+
+@sessions_app.command("upload")
+def sessions_upload(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    files: Annotated[
+        list[Path],
+        typer.Argument(
+            exists=True,
+            dir_okay=False,
+            readable=True,
+            help="File(s) to upload.",
+        ),
+    ],
+) -> None:
+    """Upload file attachment(s) to a session without sending a message."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        specs = [c.upload_attachment(session_id, path) for path in files]
+        return {"attachments": specs}
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 def _validate_permission_mode(

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1524,6 +1524,152 @@ def test_sessions_send_reports_unknown_on_timeout_idle(
     assert out["session"]["send"] == "unknown"
 
 
+# ── sessions upload / sessions send --attachment-id ───────────────────────────
+
+
+def test_sessions_upload_emits_attachment_specs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    f1 = tmp_path / "img.png"
+    f2 = tmp_path / "doc.txt"
+    f1.write_bytes(b"\x89PNG")
+    f2.write_text("hello")
+    uploads: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/sessions/s1/attachments"
+            and request.method == "POST"
+        ):
+            n = len(uploads) + 1
+            att_id = f"att{n:032x}"
+            uploads.append(att_id)
+            return httpx.Response(
+                200,
+                json={
+                    "id": att_id,
+                    "filename": f"file{n}",
+                    "mime": "application/octet-stream",
+                    "size": 4,
+                    "kind": "file",
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "upload",
+            "s1",
+            str(f1),
+            str(f2),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.stdout)
+    assert "attachments" in out
+    assert len(out["attachments"]) == 2
+    assert [a["id"] for a in out["attachments"]] == uploads
+
+
+def test_sessions_send_attachment_id_passes_ids_to_send_input(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/input":
+            state["input_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "s1"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "send",
+            "s1",
+            "hello",
+            "--attachment-id",
+            "id-aaa",
+            "--attachment-id",
+            "id-bbb",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["input_body"]["attachments"] == ["id-aaa", "id-bbb"]
+
+
+def test_sessions_send_attach_and_attachment_id_combined(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/sessions/s1/attachments"
+            and request.method == "POST"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "id": "uploaded-id",
+                    "filename": "a.txt",
+                    "mime": "text/plain",
+                    "size": 1,
+                    "kind": "file",
+                },
+            )
+        if request.url.path == "/api/sessions/s1/input":
+            state["input_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "s1"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "send",
+            "s1",
+            "hello",
+            "--attach",
+            str(f),
+            "--attachment-id",
+            "preexisting-id",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # uploaded files come first, then explicit IDs
+    assert state["input_body"]["attachments"] == ["uploaded-id", "preexisting-id"]
+
+
 # ── usage command ─────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a CLI surface for session file attachments, which until now were only reachable by bundling them into `sessions send --attach`. The upload endpoint and client methods already existed server-side; this just exposes them.

## Changes

- `waypoint sessions upload <session-id> <files...>` — uploads one or more files to a session without sending a message, printing each attachment spec (`id`, `filename`, `mime`, `size`, `kind`) as JSON via the standard emitter. The returned `id`s can be reused later.
- `waypoint sessions send` gains a repeatable `--attachment-id` option that references already-uploaded attachments. When combined with `--attach`, the uploaded files come first in the attachment list, followed by the explicit ids in the order given.
- Documents both in the `waypoint` skill's steering reference.

## Testing

- `cd backend && uv run pytest` (full suite, 1091 passed; adds three CLI tests covering upload output, `--attachment-id` passthrough, and combined `--attach` + `--attachment-id` ordering)
- `cd backend && uv run pre-commit run --all-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
