### PR TITLE
build: regenerate next-env.d.ts and tsconfig.json for Next 16

### DIFF
--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Purpose

The frontend is pinned to Next `^16.2.9`, but `frontend/next-env.d.ts` and `frontend/tsconfig.json` were still the Next 15 scaffold output (last touched in the initial scaffold). Next 16's build regenerates them, so the worktree was left perpetually dirty after every build/restart. This commits the canonical Next 16 output.

## Changes

- **`frontend/next-env.d.ts`** — Next 16 form: `import "./.next/types/routes.d.ts";` replaces the old `/// <reference path=… />`. (Auto-generated; "should not be edited.")
- **`frontend/tsconfig.json`** — Next-16-managed updates: `jsx: "preserve"` → `"react-jsx"` and `.next/dev/types/**/*.ts` added to `include` (plus Next's array reformatting).

## Design

These are generated/tool-managed files, not hand edits — they are exactly what the most recent `next build` produced (the live frontend was restarted onto this output and is healthy). Committing them aligns the tracked files with the pinned Next version so the tree stops drifting. `jsx: react-jsx` is Next 16's default and only affects `tsc`/editor type-checking (Next compiles JSX via SWC regardless); `eslint` and the production build both pass with it.

## Test Plan

- [x] `cd frontend && npm run lint` — clean.
- [x] Files are the canonical Next 16 build output — the `waypointctl restart` rebuild that generated them succeeded and the frontend is serving healthy. (`npm run build` not re-run here to avoid overwriting `.next` under the live server.)

## Test Result

`eslint .` — no errors.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. — codespell ran via the commit hook; no Python touched.
- [ ] I have added or updated tests covering my changes (if applicable). — N/A (generated config).
- [ ] If I touched the coding-agent plugin/transport contract or dispatch-by-plugin-id, I checked the affected backends still work. — N/A.
- [x] If I changed the frontend, I ran `npm run lint` and kept dark/light theme parity (screenshots optional). — lint clean; no UI/style change.
- [ ] If this is a breaking change, I marked the title and described migration. — N/A.
- [x] I have updated documentation or config examples if user-facing behavior changed. — N/A (no behavior change).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)