### PR TITLE
chore: remove the release-as pin after v0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,8 +12,7 @@
   ],
   "packages": {
     ".": {
-      "include-component-in-tag": false,
-      "release-as": "0.1.0"
+      "include-component-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Purpose

`release-as: "0.1.0"` was a one-time override to force the maiden release to `0.1.0` (release-please otherwise bootstraps a `0.0.0` baseline to `1.0.0`). `v0.1.0` is now tagged, so the pin is spent — and if left in, it would force every future release back to `0.1.0`. Remove it.

Follows #163 (which added the pin) and the `v0.1.0` release (#155).

## Changes

- **`release-please-config.json`** — drop `"release-as": "0.1.0"` from the `.` package.

## Design

With the pin gone and the manifest at `0.1.0`, release-please resumes normal computation from the `0.1.0` baseline: `feat:` → `0.2.0`, `fix:` → `0.1.1`, breaking → `0.2.0` (capped by `bump-minor-pre-major` while < 1.0.0).

## Test Plan

- [x] `release-please-config.json` is valid JSON and no longer contains `release-as`.
- [ ] Post-merge: the next release-please PR proposes a computed version (e.g. `0.2.0` from the queued `feat:` commits), not `0.1.0`.

## Test Result

n/a — release config; effect observable on the next release-please PR.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. — codespell ran via the commit hook; no Python touched.
- [ ] I have added or updated tests covering my changes (if applicable). — N/A (release config).
- [ ] If I touched the coding-agent plugin/transport contract or dispatch-by-plugin-id, I checked the affected backends still work. — N/A.
- [ ] If I changed the frontend, I ran lint + build. — N/A.
- [ ] If this is a breaking change, I marked the title and described migration. — N/A.
- [x] I have updated documentation or config examples if user-facing behavior changed. — docs/RELEASING.md already describes the flow.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)