### PR TITLE
fix: don't start or restart the stack during install and update

### DIFF
--- a/.agents/skills/waypointctl/references/update-deploy.md
+++ b/.agents/skills/waypointctl/references/update-deploy.md
@@ -12,9 +12,12 @@ waypointctl update --nightly       # tip of main
 
 `update` refuses to run if the checkout has uncommitted changes, then fetches,
 checks out the target (release tags detach; branches like `main` track the
-remote tip), reinstalls `waypointctl` via `uv tool install --force`, and
-restarts the stack with a forced frontend rebuild. Because it restarts, treat it
-like a restart: get the user's permission first and follow `restart-safety.md`.
+remote tip), and reinstalls `waypointctl` via `uv tool install --force`. It does
+**not** touch the running stack — apply the new code yourself with
+`waypointctl restart` (or `restart backend` / `restart frontend`), getting the
+user's permission and following `restart-safety.md` for backend or full-stack
+restarts. The frontend rebuilds automatically on the next restart because the
+checked-out ref changed.
 
 ## Manual flow (when you need step-by-step control)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Adding a brand-new coding agent (Aider, …) is its own flow — the runtime, AP
 curl -fsSL https://raw.githubusercontent.com/kaiitunnz/waypoint/main/scripts/install.sh | bash
 ```
 
-The installer fetches the latest tagged release, clones the repo to `~/.waypoint/app` (or `$WAYPOINT_HOME` if set — use a dedicated directory, not an existing development clone), seeds default config files with a random password, and starts the stack. To pin a specific version, pass `--ref` through the pipe:
+The installer fetches the latest tagged release, clones the repo to `~/.waypoint/app` (or `$WAYPOINT_HOME` if set — use a dedicated directory, not an existing development clone), seeds default config files with a random password, and installs `waypointctl`. It does not start the stack — run `waypointctl start` (or `waypointctl start backend`) yourself once it finishes. To pin a specific version, pass `--ref` through the pipe:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kaiitunnz/waypoint/main/scripts/install.sh | bash -s -- --ref v0.1.0
@@ -67,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/kaiitunnz/waypoint/main/scripts/ins
 
 or set `WAYPOINT_VERSION=v0.1.0` in the environment before running. To track the bleeding edge instead of a release, pass `--nightly` (the tip of `main`). Prerequisites: git and Node.js ≥ 20 (npm included); `uv` is installed automatically if absent.
 
-The stack starts automatically after installation. Use `waypointctl update` to upgrade to the latest release, `waypointctl update --ref vX.Y.Z` to pin a specific version, or `waypointctl update --nightly` to track `main`.
+Bring the stack up with `waypointctl start`. Use `waypointctl update` to upgrade to the latest release, `waypointctl update --ref vX.Y.Z` to pin a specific version, or `waypointctl update --nightly` to track `main`; `update` leaves the stack untouched, so run `waypointctl restart` afterward to apply the new code.
 
 **OpenCode** — the `opencode` CLI must be installed separately and present on your PATH; Waypoint does not bundle it.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,4 +42,4 @@ waypointctl update --ref vX.Y.Z      # pin to a specific tag
 waypointctl update --nightly         # track the tip of main
 ```
 
-`update` refuses to run on a checkout with uncommitted changes, then fetches, checks out the target (release tags detach; branches like `main` track the remote tip), reinstalls `waypointctl` via `uv tool install --force`, sets `WAYPOINT_STACK_FORCE_FRONTEND_BUILD=1`, and restarts the stack.
+`update` refuses to run on a checkout with uncommitted changes, then fetches, checks out the target (release tags detach; branches like `main` track the remote tip), and reinstalls `waypointctl` via `uv tool install --force`. It leaves the running stack untouched; run `waypointctl restart` afterward to apply the new code (the frontend rebuilds automatically because the checked-out ref changed).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -147,11 +147,6 @@ fi
 printf 'Installing waypointctl...\n'
 uv tool install --force "${INSTALL_DIR}/waypointctl"
 
-# ── start stack ─────────────────────────────────────────────────────────────
-printf 'Starting Waypoint...\n'
-export WAYPOINT_HOME="${INSTALL_DIR}"
-waypointctl start
-
 # ── persist WAYPOINT_HOME in shell profiles ─────────────────────────────────
 EXPORT_LINE="export WAYPOINT_HOME=\"${INSTALL_DIR}\""
 FISH_LINE="set -gx WAYPOINT_HOME \"${INSTALL_DIR}\""
@@ -198,4 +193,6 @@ printf '\nWaypoint %s installed to %s\n' "${TARGET_REF}" "${INSTALL_DIR}"
 printf 'To load waypointctl in this shell:\n'
 printf '  source %s\n' "${PRIMARY_RC}"
 printf '  # or open a new terminal\n\n'
-printf 'Then run: waypointctl status\n'
+printf 'Then start the stack:\n'
+printf '  waypointctl start           # backend + frontend\n'
+printf '  waypointctl start backend   # backend only\n'

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -296,7 +296,7 @@ def update(
         ),
     ] = False,
 ) -> None:
-    """Update Waypoint to the latest release and restart the stack."""
+    """Update Waypoint to the latest release; run `waypointctl restart` to apply."""
     run_update(_ctx_home(ctx), ref=ref, nightly=nightly)
 
 

--- a/waypointctl/src/waypointctl/update.py
+++ b/waypointctl/src/waypointctl/update.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 
@@ -93,7 +92,10 @@ def _checkout(home: Path, ref: str) -> None:
 def run(
     home: Path | None = None, ref: str | None = None, nightly: bool = False
 ) -> None:
-    """Update Waypoint to the latest release (or --ref / --nightly) and restart."""
+    """Update Waypoint to the latest release (or --ref / --nightly).
+
+    The stack is left untouched; run `waypointctl restart` afterward to apply.
+    """
     if nightly and ref is not None:
         raise typer.BadParameter("--nightly cannot be combined with --ref")
 
@@ -127,10 +129,4 @@ def run(
         ["uv", "tool", "install", "--force", str(resolved / "waypointctl")], check=True
     )
 
-    restart_env = {**os.environ, "WAYPOINT_STACK_FORCE_FRONTEND_BUILD": "1"}
-    subprocess.run(
-        ["waypointctl", "--home", str(resolved), "restart"],
-        check=True,
-        env=restart_env,
-    )
-    typer.echo(f"Updated to {target}")
+    typer.echo(f"Updated to {target}. Run 'waypointctl restart' to apply.")

--- a/waypointctl/tests/test_update.py
+++ b/waypointctl/tests/test_update.py
@@ -140,7 +140,7 @@ def test_nightly_with_ref_is_rejected(tmp_path: Path) -> None:
     assert mock_run.call_args_list == []  # rejected before touching git
 
 
-def test_uv_force_and_restart_env(tmp_path: Path) -> None:
+def test_uv_force_and_no_restart(tmp_path: Path) -> None:
     with (
         patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
         patch("waypointctl.update.subprocess.run", side_effect=_fake_run()) as mock_run,
@@ -150,11 +150,9 @@ def test_uv_force_and_restart_env(tmp_path: Path) -> None:
     argvs = _argvs(mock_run)
     uv_cmd = next(a for a in argvs if a and a[0] == "uv")
     assert "--force" in uv_cmd
-    restart_call = next(c for c in mock_run.call_args_list if "restart" in c.args[0])
-    assert (
-        restart_call.kwargs.get("env", {}).get("WAYPOINT_STACK_FORCE_FRONTEND_BUILD")
-        == "1"
-    )
+    # update reinstalls the tool but leaves the stack alone
+    assert not any("restart" in a for a in argvs)
+    assert not any(a and a[0] == "waypointctl" for a in argvs)
 
 
 def test_managed_update_discards_generated_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Purpose

Decouple code installation from process lifecycle. The bootstrap installer ran `waypointctl start` and `waypointctl update` ran `waypointctl restart`, so every install or upgrade forced the whole stack up. A deployment that only wants the backend running had no say. Both now stop after (re)installing `waypointctl` and tell you the command to run next.

## Changes

- `scripts/install.sh` — drop the `waypointctl start` step; print `waypointctl start` / `start backend` as the next step instead.
- `waypointctl/src/waypointctl/update.py` — drop the `waypointctl restart` call and the forced `WAYPOINT_STACK_FORCE_FRONTEND_BUILD=1`; end with a hint to run `waypointctl restart`.
- `waypointctl/src/waypointctl/cli.py` — update the `update` command help.
- `.agents/skills/waypointctl/references/update-deploy.md`, `README.md`, `docs/RELEASING.md` — document that install/update no longer touch the running stack.
- `waypointctl/tests/test_update.py` — assert `update` reinstalls the tool but invokes no restart.

## Design

Dropping the forced rebuild is safe: `waypointctl restart` already rebuilds the frontend when the checked-out ref changed (`frontend_build.is_fresh` compares `BUILD_REF` and diffs build inputs), so the explicit `WAYPOINT_STACK_FORCE_FRONTEND_BUILD=1` was redundant.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd waypointctl && uv run pytest`

## Test Result

pre-commit: all hooks passed. waypointctl suite: passed except the pre-existing `test_tailscale::test_helper_up_uses_repo_dotenv_and_exposes_ports`, which reads the repo's local `.env` ports and is unrelated to this change (green in CI).
