### PR TITLE
chore: pin the maiden release to 0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
   ],
   "packages": {
     ".": {
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "release-as": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
## Purpose

After resetting the release-please baseline to `0.0.0` (#162), release-please proposed **1.0.0** for the first release (#155), not `0.1.0`. There are no breaking-change commits — release-please simply bootstraps the first release from a `0.0.0` baseline to `1.0.0`. The `bump-minor-pre-major` strategy only governs how an *existing* 0.x is bumped, not the initial release, so no baseline value computes to `0.1.0`. This pins it explicitly.

Relates to #155.

## Changes

- **`release-please-config.json`** — add `"release-as": "0.1.0"` to the `.` package so the next release is forced to `0.1.0` regardless of the computed bump.

## Design

`release-as` overrides release-please's computed version. With it set, release-please reconciles the open release PR (#155) to `release 0.1.0`; merging that tags `v0.1.0` and writes the manifest to `0.1.0`. The commit-footer form of `Release-As` would avoid a cleanup step, but it's unreliable under squash-merge (the footer may not survive into the squashed commit), so the config form is used.

`release-as` is **sticky** — it must be removed after `v0.1.0` ships or it pins every future release to `0.1.0`. That removal is a follow-up PR (PR-B), to be merged right after #155.

## Test Plan

- [x] `release-please-config.json` is valid JSON; `release-as` lands under `packages["."]`.
- [ ] Post-merge: confirm release-please retitles #155 to `release 0.1.0` (observable only after this lands on `main`).

## Test Result

n/a — release config; effect is observable on #155 after merge.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. — codespell ran via the commit hook; no Python touched.
- [ ] I have added or updated tests covering my changes (if applicable). — N/A (release config).
- [ ] If I touched the coding-agent plugin/transport contract or dispatch-by-plugin-id, I checked the affected backends still work. — N/A.
- [ ] If I changed the frontend, I ran lint + build. — N/A.
- [ ] If this is a breaking change, I marked the title and described migration. — N/A.
- [x] I have updated documentation or config examples if user-facing behavior changed. — docs/RELEASING.md already describes the flow; no change needed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)