### PR TITLE
feat: add a branch chip, paginated tree, and file finder to the explorer

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -60,14 +60,16 @@ from waypoint.settings import Settings, load_settings
 from waypoint.storage import Storage
 from waypoint.tailnet import fetch_snapshot
 from waypoint.usage_dashboard import build_dashboard
-from waypoint.workspace_git import git_file_diff, git_status
+from waypoint.workspace_git import git_file_diff, git_list_files, git_status
 from waypoint.workspace_preview import (
     WorkspacePathError,
     is_denied,
     list_dir,
+    rank_files,
     read_text_capped,
     relative_to_base,
     resolve_in_base,
+    walk_files,
 )
 
 log = logging.getLogger("waypoint.api")
@@ -411,6 +413,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session_id: str,
         _: Annotated[str, Depends(token_dependency())],
         path: Annotated[str, Query()] = "",
+        offset: Annotated[int, Query(ge=0)] = 0,
+        limit: Annotated[int, Query(ge=1, le=2000)] = 500,
     ) -> Any:
         session = _workspace_session(session_id)
         base = Path(session.worktree_path or session.cwd)
@@ -418,9 +422,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             entries, truncated, overflow, resolved_dir = list_dir(
                 base,
                 path,
-                500,
+                limit,
                 denylist=context.settings.workspace_denylist,
                 follow_symlinks=context.settings.workspace_follow_symlinks,
+                offset=offset,
             )
         except WorkspacePathError as exc:
             raise HTTPException(
@@ -434,8 +439,41 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "root": {"cwd": session.cwd, "worktree_path": session.worktree_path},
             "path": relative_to_base(base, resolved_dir),
             "entries": entries,
+            "offset": offset,
             "truncated": truncated,
             "overflow": overflow,
+        }
+
+    @app.get("/api/sessions/{session_id}/workspace/find")
+    async def workspace_find(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        q: Annotated[str, Query()] = "",
+        limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    ) -> Any:
+        session = _workspace_session(session_id)
+        query = q.strip()
+        if not query:
+            return {"matches": [], "truncated": False}
+        base = Path(session.worktree_path or session.cwd)
+        denylist = context.settings.workspace_denylist
+        # Prefer git's index (fast, .gitignore-aware); fall back to a capped walk
+        # for non-repo workspaces.
+        listed = await git_list_files(base)
+        walk_truncated = False
+        if listed is None:
+            candidates, walk_truncated = await asyncio.to_thread(
+                walk_files,
+                base,
+                denylist,
+                context.settings.workspace_follow_symlinks,
+            )
+        else:
+            candidates = listed
+        matches, rank_truncated = rank_files(query, candidates, denylist, limit)
+        return {
+            "matches": [{"path": path, "kind": "file"} for path in matches],
+            "truncated": walk_truncated or rank_truncated,
         }
 
     @app.get("/api/sessions/{session_id}/workspace/file")
@@ -539,7 +577,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         session = _workspace_session(session_id)
-        disabled: dict[str, Any] = {"enabled": False, "branch": None, "files": []}
+        disabled: dict[str, Any] = {
+            "enabled": False,
+            "branch": None,
+            "detached": False,
+            "files": [],
+        }
         if not context.settings.workspace_git_enabled:
             return disabled
         base = Path(session.worktree_path or session.cwd)

--- a/backend/src/waypoint/workspace_git.py
+++ b/backend/src/waypoint/workspace_git.py
@@ -27,7 +27,10 @@ class GitFileStatus(BaseModel):
 
 
 class GitStatus(BaseModel):
+    # ``branch`` is the display label for HEAD: a branch name when on a branch,
+    # otherwise (detached) the exact tag, ``git describe`` output, or short SHA.
     branch: str | None
+    detached: bool = False
     files: list[GitFileStatus]
 
 
@@ -59,10 +62,31 @@ async def is_git_repo(base: Path) -> bool:
     return code == 0 and out.decode("utf-8", errors="replace").strip() == "true"
 
 
+async def _head_label(base: Path) -> tuple[str | None, bool]:
+    # On a branch, ``--abbrev-ref HEAD`` is the branch name. A detached HEAD
+    # (``git checkout`` of a tag or commit) reports the literal ``HEAD``; resolve
+    # a friendlier label so the UI never shows the bare word "HEAD".
+    branch = await _git_text(base, "rev-parse", "--abbrev-ref", "HEAD")
+    if branch and branch != "HEAD":
+        return branch, False
+    exact = await _git_text(base, "describe", "--tags", "--exact-match", "HEAD")
+    if exact:
+        return exact, True
+    described = await _git_text(base, "describe", "--tags", "--always", "HEAD")
+    if described:
+        return described, True
+    # Unborn branch (repo with no commits yet): no commit to describe, but the
+    # symbolic target still names the branch HEAD will create on first commit.
+    symbolic = await _git_text(base, "symbolic-ref", "--short", "HEAD")
+    if symbolic:
+        return symbolic, False
+    return None, False
+
+
 async def git_status(base: Path) -> GitStatus | None:
     if not await is_git_repo(base):
         return None
-    branch = await _git_text(base, "rev-parse", "--abbrev-ref", "HEAD")
+    branch, detached = await _head_label(base)
     # ``base`` may be a subdirectory of the repo; porcelain paths are always
     # repo-root-relative, so translate them to ``base``-relative and drop
     # entries living outside the browsed subtree.
@@ -79,7 +103,30 @@ async def git_status(base: Path) -> GitStatus | None:
             continue
         old_rel = _strip_prefix(entry.old_path, prefix) if entry.old_path else None
         scoped.append(entry.model_copy(update={"path": rel, "old_path": old_rel}))
-    return GitStatus(branch=branch, files=scoped)
+    return GitStatus(branch=branch, detached=detached, files=scoped)
+
+
+async def git_list_files(base: Path) -> list[str] | None:
+    # Tracked plus untracked-but-not-ignored files, ``base``-relative. ``git
+    # ls-files`` scopes to the cwd subtree and respects ``.gitignore``, so this
+    # skips ``node_modules``/build dirs for free. Returns ``None`` outside a repo
+    # so the caller can fall back to a filesystem walk.
+    if not await is_git_repo(base):
+        return None
+    code_tracked, tracked = await _run_git(base, "ls-files", "-z")
+    code_others, others = await _run_git(
+        base, "ls-files", "-z", "--others", "--exclude-standard"
+    )
+    paths: list[str] = []
+    seen: set[str] = set()
+    for code, raw in ((code_tracked, tracked), (code_others, others)):
+        if code != 0:
+            continue
+        for token in raw.decode("utf-8", errors="replace").split("\0"):
+            if token and token not in seen:
+                seen.add(token)
+                paths.append(token)
+    return paths
 
 
 async def git_file_diff(

--- a/backend/src/waypoint/workspace_preview.py
+++ b/backend/src/waypoint/workspace_preview.py
@@ -86,6 +86,7 @@ def list_dir(
     cap: int,
     denylist: list[str] | None = None,
     follow_symlinks: bool = False,
+    offset: int = 0,
 ) -> tuple[list[WorkspaceEntry], bool, int | None, Path]:
     if is_denied(rel, denylist):
         raise WorkspacePathError("path is denied")
@@ -113,8 +114,14 @@ def list_dir(
     allowed.sort(key=lambda entry: (entry["kind"] != "dir", entry["name"].lower()))
     if cap < 0:
         cap = 0
-    overflow = max(len(allowed) - cap, 0)
-    return allowed[:cap], overflow > 0, overflow or None, directory
+    if offset < 0:
+        offset = 0
+    # The sort is stable, so paging by offset over an unchanged directory is
+    # deterministic; ``overflow`` counts entries past this page so the caller can
+    # request the next one.
+    page = allowed[offset : offset + cap]
+    overflow = max(len(allowed) - (offset + cap), 0)
+    return page, overflow > 0, overflow or None, directory
 
 
 def _entry_kind(path: Path) -> WorkspaceEntryKind:
@@ -136,3 +143,97 @@ def _has_symlink_component(base_resolved: Path, target: Path) -> bool:
         if current.is_symlink():
             return True
     return False
+
+
+# Hard cap on entries visited by the fallback walk so a query never traverses an
+# unbounded tree (e.g. a non-repo workspace with a huge node_modules).
+WALK_VISIT_CAP = 20000
+
+
+def walk_files(
+    base: Path,
+    denylist: list[str] | None = None,
+    follow_symlinks: bool = False,
+    visit_cap: int = WALK_VISIT_CAP,
+) -> tuple[list[str], bool]:
+    # Filesystem fallback for the file finder outside a git repo. Returns
+    # ``base``-relative file paths and whether the visit cap was hit. Denied
+    # directories are pruned so their subtrees are never descended.
+    base_resolved = base.expanduser().resolve()
+    out: list[str] = []
+    visited = 0
+    for root, dirs, files in os.walk(base_resolved, followlinks=follow_symlinks):
+        root_path = Path(root)
+        kept: list[str] = []
+        for name in dirs:
+            child = root_path / name
+            rel = child.relative_to(base_resolved)
+            if is_denied(rel, denylist):
+                continue
+            if not follow_symlinks and child.is_symlink():
+                continue
+            kept.append(name)
+        dirs[:] = kept
+        for name in files:
+            visited += 1
+            if visited > visit_cap:
+                return out, True
+            child = root_path / name
+            if not follow_symlinks and child.is_symlink():
+                continue
+            rel = child.relative_to(base_resolved)
+            if is_denied(rel, denylist):
+                continue
+            out.append(rel.as_posix())
+    return out, False
+
+
+def _subsequence_score(query: str, path: str) -> int | None:
+    # Case-insensitive subsequence match with bonuses for word-boundary and
+    # consecutive hits, and for matches landing in the basename. Returns ``None``
+    # when ``query`` is not a subsequence of ``path``.
+    if not query:
+        return 0
+    lowered = path.lower()
+    needle = query.lower()
+    score = 0
+    qi = 0
+    prev = -2
+    for pi, ch in enumerate(lowered):
+        if qi >= len(needle) or ch != needle[qi]:
+            continue
+        score += 1
+        if pi == 0 or not lowered[pi - 1].isalnum():
+            score += 10
+        if pi == prev + 1:
+            score += 5
+        prev = pi
+        qi += 1
+    if qi != len(needle):
+        return None
+    basename = lowered.rsplit("/", 1)[-1]
+    if needle in basename:
+        score += 15
+    score -= len(lowered) // 40  # shorter paths edge ahead on ties
+    return score
+
+
+def rank_files(
+    query: str,
+    paths: list[str],
+    denylist: list[str] | None = None,
+    limit: int = 50,
+) -> tuple[list[str], bool]:
+    # Score, filter, and order candidate paths for the finder. Returns the top
+    # ``limit`` matches and whether more matched than were returned.
+    scored: list[tuple[int, int, str]] = []
+    for path in paths:
+        if is_denied(path, denylist):
+            continue
+        result = _subsequence_score(query, path)
+        if result is None:
+            continue
+        scored.append((result, len(path), path))
+    scored.sort(key=lambda item: (-item[0], item[1], item[2]))
+    truncated = len(scored) > limit
+    return [path for _, _, path in scored[:limit]], truncated

--- a/backend/src/waypoint/workspace_preview.py
+++ b/backend/src/waypoint/workspace_preview.py
@@ -225,7 +225,10 @@ def rank_files(
     limit: int = 50,
 ) -> tuple[list[str], bool]:
     # Score, filter, and order candidate paths for the finder. Returns the top
-    # ``limit`` matches and whether more matched than were returned.
+    # ``limit`` matches and whether more matched than were returned. An empty
+    # query matches nothing (callers should not search on a blank input).
+    if not query:
+        return [], False
     scored: list[tuple[int, int, str]] = []
     for path in paths:
         if is_denied(path, denylist):

--- a/backend/tests/test_workspace_api.py
+++ b/backend/tests/test_workspace_api.py
@@ -305,3 +305,53 @@ async def test_git_status_hides_denied_paths(tmp_path: Path) -> None:
     paths = [entry["path"] for entry in body["files"]]
     assert "app.py" in paths
     assert "secret.pem" not in paths
+
+
+async def test_find_returns_ranked_matches(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+
+    def _git(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(workspace), *args], check=True, capture_output=True
+        )
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@example.com")
+    _git("config", "user.name", "T")
+    (workspace / "explorer.py").write_text("x\n", encoding="utf-8")
+    (workspace / "secret.pem").write_text("KEY\n", encoding="utf-8")  # denied
+    (workspace / "readme.md").write_text("x\n", encoding="utf-8")  # no match
+
+    settings = Settings(data_dir=tmp_path / "data", workspace_denylist=["*.pem"])
+    app = create_app(settings)
+    context = app.state.context
+    now = datetime.now(UTC)
+    context.storage.create_session(
+        SessionRecord(
+            id="s1",
+            backend="codex",
+            source=SessionSource.MANAGED,
+            title="t",
+            cwd=str(workspace),
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(tmp_path / "raw.log"),
+            structured_log_path=str(tmp_path / "events.jsonl"),
+        )
+    )
+    token = context.tokens.issue().token
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions/s1/workspace/find",
+            params={"q": "explorer"},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    matches = [entry["path"] for entry in resp.json()["matches"]]
+    assert "explorer.py" in matches
+    assert "secret.pem" not in matches  # denied paths never surface
+    assert "readme.md" not in matches  # non-matching paths are dropped

--- a/backend/tests/test_workspace_git.py
+++ b/backend/tests/test_workspace_git.py
@@ -1,7 +1,12 @@
 import subprocess
 from pathlib import Path
 
-from waypoint.workspace_git import git_file_diff, git_status, is_git_repo
+from waypoint.workspace_git import (
+    git_file_diff,
+    git_list_files,
+    git_status,
+    is_git_repo,
+)
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -122,6 +127,68 @@ async def test_git_file_diff_unchanged_returns_none(tmp_path: Path) -> None:
     _commit(tmp_path, "init")
 
     assert await git_file_diff(tmp_path, "f.txt", staged=False) is None
+
+
+async def test_git_status_reports_branch(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    _git(tmp_path, "checkout", "-q", "-b", "feature/x")
+    (tmp_path / "f.txt").write_text("a\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+
+    status = await git_status(tmp_path)
+    assert status is not None
+    assert status.branch == "feature/x"
+    assert status.detached is False
+
+
+async def test_git_status_detached_on_tag(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("a\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    _git(tmp_path, "tag", "v1.0.0")
+    _git(tmp_path, "checkout", "-q", "v1.0.0")  # detaches HEAD onto the tag
+
+    status = await git_status(tmp_path)
+    assert status is not None
+    assert status.detached is True
+    assert status.branch == "v1.0.0"  # the tag, never the literal "HEAD"
+
+
+async def test_git_status_detached_on_commit(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "f.txt").write_text("a\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    sha = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "--short", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    _git(tmp_path, "checkout", "-q", sha)  # detaches onto a bare commit (no tags)
+
+    status = await git_status(tmp_path)
+    assert status is not None
+    assert status.detached is True
+    assert status.branch is not None and status.branch != "HEAD"
+
+
+async def test_git_list_files_includes_untracked_skips_ignored(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "tracked.py").write_text("x\n", encoding="utf-8")
+    (tmp_path / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+    _commit(tmp_path, "init")
+    (tmp_path / "fresh.txt").write_text("new\n", encoding="utf-8")  # untracked, listed
+    (tmp_path / "ignored.txt").write_text("no\n", encoding="utf-8")  # ignored, skipped
+
+    listed = await git_list_files(tmp_path)
+    assert listed is not None
+    assert "tracked.py" in listed
+    assert "fresh.txt" in listed
+    assert "ignored.txt" not in listed
+
+
+async def test_git_list_files_non_repo_returns_none(tmp_path: Path) -> None:
+    assert await git_list_files(tmp_path) is None
 
 
 async def test_non_repo_returns_none(tmp_path: Path) -> None:

--- a/backend/tests/test_workspace_preview.py
+++ b/backend/tests/test_workspace_preview.py
@@ -7,9 +7,11 @@ from waypoint.workspace_preview import (
     WorkspacePathError,
     is_denied,
     list_dir,
+    rank_files,
     read_text_capped,
     resolve_in_base,
     sniff_text,
+    walk_files,
 )
 
 
@@ -46,6 +48,68 @@ def test_list_dir_reports_overflow(tmp_path: Path) -> None:
     assert [entry["name"] for entry in entries] == ["file-0.txt", "file-1.txt"]
     assert truncated is True
     assert overflow == 2
+
+
+def test_list_dir_pages_with_offset(tmp_path: Path) -> None:
+    for index in range(5):
+        (tmp_path / f"file-{index}.txt").write_text(str(index), encoding="utf-8")
+
+    # The stable sort makes offset paging deterministic across requests.
+    first, first_trunc, first_overflow, _ = list_dir(tmp_path, "", 2, offset=0)
+    second, _, second_overflow, _ = list_dir(tmp_path, "", 2, offset=2)
+    last, last_trunc, last_overflow, _ = list_dir(tmp_path, "", 2, offset=4)
+
+    assert [entry["name"] for entry in first] == ["file-0.txt", "file-1.txt"]
+    assert [entry["name"] for entry in second] == ["file-2.txt", "file-3.txt"]
+    assert [entry["name"] for entry in last] == ["file-4.txt"]
+    assert first_trunc is True and first_overflow == 3
+    assert second_overflow == 1
+    assert last_trunc is False and last_overflow is None
+
+
+def test_rank_files_matches_subsequence_and_ranks_basename() -> None:
+    paths = [
+        "src/components/WorkspaceExplorer.tsx",
+        "src/lib/explorer-helpers.ts",
+        "docs/explore.md",
+        "README.md",
+    ]
+    matches, truncated = rank_files("explorer", paths, limit=10)
+
+    # "README.md" and "docs/explore.md" lack an "explorer" subsequence (no
+    # trailing "r") and are dropped.
+    assert matches == [
+        "src/lib/explorer-helpers.ts",  # query leads the basename → top
+        "src/components/WorkspaceExplorer.tsx",
+    ]
+    assert truncated is False
+
+
+def test_rank_files_reports_truncation() -> None:
+    paths = [f"file-{i}-match.txt" for i in range(5)]
+    matches, truncated = rank_files("match", paths, limit=2)
+    assert len(matches) == 2
+    assert truncated is True
+
+
+def test_walk_files_prunes_denied_dirs(tmp_path: Path) -> None:
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("x", encoding="utf-8")
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".git" / "config").write_text("x", encoding="utf-8")
+
+    found, truncated = walk_files(tmp_path, denylist=[".git"])
+    assert "src/app.py" in found
+    assert all(".git" not in path for path in found)
+    assert truncated is False
+
+
+def test_walk_files_honors_visit_cap(tmp_path: Path) -> None:
+    for index in range(10):
+        (tmp_path / f"f{index}.txt").write_text("x", encoding="utf-8")
+    found, truncated = walk_files(tmp_path, visit_cap=4)
+    assert truncated is True
+    assert len(found) <= 4
 
 
 def test_resolve_in_base_rejects_parent_traversal(tmp_path: Path) -> None:

--- a/backend/tests/test_workspace_preview.py
+++ b/backend/tests/test_workspace_preview.py
@@ -85,6 +85,10 @@ def test_rank_files_matches_subsequence_and_ranks_basename() -> None:
     assert truncated is False
 
 
+def test_rank_files_empty_query_matches_nothing() -> None:
+    assert rank_files("", ["a.py", "b.py"]) == ([], False)
+
+
 def test_rank_files_reports_truncation() -> None:
     paths = [f"file-{i}-match.txt" for i in range(5)]
     matches, truncated = rank_files("match", paths, limit=2)

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12109,6 +12109,146 @@ body.wp-dock-resizing {
   color: var(--muted);
 }
 
+/* ─── File finder ("Go to file") ─── */
+.wp-tree-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 10px;
+  border-bottom: 1px solid var(--line);
+  flex-shrink: 0;
+}
+
+.wp-tree-filter-icon {
+  flex-shrink: 0;
+  color: var(--muted-soft);
+}
+
+.wp-tree-filter.active .wp-tree-filter-icon {
+  color: var(--accent-cool);
+}
+
+.wp-tree-filter-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  padding: 2px 0;
+}
+
+.wp-tree-filter-input::placeholder {
+  color: var(--muted-soft);
+}
+
+.wp-tree-filter-input:focus {
+  outline: none;
+}
+
+.wp-tree-filter-clear {
+  flex-shrink: 0;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+.wp-tree-filter-clear:hover {
+  color: var(--text);
+}
+
+.wp-find-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.wp-find-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  cursor: pointer;
+  color: var(--text);
+  font-size: 0.8rem;
+  transition: background-color 120ms ease;
+}
+
+.wp-find-item:hover,
+.wp-find-item.active {
+  background: color-mix(in srgb, var(--accent-cool) 12%, transparent);
+}
+
+.wp-find-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted);
+}
+
+.wp-find-name {
+  flex-shrink: 0;
+  max-width: 55%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.wp-find-dir {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--muted);
+}
+
+.wp-find-item .wp-git-badge {
+  margin-left: auto;
+}
+
+.wp-find-hl {
+  background: transparent;
+  color: var(--accent-cool);
+  font-weight: 600;
+}
+
+.wp-find-item.active .wp-find-hl {
+  color: var(--text);
+}
+
+.wp-find-status {
+  padding: 10px 12px;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.wp-find-status.error {
+  color: var(--danger);
+}
+
+.wp-find-more {
+  list-style: none;
+  padding: 6px 8px 2px;
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
 /* Segmented toggles (Content/Diff and Inline/Split): a single bordered group
  * with joined cells. */
 .wp-preview-modetoggle,
@@ -12415,6 +12555,42 @@ html[data-theme="light"] .wp-diff-split .wp-diff-ln.del {
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted-soft);
+  flex-shrink: 0;
+}
+
+/* Current-branch chip: hugs the FILES label, truncates before the refresh
+   button (pushed to the far right by margin-right:auto). */
+.wp-branch {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+  margin-left: 10px;
+  margin-right: auto;
+  padding: 2px 9px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  color: var(--muted);
+  font-size: 0.7rem;
+  line-height: 1.2;
+}
+
+.wp-branch-icon {
+  flex-shrink: 0;
+  font-size: 0.78rem;
+  line-height: 1;
+  color: var(--accent-cool);
+}
+
+.wp-branch.detached .wp-branch-icon {
+  color: var(--accent);
+}
+
+.wp-branch-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
 }
 
 .wp-tree-toolbar .wp-refresh-btn {
@@ -12556,6 +12732,27 @@ html[data-theme="light"] .wp-diff-split .wp-diff-ln.del {
 
 .wp-tree-error-child {
   color: var(--danger);
+}
+
+.wp-tree-loadmore {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 0.72rem;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+
+.wp-tree-loadmore:hover:not(:disabled) {
+  color: var(--accent-cool);
+  text-decoration: underline;
+}
+
+.wp-tree-loadmore:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 .wp-preview-pane {

--- a/frontend/src/components/WorkspaceExplorer.tsx
+++ b/frontend/src/components/WorkspaceExplorer.tsx
@@ -12,15 +12,17 @@ import {
 
 import {
   fetchWorkspaceFile,
+  fetchWorkspaceFind,
   fetchWorkspaceGitDiff,
   fetchWorkspaceGitStatus,
   workspaceRawUrl,
   type WorkspaceFile,
+  type WorkspaceFindMatch,
   type WorkspaceGitFileStatus,
   type WorkspaceGitStatus,
   type WorkspaceTreePage,
 } from "@/lib/api";
-import { formatBytes } from "@/components/AttachmentTray";
+import { FileIcon, formatBytes } from "@/components/AttachmentTray";
 import { FilePreview } from "@/components/FilePreview";
 import { WorkspaceDiff } from "@/components/WorkspaceDiff";
 import { WorkspaceTree } from "@/components/WorkspaceTree";
@@ -106,6 +108,108 @@ function GitChangeGroup({
         })}
       </ul>
     </div>
+  );
+}
+
+// Bold the greedy subsequence of `query` within `text` so finder results show
+// which characters matched. Non-matching spans render plain.
+function highlightSubsequence(text: string, query: string): ReactNode {
+  if (!query) return text;
+  const needle = query.toLowerCase();
+  const lowered = text.toLowerCase();
+  const out: ReactNode[] = [];
+  let qi = 0;
+  let plain = "";
+  let hit = "";
+  const flushPlain = () => {
+    if (plain) {
+      out.push(plain);
+      plain = "";
+    }
+  };
+  const flushHit = () => {
+    if (hit) {
+      out.push(
+        <mark key={out.length} className="wp-find-hl">
+          {hit}
+        </mark>,
+      );
+      hit = "";
+    }
+  };
+  for (let i = 0; i < text.length; i += 1) {
+    if (qi < needle.length && lowered[i] === needle[qi]) {
+      flushPlain();
+      hit += text[i];
+      qi += 1;
+    } else {
+      flushHit();
+      plain += text[i];
+    }
+  }
+  flushPlain();
+  flushHit();
+  return out;
+}
+
+function WorkspaceFindResults({
+  matches,
+  truncated,
+  loading,
+  error,
+  query,
+  activeIndex,
+  gitFileMap,
+  onPick,
+}: {
+  matches: WorkspaceFindMatch[];
+  truncated: boolean;
+  loading: boolean;
+  error: string | null;
+  query: string;
+  activeIndex: number;
+  gitFileMap: Map<string, WorkspaceGitFileStatus>;
+  onPick: (path: string) => void;
+}) {
+  if (error) return <div className="wp-find-status error">{error}</div>;
+  if (loading && matches.length === 0)
+    return <div className="wp-find-status">Searching…</div>;
+  if (matches.length === 0)
+    return <div className="wp-find-status">No files match “{query}”.</div>;
+  return (
+    <ul className="wp-find-list" role="listbox" aria-label="File search results">
+      {matches.map((match, index) => {
+        const slash = match.path.lastIndexOf("/");
+        const name = slash >= 0 ? match.path.slice(slash + 1) : match.path;
+        const dir = slash >= 0 ? match.path.slice(0, slash) : "";
+        const status = gitFileMap.get(match.path);
+        const badge = status ? gitChangeLabel(status) : null;
+        return (
+          <li key={match.path} role="option" aria-selected={index === activeIndex}>
+            <button
+              type="button"
+              className={`wp-find-item${index === activeIndex ? " active" : ""}`}
+              title={match.path}
+              onClick={() => onPick(match.path)}
+            >
+              <span className="wp-find-icon" aria-hidden="true">
+                <FileIcon />
+              </span>
+              <span className="wp-find-name">{highlightSubsequence(name, query)}</span>
+              {dir ? <span className="wp-find-dir">{dir}</span> : null}
+              {badge ? (
+                <span className={`wp-git-badge ${badge.kind}`} aria-hidden="true">
+                  {badge.letter}
+                </span>
+              ) : null}
+            </button>
+          </li>
+        );
+      })}
+      {truncated ? (
+        <li className="wp-find-more">More matches — refine the search.</li>
+      ) : null}
+    </ul>
   );
 }
 
@@ -223,6 +327,13 @@ export function WorkspaceExplorer({
   } = useWorkspacePreview(host, token, sessionId);
 
   const [gitStatus, setGitStatus] = useState<WorkspaceGitStatus | null>(null);
+  const [filterQuery, setFilterQuery] = useState("");
+  const [findMatches, setFindMatches] = useState<WorkspaceFindMatch[]>([]);
+  const [findTruncated, setFindTruncated] = useState(false);
+  const [findLoading, setFindLoading] = useState(false);
+  const [findError, setFindError] = useState<string | null>(null);
+  const [findActive, setFindActive] = useState(0);
+  const filtering = filterQuery.trim().length > 0;
   const [previewMode, setPreviewMode] = useState<"content" | "diff">("content");
   const [diffStaged, setDiffStaged] = useState(false);
   const [diffData, setDiffData] = useState<EventDiffPreview | null>(null);
@@ -270,6 +381,43 @@ export function WorkspaceExplorer({
       cancelled = true;
     };
   }, [host, token, sessionId, treeRefreshSeq, active]);
+
+  // Debounced fuzzy file search. Re-runs when the file set may have changed
+  // (treeRefreshSeq) so results stay fresh after an agent edit.
+  useEffect(() => {
+    const q = filterQuery.trim();
+    if (!q) {
+      setFindMatches([]);
+      setFindTruncated(false);
+      setFindError(null);
+      setFindLoading(false);
+      return;
+    }
+    setFindLoading(true);
+    let cancelled = false;
+    const handle = window.setTimeout(() => {
+      void fetchWorkspaceFind(host, token, sessionId, q)
+        .then((res) => {
+          if (cancelled) return;
+          setFindMatches(res.matches);
+          setFindTruncated(res.truncated);
+          setFindError(null);
+          setFindActive(0);
+        })
+        .catch((e) => {
+          if (cancelled) return;
+          setFindMatches([]);
+          setFindError(e instanceof Error ? e.message : "Search failed");
+        })
+        .finally(() => {
+          if (!cancelled) setFindLoading(false);
+        });
+    }, 150);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [filterQuery, host, token, sessionId, treeRefreshSeq]);
 
   // Fetch the diff when the diff view is showing. Keyed on the open file's mtime
   // so a silent content refresh (agent edited it) re-pulls the diff too.
@@ -374,6 +522,38 @@ export function WorkspaceExplorer({
     [openFile],
   );
 
+  // Selecting a finder result opens it and reveals its directory in the tree,
+  // then clears the query so the tree returns with the file selected.
+  const pickFindResult = useCallback(
+    (path: string) => {
+      const slash = path.lastIndexOf("/");
+      setRevealDir(slash >= 0 ? path.slice(0, slash) : "");
+      setFilterQuery("");
+      void handleSelectFile(path);
+    },
+    [handleSelectFile],
+  );
+
+  const onFilterKey = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setFindActive((i) => Math.min(i + 1, findMatches.length - 1));
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setFindActive((i) => Math.max(i - 1, 0));
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const match = findMatches[findActive];
+        if (match) pickFindResult(match.path);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setFilterQuery("");
+      }
+    },
+    [findMatches, findActive, pickFindResult],
+  );
+
   const copyPath = useCallback(() => {
     if (!openPath) return;
     void copyText(openPath);
@@ -436,6 +616,21 @@ export function WorkspaceExplorer({
         <div className={`wp-tree-pane${mobileView === "preview" ? " wp-mobile-hidden" : ""}`}>
           <div className="wp-tree-toolbar">
             <span className="wp-tree-toolbar-label">Files</span>
+            {gitStatus?.enabled && gitStatus.branch ? (
+              <span
+                className={`wp-branch${gitStatus.detached ? " detached" : ""}`}
+                title={
+                  gitStatus.detached
+                    ? `Detached HEAD at ${gitStatus.branch}`
+                    : `On branch ${gitStatus.branch}`
+                }
+              >
+                <span className="wp-branch-icon" aria-hidden="true">
+                  {gitStatus.detached ? "➤" : "⎇"}
+                </span>
+                <span className="wp-branch-name">{gitStatus.branch}</span>
+              </span>
+            ) : null}
             <button
               type="button"
               className={`wp-refresh-btn${treeRefreshing ? " spinning" : ""}`}
@@ -446,6 +641,69 @@ export function WorkspaceExplorer({
               <span className="wp-refresh-icon" aria-hidden="true">⟳</span>
             </button>
           </div>
+          <div className={`wp-tree-filter${filtering ? " active" : ""}`}>
+            <svg
+              className="wp-tree-filter-icon"
+              viewBox="0 0 16 16"
+              width="13"
+              height="13"
+              aria-hidden="true"
+            >
+              <circle
+                cx="6.5"
+                cy="6.5"
+                r="4.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+              />
+              <line
+                x1="10"
+                y1="10"
+                x2="14"
+                y2="14"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+              />
+            </svg>
+            <input
+              className="wp-tree-filter-input"
+              type="text"
+              placeholder="Go to file…"
+              value={filterQuery}
+              onChange={(e) => setFilterQuery(e.target.value)}
+              onKeyDown={onFilterKey}
+              aria-label="Filter files"
+              spellCheck={false}
+              autoComplete="off"
+            />
+            {filterQuery ? (
+              <button
+                type="button"
+                className="wp-tree-filter-clear"
+                onClick={() => setFilterQuery("")}
+                aria-label="Clear filter"
+              >
+                ×
+              </button>
+            ) : null}
+          </div>
+          {filtering ? (
+            <div className="wp-tree-scroll">
+              <WorkspaceFindResults
+                matches={findMatches}
+                truncated={findTruncated}
+                loading={findLoading}
+                error={findError}
+                query={filterQuery.trim()}
+                activeIndex={findActive}
+                gitFileMap={gitFileMap}
+                onPick={pickFindResult}
+              />
+            </div>
+          ) : (
+            <>
           {stagedFiles.length > 0 || unstagedFiles.length > 0 ? (
             <div className={`wp-changes${changesCollapsed ? " collapsed" : ""}`}>
               <button
@@ -503,6 +761,8 @@ export function WorkspaceExplorer({
               onRootLoaded={setRoot}
             />
           </div>
+            </>
+          )}
         </div>
 
         <div className={`wp-preview-pane${mobileView === "tree" ? " wp-mobile-hidden" : ""}`}>

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -97,7 +97,7 @@ export function WorkspaceTree({
   );
 
   const fetchDir = useCallback(
-    async (dirPath: string) => {
+    async (dirPath: string, limit?: number) => {
       setDirCache((prev) => {
         const next = new Map(prev);
         // Preserve any already-loaded entries while reloading so a refresh
@@ -112,7 +112,7 @@ export function WorkspaceTree({
         return next;
       });
       try {
-        const page = await fetchWorkspaceTree(host, token, sessionId, dirPath);
+        const page = await fetchWorkspaceTree(host, token, sessionId, dirPath, { limit });
         if (dirPath === "") {
           onRootLoadedRef.current?.(page.root);
         }
@@ -135,6 +135,54 @@ export function WorkspaceTree({
             loading: false,
             error: e instanceof Error ? e.message : "Failed to load",
           });
+          return next;
+        });
+      }
+    },
+    [host, token, sessionId],
+  );
+
+  // Append the next page of a capped directory. Server pages are disjoint by
+  // offset and share the tree's sort, so concatenating the slice yields no
+  // duplicates; we re-sort for display only.
+  const loadMore = useCallback(
+    async (dirPath: string, offset: number) => {
+      let skip = false;
+      setDirCache((prev) => {
+        const existing = prev.get(dirPath);
+        if (existing?.loading) {
+          skip = true;
+          return prev;
+        }
+        const next = new Map(prev);
+        if (existing) next.set(dirPath, { ...existing, loading: true, error: null });
+        return next;
+      });
+      if (skip) return;
+      try {
+        const page = await fetchWorkspaceTree(host, token, sessionId, dirPath, { offset });
+        setDirCache((prev) => {
+          const next = new Map(prev);
+          const existing = prev.get(dirPath);
+          next.set(dirPath, {
+            entries: sortEntries([...(existing?.entries ?? []), ...page.entries]),
+            overflow: page.overflow,
+            loading: false,
+            error: null,
+          });
+          return next;
+        });
+      } catch (e) {
+        setDirCache((prev) => {
+          const next = new Map(prev);
+          const existing = prev.get(dirPath);
+          if (existing) {
+            next.set(dirPath, {
+              ...existing,
+              loading: false,
+              error: e instanceof Error ? e.message : "Failed to load",
+            });
+          }
           return next;
         });
       }
@@ -184,7 +232,12 @@ export function WorkspaceTree({
   // (refreshSeq starts undefined/0) so it only fires on an explicit bump.
   useEffect(() => {
     if (!refreshSeq) return;
-    for (const dir of expanded) void fetchDir(dir);
+    // Re-fetch enough rows to cover any pages the user loaded via "Load more"
+    // so a refresh doesn't snap an expanded directory back to its first page.
+    for (const dir of expanded) {
+      const loaded = dirCache.get(dir)?.entries.length ?? 0;
+      void fetchDir(dir, loaded > 0 ? Math.max(500, loaded) : undefined);
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshSeq]);
 
@@ -232,10 +285,20 @@ export function WorkspaceTree({
           dirtyDirs={dirtyDirs}
           onSelectFile={selectFile}
           onToggleDir={toggleDir}
+          onLoadMore={loadMore}
         />
       ))}
       {rootState.overflow ? (
-        <li className="wp-tree-overflow">+{rootState.overflow} more</li>
+        <li className="wp-tree-overflow">
+          <button
+            type="button"
+            className="wp-tree-loadmore"
+            disabled={rootState.loading}
+            onClick={() => loadMore("", rootState.entries.length)}
+          >
+            Show {rootState.overflow} more
+          </button>
+        </li>
       ) : null}
     </ul>
   );
@@ -254,6 +317,7 @@ function TreeNode({
   dirtyDirs,
   onSelectFile,
   onToggleDir,
+  onLoadMore,
 }: {
   entry: WorkspaceTreeEntry;
   parentPath: string;
@@ -267,6 +331,7 @@ function TreeNode({
   dirtyDirs?: Set<string>;
   onSelectFile: (path: string) => void;
   onToggleDir: (dirPath: string) => void;
+  onLoadMore: (dirPath: string, offset: number) => void;
 }) {
   const fullPath = parentPath ? `${parentPath}/${entry.name}` : entry.name;
   const isDir = entry.kind === "dir";
@@ -340,6 +405,7 @@ function TreeNode({
                   dirtyDirs={dirtyDirs}
                   onSelectFile={onSelectFile}
                   onToggleDir={onToggleDir}
+                  onLoadMore={onLoadMore}
                 />
               ))}
               {dirState.overflow ? (
@@ -347,7 +413,14 @@ function TreeNode({
                   className="wp-tree-overflow"
                   style={{ "--depth": depth + 1 } as CSSProperties}
                 >
-                  +{dirState.overflow} more
+                  <button
+                    type="button"
+                    className="wp-tree-loadmore"
+                    disabled={dirState.loading}
+                    onClick={() => onLoadMore(fullPath, dirState.entries.length)}
+                  >
+                    Show {dirState.overflow} more
+                  </button>
                 </li>
               ) : null}
             </>

--- a/frontend/src/components/WorkspaceTree.tsx
+++ b/frontend/src/components/WorkspaceTree.tsx
@@ -142,9 +142,9 @@ export function WorkspaceTree({
     [host, token, sessionId],
   );
 
-  // Append the next page of a capped directory. Server pages are disjoint by
-  // offset and share the tree's sort, so concatenating the slice yields no
-  // duplicates; we re-sort for display only.
+  // Append the next page of a capped directory. Pages are deduped by name (so a
+  // refresh landing mid-request can't leave duplicates) and re-sorted for
+  // display.
   const loadMore = useCallback(
     async (dirPath: string, offset: number) => {
       let skip = false;
@@ -164,8 +164,12 @@ export function WorkspaceTree({
         setDirCache((prev) => {
           const next = new Map(prev);
           const existing = prev.get(dirPath);
+          const byName = new Map<string, WorkspaceTreeEntry>();
+          for (const entry of [...(existing?.entries ?? []), ...page.entries]) {
+            if (!byName.has(entry.name)) byName.set(entry.name, entry);
+          }
           next.set(dirPath, {
-            entries: sortEntries([...(existing?.entries ?? []), ...page.entries]),
+            entries: sortEntries([...byName.values()]),
             overflow: page.overflow,
             loading: false,
             error: null,
@@ -236,7 +240,9 @@ export function WorkspaceTree({
     // so a refresh doesn't snap an expanded directory back to its first page.
     for (const dir of expanded) {
       const loaded = dirCache.get(dir)?.entries.length ?? 0;
-      void fetchDir(dir, loaded > 0 ? Math.max(500, loaded) : undefined);
+      // Clamped to the endpoint's max limit; a directory paged past the cap
+      // re-collapses to it on refresh rather than 422-ing.
+      void fetchDir(dir, loaded > 0 ? Math.min(2000, Math.max(500, loaded)) : undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshSeq]);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -886,9 +886,12 @@ export async function fetchWorkspaceTree(
   token: string,
   sessionId: string,
   relPath = "",
+  opts: { offset?: number; limit?: number } = {},
 ): Promise<WorkspaceTreePage> {
   const params = new URLSearchParams();
   if (relPath) params.set("path", relPath);
+  if (opts.offset) params.set("offset", String(opts.offset));
+  if (opts.limit) params.set("limit", String(opts.limit));
   const suffix = params.size ? `?${params.toString()}` : "";
   const response = await fetch(
     `${host}/api/sessions/${sessionId}/workspace/tree${suffix}`,
@@ -985,6 +988,7 @@ export interface WorkspaceGitFileStatus {
 export interface WorkspaceGitStatus {
   enabled: boolean;
   branch: string | null;
+  detached: boolean;
   files: WorkspaceGitFileStatus[];
 }
 
@@ -1006,6 +1010,7 @@ export async function fetchWorkspaceGitStatus(
   return {
     enabled: Boolean(payload.enabled),
     branch: typeof payload.branch === "string" ? payload.branch : null,
+    detached: payload.detached === true,
     files: filesRaw.map(
       (entry: Record<string, unknown>): WorkspaceGitFileStatus => ({
         path: typeof entry.path === "string" ? entry.path : "",
@@ -1037,6 +1042,51 @@ export async function fetchWorkspaceGitDiff(
   );
   await ensureOk(response, "failed to fetch git diff");
   return parseDiffPreviewPayload(await response.json());
+}
+
+export interface WorkspaceFindMatch {
+  path: string;
+  kind: "file" | "dir";
+}
+
+export interface WorkspaceFindResult {
+  matches: WorkspaceFindMatch[];
+  truncated: boolean;
+}
+
+// Fuzzy file finder ("Go to file"). The backend lists candidates via git (or a
+// capped filesystem walk outside a repo), subsequence-matches `q`, and returns
+// the top-ranked paths.
+export async function fetchWorkspaceFind(
+  host: string,
+  token: string,
+  sessionId: string,
+  q: string,
+  limit?: number,
+): Promise<WorkspaceFindResult> {
+  const params = new URLSearchParams({ q });
+  if (limit) params.set("limit", String(limit));
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/workspace/find?${params.toString()}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to search workspace");
+  const payload = await response.json();
+  const matchesRaw = Array.isArray(payload.matches) ? payload.matches : [];
+  return {
+    matches: matchesRaw
+      .map(
+        (entry: Record<string, unknown>): WorkspaceFindMatch => ({
+          path: typeof entry.path === "string" ? entry.path : "",
+          kind: entry.kind === "dir" ? "dir" : "file",
+        }),
+      )
+      .filter((match: WorkspaceFindMatch) => match.path),
+    truncated: Boolean(payload.truncated),
+  };
 }
 
 // Authenticated URL for an uploaded attachment. The token rides as a query


### PR DESCRIPTION
## Purpose

Three navigation/awareness improvements to the workspace file explorer: the current git branch is now shown, capped directories are fully reachable instead of dead-ending at "+N more", and a "Go to file" fuzzy finder lets you jump to any file without expanding the tree by hand.

## Changes

### Backend

- `backend/src/waypoint/workspace_git.py` — `git_status` resolves a friendly HEAD label for a detached HEAD (exact tag, else `git describe`/short SHA, with an unborn-branch fallback) instead of the bare `"HEAD"`, and reports a `detached` flag; new `git_list_files` lists tracked + untracked-not-ignored paths via `git ls-files` for the finder.
- `backend/src/waypoint/workspace_preview.py` — `list_dir` gains `offset` for deterministic paging over its stable sort; new `walk_files` (capped filesystem fallback) and `rank_files`/`_subsequence_score` (denylist-filtered fuzzy ranking) back the finder.
- `backend/src/waypoint/api.py` — the tree endpoint takes `offset`/`limit`; new `GET /workspace/find` prefers git's gitignore-aware listing and falls back to the capped walk, reusing `_workspace_session` and the denylist.
- `backend/tests/` — cover branch/detached/unborn classification, `git_list_files`, offset paging, the walk's denylist pruning and visit cap, fuzzy ranking, and the find endpoint's denylist filtering.

### Frontend

- `frontend/src/components/WorkspaceExplorer.tsx` — branch chip in the FILES toolbar (branch name, or detached tag/commit with a distinct glyph) and a debounced "Go to file" box that swaps the tree for a ranked, keyboard-navigable result list with match highlighting.
- `frontend/src/components/WorkspaceTree.tsx` — "+N more" becomes a "Show N more" control that appends the next page in place; a refresh re-fetches enough rows to keep already-loaded pages.
- `frontend/src/lib/api.ts` — `detached` on the git-status type, `offset`/`limit` on the tree fetcher, and the new `fetchWorkspaceFind`.
- `frontend/src/app/globals.css` — branch chip, load-more, filter input, and finder result styles, all via theme tokens for dark/light parity.

## Design

The finder is server-backed rather than a client-side filter because the tree is lazy-loaded; it sources candidates from `git ls-files` in a repo (instant and gitignore-aware, so `node_modules`/build dirs never appear) and only falls back to a hard-capped walk outside a repo. Tree pagination reuses the existing stable sort so requesting `offset = loaded count` yields disjoint pages with no dupes or gaps regardless of client-side display ordering.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- Verified live against this repo's workspace in the running stack: branch reported as `main`; tree offset paging returned disjoint sequential pages; finder returned the expected ranked match and zero `node_modules` hits (gitignore respected). Branch-chip rendering, the load-more button, and the finder list/keyboard nav remain to be eyeballed in the browser.

## Test Result

pre-commit all passed; `pytest` 1111 passed; `npm run lint` clean and `npm run build` succeeded. Live endpoint checks behaved as expected.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — not touched.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title and described migration steps above — not a breaking change.
- [x] I have updated documentation or config examples — no new config; `find` reuses existing workspace settings.

</details>