### PR TITLE
fix: don't let build-generated files block waypointctl update

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,6 +105,11 @@ if [[ -d "${INSTALL_DIR}/.git" ]]; then
     if [[ "${managed}" != "true" && "${FORCE}" -ne 1 ]]; then
         die "refusing to update ${INSTALL_DIR}: not an installer-managed checkout (it looks like your own clone). Point WAYPOINT_HOME at a dedicated directory, or re-run with --force to repoint this one."
     fi
+    # In a managed checkout, clear build-generated drift (start/restart rewrites
+    # these tracked files) so it doesn't trip the dirty-tree guard below.
+    if [[ "${managed}" = "true" ]]; then
+        git -C "${INSTALL_DIR}" checkout -- frontend/next-env.d.ts frontend/tsconfig.json 2>/dev/null || true
+    fi
     if [[ -n "$(git -C "${INSTALL_DIR}" status --porcelain)" ]]; then
         die "refusing to update ${INSTALL_DIR}: it has uncommitted changes. Commit or stash them first."
     fi

--- a/waypointctl/src/waypointctl/update.py
+++ b/waypointctl/src/waypointctl/update.py
@@ -8,6 +8,11 @@ from waypointctl.paths import resolve_waypoint_home
 
 DEFAULT_BRANCH = "main"
 
+# Tracked files the frontend build regenerates; a prior `start`/`restart` leaves
+# them modified, which would otherwise trip the dirty-tree guard. They are
+# rewritten by the post-checkout build, so discarding the drift is safe.
+_GENERATED_FILES = ("frontend/next-env.d.ts", "frontend/tsconfig.json")
+
 
 def _resolve_home(home: Path | None) -> Path:
     try:
@@ -29,6 +34,25 @@ def _is_dirty(home: Path) -> bool:
         text=True,
     )
     return bool(result.stdout.strip())
+
+
+def _is_managed(home: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(home), "config", "--get", "waypoint.managed"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() == "true"
+
+
+def _discard_generated(home: Path) -> None:
+    for rel in _GENERATED_FILES:
+        subprocess.run(
+            ["git", "-C", str(home), "checkout", "--", rel],
+            check=False,
+            capture_output=True,
+        )
 
 
 def _latest_tag(home: Path) -> str:
@@ -74,6 +98,10 @@ def run(
         raise typer.BadParameter("--nightly cannot be combined with --ref")
 
     resolved = _resolve_home(home)
+    # In an installer-managed checkout, clear build-generated drift first so a
+    # prior start/restart doesn't block the update on "uncommitted changes".
+    if _is_managed(resolved):
+        _discard_generated(resolved)
     if _is_dirty(resolved):
         raise RuntimeError(
             f"refusing to update {resolved}: it has uncommitted changes; "

--- a/waypointctl/tests/test_update.py
+++ b/waypointctl/tests/test_update.py
@@ -7,10 +7,18 @@ import typer
 from waypointctl import update
 
 
-def _fake_run(*, dirty: str = "", tags: str = "v1.0.0\n", remote_has=lambda ref: False):
+def _fake_run(
+    *,
+    dirty: str = "",
+    tags: str = "v1.0.0\n",
+    remote_has=lambda ref: False,
+    managed: bool = False,
+):
     """A subprocess.run stub that dispatches on the git subcommand."""
 
     def run(argv, **kwargs):
+        if "config" in argv and "waypoint.managed" in argv:
+            return MagicMock(returncode=0, stdout="true\n" if managed else "")
         if "status" in argv:
             return MagicMock(returncode=0, stdout=dirty)
         if "tag" in argv and "--list" in argv:
@@ -28,7 +36,7 @@ def _argvs(mock_run) -> list[list[str]]:
 
 
 def _checkout_cmd(argvs: list[list[str]]) -> list[str]:
-    return next(a for a in argvs if "checkout" in a)
+    return next(a for a in argvs if "checkout" in a and "--detach" in a)
 
 
 def test_explicit_ref_checks_out_a_tag(tmp_path: Path) -> None:
@@ -147,6 +155,40 @@ def test_uv_force_and_restart_env(tmp_path: Path) -> None:
         restart_call.kwargs.get("env", {}).get("WAYPOINT_STACK_FORCE_FRONTEND_BUILD")
         == "1"
     )
+
+
+def test_managed_update_discards_generated_files(tmp_path: Path) -> None:
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run", side_effect=_fake_run(managed=True)
+        ) as mock_run,
+    ):
+        update.run(tmp_path, ref="v1.0.0")
+
+    argvs = _argvs(mock_run)
+    for rel in ("frontend/next-env.d.ts", "frontend/tsconfig.json"):
+        assert ["git", "-C", str(tmp_path), "checkout", "--", rel] in argvs
+    # the discard doesn't abort the update
+    assert any(a and a[0] == "uv" and "--force" in a for a in argvs)
+
+
+def test_unmanaged_update_skips_discard(tmp_path: Path) -> None:
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run", side_effect=_fake_run(managed=False)
+        ) as mock_run,
+    ):
+        update.run(tmp_path, ref="v1.0.0")
+
+    argvs = _argvs(mock_run)
+    discards = [
+        a
+        for a in argvs
+        if "checkout" in a and "--" in a and any("frontend/" in x for x in a)
+    ]
+    assert discards == []
 
 
 def test_resolve_home_uses_provided_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Purpose

`waypointctl start`/`restart` run the frontend build, which regenerates the tracked `frontend/next-env.d.ts` and `frontend/tsconfig.json`. That leaves an installer-managed checkout "dirty", so the **next `waypointctl update` (and `scripts/install.sh` re-run) refuses** with *"it has uncommitted changes"* — i.e. installs can build once but then can't update. This makes the updater tolerant of that build drift.

Relates to #166 (which committed the canonical Next 16 files); this is the durable fix so future build/Next-version drift can't reintroduce the breakage.

## Changes

- **`waypointctl/src/waypointctl/update.py`** — in an installer-managed checkout (the `waypoint.managed` git-config marker), `git checkout --` the build-generated files (`_GENERATED_FILES`) before the dirty-tree guard. They're rewritten by the post-checkout build, so discarding the local drift is safe.
- **`scripts/install.sh`** — same discard in the managed update path, before its `git status --porcelain` guard.
- **`waypointctl/tests/test_update.py`** — cover that a managed update discards the generated files and still proceeds, and that an unmanaged checkout skips the discard.

## Design

The discard is **gated on the `waypoint.managed` marker** and **scoped to exactly the two generated files** — so the safety guard added earlier stays intact: real uncommitted edits to any other file still block the update, and a development clone (no marker) is never touched. `git checkout --` (vs `--skip-worktree` or gitignore) both clears the dirty state *and* lets the subsequent `git checkout <tag>` apply cleanly; `tsconfig.json` must stay tracked, so gitignore was not an option.

As a `fix:`, this also lets release-please cut the patch release that carries #166.

## Test Plan

- [x] `cd waypointctl && uv run pytest tests/test_update.py` — 12 passed (incl. the two new managed/unmanaged cases).
- [x] `bash -n scripts/install.sh` — clean.
- Note: the full `waypointctl` suite shows one unrelated failure locally — `test_tailscale.py::test_helper_up_uses_repo_dotenv_and_exposes_ports` reads the gitignored repo `.env`, which on the dev host has custom ports (8797/3010); `.env` is absent in CI so it uses defaults and passes there. Not touched by this diff.

## Test Result

```
tests/test_update.py ............ [100%]
12 passed
```

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. — black/ruff/codespell/mypy ran via the commit hook on the touched files.
- [x] I have added or updated tests covering my changes (if applicable). — managed-discard + unmanaged-skip cases.
- [ ] If I touched the coding-agent plugin/transport contract or dispatch-by-plugin-id, I checked the affected backends still work. — N/A.
- [ ] If I changed the frontend, I ran lint + build. — N/A (no frontend code change).
- [ ] If this is a breaking change, I marked the title and described migration. — N/A.
- [x] I have updated documentation or config examples if user-facing behavior changed. — behavior is internal to the updater; no docs/config change needed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)