### PR TITLE
feat: add a waypointd out-of-band remote-control console

### DIFF
--- a/.agents/skills/waypointctl/references/daemon.md
+++ b/.agents/skills/waypointctl/references/daemon.md
@@ -10,15 +10,13 @@ waypointctl daemon stop
 waypointctl daemon restart
 ```
 
-`waypointctl daemon stop` stops only the daemon, not backend/frontend services.
-Use `waypointctl stop` for services.
+`waypointctl daemon stop` stops only the daemon, not backend/frontend services
+(use `waypointctl stop` for those), and waits for it to fully exit before
+returning, so `daemon stop && daemon start` reliably replaces it. To roll the
+daemon onto new code, use `waypointctl daemon restart`.
 
-`daemon stop` waits for the daemon to fully exit before returning, so
-`daemon stop && daemon start` reliably replaces it. To apply a code change to
-the daemon itself, use `waypointctl daemon restart`.
-
-When daemon mode is active, stop/restart may return before work finishes. Check
-`waypointctl status` and logs afterward.
+In daemon mode, service `stop`/`restart` may return before the work finishes;
+check `waypointctl status` and the logs afterward.
 
 ## Out-of-band remote control
 

--- a/.agents/skills/waypointctl/references/daemon.md
+++ b/.agents/skills/waypointctl/references/daemon.md
@@ -7,10 +7,33 @@ the command is accepted.
 waypointctl daemon start
 waypointctl daemon status
 waypointctl daemon stop
+waypointctl daemon restart
 ```
 
 `waypointctl daemon stop` stops only the daemon, not backend/frontend services.
 Use `waypointctl stop` for services.
 
+`daemon stop` waits for the daemon to fully exit before returning, so
+`daemon stop && daemon start` reliably replaces it. To apply a code change to
+the daemon itself, use `waypointctl daemon restart`.
+
 When daemon mode is active, stop/restart may return before work finishes. Check
 `waypointctl status` and logs afterward.
+
+## Out-of-band remote control
+
+While `waypointd` runs it serves an HTTP control console on
+`WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale next to the
+backend/frontend ports). It lives in the supervisor, so it stays reachable when a
+corrupt frontend build or a crashed backend has made the normal app unloadable —
+the recovery path when AFK on a phone.
+
+Open `http://<host>:8799/`, enter `WAYPOINT_PASSWORD`, and you get live status,
+log tails, lifecycle (restart/stop/start per service or all), and redeploy
+(stable / nightly / current channels) — the stack layer `waypointctl` already
+owns, not the app's session UI. Login returns a
+short-lived bearer token; mutating actions run async (`202` + poll `/api/status`).
+It refuses to act unless a real password is set (blank/`change-me` → `503`) and
+locks out after repeated failed logins. It exists **only** in daemon mode — not
+in the default in-process mode. `waypointctl doctor` prints the control URL and
+whether it responds. Disable with `WAYPOINT_STACK_CONTROL_PORT=0`.

--- a/.agents/skills/waypointctl/references/daemon.md
+++ b/.agents/skills/waypointctl/references/daemon.md
@@ -23,17 +23,16 @@ When daemon mode is active, stop/restart may return before work finishes. Check
 ## Out-of-band remote control
 
 While `waypointd` runs it serves an HTTP control console on
-`WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale next to the
-backend/frontend ports). It lives in the supervisor, so it stays reachable when a
-corrupt frontend build or a crashed backend has made the normal app unloadable —
-the recovery path when AFK on a phone.
+`WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale beside the
+backend/frontend ports). Living in the supervisor, it stays reachable when a
+corrupt frontend build or a crashed backend has made the app unloadable — the
+recovery path when AFK on a phone.
 
-Open `http://<host>:8799/`, enter `WAYPOINT_PASSWORD`, and you get live status,
-log tails, lifecycle (restart/stop/start per service or all), and redeploy
-(stable / nightly / current channels) — the stack layer `waypointctl` already
-owns, not the app's session UI. Login returns a
-short-lived bearer token; mutating actions run async (`202` + poll `/api/status`).
-It refuses to act unless a real password is set (blank/`change-me` → `503`) and
-locks out after repeated failed logins. It exists **only** in daemon mode — not
-in the default in-process mode. `waypointctl doctor` prints the control URL and
-whether it responds. Disable with `WAYPOINT_STACK_CONTROL_PORT=0`.
+Open `http://<host>:8799/`, authenticate with `WAYPOINT_PASSWORD`, and drive the
+stack: live status, log tails, lifecycle (restart/stop/start per service or all),
+and redeploy on stable/nightly/current channels — what `waypointctl` controls,
+not the app's session data. Login returns a short-lived bearer token and mutating
+actions run async (`202`, then poll `/api/status`). It acts only with a real
+password set (blank/`change-me` → `503`), locks out after repeated failures, and
+exists only in daemon mode. `waypointctl doctor` prints the URL;
+`WAYPOINT_STACK_CONTROL_PORT=0` disables it.

--- a/.agents/skills/waypointctl/references/daemon.md
+++ b/.agents/skills/waypointctl/references/daemon.md
@@ -20,17 +20,11 @@ check `waypointctl status` and the logs afterward.
 
 ## Out-of-band remote control
 
-While `waypointd` runs it serves an HTTP control console on
-`WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale beside the
-backend/frontend ports). Living in the supervisor, it stays reachable when a
-corrupt frontend build or a crashed backend has made the app unloadable — the
-recovery path when AFK on a phone.
-
-Open `http://<host>:8799/`, authenticate with `WAYPOINT_PASSWORD`, and drive the
-stack: live status, log tails, lifecycle (restart/stop/start per service or all),
-and redeploy on stable/nightly/current channels — what `waypointctl` controls,
-not the app's session data. Login returns a short-lived bearer token and mutating
-actions run async (`202`, then poll `/api/status`). It acts only with a real
-password set (blank/`change-me` → `503`), locks out after repeated failures, and
-exists only in daemon mode. `waypointctl doctor` prints the URL;
-`WAYPOINT_STACK_CONTROL_PORT=0` disables it.
+While `waypointd` runs, it serves an HTTP control console (default port `8799`,
+over Tailscale) for driving the stack from a remote device when a broken frontend
+build or backend has made the app unreachable. Open `http://<host>:8799/`,
+authenticate with `WAYPOINT_PASSWORD`, and you get status, log tails, lifecycle
+(restart/stop/start), and redeploy (stable/nightly/current) — what `waypointctl`
+controls, not the app's session data. It exists only in daemon mode;
+`waypointctl doctor` prints the URL and `WAYPOINT_STACK_CONTROL_PORT=0` disables
+it.

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@
 # WAYPOINT_STACK_BACKEND_HOST=0.0.0.0
 # WAYPOINT_STACK_BACKEND_PORT=8787
 # WAYPOINT_STACK_FRONTEND_PORT=3000
+# WAYPOINT_STACK_CONTROL_HOST=0.0.0.0    # waypointd out-of-band remote-control console
+# WAYPOINT_STACK_CONTROL_PORT=8799       # 0 disables; only served while waypointd runs
 
 # Paths (relative paths resolve under the repo root)
 # WAYPOINT_STACK_CONFIG=backend/waypoint.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Coding-agent backends live in `backend/src/waypoint/backends/<id>/` (currently `
 - Check state during testing: `waypointctl status` for health, `waypointctl logs [backend|frontend]` for output. Restart before re-testing if you have changed code since the last `start`.
 Override ports or paths inline with `WAYPOINT_STACK_BACKEND_PORT`, `WAYPOINT_STACK_FRONTEND_PORT`, `WAYPOINT_STACK_CONFIG`, or `WAYPOINT_STACK_BACKEND_DATA_DIR` rather than editing config files; values may also live in `.env` at the repo root.
 
-When the `waypointd` daemon is running it also serves an out-of-band remote-control console on `WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale next to the backend/frontend ports). After authenticating with `WAYPOINT_PASSWORD` it drives the stack/process layer — status, logs, lifecycle, redeploy — from a phone, even when a corrupt frontend build or a crashed backend has made the normal app unloadable. It exists only in daemon mode (`waypointctl daemon start` or `WAYPOINTCTL_DAEMON=1`); see [`waypointctl/README.md`](waypointctl/README.md).
+When the `waypointd` daemon is running it also serves an out-of-band remote-control console for driving the stack from a phone — status, logs, lifecycle, redeploy — when a broken frontend build or backend has made the normal app unreachable. It needs `WAYPOINT_PASSWORD` and exists only in daemon mode; see [`waypointctl/README.md`](waypointctl/README.md).
 
 `scripts/waypoint.sh` is the legacy supervisor and is slated for deprecation; prefer `waypointctl` for new work and only fall back to the script if the user explicitly asks for it.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Coding-agent backends live in `backend/src/waypoint/backends/<id>/` (currently `
 - Check state during testing: `waypointctl status` for health, `waypointctl logs [backend|frontend]` for output. Restart before re-testing if you have changed code since the last `start`.
 Override ports or paths inline with `WAYPOINT_STACK_BACKEND_PORT`, `WAYPOINT_STACK_FRONTEND_PORT`, `WAYPOINT_STACK_CONFIG`, or `WAYPOINT_STACK_BACKEND_DATA_DIR` rather than editing config files; values may also live in `.env` at the repo root.
 
+When the `waypointd` daemon is running it also serves an out-of-band remote-control console on `WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale next to the backend/frontend ports). After authenticating with `WAYPOINT_PASSWORD` it drives the stack/process layer — status, logs, lifecycle, redeploy — from a phone, even when a corrupt frontend build or a crashed backend has made the normal app unloadable. It exists only in daemon mode (`waypointctl daemon start` or `WAYPOINTCTL_DAEMON=1`); see [`waypointctl/README.md`](waypointctl/README.md).
+
 `scripts/waypoint.sh` is the legacy supervisor and is slated for deprecation; prefer `waypointctl` for new work and only fall back to the script if the user explicitly asks for it.
 
 ## Distributing Coding-Agent Skills

--- a/scripts/waypoint_tailscale.sh
+++ b/scripts/waypoint_tailscale.sh
@@ -9,6 +9,7 @@ STATE_ROOT="${WAYPOINTCTL_STATE_DIR:-${HOME}/.waypoint}/tailscale"
 ACTIVE_PROFILE_FILE="${STATE_ROOT}/active-profile"
 BACKEND_PORT="${WAYPOINT_STACK_BACKEND_PORT:-8787}"
 FRONTEND_PORT="${WAYPOINT_STACK_FRONTEND_PORT:-3000}"
+CONTROL_PORT="${WAYPOINT_STACK_CONTROL_PORT:-8799}"
 HOST_ALIAS="${TS_HOST_ALIAS:-host.docker.internal}"
 
 usage() {
@@ -19,6 +20,7 @@ Environment:
   WAYPOINTCTL_STATE_DIR              Root of Waypoint control-plane state
   WAYPOINT_STACK_BACKEND_PORT        Backend HTTP port to expose through Tailscale
   WAYPOINT_STACK_FRONTEND_PORT       Frontend HTTP port to expose through Tailscale
+  WAYPOINT_STACK_CONTROL_PORT        waypointd restart control port (0 to skip exposing)
   WAYPOINT_TAILSCALE_READY_ATTEMPTS  Seconds to wait for BackendState=Running (default: 60)
   TS_AUTHKEY                         Required for `up`; read from the repo-root `.env`
   TS_HOSTNAME                        Optional node name; defaults to waypoint-<profile>
@@ -140,8 +142,15 @@ configure_serves() {
   local name="$1"
   local frontend_port="$2"
   local backend_port="$3"
+  local control_port="$4"
   docker exec "${name}" tailscale serve --bg --yes --http="${frontend_port}" "http://${HOST_ALIAS}:${frontend_port}" \
-    && docker exec "${name}" tailscale serve --bg --yes --http="${backend_port}" "http://${HOST_ALIAS}:${backend_port}"
+    && docker exec "${name}" tailscale serve --bg --yes --http="${backend_port}" "http://${HOST_ALIAS}:${backend_port}" \
+    || return 1
+  # The control port is opt-in (only served by waypointd); skip it when disabled.
+  if [[ "${control_port}" != "0" ]]; then
+    docker exec "${name}" tailscale serve --bg --yes --http="${control_port}" "http://${HOST_ALIAS}:${control_port}" \
+      || return 1
+  fi
 }
 
 cmd_up() {
@@ -177,7 +186,7 @@ cmd_up() {
     die "Timed out waiting for ${name} to join the tailnet."
   fi
 
-  if ! configure_serves "${name}" "${FRONTEND_PORT}" "${BACKEND_PORT}"; then
+  if ! configure_serves "${name}" "${FRONTEND_PORT}" "${BACKEND_PORT}" "${CONTROL_PORT}"; then
     [[ "${started_now}" -eq 1 ]] && rollback_container "${name}"
     die "Failed to configure Tailscale Serve for ${name}."
   fi
@@ -188,6 +197,7 @@ cmd_up() {
   echo "profile: ${slug}"
   echo "frontend: https://${node_name}:${FRONTEND_PORT}"
   echo "backend: https://${node_name}:${BACKEND_PORT}"
+  [[ "${CONTROL_PORT}" != "0" ]] && echo "control: https://${node_name}:${CONTROL_PORT}"
 }
 
 cmd_down() {

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -72,8 +72,8 @@ are not supported.
 | `WAYPOINT_STACK_UV_CACHE_DIR` | `<state-dir>/uv-cache` | Backend `UV_CACHE_DIR`. |
 | `WAYPOINT_STACK_FORCE_FRONTEND_BUILD` | `0` | When `1`, always rebuild the frontend before `npm run start`. |
 | `WAYPOINT_STACK_CAFFEINATE` | `1` | macOS only: hold a `caffeinate -i -s` for the lifetime of the stack. |
-| `WAYPOINT_STACK_CONTROL_HOST` | `0.0.0.0` | Bind host for the daemon's restart control plane. |
-| `WAYPOINT_STACK_CONTROL_PORT` | `8799` | Port for the daemon's restart control plane; `0` disables it. |
+| `WAYPOINT_STACK_CONTROL_HOST` | `0.0.0.0` | Bind host for the daemon's remote-control console. |
+| `WAYPOINT_STACK_CONTROL_PORT` | `8799` | Port for the daemon's remote-control console; `0` disables it. |
 
 ## Multiple tailnets per host
 
@@ -146,63 +146,57 @@ behaves. When `--wait` is set, the agent-restart safety check applies
 even in daemon mode — the CLI can't be inside the target's process tree
 because it stays on the wire across the kill.
 
-`waypointctl daemon stop` only stops the daemon. Backend/frontend
-processes survive it intentionally (they were spawned in their own
-sessions), so a daemon restart doesn't bounce running services. If
-any are still up the CLI prints a hint pointing at `waypointctl stop`.
-
-`daemon stop` **waits for the daemon to fully exit** before returning
-(graceful shutdown joins in-flight workers, up to 30s). This is what
-makes `daemon stop && daemon start` reliable: the daemon clears its
-socket and pid only at the end of shutdown, so a `start` that didn't
-wait would see the dying daemon as "already running" and decline to
-spawn a replacement, leaving nothing up. Pass `--no-wait` for the old
-fire-and-forget behavior. To apply a code change to the daemon itself,
-prefer `waypointctl daemon restart`, which stops-and-waits then starts a
-fresh daemon in one step.
+`waypointctl daemon stop` stops only the daemon; backend and frontend were
+spawned in their own sessions and keep running, so it doesn't bounce the
+stack (the CLI hints at `waypointctl stop` if you meant to bring those down
+too). It waits for the daemon to fully exit before returning — graceful
+shutdown can take up to 30s while in-flight workers drain — so that
+`daemon stop && daemon start` reliably replaces the daemon instead of racing
+a half-exited one; pass `--no-wait` to skip the wait. To roll the daemon
+onto new code, use `waypointctl daemon restart`.
 
 ### Out-of-band remote control
 
 While the daemon runs it also serves an HTTP control console on
-`WAYPOINT_STACK_CONTROL_PORT` (default `8799`). Because it lives in
-`waypointd` — the supervisor that owns both services and isn't itself
-redeployed mid-session — it stays reachable when a frontend build is
-corrupt *or* the backend has crashed, the two cases that make the normal
-app unusable. It's the break-glass console for when you're AFK on a phone
-and the agent that was editing Waypoint left the app unloadable.
+`WAYPOINT_STACK_CONTROL_PORT` (default `8799`, exposed over Tailscale beside
+the backend and frontend ports). It lives in the supervisor rather than a
+managed service, so it stays reachable when a corrupt frontend build or a
+crashed backend has made the normal app unloadable — the break-glass path
+for when the only thing to hand is a phone. It drives the same stack/process
+layer `waypointctl` does and never touches the app's session data.
 
-It is deliberately a *stack/process* console, not a reimplementation of
-the app's session UI — its blast radius is exactly what `waypointctl`
-itself can do. Open `http://<host>:8799/` (exposed over Tailscale
-alongside the frontend/backend ports), enter `WAYPOINT_PASSWORD`, and you
+Open `http://<host>:8799/`, authenticate with `WAYPOINT_PASSWORD`, and you
 get:
 
-- **Status** — live health/pid/port of backend and frontend, polled every
-  few seconds, so you can watch a restart come back up.
-- **Logs** — the tail of `backend.log` / `frontend.log`, to diagnose *why*
-  a build broke before acting.
-- **Lifecycle** — `restart` / `stop` / `start` per service or all, run the
-  same way as `waypointctl <action> <target>`.
+- **Status** — live health, pid, and port for backend and frontend, polled
+  every few seconds so you can watch a restart come back up.
+- **Logs** — the tail of `backend.log` / `frontend.log`, to see why a build
+  broke before acting.
+- **Lifecycle** — `restart` / `stop` / `start` a service or the whole stack,
+  the same as `waypointctl <action> <target>`.
 - **Redeploy** — restart the whole stack on one of three channels:
-  - **stable** — check out the latest release tag, then restart the stack.
+  - **stable** — check out the latest release tag, then restart.
   - **nightly** — check out the tip of `main`, then restart.
   - **current** — restart the checked-out tree with no git update; the only
     channel that works on a dirty or unmanaged checkout. Stable and nightly
-    fail safe on such a checkout, surfacing git's refusal and leaving the
-    stack untouched.
+    fail safe there, surfacing git's refusal and leaving the stack untouched.
 
-#### How it works
+Login exchanges the password for a short-lived bearer token, held only in
+memory — a daemon restart drops it and you log in again. It issues one only
+when a real `WAYPOINT_PASSWORD` is set (a blank or `change-me` value returns
+`503`) and locks out after five failed attempts in a minute, so it can't
+become an open surface on the tailnet. Mutating operations run on a worker
+thread and return `202` at once; the page polls `/api/status` for the
+outcome, so a 30–60s rebuild never holds a connection open, and one
+operation runs at a time. Restarting from here is safe where the same
+restart from inside a session is not, because the supervisor is the parent
+of the service process groups, not a descendant. The action set is a fixed
+allowlist with no arbitrary command execution, and every operation is logged
+to `<state-dir>/logs/waypointd.log`.
 
-Login exchanges `WAYPOINT_PASSWORD` for a short-lived bearer token (in
-memory only — lost on a daemon restart, just log in again). Mutating
-operations run asynchronously on a worker thread: the POST returns `202`
-immediately and the page polls `/api/status` to watch the result land in
-`last_op`, so a 30–60s frontend rebuild can't hit a connection timeout.
-Only one operation runs at a time (others get `409`). Restarting from the
-supervisor never hits the self-kill problem, since `waypointd` is the
-*parent* of the service process groups, not a descendant. The CLI, the
-daemon socket, and this console all dispatch through the same
-`commands.run_action`, so they can't drift apart.
+The console exists only while `waypointd` runs. Expose it over Tailscale
+only, never publicly; set `WAYPOINT_STACK_CONTROL_PORT=0` to disable it; and
+run `waypointctl doctor` to print its URL and confirm it responds.
 
 #### API
 
@@ -215,20 +209,6 @@ daemon socket, and this console all dispatch through the same
 | `GET /api/logs?target=&n=` | token | Tail of a service log. |
 | `POST /api/action` | token | `{action, target}` → `202`; async. |
 | `POST /api/redeploy` | token | `{channel: stable\|nightly\|current}` → `202`; async. |
-
-#### Safety
-
-The console refuses to act unless a real `WAYPOINT_PASSWORD` is set (a
-blank or `change-me` value returns `503`), and locks out after five failed
-logins in a minute, so it can't become an open control surface on the
-tailnet. The action set is a fixed allowlist — there is no arbitrary
-command execution — and every operation is logged to
-`<state-dir>/logs/waypointd.log`. Expose it only over Tailscale, never
-publicly. Set `WAYPOINT_STACK_CONTROL_PORT=0` to disable it. The console
-only exists while `waypointd` is running — it is **not** available in the
-default in-process mode, so start the daemon (or set
-`WAYPOINTCTL_DAEMON=1`) to rely on it. `waypointctl doctor` prints the
-control URL and whether it currently responds.
 
 ## Logs
 

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -168,8 +168,8 @@ layer `waypointctl` does and never touches the app's session data.
 Open `http://<host>:8799/`, authenticate with `WAYPOINT_PASSWORD`, and you
 get:
 
-- **Status** — live health, pid, and port for backend and frontend, polled
-  every few seconds so you can watch a restart come back up.
+- **Status** — health, pid, and port for backend and frontend, so you can
+  watch a restart come back up.
 - **Logs** — the tail of `backend.log` / `frontend.log`, to see why a build
   broke before acting.
 - **Lifecycle** — `restart` / `stop` / `start` a service or the whole stack,
@@ -181,18 +181,10 @@ get:
     channel that works on a dirty or unmanaged checkout. Stable and nightly
     fail safe there, surfacing git's refusal and leaving the stack untouched.
 
-Login exchanges the password for a short-lived bearer token, held only in
-memory — a daemon restart drops it and you log in again. It issues one only
-when a real `WAYPOINT_PASSWORD` is set (a blank or `change-me` value returns
-`503`) and locks out after five failed attempts in a minute, so it can't
-become an open surface on the tailnet. Mutating operations run on a worker
-thread and return `202` at once; the page polls `/api/status` for the
-outcome, so a 30–60s rebuild never holds a connection open, and one
-operation runs at a time. Restarting from here is safe where the same
-restart from inside a session is not, because the supervisor is the parent
-of the service process groups, not a descendant. The action set is a fixed
-allowlist with no arbitrary command execution, and every operation is logged
-to `<state-dir>/logs/waypointd.log`.
+It refuses to run unless a real `WAYPOINT_PASSWORD` is set, locking out after
+repeated failed logins, so it can't become an open control surface on the
+tailnet. It can only do what `waypointctl` itself can — a fixed set of
+actions, no arbitrary commands — and logs each one.
 
 The console exists only while `waypointd` runs. Expose it over Tailscale
 only, never publicly; set `WAYPOINT_STACK_CONTROL_PORT=0` to disable it; and
@@ -200,15 +192,30 @@ run `waypointctl doctor` to print its URL and confirm it responds.
 
 #### API
 
-| Method · path | Auth | Purpose |
+The page is backed by a token-authenticated JSON API, so an agent can drive
+it with `curl`: `POST /api/login` with the password for a bearer token, then
+pass it as `Authorization: Bearer <token>` on the rest.
+
+| Method · path | Auth | Body / query → result |
 | --- | --- | --- |
 | `GET /` | — | The console page. |
 | `GET /health` | — | Liveness of the control plane itself. |
 | `POST /api/login` | password | `{password}` → `{token, expires_in}`. |
-| `GET /api/status` | token | Service status + `last_op`. |
-| `GET /api/logs?target=&n=` | token | Tail of a service log. |
-| `POST /api/action` | token | `{action, target}` → `202`; async. |
+| `GET /api/status` | token | → service status + `last_op`. |
+| `GET /api/logs?target=&n=` | token | `target` = `backend`\|`frontend`, `n` lines → `{lines}`. |
+| `POST /api/action` | token | `{action: start\|stop\|restart, target: backend\|frontend\|all}` → `202`; async. |
 | `POST /api/redeploy` | token | `{channel: stable\|nightly\|current}` → `202`; async. |
+
+```bash
+host=http://<host>:8799
+token=$(curl -s "$host/api/login" -d '{"password":"…"}' | jq -r .token)
+curl -s "$host/api/status" -H "Authorization: Bearer $token"
+curl -s "$host/api/action" -H "Authorization: Bearer $token" \
+  -d '{"action":"restart","target":"frontend"}'
+```
+
+Mutating calls return `202` and run in the background; poll `GET /api/status`
+and read `last_op` for the outcome.
 
 ## Logs
 

--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -23,7 +23,7 @@ waypointctl --home <repo> stop  [backend|frontend|all]
 waypointctl --home <repo> restart [backend|frontend|all]
 waypointctl --home <repo> status
 waypointctl --home <repo> logs  [backend|frontend|all]
-waypointctl daemon start | stop | status
+waypointctl daemon start | stop | restart | status
 waypointctl doctor
 ```
 
@@ -72,6 +72,8 @@ are not supported.
 | `WAYPOINT_STACK_UV_CACHE_DIR` | `<state-dir>/uv-cache` | Backend `UV_CACHE_DIR`. |
 | `WAYPOINT_STACK_FORCE_FRONTEND_BUILD` | `0` | When `1`, always rebuild the frontend before `npm run start`. |
 | `WAYPOINT_STACK_CAFFEINATE` | `1` | macOS only: hold a `caffeinate -i -s` for the lifetime of the stack. |
+| `WAYPOINT_STACK_CONTROL_HOST` | `0.0.0.0` | Bind host for the daemon's restart control plane. |
+| `WAYPOINT_STACK_CONTROL_PORT` | `8799` | Port for the daemon's restart control plane; `0` disables it. |
 
 ## Multiple tailnets per host
 
@@ -148,6 +150,85 @@ because it stays on the wire across the kill.
 processes survive it intentionally (they were spawned in their own
 sessions), so a daemon restart doesn't bounce running services. If
 any are still up the CLI prints a hint pointing at `waypointctl stop`.
+
+`daemon stop` **waits for the daemon to fully exit** before returning
+(graceful shutdown joins in-flight workers, up to 30s). This is what
+makes `daemon stop && daemon start` reliable: the daemon clears its
+socket and pid only at the end of shutdown, so a `start` that didn't
+wait would see the dying daemon as "already running" and decline to
+spawn a replacement, leaving nothing up. Pass `--no-wait` for the old
+fire-and-forget behavior. To apply a code change to the daemon itself,
+prefer `waypointctl daemon restart`, which stops-and-waits then starts a
+fresh daemon in one step.
+
+### Out-of-band remote control
+
+While the daemon runs it also serves an HTTP control console on
+`WAYPOINT_STACK_CONTROL_PORT` (default `8799`). Because it lives in
+`waypointd` — the supervisor that owns both services and isn't itself
+redeployed mid-session — it stays reachable when a frontend build is
+corrupt *or* the backend has crashed, the two cases that make the normal
+app unusable. It's the break-glass console for when you're AFK on a phone
+and the agent that was editing Waypoint left the app unloadable.
+
+It is deliberately a *stack/process* console, not a reimplementation of
+the app's session UI — its blast radius is exactly what `waypointctl`
+itself can do. Open `http://<host>:8799/` (exposed over Tailscale
+alongside the frontend/backend ports), enter `WAYPOINT_PASSWORD`, and you
+get:
+
+- **Status** — live health/pid/port of backend and frontend, polled every
+  few seconds, so you can watch a restart come back up.
+- **Logs** — the tail of `backend.log` / `frontend.log`, to diagnose *why*
+  a build broke before acting.
+- **Lifecycle** — `restart` / `stop` / `start` per service or all, run the
+  same way as `waypointctl <action> <target>`.
+- **Redeploy** — restart the whole stack on one of three channels:
+  - **stable** — check out the latest release tag, then restart the stack.
+  - **nightly** — check out the tip of `main`, then restart.
+  - **current** — restart the checked-out tree with no git update; the only
+    channel that works on a dirty or unmanaged checkout. Stable and nightly
+    fail safe on such a checkout, surfacing git's refusal and leaving the
+    stack untouched.
+
+#### How it works
+
+Login exchanges `WAYPOINT_PASSWORD` for a short-lived bearer token (in
+memory only — lost on a daemon restart, just log in again). Mutating
+operations run asynchronously on a worker thread: the POST returns `202`
+immediately and the page polls `/api/status` to watch the result land in
+`last_op`, so a 30–60s frontend rebuild can't hit a connection timeout.
+Only one operation runs at a time (others get `409`). Restarting from the
+supervisor never hits the self-kill problem, since `waypointd` is the
+*parent* of the service process groups, not a descendant. The CLI, the
+daemon socket, and this console all dispatch through the same
+`commands.run_action`, so they can't drift apart.
+
+#### API
+
+| Method · path | Auth | Purpose |
+| --- | --- | --- |
+| `GET /` | — | The console page. |
+| `GET /health` | — | Liveness of the control plane itself. |
+| `POST /api/login` | password | `{password}` → `{token, expires_in}`. |
+| `GET /api/status` | token | Service status + `last_op`. |
+| `GET /api/logs?target=&n=` | token | Tail of a service log. |
+| `POST /api/action` | token | `{action, target}` → `202`; async. |
+| `POST /api/redeploy` | token | `{channel: stable\|nightly\|current}` → `202`; async. |
+
+#### Safety
+
+The console refuses to act unless a real `WAYPOINT_PASSWORD` is set (a
+blank or `change-me` value returns `503`), and locks out after five failed
+logins in a minute, so it can't become an open control surface on the
+tailnet. The action set is a fixed allowlist — there is no arbitrary
+command execution — and every operation is logged to
+`<state-dir>/logs/waypointd.log`. Expose it only over Tailscale, never
+publicly. Set `WAYPOINT_STACK_CONTROL_PORT=0` to disable it. The console
+only exists while `waypointd` is running — it is **not** available in the
+default in-process mode, so start the daemon (or set
+`WAYPOINTCTL_DAEMON=1`) to rely on it. `waypointctl doctor` prints the
+control URL and whether it currently responds.
 
 ## Logs
 

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -3,6 +3,7 @@ import json
 import os
 import signal
 import subprocess
+import time
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 from typing import Annotated, Any, cast
@@ -10,6 +11,7 @@ from typing import Annotated, Any, cast
 import click
 import typer
 
+from waypointctl import commands
 from waypointctl.ancestry import is_descendant_of
 from waypointctl.client import (
     DaemonClient,
@@ -18,6 +20,7 @@ from waypointctl.client import (
     ensure_daemon,
 )
 from waypointctl.config import apply_dotenv, load_stack_config
+from waypointctl.health import http_ok
 from waypointctl.paths import (
     pid_file_for,
     resolve_state_dir,
@@ -280,6 +283,16 @@ def doctor(ctx: typer.Context) -> None:
     typer.echo(f"daemon socket={waypoint_socket_path()}")
     typer.echo(f"daemon for this home={'yes' if daemon_available(home) else 'no'}")
 
+    config = load_stack_config(home)
+    if config.control_port:
+        reachable = http_ok(f"http://127.0.0.1:{config.control_port}/health")
+        typer.echo(
+            f"control plane=http://{config.control_host}:{config.control_port}/ "
+            f"reachable={'yes' if reachable else 'no'}"
+        )
+    else:
+        typer.echo("control plane=disabled (WAYPOINT_STACK_CONTROL_PORT=0)")
+
 
 @app.command("update")
 def update(
@@ -379,8 +392,39 @@ def daemon_start(ctx: typer.Context) -> None:
     typer.echo("waypointd started")
 
 
+# Graceful shutdown joins deferred workers (up to WORKER_SHUTDOWN_GRACE_SECONDS
+# = 30s) before unlinking its socket/pid, so allow comfortably more than that.
+_DAEMON_STOP_TIMEOUT_SECONDS = 35.0
+
+
+def _daemon_gone(home: Path) -> bool:
+    # The exact condition a fresh `start` needs: the socket no longer answers
+    # and the pid file points at nothing live. Both are cleared together at the
+    # end of shutdown, so this flips true only once a restart can safely proceed.
+    return not daemon_available(home) and running_pid(waypoint_pid_path()) is None
+
+
+def _wait_for_daemon_stop(
+    home: Path, timeout: float = _DAEMON_STOP_TIMEOUT_SECONDS
+) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if _daemon_gone(home):
+            return True
+        time.sleep(0.1)
+    return _daemon_gone(home)
+
+
 @daemon_app.command("stop")
-def daemon_stop(ctx: typer.Context) -> None:
+def daemon_stop(
+    ctx: typer.Context,
+    wait: bool = typer.Option(
+        True,
+        "--wait/--no-wait",
+        help="Block until the daemon has fully exited (default).",
+    ),
+) -> None:
+    home = _ctx_home(ctx)
     pid_path = waypoint_pid_path()
     pid = read_pid_file(pid_path)
     if pid is None or not is_pid_running(pid):
@@ -390,8 +434,37 @@ def daemon_stop(ctx: typer.Context) -> None:
         _warn_if_services_running()
         return
     os.kill(pid, signal.SIGTERM)
+    if wait and not _wait_for_daemon_stop(home):
+        typer.echo(
+            f"waypointd (pid {pid}) did not exit within "
+            f"{int(_DAEMON_STOP_TIMEOUT_SECONDS)}s; check `waypointctl daemon status`",
+            err=True,
+        )
+        raise typer.Exit(code=1)
     typer.echo(f"waypointd stopped (pid {pid})")
     _warn_if_services_running()
+
+
+@daemon_app.command("restart")
+def daemon_restart(ctx: typer.Context) -> None:
+    """Stop the daemon (waiting for full exit) and start a fresh one."""
+    home = _ctx_home(ctx)
+    pid = read_pid_file(waypoint_pid_path())
+    if pid is not None and is_pid_running(pid):
+        os.kill(pid, signal.SIGTERM)
+        if not _wait_for_daemon_stop(home):
+            typer.echo(
+                f"waypointd (pid {pid}) did not exit within "
+                f"{int(_DAEMON_STOP_TIMEOUT_SECONDS)}s; not restarting",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+    try:
+        ensure_daemon(home)
+    except DaemonUnavailableError as exc:
+        typer.echo(f"failed to start waypointd: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo("waypointd restarted")
 
 
 def _warn_if_services_running() -> None:
@@ -470,15 +543,9 @@ def _run_in_process(home: Path, command: str, args: list[str]) -> None:
     def log(stream: str, line: str) -> None:
         typer.echo(line, err=(stream == "stderr"))
 
-    if command == "start":
+    if command in commands.ACTIONS:
         target = args[0] if args else "all"
-        result = stack.start(log, target)
-    elif command == "stop":
-        target = args[0] if args else "all"
-        result = stack.stop(log, target)
-    elif command == "restart":
-        target = args[0] if args else "all"
-        result = stack.restart(target, log)
+        result = commands.run_action(stack, command, target, log)
     elif command == "status":
         result = stack.status(log)
     else:

--- a/waypointctl/src/waypointctl/commands.py
+++ b/waypointctl/src/waypointctl/commands.py
@@ -1,0 +1,75 @@
+"""The one stack-control vocabulary shared by every front door.
+
+The CLI (`_run_in_process`), the daemon socket dispatch, and the HTTP remote
+control all route through here so they can't drift apart. Human-facing log
+streaming stays with the callers; this module is the action + structured-state
+core.
+"""
+
+from collections.abc import Callable
+
+from waypointctl.paths import log_file_for
+from waypointctl.services import ManagedService, ServiceResult
+from waypointctl.stack import WaypointStack
+
+LogFn = Callable[[str, str], None]
+
+ACTIONS = ("start", "stop", "restart")
+LOG_TARGETS = ("backend", "frontend")
+_MAX_LOG_LINES = 1000
+_TAIL_BYTES = 256 * 1024
+
+
+def run_action(
+    stack: WaypointStack, action: str, target: str, log: LogFn
+) -> ServiceResult:
+    if action == "start":
+        return stack.start(log, target)
+    if action == "stop":
+        return stack.stop(log, target)
+    if action == "restart":
+        return stack.restart(target, log)
+    return ServiceResult(ok=False, message=f"unknown action: {action}")
+
+
+def status_payload(stack: WaypointStack) -> list[dict[str, object]]:
+    services = [_status_dict(stack.backend), _status_dict(stack.frontend)]
+    caffeinate = stack.caffeinate.status()
+    if caffeinate.state == "running":
+        services.append(
+            {
+                "name": caffeinate.name,
+                "state": caffeinate.state,
+                "pid": caffeinate.pid,
+                "port": caffeinate.port,
+                "health": caffeinate.health,
+            }
+        )
+    return services
+
+
+def _status_dict(service: ManagedService) -> dict[str, object]:
+    status = service.status()
+    return {
+        "name": status.name,
+        "state": status.state,
+        "pid": status.pid,
+        "port": status.port,
+        "health": status.health,
+    }
+
+
+def tail_log(target: str, lines: int) -> list[str]:
+    if target not in LOG_TARGETS:
+        raise ValueError(f"unknown log target: {target}")
+    path = log_file_for(target)
+    if not path.exists():
+        return []
+    count = max(1, min(lines, _MAX_LOG_LINES))
+    with path.open("rb") as handle:
+        handle.seek(0, 2)
+        size = handle.tell()
+        handle.seek(max(0, size - _TAIL_BYTES))
+        data = handle.read()
+    text = data.decode("utf-8", errors="replace")
+    return text.splitlines()[-count:]

--- a/waypointctl/src/waypointctl/config.py
+++ b/waypointctl/src/waypointctl/config.py
@@ -21,6 +21,8 @@ class StackConfig:
     uv_cache_dir: Path
     force_frontend_build: bool
     caffeinate: bool
+    control_host: str
+    control_port: int
     child_env: dict[str, str]
 
 
@@ -75,6 +77,8 @@ def load_stack_config(home: Path, env: dict[str, str] | None = None) -> StackCon
             env.get("WAYPOINT_STACK_FORCE_FRONTEND_BUILD"), default=False
         ),
         caffeinate=_parse_bool(env.get("WAYPOINT_STACK_CAFFEINATE"), default=True),
+        control_host=env.get("WAYPOINT_STACK_CONTROL_HOST", "0.0.0.0"),
+        control_port=int(env.get("WAYPOINT_STACK_CONTROL_PORT", "8799")),
         child_env=env,
     )
 

--- a/waypointctl/src/waypointctl/control.py
+++ b/waypointctl/src/waypointctl/control.py
@@ -81,8 +81,11 @@ class ControlServer(ThreadingHTTPServer):
                 self._login_failures.append(time.monotonic())
                 return None
             self._login_failures.clear()
+            now = time.monotonic()
+            # Drop lapsed tokens so a long-lived daemon doesn't accumulate them.
+            self._tokens = {t: exp for t, exp in self._tokens.items() if exp > now}
             token = secrets.token_urlsafe(32)
-            self._tokens[token] = time.monotonic() + TOKEN_TTL_SECONDS
+            self._tokens[token] = now + TOKEN_TTL_SECONDS
             return token
 
     def token_valid(self, header: str | None) -> bool:

--- a/waypointctl/src/waypointctl/control.py
+++ b/waypointctl/src/waypointctl/control.py
@@ -1,0 +1,773 @@
+"""Out-of-band remote control hosted by waypointd.
+
+A minimal, dependency-free HTTP console that lets a phone drive the whole
+stack/process layer — status, logs, lifecycle, redeploy — when the frontend
+build is corrupt or the backend has crashed. It lives in the supervisor
+(waypointd), not in either managed service, so it survives a broken frontend
+*and* a broken backend.
+
+It is deliberately a *stack* console, not a reimplementation of the app's
+session UI: its blast radius is exactly what `waypointctl` can already do.
+The action set is a fixed allowlist; there is no arbitrary command execution.
+"""
+
+import hmac
+import json
+import secrets
+import threading
+import time
+from collections.abc import Callable
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlsplit
+
+from waypointctl import commands
+from waypointctl.services import ServiceResult
+from waypointctl.stack import WaypointStack
+from waypointctl.update import run as run_update
+
+# A blank or default password would expose an unauthenticated control surface
+# on the tailnet, so the console refuses to act until a real one is set.
+INSECURE_PASSWORDS = frozenset({"", "change-me"})
+
+TOKEN_TTL_SECONDS = 30 * 60
+LOGIN_WINDOW_SECONDS = 60.0
+LOGIN_MAX_FAILURES = 5
+DEFAULT_LOG_LINES = 200
+
+# stable = latest release tag; nightly = tip of main; current = restart the
+# checked-out tree with no git update (the channel that works on a dirty/
+# unmanaged dev checkout).
+REDEPLOY_CHANNELS = ("stable", "nightly", "current")
+
+
+class ControlServer(ThreadingHTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+    def __init__(
+        self, address: tuple[str, int], stack: WaypointStack, password: str | None
+    ) -> None:
+        self.stack = stack
+        self.password = password
+        self._lock = threading.Lock()
+        self._tokens: dict[str, float] = {}
+        self._login_failures: list[float] = []
+        # One mutating op at a time; status/logs stay lock-free.
+        self._op_lock = threading.Lock()
+        self._op_thread: threading.Thread | None = None
+        self.last_op: dict[str, object] | None = None
+        super().__init__(address, ControlHandler)
+
+    # ── auth ──────────────────────────────────────────────────────────
+    @property
+    def password_ready(self) -> bool:
+        return self.password is not None and self.password not in INSECURE_PASSWORDS
+
+    def login_locked(self) -> bool:
+        with self._lock:
+            self._prune_failures()
+            return len(self._login_failures) >= LOGIN_MAX_FAILURES
+
+    def login(self, supplied: object) -> str | None:
+        if not self.password_ready:
+            return None
+        ok = isinstance(supplied, str) and hmac.compare_digest(
+            supplied, self.password or ""
+        )
+        with self._lock:
+            self._prune_failures()
+            if not ok:
+                self._login_failures.append(time.monotonic())
+                return None
+            self._login_failures.clear()
+            token = secrets.token_urlsafe(32)
+            self._tokens[token] = time.monotonic() + TOKEN_TTL_SECONDS
+            return token
+
+    def token_valid(self, header: str | None) -> bool:
+        if not header or not header.startswith("Bearer "):
+            return False
+        token = header[len("Bearer ") :]
+        now = time.monotonic()
+        with self._lock:
+            expiry = self._tokens.get(token)
+            if expiry is None:
+                return False
+            if expiry < now:
+                self._tokens.pop(token, None)
+                return False
+            return True
+
+    def _prune_failures(self) -> None:
+        cutoff = time.monotonic() - LOGIN_WINDOW_SECONDS
+        self._login_failures = [t for t in self._login_failures if t >= cutoff]
+
+    # ── operations ────────────────────────────────────────────────────
+    def start_op(
+        self,
+        action: str,
+        target: str,
+        run: Callable[[commands.LogFn], ServiceResult],
+    ) -> bool:
+        """Kick off a mutating op on a worker thread. False if one is running."""
+        if not self._op_lock.acquire(blocking=False):
+            return False
+        self._set_last_op(action, target, "running", "")
+
+        def worker() -> None:
+            lines: list[str] = []
+            state, message = "failed", ""
+            try:
+                result = run(lambda _stream, line: lines.append(line))
+                state = "ok" if result.ok else "failed"
+                message = result.message or "\n".join(lines[-6:])
+            except Exception as exc:  # noqa: BLE001
+                message = str(exc)
+            finally:
+                # Record the terminal state before releasing the lock, so a
+                # waiting op can't acquire it and flip last_op to "running"
+                # only to have this worker clobber it with the finished result.
+                self._set_last_op(action, target, state, message)
+                print(f"[control] {action} {target} -> {state}", flush=True)
+                self._op_lock.release()
+
+        thread = threading.Thread(target=worker, name=f"control-{action}", daemon=True)
+        self._op_thread = thread
+        thread.start()
+        return True
+
+    def redeploy(self, channel: str, log: commands.LogFn) -> ServiceResult:
+        # `current` redeploys the checked-out tree as-is — the only channel that
+        # works on an unmanaged/dirty repo. `stable`/`nightly` git-update first;
+        # an unmanaged or dirty tree surfaces git's own refusal and the stack is
+        # left untouched (no restart on a failed update).
+        if channel != "current":
+            try:
+                run_update(self.stack.config.home, nightly=channel == "nightly")
+            except Exception as exc:  # noqa: BLE001
+                return ServiceResult(ok=False, message=f"update failed: {exc}")
+        return commands.run_action(self.stack, "restart", "all", log)
+
+    def join_op(self, timeout: float | None = None) -> None:
+        thread = self._op_thread
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    def _set_last_op(self, action: str, target: str, state: str, message: str) -> None:
+        with self._lock:
+            self.last_op = {
+                "action": action,
+                "target": target,
+                "state": state,
+                "message": message,
+                "ts": time.time(),
+            }
+
+
+class ControlHandler(BaseHTTPRequestHandler):
+    server_version = "waypointd-control"
+
+    @property
+    def control(self) -> ControlServer:
+        server = self.server
+        assert isinstance(server, ControlServer)
+        return server
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    # ── routing ───────────────────────────────────────────────────────
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlsplit(self.path).path
+        if path in ("/", "/index.html"):
+            self._send_html(HTTPStatus.OK, _PAGE)
+        elif path == "/health":
+            self._send_json(HTTPStatus.OK, {"status": "ok"})
+        elif path == "/api/status":
+            self._handle_status()
+        elif path == "/api/logs":
+            self._handle_logs()
+        else:
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlsplit(self.path).path
+        if path == "/api/login":
+            self._handle_login()
+        elif path == "/api/action":
+            self._handle_action()
+        elif path == "/api/redeploy":
+            self._handle_redeploy()
+        else:
+            self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    # ── handlers ──────────────────────────────────────────────────────
+    def _handle_login(self) -> None:
+        if not self.control.password_ready:
+            self._send_json(
+                HTTPStatus.SERVICE_UNAVAILABLE,
+                {"error": "set WAYPOINT_PASSWORD to enable remote control"},
+            )
+            return
+        if self.control.login_locked():
+            self._send_json(
+                HTTPStatus.TOO_MANY_REQUESTS,
+                {"error": "too many attempts; wait a minute"},
+            )
+            return
+        body = self._read_json_body()
+        if body is None:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON body"})
+            return
+        token = self.control.login(body.get("password"))
+        if token is None:
+            self._send_json(HTTPStatus.UNAUTHORIZED, {"error": "wrong password"})
+            return
+        self._send_json(
+            HTTPStatus.OK, {"token": token, "expires_in": TOKEN_TTL_SECONDS}
+        )
+
+    def _handle_status(self) -> None:
+        if not self._authorized():
+            return
+        self._send_json(
+            HTTPStatus.OK,
+            {
+                "services": commands.status_payload(self.control.stack),
+                "last_op": self.control.last_op,
+            },
+        )
+
+    def _handle_logs(self) -> None:
+        if not self._authorized():
+            return
+        params = parse_qs(urlsplit(self.path).query)
+        target = (params.get("target", ["backend"])[0]).lower()
+        try:
+            count = int(params.get("n", [str(DEFAULT_LOG_LINES)])[0])
+        except ValueError:
+            count = DEFAULT_LOG_LINES
+        try:
+            lines = commands.tail_log(target, count)
+        except ValueError as exc:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        self._send_json(HTTPStatus.OK, {"target": target, "lines": lines})
+
+    def _handle_action(self) -> None:
+        if not self._authorized():
+            return
+        body = self._read_json_body()
+        if body is None:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON body"})
+            return
+        action = body.get("action")
+        target = body.get("target")
+        if action not in commands.ACTIONS:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": f"action must be one of {', '.join(commands.ACTIONS)}"},
+            )
+            return
+        if target not in ("frontend", "backend", "all"):
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": "target must be frontend, backend, or all"},
+            )
+            return
+        stack = self.control.stack
+        started = self.control.start_op(
+            action,
+            target,
+            lambda log: commands.run_action(stack, action, target, log),
+        )
+        self._respond_started(started, action, target)
+
+    def _handle_redeploy(self) -> None:
+        if not self._authorized():
+            return
+        body = self._read_json_body()
+        if body is None:
+            self._send_json(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON body"})
+            return
+        channel = body.get("channel")
+        if channel not in REDEPLOY_CHANNELS:
+            self._send_json(
+                HTTPStatus.BAD_REQUEST,
+                {"error": f"channel must be one of {', '.join(REDEPLOY_CHANNELS)}"},
+            )
+            return
+        started = self.control.start_op(
+            "redeploy",
+            channel,
+            lambda log: self.control.redeploy(channel, log),
+        )
+        self._respond_started(started, "redeploy", channel)
+
+    def _respond_started(self, started: bool, action: str, target: str) -> None:
+        if not started:
+            self._send_json(
+                HTTPStatus.CONFLICT, {"error": "an operation is already running"}
+            )
+            return
+        self._send_json(
+            HTTPStatus.ACCEPTED, {"accepted": True, "action": action, "target": target}
+        )
+
+    # ── helpers ───────────────────────────────────────────────────────
+    def _authorized(self) -> bool:
+        if self.control.token_valid(self.headers.get("Authorization")):
+            return True
+        self._send_json(HTTPStatus.UNAUTHORIZED, {"error": "unauthorized"})
+        return False
+
+    def _read_json_body(self) -> dict[str, object] | None:
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            return None
+        raw = self.rfile.read(length) if length > 0 else b""
+        try:
+            parsed = json.loads(raw.decode("utf-8") or "{}")
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    def _send_json(self, status: HTTPStatus, payload: dict[str, object]) -> None:
+        self._send_bytes(
+            status, "application/json", json.dumps(payload).encode("utf-8")
+        )
+
+    def _send_html(self, status: HTTPStatus, html: str) -> None:
+        self._send_bytes(status, "text/html; charset=utf-8", html.encode("utf-8"))
+
+    def _send_bytes(self, status: HTTPStatus, content_type: str, body: bytes) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except BrokenPipeError:
+            pass
+
+
+_PAGE = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="robots" content="noindex" />
+<meta name="color-scheme" content="dark" />
+<title>WAYPOINT · stack control</title>
+<style>
+  :root {
+    --bg: #07090c;
+    --panel: #0d1117;
+    --panel-2: #11171f;
+    --line: #1e2733;
+    --ink: #d7e0ea;
+    --ink-dim: #6b7a8d;
+    --ink-faint: #43505f;
+    --amber: #ffb454;
+    --amber-dim: #8a6526;
+    --green: #3fb950;
+    --red: #f85149;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo,
+            Consolas, "Liberation Mono", monospace;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; }
+  body {
+    background:
+      radial-gradient(120% 80% at 50% -10%, rgba(255,180,84,0.06), transparent 60%),
+      linear-gradient(0deg, var(--bg), var(--bg));
+    color: var(--ink);
+    font-family: var(--mono);
+    font-size: 14px;
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+    padding: env(safe-area-inset-top) env(safe-area-inset-right)
+             env(safe-area-inset-bottom) env(safe-area-inset-left);
+  }
+  /* faint engineering grid */
+  body::before {
+    content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+    background-image:
+      linear-gradient(var(--line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--line) 1px, transparent 1px);
+    background-size: 30px 30px;
+    opacity: 0.18;
+    -webkit-mask-image: radial-gradient(120% 100% at 50% 0%, #000 30%, transparent 75%);
+            mask-image: radial-gradient(120% 100% at 50% 0%, #000 30%, transparent 75%);
+  }
+  .wrap { position: relative; z-index: 1; max-width: 720px; margin: 0 auto; padding: 22px 18px 40px; }
+
+  header { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+           border-bottom: 1px solid var(--line); padding-bottom: 14px; }
+  .mark { font-size: 19px; font-weight: 700; letter-spacing: 0.28em; }
+  .mark b { color: var(--amber); }
+  .tag { color: var(--ink-faint); font-size: 11px; letter-spacing: 0.18em;
+         text-transform: uppercase; }
+  .beat { margin-left: auto; display: flex; align-items: center; gap: 7px;
+          color: var(--ink-dim); font-size: 11px; letter-spacing: 0.12em; }
+  .beat .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ink-faint); }
+  .beat.live .dot { background: var(--green); box-shadow: 0 0 8px var(--green);
+                    animation: pulse 2s infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }
+
+  .stagger > * { opacity: 0; transform: translateY(8px); animation: rise .5s ease forwards; }
+  .stagger > *:nth-child(1) { animation-delay: .04s }
+  .stagger > *:nth-child(2) { animation-delay: .10s }
+  .stagger > *:nth-child(3) { animation-delay: .16s }
+  .stagger > *:nth-child(4) { animation-delay: .22s }
+  .stagger > *:nth-child(5) { animation-delay: .28s }
+  @keyframes rise { to { opacity: 1; transform: none } }
+  @media (prefers-reduced-motion: reduce) {
+    .stagger > * { animation: none; opacity: 1; transform: none }
+    .beat.live .dot { animation: none }
+  }
+
+  .label { color: var(--ink-faint); font-size: 11px; letter-spacing: 0.18em;
+           text-transform: uppercase; margin: 26px 2px 10px; }
+
+  /* login */
+  #login { margin-top: 14vh; }
+  #login .card { background: var(--panel); border: 1px solid var(--line);
+                 border-radius: 12px; padding: 26px 22px;
+                 box-shadow: 0 30px 80px -40px #000; }
+  #login h1 { font-size: 14px; letter-spacing: 0.1em; margin: 0 0 4px; color: var(--ink); }
+  #login p { color: var(--ink-dim); font-size: 12px; margin: 0 0 20px; }
+  input {
+    width: 100%; padding: 13px 14px; font: inherit; color: var(--ink);
+    background: var(--bg); border: 1px solid var(--line); border-radius: 9px;
+    letter-spacing: 0.04em;
+  }
+  input:focus { outline: none; border-color: var(--amber-dim);
+                box-shadow: 0 0 0 3px rgba(255,180,84,0.12); }
+
+  button {
+    font: inherit; color: var(--ink); background: var(--panel-2);
+    border: 1px solid var(--line); border-radius: 9px; padding: 11px 14px;
+    cursor: pointer; letter-spacing: 0.06em; transition: border-color .15s, background .15s;
+    -webkit-tap-highlight-color: transparent;
+  }
+  button:hover:not(:disabled) { border-color: var(--ink-faint); }
+  button:active:not(:disabled) { transform: translateY(1px); }
+  button:disabled { opacity: 0.4; cursor: default; }
+  button.amber { background: var(--amber); color: #1a1206; border-color: var(--amber);
+                 font-weight: 700; }
+  button.amber:hover:not(:disabled) { filter: brightness(1.08); }
+  button.danger { border-color: #4d2422; color: #ffb1ab; }
+  button.danger:hover:not(:disabled) { background: #1d1413; border-color: var(--red); }
+  button.block { width: 100%; }
+
+  /* service cards */
+  .svc { display: flex; align-items: center; gap: 14px;
+         background: var(--panel); border: 1px solid var(--line);
+         border-radius: 11px; padding: 14px 16px; margin-bottom: 10px; }
+  .led { width: 11px; height: 11px; border-radius: 50%; background: var(--ink-faint);
+         flex: none; box-shadow: 0 0 0 0 transparent; }
+  .led.up { background: var(--green); box-shadow: 0 0 10px var(--green); }
+  .led.down { background: var(--red); box-shadow: 0 0 10px var(--red); }
+  .led.warn { background: var(--amber); box-shadow: 0 0 10px var(--amber);
+              animation: pulse 1.1s infinite; }
+  .svc .meta { min-width: 0; }
+  .svc .name { font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+  .svc .sub { color: var(--ink-dim); font-size: 11.5px; }
+  .svc .acts { margin-left: auto; display: flex; gap: 6px; }
+  .svc .acts button { padding: 8px 11px; font-size: 12px; }
+
+  .logs { background: #05070a; border: 1px solid var(--line); border-radius: 11px;
+          overflow: hidden; }
+  .logs .bar { display: flex; gap: 4px; padding: 8px; border-bottom: 1px solid var(--line);
+               align-items: center; }
+  .logs .bar .seg { display: flex; gap: 4px; }
+  .logs .bar button { padding: 6px 12px; font-size: 12px; }
+  .logs .bar button.on { background: var(--panel-2); border-color: var(--ink-faint);
+                         color: var(--amber); }
+  .logs .bar .spacer { margin-left: auto; }
+  pre#log { margin: 0; padding: 12px 14px; max-height: 46vh; overflow: auto;
+            font-size: 12px; line-height: 1.5; color: #aebccb; white-space: pre-wrap;
+            word-break: break-word; }
+  pre#log:empty::before { content: "no output"; color: var(--ink-faint); }
+
+  .danger-zone { border: 1px solid #2a1a18; background: linear-gradient(0deg,#0e0a0a,#0d1117);
+                 border-radius: 11px; padding: 14px 16px; }
+  .danger-zone .hd { color: #ffb1ab; font-size: 11px; letter-spacing: 0.18em;
+                     text-transform: uppercase; margin-bottom: 4px; }
+  .danger-zone p { color: var(--ink-dim); font-size: 12px; margin: 0 0 12px; }
+  .danger-zone p b { color: #ffb1ab; font-weight: 600; }
+  .redeploy { display: flex; gap: 6px; }
+  .redeploy button { flex: 1; }
+
+  #op { position: sticky; bottom: 8px; margin-top: 22px; padding: 11px 14px;
+        border-radius: 10px; border: 1px solid var(--line); background: var(--panel);
+        font-size: 12.5px; display: none; box-shadow: 0 18px 40px -28px #000; }
+  #op.show { display: block; }
+  #op.run { border-color: var(--amber-dim); }
+  #op.ok { border-color: #1f5a2a; }
+  #op.err { border-color: #4d2422; }
+  #op .st { letter-spacing: 0.1em; text-transform: uppercase; font-weight: 700; }
+  #op.run .st { color: var(--amber); } #op.ok .st { color: var(--green); }
+  #op.err .st { color: var(--red); }
+  #op .msg { color: var(--ink-dim); white-space: pre-wrap; word-break: break-word;
+             margin-top: 4px; max-height: 9em; overflow: auto; }
+
+  .hidden { display: none !important; }
+  .err-line { color: var(--red); font-size: 12px; margin-top: 12px; min-height: 1em; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <span class="mark">WAY<b>·</b>POINT</span>
+    <span class="tag">stack&nbsp;control</span>
+    <span class="beat" id="beat"><span class="dot"></span><span id="beatTxt">offline</span></span>
+  </header>
+
+  <section id="login">
+    <div class="card">
+      <h1>AUTHENTICATE</h1>
+      <p>Out-of-band control plane. Enter the Waypoint password.</p>
+      <input id="pw" type="password" autocomplete="current-password"
+             placeholder="WAYPOINT_PASSWORD" />
+      <div class="err-line" id="loginErr"></div>
+      <button class="amber block" id="loginBtn" style="margin-top:14px">Unlock</button>
+    </div>
+  </section>
+
+  <main id="console" class="hidden stagger">
+    <div class="label">Services</div>
+    <div id="services"></div>
+
+    <div class="label">Logs</div>
+    <div class="logs">
+      <div class="bar">
+        <div class="seg">
+          <button data-log="backend" class="on">backend</button>
+          <button data-log="frontend">frontend</button>
+        </div>
+        <div class="spacer"></div>
+        <button id="logRefresh">refresh</button>
+      </div>
+      <pre id="log"></pre>
+    </div>
+
+    <div class="label">Danger zone</div>
+    <div class="danger-zone">
+      <div class="hd">Redeploy</div>
+      <p>Each restarts the whole stack and interrupts every running session.
+         <b>Stable</b> / <b>Nightly</b> git-update first (fail safe on a dirty or
+         unmanaged checkout); <b>Current</b> just restarts the checked-out tree.</p>
+      <div class="redeploy">
+        <button class="danger" data-channel="stable">Stable</button>
+        <button class="danger" data-channel="nightly">Nightly</button>
+        <button class="danger" data-channel="current">Current</button>
+      </div>
+    </div>
+  </main>
+
+  <div id="op">
+    <span class="st" id="opSt"></span> <span id="opTitle"></span>
+    <div class="msg" id="opMsg"></div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var token = sessionStorage.getItem("wp_token") || null;
+  var curLog = "backend";
+  var statusTimer = null;
+
+  var $ = function (id) { return document.getElementById(id); };
+
+  function authHeaders(extra) {
+    var h = extra || {};
+    if (token) h["Authorization"] = "Bearer " + token;
+    return h;
+  }
+
+  async function api(path, opts) {
+    opts = opts || {};
+    opts.headers = authHeaders(opts.headers);
+    var res = await fetch(path, opts);
+    if (res.status === 401) { logout(); throw new Error("session expired"); }
+    return res;
+  }
+
+  // ── auth ──
+  async function login() {
+    var pw = $("pw").value;
+    if (!pw) { $("loginErr").textContent = "Enter the password."; return; }
+    $("loginBtn").disabled = true;
+    $("loginErr").textContent = "";
+    try {
+      var res = await fetch("/api/login", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: pw }),
+      });
+      var data = await res.json().catch(function () { return {}; });
+      if (res.ok && data.token) {
+        token = data.token; sessionStorage.setItem("wp_token", token);
+        $("pw").value = ""; enterConsole();
+      } else {
+        $("loginErr").textContent = data.error || ("Failed (HTTP " + res.status + ")");
+      }
+    } catch (e) { $("loginErr").textContent = "Request failed."; }
+    finally { $("loginBtn").disabled = false; }
+  }
+
+  function logout() {
+    token = null; sessionStorage.removeItem("wp_token");
+    if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
+    setBeat(false);
+    $("console").classList.add("hidden");
+    $("login").classList.remove("hidden");
+  }
+
+  function enterConsole() {
+    $("login").classList.add("hidden");
+    $("console").classList.remove("hidden");
+    refreshStatus(); loadLog();
+    statusTimer = setInterval(refreshStatus, 3000);
+  }
+
+  // ── status ──
+  function setBeat(live) {
+    $("beat").classList.toggle("live", live);
+    $("beatTxt").textContent = live ? "live" : "offline";
+  }
+
+  function ledClass(s) {
+    if (s.state !== "running") return "down";
+    if (s.health === "unhealthy") return "warn";
+    return "up";
+  }
+  function subLine(s) {
+    if (s.state !== "running") return s.state;
+    var bits = [];
+    if (s.pid) bits.push("pid " + s.pid);
+    if (s.port) bits.push("port " + s.port);
+    if (s.health) bits.push(s.health);
+    return bits.join("  ·  ");
+  }
+
+  function renderServices(list) {
+    var html = "";
+    for (var i = 0; i < list.length; i++) {
+      var s = list[i];
+      var acts = s.name === "caffeinate" ? "" :
+        '<div class="acts">' +
+          '<button data-act="restart" data-t="' + s.name + '">restart</button>' +
+          '<button data-act="' + (s.state === "running" ? "stop" : "start") + '" data-t="' + s.name + '">' +
+            (s.state === "running" ? "stop" : "start") + '</button>' +
+        '</div>';
+      html +=
+        '<div class="svc">' +
+          '<span class="led ' + ledClass(s) + '"></span>' +
+          '<div class="meta"><div class="name">' + s.name + '</div>' +
+          '<div class="sub">' + subLine(s) + '</div></div>' + acts +
+        '</div>';
+    }
+    $("services").innerHTML = html;
+    var btns = $("services").querySelectorAll("button[data-act]");
+    for (var j = 0; j < btns.length; j++) {
+      btns[j].addEventListener("click", function () {
+        doAction(this.getAttribute("data-act"), this.getAttribute("data-t"));
+      });
+    }
+  }
+
+  async function refreshStatus() {
+    try {
+      var res = await api("/api/status");
+      var data = await res.json();
+      renderServices(data.services || []);
+      renderOp(data.last_op);
+      setBeat(true);
+    } catch (e) { setBeat(false); }
+  }
+
+  // ── operations ──
+  function renderOp(op) {
+    var box = $("op");
+    if (!op) { box.className = ""; box.classList.remove("show"); return; }
+    box.classList.add("show");
+    box.classList.remove("run", "ok", "err");
+    box.classList.add(op.state === "running" ? "run" : op.state === "ok" ? "ok" : "err");
+    $("opSt").textContent = op.state === "running" ? "working" : op.state;
+    $("opTitle").textContent = op.action + " · " + op.target;
+    $("opMsg").textContent = op.message || "";
+  }
+
+  async function doAction(action, target) {
+    if (target === "backend" || target === "all") {
+      if (!confirm(action + " " + target + "? This interrupts running sessions."))
+        return;
+    }
+    await fire("/api/action", { action: action, target: target });
+  }
+
+  async function redeploy(channel) {
+    var what = channel === "current"
+      ? "Restart the whole stack from the current checkout?"
+      : "Redeploy " + channel + ": pull and restart the whole stack?";
+    if (!confirm(what + " This interrupts running sessions.")) return;
+    await fire("/api/redeploy", { channel: channel });
+  }
+
+  async function fire(path, payload) {
+    try {
+      var res = await api(path, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      var data = await res.json().catch(function () { return {}; });
+      if (res.status === 202) { refreshStatus(); }
+      else { renderOp({ action: payload.action || "redeploy",
+                        target: payload.target || payload.channel || "all",
+                        state: "failed",
+                        message: data.error || ("HTTP " + res.status) }); }
+    } catch (e) { /* logout already handled */ }
+  }
+
+  // ── logs ──
+  async function loadLog() {
+    try {
+      var res = await api("/api/logs?target=" + curLog + "&n=200");
+      var data = await res.json();
+      var pre = $("log");
+      pre.textContent = (data.lines || []).join("\n");
+      pre.scrollTop = pre.scrollHeight;
+    } catch (e) {}
+  }
+
+  // ── wiring ──
+  $("loginBtn").addEventListener("click", login);
+  $("pw").addEventListener("keydown", function (e) { if (e.key === "Enter") login(); });
+  $("logRefresh").addEventListener("click", loadLog);
+  var redeployBtns = document.querySelectorAll("button[data-channel]");
+  for (var r = 0; r < redeployBtns.length; r++) {
+    redeployBtns[r].addEventListener("click", function () {
+      redeploy(this.getAttribute("data-channel"));
+    });
+  }
+  var logBtns = document.querySelectorAll("button[data-log]");
+  for (var k = 0; k < logBtns.length; k++) {
+    logBtns[k].addEventListener("click", function () {
+      curLog = this.getAttribute("data-log");
+      for (var m = 0; m < logBtns.length; m++) logBtns[m].classList.remove("on");
+      this.classList.add("on");
+      loadLog();
+    });
+  }
+
+  if (token) enterConsole(); else setBeat(false);
+})();
+</script>
+</body>
+</html>
+"""

--- a/waypointctl/src/waypointctl/daemon.py
+++ b/waypointctl/src/waypointctl/daemon.py
@@ -10,7 +10,9 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
+from waypointctl import commands
 from waypointctl.config import apply_dotenv, load_stack_config
+from waypointctl.control import ControlServer
 from waypointctl.paths import (
     resolve_waypoint_home,
     state_log_dir,
@@ -116,17 +118,11 @@ class WaypointDaemonHandler(socketserver.StreamRequestHandler):
             with write_lock:
                 self._send_log(DaemonLog(stream=stream, line=line))
 
-        if request.command == "start":
+        if request.command in commands.ACTIONS:
             target = request.args[0] if request.args else "all"
-            result = stack.start(log, target)
+            result = commands.run_action(stack, request.command, target, log)
         elif request.command == "status":
             result = stack.status(log)
-        elif request.command == "stop":
-            target = request.args[0] if request.args else "all"
-            result = stack.stop(log, target)
-        elif request.command == "restart":
-            target = request.args[0] if request.args else "all"
-            result = stack.restart(target, log)
         else:
             self._send_result(
                 DaemonResult(
@@ -157,17 +153,11 @@ class WaypointDaemonHandler(socketserver.StreamRequestHandler):
             tag = "stderr" if stream == "stderr" else "stdout"
             print(f"[{command}] {tag}: {line}", flush=True)
 
-        if command == "restart":
+        if command in ("restart", "stop"):
             target = request.args[0] if request.args else "all"
 
             def worker() -> None:
-                stack.restart(target, file_log)
-
-        elif command == "stop":
-            target = request.args[0] if request.args else "all"
-
-            def worker() -> None:
-                stack.stop(file_log, target)
+                commands.run_action(stack, command, target, file_log)
 
         else:
             self._send_result(
@@ -214,6 +204,8 @@ def serve(home: Path) -> None:
     server = WaypointDaemonServer(socket_path, home)
     write_pid_file(pid_path, os.getpid())
 
+    control_server, control_thread = _start_control_server(server)
+
     shutdown_event = threading.Event()
 
     def _shutdown(_signum: int, _frame: object) -> None:
@@ -229,12 +221,55 @@ def serve(home: Path) -> None:
     try:
         shutdown_event.wait()
     finally:
+        if control_server is not None:
+            control_server.shutdown()
         server.shutdown()
         server_thread.join(timeout=2.0)
+        if control_thread is not None:
+            control_thread.join(timeout=2.0)
+        if control_server is not None:
+            control_server.server_close()
         server.join_workers(timeout=WORKER_SHUTDOWN_GRACE_SECONDS)
         server.server_close()
         socket_path.unlink(missing_ok=True)
         pid_path.unlink(missing_ok=True)
+
+
+def _start_control_server(
+    server: WaypointDaemonServer,
+) -> tuple[ControlServer | None, threading.Thread | None]:
+    config = server.stack.config
+    if not config.control_port:
+        return None, None
+    password = config.child_env.get("WAYPOINT_PASSWORD")
+    try:
+        # Share the daemon's WaypointStack so restarts hit the same managed
+        # process group the socket commands do.
+        control_server = ControlServer(
+            (config.control_host, config.control_port), server.stack, password
+        )
+    except OSError as exc:
+        # A control-port conflict must not take down the supervisor; the
+        # socket commands still work without the HTTP switch.
+        print(
+            f"control plane disabled: cannot bind "
+            f"{config.control_host}:{config.control_port} ({exc})",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None, None
+    thread = threading.Thread(
+        target=control_server.serve_forever,
+        args=(0.5,),
+        daemon=True,
+        name="waypointd-control",
+    )
+    thread.start()
+    print(
+        f"control plane on http://{config.control_host}:{config.control_port}",
+        flush=True,
+    )
+    return control_server, thread
 
 
 def main() -> None:

--- a/waypointctl/src/waypointctl/daemon.py
+++ b/waypointctl/src/waypointctl/daemon.py
@@ -153,7 +153,7 @@ class WaypointDaemonHandler(socketserver.StreamRequestHandler):
             tag = "stderr" if stream == "stderr" else "stdout"
             print(f"[{command}] {tag}: {line}", flush=True)
 
-        if command in ("restart", "stop"):
+        if command in DEFERRED_COMMANDS:
             target = request.args[0] if request.args else "all"
 
             def worker() -> None:

--- a/waypointctl/tests/test_config.py
+++ b/waypointctl/tests/test_config.py
@@ -51,6 +51,8 @@ def test_load_stack_config_defaults(
     assert config.uv_cache_dir == (tmp_path / "state").resolve() / "uv-cache"
     assert config.force_frontend_build is False
     assert config.caffeinate is True
+    assert config.control_host == "0.0.0.0"
+    assert config.control_port == 8799
 
 
 def test_load_stack_config_env_overrides(
@@ -67,6 +69,8 @@ def test_load_stack_config_env_overrides(
         "WAYPOINT_STACK_START_TIMEOUT": "60",
         "WAYPOINT_STACK_FORCE_FRONTEND_BUILD": "true",
         "WAYPOINT_STACK_CAFFEINATE": "0",
+        "WAYPOINT_STACK_CONTROL_HOST": "127.0.0.1",
+        "WAYPOINT_STACK_CONTROL_PORT": "9099",
     }
 
     config = load_stack_config(home, env=env)
@@ -78,6 +82,8 @@ def test_load_stack_config_env_overrides(
     assert config.start_timeout == 60
     assert config.force_frontend_build is True
     assert config.caffeinate is False
+    assert config.control_host == "127.0.0.1"
+    assert config.control_port == 9099
 
 
 def test_load_stack_config_relative_path_resolves_under_home(

--- a/waypointctl/tests/test_control.py
+++ b/waypointctl/tests/test_control.py
@@ -1,0 +1,334 @@
+import json
+import socket
+import threading
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from waypointctl.config import StackConfig
+from waypointctl.control import ControlServer
+from waypointctl.services import ServiceResult, ServiceStatus
+from waypointctl.stack import WaypointStack
+
+
+class _StubService:
+    def __init__(self, name: str, state: str = "running") -> None:
+        self.name = name
+        self.state = state
+        self.calls: list[str] = []
+        self.started_marker_value = False
+
+    @property
+    def started_marker(self):  # type: ignore[no-untyped-def]
+        class _Marker:
+            def __init__(self, parent: "_StubService") -> None:
+                self.parent = parent
+
+            def exists(self) -> bool:
+                return self.parent.started_marker_value
+
+            def unlink(self, missing_ok: bool = False) -> None:
+                self.parent.started_marker_value = False
+
+        return _Marker(self)
+
+    def start(self, log):  # type: ignore[no-untyped-def]
+        log("stdout", f"start {self.name}")
+        self.calls.append("start")
+        self.state = "running"
+        self.started_marker_value = True
+        return ServiceResult(ok=True)
+
+    def stop(self, log):  # type: ignore[no-untyped-def]
+        log("stdout", f"stop {self.name}")
+        self.calls.append("stop")
+        self.state = "stopped"
+        return ServiceResult(ok=True)
+
+    def status(self) -> ServiceStatus:
+        if self.state == "running":
+            return ServiceStatus(
+                name=self.name, state="running", pid=123, port=8787, health="healthy"
+            )
+        return ServiceStatus(name=self.name, state="stopped")
+
+
+def _build_stack(tmp_path: Path) -> WaypointStack:
+    home = tmp_path / "repo"
+    home.mkdir(exist_ok=True)
+    config = StackConfig(
+        home=home,
+        state_dir=tmp_path / "state",
+        backend_host="127.0.0.1",
+        backend_port=8787,
+        backend_config=home / "backend" / "waypoint.yaml",
+        backend_data_dir=tmp_path / "state" / "backend-data",
+        frontend_port=3000,
+        frontend_dev=False,
+        start_timeout=1,
+        uv_cache_dir=tmp_path / "state" / "uv-cache",
+        force_frontend_build=False,
+        caffeinate=False,
+        control_host="127.0.0.1",
+        control_port=0,
+        child_env={},
+    )
+    stack = WaypointStack(config)
+    stack.backend = _StubService("backend")  # type: ignore[assignment]
+    stack.frontend = _StubService("frontend")  # type: ignore[assignment]
+    stack.caffeinate = _StubService("caffeinate", state="stopped")  # type: ignore[assignment]
+    return stack
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _serve(stack: WaypointStack, password: str | None) -> tuple[ControlServer, int]:
+    port = _free_port()
+    server = ControlServer(("127.0.0.1", port), stack, password)
+    thread = threading.Thread(target=server.serve_forever, args=(0.1,), daemon=True)
+    thread.start()
+    return server, port
+
+
+@pytest.fixture
+def control(tmp_path: Path) -> Iterator[tuple[ControlServer, int, str]]:
+    stack = _build_stack(tmp_path)
+    server, port = _serve(stack, "s3cret")
+    try:
+        yield server, port, "s3cret"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def _request(
+    port: int, path: str, method: str = "GET", token: str | None = None, body=None
+) -> tuple[int, dict]:
+    headers = {}
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}", data=data, headers=headers, method=method
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else {})
+
+
+def _login(port: int, password: str) -> str:
+    status, body = _request(port, "/api/login", "POST", body={"password": password})
+    assert status == 200
+    return body["token"]
+
+
+# ── unauthenticated surface ──────────────────────────────────────────
+def test_page_and_health(control: tuple[ControlServer, int, str]) -> None:
+    _, port, _ = control
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=5) as resp:
+        assert resp.status == 200
+        assert "WAYPOINT" in resp.read().decode("utf-8")
+    status, body = _request(port, "/health")
+    assert status == 200 and body["status"] == "ok"
+
+
+# ── auth ──────────────────────────────────────────────────────────────
+def test_login_wrong_password(control: tuple[ControlServer, int, str]) -> None:
+    _, port, _ = control
+    status, _ = _request(port, "/api/login", "POST", body={"password": "nope"})
+    assert status == 401
+
+
+def test_login_lockout_after_repeated_failures(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    _, port, _ = control
+    for _ in range(5):
+        _request(port, "/api/login", "POST", body={"password": "nope"})
+    status, body = _request(port, "/api/login", "POST", body={"password": "s3cret"})
+    assert status == 429
+    assert "attempts" in body["error"]
+
+
+@pytest.mark.parametrize("password", ["", "change-me", None])
+def test_insecure_password_disables_control(
+    tmp_path: Path, password: str | None
+) -> None:
+    stack = _build_stack(tmp_path)
+    server, port = _serve(stack, password)
+    try:
+        status, body = _request(
+            port, "/api/login", "POST", body={"password": "anything"}
+        )
+        assert status == 503
+        assert "WAYPOINT_PASSWORD" in body["error"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_protected_endpoints_require_token(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    _, port, _ = control
+    for path in ("/api/status", "/api/logs"):
+        status, _ = _request(port, path)
+        assert status == 401
+    status, _ = _request(
+        port, "/api/action", "POST", body={"action": "restart", "target": "frontend"}
+    )
+    assert status == 401
+
+
+# ── status & logs ──────────────────────────────────────────────────────
+def test_status_reports_services(control: tuple[ControlServer, int, str]) -> None:
+    _, port, password = control
+    token = _login(port, password)
+    status, body = _request(port, "/api/status", token=token)
+    assert status == 200
+    names = {s["name"] for s in body["services"]}
+    assert {"backend", "frontend"} <= names
+    assert body["last_op"] is None
+
+
+def test_logs_unknown_target_rejected(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    _, port, password = control
+    token = _login(port, password)
+    status, _ = _request(port, "/api/logs?target=teleporter", token=token)
+    assert status == 400
+
+
+# ── actions ─────────────────────────────────────────────────────────────
+def test_action_invalid_inputs_rejected(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    _, port, password = control
+    token = _login(port, password)
+    status, _ = _request(
+        port,
+        "/api/action",
+        "POST",
+        token=token,
+        body={"action": "explode", "target": "frontend"},
+    )
+    assert status == 400
+    status, _ = _request(
+        port,
+        "/api/action",
+        "POST",
+        token=token,
+        body={"action": "restart", "target": "teleporter"},
+    )
+    assert status == 400
+
+
+def test_action_restart_runs_async_and_records_last_op(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    server, port, password = control
+    token = _login(port, password)
+    status, body = _request(
+        port,
+        "/api/action",
+        "POST",
+        token=token,
+        body={"action": "restart", "target": "frontend"},
+    )
+    assert status == 202 and body["accepted"] is True
+
+    server.join_op(timeout=5)
+    status, body = _request(port, "/api/status", token=token)
+    last = body["last_op"]
+    assert last["action"] == "restart" and last["target"] == "frontend"
+    assert last["state"] == "ok"
+    assert server.stack.frontend.calls == ["stop", "start"]  # type: ignore[attr-defined]
+
+
+def test_action_conflict_when_op_running(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    server, port, password = control
+    token = _login(port, password)
+    # Hold the op lock to simulate an in-flight operation.
+    assert server._op_lock.acquire(blocking=False)
+    try:
+        status, body = _request(
+            port,
+            "/api/action",
+            "POST",
+            token=token,
+            body={"action": "restart", "target": "all"},
+        )
+        assert status == 409
+        assert "already running" in body["error"]
+    finally:
+        server._op_lock.release()
+
+
+# ── redeploy ─────────────────────────────────────────────────────────────
+def test_redeploy_invalid_channel_rejected(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    _, port, password = control
+    token = _login(port, password)
+    status, _ = _request(
+        port, "/api/redeploy", "POST", token=token, body={"channel": "beta"}
+    )
+    assert status == 400
+    status, _ = _request(port, "/api/redeploy", "POST", token=token, body={})
+    assert status == 400
+
+
+def test_redeploy_current_restarts_without_git(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    server, port, password = control
+    token = _login(port, password)
+    status, body = _request(
+        port, "/api/redeploy", "POST", token=token, body={"channel": "current"}
+    )
+    assert status == 202 and body["target"] == "current"
+
+    server.join_op(timeout=5)
+    _, body = _request(port, "/api/status", token=token)
+    last = body["last_op"]
+    assert last["action"] == "redeploy" and last["target"] == "current"
+    assert last["state"] == "ok"
+    # `current` restarts the checked-out tree, no git update involved.
+    assert server.stack.frontend.calls == ["stop", "start"]  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("channel", ["stable", "nightly"])
+def test_redeploy_update_channel_fails_safe_outside_git(
+    control: tuple[ControlServer, int, str], channel: str
+) -> None:
+    server, port, password = control
+    token = _login(port, password)
+    status, body = _request(
+        port, "/api/redeploy", "POST", token=token, body={"channel": channel}
+    )
+    assert status == 202 and body["target"] == channel
+
+    server.join_op(timeout=10)
+    _, body = _request(port, "/api/status", token=token)
+    last = body["last_op"]
+    # The stub home is not a git checkout, so the update step fails cleanly
+    # and the stack is left untouched.
+    assert last["action"] == "redeploy" and last["target"] == channel
+    assert last["state"] == "failed"
+    assert server.stack.frontend.calls == []  # type: ignore[attr-defined]

--- a/waypointctl/tests/test_daemon_e2e.py
+++ b/waypointctl/tests/test_daemon_e2e.py
@@ -9,10 +9,12 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from waypointctl.cli import app
 from waypointctl.client import DaemonClient, daemon_available
 from waypointctl.paths import waypoint_pid_path, waypoint_socket_path
-from waypointctl.process import read_pid_file
+from waypointctl.process import read_pid_file, running_pid
 
 
 @pytest.fixture
@@ -60,6 +62,65 @@ def _terminate(proc: subprocess.Popen) -> None:
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait(timeout=10)
+
+
+def _reap_remaining(timeout: float = 10.0) -> None:
+    # `daemon restart` spawns its replacement via subprocess in-process, so the
+    # test owns that child too. Reap any exited children so they don't linger.
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            reaped, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return
+        if reaped == 0:
+            time.sleep(0.05)
+
+
+def test_cli_daemon_stop_waits_for_full_exit(state_dir: Path) -> None:
+    home = _make_home(state_dir)
+    env = {**os.environ, "WAYPOINTCTL_STATE_DIR": str(state_dir)}
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "waypointctl.daemon", "--home", str(home)],
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        assert _wait_until(daemon_available, timeout=_DAEMON_START_TIMEOUT)
+        result = CliRunner().invoke(app, ["--home", str(home), "daemon", "stop"])
+        assert result.exit_code == 0, result.output
+        # The race fix: once `stop` returns, a fresh `start` must see nothing —
+        # socket no longer answers and no live pid remains.
+        assert not daemon_available(home)
+        assert running_pid(waypoint_pid_path()) is None
+    finally:
+        _terminate(proc)
+
+
+def test_cli_daemon_restart_replaces_daemon(state_dir: Path) -> None:
+    home = _make_home(state_dir)
+    env = {**os.environ, "WAYPOINTCTL_STATE_DIR": str(state_dir)}
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "waypointctl.daemon", "--home", str(home)],
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        assert _wait_until(daemon_available, timeout=_DAEMON_START_TIMEOUT)
+        old_pid = read_pid_file(waypoint_pid_path())
+
+        result = CliRunner().invoke(app, ["--home", str(home), "daemon", "restart"])
+        assert result.exit_code == 0, result.output
+
+        # ensure_daemon already waited for readiness, so a fresh daemon is live
+        # under a new pid.
+        assert daemon_available(home)
+        new_pid = read_pid_file(waypoint_pid_path())
+        assert new_pid is not None and new_pid != old_pid
+    finally:
+        CliRunner().invoke(app, ["--home", str(home), "daemon", "stop"])
+        _terminate(proc)
+        _reap_remaining()
 
 
 def test_daemon_stop_waits_when_wait_flag_set(state_dir: Path) -> None:

--- a/waypointctl/tests/test_services.py
+++ b/waypointctl/tests/test_services.py
@@ -40,6 +40,8 @@ def _build_config(tmp_path: Path, state_dir: Path, **overrides: object) -> Stack
         uv_cache_dir=state_dir / "uv-cache",
         force_frontend_build=False,
         caffeinate=False,
+        control_host="127.0.0.1",
+        control_port=0,
         child_env={},
     )
     defaults.update(overrides)

--- a/waypointctl/tests/test_stack.py
+++ b/waypointctl/tests/test_stack.py
@@ -30,6 +30,8 @@ def _build_config(tmp_path: Path, state_dir: Path) -> StackConfig:
         uv_cache_dir=state_dir / "uv-cache",
         force_frontend_build=False,
         caffeinate=False,
+        control_host="127.0.0.1",
+        control_port=0,
         child_env={},
     )
 

--- a/waypointctl/tests/test_tailscale.py
+++ b/waypointctl/tests/test_tailscale.py
@@ -315,6 +315,11 @@ def test_helper_up_uses_repo_dotenv_and_exposes_ports(
     monkeypatch.setenv("TS_AUTHKEY", "from-shell")
     monkeypatch.setenv("TS_HOSTNAME", "shell-host")
     monkeypatch.setenv("TS_IMAGE", "shell-image")
+    # The dev's gitignored repo-root .env can export these into the process
+    # env; clear them so the helper falls back to defaults deterministically.
+    monkeypatch.delenv("WAYPOINT_STACK_FRONTEND_PORT", raising=False)
+    monkeypatch.delenv("WAYPOINT_STACK_BACKEND_PORT", raising=False)
+    monkeypatch.delenv("WAYPOINT_STACK_CONTROL_PORT", raising=False)
 
     bash = shutil.which("bash") or "/bin/bash"
     completed = subprocess.run(
@@ -352,6 +357,10 @@ def test_helper_up_uses_repo_dotenv_and_exposes_ports(
     )
     assert (
         "tailscale serve --bg --yes --http=8787 http://host.docker.internal:8787"
+        in text
+    )
+    assert (
+        "tailscale serve --bg --yes --http=8799 http://host.docker.internal:8799"
         in text
     )
     assert "tailscale container ready: waypoint-tailscale-profile-a" in completed.stdout


### PR DESCRIPTION
## Purpose

When a Waypoint agent is developing Waypoint itself, a corrupt frontend build or a crashed backend can leave the app unloadable — with no way to recover from a phone. This adds an out-of-band remote-control console hosted by the `waypointd` daemon, one layer below the app, so the stack stays drivable even when the frontend or backend is down.

## Changes

### Control plane (`waypointctl/`)

- `src/waypointctl/control.py` — new dependency-free stdlib HTTP server hosted by the daemon: a self-contained console page (inline CSS/JS, no external assets) plus `POST /api/login` (password → short-lived bearer token, constant-time compare, failed-login lockout, refusal when the password is unset/`change-me`), `GET /api/status`, `GET /api/logs`, `POST /api/action` (start/stop/restart per service, run async with a single in-flight op and a polled `last_op`), and `POST /api/redeploy` (stable/nightly/current channels).
- `src/waypointctl/commands.py` — new shared stack-control vocabulary (`run_action`, `status_payload`, `tail_log`) that the CLI, daemon socket dispatch, and console all route through so they cannot drift; `tail_log` reads only the file's tail, not the whole log.
- `src/waypointctl/config.py` — `WAYPOINT_STACK_CONTROL_HOST`/`PORT` (default `0.0.0.0:8799`; `0` disables).
- `src/waypointctl/daemon.py` — run the control server alongside the socket server, sharing the daemon's `WaypointStack`; a control-port bind conflict degrades to socket-only rather than taking down the supervisor.
- `src/waypointctl/cli.py` — `doctor` reports the control URL and reachability; `daemon stop` waits for the daemon to fully exit and a new `daemon restart` lands it on new code, closing the `stop && start` race; CLI lifecycle dispatch routes through `commands.run_action`.
- `scripts/waypoint_tailscale.sh` — expose the control port over Tailscale next to the backend/frontend ports (skipped when `WAYPOINT_STACK_CONTROL_PORT=0`).
- `waypointctl/tests/` — cover login/lockout/insecure-password refusal, token gating, status/logs, async actions + `last_op`, op conflict, the three redeploy channels (current restarts; stable/nightly fail safe outside a git checkout), and the `daemon stop`-waits / `daemon restart` behavior.

### Docs

- `waypointctl/README.md`, `AGENTS.md`, `.agents/skills/waypointctl/references/daemon.md`, `.env.example` — document the console (purpose, API, channels, safety), the new env vars, and the `daemon restart` workflow.

## Design

The console lives in `waypointd` rather than the backend or frontend because that is the one process the developing agent does not redeploy mid-session, so it survives a broken frontend *and* a broken backend — the two failure modes that make the normal app unreachable. It is deliberately a stack/process console, not a reimplementation of the app's session UI; its blast radius is exactly what `waypointctl` already does, behind a fixed action allowlist with no arbitrary command execution. Mutating operations run on a worker thread and return `202` so the page polls `last_op` instead of holding a connection open across a 30–60s rebuild. Auth reuses `WAYPOINT_PASSWORD` (one secret) exchanged for an in-memory bearer token. The console is opt-in: it exists only while the daemon runs (`waypointctl daemon start` or `WAYPOINTCTL_DAEMON=1`), preserving the default one-shot behavior.

## Test Plan

- `cd waypointctl && uv run pytest`
- `cd waypointctl && uvx ruff check src/ tests/`, `uvx black --check`, `uvx isort --check-only` (plus the pre-commit hook's black/ruff/codespell/mypy on commit)
- Verified live against the running stack: reinstalled `waypointctl`, brought the daemon onto the new code with `waypointctl daemon restart` (race-free, no service bounce), confirmed `doctor` reports `control plane … reachable=yes`; exercised `POST /api/login` (wrong password → 401, valid → token), `GET /api/status` (both services healthy), `GET /api/logs`, and `POST /api/redeploy` (invalid channel → 400); confirmed the page serves the stable/nightly/current buttons; exposed the control port over Tailscale via `waypointctl tailscale up nat`.

## Test Result

`cd waypointctl && uv run pytest` — 159 passed. ruff/black/isort clean; codespell clean; mypy passed via the commit hook. Live checks behaved as expected: race-free `daemon restart`, control plane reachable, auth/status/logs/redeploy-validation returned the expected codes, and the console served the three redeploy channels.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run pre-commit and fixed any issues — change is not under `backend/`; the commit hook's black/ruff/isort/codespell/mypy passed on the `waypointctl` files.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd waypointctl && uv run pytest` — 159 passed).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — not touched.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity — frontend not changed.
- [ ] If this is a breaking change, I marked the title and described migration steps above — not a breaking change.
- [x] I have updated documentation or config examples (`.env.example`, README, AGENTS.md, skill reference).

</details>