### PR TITLE
ci: exempt automation bots from the DCO sign-off check

### DIFF
--- a/.github/workflows/check-signoff.yml
+++ b/.github/workflows/check-signoff.yml
@@ -31,6 +31,11 @@ jobs:
             if [ "$(git rev-list --parents -n1 "$SHA" | wc -w)" -gt 2 ]; then
               continue
             fi
+            # Skip bot authors (release-please via github-actions, dependabot) —
+            # automated commits can't carry a meaningful DCO sign-off.
+            case "$(git log -1 --format='%an' "$SHA")" in
+              'github-actions[bot]'|'dependabot[bot]') continue ;;
+            esac
             if ! git log -1 --format='%B' "$SHA" | grep -qE '^Signed-off-by: .+ <.+>'; then
               echo "::error::Missing sign-off: $(git log -1 --oneline "$SHA")"
               FAILED=1


### PR DESCRIPTION
## Purpose

The DCO sign-off check blocks every release-please PR (e.g. the 0.1.0 release, #155): release-please's release commit is authored by `github-actions[bot]` with no `Signed-off-by:` trailer, and release-please has no option to add one. Exempt automation bots so the check stops blocking release/dep PRs while still enforcing DCO for humans.

Relates to #155.

## Changes

- **`.github/workflows/check-signoff.yml`** — skip commits authored by `github-actions[bot]` or `dependabot[bot]` in the sign-off loop (in addition to merge commits).

## Design

An explicit author allowlist rather than a `*[bot]` wildcard, so a human can't bypass DCO by setting their git author name to `something[bot]`. Dependabot already self-signs (`Signed-off-by: dependabot[bot]`), so it would pass regardless; it's listed for clarity/robustness. The check stays a normal passing job (no job-level skip), so it still satisfies branch protection if it's a required check.

## Test Plan

- [x] `check-signoff.yml` parses as YAML.
- [x] Exercised the `case` locally: `github-actions[bot]` and `dependabot[bot]` skip; `Noppanat Wadlom` and a spoofed `sneaky[bot]` are still checked.
- [ ] Post-merge: release-please regenerates #155 off updated `main`; its DCO check then passes.

## Test Result

```
SKIP  | github-actions[bot]
SKIP  | dependabot[bot]
CHECK | Noppanat Wadlom
CHECK | sneaky[bot]
```

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. — codespell ran via the commit hook; no Python touched.
- [ ] I have added or updated tests covering my changes (if applicable). — N/A (CI workflow).
- [ ] If I touched the coding-agent plugin/transport contract or dispatch-by-plugin-id, I checked the affected backends still work. — N/A.
- [ ] If I changed the frontend, I ran lint + build. — N/A.
- [ ] If this is a breaking change, I marked the title and described migration. — N/A.
- [x] I have updated documentation or config examples if user-facing behavior changed. — workflow self-explanatory; CONTRIBUTING already documents the DCO requirement.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)