### PR TITLE
feat: add a copy button and syntax highlighting to transcript code blocks

### DIFF
--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/api";
 import { buildCatalog, humaniseBackend, transportPresentation } from "@/lib/backends";
 import { copyText } from "@/lib/clipboard";
+import { useCopied } from "@/lib/use-copied";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
 import {
@@ -52,14 +53,12 @@ const STATUS_LABELS: Record<SessionStatus, string> = {
 };
 
 function CopyField({ label, value }: { label: string; value: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, markCopied } = useCopied();
   const copy = useCallback(() => {
     void copyText(value).then((ok) => {
-      if (!ok) return;
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1400);
+      if (ok) markCopied();
     });
-  }, [value]);
+  }, [value, markCopied]);
   return (
     <div className="assistant-id">
       <span className="assistant-id-label">{label}</span>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3419,6 +3419,10 @@ html[data-theme="light"] .inline-code {
   color: var(--text-strong);
 }
 
+.markdown-codeblock {
+  position: relative;
+}
+
 .markdown-pre {
   background: var(--bg-input);
   border: 1px solid var(--line);
@@ -3428,6 +3432,76 @@ html[data-theme="light"] .inline-code {
   min-width: 0;
   max-width: 100%;
   word-break: break-word;
+}
+
+/* Floats top-right inside the block, anchored to the wrapper (not the scrolling
+ * pre) so it stays put as code scrolls horizontally; a translucent backdrop
+ * keeps it legible over the first line. */
+.code-copy {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  background: rgba(8, 11, 16, 0.55);
+  border: 1px solid var(--line-soft);
+  color: var(--text-soft);
+  font-size: 0.95rem;
+  line-height: 1;
+  cursor: pointer;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  opacity: 0;
+  transform: translateY(-2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.markdown-codeblock:hover .code-copy,
+.markdown-codeblock:focus-within .code-copy,
+.code-copy:focus-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.code-copy:hover {
+  background: var(--surface-2);
+  border-color: var(--line-strong);
+  color: var(--text-strong);
+}
+
+/* Note: no opacity/transform pin here, so on desktop the confirmed button
+ * still fades out once the pointer leaves the block; touch keeps it visible
+ * via the hover:none rule below. */
+.code-copy.copied {
+  color: var(--accent-cool);
+  border-color: rgba(143, 179, 214, 0.32);
+  background: rgba(143, 179, 214, 0.12);
+}
+
+html[data-theme="light"] .code-copy {
+  background: rgba(255, 252, 245, 0.72);
+}
+
+html[data-theme="light"] .code-copy.copied {
+  border-color: rgba(47, 111, 158, 0.3);
+  background: rgba(47, 111, 158, 0.1);
+}
+
+@media (hover: none) {
+  /* No hover on touch — reveal it permanently so it stays discoverable. */
+  .code-copy {
+    opacity: 1;
+    transform: none;
+  }
 }
 
 /* ─── Scroll controls & floaters ─── */
@@ -12287,11 +12361,12 @@ html[data-theme="light"] .wp-code-toolbar {
   overflow-wrap: anywhere;
 }
 
-/* ─── Syntax highlighting (file preview) ─── */
+/* ─── Syntax highlighting (file preview + transcript code blocks) ─── */
 /* highlight.js token classes, recolored to the app's warm-gold / cool-blue
-   palette rather than a stock theme. Tokens are scoped to .wp-code-pre so the
-   highlighter never bleeds into the transcript. */
-.wp-code-pre {
+   palette rather than a stock theme. Both the file preview (.wp-code-pre) and
+   transcript fenced blocks (.markdown-pre) opt in via the shared .wp-hl class,
+   which also carries the palette variables the token rules below resolve. */
+.wp-hl {
   --hl-comment: #6f7a8c;
   --hl-keyword: #cf98b1;
   --hl-string: #9cc7a6;
@@ -12305,7 +12380,7 @@ html[data-theme="light"] .wp-code-toolbar {
   --hl-punct: #97a2b3;
 }
 
-html[data-theme="light"] .wp-code-pre {
+html[data-theme="light"] .wp-hl {
   --hl-comment: #857a66;
   --hl-keyword: #9c3f6e;
   --hl-string: #2f7d4f;
@@ -12319,73 +12394,73 @@ html[data-theme="light"] .wp-code-pre {
   --hl-punct: #6e6356;
 }
 
-.wp-code-pre .hljs-comment,
-.wp-code-pre .hljs-quote {
+.wp-hl .hljs-comment,
+.wp-hl .hljs-quote {
   color: var(--hl-comment);
   font-style: italic;
 }
-.wp-code-pre .hljs-keyword,
-.wp-code-pre .hljs-selector-tag,
-.wp-code-pre .hljs-subst {
+.wp-hl .hljs-keyword,
+.wp-hl .hljs-selector-tag,
+.wp-hl .hljs-subst {
   color: var(--hl-keyword);
 }
-.wp-code-pre .hljs-string,
-.wp-code-pre .hljs-regexp,
-.wp-code-pre .hljs-meta .hljs-string {
+.wp-hl .hljs-string,
+.wp-hl .hljs-regexp,
+.wp-hl .hljs-meta .hljs-string {
   color: var(--hl-string);
 }
-.wp-code-pre .hljs-number,
-.wp-code-pre .hljs-literal,
-.wp-code-pre .hljs-bullet {
+.wp-hl .hljs-number,
+.wp-hl .hljs-literal,
+.wp-hl .hljs-bullet {
   color: var(--hl-number);
 }
-.wp-code-pre .hljs-title,
-.wp-code-pre .hljs-title.function_,
-.wp-code-pre .hljs-section,
-.wp-code-pre .hljs-name {
+.wp-hl .hljs-title,
+.wp-hl .hljs-title.function_,
+.wp-hl .hljs-section,
+.wp-hl .hljs-name {
   color: var(--hl-function);
 }
-.wp-code-pre .hljs-type,
-.wp-code-pre .hljs-built_in,
-.wp-code-pre .hljs-title.class_ {
+.wp-hl .hljs-type,
+.wp-hl .hljs-built_in,
+.wp-hl .hljs-title.class_ {
   color: var(--hl-type);
 }
-.wp-code-pre .hljs-attr,
-.wp-code-pre .hljs-attribute,
-.wp-code-pre .hljs-property,
-.wp-code-pre .hljs-selector-attr,
-.wp-code-pre .hljs-selector-class,
-.wp-code-pre .hljs-selector-id {
+.wp-hl .hljs-attr,
+.wp-hl .hljs-attribute,
+.wp-hl .hljs-property,
+.wp-hl .hljs-selector-attr,
+.wp-hl .hljs-selector-class,
+.wp-hl .hljs-selector-id {
   color: var(--hl-attr);
 }
-.wp-code-pre .hljs-variable,
-.wp-code-pre .hljs-template-variable {
+.wp-hl .hljs-variable,
+.wp-hl .hljs-template-variable {
   color: var(--hl-variable);
 }
-.wp-code-pre .hljs-meta,
-.wp-code-pre .hljs-doctag {
+.wp-hl .hljs-meta,
+.wp-hl .hljs-doctag {
   color: var(--hl-meta);
 }
-.wp-code-pre .hljs-symbol,
-.wp-code-pre .hljs-link,
-.wp-code-pre .hljs-params {
+.wp-hl .hljs-symbol,
+.wp-hl .hljs-link,
+.wp-hl .hljs-params {
   color: var(--hl-symbol);
 }
-.wp-code-pre .hljs-tag,
-.wp-code-pre .hljs-punctuation,
-.wp-code-pre .hljs-operator {
+.wp-hl .hljs-tag,
+.wp-hl .hljs-punctuation,
+.wp-hl .hljs-operator {
   color: var(--hl-punct);
 }
-.wp-code-pre .hljs-emphasis {
+.wp-hl .hljs-emphasis {
   font-style: italic;
 }
-.wp-code-pre .hljs-strong {
+.wp-hl .hljs-strong {
   font-weight: 600;
 }
-.wp-code-pre .hljs-deletion {
+.wp-hl .hljs-deletion {
   color: var(--danger);
 }
-.wp-code-pre .hljs-addition {
+.wp-hl .hljs-addition {
   color: var(--success);
 }
 

--- a/frontend/src/components/CopyCodeButton.tsx
+++ b/frontend/src/components/CopyCodeButton.tsx
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+
+import { copyText } from "@/lib/clipboard";
+import { useCopied } from "@/lib/use-copied";
+
+export function CopyCodeButton({ text }: { text: string }) {
+  const { copied, markCopied, reset } = useCopied();
+  const onCopy = useCallback(async () => {
+    if (await copyText(text)) markCopied();
+  }, [text, markCopied]);
+  const onMouseLeave = useCallback(() => {
+    // Desktop: revert the confirmation the moment the pointer leaves so a
+    // re-hover shows the copy glyph, not a stale check. Touch has no hover,
+    // so the timeout handles the reset there.
+    if (window.matchMedia("(hover: hover)").matches) reset();
+  }, [reset]);
+  return (
+    <button
+      type="button"
+      className={`code-copy${copied ? " copied" : ""}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        event.preventDefault();
+        void onCopy();
+      }}
+      onMouseLeave={onMouseLeave}
+      aria-label={copied ? "Copied" : "Copy code"}
+      title={copied ? "Copied" : "Copy code"}
+    >
+      <span aria-hidden>{copied ? "✓" : "⎘"}</span>
+    </button>
+  );
+}

--- a/frontend/src/components/CopyMessageButton.tsx
+++ b/frontend/src/components/CopyMessageButton.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { copyText } from "@/lib/clipboard";
+import { useCopied } from "@/lib/use-copied";
 
 export function CopyMessageButton({
   text,
@@ -9,13 +10,10 @@ export function CopyMessageButton({
   text: string;
   label?: string;
 }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, markCopied } = useCopied();
   const onCopy = useCallback(async () => {
-    const ok = await copyText(text);
-    if (!ok) return;
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1500);
-  }, [text]);
+    if (await copyText(text)) markCopied();
+  }, [text, markCopied]);
   return (
     <button
       type="button"

--- a/frontend/src/components/FilePreview.tsx
+++ b/frontend/src/components/FilePreview.tsx
@@ -176,7 +176,7 @@ function FileCodeView({
         </button>
       </div>
       <pre
-        className={`diff-code wp-code-pre${softWrap ? " soft-wrap" : ""}`}
+        className={`diff-code wp-code-pre wp-hl${softWrap ? " soft-wrap" : ""}`}
         style={{ "--lnw": lnw } as CSSProperties}
         aria-label={`Contents of ${path}`}
       >

--- a/frontend/src/components/MarkdownMessage.tsx
+++ b/frontend/src/components/MarkdownMessage.tsx
@@ -1,10 +1,21 @@
-import { memo, type ComponentPropsWithoutRef } from "react";
+import {
+  Fragment,
+  isValidElement,
+  memo,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
 
 import ReactMarkdown, { type Components } from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
+import { CopyCodeButton } from "@/components/CopyCodeButton";
 import { useWorkspaceFileLink } from "@/components/WorkspaceFileLinkContext";
+import { highlightFenceToLines, type HighlightToken } from "@/lib/highlight";
 import { isWorkspacePathHref, remarkLinkifyPaths } from "@/lib/workspacePaths";
 
 interface MarkdownMessageProps {
@@ -15,6 +26,86 @@ interface MarkdownMessageProps {
 // stable identity across renders — combined with the memo() below, an
 // unchanged `text` skips the remark parse entirely during streaming.
 const REMARK_PLUGINS = [remarkGfm, remarkBreaks, remarkLinkifyPaths];
+
+// react-markdown renders fenced blocks as <pre><code>…</code></pre>; the pre
+// override only receives the rendered tree, so recover the raw code by walking
+// the children for the copy button.
+function nodeToText(node: ReactNode): string {
+  if (typeof node === "string") return node;
+  if (typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeToText).join("");
+  if (isValidElement(node)) {
+    return nodeToText((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}
+
+// react-markdown stamps the fence info onto the inner <code> as
+// `language-<info>`; pull it back out for the highlighter.
+function fenceLanguage(children: ReactNode): string {
+  const child = Array.isArray(children) ? children[0] : children;
+  if (isValidElement(child)) {
+    const className = (child.props as { className?: string }).className ?? "";
+    const match = /(?:^|\s)language-(\S+)/.exec(className);
+    if (match) return match[1];
+  }
+  return "";
+}
+
+// Highlight only once the code stops changing: every streamed delta grows the
+// text and resets this timer, so an in-flight message renders raw and a
+// finalized one upgrades ~one debounce later. Comfortably longer than the gap
+// between streamed tokens, short enough to feel instant on loaded history.
+const HIGHLIGHT_DEBOUNCE_MS = 300;
+
+function CodeBlock({ children }: { children?: ReactNode }) {
+  const code = useMemo(() => nodeToText(children).replace(/\n$/, ""), [children]);
+  const lang = useMemo(() => fenceLanguage(children), [children]);
+  const [lines, setLines] = useState<HighlightToken[][] | null>(null);
+
+  useEffect(() => {
+    // Drop any stale highlight first so the raw text — not a shorter,
+    // previously-tokenized prefix — shows while the block is still growing.
+    setLines(null);
+    if (!lang) return;
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      void highlightFenceToLines(code, lang).then((highlighted) => {
+        if (!cancelled && highlighted) setLines(highlighted);
+      });
+    }, HIGHLIGHT_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [code, lang]);
+
+  return (
+    <div className="markdown-codeblock">
+      <CopyCodeButton text={code} />
+      {lines ? (
+        <pre className="markdown-pre wp-hl">
+          {lines.map((tokens, idx) => (
+            <Fragment key={idx}>
+              {idx > 0 ? "\n" : null}
+              {tokens.map((token, i) =>
+                token.className ? (
+                  <span key={i} className={token.className}>
+                    {token.text}
+                  </span>
+                ) : (
+                  <Fragment key={i}>{token.text}</Fragment>
+                ),
+              )}
+            </Fragment>
+          ))}
+        </pre>
+      ) : (
+        <pre className="markdown-pre">{children}</pre>
+      )}
+    </div>
+  );
+}
 
 function MarkdownAnchor({
   href,
@@ -76,7 +167,7 @@ const COMPONENTS: Components = {
     );
   },
   pre({ children }) {
-    return <pre className="markdown-pre">{children}</pre>;
+    return <CodeBlock>{children}</CodeBlock>;
   },
 };
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -67,6 +67,7 @@ import { clearToken } from "@/lib/store";
 import { type TerminalSubmitResult } from "@/lib/composer";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import { useFileMentions } from "@/lib/use-file-mentions";
+import { useCopied } from "@/lib/use-copied";
 import {
   isPlanEvent,
   itemIdForEvent,
@@ -178,7 +179,7 @@ function copyTextSync(text: string): boolean {
 // occasionally needs the raw id for a `waypoint sessions …` call or to hand to
 // an agent). Copies the full id even though the display truncates it.
 function SessionIdCopy({ id }: { id: string }) {
-  const [copied, setCopied] = useState(false);
+  const { copied, markCopied } = useCopied();
   return (
     <button
       type="button"
@@ -187,10 +188,7 @@ function SessionIdCopy({ id }: { id: string }) {
       aria-label={copied ? "Session id copied" : `Copy session id ${id}`}
       onClick={(event) => {
         event.stopPropagation();
-        if (copyTextSync(id)) {
-          setCopied(true);
-          window.setTimeout(() => setCopied(false), 1500);
-        }
+        if (copyTextSync(id)) markCopied();
       }}
     >
       <span className="session-id-copy-key">id</span>

--- a/frontend/src/lib/highlight.ts
+++ b/frontend/src/lib/highlight.ts
@@ -74,6 +74,18 @@ function languageForPath(path: string): string | null {
   return EXTENSION_LANGUAGE[name.slice(dot + 1).toLowerCase()] ?? null;
 }
 
+// Resolve a markdown fence info string (the token after the opening ```) to an
+// hljs language name. Many fence tokens are already hljs names (python, go,
+// rust); the rest are the same aliases we map for file extensions (ts, py,
+// yml, sh). The token itself is the last resort — `registered()` downstream
+// rejects anything lowlight doesn't know, so a bad guess just falls back to
+// raw rendering.
+function languageForFence(info: string): string | null {
+  const token = info.trim().toLowerCase().split(/\s+/)[0];
+  if (!token) return null;
+  return EXTENSION_LANGUAGE[token] ?? token;
+}
+
 interface HastNode {
   type: string;
   value?: string;
@@ -123,13 +135,12 @@ function splitIntoLines(tokens: HighlightToken[]): HighlightToken[][] {
 }
 
 // Returns per-line token arrays, or null when highlighting is unavailable
-// (unknown language, oversized content, unregistered grammar, or a parse
-// error) — callers fall back to rendering the raw lines.
-export async function highlightToLines(
+// (oversized content, unregistered grammar, or a parse error) — callers fall
+// back to rendering the raw lines.
+async function highlightCodeToLines(
   code: string,
-  path: string,
+  language: string | null,
 ): Promise<HighlightToken[][] | null> {
-  const language = languageForPath(path);
   if (!language || code.length > MAX_HIGHLIGHT_CHARS) return null;
   const lowlight = await getLowlight();
   if (!lowlight.registered(language)) return null;
@@ -141,4 +152,21 @@ export async function highlightToLines(
   } catch {
     return null;
   }
+}
+
+// Highlight a workspace file, inferring the language from its path/extension.
+export function highlightToLines(
+  code: string,
+  path: string,
+): Promise<HighlightToken[][] | null> {
+  return highlightCodeToLines(code, languageForPath(path));
+}
+
+// Highlight a markdown fenced code block, using its info string as the
+// language hint. Returns null (raw fallback) for unlabeled fences.
+export function highlightFenceToLines(
+  code: string,
+  info: string,
+): Promise<HighlightToken[][] | null> {
+  return highlightCodeToLines(code, languageForFence(info));
 }

--- a/frontend/src/lib/use-copied.ts
+++ b/frontend/src/lib/use-copied.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Shared reset window for every copy button's "copied" confirmation, so the
+// glyph/label flips back after a consistent delay app-wide.
+export const COPIED_RESET_MS = 800;
+
+// Drives the transient "copied" confirmation state shared by every copy button.
+// The copy mechanism stays at the call site (async clipboard vs the sync
+// execCommand path some surfaces need) — this only owns the flag and its timer,
+// clearing it on re-copy and unmount so a stale timeout never sets state on a
+// gone component.
+export function useCopied(resetMs: number = COPIED_RESET_MS) {
+  const [copied, setCopied] = useState(false);
+  const timer = useRef<number | null>(null);
+  const clear = useCallback(() => {
+    if (timer.current !== null) {
+      window.clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+  useEffect(() => clear, [clear]);
+  const markCopied = useCallback(() => {
+    clear();
+    setCopied(true);
+    timer.current = window.setTimeout(() => {
+      timer.current = null;
+      setCopied(false);
+    }, resetMs);
+  }, [clear, resetMs]);
+  const reset = useCallback(() => {
+    clear();
+    setCopied(false);
+  }, [clear]);
+  return { copied, markCopied, reset };
+}


### PR DESCRIPTION
## Purpose

Fenced code blocks in transcript message bubbles were plain, unstyled monospace with no quick way to copy them. This adds a hover-reveal copy button and syntax highlighting to those blocks, and unifies the copy-button confirmation behavior shared across the app.

## Changes

### Frontend

- `frontend/src/lib/use-copied.ts` — new `useCopied` hook owning the transient "copied" confirmation state and reset timer (shared `COPIED_RESET_MS`), clearing the timer on re-copy and unmount.
- `frontend/src/components/CopyMessageButton.tsx`, `SessionDetail.tsx` (`SessionIdCopy`), `app/assistant/page.tsx` (`CopyField`) — rebuilt on `useCopied`; the session id keeps its sync `execCommand` copy path for WebKit/iOS, now just calling `markCopied()`.
- `frontend/src/components/CopyCodeButton.tsx` — new hover-reveal copy button for code blocks; reverts on mouse-out (desktop) and stays visible on touch.
- `frontend/src/components/MarkdownMessage.tsx` — the `pre` override is now a hooked `CodeBlock` that renders raw text synchronously, then upgrades to highlighted tokens once the text settles.
- `frontend/src/lib/highlight.ts` — factored the core out of `highlightToLines`; added `languageForFence` + `highlightFenceToLines` to resolve a markdown fence info string to an hljs language.
- `frontend/src/app/globals.css` — `.markdown-codeblock`/`.code-copy` styles, and the `--hl-*` palette plus token rules moved from `.wp-code-pre` to a shared `.wp-hl` class.
- `frontend/src/components/FilePreview.tsx` — opts its pre into the shared `.wp-hl` class.

## Design

Transcript messages stream by appending deltas to one coalesced event, and there is no per-message "complete" flag to key off. Rather than thread a streaming signal down through the render tree, `CodeBlock` uses the block's own text as the completion signal: highlighting runs on a short debounce, and every streamed delta resets the timer (clearing any stale highlight first), so an in-flight message renders raw and only a finalized block upgrades to colored tokens — no mid-stream flicker or mis-coloring of incomplete syntax. Unlabeled fences stay plain (no auto-detection). Highlighting reuses the file preview's lazy lowlight tokenizer and warm-gold/cool-blue palette; the palette variables move onto the shared `.wp-hl` class so both surfaces resolve them, with dark/light parity riding on the existing theme variables.

## Test Plan

- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Manually verified in the running stack: code blocks in agent messages show the hover-reveal copy button (copy → ✓ → revert) and syntax highlighting across Python/TypeScript/bash; bare fences stay plain; dark and light themes both render correct token colors.

## Test Result

`npm run lint` clean; `npm run build` succeeded. Manual checks behaved as expected in both themes. No backend changes, so the Python suites were not run.