### PR TITLE
fix: add a clean uninstall path (waypointctl uninstall + uninstall.sh)

### DIFF
--- a/.agents/skills/waypointctl/SKILL.md
+++ b/.agents/skills/waypointctl/SKILL.md
@@ -21,6 +21,7 @@ trusting any list reproduced in this skill.
 - Start, stop, or restart services: see `references/lifecycle.md`.
 - Handle backend/full-stack restart safely: see `references/restart-safety.md`.
 - Pull/update/redeploy the app: see `references/update-deploy.md`.
+- Uninstall the app: see `references/uninstall.md`.
 - Manage `waypointd`: see `references/daemon.md`.
 - Manage Docker-backed tailnet profiles: see `references/tailscale.md`.
 - Understand env vars and state paths: see `references/env-state.md`.

--- a/.agents/skills/waypointctl/references/uninstall.md
+++ b/.agents/skills/waypointctl/references/uninstall.md
@@ -1,0 +1,27 @@
+# Uninstall
+
+```bash
+waypointctl uninstall          # stop, remove checkout + tool, keep data
+waypointctl uninstall --purge  # also wipe the state and data directories
+waypointctl uninstall --yes    # skip the confirmation prompt
+```
+
+`uninstall` stops the stack and daemon, strips the `WAYPOINT_HOME` block from the
+shell profiles, removes the installer-managed checkout, and uninstalls the
+`waypointctl` tool. It is **destructive** — confirm with the user first, and
+treat it like a full-stack stop (it interrupts every running session, including
+this assistant).
+
+Safety rails baked into the command:
+
+- The checkout is removed only when it is installer-managed (`git config
+  waypoint.managed == true`); a development clone is left in place unless
+  `--force` is passed.
+- If the backend data dir lives **inside** the checkout, the checkout is kept
+  (with a warning) so the data survives — `--purge` overrides this and removes
+  both.
+- Without `--purge`, the state dir and backend data dir are preserved.
+
+The command runs `scripts/uninstall.sh` from a temporary copy so deleting the
+checkout cannot interrupt it. A host installed via `curl | bash` can run that
+script directly: `bash scripts/uninstall.sh --home "$WAYPOINT_HOME" [--purge]`.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ or set `WAYPOINT_VERSION=v0.1.0` in the environment before running. To track the
 
 Bring the stack up with `waypointctl start`. Use `waypointctl update` to upgrade to the latest release, `waypointctl update --ref vX.Y.Z` to pin a specific version, or `waypointctl update --nightly` to track `main`; `update` leaves the stack untouched, so run `waypointctl restart` afterward to apply the new code.
 
+To remove Waypoint, run `waypointctl uninstall` (add `--purge` to also delete the state and data directories). It stops the stack, strips the `WAYPOINT_HOME` shell-profile entry, removes the managed checkout, and uninstalls `waypointctl`; `curl`-based installs can instead run `scripts/uninstall.sh` directly.
+
 **OpenCode** — the `opencode` CLI must be installed separately and present on your PATH; Waypoint does not bundle it.
 
 ### Install from source / development

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -43,3 +43,12 @@ waypointctl update --nightly         # track the tip of main
 ```
 
 `update` refuses to run on a checkout with uncommitted changes, then fetches, checks out the target (release tags detach; branches like `main` track the remote tip), and reinstalls `waypointctl` via `uv tool install --force`. It leaves the running stack untouched; run `waypointctl restart` afterward to apply the new code (the frontend rebuilds automatically because the checked-out ref changed).
+
+## Uninstalling
+
+```bash
+waypointctl uninstall                 # stop, remove the checkout + tool, keep data
+waypointctl uninstall --purge         # also wipe the state and data directories
+```
+
+`uninstall` stops the stack and daemon, strips the `WAYPOINT_HOME` block from your shell profiles, removes the installer-managed checkout (it refuses a non-managed clone unless `--force`, and keeps the checkout if your data dir lives inside it), and uninstalls the `waypointctl` tool. Data under the state dir is preserved unless you pass `--purge`. The command runs `scripts/uninstall.sh` from a temporary copy so deleting the checkout can't interrupt it; `curl`-based installs can run that script directly instead.

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reverses scripts/install.sh. Safe to run via `curl | bash` or through
+# `waypointctl uninstall`, which copies this script out of the checkout before
+# running it so removing the checkout can't pull the rug.
+#
+# Default: stop the stack, strip the shell-profile block, remove the managed
+# checkout, and uninstall the waypointctl tool — but keep your data.
+# --purge: also delete the state dir and backend data dir.
+
+# These markers must match scripts/install.sh.
+WP_BEGIN="# >>> waypoint >>>"
+WP_END="# <<< waypoint <<<"
+
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# ── argument parsing ────────────────────────────────────────────────────────
+HOME_DIR="${WAYPOINT_HOME:-${HOME}/.waypoint/app}"
+PURGE=0
+FORCE=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --home)
+            [[ $# -ge 2 ]] || die "--home requires a value"
+            HOME_DIR="$2"
+            shift 2
+            ;;
+        --purge)
+            PURGE=1
+            shift
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        *)
+            die "unknown argument: $1 (supported: --home <dir>, --purge, --force)"
+            ;;
+    esac
+done
+
+# ── resolve paths ───────────────────────────────────────────────────────────
+STATE_DIR="${WAYPOINTCTL_STATE_DIR:-${HOME}/.waypoint}"
+
+# Read a KEY=value from a dotenv file (last assignment wins, quotes stripped).
+read_dotenv() {
+    local key="$1" file="$2"
+    [[ -f "${file}" ]] || return 0
+    sed -n "s/^[[:space:]]*${key}=//p" "${file}" | tail -n1 \
+        | sed -e 's/^["'\'']//' -e 's/["'\'']$//'
+}
+
+# backend_data_dir mirrors config.py: WAYPOINT_STACK_BACKEND_DATA_DIR (from .env,
+# else the environment), relative paths resolved under home, default under state.
+DATA_RAW="$(read_dotenv WAYPOINT_STACK_BACKEND_DATA_DIR "${HOME_DIR}/.env")"
+[[ -n "${DATA_RAW}" ]] || DATA_RAW="${WAYPOINT_STACK_BACKEND_DATA_DIR:-}"
+if [[ -z "${DATA_RAW}" ]]; then
+    DATA_DIR="${STATE_DIR}/backend-data"
+elif [[ "${DATA_RAW}" = /* ]]; then
+    DATA_DIR="${DATA_RAW}"
+else
+    DATA_DIR="${HOME_DIR}/${DATA_RAW}"
+fi
+
+printf 'Uninstalling Waypoint at %s\n' "${HOME_DIR}"
+
+# ── stop the running stack ──────────────────────────────────────────────────
+if command -v waypointctl >/dev/null 2>&1; then
+    printf 'Stopping the stack...\n'
+    waypointctl --home "${HOME_DIR}" stop >/dev/null 2>&1 || true
+    waypointctl daemon stop >/dev/null 2>&1 || true
+fi
+
+# ── strip the shell-profile block ───────────────────────────────────────────
+strip_block() {
+    local rc="$1"
+    [[ -f "${rc}" ]] || return 0
+    grep -qF "${WP_BEGIN}" "${rc}" 2>/dev/null || return 0
+    local tmp
+    tmp="$(mktemp)"
+    awk -v b="${WP_BEGIN}" -v e="${WP_END}" '
+        $0==b {skip=1}
+        skip==0 {print}
+        $0==e {skip=0}
+    ' "${rc}" > "${tmp}"
+    cat "${tmp}" > "${rc}"
+    rm -f "${tmp}"
+    printf 'Removed WAYPOINT_HOME from %s\n' "${rc}"
+}
+
+for rc in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile" \
+          "${HOME}/.config/fish/config.fish"; do
+    strip_block "${rc}"
+done
+
+# ── remove the managed checkout ─────────────────────────────────────────────
+remove_checkout() {
+    if [[ ! -d "${HOME_DIR}" ]]; then
+        return 0
+    fi
+    local managed
+    managed="$(git -C "${HOME_DIR}" config --get waypoint.managed 2>/dev/null || true)"
+    if [[ "${managed}" != "true" && "${FORCE}" -ne 1 ]]; then
+        printf 'warning: %s is not an installer-managed checkout; leaving it in place (use --force to remove it)\n' \
+            "${HOME_DIR}" >&2
+        return 0
+    fi
+    # Preserve a data dir that lives inside the checkout unless we are purging.
+    if [[ "${PURGE}" -ne 1 && "${DATA_DIR}/" = "${HOME_DIR}/"* ]]; then
+        printf 'warning: data dir %s is inside the checkout; leaving %s in place to preserve it (re-run with --purge to remove both)\n' \
+            "${DATA_DIR}" "${HOME_DIR}" >&2
+        return 0
+    fi
+    printf 'Removing checkout %s\n' "${HOME_DIR}"
+    rm -rf "${HOME_DIR}"
+}
+remove_checkout
+
+# ── purge data ──────────────────────────────────────────────────────────────
+if [[ "${PURGE}" -eq 1 ]]; then
+    for target in "${STATE_DIR}" "${DATA_DIR}"; do
+        if [[ -e "${target}" ]]; then
+            printf 'Removing %s\n' "${target}"
+            rm -rf "${target}"
+        fi
+    done
+fi
+
+# ── uninstall the tool (last; it removes the command running this) ───────────
+if command -v uv >/dev/null 2>&1; then
+    printf 'Uninstalling waypointctl...\n'
+    uv tool uninstall waypointctl >/dev/null 2>&1 || true
+fi
+
+printf '\nWaypoint uninstalled.\n'
+if [[ "${PURGE}" -ne 1 ]]; then
+    printf 'Kept data dir %s and state dir %s (re-run with --purge to remove them).\n' \
+        "${DATA_DIR}" "${STATE_DIR}"
+fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -15,6 +15,16 @@ WP_END="# <<< waypoint <<<"
 
 die() { printf 'error: %s\n' "$*" >&2; exit 1; }
 
+# Expand a leading ~ like config.py's Path.expanduser(), so a tilde in
+# WAYPOINT_HOME/.env matches the resolution the backend used.
+expand_tilde() {
+    case "$1" in
+        "~")   printf '%s' "${HOME}" ;;
+        "~/"*) printf '%s' "${HOME}/${1#\~/}" ;;
+        *)     printf '%s' "$1" ;;
+    esac
+}
+
 # ── argument parsing ────────────────────────────────────────────────────────
 HOME_DIR="${WAYPOINT_HOME:-${HOME}/.waypoint/app}"
 PURGE=0
@@ -41,7 +51,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # ── resolve paths ───────────────────────────────────────────────────────────
-STATE_DIR="${WAYPOINTCTL_STATE_DIR:-${HOME}/.waypoint}"
+HOME_DIR="$(expand_tilde "${HOME_DIR}")"
+STATE_DIR="$(expand_tilde "${WAYPOINTCTL_STATE_DIR:-${HOME}/.waypoint}")"
 
 # Read a KEY=value from a dotenv file (last assignment wins, quotes stripped).
 read_dotenv() {
@@ -52,9 +63,10 @@ read_dotenv() {
 }
 
 # backend_data_dir mirrors config.py: WAYPOINT_STACK_BACKEND_DATA_DIR (from .env,
-# else the environment), relative paths resolved under home, default under state.
+# else the environment), ~ expanded, relative paths under home, default in state.
 DATA_RAW="$(read_dotenv WAYPOINT_STACK_BACKEND_DATA_DIR "${HOME_DIR}/.env")"
 [[ -n "${DATA_RAW}" ]] || DATA_RAW="${WAYPOINT_STACK_BACKEND_DATA_DIR:-}"
+DATA_RAW="$(expand_tilde "${DATA_RAW}")"
 if [[ -z "${DATA_RAW}" ]]; then
     DATA_DIR="${STATE_DIR}/backend-data"
 elif [[ "${DATA_RAW}" = /* ]]; then
@@ -79,10 +91,14 @@ strip_block() {
     grep -qF "${WP_BEGIN}" "${rc}" 2>/dev/null || return 0
     local tmp
     tmp="$(mktemp)"
+    # Drop the marker block inclusive, plus the blank line install.sh prepends
+    # (buffer blank lines and discard them when they immediately precede a block).
     awk -v b="${WP_BEGIN}" -v e="${WP_END}" '
-        $0==b {skip=1}
-        skip==0 {print}
-        $0==e {skip=0}
+        $0==b {skip=1; blank=0; next}
+        skip {if ($0==e) skip=0; next}
+        /^$/ {blank++; next}
+        {for (; blank>0; blank--) print ""; print}
+        END {for (; blank>0; blank--) print ""}
     ' "${rc}" > "${tmp}"
     cat "${tmp}" > "${rc}"
     rm -f "${tmp}"

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -30,6 +30,7 @@ from waypointctl.protocol import DaemonResult
 from waypointctl.skills import run_skills_helper
 from waypointctl.stack import WaypointStack
 from waypointctl.tailscale import preflight_tailscale_command, run_tailscale_helper
+from waypointctl.uninstall import run as run_uninstall
 from waypointctl.update import run as run_update
 
 app = typer.Typer(
@@ -298,6 +299,32 @@ def update(
 ) -> None:
     """Update Waypoint to the latest release; run `waypointctl restart` to apply."""
     run_update(_ctx_home(ctx), ref=ref, nightly=nightly)
+
+
+@app.command("uninstall")
+def uninstall(
+    ctx: typer.Context,
+    purge: Annotated[
+        bool,
+        typer.Option(
+            "--purge", help="Also remove the state and backend data directories."
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+) -> None:
+    """Stop the stack, remove the managed checkout, and uninstall waypointctl."""
+    home = _ctx_home(ctx)
+    if not yes:
+        extra = " and wipe the state and data directories" if purge else ""
+        typer.confirm(
+            f"This stops the stack, removes {home}{extra}, and uninstalls "
+            "waypointctl. Continue?",
+            abort=True,
+        )
+    run_uninstall(home, purge=purge)
 
 
 @tailscale_app.command("up")

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -310,6 +310,12 @@ def uninstall(
             "--purge", help="Also remove the state and backend data directories."
         ),
     ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force", help="Remove the checkout even if it is not installer-managed."
+        ),
+    ] = False,
     yes: Annotated[
         bool,
         typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
@@ -324,7 +330,7 @@ def uninstall(
             "waypointctl. Continue?",
             abort=True,
         )
-    run_uninstall(home, purge=purge)
+    run_uninstall(home, purge=purge, force=force)
 
 
 @tailscale_app.command("up")

--- a/waypointctl/src/waypointctl/uninstall.py
+++ b/waypointctl/src/waypointctl/uninstall.py
@@ -4,7 +4,7 @@ import tempfile
 from pathlib import Path
 
 
-def run(home: Path, purge: bool = False) -> None:
+def run(home: Path, purge: bool = False, force: bool = False) -> None:
     """Uninstall Waypoint by running scripts/uninstall.sh from a temp copy.
 
     The script deletes the checkout it lives in, so it is staged outside the
@@ -21,4 +21,6 @@ def run(home: Path, purge: bool = False) -> None:
         argv = ["bash", str(staged), "--home", str(home)]
         if purge:
             argv.append("--purge")
+        if force:
+            argv.append("--force")
         subprocess.run(argv, check=True)

--- a/waypointctl/src/waypointctl/uninstall.py
+++ b/waypointctl/src/waypointctl/uninstall.py
@@ -1,0 +1,24 @@
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def run(home: Path, purge: bool = False) -> None:
+    """Uninstall Waypoint by running scripts/uninstall.sh from a temp copy.
+
+    The script deletes the checkout it lives in, so it is staged outside the
+    checkout first; otherwise removing the directory would yank the script out
+    from under the running shell.
+    """
+    script = home / "scripts" / "uninstall.sh"
+    if not script.is_file():
+        raise RuntimeError(f"uninstall script not found at {script}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        staged = Path(tmp) / "uninstall.sh"
+        shutil.copy2(script, staged)
+        argv = ["bash", str(staged), "--home", str(home)]
+        if purge:
+            argv.append("--purge")
+        subprocess.run(argv, check=True)

--- a/waypointctl/tests/test_uninstall.py
+++ b/waypointctl/tests/test_uninstall.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from waypointctl import uninstall
+
+
+def _make_home(tmp_path: Path) -> Path:
+    home = tmp_path / "app"
+    (home / "scripts").mkdir(parents=True)
+    (home / "scripts" / "uninstall.sh").write_text("#!/usr/bin/env bash\n")
+    return home
+
+
+def test_runs_staged_copy_with_home(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    seen: dict[str, object] = {}
+
+    def fake_run(argv, **kwargs):
+        seen["argv"] = argv
+        # the staged script must exist (and live outside the checkout) at call time
+        seen["staged_exists"] = Path(argv[1]).is_file()
+        seen["outside_home"] = home not in Path(argv[1]).parents
+
+    with patch("waypointctl.uninstall.subprocess.run", side_effect=fake_run):
+        uninstall.run(home)
+
+    argv = seen["argv"]
+    assert argv[0] == "bash"
+    assert Path(argv[1]).name == "uninstall.sh"
+    assert argv[2:] == ["--home", str(home)]
+    assert seen["staged_exists"] is True
+    assert seen["outside_home"] is True
+
+
+def test_purge_appends_flag(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    with patch("waypointctl.uninstall.subprocess.run") as mock_run:
+        uninstall.run(home, purge=True)
+    argv = mock_run.call_args.args[0]
+    assert argv[-1] == "--purge"
+    assert mock_run.call_args.kwargs.get("check") is True
+
+
+def test_missing_script_raises(tmp_path: Path) -> None:
+    home = tmp_path / "app"
+    home.mkdir()
+    with (
+        patch("waypointctl.uninstall.subprocess.run") as mock_run,
+        pytest.raises(RuntimeError, match="uninstall script not found"),
+    ):
+        uninstall.run(home)
+    mock_run.assert_not_called()

--- a/waypointctl/tests/test_uninstall.py
+++ b/waypointctl/tests/test_uninstall.py
@@ -1,9 +1,15 @@
+import os
+import shutil
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from waypointctl import uninstall
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+UNINSTALL_SH = REPO_ROOT / "scripts" / "uninstall.sh"
 
 
 def _make_home(tmp_path: Path) -> Path:
@@ -43,6 +49,13 @@ def test_purge_appends_flag(tmp_path: Path) -> None:
     assert mock_run.call_args.kwargs.get("check") is True
 
 
+def test_force_appends_flag(tmp_path: Path) -> None:
+    home = _make_home(tmp_path)
+    with patch("waypointctl.uninstall.subprocess.run") as mock_run:
+        uninstall.run(home, force=True)
+    assert "--force" in mock_run.call_args.args[0]
+
+
 def test_missing_script_raises(tmp_path: Path) -> None:
     home = tmp_path / "app"
     home.mkdir()
@@ -52,3 +65,96 @@ def test_missing_script_raises(tmp_path: Path) -> None:
     ):
         uninstall.run(home)
     mock_run.assert_not_called()
+
+
+# ── integration tests that drive the real scripts/uninstall.sh ──────────────
+
+WP_BLOCK = '# >>> waypoint >>>\nexport WAYPOINT_HOME="x"\n# <<< waypoint <<<'
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _sandbox(
+    tmp_path: Path, *, managed: bool = True, data_env: str | None = None
+) -> tuple[Path, Path, Path]:
+    """Build a fake HOME with a managed checkout, data dir, rc file, and stubs."""
+    home = tmp_path / "home"
+    app = home / ".waypoint" / "app"
+    (app / "backend").mkdir(parents=True)
+    (app / "frontend").mkdir()
+    _git(["init", "-q"], app)
+    _git(["config", "user.email", "t@t"], app)
+    _git(["config", "user.name", "t"], app)
+    if managed:
+        _git(["config", "waypoint.managed", "true"], app)
+
+    data = home / ".waypoint" / "backend-data"
+    data.mkdir(parents=True)
+    (data / "db").write_text("data")
+    if data_env is not None:
+        (app / ".env").write_text(f"WAYPOINT_STACK_BACKEND_DATA_DIR={data_env}\n")
+
+    (home / ".bashrc").write_text(f"before\n\n{WP_BLOCK}\nafter\n")
+
+    # Run the script from outside the checkout (as the wrapper / curl pipe does),
+    # so deleting the checkout can't pull the running script.
+    staged = tmp_path / "uninstall.sh"
+    shutil.copy2(UNINSTALL_SH, staged)
+    stub = tmp_path / "stub"
+    stub.mkdir()
+    for name in ("waypointctl", "uv"):
+        p = stub / name
+        p.write_text("#!/usr/bin/env bash\nexit 0\n")
+        p.chmod(0o755)
+    return home, app, stub
+
+
+def _run(tmp_path: Path, home: Path, app: Path, stub: Path, *args: str) -> None:
+    env = {"HOME": str(home), "PATH": f"{stub}{os.pathsep}{os.environ['PATH']}"}
+    subprocess.run(
+        ["bash", str(tmp_path / "uninstall.sh"), "--home", str(app), *args],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_script_default_removes_checkout_keeps_data(tmp_path: Path) -> None:
+    home, app, stub = _sandbox(tmp_path)
+    _run(tmp_path, home, app, stub)
+    assert not app.exists()
+    assert (home / ".waypoint" / "backend-data" / "db").exists()
+    # the block (and the blank line install.sh prepends) is gone, rest preserved
+    assert (home / ".bashrc").read_text() == "before\nafter\n"
+
+
+def test_script_purge_removes_state_and_data(tmp_path: Path) -> None:
+    home, app, stub = _sandbox(tmp_path)
+    _run(tmp_path, home, app, stub, "--purge")
+    assert not (home / ".waypoint").exists()
+
+
+def test_script_tilde_data_dir_resolves_outside_checkout(tmp_path: Path) -> None:
+    # ~ must expand like config.py; the default checkout removal must still run
+    home, app, stub = _sandbox(tmp_path, data_env="~/.waypoint/backend-data")
+    _run(tmp_path, home, app, stub)
+    assert not app.exists()
+    assert (home / ".waypoint" / "backend-data" / "db").exists()
+
+
+def test_script_relative_data_inside_checkout_is_preserved(tmp_path: Path) -> None:
+    home, app, stub = _sandbox(tmp_path, data_env="./data")
+    (app / "data").mkdir()
+    _run(tmp_path, home, app, stub)
+    assert app.exists()  # kept so the inside-checkout data survives
+
+
+def test_script_non_managed_checkout_preserved_without_force(tmp_path: Path) -> None:
+    home, app, stub = _sandbox(tmp_path, managed=False)
+    _run(tmp_path, home, app, stub)
+    assert app.exists()
+    _run(tmp_path, home, app, stub, "--force")
+    assert not app.exists()


### PR DESCRIPTION
## Purpose

There was no supported way to remove a Waypoint install. This adds a clean uninstall path that reverses the bootstrap installer.

## Changes

- `scripts/uninstall.sh` — the logic, runnable on its own for `curl`-based installs. Stops the stack and daemon, strips the `WAYPOINT_HOME` block from shell profiles, removes the installer-managed checkout, and uninstalls the `waypointctl` tool. Keeps data unless `--purge`.
- `waypointctl/src/waypointctl/uninstall.py` + `cli.py` — `waypointctl uninstall [--purge] [--yes]`. Copies the script to a temp dir and runs the copy, then confirms before acting unless `--yes`.
- `waypointctl/tests/test_uninstall.py` — cover the temp-copy invocation, `--purge`, and the missing-script error.
- `README.md`, `docs/RELEASING.md`, `.agents/skills/waypointctl/` — document the command and its safety rails.

## Design

The script deletes the checkout it lives in, so the command stages it outside the checkout first; otherwise removing the directory would yank the running script. Safety rails: the checkout is removed only when `git config waypoint.managed == true` (a dev clone needs `--force`); if the data dir resolves inside the checkout it is kept with a warning unless `--purge`; the state and data dirs survive without `--purge`. Data-dir resolution mirrors `config.py` (reads `WAYPOINT_STACK_BACKEND_DATA_DIR` from `.env`/env, relative paths under home, default under the state dir).

## Test Plan

- `cd waypointctl && uv run pytest`
- `cd backend && uv run pre-commit run --all-files`
- `scripts/uninstall.sh` exercised in a sandbox (stubbed `waypointctl`/`uv`, real `git`): default keeps data + removes checkout + strips rc block; `--purge` wipes the state dir; data-inside-checkout keeps the checkout; non-managed checkout is left in place.

## Test Result

waypointctl suite: 134 passed (incl. 3 new uninstall tests); the only failure is the pre-existing `test_tailscale::test_helper_up_uses_repo_dotenv_and_exposes_ports`, which reads the repo's local `.env` ports and is unrelated (green in CI). pre-commit all passed. Sandbox cases all behaved as expected.
