### PR TITLE
feat: add git status and a full-file diff viewer to the file explorer

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -60,6 +60,7 @@ from waypoint.settings import Settings, load_settings
 from waypoint.storage import Storage
 from waypoint.tailnet import fetch_snapshot
 from waypoint.usage_dashboard import build_dashboard
+from waypoint.workspace_git import git_file_diff, git_status
 from waypoint.workspace_preview import (
     WorkspacePathError,
     is_denied,
@@ -531,6 +532,65 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "path": relative_to_base(base, resolved),
             "kind": "dir" if resolved.is_dir() else "file",
         }
+
+    @app.get("/api/sessions/{session_id}/workspace/git/status")
+    async def workspace_git_status(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        session = _workspace_session(session_id)
+        disabled: dict[str, Any] = {"enabled": False, "branch": None, "files": []}
+        if not context.settings.workspace_git_enabled:
+            return disabled
+        base = Path(session.worktree_path or session.cwd)
+        result = await git_status(base)
+        if result is None:
+            return disabled
+        return {"enabled": True, **result.model_dump(mode="json")}
+
+    @app.get("/api/sessions/{session_id}/workspace/git/diff")
+    async def workspace_git_diff(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        path: Annotated[str, Query()] = "",
+        staged: Annotated[bool, Query()] = False,
+    ) -> Any:
+        session = _workspace_session(session_id)
+        if not context.settings.workspace_git_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="disabled"
+            )
+        base = Path(session.worktree_path or session.cwd)
+        try:
+            if not path or is_denied(path, context.settings.workspace_denylist):
+                raise WorkspacePathError("path is denied")
+            # Validate the path stays inside the workspace without requiring it to
+            # exist on disk — a deleted file still has a diff against HEAD.
+            resolve_in_base(
+                base,
+                path,
+                follow_symlinks=context.settings.workspace_follow_symlinks,
+            )
+        except WorkspacePathError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN, detail="workspace path denied"
+            ) from exc
+        preview = await git_file_diff(
+            base,
+            path,
+            staged=staged,
+            max_file_bytes=context.settings.workspace_max_file_bytes,
+        )
+        if preview is None:
+            return {
+                "schema_version": 1,
+                "phase": "aggregate",
+                "files": [],
+                "total_additions": 0,
+                "total_deletions": 0,
+                "truncated": False,
+            }
+        return preview.model_dump(mode="json")
 
     @app.delete("/api/sessions/{session_id}/attachments/{attachment_id}")
     async def delete_attachment(

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -546,6 +546,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         result = await git_status(base)
         if result is None:
             return disabled
+        # Hide denied paths so the Changes list matches what the tree, file, and
+        # diff endpoints will serve.
+        denylist = context.settings.workspace_denylist
+        result = result.model_copy(
+            update={
+                "files": [
+                    entry
+                    for entry in result.files
+                    if not is_denied(entry.path, denylist)
+                ]
+            }
+        )
         return {"enabled": True, **result.model_dump(mode="json")}
 
     @app.get("/api/sessions/{session_id}/workspace/git/diff")

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -120,6 +120,7 @@ class Settings(BaseModel):
         default_factory=lambda: list(DEFAULT_WORKSPACE_DENYLIST)
     )
     workspace_follow_symlinks: bool = False
+    workspace_git_enabled: bool = True
     database_name: str = "waypoint.db"
     token_ttl_seconds: int = 60 * 60 * 24 * 30
     stream_poll_interval: float = 1.0
@@ -284,6 +285,10 @@ def _env_overrides() -> dict[str, Any]:
     if "WAYPOINT_WORKSPACE_FOLLOW_SYMLINKS" in os.environ:
         overrides["workspace_follow_symlinks"] = os.environ[
             "WAYPOINT_WORKSPACE_FOLLOW_SYMLINKS"
+        ].lower() not in {"0", "false", "no", ""}
+    if "WAYPOINT_WORKSPACE_GIT_ENABLED" in os.environ:
+        overrides["workspace_git_enabled"] = os.environ[
+            "WAYPOINT_WORKSPACE_GIT_ENABLED"
         ].lower() not in {"0", "false", "no", ""}
     if "WAYPOINT_CORS_ORIGINS" in os.environ:
         overrides["cors_origins"] = parse_cors_origins(

--- a/backend/src/waypoint/workspace_git.py
+++ b/backend/src/waypoint/workspace_git.py
@@ -1,0 +1,169 @@
+import asyncio
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from waypoint.backends.diff_preview import (
+    DEFAULT_MAX_FILE_BYTES,
+    DEFAULT_MAX_TOTAL_BYTES,
+    DiffPreviewFile,
+    DiffPreviewPayload,
+    build_preview,
+    file_from_old_new,
+    files_from_unified_diff,
+    unavailable_file,
+)
+from waypoint.workspace_preview import read_text_capped
+
+
+class GitFileStatus(BaseModel):
+    path: str
+    old_path: str | None = None
+    # The two porcelain v1 status columns: ``index`` (staged) and ``worktree``
+    # (unstaged). A space means unmodified in that area; ``?`` marks untracked.
+    index_status: str
+    worktree_status: str
+    untracked: bool
+
+
+class GitStatus(BaseModel):
+    branch: str | None
+    files: list[GitFileStatus]
+
+
+async def _run_git(cwd: Path, *args: str) -> tuple[int, bytes]:
+    try:
+        process = await asyncio.create_subprocess_exec(
+            "git",
+            "-C",
+            str(cwd),
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+    except FileNotFoundError:
+        return 127, b""
+    stdout, _ = await process.communicate()
+    return process.returncode if process.returncode is not None else -1, stdout
+
+
+async def _git_text(cwd: Path, *args: str) -> str | None:
+    code, out = await _run_git(cwd, *args)
+    if code != 0:
+        return None
+    return out.decode("utf-8", errors="replace").strip() or None
+
+
+async def is_git_repo(base: Path) -> bool:
+    code, out = await _run_git(base, "rev-parse", "--is-inside-work-tree")
+    return code == 0 and out.decode("utf-8", errors="replace").strip() == "true"
+
+
+async def git_status(base: Path) -> GitStatus | None:
+    if not await is_git_repo(base):
+        return None
+    branch = await _git_text(base, "rev-parse", "--abbrev-ref", "HEAD")
+    # ``base`` may be a subdirectory of the repo; porcelain paths are always
+    # repo-root-relative, so translate them to ``base``-relative and drop
+    # entries living outside the browsed subtree.
+    prefix = await _git_text(base, "rev-parse", "--show-prefix") or ""
+    code, raw = await _run_git(
+        base, "status", "--porcelain=v1", "-z", "--untracked-files=all"
+    )
+    if code != 0:
+        return None
+    scoped: list[GitFileStatus] = []
+    for entry in _parse_porcelain_z(raw):
+        rel = _strip_prefix(entry.path, prefix)
+        if rel is None:
+            continue
+        old_rel = _strip_prefix(entry.old_path, prefix) if entry.old_path else None
+        scoped.append(entry.model_copy(update={"path": rel, "old_path": old_rel}))
+    return GitStatus(branch=branch, files=scoped)
+
+
+async def git_file_diff(
+    base: Path,
+    rel: str,
+    *,
+    staged: bool,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BYTES,
+) -> DiffPreviewPayload | None:
+    # ``staged`` shows only the index-vs-HEAD slice; otherwise the combined
+    # working-tree-vs-HEAD view (staged + unstaged together).
+    # ``-U1000000`` forces git to emit the entire file as context (clamped to
+    # the file length) so the frontend can render full-file inline diffs.
+    diff_args = ("-U1000000", "--cached") if staged else ("-U1000000", "HEAD")
+    diff = await _git_diff(base, *diff_args, "--", rel)
+    if diff and diff.strip():
+        files = files_from_unified_diff(diff, fallback_path=rel)
+    else:
+        files = await _untracked_add(base, rel, max_file_bytes)
+    if not files:
+        return None
+    return build_preview("aggregate", files, max_file_bytes, max_total_bytes)
+
+
+async def _git_diff(base: Path, *args: str) -> str | None:
+    code, out = await _run_git(base, "diff", *args)
+    if code != 0:
+        return None
+    return out.decode("utf-8", errors="replace")
+
+
+async def _untracked_add(
+    base: Path, rel: str, max_file_bytes: int
+) -> list[DiffPreviewFile]:
+    code, out = await _run_git(base, "status", "--porcelain=v1", "-z", "--", rel)
+    if code != 0:
+        return []
+    first = out.decode("utf-8", errors="replace").split("\0", 1)[0]
+    if not first.startswith("??"):
+        return []
+    target = base.expanduser() / rel
+    try:
+        content, _truncated, binary, _encoding = read_text_capped(
+            target, max_file_bytes
+        )
+    except OSError:
+        return []
+    if binary or content is None:
+        return [unavailable_file(rel, "Untracked file is binary or too large", "add")]
+    return [file_from_old_new(rel, "", content, "add")]
+
+
+def _parse_porcelain_z(raw: bytes) -> list[GitFileStatus]:
+    tokens = raw.decode("utf-8", errors="replace").split("\0")
+    files: list[GitFileStatus] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        index += 1
+        if len(token) < 3:
+            continue
+        status_field = token[:2]
+        path = token[3:]
+        old_path: str | None = None
+        # A rename/copy in the index emits the source path as the next token.
+        if status_field[0] in ("R", "C") and index < len(tokens):
+            old_path = tokens[index]
+            index += 1
+        files.append(
+            GitFileStatus(
+                path=path,
+                old_path=old_path,
+                index_status=status_field[0],
+                worktree_status=status_field[1],
+                untracked=status_field == "??",
+            )
+        )
+    return files
+
+
+def _strip_prefix(path: str, prefix: str) -> str | None:
+    if not prefix:
+        return path
+    if path.startswith(prefix):
+        return path[len(prefix) :]
+    return None

--- a/backend/tests/test_workspace_api.py
+++ b/backend/tests/test_workspace_api.py
@@ -5,6 +5,7 @@ FastAPI app (over an in-process ASGI transport) rather than the helper layer.
 The routes only read storage/tokens, so the runtime lifespan is not started.
 """
 
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -251,3 +252,56 @@ async def test_empty_denylist_disables_filtering(tmp_path: Path) -> None:
         )
     assert resp.status_code == 200
     assert resp.json()["content"] == "[core]\n"
+
+
+async def test_git_status_hides_denied_paths(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(workspace), *args], check=True, capture_output=True
+        )
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    _git("config", "commit.gpgsign", "false")
+    (workspace / "app.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "-A")
+    _git("commit", "-q", "-m", "init")
+    (workspace / "app.py").write_text("x = 2\n", encoding="utf-8")  # changed, shown
+    (workspace / "secret.pem").write_text("KEY\n", encoding="utf-8")  # denied, hidden
+
+    settings = Settings(data_dir=tmp_path / "data", workspace_denylist=["*.pem"])
+    app = create_app(settings)
+    context = app.state.context
+    now = datetime.now(UTC)
+    context.storage.create_session(
+        SessionRecord(
+            id="s1",
+            backend="codex",
+            source=SessionSource.MANAGED,
+            title="t",
+            cwd=str(workspace),
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(tmp_path / "raw.log"),
+            structured_log_path=str(tmp_path / "events.jsonl"),
+        )
+    )
+    token = context.tokens.issue().token
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/git/status",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["enabled"] is True
+    paths = [entry["path"] for entry in body["files"]]
+    assert "app.py" in paths
+    assert "secret.pem" not in paths

--- a/backend/tests/test_workspace_git.py
+++ b/backend/tests/test_workspace_git.py
@@ -1,0 +1,129 @@
+import subprocess
+from pathlib import Path
+
+from waypoint.workspace_git import git_file_diff, git_status, is_git_repo
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True)
+
+
+def _init_repo(repo: Path) -> None:
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _commit(repo: Path, message: str) -> None:
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", message)
+
+
+async def test_git_status_classifies_changes(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "tracked.txt").write_text("one\n", encoding="utf-8")
+    (tmp_path / "doomed.txt").write_text("bye\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+
+    (tmp_path / "tracked.txt").write_text("one\ntwo\n", encoding="utf-8")  # modified
+    (tmp_path / "doomed.txt").unlink()  # deleted
+    (tmp_path / "fresh.txt").write_text("new\n", encoding="utf-8")  # untracked
+    (tmp_path / "staged.txt").write_text("staged\n", encoding="utf-8")
+    _git(tmp_path, "add", "staged.txt")  # staged add
+
+    status = await git_status(tmp_path)
+    assert status is not None
+    by_path = {entry.path: entry for entry in status.files}
+
+    assert by_path["tracked.txt"].worktree_status == "M"
+    assert by_path["doomed.txt"].worktree_status == "D"
+    assert by_path["fresh.txt"].untracked is True
+    assert by_path["staged.txt"].index_status == "A"
+
+
+async def test_git_status_translates_subdir_prefix(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    sub = tmp_path / "backend"
+    sub.mkdir()
+    (sub / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (tmp_path / "root.txt").write_text("root\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    (sub / "app.py").write_text("x = 2\n", encoding="utf-8")
+    (tmp_path / "root.txt").write_text("changed\n", encoding="utf-8")
+
+    # Browsing from the subdir, paths are reported relative to it and entries
+    # outside the subtree are dropped.
+    status = await git_status(sub)
+    assert status is not None
+    paths = {entry.path for entry in status.files}
+    assert "app.py" in paths
+    assert all("root.txt" not in path for path in paths)
+
+
+async def test_git_file_diff_tracked_modification(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("a\nb\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    (tmp_path / "f.txt").write_text("a\nc\n", encoding="utf-8")
+
+    preview = await git_file_diff(tmp_path, "f.txt", staged=False)
+    assert preview is not None
+    assert len(preview.files) == 1
+    diff = preview.files[0].diff
+    assert "-b" in diff and "+c" in diff
+    assert preview.total_additions == 1
+    assert preview.total_deletions == 1
+
+
+async def test_git_file_diff_includes_full_file_context(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("l1\nl2\nl3\nl4\nl5\nl6\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    (tmp_path / "f.txt").write_text("l1\nl2\nl3\nCHANGED\nl5\nl6\n", encoding="utf-8")
+
+    preview = await git_file_diff(tmp_path, "f.txt", staged=False)
+    assert preview is not None
+    diff = preview.files[0].diff
+    assert "-l4" in diff and "+CHANGED" in diff
+    # Unchanged first and last lines are emitted as context, not elided.
+    assert " l1" in diff and " l6" in diff
+
+
+async def test_git_file_diff_staged_only(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("a\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    (tmp_path / "f.txt").write_text("a\nstaged\n", encoding="utf-8")
+    _git(tmp_path, "add", "f.txt")
+    (tmp_path / "f.txt").write_text("a\nstaged\nunstaged\n", encoding="utf-8")
+
+    staged = await git_file_diff(tmp_path, "f.txt", staged=True)
+    assert staged is not None
+    assert "+staged" in staged.files[0].diff
+    assert "unstaged" not in staged.files[0].diff
+
+
+async def test_git_file_diff_untracked_synthesizes_add(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "seed.txt").write_text("seed\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    (tmp_path / "new.txt").write_text("hello\nworld\n", encoding="utf-8")
+
+    preview = await git_file_diff(tmp_path, "new.txt", staged=False)
+    assert preview is not None
+    assert preview.files[0].change_type == "add"
+    assert "+hello" in preview.files[0].diff
+
+
+async def test_git_file_diff_unchanged_returns_none(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("a\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+
+    assert await git_file_diff(tmp_path, "f.txt", staged=False) is None
+
+
+async def test_non_repo_returns_none(tmp_path: Path) -> None:
+    assert await is_git_repo(tmp_path) is False
+    assert await git_status(tmp_path) is None

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -26,6 +26,9 @@ cors_origins: []
 # workspace_max_file_bytes: 200000   # larger files preview as a placeholder
 # workspace_follow_symlinks: false   # if true, allow paths through symlinks that
 #                                    #   still resolve inside the working dir
+# workspace_git_enabled: true        # show git status + per-file diffs in the
+#                                    #   explorer (no-op outside a git repo).
+#                                    #   Env: WAYPOINT_WORKSPACE_GIT_ENABLED
 
 # Per-plugin config blocks keyed by plugin id. Each block is validated
 # against the plugin's `config_schema` (see `backends/<id>/plugin.py`).

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11626,6 +11626,10 @@ html[data-theme="light"]
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  /* Make the dock a scroll-chaining boundary: gestures over a non-scrollable or
+     already-at-edge pane stay inside the dock instead of scrolling the
+     transcript behind it (notably when the dock is a full-screen sheet). */
+  overscroll-behavior: contain;
   background: rgba(14, 17, 24, 0.98);
   border-right: 1px solid var(--line-strong);
   box-shadow: 4px 0 32px rgba(0, 0, 0, 0.36);
@@ -11714,9 +11718,12 @@ body.wp-dock-resizing {
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 14px 16px;
+  /* Right padding reserves space for the absolutely-pinned close button so
+     wrapping header content never runs under it. */
+  padding: 14px 56px 14px 16px;
   border-bottom: 1px solid var(--line);
   flex-shrink: 0;
+  position: relative;
 }
 
 .wp-panel-title {
@@ -11731,6 +11738,7 @@ body.wp-dock-resizing {
   font-family: var(--font-display);
   font-size: 1.02rem;
   color: var(--text-strong);
+  white-space: nowrap;
 }
 
 .wp-panel-cwd {
@@ -11772,6 +11780,9 @@ body.wp-dock-resizing {
 }
 
 .wp-panel-close {
+  position: absolute;
+  top: 12px;
+  right: 14px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -11910,6 +11921,485 @@ body.wp-dock-resizing {
   text-overflow: ellipsis;
 }
 
+/* ─── Workspace git status ─── */
+/* All colors resolve from semantic tokens (--success/--danger/--accent/
+ * --accent-cool), which already carry per-theme values, so these rules need no
+ * separate light-mode overrides. */
+.wp-git-badge {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+  line-height: 1;
+  width: 13px;
+  text-align: center;
+}
+
+.wp-tree-node .wp-git-badge {
+  margin-left: auto;
+}
+
+.wp-git-badge.modified {
+  color: var(--accent);
+}
+
+.wp-git-badge.added,
+.wp-git-badge.untracked {
+  color: var(--success);
+}
+
+.wp-git-badge.deleted {
+  color: var(--danger);
+}
+
+.wp-git-badge.renamed {
+  color: var(--accent-cool);
+}
+
+.wp-git-dot {
+  flex-shrink: 0;
+  margin-left: auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  opacity: 0.65;
+}
+
+.wp-tree-node.git-modified .wp-tree-name {
+  color: var(--accent);
+}
+
+.wp-tree-node.git-added .wp-tree-name,
+.wp-tree-node.git-untracked .wp-tree-name {
+  color: var(--success);
+}
+
+.wp-tree-node.git-renamed .wp-tree-name {
+  color: var(--accent-cool);
+}
+
+.wp-tree-node.git-deleted .wp-tree-name {
+  color: var(--danger);
+  text-decoration: line-through;
+}
+
+.wp-changes {
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: 30%;
+}
+
+.wp-changes.collapsed {
+  max-height: none;
+}
+
+.wp-changes-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 8px 10px;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.wp-changes-chevron {
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.wp-changes-total {
+  color: var(--muted-soft);
+  background: var(--bg-card-soft);
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+  font-size: 0.6rem;
+}
+
+.wp-changes-groups {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 8px 8px;
+  min-height: 0;
+}
+
+.wp-changes-group + .wp-changes-group {
+  margin-top: 6px;
+}
+
+.wp-changes-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  padding: 0 4px 4px;
+  margin: 0;
+}
+
+.wp-changes-count {
+  color: var(--muted-soft);
+  background: var(--bg-card-soft);
+  border-radius: var(--radius-pill);
+  padding: 0 6px;
+  font-size: 0.6rem;
+  text-transform: none;
+}
+
+.wp-changes-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.wp-changes-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 0.8rem;
+  transition: background-color 120ms ease;
+}
+
+.wp-changes-item:hover,
+.wp-changes-item.selected {
+  background: color-mix(in srgb, var(--accent-cool) 12%, transparent);
+}
+
+.wp-changes-name {
+  flex-shrink: 0;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wp-changes-dir {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--muted);
+}
+
+/* Segmented toggles (Content/Diff and Inline/Split): a single bordered group
+ * with joined cells. */
+.wp-preview-modetoggle,
+.wp-diff-layout {
+  display: inline-flex;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.wp-mode-btn {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 4px 11px;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.wp-mode-btn + .wp-mode-btn {
+  border-left: 1px solid var(--line);
+}
+
+.wp-mode-btn.active {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent-cool) 16%, transparent);
+}
+
+/* ─── Workspace diff (dedicated full-file viewer) ─── */
+.wp-diff {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  flex: 1;
+}
+
+.wp-diff-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+
+.wp-diff-stat {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.wp-diff-stat.add {
+  color: var(--success);
+}
+
+.wp-diff-stat.del {
+  color: var(--danger);
+}
+
+.wp-diff-note {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--accent);
+}
+
+.wp-diff-layout {
+  margin-left: auto;
+}
+
+.wp-diff-empty {
+  padding: 16px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.wp-diff-inline,
+.wp-diff-split {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  line-height: 1.5;
+  overflow-x: auto;
+}
+
+/* Inline (unified) full-file view: dual line-number gutters + sign + code. */
+.wp-diff-row {
+  display: flex;
+  align-items: flex-start;
+  min-width: max-content;
+  white-space: pre;
+}
+
+.wp-diff-row.add {
+  background: rgba(108, 201, 154, 0.13);
+}
+
+html[data-theme="light"] .wp-diff-row.add {
+  background: rgba(37, 122, 80, 0.1);
+}
+
+.wp-diff-row.del {
+  background: rgba(226, 108, 112, 0.13);
+}
+
+html[data-theme="light"] .wp-diff-row.del {
+  background: rgba(184, 48, 56, 0.09);
+}
+
+.wp-diff-ln {
+  flex: none;
+  min-width: calc(var(--lnw, 2ch) + 14px);
+  padding: 0 7px;
+  text-align: right;
+  color: var(--muted-soft);
+  user-select: none;
+}
+
+.wp-diff-sign {
+  flex: none;
+  width: 2ch;
+  text-align: center;
+  color: var(--muted);
+  user-select: none;
+}
+
+.wp-diff-row.add .wp-diff-sign {
+  color: var(--success);
+}
+
+.wp-diff-row.del .wp-diff-sign {
+  color: var(--danger);
+}
+
+.wp-diff-code {
+  flex: 1;
+  padding-right: 12px;
+}
+
+/* Split (side-by-side) view: a 4-column grid (gutter|code|gutter|code) whose
+ * rows are display:contents so the columns align across the whole file. */
+.wp-diff-split {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr);
+}
+
+.wp-diff-srow {
+  display: contents;
+}
+
+.wp-diff-scode {
+  padding: 0 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.wp-diff-split .wp-diff-ln.new {
+  border-left: 1px solid var(--line);
+}
+
+.wp-diff-scode.add,
+.wp-diff-split .wp-diff-ln.add {
+  background: rgba(108, 201, 154, 0.13);
+}
+
+html[data-theme="light"] .wp-diff-scode.add,
+html[data-theme="light"] .wp-diff-split .wp-diff-ln.add {
+  background: rgba(37, 122, 80, 0.1);
+}
+
+.wp-diff-scode.del,
+.wp-diff-split .wp-diff-ln.del {
+  background: rgba(226, 108, 112, 0.13);
+}
+
+html[data-theme="light"] .wp-diff-scode.del,
+html[data-theme="light"] .wp-diff-split .wp-diff-ln.del {
+  background: rgba(184, 48, 56, 0.09);
+}
+
+.wp-diff-scode.blank,
+.wp-diff-split .wp-diff-ln.blank {
+  background: rgba(127, 138, 156, 0.06);
+}
+
+/* GitHub-style fold: a collapsed run of unchanged lines with capped two-way
+ * expanders (⌃ up / ⌄ down) and an explicit expand-all. */
+/* A quiet seam between hunks: a soft accent-tinted bar with borderless chevron
+   wells on the left (aligned to the line-number gutter) and a plain text link on
+   the right — no boxed buttons. */
+.wp-diff-fold {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  min-height: 30px;
+  background: color-mix(in srgb, var(--accent-cool) 6%, transparent);
+  border-top: 1px solid color-mix(in srgb, var(--accent-cool) 20%, var(--line));
+  border-bottom: 1px solid color-mix(in srgb, var(--accent-cool) 20%, var(--line));
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted);
+}
+
+.wp-diff-fold.split {
+  grid-column: 1 / -1;
+}
+
+.wp-diff-fold-steps {
+  display: flex;
+  flex-shrink: 0;
+  /* Span exactly the diff's twin line-number gutters and divide from the text
+     with the same hairline the code rows use; the chevrons fill it edge to
+     edge (one per gutter column). */
+  width: calc((var(--lnw, 2ch) + 14px) * 2);
+  border-right: 1px solid color-mix(in srgb, var(--accent-cool) 16%, var(--line));
+  background: color-mix(in srgb, var(--accent-cool) 8%, transparent);
+}
+
+.wp-diff-fold-step {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: var(--accent-cool);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 120ms ease;
+}
+
+.wp-diff-fold-step:hover {
+  background: color-mix(in srgb, var(--accent-cool) 22%, transparent);
+}
+
+.wp-diff-fold-label {
+  flex: 1;
+  min-width: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 10px;
+}
+
+.wp-diff-fold-all {
+  background: transparent;
+  border: none;
+  color: var(--accent-cool);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  padding: 0 12px;
+  flex-shrink: 0;
+}
+
+.wp-diff-fold-all:hover {
+  color: var(--text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* Short gap: a single quiet expand affordance spanning the bar. */
+.wp-diff-fold-solo {
+  background: transparent;
+  border: none;
+  color: var(--accent-cool);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  width: 100%;
+}
+
+.wp-diff-fold-solo:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--accent-cool) 8%, transparent);
+}
+
+.wp-diff-fold-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .wp-tree-toolbar {
   display: flex;
   align-items: center;
@@ -11968,6 +12458,7 @@ body.wp-dock-resizing {
   flex: 1;
   min-height: 0;
   overflow-y: auto;
+  overscroll-behavior: contain;
   padding: 4px;
 }
 
@@ -12094,8 +12585,11 @@ html[data-theme="light"] .wp-preview-header {
   font-family: var(--font-mono);
   font-size: 0.78rem;
   color: var(--text);
-  flex: 1;
-  min-width: 0;
+  /* A min-width floor keeps the filename readable: when it plus the actions no
+     longer fit, the actions wrap to the next row instead of starving the path
+     down to an ellipsis. */
+  flex: 1 1 16ch;
+  min-width: 16ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -12145,6 +12639,7 @@ html[data-theme="light"] .wp-preview-header {
   flex: 1;
   min-height: 0;
   overflow: auto;
+  overscroll-behavior: contain;
   display: flex;
   flex-direction: column;
 }
@@ -12493,6 +12988,17 @@ html[data-theme="light"] .wp-hl {
    container query), so this fires both for a narrow desktop dock and the
    mobile full-screen sheet. */
 @container (max-width: 700px) {
+  /* The header controls (Tree/Preview toggle, full-page link, close) no longer
+     fit beside the title, so let the title claim its own row and the controls
+     wrap beneath it. */
+  .wp-panel-header {
+    flex-wrap: wrap;
+  }
+
+  .wp-panel-title {
+    flex: 1 1 100%;
+  }
+
   .wp-panel-mobile-toggle {
     display: flex;
   }
@@ -12511,6 +13017,22 @@ html[data-theme="light"] .wp-hl {
 
   .wp-mobile-hidden {
     display: none;
+  }
+
+  /* Wrap inline diff lines instead of horizontal-scrolling them, matching the
+     transcript diff's narrow-viewport behavior (see .diff-line @media). */
+  .wp-diff-inline {
+    overflow-x: visible;
+  }
+
+  .wp-diff-row {
+    min-width: 0;
+    white-space: normal;
+  }
+
+  .wp-diff-code {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 }
 

--- a/frontend/src/app/session/[id]/files/page.tsx
+++ b/frontend/src/app/session/[id]/files/page.tsx
@@ -108,7 +108,6 @@ export default function SessionFilesPage() {
           host={host}
           token={token}
           sessionId={sessionId}
-          recentPaths={[]}
           initialPath={initialPath}
           initialDir={initialDir}
         />

--- a/frontend/src/components/DiffPreview.tsx
+++ b/frontend/src/components/DiffPreview.tsx
@@ -1,4 +1,12 @@
+import { Fragment, useEffect, useMemo, useState } from "react";
+
 import type { EventDiffPreview, EventDiffPreviewFile } from "@/lib/events";
+import {
+  buildPlainDiffLines,
+  DIFF_MARKER,
+  highlightDiffToLines,
+  type DiffLine,
+} from "@/lib/highlight";
 
 const PHASE_LABEL: Record<EventDiffPreview["phase"], string> = {
   proposed: "Proposed changes",
@@ -73,13 +81,7 @@ function DiffPreviewFileView({
       {file.unavailableReason ? (
         <p className="diff-unavailable">{file.unavailableReason}</p>
       ) : file.diff ? (
-        <pre className="diff-code" aria-label={`Diff for ${file.path}`}>
-          {file.diff.split("\n").map((line, index) => (
-            <span className={`diff-line ${classForDiffLine(line)}`} key={index}>
-              {line || " "}
-            </span>
-          ))}
-        </pre>
+        <DiffCode diff={file.diff} path={file.path} />
       ) : (
         <p className="diff-unavailable">No diff content available.</p>
       )}
@@ -124,12 +126,40 @@ function cleanDiffPath(path: string): string {
     : withoutTimestamp;
 }
 
-function classForDiffLine(line: string): string {
-  if (line.startsWith("@@")) return "hunk";
-  if (line.startsWith("diff --git") || line.startsWith("---") || line.startsWith("+++")) {
-    return "meta";
-  }
-  if (line.startsWith("+")) return "add";
-  if (line.startsWith("-")) return "del";
-  return "context";
+// Renders a unified diff with syntax-highlighted content. Starts from the plain
+// classified lines, then swaps in highlighted tokens once the lazy highlighter
+// resolves (falling back to plain when the language is unknown or too large).
+function DiffCode({ diff, path }: { diff: string; path: string }) {
+  const plain = useMemo(() => buildPlainDiffLines(diff), [diff]);
+  const [lines, setLines] = useState<DiffLine[]>(plain);
+
+  useEffect(() => {
+    setLines(plain);
+    let cancelled = false;
+    void highlightDiffToLines(diff, path).then((highlighted) => {
+      if (!cancelled && highlighted) setLines(highlighted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [diff, path, plain]);
+
+  return (
+    <pre className="diff-code wp-hl" aria-label={`Diff for ${path}`}>
+      {lines.map((line, index) => (
+        <span className={`diff-line ${line.kind}`} key={index}>
+          {DIFF_MARKER[line.kind]}
+          {line.tokens.map((token, i) =>
+            token.className ? (
+              <span key={i} className={token.className}>
+                {token.text}
+              </span>
+            ) : (
+              <Fragment key={i}>{token.text}</Fragment>
+            ),
+          )}
+        </span>
+      ))}
+    </pre>
+  );
 }

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -71,7 +71,6 @@ import { useCopied } from "@/lib/use-copied";
 import {
   isPlanEvent,
   itemIdForEvent,
-  parseEvent,
   planForEvent,
   type PlanDecision,
   type PlanViewModel,
@@ -1321,24 +1320,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => transcriptItems.some((item) => item.kind === "tool_run"),
     [transcriptItems],
   );
-  // Workspace preview: collect recently written file paths from applied diff
-  // previews, newest-first and deduplicated. Backend-agnostic: keyed off the
-  // diff_preview phase, not tool names.
-  const recentPaths = useMemo(() => {
-    const seen = new Set<string>();
-    const paths: string[] = [];
-    for (let i = events.length - 1; i >= 0; i--) {
-      const diff = parseEvent(events[i]).diffPreview;
-      if (!diff || diff.phase !== "applied") continue;
-      for (const file of diff.files) {
-        if (!seen.has(file.path)) {
-          seen.add(file.path);
-          paths.push(file.path);
-        }
-      }
-    }
-    return paths;
-  }, [events]);
   // True for local sessions only; remote sessions return 400 from the workspace
   // endpoints.
   const workspacePreviewEnabled = Boolean(session && !session.launch_target_id);
@@ -2265,7 +2246,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           initialPath={workspaceInitialPath}
           initialDir={workspaceInitialDir}
           revealSeq={workspaceRevealSeq}
-          recentPaths={recentPaths}
           width={dockWidth}
           onResize={setDockWidth}
           onClose={() => setWorkspaceOpen(false)}

--- a/frontend/src/components/WorkspaceDiff.tsx
+++ b/frontend/src/components/WorkspaceDiff.tsx
@@ -1,0 +1,449 @@
+"use client";
+
+import {
+  type CSSProperties,
+  Fragment,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { EventDiffPreview, EventDiffPreviewFile } from "@/lib/events";
+import {
+  buildPlainDiffLines,
+  highlightDiffToLines,
+  type DiffLine,
+  type HighlightToken,
+} from "@/lib/highlight";
+
+// Below this container width the side-by-side layout is too cramped, so the
+// diff defaults to inline until the user explicitly switches.
+const SPLIT_MIN_WIDTH = 720;
+// Unchanged lines kept adjacent to each change; longer runs collapse into an
+// expandable fold (GitHub-style), so a small edit in a big file reads compactly.
+const CONTEXT = 3;
+const MIN_FOLD = 4;
+// Lines revealed per directional expander click.
+const EXPAND_STEP = 20;
+
+type DiffLayout = "inline" | "split";
+
+type DisplayItem =
+  | { type: "line"; row: DiffLine }
+  | { type: "fold"; key: string; count: number; isTop: boolean; isBottom: boolean };
+
+type Segment = { type: "row"; index: number } | { type: "fold"; key: string; start: number; end: number };
+
+interface FoldBounds {
+  from: number;
+  to: number;
+}
+
+interface WorkspaceDiffProps {
+  preview: EventDiffPreview;
+  path: string;
+}
+
+export function WorkspaceDiff({ preview, path }: WorkspaceDiffProps) {
+  const file = preview.files[0];
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [override, setOverride] = useState<DiffLayout | null>(null);
+  const [wide, setWide] = useState(false);
+  const [folds, setFolds] = useState<Record<string, FoldBounds>>({});
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) setWide(entry.contentRect.width >= SPLIT_MIN_WIDTH);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const diffText = file?.diff ?? "";
+  const plain = useMemo(() => (diffText ? buildPlainDiffLines(diffText) : []), [diffText]);
+  const [lines, setLines] = useState<DiffLine[]>(plain);
+  useEffect(() => {
+    setLines(plain);
+    setFolds({});
+    if (!diffText) return;
+    let cancelled = false;
+    void highlightDiffToLines(diffText, path).then((highlighted) => {
+      if (!cancelled && highlighted) setLines(highlighted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [diffText, path, plain]);
+
+  // Only actual file lines render; file/hunk headers are dropped so the view
+  // reads as the whole file with changes marked.
+  const rows = useMemo(
+    () => lines.filter((line) => line.kind !== "meta" && line.kind !== "hunk"),
+    [lines],
+  );
+  const gutter = useMemo(() => {
+    let max = 1;
+    for (const row of rows) {
+      if (row.oldNo && row.oldNo > max) max = row.oldNo;
+      if (row.newNo && row.newNo > max) max = row.newNo;
+    }
+    return `${String(max).length}ch`;
+  }, [rows]);
+
+  const segments = useMemo(() => computeSegments(rows), [rows]);
+  const foldSpans = useMemo(() => {
+    const map = new Map<string, Segment & { type: "fold" }>();
+    for (const segment of segments) if (segment.type === "fold") map.set(segment.key, segment);
+    return map;
+  }, [segments]);
+
+  const display = useMemo<DisplayItem[]>(() => {
+    const out: DisplayItem[] = [];
+    for (const segment of segments) {
+      if (segment.type === "row") {
+        out.push({ type: "line", row: rows[segment.index] });
+        continue;
+      }
+      const bounds = folds[segment.key] ?? { from: segment.start, to: segment.end };
+      for (let k = segment.start; k < bounds.from; k += 1) {
+        out.push({ type: "line", row: rows[k] });
+      }
+      if (bounds.from < bounds.to) {
+        out.push({
+          type: "fold",
+          key: segment.key,
+          count: bounds.to - bounds.from,
+          isTop: segment.start === 0,
+          isBottom: segment.end === rows.length,
+        });
+      }
+      for (let k = bounds.to; k < segment.end; k += 1) {
+        out.push({ type: "line", row: rows[k] });
+      }
+    }
+    return out;
+  }, [segments, folds, rows]);
+
+  const boundsFor = (key: string): FoldBounds => {
+    const span = foldSpans.get(key);
+    return folds[key] ?? { from: span?.start ?? 0, to: span?.end ?? 0 };
+  };
+  // "Show next lines" reveals from the top of the hidden region (lines flow down
+  // from the content above); "Show previous lines" reveals from the bottom (the
+  // lines just above the content below).
+  const expandDown = (key: string) => {
+    const b = boundsFor(key);
+    setFolds((prev) => ({ ...prev, [key]: { from: Math.min(b.to, b.from + EXPAND_STEP), to: b.to } }));
+  };
+  const expandUp = (key: string) => {
+    const b = boundsFor(key);
+    setFolds((prev) => ({ ...prev, [key]: { from: b.from, to: Math.max(b.from, b.to - EXPAND_STEP) } }));
+  };
+  const expandAll = (key: string) => {
+    const b = boundsFor(key);
+    setFolds((prev) => ({ ...prev, [key]: { from: b.to, to: b.to } }));
+  };
+  const expanders = { onUp: expandUp, onDown: expandDown, onAll: expandAll };
+
+  const layout: DiffLayout = override ?? (wide ? "split" : "inline");
+
+  return (
+    <div className="wp-diff" ref={containerRef}>
+      <div className="wp-diff-toolbar">
+        <span className="wp-diff-stat add">+{file?.additions ?? 0}</span>
+        <span className="wp-diff-stat del">-{file?.deletions ?? 0}</span>
+        {file?.truncated ? <span className="wp-diff-note">truncated</span> : null}
+        <div className="wp-diff-layout">
+          <button
+            type="button"
+            className={`wp-mode-btn${layout === "inline" ? " active" : ""}`}
+            onClick={() => setOverride("inline")}
+          >
+            Inline
+          </button>
+          <button
+            type="button"
+            className={`wp-mode-btn${layout === "split" ? " active" : ""}`}
+            onClick={() => setOverride("split")}
+          >
+            Split
+          </button>
+        </div>
+      </div>
+      <DiffBody
+        file={file}
+        rows={rows}
+        display={display}
+        layout={layout}
+        gutter={gutter}
+        expanders={expanders}
+      />
+    </div>
+  );
+}
+
+interface Expanders {
+  onUp: (key: string) => void;
+  onDown: (key: string) => void;
+  onAll: (key: string) => void;
+}
+
+function DiffBody({
+  file,
+  rows,
+  display,
+  layout,
+  gutter,
+  expanders,
+}: {
+  file: EventDiffPreviewFile | undefined;
+  rows: DiffLine[];
+  display: DisplayItem[];
+  layout: DiffLayout;
+  gutter: string;
+  expanders: Expanders;
+}) {
+  if (!file) {
+    return <div className="wp-diff-empty">No changes against HEAD</div>;
+  }
+  if (file.unavailableReason || (!file.diff && !rows.length)) {
+    return (
+      <div className="wp-diff-empty">
+        {file.binary
+          ? "Binary file — open the Content tab."
+          : (file.unavailableReason ?? "No diff content available.")}
+      </div>
+    );
+  }
+  return layout === "split" ? (
+    <SplitDiff display={display} gutter={gutter} expanders={expanders} />
+  ) : (
+    <InlineDiff display={display} gutter={gutter} expanders={expanders} />
+  );
+}
+
+function InlineDiff({
+  display,
+  gutter,
+  expanders,
+}: {
+  display: DisplayItem[];
+  gutter: string;
+  expanders: Expanders;
+}) {
+  return (
+    <div className="wp-diff-inline wp-hl" style={{ "--lnw": gutter } as CSSProperties}>
+      {display.map((item, index) =>
+        item.type === "fold" ? (
+          <FoldRow key={`f${item.key}`} item={item} expanders={expanders} />
+        ) : (
+          <div className={`wp-diff-row ${item.row.kind}`} key={index}>
+            <span className="wp-diff-ln">{item.row.oldNo ?? ""}</span>
+            <span className="wp-diff-ln">{item.row.newNo ?? ""}</span>
+            <span className="wp-diff-sign">
+              {item.row.kind === "add" ? "+" : item.row.kind === "del" ? "-" : " "}
+            </span>
+            <span className="wp-diff-code">{renderCode(item.row.tokens)}</span>
+          </div>
+        ),
+      )}
+    </div>
+  );
+}
+
+function SplitDiff({
+  display,
+  gutter,
+  expanders,
+}: {
+  display: DisplayItem[];
+  gutter: string;
+  expanders: Expanders;
+}) {
+  const nodes: ReactNode[] = [];
+  let run: DiffLine[] = [];
+  let runStart = 0;
+  const flush = () => {
+    if (!run.length) return;
+    buildSplitPairs(run).forEach((pair, i) => {
+      nodes.push(
+        <div className="wp-diff-srow" key={`s${runStart}-${i}`}>
+          <span className={`wp-diff-ln ${pair.left ? pair.left.kind : "blank"}`}>
+            {pair.left?.oldNo ?? ""}
+          </span>
+          <span className={`wp-diff-scode ${pair.left ? pair.left.kind : "blank"}`}>
+            {pair.left ? renderCode(pair.left.tokens) : ""}
+          </span>
+          <span className={`wp-diff-ln new ${pair.right ? pair.right.kind : "blank"}`}>
+            {pair.right?.newNo ?? ""}
+          </span>
+          <span className={`wp-diff-scode ${pair.right ? pair.right.kind : "blank"}`}>
+            {pair.right ? renderCode(pair.right.tokens) : ""}
+          </span>
+        </div>,
+      );
+    });
+    run = [];
+  };
+  display.forEach((item, index) => {
+    if (item.type === "line") {
+      if (!run.length) runStart = index;
+      run.push(item.row);
+    } else {
+      flush();
+      nodes.push(<FoldRow split key={`f${item.key}`} item={item} expanders={expanders} />);
+    }
+  });
+  flush();
+  return (
+    <div className="wp-diff-split wp-hl" style={{ "--lnw": gutter } as CSSProperties}>
+      {nodes}
+    </div>
+  );
+}
+
+// A single position-aware fold bar per gap: directional step buttons for the
+// available direction(s) — ⤓ reveals downward from the block above, ⤒ reveals
+// upward from the block below — a line count, and one Expand all. A short gap is
+// a single full-width expand control.
+function FoldRow({
+  item,
+  split,
+  expanders,
+}: {
+  item: { key: string; count: number; isTop: boolean; isBottom: boolean };
+  split?: boolean;
+  expanders: Expanders;
+}) {
+  const { key, count, isTop, isBottom } = item;
+  const className = `wp-diff-fold${split ? " split" : ""}`;
+
+  if (count <= EXPAND_STEP) {
+    return (
+      <div className={className}>
+        <button
+          type="button"
+          className="wp-diff-fold-solo"
+          onClick={() => expanders.onAll(key)}
+        >
+          <span className="wp-diff-fold-icon" aria-hidden="true">
+            ⌄
+          </span>
+          Expand {count} unchanged {count === 1 ? "line" : "lines"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <div className="wp-diff-fold-steps">
+        {!isTop ? (
+          <button
+            type="button"
+            className="wp-diff-fold-step"
+            title="Show next lines"
+            aria-label="Show next lines"
+            onClick={() => expanders.onDown(key)}
+          >
+            ⌄
+          </button>
+        ) : null}
+        {!isBottom ? (
+          <button
+            type="button"
+            className="wp-diff-fold-step"
+            title="Show previous lines"
+            aria-label="Show previous lines"
+            onClick={() => expanders.onUp(key)}
+          >
+            ⌃
+          </button>
+        ) : null}
+      </div>
+      <span className="wp-diff-fold-label">{count} unchanged lines</span>
+      <button
+        type="button"
+        className="wp-diff-fold-all"
+        onClick={() => expanders.onAll(key)}
+      >
+        Expand all
+      </button>
+    </div>
+  );
+}
+
+interface SplitPair {
+  left: DiffLine | null;
+  right: DiffLine | null;
+}
+
+// Pair deletions with the additions that replace them so a change block lines up
+// side by side; context lines mirror on both sides.
+function buildSplitPairs(rows: DiffLine[]): SplitPair[] {
+  const pairs: SplitPair[] = [];
+  let index = 0;
+  while (index < rows.length) {
+    if (rows[index].kind === "context") {
+      pairs.push({ left: rows[index], right: rows[index] });
+      index += 1;
+      continue;
+    }
+    const dels: DiffLine[] = [];
+    const adds: DiffLine[] = [];
+    while (index < rows.length && rows[index].kind === "del") dels.push(rows[index++]);
+    while (index < rows.length && rows[index].kind === "add") adds.push(rows[index++]);
+    const span = Math.max(dels.length, adds.length);
+    for (let k = 0; k < span; k += 1) {
+      pairs.push({ left: dels[k] ?? null, right: adds[k] ?? null });
+    }
+  }
+  return pairs;
+}
+
+// Keep CONTEXT unchanged lines around every change and mark longer runs of
+// untouched context (including the file's head and tail) as folds.
+function computeSegments(rows: DiffLine[]): Segment[] {
+  const near = rows.map(() => false);
+  rows.forEach((row, i) => {
+    if (row.kind === "context") return;
+    for (let j = Math.max(0, i - CONTEXT); j <= Math.min(rows.length - 1, i + CONTEXT); j += 1) {
+      near[j] = true;
+    }
+  });
+  const segments: Segment[] = [];
+  let i = 0;
+  while (i < rows.length) {
+    if (near[i] || rows[i].kind !== "context") {
+      segments.push({ type: "row", index: i });
+      i += 1;
+      continue;
+    }
+    let j = i;
+    while (j < rows.length && !near[j] && rows[j].kind === "context") j += 1;
+    if (j - i >= MIN_FOLD) {
+      segments.push({ type: "fold", key: `fold-${i}`, start: i, end: j });
+    } else {
+      for (let k = i; k < j; k += 1) segments.push({ type: "row", index: k });
+    }
+    i = j;
+  }
+  return segments;
+}
+
+function renderCode(tokens: HighlightToken[]): ReactNode {
+  if (!tokens.length || tokens.every((token) => token.text === "")) return " ";
+  return tokens.map((token, i) =>
+    token.className ? (
+      <span key={i} className={token.className}>
+        {token.text}
+      </span>
+    ) : (
+      <Fragment key={i}>{token.text}</Fragment>
+    ),
+  );
+}

--- a/frontend/src/components/WorkspaceExplorer.tsx
+++ b/frontend/src/components/WorkspaceExplorer.tsx
@@ -1,24 +1,118 @@
 "use client";
 
 import Link from "next/link";
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import {
   fetchWorkspaceFile,
+  fetchWorkspaceGitDiff,
+  fetchWorkspaceGitStatus,
   workspaceRawUrl,
   type WorkspaceFile,
+  type WorkspaceGitFileStatus,
+  type WorkspaceGitStatus,
   type WorkspaceTreePage,
 } from "@/lib/api";
 import { formatBytes } from "@/components/AttachmentTray";
 import { FilePreview } from "@/components/FilePreview";
+import { WorkspaceDiff } from "@/components/WorkspaceDiff";
 import { WorkspaceTree } from "@/components/WorkspaceTree";
+import type { EventDiffPreview } from "@/lib/events";
 import { copyText } from "@/lib/clipboard";
+
+function gitChangeLabel(status: WorkspaceGitFileStatus): {
+  letter: string;
+  kind: string;
+} {
+  if (status.untracked) return { letter: "U", kind: "untracked" };
+  const code = status.indexStatus !== " " ? status.indexStatus : status.worktreeStatus;
+  switch (code) {
+    case "A":
+      return { letter: "A", kind: "added" };
+    case "D":
+      return { letter: "D", kind: "deleted" };
+    case "R":
+      return { letter: "R", kind: "renamed" };
+    case "C":
+      return { letter: "C", kind: "added" };
+    default:
+      return { letter: "M", kind: "modified" };
+  }
+}
+
+function isStaged(status: WorkspaceGitFileStatus): boolean {
+  return !status.untracked && status.indexStatus !== " ";
+}
+
+function isUnstaged(status: WorkspaceGitFileStatus): boolean {
+  return status.untracked || status.worktreeStatus !== " ";
+}
+
+function GitChangeGroup({
+  label,
+  files,
+  staged,
+  openPath,
+  active,
+  showLabel,
+  onOpen,
+}: {
+  label: string;
+  files: WorkspaceGitFileStatus[];
+  staged: boolean;
+  openPath: string | null;
+  active: boolean;
+  showLabel: boolean;
+  onOpen: (status: WorkspaceGitFileStatus, staged: boolean) => void;
+}) {
+  return (
+    <div className="wp-changes-group">
+      {showLabel ? (
+        <p className="wp-changes-label">
+          {label}
+          <span className="wp-changes-count">{files.length}</span>
+        </p>
+      ) : null}
+      <ul className="wp-changes-list">
+        {files.map((file) => {
+          const { letter, kind } = gitChangeLabel(file);
+          const selected = active && openPath === file.path;
+          const slash = file.path.lastIndexOf("/");
+          const name = slash >= 0 ? file.path.slice(slash + 1) : file.path;
+          const dir = slash >= 0 ? file.path.slice(0, slash) : "";
+          return (
+            <li key={file.path}>
+              <button
+                type="button"
+                className={`wp-changes-item${selected ? " selected" : ""}`}
+                title={file.path}
+                onClick={() => onOpen(file, staged)}
+              >
+                <span className={`wp-git-badge ${kind}`} aria-hidden="true">
+                  {letter}
+                </span>
+                <span className="wp-changes-name">{name}</span>
+                {dir ? <span className="wp-changes-dir">{dir}</span> : null}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
 
 interface WorkspaceExplorerProps {
   host: string;
   token: string;
   sessionId: string;
-  recentPaths: string[];
   initialPath?: string;
   initialDir?: string;
   revealSeq?: number;
@@ -103,7 +197,6 @@ export function WorkspaceExplorer({
   host,
   token,
   sessionId,
-  recentPaths,
   initialPath,
   initialDir,
   revealSeq,
@@ -113,6 +206,7 @@ export function WorkspaceExplorer({
 }: WorkspaceExplorerProps) {
   const [mobileView, setMobileView] = useState<"tree" | "preview">("tree");
   const [revealDir, setRevealDir] = useState<string | null>(null);
+  const [changesCollapsed, setChangesCollapsed] = useState(false);
   const [treeRefreshSeq, setTreeRefreshSeq] = useState(0);
   const [treeRefreshing, setTreeRefreshing] = useState(false);
   const [fileRefreshing, setFileRefreshing] = useState(false);
@@ -128,9 +222,83 @@ export function WorkspaceExplorer({
     reset,
   } = useWorkspacePreview(host, token, sessionId);
 
+  const [gitStatus, setGitStatus] = useState<WorkspaceGitStatus | null>(null);
+  const [previewMode, setPreviewMode] = useState<"content" | "diff">("content");
+  const [diffStaged, setDiffStaged] = useState(false);
+  const [diffData, setDiffData] = useState<EventDiffPreview | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
+
+  const gitFiles = gitStatus?.enabled ? gitStatus.files : null;
+  const gitFileMap = useMemo(() => {
+    const map = new Map<string, WorkspaceGitFileStatus>();
+    for (const file of gitFiles ?? []) map.set(file.path, file);
+    return map;
+  }, [gitFiles]);
+  const dirtyDirs = useMemo(() => {
+    const dirs = new Set<string>();
+    for (const file of gitFiles ?? []) {
+      const parts = file.path.split("/");
+      parts.pop();
+      let acc = "";
+      for (const part of parts) {
+        acc = acc ? `${acc}/${part}` : part;
+        dirs.add(acc);
+      }
+    }
+    return dirs;
+  }, [gitFiles]);
+  const stagedFiles = useMemo(() => (gitFiles ?? []).filter(isStaged), [gitFiles]);
+  const unstagedFiles = useMemo(() => (gitFiles ?? []).filter(isUnstaged), [gitFiles]);
+  const changedCount = useMemo(
+    () => new Set((gitFiles ?? []).map((file) => file.path)).size,
+    [gitFiles],
+  );
+
+  // Refresh git status alongside the tree (mount, refresh button, tab focus).
+  useEffect(() => {
+    if (!active) return;
+    let cancelled = false;
+    void fetchWorkspaceGitStatus(host, token, sessionId)
+      .then((status) => {
+        if (!cancelled) setGitStatus(status);
+      })
+      .catch(() => {
+        if (!cancelled) setGitStatus(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [host, token, sessionId, treeRefreshSeq, active]);
+
+  // Fetch the diff when the diff view is showing. Keyed on the open file's mtime
+  // so a silent content refresh (agent edited it) re-pulls the diff too.
+  const openMtime = fileData?.mtime ?? null;
+  useEffect(() => {
+    if (previewMode !== "diff" || !openPath) return;
+    let cancelled = false;
+    setDiffData(null);
+    setDiffError(null);
+    setDiffLoading(true);
+    void fetchWorkspaceGitDiff(host, token, sessionId, openPath, diffStaged)
+      .then((data) => {
+        if (!cancelled) setDiffData(data);
+      })
+      .catch((e) => {
+        if (!cancelled) setDiffError(e instanceof Error ? e.message : "Failed to load diff");
+      })
+      .finally(() => {
+        if (!cancelled) setDiffLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [previewMode, openPath, diffStaged, host, token, sessionId, treeRefreshSeq, openMtime]);
+
   useEffect(() => {
     if (initialPath) {
       reset();
+      setPreviewMode("content");
       void openFile(initialPath);
       setRevealDir(null);
       setMobileView("preview");
@@ -185,8 +353,23 @@ export function WorkspaceExplorer({
 
   const handleSelectFile = useCallback(
     async (path: string) => {
-      await openFile(path);
+      setPreviewMode("content");
       setMobileView("preview");
+      await openFile(path);
+    },
+    [openFile],
+  );
+
+  // Opening from the Changes list jumps straight to the diff view. The staged
+  // group shows the index-vs-HEAD slice; the unstaged group shows the combined
+  // working-tree-vs-HEAD diff. openFile still runs to populate the path/meta and
+  // back the "Content" tab (it no-ops visibly for a deleted file).
+  const openFromChanges = useCallback(
+    (status: WorkspaceGitFileStatus, staged: boolean) => {
+      setDiffStaged(staged);
+      setPreviewMode("diff");
+      setMobileView("preview");
+      void openFile(status.path);
     },
     [openFile],
   );
@@ -263,24 +446,46 @@ export function WorkspaceExplorer({
               <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
             </button>
           </div>
-          {recentPaths.length > 0 ? (
-            <div className="wp-recent">
-              <p className="wp-recent-label">Recently written</p>
-              <ul className="wp-recent-list">
-                {recentPaths.slice(0, 10).map((p) => (
-                  <li key={p}>
-                    <button
-                      type="button"
-                      className={`wp-recent-item${openPath === p ? " selected" : ""}`}
-                      title={p}
-                      onClick={() => void handleSelectFile(p)}
-                    >
-                      {p.split("/").pop() ?? p}
-                      <span className="wp-recent-full">{p}</span>
-                    </button>
-                  </li>
-                ))}
-              </ul>
+          {stagedFiles.length > 0 || unstagedFiles.length > 0 ? (
+            <div className={`wp-changes${changesCollapsed ? " collapsed" : ""}`}>
+              <button
+                type="button"
+                className="wp-changes-header"
+                onClick={() => setChangesCollapsed((c) => !c)}
+                aria-expanded={!changesCollapsed}
+              >
+                <span className="wp-changes-chevron" aria-hidden="true">
+                  {changesCollapsed ? "▸" : "▾"}
+                </span>
+                <span>Changes</span>
+                <span className="wp-changes-total">{changedCount}</span>
+              </button>
+              {!changesCollapsed ? (
+                <div className="wp-changes-groups">
+                  {stagedFiles.length > 0 ? (
+                    <GitChangeGroup
+                      label="Staged"
+                      files={stagedFiles}
+                      staged
+                      openPath={openPath}
+                      active={previewMode === "diff" && diffStaged}
+                      showLabel={stagedFiles.length > 0 && unstagedFiles.length > 0}
+                      onOpen={openFromChanges}
+                    />
+                  ) : null}
+                  {unstagedFiles.length > 0 ? (
+                    <GitChangeGroup
+                      label="Unstaged"
+                      files={unstagedFiles}
+                      staged={false}
+                      openPath={openPath}
+                      active={previewMode === "diff" && !diffStaged}
+                      showLabel={stagedFiles.length > 0 && unstagedFiles.length > 0}
+                      onOpen={openFromChanges}
+                    />
+                  ) : null}
+                </div>
+              ) : null}
             </div>
           ) : null}
           <div className="wp-tree-scroll">
@@ -292,6 +497,8 @@ export function WorkspaceExplorer({
               revealPath={revealDir}
               revealSeq={revealSeq}
               refreshSeq={treeRefreshSeq}
+              gitStatus={gitFileMap}
+              dirtyDirs={dirtyDirs}
               onSelectFile={handleSelectFile}
               onRootLoaded={setRoot}
             />
@@ -306,7 +513,25 @@ export function WorkspaceExplorer({
                   {openPath}
                 </span>
                 <div className="wp-preview-actions">
-                  {fileData ? (
+                  {gitFileMap.has(openPath) ? (
+                    <div className="wp-preview-modetoggle">
+                      <button
+                        type="button"
+                        className={`wp-mode-btn${previewMode === "content" ? " active" : ""}`}
+                        onClick={() => setPreviewMode("content")}
+                      >
+                        Content
+                      </button>
+                      <button
+                        type="button"
+                        className={`wp-mode-btn${previewMode === "diff" ? " active" : ""}`}
+                        onClick={() => setPreviewMode("diff")}
+                      >
+                        Diff
+                      </button>
+                    </div>
+                  ) : null}
+                  {previewMode === "content" && fileData ? (
                     <span className="wp-preview-meta">
                       {formatBytes(fileData.size)} · {mtime}
                     </span>
@@ -328,7 +553,7 @@ export function WorkspaceExplorer({
                   >
                     Copy path
                   </button>
-                  {fileData?.content ? (
+                  {previewMode === "content" && fileData?.content ? (
                     <button
                       type="button"
                       className="wp-preview-btn"
@@ -338,7 +563,7 @@ export function WorkspaceExplorer({
                       Copy contents
                     </button>
                   ) : null}
-                  {rawUrl ? (
+                  {previewMode === "content" && rawUrl ? (
                     <a
                       href={rawUrl}
                       target="_blank"
@@ -352,7 +577,17 @@ export function WorkspaceExplorer({
                 </div>
               </div>
               <div className="wp-preview-body">
-                {fileLoading ? (
+                {previewMode === "diff" ? (
+                  diffLoading ? (
+                    <div className="wp-preview-loading">Loading…</div>
+                  ) : diffError ? (
+                    <div className="wp-preview-error">{diffError}</div>
+                  ) : diffData && diffData.files.length > 0 ? (
+                    <WorkspaceDiff preview={diffData} path={openPath} />
+                  ) : (
+                    <div className="wp-preview-empty">No changes against HEAD</div>
+                  )
+                ) : fileLoading ? (
                   <div className="wp-preview-loading">Loading…</div>
                 ) : fileError ? (
                   <div className="wp-preview-error">{fileError}</div>

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -13,7 +13,6 @@ interface WorkspaceFilesPanelProps {
   initialPath?: string;
   initialDir?: string;
   revealSeq?: number;
-  recentPaths: string[];
   width: number;
   onResize: (width: number) => void;
   onClose: () => void;
@@ -27,7 +26,6 @@ export function WorkspaceFilesPanel({
   initialPath,
   initialDir,
   revealSeq,
-  recentPaths,
   width,
   onResize,
   onClose,
@@ -90,7 +88,6 @@ export function WorkspaceFilesPanel({
         host={host}
         token={token}
         sessionId={sessionId}
-        recentPaths={recentPaths}
         initialPath={initialPath}
         initialDir={initialDir}
         revealSeq={revealSeq}

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -4,10 +4,39 @@ import { type CSSProperties, useCallback, useEffect, useRef, useState } from "re
 
 import {
   fetchWorkspaceTree,
+  type WorkspaceGitFileStatus,
   type WorkspaceTreeEntry,
   type WorkspaceTreePage,
 } from "@/lib/api";
 import { FileIcon, FolderIcon } from "@/components/AttachmentTray";
+
+type GitDecorationKind =
+  | "modified"
+  | "added"
+  | "deleted"
+  | "renamed"
+  | "untracked";
+
+function gitDecoration(
+  status: WorkspaceGitFileStatus | undefined,
+): { letter: string; kind: GitDecorationKind } | null {
+  if (!status) return null;
+  if (status.untracked) return { letter: "U", kind: "untracked" };
+  // Prefer the staged (index) column, falling back to the worktree column.
+  const code = status.indexStatus !== " " ? status.indexStatus : status.worktreeStatus;
+  switch (code) {
+    case "A":
+      return { letter: "A", kind: "added" };
+    case "D":
+      return { letter: "D", kind: "deleted" };
+    case "R":
+      return { letter: "R", kind: "renamed" };
+    case "C":
+      return { letter: "C", kind: "added" };
+    default:
+      return { letter: "M", kind: "modified" };
+  }
+}
 
 interface DirState {
   entries: WorkspaceTreeEntry[];
@@ -32,6 +61,8 @@ interface WorkspaceTreeProps {
   revealPath?: string | null;
   revealSeq?: number;
   refreshSeq?: number;
+  gitStatus?: Map<string, WorkspaceGitFileStatus>;
+  dirtyDirs?: Set<string>;
   onSelectFile: (path: string) => void;
   onRootLoaded?: (root: WorkspaceTreePage["root"]) => void;
 }
@@ -44,6 +75,8 @@ export function WorkspaceTree({
   revealPath,
   revealSeq,
   refreshSeq,
+  gitStatus,
+  dirtyDirs,
   onSelectFile,
   onRootLoaded,
 }: WorkspaceTreeProps) {
@@ -195,6 +228,8 @@ export function WorkspaceTree({
           selectedPath={selectedPath}
           revealTarget={activeReveal}
           revealSeq={revealSeq}
+          gitStatus={gitStatus}
+          dirtyDirs={dirtyDirs}
           onSelectFile={selectFile}
           onToggleDir={toggleDir}
         />
@@ -215,6 +250,8 @@ function TreeNode({
   selectedPath,
   revealTarget,
   revealSeq,
+  gitStatus,
+  dirtyDirs,
   onSelectFile,
   onToggleDir,
 }: {
@@ -226,6 +263,8 @@ function TreeNode({
   selectedPath: string | null;
   revealTarget: string | null;
   revealSeq?: number;
+  gitStatus?: Map<string, WorkspaceGitFileStatus>;
+  dirtyDirs?: Set<string>;
   onSelectFile: (path: string) => void;
   onToggleDir: (dirPath: string) => void;
 }) {
@@ -236,6 +275,8 @@ function TreeNode({
   const isSelected = !isDir && selectedPath === fullPath;
   const isRevealed = revealTarget != null && revealTarget === fullPath;
   const nodeRef = useRef<HTMLButtonElement>(null);
+  const decoration = isDir ? null : gitDecoration(gitStatus?.get(fullPath));
+  const isDirtyDir = isDir && (dirtyDirs?.has(fullPath) ?? false);
 
   // revealSeq is in the deps so a repeat reveal of the same (already-revealed)
   // node re-scrolls it into view even though `isRevealed` stays true.
@@ -255,7 +296,7 @@ function TreeNode({
       <button
         ref={nodeRef}
         type="button"
-        className={`wp-tree-node${isSelected || isRevealed ? " selected" : ""}${isDir ? " is-dir" : ""}`}
+        className={`wp-tree-node${isSelected || isRevealed ? " selected" : ""}${isDir ? " is-dir" : ""}${decoration ? ` git-${decoration.kind}` : ""}${isDirtyDir ? " git-dirty" : ""}`}
         onClick={() => {
           if (isDir) {
             onToggleDir(fullPath);
@@ -272,6 +313,13 @@ function TreeNode({
           {isDir ? <FolderIcon /> : <FileIcon />}
         </span>
         <span className="wp-tree-name">{entry.name}</span>
+        {decoration ? (
+          <span className={`wp-git-badge ${decoration.kind}`} aria-hidden="true">
+            {decoration.letter}
+          </span>
+        ) : isDirtyDir ? (
+          <span className="wp-git-dot" aria-hidden="true" />
+        ) : null}
       </button>
       {isDir && isExpanded ? (
         <ul role="group">
@@ -288,6 +336,8 @@ function TreeNode({
                   selectedPath={selectedPath}
                   revealTarget={revealTarget}
                   revealSeq={revealSeq}
+                  gitStatus={gitStatus}
+                  dirtyDirs={dirtyDirs}
                   onSelectFile={onSelectFile}
                   onToggleDir={onToggleDir}
                 />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -22,6 +22,7 @@ import {
   SessionRecord,
   UsageDashboardResponse,
 } from "@/lib/types";
+import { parseDiffPreviewPayload, type EventDiffPreview } from "@/lib/events";
 
 export class AuthError extends Error {
   constructor(message = "session expired") {
@@ -970,6 +971,72 @@ export function workspaceRawUrl(
   relPath: string,
 ): string {
   return `${host}/api/sessions/${sessionId}/workspace/file?path=${encodeURIComponent(relPath)}&raw=1&token=${encodeURIComponent(token)}`;
+}
+
+export interface WorkspaceGitFileStatus {
+  path: string;
+  oldPath: string | null;
+  // The two porcelain columns. A space means unmodified in that area.
+  indexStatus: string;
+  worktreeStatus: string;
+  untracked: boolean;
+}
+
+export interface WorkspaceGitStatus {
+  enabled: boolean;
+  branch: string | null;
+  files: WorkspaceGitFileStatus[];
+}
+
+export async function fetchWorkspaceGitStatus(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<WorkspaceGitStatus> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/workspace/git/status`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch git status");
+  const payload = await response.json();
+  const filesRaw = Array.isArray(payload.files) ? payload.files : [];
+  return {
+    enabled: Boolean(payload.enabled),
+    branch: typeof payload.branch === "string" ? payload.branch : null,
+    files: filesRaw.map(
+      (entry: Record<string, unknown>): WorkspaceGitFileStatus => ({
+        path: typeof entry.path === "string" ? entry.path : "",
+        oldPath: typeof entry.old_path === "string" ? entry.old_path : null,
+        indexStatus: typeof entry.index_status === "string" ? entry.index_status : " ",
+        worktreeStatus:
+          typeof entry.worktree_status === "string" ? entry.worktree_status : " ",
+        untracked: entry.untracked === true,
+      }),
+    ),
+  };
+}
+
+export async function fetchWorkspaceGitDiff(
+  host: string,
+  token: string,
+  sessionId: string,
+  relPath: string,
+  staged = false,
+): Promise<EventDiffPreview | null> {
+  const params = new URLSearchParams({ path: relPath });
+  if (staged) params.set("staged", "1");
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/workspace/git/diff?${params.toString()}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch git diff");
+  return parseDiffPreviewPayload(await response.json());
 }
 
 // Authenticated URL for an uploaded attachment. The token rides as a query

--- a/frontend/src/lib/events.ts
+++ b/frontend/src/lib/events.ts
@@ -101,7 +101,15 @@ function readBoolean(metadata: Record<string, unknown>, key: string): boolean {
 }
 
 function readDiffPreview(metadata: Record<string, unknown>): EventDiffPreview | null {
-  const raw = readRecord(metadata, "diff_preview");
+  return parseDiffPreviewPayload(readRecord(metadata, "diff_preview"));
+}
+
+// Parse a raw DiffPreviewPayload (snake_case, as emitted by the backend) into
+// the camelCase event shape. Shared by transcript event metadata and the
+// workspace git-diff endpoint.
+export function parseDiffPreviewPayload(
+  raw: Record<string, unknown> | null,
+): EventDiffPreview | null {
   if (!raw) return null;
   const filesRaw = raw.files;
   if (!Array.isArray(filesRaw)) return null;

--- a/frontend/src/lib/highlight.ts
+++ b/frontend/src/lib/highlight.ts
@@ -170,3 +170,154 @@ export function highlightFenceToLines(
 ): Promise<HighlightToken[][] | null> {
   return highlightCodeToLines(code, languageForFence(info));
 }
+
+export type DiffLineKind = "add" | "del" | "hunk" | "meta" | "context";
+
+export interface DiffLine {
+  kind: DiffLineKind;
+  // Source line numbers: both for context, new-only for additions, old-only for
+  // deletions, null for meta/hunk rows. Drive the diff gutters.
+  oldNo: number | null;
+  newNo: number | null;
+  // Highlighted content tokens, WITHOUT the leading +/-/space marker. Renderers
+  // supply the marker (DIFF_MARKER) or line-number gutters themselves.
+  tokens: HighlightToken[];
+}
+
+// The gutter sign per kind. Renderers that want an inline marker (the transcript
+// diff) prepend this; the explorer diff uses line-number gutters instead.
+export const DIFF_MARKER: Record<DiffLineKind, string> = {
+  add: "+",
+  del: "-",
+  context: " ",
+  hunk: "",
+  meta: "",
+};
+
+function classifyDiffLine(line: string): DiffLineKind {
+  if (line.startsWith("@@")) return "hunk";
+  if (line.startsWith("+++") || line.startsWith("---")) return "meta";
+  if (
+    line.startsWith("diff --git") ||
+    line.startsWith("index ") ||
+    line.startsWith("new file") ||
+    line.startsWith("deleted file") ||
+    line.startsWith("rename ") ||
+    line.startsWith("similarity ") ||
+    line.startsWith("Binary files") ||
+    line.startsWith("\\ ")
+  ) {
+    return "meta";
+  }
+  if (line.startsWith("+")) return "add";
+  if (line.startsWith("-")) return "del";
+  return "context";
+}
+
+interface DiffStructRow {
+  kind: DiffLineKind;
+  oldNo: number | null;
+  newNo: number | null;
+  content: string; // marker-stripped for add/del/context; raw for meta/hunk
+}
+
+// Parse a unified diff into rows, tracking old/new line numbers from each hunk
+// header. Single source of truth for classification + numbering, shared by the
+// plain fallback and the highlighter.
+function parseDiffStructure(diff: string): DiffStructRow[] {
+  const body = diff.endsWith("\n") ? diff.slice(0, -1) : diff;
+  const rows: DiffStructRow[] = [];
+  let oldLine = 0;
+  let newLine = 0;
+  let inHunk = false;
+  for (const line of body.split("\n")) {
+    const kind = classifyDiffLine(line);
+    if (kind === "hunk") {
+      const match = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      if (match) {
+        oldLine = Number(match[1]);
+        newLine = Number(match[2]);
+        inHunk = true;
+      }
+      rows.push({ kind, oldNo: null, newNo: null, content: line });
+      continue;
+    }
+    if (kind === "meta" || !inHunk) {
+      rows.push({ kind: "meta", oldNo: null, newNo: null, content: line });
+      continue;
+    }
+    const content = line.slice(1);
+    if (kind === "add") {
+      rows.push({ kind, oldNo: null, newNo: newLine++, content });
+    } else if (kind === "del") {
+      rows.push({ kind, oldNo: oldLine++, newNo: null, content });
+    } else {
+      rows.push({ kind: "context", oldNo: oldLine++, newNo: newLine++, content });
+    }
+  }
+  return rows;
+}
+
+// Synchronous fallback: classified rows with content as a single plain token.
+// Used as the initial render before async highlighting resolves, and as the
+// permanent rendering when highlighting is unavailable.
+export function buildPlainDiffLines(diff: string): DiffLine[] {
+  return parseDiffStructure(diff).map((row) => ({
+    kind: row.kind,
+    oldNo: row.oldNo,
+    newNo: row.newNo,
+    tokens: [{ text: row.content, className: "" }],
+  }));
+}
+
+// Highlight the code inside a unified diff. Reconstructs the "before" (context +
+// deletions) and "after" (context + additions) sides as whole documents so the
+// tokenizer sees multi-line context, highlights each, then re-threads the
+// per-line tokens back onto their diff rows. Returns null (raw fallback) when
+// the language is unknown or either side is too large to highlight.
+export async function highlightDiffToLines(
+  diff: string,
+  path: string,
+): Promise<DiffLine[] | null> {
+  const language = languageForPath(path);
+  if (!language) return null;
+  const rows = parseDiffStructure(diff);
+
+  const afterSrc: string[] = [];
+  const beforeSrc: string[] = [];
+  for (const row of rows) {
+    if (row.kind === "add" || row.kind === "context") afterSrc.push(row.content);
+    if (row.kind === "del" || row.kind === "context") beforeSrc.push(row.content);
+  }
+
+  const afterHl = afterSrc.length
+    ? await highlightCodeToLines(afterSrc.join("\n"), language)
+    : [];
+  const beforeHl = beforeSrc.length
+    ? await highlightCodeToLines(beforeSrc.join("\n"), language)
+    : [];
+  if (afterHl === null || beforeHl === null) return null;
+
+  let ai = 0;
+  let bi = 0;
+  return rows.map((row) => {
+    if (row.kind === "meta" || row.kind === "hunk") {
+      return {
+        kind: row.kind,
+        oldNo: null,
+        newNo: null,
+        tokens: [{ text: row.content, className: "" }],
+      };
+    }
+    let tokens: HighlightToken[];
+    if (row.kind === "del") {
+      tokens = beforeHl[bi++] ?? [{ text: row.content, className: "" }];
+    } else {
+      // add or context both consume the "after" side; context also advances
+      // the "before" cursor to keep the two queues aligned.
+      tokens = afterHl[ai++] ?? [{ text: row.content, className: "" }];
+      if (row.kind === "context") bi++;
+    }
+    return { kind: row.kind, oldNo: row.oldNo, newNo: row.newNo, tokens };
+  });
+}


### PR DESCRIPTION
## Purpose

The file explorer could browse and preview files but had no git awareness. This makes it git-aware: a Changes list of the working tree, VS Code-style status decorations on the tree, and a Content/Diff toggle whose dedicated viewer shows the whole file with the changes marked, in inline or side-by-side layouts.

## Changes

### Backend

- `backend/src/waypoint/workspace_git.py` — new async git helpers (`is_git_repo`, `git_status`, `git_file_diff`) over `git -C <base>`; porcelain parsing translates repo-root-relative paths to the browsed subtree via `--show-prefix`, and diffs use full-file context (`-U1000000`) so the frontend can render the entire file inline. Untracked files synthesize an add diff; results reuse the existing `DiffPreviewPayload`.
- `backend/src/waypoint/api.py` — `GET /workspace/git/status` and `GET /workspace/git/diff`, scoped to the session worktree/cwd and reusing `_workspace_session` plus the path sandbox; both no-op gracefully outside a git repo.
- `backend/src/waypoint/settings.py`, `backend/waypoint.example.yaml` — `workspace_git_enabled` flag (env `WAYPOINT_WORKSPACE_GIT_ENABLED`).
- `backend/tests/test_workspace_git.py` — cover status classification, subdir prefix translation, tracked/staged/untracked diffs, full-file context, and the non-repo case.

### Frontend

- `frontend/src/components/WorkspaceDiff.tsx` — new dedicated diff viewer: whole-file, syntax-highlighted, inline or side-by-side (defaulting by width), with GitHub-style fold/expand of unchanged runs (capped directional steps + Expand all).
- `frontend/src/components/WorkspaceExplorer.tsx`, `WorkspaceTree.tsx` — collapsible Changes list (Staged/Unstaged), a Content/Diff toggle, and M/A/D/U/R status decorations on the tree; drops the Recently written section.
- `frontend/src/lib/highlight.ts`, `frontend/src/components/DiffPreview.tsx`, `frontend/src/lib/events.ts` — the shared diff parser now carries old/new line numbers and marker-free tokens, syntax-highlighting transcript diffs too; `parseDiffPreviewPayload` is extracted for reuse.
- `frontend/src/lib/api.ts`, `WorkspaceFilesPanel.tsx`, `SessionDetail.tsx`, `app/session/[id]/files/page.tsx` — git fetchers/types and the prop-chain cleanup from dropping Recently written.
- `frontend/src/app/globals.css` — Changes list, status badges, diff viewer, fold controls, and the mobile header/diff fixes; all via theme tokens for dark/light parity.

## Design

The backend serves a full-file-context diff and the client folds long unchanged runs locally, so expansion is instant with no extra round-trips and the whole file is always available. Folds are position-aware (top/bottom one-way, middle two-way) and reveal in capped steps. The diff renderer is shared with the transcript but the explorer wraps it in a separate full-height viewer; the diff baseline is working-tree-vs-HEAD, with staged changes shown separately in the Changes list.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- Manually verified in the running stack: status/diff endpoints against this repo's own changes; inline and split layouts; fold expand (up/down/all); mobile line wrapping; denylist/path-escape guards return 403/401; dark and light themes.

## Test Result

pre-commit all passed; `pytest` 1099 passed; `npm run lint` clean and `npm run build` succeeded. Manual checks behaved as expected; the live endpoints returned correct status classification and full-file diffs.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — not touched.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title and described migration steps above — not a breaking change.
- [x] I have updated documentation or config examples (`backend/waypoint.example.yaml`).

</details>