### PR TITLE
feat: workspace file side-dock and full-page browser

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11528,44 +11528,98 @@ html[data-theme="light"]
 }
 
 /* ─── Workspace preview ─── */
-.wp-panel-backdrop {
+/* The workspace dock is a non-modal left side-panel that coexists with the
+   live session (transcript + composer stay interactive). Three regimes: push
+   (wide, the column slides clear), overlay (mid), and full-screen sheet
+   (mobile). */
+.wp-dock {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
   height: 100dvh;
-  z-index: 100;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
-  /* Keep the modal clear of the notch/home indicator on mobile; the panel is
-     near-full-height, so without this the header slides under the status bar. */
-  padding: max(16px, env(safe-area-inset-top)) max(16px, env(safe-area-inset-right))
-    max(16px, env(safe-area-inset-bottom)) max(16px, env(safe-area-inset-left));
-}
-
-.wp-panel-modal {
-  width: 100%;
-  max-width: min(960px, calc(100vw - 32px));
-  height: 100%;
-  max-height: 100%;
-  min-height: 0;
-  background: rgba(14, 17, 24, 0.96);
-  border: 1px solid var(--line-strong);
-  border-radius: var(--radius);
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.48);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  width: var(--wp-dock-width, 400px);
+  z-index: 60;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  animation: session-files-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  background: rgba(14, 17, 24, 0.98);
+  border-right: 1px solid var(--line-strong);
+  box-shadow: 4px 0 32px rgba(0, 0, 0, 0.36);
+  /* Inner tree/preview split keys off the dock's own width, not the viewport. */
+  container-type: inline-size;
+  padding-left: env(safe-area-inset-left);
+  animation: wp-dock-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
 
-html[data-theme="light"] .wp-panel-modal {
-  background: rgba(252, 249, 242, 0.98);
-  box-shadow: 0 16px 48px rgba(60, 45, 20, 0.2);
+html[data-theme="light"] .wp-dock {
+  background: rgba(252, 249, 242, 0.99);
+  box-shadow: 4px 0 28px rgba(60, 45, 20, 0.16);
+}
+
+@keyframes wp-dock-in {
+  from {
+    transform: translateX(-100%);
+    opacity: 0.4;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}
+
+/* Push regime: on wide viewports, inset the containing block (body) by the dock
+   width so the centered .page-shell re-centers in the space beside the dock
+   instead of being padded into a squished, off-center strip. The fixed dock and
+   the fixed body::before background both ignore body padding. */
+body {
+  transition: padding-left 160ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+@media (min-width: 1180px) {
+  html[data-wp-dock="open"] body {
+    padding-left: var(--wp-dock-width, 400px);
+  }
+}
+
+/* Resize seam on the dock's right edge (VS Code-style). */
+.wp-dock-resizer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 7px;
+  height: 100%;
+  z-index: 2;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.wp-dock-resizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 1px;
+  height: 100%;
+  background: transparent;
+  transition: background-color 120ms ease;
+}
+
+.wp-dock-resizer:hover::after,
+.wp-dock-resizer:focus-visible::after,
+body.wp-dock-resizing .wp-dock-resizer::after {
+  background: var(--accent-cool);
+}
+
+.wp-dock-resizer:focus-visible {
+  outline: none;
+}
+
+body.wp-dock-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .wp-panel-header {
@@ -12304,7 +12358,11 @@ html[data-theme="light"] .wp-code-pre {
   color: var(--accent-cool);
 }
 
-@media (max-width: 640px) {
+/* When the dock itself is too narrow for a side-by-side tree+preview, collapse
+   to a single pane with the Tree/Preview toggle. Keyed on the dock width (a
+   container query), so this fires both for a narrow desktop dock and the
+   mobile full-screen sheet. */
+@container (max-width: 700px) {
   .wp-panel-mobile-toggle {
     display: flex;
   }
@@ -12322,6 +12380,22 @@ html[data-theme="light"] .wp-code-pre {
   }
 
   .wp-mobile-hidden {
+    display: none;
+  }
+}
+
+/* Full-screen sheet on phones: the dock fills the viewport (no push, no resize
+   seam) and clears the notch/home indicator. */
+@media (max-width: 640px) {
+  .wp-dock {
+    width: 100%;
+    border-right: none;
+    box-shadow: none;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right)
+      env(safe-area-inset-bottom) env(safe-area-inset-left);
+  }
+
+  .wp-dock-resizer {
     display: none;
   }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11756,10 +11756,6 @@ body.wp-dock-resizing {
   min-height: 0;
 }
 
-html[data-theme="light"] .wp-page {
-  background: var(--bg);
-}
-
 .wp-panel-body {
   display: flex;
   flex: 1;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11559,6 +11559,12 @@ html[data-theme="light"]
   animation: wp-dock-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
 
+/* Closed: hidden but kept mounted so the explorer's state (tree expansion,
+   open file) persists across a close/reopen. */
+.wp-dock.wp-dock-closed {
+  display: none;
+}
+
 html[data-theme="light"] .wp-dock {
   background: rgba(252, 249, 242, 0.99);
   box-shadow: 4px 0 28px rgba(60, 45, 20, 0.16);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11532,6 +11532,16 @@ html[data-theme="light"]
    live session (transcript + composer stay interactive). Three regimes: push
    (wide, the column slides clear), overlay (mid), and full-screen sheet
    (mobile). */
+/* Explorer fills whatever container mounts it (dock or full page).
+   container-type lives here so the @container tree/preview toggle works in both. */
+.wp-explorer {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  container-type: inline-size;
+}
+
 .wp-dock {
   position: fixed;
   top: 0;
@@ -11545,8 +11555,6 @@ html[data-theme="light"]
   background: rgba(14, 17, 24, 0.98);
   border-right: 1px solid var(--line-strong);
   box-shadow: 4px 0 32px rgba(0, 0, 0, 0.36);
-  /* Inner tree/preview split keys off the dock's own width, not the viewport. */
-  container-type: inline-size;
   padding-left: env(safe-area-inset-left);
   animation: wp-dock-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
@@ -11705,6 +11713,51 @@ body.wp-dock-resizing {
 .wp-panel-close:hover {
   background: color-mix(in srgb, var(--text) 12%, transparent);
   color: var(--text-strong);
+}
+
+.wp-panel-fullpage-link {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  text-decoration: none;
+  white-space: nowrap;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  transition:
+    color 120ms ease,
+    border-color 120ms ease,
+    background-color 120ms ease;
+}
+
+.wp-panel-fullpage-link:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+/* Full-page workspace file browser layout. */
+.wp-page {
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.wp-page > .app-bar {
+  flex-shrink: 0;
+  margin: 12px 16px;
+}
+
+.wp-page > .wp-explorer {
+  flex: 1;
+  min-height: 0;
+}
+
+html[data-theme="light"] .wp-page {
+  background: var(--bg);
 }
 
 .wp-panel-body {

--- a/frontend/src/app/session/[id]/files/page.tsx
+++ b/frontend/src/app/session/[id]/files/page.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useParams, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { WorkspaceExplorer } from "@/components/WorkspaceExplorer";
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { resolveWorkspacePath } from "@/lib/api";
+import { readHost, readToken } from "@/lib/store";
+import { useTheme } from "@/lib/theme";
+
+export default function SessionFilesPage() {
+  const params = useParams<{ id: string }>();
+  const searchParams = useSearchParams();
+  const { theme } = useTheme();
+  const [host, setHost] = useState("");
+  const [token, setToken] = useState("");
+  const [sessionId, setSessionId] = useState("");
+  const [initialPath, setInitialPath] = useState<string | undefined>(undefined);
+  const [initialDir, setInitialDir] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    const id = params.id;
+    const h = readHost();
+    const t = readToken();
+    setSessionId(id);
+    setHost(h);
+    setToken(t);
+
+    const rawPath = searchParams.get("path");
+    if (rawPath && h && t && id) {
+      resolveWorkspacePath(h, t, id, rawPath)
+        .then((resolved) => {
+          if (resolved.kind === "file") {
+            setInitialPath(resolved.path);
+          } else {
+            setInitialDir(resolved.path);
+          }
+        })
+        .catch(() => {
+          // If resolve fails, open without a seeded path.
+        });
+    }
+  }, [params, searchParams]);
+
+  return (
+    <div className="wp-page">
+      <header className="app-bar">
+        <div className="app-bar-brand">
+          <Link className="app-bar-mark" href="/" aria-label="Waypoint home">
+            <Image
+              src={theme === "light" ? "/waypoint-light.svg" : "/waypoint.svg"}
+              alt=""
+              width={38}
+              height={38}
+              priority
+            />
+          </Link>
+        </div>
+        <div className="app-bar-meta">
+          {sessionId ? (
+            <Link className="back-link" href={`/session/${sessionId}`}>
+              ← back to session
+            </Link>
+          ) : null}
+          <ThemeToggle />
+        </div>
+      </header>
+      {host && token && sessionId ? (
+        <WorkspaceExplorer
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          recentPaths={[]}
+          initialPath={initialPath}
+          initialDir={initialDir}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/app/session/[id]/files/page.tsx
+++ b/frontend/src/app/session/[id]/files/page.tsx
@@ -33,9 +33,12 @@ export default function SessionFilesPage() {
     setHost(h);
     setToken(t);
 
+    let cancelled = false;
     if (h && t && id) {
       fetchSession(h, t, id)
-        .then((s) => setSession(s))
+        .then((s) => {
+          if (!cancelled) setSession(s);
+        })
         .catch(() => {
           // Title is decorative here; ignore failures.
         });
@@ -45,6 +48,7 @@ export default function SessionFilesPage() {
     if (rawPath && h && t && id) {
       resolveWorkspacePath(h, t, id, rawPath)
         .then((resolved) => {
+          if (cancelled) return;
           if (resolved.kind === "file") {
             setInitialPath(resolved.path);
           } else {
@@ -55,6 +59,9 @@ export default function SessionFilesPage() {
           // If resolve fails, open without a seeded path.
         });
     }
+    return () => {
+      cancelled = true;
+    };
   }, [params, searchParams]);
 
   // Match the session page's tab-title format (`<backend> · <title>`), with a

--- a/frontend/src/app/session/[id]/files/page.tsx
+++ b/frontend/src/app/session/[id]/files/page.tsx
@@ -8,8 +8,10 @@ import { useEffect, useState } from "react";
 import { WorkspaceExplorer } from "@/components/WorkspaceExplorer";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { fetchSession, resolveWorkspacePath } from "@/lib/api";
+import { humaniseBackend, useBackendCatalog } from "@/lib/backends";
 import { readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
+import type { SessionRecord } from "@/lib/types";
 
 export default function SessionFilesPage() {
   const params = useParams<{ id: string }>();
@@ -20,7 +22,8 @@ export default function SessionFilesPage() {
   const [sessionId, setSessionId] = useState("");
   const [initialPath, setInitialPath] = useState<string | undefined>(undefined);
   const [initialDir, setInitialDir] = useState<string | undefined>(undefined);
-  const [sessionTitle, setSessionTitle] = useState("");
+  const [session, setSession] = useState<SessionRecord | null>(null);
+  const catalog = useBackendCatalog(host || null, token || null, null);
 
   useEffect(() => {
     const id = params.id;
@@ -32,7 +35,7 @@ export default function SessionFilesPage() {
 
     if (h && t && id) {
       fetchSession(h, t, id)
-        .then((s) => setSessionTitle(s.title))
+        .then((s) => setSession(s))
         .catch(() => {
           // Title is decorative here; ignore failures.
         });
@@ -54,12 +57,17 @@ export default function SessionFilesPage() {
     }
   }, [params, searchParams]);
 
-  // Reflect the session in the browser tab/window title, not just the in-page
-  // header (the root metadata title is the generic "Waypoint").
+  // Match the session page's tab-title format (`<backend> · <title>`), with a
+  // "· Files" marker so the two tabs stay distinguishable. Restore the previous
+  // title on unmount, as SessionDetail does.
   useEffect(() => {
-    const label = sessionTitle ? `${sessionTitle} · Files` : "Workspace files";
-    document.title = `${label} — Waypoint`;
-  }, [sessionTitle]);
+    if (!session) return;
+    const prev = document.title;
+    document.title = `${humaniseBackend(session.backend, catalog)} · ${session.title} · Files`;
+    return () => {
+      document.title = prev;
+    };
+  }, [session, catalog]);
 
   return (
     <div className="wp-page">
@@ -76,7 +84,7 @@ export default function SessionFilesPage() {
           </Link>
           <div className="app-bar-titles">
             <p className="app-bar-eyebrow">Waypoint · files</p>
-            <h1 className="app-bar-title">{sessionTitle || "Workspace files"}</h1>
+            <h1 className="app-bar-title">{session?.title || "Workspace files"}</h1>
           </div>
         </div>
         <div className="app-bar-meta">

--- a/frontend/src/app/session/[id]/files/page.tsx
+++ b/frontend/src/app/session/[id]/files/page.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 
 import { WorkspaceExplorer } from "@/components/WorkspaceExplorer";
 import { ThemeToggle } from "@/components/ThemeToggle";
-import { resolveWorkspacePath } from "@/lib/api";
+import { fetchSession, resolveWorkspacePath } from "@/lib/api";
 import { readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
 
@@ -20,6 +20,7 @@ export default function SessionFilesPage() {
   const [sessionId, setSessionId] = useState("");
   const [initialPath, setInitialPath] = useState<string | undefined>(undefined);
   const [initialDir, setInitialDir] = useState<string | undefined>(undefined);
+  const [sessionTitle, setSessionTitle] = useState("");
 
   useEffect(() => {
     const id = params.id;
@@ -28,6 +29,14 @@ export default function SessionFilesPage() {
     setSessionId(id);
     setHost(h);
     setToken(t);
+
+    if (h && t && id) {
+      fetchSession(h, t, id)
+        .then((s) => setSessionTitle(s.title))
+        .catch(() => {
+          // Title is decorative here; ignore failures.
+        });
+    }
 
     const rawPath = searchParams.get("path");
     if (rawPath && h && t && id) {
@@ -58,6 +67,10 @@ export default function SessionFilesPage() {
               priority
             />
           </Link>
+          <div className="app-bar-titles">
+            <p className="app-bar-eyebrow">Waypoint · files</p>
+            <h1 className="app-bar-title">{sessionTitle || "Workspace files"}</h1>
+          </div>
         </div>
         <div className="app-bar-meta">
           {sessionId ? (

--- a/frontend/src/app/session/[id]/files/page.tsx
+++ b/frontend/src/app/session/[id]/files/page.tsx
@@ -54,6 +54,13 @@ export default function SessionFilesPage() {
     }
   }, [params, searchParams]);
 
+  // Reflect the session in the browser tab/window title, not just the in-page
+  // header (the root metadata title is the generic "Waypoint").
+  useEffect(() => {
+    const label = sessionTitle ? `${sessionTitle} · Files` : "Workspace files";
+    document.title = `${label} — Waypoint`;
+  }, [sessionTitle]);
+
   return (
     <div className="wp-page">
       <header className="app-bar">

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -322,6 +322,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // results of out-of-order resolve() calls.
   const [workspaceRevealSeq, setWorkspaceRevealSeq] = useState(0);
   const workspaceRequestRef = useRef(0);
+  // Persisted width of the docked workspace panel (px). The dock is a left
+  // side-panel that coexists with the session rather than a blocking modal.
+  const [dockWidth, setDockWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return 400;
+    const stored = Number(window.localStorage.getItem("waypoint.workspaceDockWidth"));
+    return Number.isFinite(stored) && stored >= 300 ? stored : 400;
+  });
   // The todo-event sequence the user last dismissed from the progress dock.
   // `undefined` means we haven't read the persisted value yet — the dock stays
   // hidden until then so a dismissed dock doesn't flash on load (and to avoid
@@ -1695,6 +1702,27 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     [workspacePreviewEnabled, openWorkspacePath],
   );
 
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("waypoint.workspaceDockWidth", String(dockWidth));
+  }, [dockWidth]);
+
+  // Drive the layout from the document root: when the dock is open on a wide
+  // viewport, `.page-shell` pads left by --wp-dock-width so the session column
+  // slides clear of the dock instead of sitting under it.
+  useEffect(() => {
+    const root = document.documentElement;
+    if (workspacePreviewEnabled && workspaceOpen) {
+      root.style.setProperty("--wp-dock-width", `${dockWidth}px`);
+      root.setAttribute("data-wp-dock", "open");
+    } else {
+      root.removeAttribute("data-wp-dock");
+    }
+    return () => {
+      root.removeAttribute("data-wp-dock");
+    };
+  }, [workspacePreviewEnabled, workspaceOpen, dockWidth]);
+
   return (
     <WorkspaceFileLinkProvider value={workspaceLink}>
     <section className="stack" ref={sectionRef}>
@@ -2240,6 +2268,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           initialDir={workspaceInitialDir}
           revealSeq={workspaceRevealSeq}
           recentPaths={recentPaths}
+          width={dockWidth}
+          onResize={setDockWidth}
           onClose={() => setWorkspaceOpen(false)}
         />
       ) : null}

--- a/frontend/src/components/WorkspaceExplorer.tsx
+++ b/frontend/src/components/WorkspaceExplorer.tsx
@@ -139,7 +139,9 @@ export function WorkspaceExplorer({
       setMobileView("tree");
     } else {
       // No specific target (e.g. "Browse workspace"): keep the preserved open
-      // file and tree expansion; just surface the tree pane.
+      // file and tree expansion, but clear any stale directory reveal so the
+      // tree doesn't re-expand/scroll to a previously-clicked directory.
+      setRevealDir(null);
       setMobileView("tree");
     }
     // revealSeq is the retrigger knob: it bumps on every open request so an

--- a/frontend/src/components/WorkspaceExplorer.tsx
+++ b/frontend/src/components/WorkspaceExplorer.tsx
@@ -24,6 +24,9 @@ interface WorkspaceExplorerProps {
   revealSeq?: number;
   headerActions?: ReactNode;
   showFullPageLink?: boolean;
+  // When false (e.g. the dock is closed but kept mounted to preserve state),
+  // the focus auto-refresh is suspended.
+  active?: boolean;
 }
 
 function useWorkspacePreview(host: string, token: string, sessionId: string) {
@@ -106,6 +109,7 @@ export function WorkspaceExplorer({
   revealSeq,
   headerActions,
   showFullPageLink = false,
+  active = true,
 }: WorkspaceExplorerProps) {
   const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
   const [revealDir, setRevealDir] = useState<string | null>(null);
@@ -125,8 +129,8 @@ export function WorkspaceExplorer({
   } = useWorkspacePreview(host, token, sessionId);
 
   useEffect(() => {
-    reset();
     if (initialPath) {
+      reset();
       void openFile(initialPath);
       setRevealDir(null);
       setMobileView("preview");
@@ -134,7 +138,8 @@ export function WorkspaceExplorer({
       setRevealDir(initialDir);
       setMobileView("tree");
     } else {
-      setRevealDir(null);
+      // No specific target (e.g. "Browse workspace"): keep the preserved open
+      // file and tree expansion; just surface the tree pane.
       setMobileView("tree");
     }
     // revealSeq is the retrigger knob: it bumps on every open request so an
@@ -159,6 +164,7 @@ export function WorkspaceExplorer({
   // Throttled so visibilitychange + focus firing together only refresh once.
   const lastFocusRefresh = useRef(0);
   useEffect(() => {
+    if (!active) return;
     const onVisible = () => {
       if (document.visibilityState !== "visible") return;
       const now = Date.now();
@@ -173,7 +179,7 @@ export function WorkspaceExplorer({
       document.removeEventListener("visibilitychange", onVisible);
       window.removeEventListener("focus", onVisible);
     };
-  }, [silentRefreshFile]);
+  }, [silentRefreshFile, active]);
 
   const handleSelectFile = useCallback(
     async (path: string) => {

--- a/frontend/src/components/WorkspaceExplorer.tsx
+++ b/frontend/src/components/WorkspaceExplorer.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+
+import {
+  fetchWorkspaceFile,
+  workspaceRawUrl,
+  type WorkspaceFile,
+  type WorkspaceTreePage,
+} from "@/lib/api";
+import { formatBytes } from "@/components/AttachmentTray";
+import { FilePreview } from "@/components/FilePreview";
+import { WorkspaceTree } from "@/components/WorkspaceTree";
+import { copyText } from "@/lib/clipboard";
+
+interface WorkspaceExplorerProps {
+  host: string;
+  token: string;
+  sessionId: string;
+  recentPaths: string[];
+  initialPath?: string;
+  initialDir?: string;
+  revealSeq?: number;
+  headerActions?: ReactNode;
+  showFullPageLink?: boolean;
+}
+
+function useWorkspacePreview(host: string, token: string, sessionId: string) {
+  const [openPath, setOpenPathState] = useState<string | null>(null);
+  const [fileData, setFileData] = useState<WorkspaceFile | null>(null);
+  const [fileLoading, setFileLoading] = useState(false);
+  const [fileError, setFileError] = useState<string | null>(null);
+  const [root, setRoot] = useState<WorkspaceTreePage["root"] | null>(null);
+
+  // Tracks the most recent request so a slow fetch for a previously-selected
+  // file can't overwrite the content of the file the user switched to.
+  const latestRequest = useRef<string | null>(null);
+
+  const openFile = useCallback(
+    async (path: string) => {
+      latestRequest.current = path;
+      setOpenPathState(path);
+      setFileData(null);
+      setFileError(null);
+      setFileLoading(true);
+      try {
+        const data = await fetchWorkspaceFile(host, token, sessionId, path);
+        if (latestRequest.current !== path) return;
+        setFileData(data);
+      } catch (e) {
+        if (latestRequest.current !== path) return;
+        setFileError(e instanceof Error ? e.message : "Failed to load file");
+      } finally {
+        if (latestRequest.current === path) setFileLoading(false);
+      }
+    },
+    [host, token, sessionId],
+  );
+
+  // Background re-fetch of the open file with no loading flash; swaps content
+  // only when mtime/size actually changed, so an auto-refresh that finds nothing
+  // new never disturbs the reader's scroll position.
+  const silentRefreshFile = useCallback(async () => {
+    const path = latestRequest.current;
+    if (!path) return;
+    try {
+      const data = await fetchWorkspaceFile(host, token, sessionId, path);
+      if (latestRequest.current !== path) return;
+      setFileData((prev) =>
+        prev && prev.mtime === data.mtime && prev.size === data.size ? prev : data,
+      );
+    } catch {
+      // Silent: leave the current content in place on a transient failure.
+    }
+  }, [host, token, sessionId]);
+
+  const reset = useCallback(() => {
+    latestRequest.current = null;
+    setOpenPathState(null);
+    setFileData(null);
+    setFileError(null);
+    setFileLoading(false);
+  }, []);
+
+  return {
+    openPath,
+    openFile,
+    silentRefreshFile,
+    fileData,
+    fileLoading,
+    fileError,
+    root,
+    setRoot,
+    reset,
+  };
+}
+
+export function WorkspaceExplorer({
+  host,
+  token,
+  sessionId,
+  recentPaths,
+  initialPath,
+  initialDir,
+  revealSeq,
+  headerActions,
+  showFullPageLink = false,
+}: WorkspaceExplorerProps) {
+  const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
+  const [revealDir, setRevealDir] = useState<string | null>(null);
+  const [treeRefreshSeq, setTreeRefreshSeq] = useState(0);
+  const [treeRefreshing, setTreeRefreshing] = useState(false);
+  const [fileRefreshing, setFileRefreshing] = useState(false);
+  const {
+    openPath,
+    openFile,
+    silentRefreshFile,
+    fileData,
+    fileLoading,
+    fileError,
+    root,
+    setRoot,
+    reset,
+  } = useWorkspacePreview(host, token, sessionId);
+
+  useEffect(() => {
+    reset();
+    if (initialPath) {
+      void openFile(initialPath);
+      setRevealDir(null);
+      setMobileView("preview");
+    } else if (initialDir != null) {
+      setRevealDir(initialDir);
+      setMobileView("tree");
+    } else {
+      setRevealDir(null);
+      setMobileView("tree");
+    }
+    // revealSeq is the retrigger knob: it bumps on every open request so an
+    // identical path still re-reveals.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialPath, initialDir, revealSeq]);
+
+  const refreshTree = useCallback(() => {
+    setTreeRefreshSeq((s) => s + 1);
+    setTreeRefreshing(true);
+    window.setTimeout(() => setTreeRefreshing(false), 600);
+  }, []);
+  const refreshFile = useCallback(() => {
+    if (!openPath) return;
+    void silentRefreshFile();
+    setFileRefreshing(true);
+    window.setTimeout(() => setFileRefreshing(false), 600);
+  }, [openPath, silentRefreshFile]);
+
+  // Auto-refresh when the tab regains focus — the common case is the user
+  // switching to the terminal, the agent editing files, then switching back.
+  // Throttled so visibilitychange + focus firing together only refresh once.
+  const lastFocusRefresh = useRef(0);
+  useEffect(() => {
+    const onVisible = () => {
+      if (document.visibilityState !== "visible") return;
+      const now = Date.now();
+      if (now - lastFocusRefresh.current < 1000) return;
+      lastFocusRefresh.current = now;
+      void silentRefreshFile();
+      setTreeRefreshSeq((s) => s + 1);
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [silentRefreshFile]);
+
+  const handleSelectFile = useCallback(
+    async (path: string) => {
+      await openFile(path);
+      setMobileView("preview");
+    },
+    [openFile],
+  );
+
+  const copyPath = useCallback(() => {
+    if (!openPath) return;
+    void copyText(openPath);
+  }, [openPath]);
+
+  const copyContents = useCallback(() => {
+    if (fileData?.content) {
+      void copyText(fileData.content);
+    }
+  }, [fileData]);
+
+  const rawUrl = openPath ? workspaceRawUrl(host, token, sessionId, openPath) : null;
+  const mtime = fileData ? new Date(fileData.mtime * 1000).toLocaleString() : null;
+
+  const fullPageHref = showFullPageLink
+    ? `/session/${sessionId}/files${openPath ? `?path=${encodeURIComponent(openPath)}` : ""}`
+    : null;
+
+  return (
+    <div className="wp-explorer">
+      <div className="wp-panel-header">
+        <div className="wp-panel-title">
+          <span>Workspace files</span>
+          {root ? (
+            <span className="wp-panel-cwd" title={root.worktreePath ?? root.cwd}>
+              {root.worktreePath ?? root.cwd}
+            </span>
+          ) : null}
+        </div>
+        <div className="wp-panel-mobile-toggle">
+          <button
+            type="button"
+            className={`wp-toggle-btn${mobileView === "tree" ? " active" : ""}`}
+            onClick={() => setMobileView("tree")}
+          >
+            Tree
+          </button>
+          <button
+            type="button"
+            className={`wp-toggle-btn${mobileView === "preview" ? " active" : ""}`}
+            onClick={() => setMobileView("preview")}
+          >
+            Preview
+          </button>
+        </div>
+        {fullPageHref ? (
+          <Link
+            href={fullPageHref}
+            target="_blank"
+            rel="noreferrer"
+            className="wp-panel-fullpage-link"
+          >
+            Open in full page ↗
+          </Link>
+        ) : null}
+        {headerActions}
+      </div>
+
+      <div className="wp-panel-body">
+        <div className={`wp-tree-pane${mobileView === "preview" ? " wp-mobile-hidden" : ""}`}>
+          <div className="wp-tree-toolbar">
+            <span className="wp-tree-toolbar-label">Files</span>
+            <button
+              type="button"
+              className={`wp-refresh-btn${treeRefreshing ? " spinning" : ""}`}
+              onClick={refreshTree}
+              title="Refresh files"
+              aria-label="Refresh files"
+            >
+              <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
+            </button>
+          </div>
+          {recentPaths.length > 0 ? (
+            <div className="wp-recent">
+              <p className="wp-recent-label">Recently written</p>
+              <ul className="wp-recent-list">
+                {recentPaths.slice(0, 10).map((p) => (
+                  <li key={p}>
+                    <button
+                      type="button"
+                      className={`wp-recent-item${openPath === p ? " selected" : ""}`}
+                      title={p}
+                      onClick={() => void handleSelectFile(p)}
+                    >
+                      {p.split("/").pop() ?? p}
+                      <span className="wp-recent-full">{p}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+          <div className="wp-tree-scroll">
+            <WorkspaceTree
+              host={host}
+              token={token}
+              sessionId={sessionId}
+              selectedPath={openPath}
+              revealPath={revealDir}
+              revealSeq={revealSeq}
+              refreshSeq={treeRefreshSeq}
+              onSelectFile={handleSelectFile}
+              onRootLoaded={setRoot}
+            />
+          </div>
+        </div>
+
+        <div className={`wp-preview-pane${mobileView === "tree" ? " wp-mobile-hidden" : ""}`}>
+          {openPath ? (
+            <>
+              <div className="wp-preview-header">
+                <span className="wp-preview-path" title={openPath}>
+                  {openPath}
+                </span>
+                <div className="wp-preview-actions">
+                  {fileData ? (
+                    <span className="wp-preview-meta">
+                      {formatBytes(fileData.size)} · {mtime}
+                    </span>
+                  ) : null}
+                  <button
+                    type="button"
+                    className={`wp-preview-btn wp-refresh-btn${fileLoading || fileRefreshing ? " spinning" : ""}`}
+                    onClick={refreshFile}
+                    title="Refresh file"
+                    aria-label="Refresh file"
+                  >
+                    <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
+                  </button>
+                  <button
+                    type="button"
+                    className="wp-preview-btn"
+                    onClick={copyPath}
+                    title="Copy path"
+                  >
+                    Copy path
+                  </button>
+                  {fileData?.content ? (
+                    <button
+                      type="button"
+                      className="wp-preview-btn"
+                      onClick={copyContents}
+                      title="Copy contents"
+                    >
+                      Copy contents
+                    </button>
+                  ) : null}
+                  {rawUrl ? (
+                    <a
+                      href={rawUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="wp-preview-btn"
+                      title="Open raw"
+                    >
+                      Open raw ↗
+                    </a>
+                  ) : null}
+                </div>
+              </div>
+              <div className="wp-preview-body">
+                {fileLoading ? (
+                  <div className="wp-preview-loading">Loading…</div>
+                ) : fileError ? (
+                  <div className="wp-preview-error">{fileError}</div>
+                ) : fileData ? (
+                  <FilePreview
+                    key={fileData.path}
+                    file={fileData}
+                    rawUrl={rawUrl ?? ""}
+                  />
+                ) : null}
+              </div>
+            </>
+          ) : (
+            <div className="wp-preview-empty">Select a file to preview</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -112,6 +112,9 @@ export function WorkspaceFilesPanel({
         role="separator"
         aria-orientation="vertical"
         aria-label="Resize files panel"
+        aria-valuenow={Math.round(width)}
+        aria-valuemin={300}
+        aria-valuemax={Math.round(window.innerWidth * 0.6)}
         tabIndex={0}
         onPointerDown={startResize}
         onKeyDown={onResizeKey}

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -1,18 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback } from "react";
 import { createPortal } from "react-dom";
 
-import {
-  fetchWorkspaceFile,
-  workspaceRawUrl,
-  type WorkspaceFile,
-  type WorkspaceTreePage,
-} from "@/lib/api";
-import { formatBytes } from "@/components/AttachmentTray";
-import { FilePreview } from "@/components/FilePreview";
-import { WorkspaceTree } from "@/components/WorkspaceTree";
-import { copyText } from "@/lib/clipboard";
+import { WorkspaceExplorer } from "@/components/WorkspaceExplorer";
 
 interface WorkspaceFilesPanelProps {
   host: string;
@@ -28,76 +19,6 @@ interface WorkspaceFilesPanelProps {
   onClose: () => void;
 }
 
-function useWorkspacePreview(host: string, token: string, sessionId: string) {
-  const [openPath, setOpenPathState] = useState<string | null>(null);
-  const [fileData, setFileData] = useState<WorkspaceFile | null>(null);
-  const [fileLoading, setFileLoading] = useState(false);
-  const [fileError, setFileError] = useState<string | null>(null);
-  const [root, setRoot] = useState<WorkspaceTreePage["root"] | null>(null);
-
-  // Tracks the most recent request so a slow fetch for a previously-selected
-  // file can't overwrite the content of the file the user switched to.
-  const latestRequest = useRef<string | null>(null);
-
-  const openFile = useCallback(
-    async (path: string) => {
-      latestRequest.current = path;
-      setOpenPathState(path);
-      setFileData(null);
-      setFileError(null);
-      setFileLoading(true);
-      try {
-        const data = await fetchWorkspaceFile(host, token, sessionId, path);
-        if (latestRequest.current !== path) return;
-        setFileData(data);
-      } catch (e) {
-        if (latestRequest.current !== path) return;
-        setFileError(e instanceof Error ? e.message : "Failed to load file");
-      } finally {
-        if (latestRequest.current === path) setFileLoading(false);
-      }
-    },
-    [host, token, sessionId],
-  );
-
-  // Background re-fetch of the open file with no loading flash; swaps content
-  // only when mtime/size actually changed, so an auto-refresh that finds nothing
-  // new never disturbs the reader's scroll position.
-  const silentRefreshFile = useCallback(async () => {
-    const path = latestRequest.current;
-    if (!path) return;
-    try {
-      const data = await fetchWorkspaceFile(host, token, sessionId, path);
-      if (latestRequest.current !== path) return;
-      setFileData((prev) =>
-        prev && prev.mtime === data.mtime && prev.size === data.size ? prev : data,
-      );
-    } catch {
-      // Silent: leave the current content in place on a transient failure.
-    }
-  }, [host, token, sessionId]);
-
-  const reset = useCallback(() => {
-    latestRequest.current = null;
-    setOpenPathState(null);
-    setFileData(null);
-    setFileError(null);
-    setFileLoading(false);
-  }, []);
-
-  return {
-    openPath,
-    openFile,
-    silentRefreshFile,
-    fileData,
-    fileLoading,
-    fileError,
-    root,
-    setRoot,
-    reset,
-  };
-}
-
 export function WorkspaceFilesPanel({
   host,
   token,
@@ -111,44 +32,6 @@ export function WorkspaceFilesPanel({
   onResize,
   onClose,
 }: WorkspaceFilesPanelProps) {
-  const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
-  const [revealDir, setRevealDir] = useState<string | null>(null);
-  const [treeRefreshSeq, setTreeRefreshSeq] = useState(0);
-  const [treeRefreshing, setTreeRefreshing] = useState(false);
-  const [fileRefreshing, setFileRefreshing] = useState(false);
-  const {
-    openPath,
-    openFile,
-    silentRefreshFile,
-    fileData,
-    fileLoading,
-    fileError,
-    root,
-    setRoot,
-    reset,
-  } = useWorkspacePreview(host, token, sessionId);
-
-  useEffect(() => {
-    if (!open) return;
-    reset();
-    if (initialPath) {
-      void openFile(initialPath);
-      setRevealDir(null);
-      setMobileView("preview");
-    } else if (initialDir != null) {
-      setRevealDir(initialDir);
-      setMobileView("tree");
-    } else {
-      setRevealDir(null);
-      setMobileView("tree");
-    }
-    // revealSeq is the retrigger knob: it bumps on every open request so an
-    // identical path still re-reveals.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, initialPath, initialDir, revealSeq]);
-
-  // Drag the right-edge seam to resize the dock. The dock is non-modal, so the
-  // width lives in the parent and is persisted there; this only reports deltas.
   const clampWidth = useCallback(
     (w: number) => Math.max(300, Math.min(w, Math.round(window.innerWidth * 0.6))),
     [],
@@ -183,62 +66,6 @@ export function WorkspaceFilesPanel({
     [clampWidth, onResize, width],
   );
 
-  const refreshTree = useCallback(() => {
-    setTreeRefreshSeq((s) => s + 1);
-    setTreeRefreshing(true);
-    window.setTimeout(() => setTreeRefreshing(false), 600);
-  }, []);
-  const refreshFile = useCallback(() => {
-    if (!openPath) return;
-    void silentRefreshFile();
-    setFileRefreshing(true);
-    window.setTimeout(() => setFileRefreshing(false), 600);
-  }, [openPath, silentRefreshFile]);
-
-  // Auto-refresh when the tab regains focus — the common case is the user
-  // switching to the terminal, the agent editing files, then switching back.
-  // Throttled so visibilitychange + focus firing together only refresh once.
-  const lastFocusRefresh = useRef(0);
-  useEffect(() => {
-    if (!open) return;
-    const onVisible = () => {
-      if (document.visibilityState !== "visible") return;
-      const now = Date.now();
-      if (now - lastFocusRefresh.current < 1000) return;
-      lastFocusRefresh.current = now;
-      void silentRefreshFile();
-      setTreeRefreshSeq((s) => s + 1);
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    window.addEventListener("focus", onVisible);
-    return () => {
-      document.removeEventListener("visibilitychange", onVisible);
-      window.removeEventListener("focus", onVisible);
-    };
-  }, [open, silentRefreshFile]);
-
-  const handleSelectFile = useCallback(
-    async (path: string) => {
-      await openFile(path);
-      setMobileView("preview");
-    },
-    [openFile],
-  );
-
-  const copyPath = useCallback(() => {
-    if (!openPath) return;
-    void copyText(openPath);
-  }, [openPath]);
-
-  const copyContents = useCallback(() => {
-    if (fileData?.content) {
-      void copyText(fileData.content);
-    }
-  }, [fileData]);
-
-  const rawUrl = openPath ? workspaceRawUrl(host, token, sessionId, openPath) : null;
-  const mtime = fileData ? new Date(fileData.mtime * 1000).toLocaleString() : null;
-
   if (!open || typeof document === "undefined") return null;
 
   return createPortal(
@@ -250,31 +77,16 @@ export function WorkspaceFilesPanel({
         if (e.key === "Escape") onClose();
       }}
     >
-        <div className="wp-panel-header">
-          <div className="wp-panel-title">
-            <span>Workspace files</span>
-            {root ? (
-              <span className="wp-panel-cwd" title={root.worktreePath ?? root.cwd}>
-                {root.worktreePath ?? root.cwd}
-              </span>
-            ) : null}
-          </div>
-          <div className="wp-panel-mobile-toggle">
-            <button
-              type="button"
-              className={`wp-toggle-btn${mobileView === "tree" ? " active" : ""}`}
-              onClick={() => setMobileView("tree")}
-            >
-              Tree
-            </button>
-            <button
-              type="button"
-              className={`wp-toggle-btn${mobileView === "preview" ? " active" : ""}`}
-              onClick={() => setMobileView("preview")}
-            >
-              Preview
-            </button>
-          </div>
+      <WorkspaceExplorer
+        host={host}
+        token={token}
+        sessionId={sessionId}
+        recentPaths={recentPaths}
+        initialPath={initialPath}
+        initialDir={initialDir}
+        revealSeq={revealSeq}
+        showFullPageLink
+        headerActions={
           <button
             type="button"
             className="wp-panel-close"
@@ -283,138 +95,17 @@ export function WorkspaceFilesPanel({
           >
             ×
           </button>
-        </div>
-
-        <div className="wp-panel-body">
-          <div className={`wp-tree-pane${mobileView === "preview" ? " wp-mobile-hidden" : ""}`}>
-            <div className="wp-tree-toolbar">
-              <span className="wp-tree-toolbar-label">Files</span>
-              <button
-                type="button"
-                className={`wp-refresh-btn${treeRefreshing ? " spinning" : ""}`}
-                onClick={refreshTree}
-                title="Refresh files"
-                aria-label="Refresh files"
-              >
-                <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
-              </button>
-            </div>
-            {recentPaths.length > 0 ? (
-              <div className="wp-recent">
-                <p className="wp-recent-label">Recently written</p>
-                <ul className="wp-recent-list">
-                  {recentPaths.slice(0, 10).map((p) => (
-                    <li key={p}>
-                      <button
-                        type="button"
-                        className={`wp-recent-item${openPath === p ? " selected" : ""}`}
-                        title={p}
-                        onClick={() => void handleSelectFile(p)}
-                      >
-                        {p.split("/").pop() ?? p}
-                        <span className="wp-recent-full">{p}</span>
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            <div className="wp-tree-scroll">
-              <WorkspaceTree
-                host={host}
-                token={token}
-                sessionId={sessionId}
-                selectedPath={openPath}
-                revealPath={revealDir}
-                revealSeq={revealSeq}
-                refreshSeq={treeRefreshSeq}
-                onSelectFile={handleSelectFile}
-                onRootLoaded={setRoot}
-              />
-            </div>
-          </div>
-
-          <div className={`wp-preview-pane${mobileView === "tree" ? " wp-mobile-hidden" : ""}`}>
-            {openPath ? (
-              <>
-                <div className="wp-preview-header">
-                  <span className="wp-preview-path" title={openPath}>
-                    {openPath}
-                  </span>
-                  <div className="wp-preview-actions">
-                    {fileData ? (
-                      <span className="wp-preview-meta">
-                        {formatBytes(fileData.size)} · {mtime}
-                      </span>
-                    ) : null}
-                    <button
-                      type="button"
-                      className={`wp-preview-btn wp-refresh-btn${fileLoading || fileRefreshing ? " spinning" : ""}`}
-                      onClick={refreshFile}
-                      title="Refresh file"
-                      aria-label="Refresh file"
-                    >
-                      <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
-                    </button>
-                    <button
-                      type="button"
-                      className="wp-preview-btn"
-                      onClick={copyPath}
-                      title="Copy path"
-                    >
-                      Copy path
-                    </button>
-                    {fileData?.content ? (
-                      <button
-                        type="button"
-                        className="wp-preview-btn"
-                        onClick={copyContents}
-                        title="Copy contents"
-                      >
-                        Copy contents
-                      </button>
-                    ) : null}
-                    {rawUrl ? (
-                      <a
-                        href={rawUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="wp-preview-btn"
-                        title="Open raw"
-                      >
-                        Open raw ↗
-                      </a>
-                    ) : null}
-                  </div>
-                </div>
-                <div className="wp-preview-body">
-                  {fileLoading ? (
-                    <div className="wp-preview-loading">Loading…</div>
-                  ) : fileError ? (
-                    <div className="wp-preview-error">{fileError}</div>
-                  ) : fileData ? (
-                    <FilePreview
-                      key={fileData.path}
-                      file={fileData}
-                      rawUrl={rawUrl ?? ""}
-                    />
-                  ) : null}
-                </div>
-              </>
-            ) : (
-              <div className="wp-preview-empty">Select a file to preview</div>
-            )}
-          </div>
-        </div>
-        <div
-          className="wp-dock-resizer"
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize files panel"
-          tabIndex={0}
-          onPointerDown={startResize}
-          onKeyDown={onResizeKey}
-        />
+        }
+      />
+      <div
+        className="wp-dock-resizer"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize files panel"
+        tabIndex={0}
+        onPointerDown={startResize}
+        onKeyDown={onResizeKey}
+      />
     </aside>,
     document.body,
   );

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -23,6 +23,8 @@ interface WorkspaceFilesPanelProps {
   initialDir?: string;
   revealSeq?: number;
   recentPaths: string[];
+  width: number;
+  onResize: (width: number) => void;
   onClose: () => void;
 }
 
@@ -105,6 +107,8 @@ export function WorkspaceFilesPanel({
   initialDir,
   revealSeq,
   recentPaths,
+  width,
+  onResize,
   onClose,
 }: WorkspaceFilesPanelProps) {
   const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
@@ -143,14 +147,41 @@ export function WorkspaceFilesPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, initialPath, initialDir, revealSeq]);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  // Drag the right-edge seam to resize the dock. The dock is non-modal, so the
+  // width lives in the parent and is persisted there; this only reports deltas.
+  const clampWidth = useCallback(
+    (w: number) => Math.max(300, Math.min(w, Math.round(window.innerWidth * 0.6))),
+    [],
+  );
+  const startResize = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = width;
+      const onMove = (ev: PointerEvent) => onResize(clampWidth(startWidth + (ev.clientX - startX)));
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        document.body.classList.remove("wp-dock-resizing");
+      };
+      document.body.classList.add("wp-dock-resizing");
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [clampWidth, onResize, width],
+  );
+  const onResizeKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        onResize(clampWidth(width + 24));
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        onResize(clampWidth(width - 24));
+      }
+    },
+    [clampWidth, onResize, width],
+  );
 
   const refreshTree = useCallback(() => {
     setTreeRefreshSeq((s) => s + 1);
@@ -211,18 +242,14 @@ export function WorkspaceFilesPanel({
   if (!open || typeof document === "undefined") return null;
 
   return createPortal(
-    <div
-      className="wp-panel-backdrop"
-      onPointerDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
+    <aside
+      className="wp-dock"
+      role="complementary"
+      aria-label="Workspace files"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") onClose();
       }}
     >
-      <div
-        className="wp-panel-modal"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Workspace files"
-      >
         <div className="wp-panel-header">
           <div className="wp-panel-title">
             <span>Workspace files</span>
@@ -379,8 +406,16 @@ export function WorkspaceFilesPanel({
             )}
           </div>
         </div>
-      </div>
-    </div>,
+        <div
+          className="wp-dock-resizer"
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize files panel"
+          tabIndex={0}
+          onPointerDown={startResize}
+          onKeyDown={onResizeKey}
+        />
+    </aside>,
     document.body,
   );
 }

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { WorkspaceExplorer } from "@/components/WorkspaceExplorer";
@@ -66,13 +66,22 @@ export function WorkspaceFilesPanel({
     [clampWidth, onResize, width],
   );
 
-  if (!open || typeof document === "undefined") return null;
+  // Mount the dock lazily on first open (no eager tree fetch before then), and
+  // keep it mounted afterwards — hidden via CSS when closed — so its tree
+  // expansion and open file survive a close/reopen.
+  const [hasOpened, setHasOpened] = useState(false);
+  useEffect(() => {
+    if (open) setHasOpened(true);
+  }, [open]);
+
+  if (typeof document === "undefined" || !hasOpened) return null;
 
   return createPortal(
     <aside
-      className="wp-dock"
+      className={`wp-dock${open ? "" : " wp-dock-closed"}`}
       role="complementary"
       aria-label="Workspace files"
+      aria-hidden={!open}
       onKeyDown={(e) => {
         if (e.key === "Escape") onClose();
       }}
@@ -85,6 +94,7 @@ export function WorkspaceFilesPanel({
         initialPath={initialPath}
         initialDir={initialDir}
         revealSeq={revealSeq}
+        active={open}
         showFullPageLink
         headerActions={
           <button


### PR DESCRIPTION
## Summary

Reworks the workspace file panel from a blocking modal into a non-modal **side dock** you can browse while still using the session, and adds a dedicated **full-page file browser** route that reuses the same component. Frontend-only.

## Changes

- **Side dock** — the file panel is now a non-modal left `<aside>` (transcript + composer stay interactive) with three responsive regimes: push (the session column insets beside the dock on wide viewports), overlay (mid), and a mobile full-screen sheet. Includes a resizable right-edge seam with persisted width and a dock-width container query driving the tree/preview split. Dock state (tree expansion, open file) is preserved across close/reopen, and it mounts lazily on first open.
- **Full-page browser** — extracts a presentation-agnostic `WorkspaceExplorer` from the panel and reuses it in a new `/session/[id]/files` route: app-bar matching the session page, `?path=` deep-linking, and a browser-tab title that mirrors the session page format. An "Open in full page ↗" link in the dock header opens it in a new tab.

## Testing

- `cd frontend && npx tsc --noEmit && npm run lint && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)