### PR TITLE
fix: reinstall waypointctl on update so the version isn't masked by uv's cache

### DIFF
--- a/.agents/skills/waypointctl/references/update-deploy.md
+++ b/.agents/skills/waypointctl/references/update-deploy.md
@@ -12,7 +12,7 @@ waypointctl update --nightly       # tip of main
 
 `update` refuses to run if the checkout has uncommitted changes, then fetches,
 checks out the target (release tags detach; branches like `main` track the
-remote tip), and reinstalls `waypointctl` via `uv tool install --force`. It does
+remote tip), and reinstalls `waypointctl` via `uv tool install --reinstall --force`. It does
 **not** touch the running stack — apply the new code yourself with
 `waypointctl restart` (or `restart backend` / `restart frontend`), getting the
 user's permission and following `restart-safety.md` for backend or full-stack

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -42,7 +42,7 @@ waypointctl update --ref vX.Y.Z      # pin to a specific tag
 waypointctl update --nightly         # track the tip of main
 ```
 
-`update` refuses to run on a checkout with uncommitted changes, then fetches, checks out the target (release tags detach; branches like `main` track the remote tip), and reinstalls `waypointctl` via `uv tool install --force`. It leaves the running stack untouched; run `waypointctl restart` afterward to apply the new code (the frontend rebuilds automatically because the checked-out ref changed).
+`update` refuses to run on a checkout with uncommitted changes, then fetches, checks out the target (release tags detach; branches like `main` track the remote tip), and reinstalls `waypointctl` via `uv tool install --reinstall --force`. It leaves the running stack untouched; run `waypointctl restart` afterward to apply the new code (the frontend rebuilds automatically because the checked-out ref changed).
 
 ## Uninstalling
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -147,8 +147,11 @@ if [[ ! -f "${INSTALL_DIR}/.env" ]]; then
 fi
 
 # ── install waypointctl ─────────────────────────────────────────────────────
+# --reinstall (not just --force): the version comes from the git tag via
+# setuptools-scm, which isn't in uv's build-cache key, so re-running the
+# installer to update would otherwise reuse the previous wheel.
 printf 'Installing waypointctl...\n'
-uv tool install --force "${INSTALL_DIR}/waypointctl"
+uv tool install --reinstall --force "${INSTALL_DIR}/waypointctl"
 
 # ── persist WAYPOINT_HOME in the primary shell profile ──────────────────────
 # Write to the current shell's rc only, and skip entirely when WAYPOINT_HOME is

--- a/waypointctl/src/waypointctl/update.py
+++ b/waypointctl/src/waypointctl/update.py
@@ -125,8 +125,19 @@ def run(
     typer.echo(f"Checking out {target}")
     _checkout(resolved, target)
 
+    # --reinstall (not just --force): waypointctl's version comes from the git
+    # tag via setuptools-scm, and a tag-only change isn't in uv's build-cache
+    # key, so --force alone reuses the previous wheel and reports a stale version.
     subprocess.run(
-        ["uv", "tool", "install", "--force", str(resolved / "waypointctl")], check=True
+        [
+            "uv",
+            "tool",
+            "install",
+            "--reinstall",
+            "--force",
+            str(resolved / "waypointctl"),
+        ],
+        check=True,
     )
 
     typer.echo(f"Updated to {target}. Run 'waypointctl restart' to apply.")

--- a/waypointctl/tests/test_update.py
+++ b/waypointctl/tests/test_update.py
@@ -149,6 +149,8 @@ def test_uv_force_and_no_restart(tmp_path: Path) -> None:
 
     argvs = _argvs(mock_run)
     uv_cmd = next(a for a in argvs if a and a[0] == "uv")
+    # --reinstall is required so a tag-only version bump isn't masked by uv's cache
+    assert "--reinstall" in uv_cmd
     assert "--force" in uv_cmd
     # update reinstalls the tool but leaves the stack alone
     assert not any("restart" in a for a in argvs)


### PR DESCRIPTION
## Purpose

`waypointctl update` to a new release silently kept reporting the old version. On another machine, `waypointctl update` checked out `v0.1.2` correctly but the reinstalled tool still reported `waypointctl==0.1.1`.

## Changes

- `waypointctl/src/waypointctl/update.py` — `uv tool install` now passes `--reinstall` (alongside `--force`).
- `scripts/install.sh` — same `--reinstall` for the installer's update path.
- `waypointctl/tests/test_update.py` — assert the `uv` invocation includes `--reinstall`.

## Design

waypointctl's version is derived from the git tag via setuptools-scm. A tag-only change isn't part of uv's build-cache key, so `uv tool install --force` reuses the wheel it built at the previous tag and reports a stale version. `--reinstall` forces a rebuild — the same flag the manual `update-deploy.md` flow already documents; the automated paths had diverged.

## Test Plan

- Reproduced in an isolated worktree + temp cache/tool dirs: install at `v0.1.1`, check out `v0.1.2`, reinstall.
- `cd waypointctl && uv run pytest`
- `cd backend && uv run pre-commit run --all-files`

## Test Result

Repro: `--force` after checking out `v0.1.2` → `0.1.1` (cache hit); `--reinstall` → `0.1.2`. A clean-room `uv build --no-cache` confirmed setuptools-scm itself resolves `0.1.2`, so the cache was the only cause. waypointctl suite: 140 passed (only the pre-existing env-only `test_tailscale` dotenv-ports failure, unrelated). pre-commit all passed.
