### PR TITLE
fix: persist WAYPOINT_HOME only to the primary shell profile

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -169,6 +169,7 @@ fi
 
 if [[ -n "${WAYPOINT_HOME_PRESET}" ]]; then
     printf 'WAYPOINT_HOME already set in your environment; leaving shell profiles untouched\n'
+    printf '  (persist %s in your shell profile yourself if you want it permanent)\n' "${INSTALL_DIR}"
 elif grep -qF "${WP_BEGIN}" "${PRIMARY_RC}" 2>/dev/null; then
     printf 'WAYPOINT_HOME already configured in %s\n' "${PRIMARY_RC}"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 REPO="https://github.com/kaiitunnz/waypoint"
 WP_BEGIN="# >>> waypoint >>>"
 WP_END="# <<< waypoint <<<"
+# Snapshot before the script exports its own value: a WAYPOINT_HOME already in
+# the environment means the user manages it, so we leave shell profiles alone.
+WAYPOINT_HOME_PRESET="${WAYPOINT_HOME:-}"
 INSTALL_DIR="${WAYPOINT_HOME:-${HOME}/.waypoint/app}"
 
 die()  { printf 'error: %s\n' "$*" >&2; exit 1; }
@@ -147,24 +150,10 @@ fi
 printf 'Installing waypointctl...\n'
 uv tool install --force "${INSTALL_DIR}/waypointctl"
 
-# ── persist WAYPOINT_HOME in shell profiles ─────────────────────────────────
-EXPORT_LINE="export WAYPOINT_HOME=\"${INSTALL_DIR}\""
-FISH_LINE="set -gx WAYPOINT_HOME \"${INSTALL_DIR}\""
-
-inject_export() {
-    local rc_file="$1"
-    local line="$2"
-    grep -qF "${WP_BEGIN}" "${rc_file}" 2>/dev/null && return 0
-    printf '\n%s\n%s\n%s\n' "${WP_BEGIN}" "${line}" "${WP_END}" >> "${rc_file}"
-    printf 'Added WAYPOINT_HOME to %s\n' "${rc_file}"
-}
-
-inject_if_exists() {
-    if [[ -f "$1" ]]; then
-        inject_export "$1" "$2"
-    fi
-}
-
+# ── persist WAYPOINT_HOME in the primary shell profile ──────────────────────
+# Write to the current shell's rc only, and skip entirely when WAYPOINT_HOME is
+# already set (user-managed) or the block is already present, so re-runs don't
+# pile up duplicate edits across profiles.
 SHELL_NAME="$(basename "${SHELL:-bash}")"
 case "${SHELL_NAME}" in
     zsh)  PRIMARY_RC="${HOME}/.zshrc" ;;
@@ -173,19 +162,19 @@ case "${SHELL_NAME}" in
 esac
 
 if [[ "${SHELL_NAME}" = "fish" ]]; then
-    mkdir -p "$(dirname "${PRIMARY_RC}")"
-    inject_export "${PRIMARY_RC}" "${FISH_LINE}"
+    EXPORT_LINE="set -gx WAYPOINT_HOME \"${INSTALL_DIR}\""
 else
-    inject_export "${PRIMARY_RC}" "${EXPORT_LINE}"
+    EXPORT_LINE="export WAYPOINT_HOME=\"${INSTALL_DIR}\""
 fi
 
-for extra_rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
-    [[ "${extra_rc}" = "${PRIMARY_RC}" ]] && continue
-    inject_if_exists "${extra_rc}" "${EXPORT_LINE}"
-done
-
-if [[ "${SHELL_NAME}" != "fish" ]]; then
-    inject_if_exists "${HOME}/.config/fish/config.fish" "${FISH_LINE}"
+if [[ -n "${WAYPOINT_HOME_PRESET}" ]]; then
+    printf 'WAYPOINT_HOME already set in your environment; leaving shell profiles untouched\n'
+elif grep -qF "${WP_BEGIN}" "${PRIMARY_RC}" 2>/dev/null; then
+    printf 'WAYPOINT_HOME already configured in %s\n' "${PRIMARY_RC}"
+else
+    mkdir -p "$(dirname "${PRIMARY_RC}")"
+    printf '\n%s\n%s\n%s\n' "${WP_BEGIN}" "${EXPORT_LINE}" "${WP_END}" >> "${PRIMARY_RC}"
+    printf 'Added WAYPOINT_HOME to %s\n' "${PRIMARY_RC}"
 fi
 
 # ── done ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose

Stop the installer from making redundant shell-profile edits. It previously injected the `WAYPOINT_HOME` block into `.bashrc`, `.zshrc`, `.profile`, and the fish config, so re-running it kept appending the block to whichever profiles didn't already have it.

## Changes

- `scripts/install.sh` — write the `WAYPOINT_HOME` block to the current shell's primary rc only. Skip the step entirely when `WAYPOINT_HOME` was already set in the environment (user-managed) or the block is already present in that rc. Snapshot the pre-existing `WAYPOINT_HOME` at the top of the script, before it exports its own value.

## Design

The pre-existing `WAYPOINT_HOME` must be captured before the script's own `export`, otherwise the skip check would always see it set. The old fan-out + helper functions are removed in favor of a single inline write.

## Test Plan

Extracted the persistence block and exercised it against temp `HOME`s: (1) fresh `.bashrc`, no preset; (2) re-run with the block present; (3) `WAYPOINT_HOME` preset. Also `bash -n` and `cd backend && uv run pre-commit run --all-files`.

## Test Result

(1) wrote the block once; (2) detected the existing block and skipped (one occurrence); (3) skipped with "already set in your environment". `bash -n` clean; pre-commit (incl. codespell over the script) all passed.
