### PR TITLE
fix: rework the control console for robust, concurrent ops

### DIFF
--- a/waypointctl/README.md
+++ b/waypointctl/README.md
@@ -201,7 +201,7 @@ pass it as `Authorization: Bearer <token>` on the rest.
 | `GET /` | — | The console page. |
 | `GET /health` | — | Liveness of the control plane itself. |
 | `POST /api/login` | password | `{password}` → `{token, expires_in}`. |
-| `GET /api/status` | token | → service status + `last_op`. |
+| `GET /api/status` | token | → service status + in-flight/last `ops` per target. |
 | `GET /api/logs?target=&n=` | token | `target` = `backend`\|`frontend`, `n` lines → `{lines}`. |
 | `POST /api/action` | token | `{action: start\|stop\|restart, target: backend\|frontend\|all}` → `202`; async. |
 | `POST /api/redeploy` | token | `{channel: stable\|nightly\|current}` → `202`; async. |
@@ -215,7 +215,9 @@ curl -s "$host/api/action" -H "Authorization: Bearer $token" \
 ```
 
 Mutating calls return `202` and run in the background; poll `GET /api/status`
-and read `last_op` for the outcome.
+and read the matching entry in `ops` for the outcome. `backend` and `frontend`
+run on independent lanes (so they can proceed at once); an `all` action or a
+redeploy holds both, and a busy lane rejects a conflicting call with `409`.
 
 ## Logs
 

--- a/waypointctl/pyproject.toml
+++ b/waypointctl/pyproject.toml
@@ -31,6 +31,9 @@ fallback_version = "0.1.0"
 where = ["src"]
 include = ["waypointctl*"]
 
+[tool.setuptools.package-data]
+waypointctl = ["control_assets/*.html", "control_assets/*.css", "control_assets/*.js"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]

--- a/waypointctl/src/waypointctl/control.py
+++ b/waypointctl/src/waypointctl/control.py
@@ -9,6 +9,10 @@ build is corrupt or the backend has crashed. It lives in the supervisor
 It is deliberately a *stack* console, not a reimplementation of the app's
 session UI: its blast radius is exactly what `waypointctl` can already do.
 The action set is a fixed allowlist; there is no arbitrary command execution.
+
+The console page is assembled from the source files in `control_assets/` and
+inlined into one self-contained document, so the daemon can serve it without a
+static-file route — see `_render_page`.
 """
 
 import hmac
@@ -19,6 +23,7 @@ import time
 from collections.abc import Callable
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.resources import files
 from urllib.parse import parse_qs, urlsplit
 
 from waypointctl import commands
@@ -53,10 +58,15 @@ class ControlServer(ThreadingHTTPServer):
         self._lock = threading.Lock()
         self._tokens: dict[str, float] = {}
         self._login_failures: list[float] = []
-        # One mutating op at a time; status/logs stay lock-free.
-        self._op_lock = threading.Lock()
-        self._op_thread: threading.Thread | None = None
-        self.last_op: dict[str, object] | None = None
+        # Per-service lanes so frontend and backend can run at once; an "all"
+        # op (or a redeploy) holds both. status/logs stay lock-free.
+        self._lane_locks = {
+            "backend": threading.Lock(),
+            "frontend": threading.Lock(),
+        }
+        self._ops_lock = threading.Lock()
+        self._op_threads: list[threading.Thread] = []
+        self.ops: dict[str, dict[str, object]] = {}
         super().__init__(address, ControlHandler)
 
     # ── auth ──────────────────────────────────────────────────────────
@@ -107,16 +117,32 @@ class ControlServer(ThreadingHTTPServer):
         self._login_failures = [t for t in self._login_failures if t >= cutoff]
 
     # ── operations ────────────────────────────────────────────────────
+    def _lanes_for(self, key: str) -> tuple[str, ...]:
+        return ("backend", "frontend") if key == "all" else (key,)
+
     def start_op(
         self,
+        key: str,
         action: str,
         target: str,
         run: Callable[[commands.LogFn], ServiceResult],
     ) -> bool:
-        """Kick off a mutating op on a worker thread. False if one is running."""
-        if not self._op_lock.acquire(blocking=False):
-            return False
-        self._set_last_op(action, target, "running", "")
+        """Kick off a mutating op on a worker thread, keyed by service lane.
+
+        Returns False if a conflicting op already holds a lane this key needs.
+        `backend` and `frontend` are independent lanes; `all` (and redeploy)
+        holds both, so it can't overlap either.
+        """
+        lanes = self._lanes_for(key)
+        acquired: list[str] = []
+        for lane in lanes:
+            if self._lane_locks[lane].acquire(blocking=False):
+                acquired.append(lane)
+            else:
+                for held in acquired:
+                    self._lane_locks[held].release()
+                return False
+        self._set_op(key, action, target, "running", "")
 
         def worker() -> None:
             lines: list[str] = []
@@ -128,15 +154,18 @@ class ControlServer(ThreadingHTTPServer):
             except Exception as exc:  # noqa: BLE001
                 message = str(exc)
             finally:
-                # Record the terminal state before releasing the lock, so a
-                # waiting op can't acquire it and flip last_op to "running"
+                # Record the terminal state before releasing the lanes, so a
+                # waiting op can't acquire one and flip the record to "running"
                 # only to have this worker clobber it with the finished result.
-                self._set_last_op(action, target, state, message)
+                self._set_op(key, action, target, state, message)
                 print(f"[control] {action} {target} -> {state}", flush=True)
-                self._op_lock.release()
+                for lane in acquired:
+                    self._lane_locks[lane].release()
 
-        thread = threading.Thread(target=worker, name=f"control-{action}", daemon=True)
-        self._op_thread = thread
+        thread = threading.Thread(target=worker, name=f"control-{key}", daemon=True)
+        with self._ops_lock:
+            self._op_threads = [t for t in self._op_threads if t.is_alive()]
+            self._op_threads.append(thread)
         thread.start()
         return True
 
@@ -153,13 +182,21 @@ class ControlServer(ThreadingHTTPServer):
         return commands.run_action(self.stack, "restart", "all", log)
 
     def join_op(self, timeout: float | None = None) -> None:
-        thread = self._op_thread
-        if thread is not None:
+        with self._ops_lock:
+            threads = list(self._op_threads)
+        for thread in threads:
             thread.join(timeout=timeout)
 
-    def _set_last_op(self, action: str, target: str, state: str, message: str) -> None:
-        with self._lock:
-            self.last_op = {
+    def ops_snapshot(self) -> list[dict[str, object]]:
+        with self._ops_lock:
+            return list(self.ops.values())
+
+    def _set_op(
+        self, key: str, action: str, target: str, state: str, message: str
+    ) -> None:
+        with self._ops_lock:
+            self.ops[key] = {
+                "key": key,
                 "action": action,
                 "target": target,
                 "state": state,
@@ -238,7 +275,7 @@ class ControlHandler(BaseHTTPRequestHandler):
             HTTPStatus.OK,
             {
                 "services": commands.status_payload(self.control.stack),
-                "last_op": self.control.last_op,
+                "ops": self.control.ops_snapshot(),
             },
         )
 
@@ -281,6 +318,7 @@ class ControlHandler(BaseHTTPRequestHandler):
             return
         stack = self.control.stack
         started = self.control.start_op(
+            target,
             action,
             target,
             lambda log: commands.run_action(stack, action, target, log),
@@ -302,6 +340,7 @@ class ControlHandler(BaseHTTPRequestHandler):
             )
             return
         started = self.control.start_op(
+            "all",
             "redeploy",
             channel,
             lambda log: self.control.redeploy(channel, log),
@@ -311,7 +350,8 @@ class ControlHandler(BaseHTTPRequestHandler):
     def _respond_started(self, started: bool, action: str, target: str) -> None:
         if not started:
             self._send_json(
-                HTTPStatus.CONFLICT, {"error": "an operation is already running"}
+                HTTPStatus.CONFLICT,
+                {"error": "a conflicting operation is already running"},
             )
             return
         self._send_json(
@@ -357,420 +397,13 @@ class ControlHandler(BaseHTTPRequestHandler):
             pass
 
 
-_PAGE = r"""<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
-<meta name="robots" content="noindex" />
-<meta name="color-scheme" content="dark" />
-<title>WAYPOINT · stack control</title>
-<style>
-  :root {
-    --bg: #07090c;
-    --panel: #0d1117;
-    --panel-2: #11171f;
-    --line: #1e2733;
-    --ink: #d7e0ea;
-    --ink-dim: #6b7a8d;
-    --ink-faint: #43505f;
-    --amber: #ffb454;
-    --amber-dim: #8a6526;
-    --green: #3fb950;
-    --red: #f85149;
-    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo,
-            Consolas, "Liberation Mono", monospace;
-  }
-  * { box-sizing: border-box; }
-  html, body { margin: 0; height: 100%; }
-  body {
-    background:
-      radial-gradient(120% 80% at 50% -10%, rgba(255,180,84,0.06), transparent 60%),
-      linear-gradient(0deg, var(--bg), var(--bg));
-    color: var(--ink);
-    font-family: var(--mono);
-    font-size: 14px;
-    line-height: 1.45;
-    -webkit-font-smoothing: antialiased;
-    padding: env(safe-area-inset-top) env(safe-area-inset-right)
-             env(safe-area-inset-bottom) env(safe-area-inset-left);
-  }
-  /* faint engineering grid */
-  body::before {
-    content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
-    background-image:
-      linear-gradient(var(--line) 1px, transparent 1px),
-      linear-gradient(90deg, var(--line) 1px, transparent 1px);
-    background-size: 30px 30px;
-    opacity: 0.18;
-    -webkit-mask-image: radial-gradient(120% 100% at 50% 0%, #000 30%, transparent 75%);
-            mask-image: radial-gradient(120% 100% at 50% 0%, #000 30%, transparent 75%);
-  }
-  .wrap { position: relative; z-index: 1; max-width: 720px; margin: 0 auto; padding: 22px 18px 40px; }
+def _render_page() -> str:
+    """Inline the control_assets sources into one self-contained document."""
+    assets = files(__package__).joinpath("control_assets")
+    html = assets.joinpath("control.html").read_text(encoding="utf-8")
+    css = assets.joinpath("control.css").read_text(encoding="utf-8")
+    js = assets.joinpath("control.js").read_text(encoding="utf-8")
+    return html.replace("/*__CONTROL_CSS__*/", css).replace("//__CONTROL_JS__", js)
 
-  header { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
-           border-bottom: 1px solid var(--line); padding-bottom: 14px; }
-  .mark { font-size: 19px; font-weight: 700; letter-spacing: 0.28em; }
-  .mark b { color: var(--amber); }
-  .tag { color: var(--ink-faint); font-size: 11px; letter-spacing: 0.18em;
-         text-transform: uppercase; }
-  .beat { margin-left: auto; display: flex; align-items: center; gap: 7px;
-          color: var(--ink-dim); font-size: 11px; letter-spacing: 0.12em; }
-  .beat .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ink-faint); }
-  .beat.live .dot { background: var(--green); box-shadow: 0 0 8px var(--green);
-                    animation: pulse 2s infinite; }
-  @keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.35 } }
 
-  .stagger > * { opacity: 0; transform: translateY(8px); animation: rise .5s ease forwards; }
-  .stagger > *:nth-child(1) { animation-delay: .04s }
-  .stagger > *:nth-child(2) { animation-delay: .10s }
-  .stagger > *:nth-child(3) { animation-delay: .16s }
-  .stagger > *:nth-child(4) { animation-delay: .22s }
-  .stagger > *:nth-child(5) { animation-delay: .28s }
-  @keyframes rise { to { opacity: 1; transform: none } }
-  @media (prefers-reduced-motion: reduce) {
-    .stagger > * { animation: none; opacity: 1; transform: none }
-    .beat.live .dot { animation: none }
-  }
-
-  .label { color: var(--ink-faint); font-size: 11px; letter-spacing: 0.18em;
-           text-transform: uppercase; margin: 26px 2px 10px; }
-
-  /* login */
-  #login { margin-top: 14vh; }
-  #login .card { background: var(--panel); border: 1px solid var(--line);
-                 border-radius: 12px; padding: 26px 22px;
-                 box-shadow: 0 30px 80px -40px #000; }
-  #login h1 { font-size: 14px; letter-spacing: 0.1em; margin: 0 0 4px; color: var(--ink); }
-  #login p { color: var(--ink-dim); font-size: 12px; margin: 0 0 20px; }
-  input {
-    width: 100%; padding: 13px 14px; font: inherit; color: var(--ink);
-    background: var(--bg); border: 1px solid var(--line); border-radius: 9px;
-    letter-spacing: 0.04em;
-  }
-  input:focus { outline: none; border-color: var(--amber-dim);
-                box-shadow: 0 0 0 3px rgba(255,180,84,0.12); }
-
-  button {
-    font: inherit; color: var(--ink); background: var(--panel-2);
-    border: 1px solid var(--line); border-radius: 9px; padding: 11px 14px;
-    cursor: pointer; letter-spacing: 0.06em; transition: border-color .15s, background .15s;
-    -webkit-tap-highlight-color: transparent;
-  }
-  button:hover:not(:disabled) { border-color: var(--ink-faint); }
-  button:active:not(:disabled) { transform: translateY(1px); }
-  button:disabled { opacity: 0.4; cursor: default; }
-  button.amber { background: var(--amber); color: #1a1206; border-color: var(--amber);
-                 font-weight: 700; }
-  button.amber:hover:not(:disabled) { filter: brightness(1.08); }
-  button.danger { border-color: #4d2422; color: #ffb1ab; }
-  button.danger:hover:not(:disabled) { background: #1d1413; border-color: var(--red); }
-  button.block { width: 100%; }
-
-  /* service cards */
-  .svc { display: flex; align-items: center; gap: 14px;
-         background: var(--panel); border: 1px solid var(--line);
-         border-radius: 11px; padding: 14px 16px; margin-bottom: 10px; }
-  .led { width: 11px; height: 11px; border-radius: 50%; background: var(--ink-faint);
-         flex: none; box-shadow: 0 0 0 0 transparent; }
-  .led.up { background: var(--green); box-shadow: 0 0 10px var(--green); }
-  .led.down { background: var(--red); box-shadow: 0 0 10px var(--red); }
-  .led.warn { background: var(--amber); box-shadow: 0 0 10px var(--amber);
-              animation: pulse 1.1s infinite; }
-  .svc .meta { min-width: 0; }
-  .svc .name { font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
-  .svc .sub { color: var(--ink-dim); font-size: 11.5px; }
-  .svc .acts { margin-left: auto; display: flex; gap: 6px; }
-  .svc .acts button { padding: 8px 11px; font-size: 12px; }
-
-  .logs { background: #05070a; border: 1px solid var(--line); border-radius: 11px;
-          overflow: hidden; }
-  .logs .bar { display: flex; gap: 4px; padding: 8px; border-bottom: 1px solid var(--line);
-               align-items: center; }
-  .logs .bar .seg { display: flex; gap: 4px; }
-  .logs .bar button { padding: 6px 12px; font-size: 12px; }
-  .logs .bar button.on { background: var(--panel-2); border-color: var(--ink-faint);
-                         color: var(--amber); }
-  .logs .bar .spacer { margin-left: auto; }
-  pre#log { margin: 0; padding: 12px 14px; max-height: 46vh; overflow: auto;
-            font-size: 12px; line-height: 1.5; color: #aebccb; white-space: pre-wrap;
-            word-break: break-word; }
-  pre#log:empty::before { content: "no output"; color: var(--ink-faint); }
-
-  .danger-zone { border: 1px solid #2a1a18; background: linear-gradient(0deg,#0e0a0a,#0d1117);
-                 border-radius: 11px; padding: 14px 16px; }
-  .danger-zone .hd { color: #ffb1ab; font-size: 11px; letter-spacing: 0.18em;
-                     text-transform: uppercase; margin-bottom: 4px; }
-  .danger-zone p { color: var(--ink-dim); font-size: 12px; margin: 0 0 12px; }
-  .danger-zone p b { color: #ffb1ab; font-weight: 600; }
-  .redeploy { display: flex; gap: 6px; }
-  .redeploy button { flex: 1; }
-
-  #op { position: sticky; bottom: 8px; margin-top: 22px; padding: 11px 14px;
-        border-radius: 10px; border: 1px solid var(--line); background: var(--panel);
-        font-size: 12.5px; display: none; box-shadow: 0 18px 40px -28px #000; }
-  #op.show { display: block; }
-  #op.run { border-color: var(--amber-dim); }
-  #op.ok { border-color: #1f5a2a; }
-  #op.err { border-color: #4d2422; }
-  #op .st { letter-spacing: 0.1em; text-transform: uppercase; font-weight: 700; }
-  #op.run .st { color: var(--amber); } #op.ok .st { color: var(--green); }
-  #op.err .st { color: var(--red); }
-  #op .msg { color: var(--ink-dim); white-space: pre-wrap; word-break: break-word;
-             margin-top: 4px; max-height: 9em; overflow: auto; }
-
-  .hidden { display: none !important; }
-  .err-line { color: var(--red); font-size: 12px; margin-top: 12px; min-height: 1em; }
-</style>
-</head>
-<body>
-<div class="wrap">
-  <header>
-    <span class="mark">WAY<b>·</b>POINT</span>
-    <span class="tag">stack&nbsp;control</span>
-    <span class="beat" id="beat"><span class="dot"></span><span id="beatTxt">offline</span></span>
-  </header>
-
-  <section id="login">
-    <div class="card">
-      <h1>AUTHENTICATE</h1>
-      <p>Out-of-band control plane. Enter the Waypoint password.</p>
-      <input id="pw" type="password" autocomplete="current-password"
-             placeholder="WAYPOINT_PASSWORD" />
-      <div class="err-line" id="loginErr"></div>
-      <button class="amber block" id="loginBtn" style="margin-top:14px">Unlock</button>
-    </div>
-  </section>
-
-  <main id="console" class="hidden stagger">
-    <div class="label">Services</div>
-    <div id="services"></div>
-
-    <div class="label">Logs</div>
-    <div class="logs">
-      <div class="bar">
-        <div class="seg">
-          <button data-log="backend" class="on">backend</button>
-          <button data-log="frontend">frontend</button>
-        </div>
-        <div class="spacer"></div>
-        <button id="logRefresh">refresh</button>
-      </div>
-      <pre id="log"></pre>
-    </div>
-
-    <div class="label">Danger zone</div>
-    <div class="danger-zone">
-      <div class="hd">Redeploy</div>
-      <p>Each restarts the whole stack and interrupts every running session.
-         <b>Stable</b> / <b>Nightly</b> git-update first (fail safe on a dirty or
-         unmanaged checkout); <b>Current</b> just restarts the checked-out tree.</p>
-      <div class="redeploy">
-        <button class="danger" data-channel="stable">Stable</button>
-        <button class="danger" data-channel="nightly">Nightly</button>
-        <button class="danger" data-channel="current">Current</button>
-      </div>
-    </div>
-  </main>
-
-  <div id="op">
-    <span class="st" id="opSt"></span> <span id="opTitle"></span>
-    <div class="msg" id="opMsg"></div>
-  </div>
-</div>
-
-<script>
-(function () {
-  var token = sessionStorage.getItem("wp_token") || null;
-  var curLog = "backend";
-  var statusTimer = null;
-
-  var $ = function (id) { return document.getElementById(id); };
-
-  function authHeaders(extra) {
-    var h = extra || {};
-    if (token) h["Authorization"] = "Bearer " + token;
-    return h;
-  }
-
-  async function api(path, opts) {
-    opts = opts || {};
-    opts.headers = authHeaders(opts.headers);
-    var res = await fetch(path, opts);
-    if (res.status === 401) { logout(); throw new Error("session expired"); }
-    return res;
-  }
-
-  // ── auth ──
-  async function login() {
-    var pw = $("pw").value;
-    if (!pw) { $("loginErr").textContent = "Enter the password."; return; }
-    $("loginBtn").disabled = true;
-    $("loginErr").textContent = "";
-    try {
-      var res = await fetch("/api/login", {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password: pw }),
-      });
-      var data = await res.json().catch(function () { return {}; });
-      if (res.ok && data.token) {
-        token = data.token; sessionStorage.setItem("wp_token", token);
-        $("pw").value = ""; enterConsole();
-      } else {
-        $("loginErr").textContent = data.error || ("Failed (HTTP " + res.status + ")");
-      }
-    } catch (e) { $("loginErr").textContent = "Request failed."; }
-    finally { $("loginBtn").disabled = false; }
-  }
-
-  function logout() {
-    token = null; sessionStorage.removeItem("wp_token");
-    if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
-    setBeat(false);
-    $("console").classList.add("hidden");
-    $("login").classList.remove("hidden");
-  }
-
-  function enterConsole() {
-    $("login").classList.add("hidden");
-    $("console").classList.remove("hidden");
-    refreshStatus(); loadLog();
-    statusTimer = setInterval(refreshStatus, 3000);
-  }
-
-  // ── status ──
-  function setBeat(live) {
-    $("beat").classList.toggle("live", live);
-    $("beatTxt").textContent = live ? "live" : "offline";
-  }
-
-  function ledClass(s) {
-    if (s.state !== "running") return "down";
-    if (s.health === "unhealthy") return "warn";
-    return "up";
-  }
-  function subLine(s) {
-    if (s.state !== "running") return s.state;
-    var bits = [];
-    if (s.pid) bits.push("pid " + s.pid);
-    if (s.port) bits.push("port " + s.port);
-    if (s.health) bits.push(s.health);
-    return bits.join("  ·  ");
-  }
-
-  function renderServices(list) {
-    var html = "";
-    for (var i = 0; i < list.length; i++) {
-      var s = list[i];
-      var acts = s.name === "caffeinate" ? "" :
-        '<div class="acts">' +
-          '<button data-act="restart" data-t="' + s.name + '">restart</button>' +
-          '<button data-act="' + (s.state === "running" ? "stop" : "start") + '" data-t="' + s.name + '">' +
-            (s.state === "running" ? "stop" : "start") + '</button>' +
-        '</div>';
-      html +=
-        '<div class="svc">' +
-          '<span class="led ' + ledClass(s) + '"></span>' +
-          '<div class="meta"><div class="name">' + s.name + '</div>' +
-          '<div class="sub">' + subLine(s) + '</div></div>' + acts +
-        '</div>';
-    }
-    $("services").innerHTML = html;
-    var btns = $("services").querySelectorAll("button[data-act]");
-    for (var j = 0; j < btns.length; j++) {
-      btns[j].addEventListener("click", function () {
-        doAction(this.getAttribute("data-act"), this.getAttribute("data-t"));
-      });
-    }
-  }
-
-  async function refreshStatus() {
-    try {
-      var res = await api("/api/status");
-      var data = await res.json();
-      renderServices(data.services || []);
-      renderOp(data.last_op);
-      setBeat(true);
-    } catch (e) { setBeat(false); }
-  }
-
-  // ── operations ──
-  function renderOp(op) {
-    var box = $("op");
-    if (!op) { box.className = ""; box.classList.remove("show"); return; }
-    box.classList.add("show");
-    box.classList.remove("run", "ok", "err");
-    box.classList.add(op.state === "running" ? "run" : op.state === "ok" ? "ok" : "err");
-    $("opSt").textContent = op.state === "running" ? "working" : op.state;
-    $("opTitle").textContent = op.action + " · " + op.target;
-    $("opMsg").textContent = op.message || "";
-  }
-
-  async function doAction(action, target) {
-    if (target === "backend" || target === "all") {
-      if (!confirm(action + " " + target + "? This interrupts running sessions."))
-        return;
-    }
-    await fire("/api/action", { action: action, target: target });
-  }
-
-  async function redeploy(channel) {
-    var what = channel === "current"
-      ? "Restart the whole stack from the current checkout?"
-      : "Redeploy " + channel + ": pull and restart the whole stack?";
-    if (!confirm(what + " This interrupts running sessions.")) return;
-    await fire("/api/redeploy", { channel: channel });
-  }
-
-  async function fire(path, payload) {
-    try {
-      var res = await api(path, {
-        method: "POST", headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
-      });
-      var data = await res.json().catch(function () { return {}; });
-      if (res.status === 202) { refreshStatus(); }
-      else { renderOp({ action: payload.action || "redeploy",
-                        target: payload.target || payload.channel || "all",
-                        state: "failed",
-                        message: data.error || ("HTTP " + res.status) }); }
-    } catch (e) { /* logout already handled */ }
-  }
-
-  // ── logs ──
-  async function loadLog() {
-    try {
-      var res = await api("/api/logs?target=" + curLog + "&n=200");
-      var data = await res.json();
-      var pre = $("log");
-      pre.textContent = (data.lines || []).join("\n");
-      pre.scrollTop = pre.scrollHeight;
-    } catch (e) {}
-  }
-
-  // ── wiring ──
-  $("loginBtn").addEventListener("click", login);
-  $("pw").addEventListener("keydown", function (e) { if (e.key === "Enter") login(); });
-  $("logRefresh").addEventListener("click", loadLog);
-  var redeployBtns = document.querySelectorAll("button[data-channel]");
-  for (var r = 0; r < redeployBtns.length; r++) {
-    redeployBtns[r].addEventListener("click", function () {
-      redeploy(this.getAttribute("data-channel"));
-    });
-  }
-  var logBtns = document.querySelectorAll("button[data-log]");
-  for (var k = 0; k < logBtns.length; k++) {
-    logBtns[k].addEventListener("click", function () {
-      curLog = this.getAttribute("data-log");
-      for (var m = 0; m < logBtns.length; m++) logBtns[m].classList.remove("on");
-      this.classList.add("on");
-      loadLog();
-    });
-  }
-
-  if (token) enterConsole(); else setBeat(false);
-})();
-</script>
-</body>
-</html>
-"""
+_PAGE = _render_page()

--- a/waypointctl/src/waypointctl/control_assets/control.css
+++ b/waypointctl/src/waypointctl/control_assets/control.css
@@ -1,0 +1,199 @@
+:root {
+  --bg: #07090c;
+  --panel: #0d1117;
+  --panel-2: #11171f;
+  --line: #1e2733;
+  --line-2: #2a3441;
+  --ink: #d7e0ea;
+  --ink-dim: #8794a4;
+  --ink-faint: #4a5666;
+  --amber: #ffb454;
+  --amber-dim: #8a6526;
+  --green: #4ec46a;
+  --red: #f8615a;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo,
+          Consolas, "Liberation Mono", monospace;
+}
+* { box-sizing: border-box; }
+html, body { margin: 0; min-height: 100%; }
+body {
+  background:
+    radial-gradient(120% 80% at 50% -10%, rgba(255,180,84,0.06), transparent 60%),
+    var(--bg);
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 14px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+           env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+/* faint engineering grid */
+body::before {
+  content: ""; position: fixed; inset: 0; pointer-events: none; z-index: 0;
+  background-image:
+    linear-gradient(var(--line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--line) 1px, transparent 1px);
+  background-size: 32px 32px;
+  opacity: 0.16;
+  -webkit-mask-image: radial-gradient(120% 100% at 50% 0%, #000 25%, transparent 75%);
+          mask-image: radial-gradient(120% 100% at 50% 0%, #000 25%, transparent 75%);
+}
+.wrap { position: relative; z-index: 1; max-width: 640px; margin: 0 auto;
+        padding: 22px 18px 48px; }
+
+header { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap;
+         border-bottom: 1px solid var(--line); padding-bottom: 14px; }
+.mark { font-size: 19px; font-weight: 700; letter-spacing: 0.28em; }
+.mark b { color: var(--amber); }
+.tag { color: var(--ink-faint); font-size: 11px; letter-spacing: 0.18em;
+       text-transform: uppercase; }
+.beat { margin-left: auto; display: flex; align-items: center; gap: 7px;
+        color: var(--ink-dim); font-size: 11px; letter-spacing: 0.14em;
+        text-transform: uppercase; }
+.beat .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ink-faint);
+             transition: background .2s, box-shadow .2s; }
+.beat.live .dot { background: var(--green); box-shadow: 0 0 8px var(--green);
+                  animation: pulse 2.4s infinite; }
+@keyframes pulse { 0%,100% { opacity: 1 } 50% { opacity: 0.4 } }
+
+.stagger > * { opacity: 0; transform: translateY(8px); animation: rise .45s ease forwards; }
+.stagger > *:nth-child(1) { animation-delay: .04s }
+.stagger > *:nth-child(2) { animation-delay: .10s }
+.stagger > *:nth-child(3) { animation-delay: .16s }
+.stagger > *:nth-child(4) { animation-delay: .22s }
+.stagger > *:nth-child(5) { animation-delay: .28s }
+.stagger > *:nth-child(6) { animation-delay: .34s }
+@keyframes rise { to { opacity: 1; transform: none } }
+
+.label { color: var(--ink-faint); font-size: 11px; letter-spacing: 0.18em;
+         text-transform: uppercase; margin: 24px 2px 10px; }
+
+input {
+  width: 100%; padding: 13px 14px; font: inherit; color: var(--ink);
+  background: var(--bg); border: 1px solid var(--line); border-radius: 9px;
+  letter-spacing: 0.04em;
+}
+input:focus { outline: none; border-color: var(--amber-dim);
+              box-shadow: 0 0 0 3px rgba(255,180,84,0.12); }
+
+button {
+  font: inherit; color: var(--ink); background: var(--panel-2);
+  border: 1px solid var(--line-2); border-radius: 9px; padding: 11px 14px;
+  cursor: pointer; letter-spacing: 0.05em;
+  transition: border-color .15s, background .15s, opacity .15s;
+  -webkit-tap-highlight-color: transparent;
+}
+button:hover:not(:disabled) { border-color: var(--ink-faint); }
+button:active:not(:disabled) { transform: translateY(1px); }
+button:disabled { opacity: 0.35; cursor: default; }
+button.amber { background: var(--amber); color: #1a1206; border-color: var(--amber);
+               font-weight: 700; }
+button.amber:hover:not(:disabled) { filter: brightness(1.08); }
+button.danger { border-color: #4d2422; color: #ffb1ab; background: #160f10; }
+button.danger:hover:not(:disabled) { background: #1d1413; border-color: var(--red); }
+button.block { width: 100%; }
+.hidden { display: none !important; }
+
+/* login */
+#login { margin-top: 13vh; }
+#login .card { background: var(--panel); border: 1px solid var(--line);
+               border-radius: 14px; padding: 26px 22px;
+               box-shadow: 0 30px 80px -40px #000; }
+#login h1 { font-size: 13px; letter-spacing: 0.22em; margin: 0 0 6px; }
+#login p { color: var(--ink-dim); font-size: 12px; margin: 0 0 20px; }
+#login button { margin-top: 14px; }
+.err-line { color: var(--red); font-size: 12px; margin-top: 12px; min-height: 1em; }
+
+@keyframes spin { to { transform: rotate(360deg) } }
+
+/* services */
+.svc { display: flex; align-items: center; gap: 13px;
+       background: var(--panel); border: 1px solid var(--line);
+       border-radius: 12px; padding: 13px 15px; margin-bottom: 9px; }
+.svc .led { width: 10px; height: 10px; border-radius: 50%; flex: none;
+            background: var(--ink-faint); transition: background .25s, box-shadow .25s; }
+.svc[data-led="up"]   .led { background: var(--green); box-shadow: 0 0 9px var(--green); }
+.svc[data-led="down"] .led { background: var(--red);   box-shadow: 0 0 9px var(--red); }
+.svc[data-led="warn"] .led { background: var(--amber); box-shadow: 0 0 9px var(--amber);
+                             animation: pulse 1.1s infinite; }
+.svc .meta { min-width: 0; flex: 1; }
+.svc .name { font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase;
+             font-size: 13px; }
+.svc .sub { color: var(--ink-dim); font-size: 11.5px; margin-top: 2px;
+            white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.svc .acts { display: flex; gap: 6px; flex: none; }
+.svc .acts button { padding: 8px 11px; font-size: 12px; }
+
+/* logs */
+.logs { background: #05070a; border: 1px solid var(--line); border-radius: 12px;
+        overflow: hidden; }
+.logs .bar { display: flex; gap: 8px; align-items: center;
+             padding: 8px; border-bottom: 1px solid var(--line); }
+.seg { display: inline-flex; background: var(--bg); border: 1px solid var(--line);
+       border-radius: 8px; padding: 2px; }
+.seg button { border: none; background: none; padding: 6px 13px; font-size: 12px;
+              border-radius: 6px; color: var(--ink-dim); letter-spacing: 0.04em; }
+.seg button.on { background: var(--panel-2); color: var(--amber); }
+.bar .grow { flex: 1; }
+.bar .ghost { padding: 6px 12px; font-size: 12px; background: none;
+              border-color: var(--line); color: var(--ink-dim); }
+pre#log { margin: 0; padding: 12px 14px; max-height: 44vh; overflow: auto;
+          font-size: 12px; line-height: 1.5; color: #aebccb; white-space: pre-wrap;
+          word-break: break-word; }
+pre#log:empty::before { content: "no output"; color: var(--ink-faint); }
+
+/* danger zone */
+.danger-zone { border: 1px solid #2a1a18;
+               background: linear-gradient(0deg, #0e0a0a, var(--panel));
+               border-radius: 12px; padding: 14px 16px; }
+.danger-zone .hd { color: #ffb1ab; font-size: 11px; letter-spacing: 0.18em;
+                   text-transform: uppercase; margin-bottom: 5px; }
+.danger-zone p { color: var(--ink-dim); font-size: 12px; margin: 0 0 12px; }
+.danger-zone p b { color: #ffb1ab; font-weight: 600; }
+.redeploy { display: flex; gap: 6px; }
+.redeploy button { flex: 1; }
+
+/* toasts — transient operation results */
+#toasts { position: fixed; left: 0; right: 0; bottom: 0; z-index: 5;
+          display: flex; flex-direction: column; align-items: center; gap: 8px;
+          padding: 0 14px calc(14px + env(safe-area-inset-bottom)); pointer-events: none; }
+.toast { pointer-events: auto; width: 100%; max-width: 600px; position: relative;
+         display: flex; align-items: flex-start; gap: 11px; overflow: hidden;
+         background: var(--panel); border: 1px solid var(--line-2);
+         border-radius: 11px; padding: 12px 13px;
+         box-shadow: 0 20px 50px -24px #000;
+         opacity: 0; transform: translateY(12px); transition: opacity .2s, transform .2s; }
+.toast.in { opacity: 1; transform: none; }
+.toast.run { border-color: var(--amber-dim); }
+.toast.ok  { border-color: #1f5a2a; }
+.toast.err { border-color: #4d2422; }
+.toast .tdot { width: 9px; height: 9px; border-radius: 50%; flex: none; margin-top: 4px; }
+.toast.ok  .tdot { background: var(--green); box-shadow: 0 0 8px var(--green); }
+.toast.err .tdot { background: var(--red); box-shadow: 0 0 8px var(--red); }
+.toast.run .tdot { background: none; box-shadow: none; width: 12px; height: 12px;
+                   margin-top: 2px; border: 2px solid var(--amber-dim);
+                   border-top-color: var(--amber); animation: spin .8s linear infinite; }
+.toast .tbody { flex: 1; min-width: 0; }
+.toast .ttitle { font-size: 12.5px; letter-spacing: 0.06em; }
+.toast.run .ttitle { color: var(--amber); }
+.toast.ok  .ttitle { color: var(--green); }
+.toast.err .ttitle { color: #ffb1ab; }
+.toast .tmsg { color: var(--ink-dim); font-size: 11.5px; margin-top: 4px;
+               white-space: pre-wrap; word-break: break-word;
+               max-height: 8em; overflow: auto; }
+.toast .x { flex: none; background: none; border: none; color: var(--ink-faint);
+            font-size: 18px; line-height: 1; padding: 0 2px; cursor: pointer; }
+.toast .x:hover { color: var(--ink); }
+.toast .tbar { position: absolute; left: 0; bottom: 0; height: 2px; width: 100%;
+               background: var(--green); transform-origin: left;
+               animation: drain 5s linear forwards; }
+@keyframes drain { from { transform: scaleX(1) } to { transform: scaleX(0) } }
+
+@media (prefers-reduced-motion: reduce) {
+  .stagger > * { animation: none; opacity: 1; transform: none }
+  .beat.live .dot, .svc[data-led="warn"] .led { animation: none }
+  .toast.run .tdot { animation: none }
+  .toast { transition: none; opacity: 1; transform: none }
+  .toast .tbar { animation: none; display: none }
+}

--- a/waypointctl/src/waypointctl/control_assets/control.html
+++ b/waypointctl/src/waypointctl/control_assets/control.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+<meta name="robots" content="noindex" />
+<meta name="color-scheme" content="dark" />
+<title>WAYPOINT · stack control</title>
+<style>
+/*__CONTROL_CSS__*/
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header>
+    <span class="mark">WAY<b>·</b>POINT</span>
+    <span class="tag">stack&nbsp;control</span>
+    <span class="beat" id="beat"><span class="dot"></span><span id="beatTxt">offline</span></span>
+  </header>
+
+  <section id="login">
+    <div class="card">
+      <h1>AUTHENTICATE</h1>
+      <p>Out-of-band control plane. Enter the Waypoint password.</p>
+      <input id="pw" type="password" autocomplete="current-password"
+             placeholder="WAYPOINT_PASSWORD" />
+      <div class="err-line" id="loginErr" role="alert"></div>
+      <button class="amber block" id="loginBtn">Unlock</button>
+    </div>
+  </section>
+
+  <main id="console" class="hidden stagger">
+    <div class="label">Services</div>
+    <div id="services"></div>
+
+    <div class="label">Logs</div>
+    <div class="logs">
+      <div class="bar">
+        <div class="seg" id="logSeg">
+          <button data-log="backend" class="on">backend</button>
+          <button data-log="frontend">frontend</button>
+        </div>
+        <span class="grow"></span>
+        <button id="logRefresh" class="ghost">refresh</button>
+      </div>
+      <pre id="log"></pre>
+    </div>
+
+    <div class="label">Danger zone</div>
+    <div class="danger-zone">
+      <div class="hd">Redeploy</div>
+      <p>Each restarts the whole stack and interrupts every running session.
+         <b>Stable</b> / <b>Nightly</b> update first (fail safe on a dirty or
+         unmanaged checkout); <b>Current</b> just restarts the checked-out tree.</p>
+      <div class="redeploy">
+        <button class="danger" data-channel="stable">Stable</button>
+        <button class="danger" data-channel="nightly">Nightly</button>
+        <button class="danger" data-channel="current">Current</button>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div id="toasts" aria-live="polite" aria-atomic="false"></div>
+
+<script>
+//__CONTROL_JS__
+</script>
+</body>
+</html>

--- a/waypointctl/src/waypointctl/control_assets/control.js
+++ b/waypointctl/src/waypointctl/control_assets/control.js
@@ -1,0 +1,347 @@
+(function () {
+  var $ = function (id) { return document.getElementById(id); };
+
+  var token = sessionStorage.getItem("wp_token") || null;
+  var curLog = "backend";
+  var statusTimer = null;
+  var statusSeq = 0;          // drops stale/overlapping poll responses
+
+  // The server's `ops` are the single source of truth for what is running and
+  // for results; the client never invents them. Keyed by lane
+  // ("backend" / "frontend" / "all"): backend and frontend are independent, so
+  // each gets its own toast and seen-timestamp; "all" (and redeploy) holds both.
+  //   running  — lanes the latest poll reports running
+  //   pending  — lanes we just fired, awaiting the server's reflection; this
+  //              alone disables buttons so a second click can't race a poll
+  //   seenTs   — last terminal ts already surfaced, so a stale result on the
+  //              daemon at load (or one already shown) never re-pops
+  var running = {};
+  var pending = {};
+  var seenTs = {};
+  var initialized = false;
+  var opEls = {};
+  var opTimers = {};
+
+  function authHeaders(extra) {
+    var h = extra || {};
+    if (token) h["Authorization"] = "Bearer " + token;
+    return h;
+  }
+
+  async function api(path, opts) {
+    opts = opts || {};
+    opts.headers = authHeaders(opts.headers);
+    var res = await fetch(path, opts);
+    if (res.status === 401) { logout(); throw new Error("session expired"); }
+    return res;
+  }
+
+  // ── auth ──
+  async function login() {
+    var pw = $("pw").value;
+    if (!pw) { $("loginErr").textContent = "Enter the password."; return; }
+    $("loginBtn").disabled = true;
+    $("loginErr").textContent = "";
+    try {
+      var res = await fetch("/api/login", {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password: pw }),
+      });
+      var data = await res.json().catch(function () { return {}; });
+      if (res.ok && data.token) {
+        token = data.token; sessionStorage.setItem("wp_token", token);
+        $("pw").value = ""; enterConsole();
+      } else {
+        $("loginErr").textContent = data.error || ("Failed (HTTP " + res.status + ")");
+      }
+    } catch (e) { $("loginErr").textContent = "Request failed."; }
+    finally { $("loginBtn").disabled = false; }
+  }
+
+  function logout() {
+    token = null; sessionStorage.removeItem("wp_token");
+    if (statusTimer) { clearInterval(statusTimer); statusTimer = null; }
+    setBeat(false);
+    $("console").classList.add("hidden");
+    $("login").classList.remove("hidden");
+  }
+
+  function enterConsole() {
+    running = {}; pending = {}; seenTs = {}; initialized = false;
+    for (var k in opEls) clearOp(k);
+    $("login").classList.add("hidden");
+    $("console").classList.remove("hidden");
+    refreshStatus(); loadLog();
+    statusTimer = setInterval(refreshStatus, 3000);
+  }
+
+  // ── connection ──
+  function setBeat(live) {
+    $("beat").classList.toggle("live", live);
+    $("beatTxt").textContent = live ? "live" : "offline";
+  }
+
+  // ── busy lanes (a lane is busy if fired-but-unconfirmed or server-running) ──
+  function active(key) { return !!pending[key] || !!running[key]; }
+  function anyActive() {
+    for (var k in pending) if (pending[k]) return true;
+    for (var k in running) if (running[k]) return true;
+    return false;
+  }
+  function laneBusy(target) {
+    if (active("all")) return true;
+    return target === "all" ? anyActive() : active(target);
+  }
+  function applyBusy() {
+    var allBusy = active("all");
+    for (var name in cards) {
+      var c = cards[name];
+      if (!c.toggle) continue;
+      var d = allBusy || active(name);
+      c.toggle.disabled = d; c.restart.disabled = d;
+    }
+    var rb = document.querySelectorAll(".redeploy button");
+    var anyB = anyActive();           // redeploy needs both lanes free
+    for (var i = 0; i < rb.length; i++) rb[i].disabled = anyB;
+  }
+
+  // ── operation toasts (one per lane, running -> ok/failed in place) ──
+  function showOp(key, kind, label, msg) {
+    if (opTimers[key]) { clearTimeout(opTimers[key]); delete opTimers[key]; }
+    var el = opEls[key];
+    if (!el) {
+      el = document.createElement("div");
+      el.className = "toast";
+      el.innerHTML =
+        '<span class="tdot"></span>' +
+        '<div class="tbody"><div class="ttitle"></div><div class="tmsg"></div></div>' +
+        '<button class="x" aria-label="dismiss">×</button>';
+      el.querySelector(".x").addEventListener("click", function () { clearOp(key); });
+      opEls[key] = el;
+      $("toasts").appendChild(el);
+      requestAnimationFrame(function () { el.classList.add("in"); });
+    }
+    var run = kind === "running";
+    el.classList.remove("run", "ok", "err");
+    el.classList.add(run ? "run" : kind === "ok" ? "ok" : "err");
+    el.querySelector(".ttitle").textContent = label;
+    var m = el.querySelector(".tmsg");
+    m.textContent = msg || "";
+    m.style.display = msg ? "" : "none";
+    el.querySelector(".x").style.display = run ? "none" : "";
+
+    var oldBar = el.querySelector(".tbar");
+    if (oldBar) oldBar.remove();
+    if (kind === "ok") {              // success self-dismisses with a drain bar
+      var bar = document.createElement("span"); bar.className = "tbar";
+      el.appendChild(bar);
+      opTimers[key] = setTimeout(function () { clearOp(key); }, 5000);
+    }
+  }
+
+  function clearOp(key) {
+    if (opTimers[key]) { clearTimeout(opTimers[key]); delete opTimers[key]; }
+    var el = opEls[key];
+    if (!el) return;
+    delete opEls[key];
+    el.classList.remove("in");
+    setTimeout(function () { el.remove(); }, 220);
+  }
+
+  // A one-off toast for a client-side request error (network / 5xx) — same
+  // component, but not tied to a lane's op lifecycle.
+  function errorToast(label, msg) {
+    var el = document.createElement("div");
+    el.className = "toast err";
+    el.innerHTML =
+      '<span class="tdot"></span>' +
+      '<div class="tbody"><div class="ttitle"></div><div class="tmsg"></div></div>' +
+      '<button class="x" aria-label="dismiss">×</button>';
+    el.querySelector(".ttitle").textContent = label;
+    var m = el.querySelector(".tmsg");
+    m.textContent = msg || ""; m.style.display = msg ? "" : "none";
+    function close() { el.classList.remove("in"); setTimeout(function () { el.remove(); }, 220); }
+    el.querySelector(".x").addEventListener("click", close);
+    $("toasts").appendChild(el);
+    requestAnimationFrame(function () { el.classList.add("in"); });
+    setTimeout(close, 6000);
+  }
+
+  // ── service cards (built once, reconciled in place) ──
+  var cards = {};
+
+  function buildCard(name) {
+    var el = document.createElement("div");
+    el.className = "svc";
+    el.setAttribute("data-name", name);
+    el.innerHTML =
+      '<span class="led"></span>' +
+      '<div class="meta"><div class="name"></div><div class="sub"></div></div>';
+    el.querySelector(".name").textContent = name;
+    var subEl = el.querySelector(".sub");
+
+    var card = { el: el, sub: subEl, restart: null, toggle: null };
+    if (name !== "caffeinate") {
+      var acts = document.createElement("div");
+      acts.className = "acts";
+      var restart = document.createElement("button");
+      restart.textContent = "restart";
+      restart.addEventListener("click", function () { doAction("restart", name); });
+      var toggle = document.createElement("button");
+      toggle.addEventListener("click", function () {
+        doAction(toggle.getAttribute("data-act"), name);
+      });
+      acts.appendChild(restart); acts.appendChild(toggle);
+      el.appendChild(acts);
+      card.restart = restart; card.toggle = toggle;
+    }
+    return card;
+  }
+
+  function ledFor(s) {
+    if (s.state !== "running") return "down";
+    if (s.health === "unhealthy") return "warn";
+    return "up";
+  }
+  function subFor(s) {
+    if (s.state !== "running") return s.state;
+    var bits = [];
+    if (s.pid) bits.push("pid " + s.pid);
+    if (s.port) bits.push(":" + s.port);
+    if (s.health) bits.push(s.health);
+    return bits.join("  ·  ");
+  }
+
+  function renderServices(list) {
+    var present = {};
+    for (var i = 0; i < list.length; i++) {
+      var s = list[i];
+      present[s.name] = true;
+      var card = cards[s.name];
+      if (!card) { card = buildCard(s.name); cards[s.name] = card; $("services").appendChild(card.el); }
+      card.el.setAttribute("data-led", ledFor(s));
+      card.sub.textContent = subFor(s);
+      if (card.toggle) {
+        var act = s.state === "running" ? "stop" : "start";
+        card.toggle.setAttribute("data-act", act);
+        card.toggle.textContent = act;
+      }
+    }
+    for (var name in cards) {
+      if (!present[name]) { cards[name].el.remove(); delete cards[name]; }
+    }
+  }
+
+  // ── status poll ──
+  async function refreshStatus() {
+    var seq = ++statusSeq;
+    try {
+      var res = await api("/api/status");
+      var data = await res.json();
+      if (seq !== statusSeq) return;  // a newer poll superseded this one
+      setBeat(true);
+      renderServices(data.services || []);
+      handleOps(data.ops || []);
+      if (anyActive()) loadLog();     // watch the rebuild while an op runs
+      initialized = true;
+    } catch (e) { if (seq === statusSeq) setBeat(false); }
+  }
+
+  function opLabel(op) { return op.action + " · " + op.target; }
+
+  function handleOps(list) {
+    var next = {};
+    for (var i = 0; i < list.length; i++) {
+      var op = list[i];
+      if (op.state === "running") {
+        next[op.key] = true;
+        delete pending[op.key];       // the server now owns this lane's state
+        showOp(op.key, "running", opLabel(op), "");
+      } else if (!initialized) {
+        seenTs[op.key] = op.ts;       // suppress whatever was sitting there at load
+      } else if (op.ts !== seenTs[op.key]) {
+        seenTs[op.key] = op.ts;
+        delete pending[op.key];
+        showOp(op.key, op.state, opLabel(op), op.state === "failed" ? op.message : "");
+      }
+    }
+    running = next;
+    applyBusy();
+  }
+
+  // ── operations ──
+  async function doAction(action, target) {
+    if (laneBusy(target)) return;
+    if (target === "backend" || target === "all") {
+      if (!confirm(action + " " + target + "? This interrupts running sessions."))
+        return;
+    }
+    fire("/api/action", { action: action, target: target }, target);
+  }
+
+  async function redeploy(channel) {
+    if (anyActive()) return;          // redeploy needs both lanes
+    var what = channel === "current"
+      ? "Restart the whole stack from the current checkout?"
+      : "Redeploy " + channel + ": pull and restart the whole stack?";
+    if (!confirm(what + " This interrupts running sessions.")) return;
+    fire("/api/redeploy", { channel: channel }, "all");
+  }
+
+  // Fire only touches `pending` (to disable the lane immediately) and re-syncs;
+  // the toast and running state come solely from the poll, so a rejected or
+  // failed request can never corrupt a genuinely running op.
+  async function fire(path, payload, key) {
+    pending[key] = true; applyBusy();
+    try {
+      var res = await api(path, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (res.status !== 202) {
+        delete pending[key]; applyBusy();
+        if (res.status !== 409) {     // 409 just means a lane is busy; the poll shows it
+          var data = await res.json().catch(function () { return {}; });
+          errorToast("request failed", data.error || ("HTTP " + res.status));
+        }
+      }
+      refreshStatus();
+    } catch (e) { delete pending[key]; applyBusy(); }
+  }
+
+  // ── logs ──
+  async function loadLog() {
+    try {
+      var res = await api("/api/logs?target=" + curLog + "&n=200");
+      var data = await res.json();
+      var pre = $("log");
+      var atBottom = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 24;
+      pre.textContent = (data.lines || []).join("\n");
+      if (atBottom) pre.scrollTop = pre.scrollHeight;
+    } catch (e) {}
+  }
+
+  // ── wiring ──
+  $("loginBtn").addEventListener("click", login);
+  $("pw").addEventListener("keydown", function (e) { if (e.key === "Enter") login(); });
+  $("logRefresh").addEventListener("click", loadLog);
+
+  var chans = document.querySelectorAll("button[data-channel]");
+  for (var r = 0; r < chans.length; r++) {
+    chans[r].addEventListener("click", function () {
+      redeploy(this.getAttribute("data-channel"));
+    });
+  }
+
+  var logBtns = $("logSeg").querySelectorAll("button[data-log]");
+  for (var k = 0; k < logBtns.length; k++) {
+    logBtns[k].addEventListener("click", function () {
+      curLog = this.getAttribute("data-log");
+      for (var m = 0; m < logBtns.length; m++) logBtns[m].classList.remove("on");
+      this.classList.add("on");
+      loadLog();
+    });
+  }
+
+  if (token) enterConsole(); else setBeat(false);
+})();

--- a/waypointctl/tests/test_control.py
+++ b/waypointctl/tests/test_control.py
@@ -201,7 +201,7 @@ def test_status_reports_services(control: tuple[ControlServer, int, str]) -> Non
     assert status == 200
     names = {s["name"] for s in body["services"]}
     assert {"backend", "frontend"} <= names
-    assert body["last_op"] is None
+    assert body["ops"] == []
 
 
 def test_logs_unknown_target_rejected(
@@ -237,7 +237,7 @@ def test_action_invalid_inputs_rejected(
     assert status == 400
 
 
-def test_action_restart_runs_async_and_records_last_op(
+def test_action_restart_runs_async_and_records_op(
     control: tuple[ControlServer, int, str],
 ) -> None:
     server, port, password = control
@@ -253,21 +253,53 @@ def test_action_restart_runs_async_and_records_last_op(
 
     server.join_op(timeout=5)
     status, body = _request(port, "/api/status", token=token)
-    last = body["last_op"]
-    assert last["action"] == "restart" and last["target"] == "frontend"
-    assert last["state"] == "ok"
+    ops = {op["key"]: op for op in body["ops"]}
+    assert ops["frontend"]["action"] == "restart"
+    assert ops["frontend"]["target"] == "frontend" and ops["frontend"]["state"] == "ok"
     assert server.stack.frontend.calls == ["stop", "start"]  # type: ignore[attr-defined]
 
 
-def test_action_conflict_when_op_running(
+def test_same_lane_conflicts_but_other_lane_runs(
     control: tuple[ControlServer, int, str],
 ) -> None:
     server, port, password = control
     token = _login(port, password)
-    # Hold the op lock to simulate an in-flight operation.
-    assert server._op_lock.acquire(blocking=False)
+    # Hold the backend lane to simulate a backend op already in flight.
+    assert server._lane_locks["backend"].acquire(blocking=False)
     try:
-        status, body = _request(
+        # Same lane is refused...
+        status, _ = _request(
+            port,
+            "/api/action",
+            "POST",
+            token=token,
+            body={"action": "restart", "target": "backend"},
+        )
+        assert status == 409
+        # ...while the independent frontend lane still runs.
+        status, _ = _request(
+            port,
+            "/api/action",
+            "POST",
+            token=token,
+            body={"action": "restart", "target": "frontend"},
+        )
+        assert status == 202
+        server.join_op(timeout=5)
+        assert server.stack.frontend.calls == ["stop", "start"]  # type: ignore[attr-defined]
+    finally:
+        server._lane_locks["backend"].release()
+
+
+def test_all_conflicts_with_a_held_lane(
+    control: tuple[ControlServer, int, str],
+) -> None:
+    server, port, password = control
+    token = _login(port, password)
+    # An `all`/redeploy op needs both lanes, so a single held lane blocks it.
+    assert server._lane_locks["frontend"].acquire(blocking=False)
+    try:
+        status, _ = _request(
             port,
             "/api/action",
             "POST",
@@ -275,9 +307,12 @@ def test_action_conflict_when_op_running(
             body={"action": "restart", "target": "all"},
         )
         assert status == 409
-        assert "already running" in body["error"]
+        status, _ = _request(
+            port, "/api/redeploy", "POST", token=token, body={"channel": "current"}
+        )
+        assert status == 409
     finally:
-        server._op_lock.release()
+        server._lane_locks["frontend"].release()
 
 
 # ── redeploy ─────────────────────────────────────────────────────────────
@@ -306,9 +341,9 @@ def test_redeploy_current_restarts_without_git(
 
     server.join_op(timeout=5)
     _, body = _request(port, "/api/status", token=token)
-    last = body["last_op"]
-    assert last["action"] == "redeploy" and last["target"] == "current"
-    assert last["state"] == "ok"
+    ops = {op["key"]: op for op in body["ops"]}
+    assert ops["all"]["action"] == "redeploy" and ops["all"]["target"] == "current"
+    assert ops["all"]["state"] == "ok"
     # `current` restarts the checked-out tree, no git update involved.
     assert server.stack.frontend.calls == ["stop", "start"]  # type: ignore[attr-defined]
 
@@ -326,9 +361,9 @@ def test_redeploy_update_channel_fails_safe_outside_git(
 
     server.join_op(timeout=10)
     _, body = _request(port, "/api/status", token=token)
-    last = body["last_op"]
+    ops = {op["key"]: op for op in body["ops"]}
     # The stub home is not a git checkout, so the update step fails cleanly
     # and the stack is left untouched.
-    assert last["action"] == "redeploy" and last["target"] == channel
-    assert last["state"] == "failed"
+    assert ops["all"]["action"] == "redeploy" and ops["all"]["target"] == channel
+    assert ops["all"]["state"] == "failed"
     assert server.stack.frontend.calls == []  # type: ignore[attr-defined]


### PR DESCRIPTION
## Purpose

The out-of-band control console (shipped in #179) had a broken operation model: its progress/result feedback was a single server-persisted banner that never cleared — undismissable, and it reappeared on reload — and every action serialized behind one global lock, so the frontend and backend couldn't be operated at the same time. This reworks the operation model so feedback is transient and per-target, frontend and backend run concurrently, and the page source is maintainable. The change is entirely within `waypointctl/`.

## Changes

- `waypointctl/src/waypointctl/control.py` — replace the single op lock with per-service lane locks (`backend`, `frontend`); an `all` action or a redeploy holds both lanes, so independent services run concurrently while same-lane and lane-overlapping ops still get `409`. `last_op` becomes per-lane `ops` (keyed by lane), exposed by `GET /api/status`. The page is now assembled from `control_assets/` and inlined at load (`_render_page`).
- `waypointctl/src/waypointctl/control_assets/{control.html,control.css,control.js}` — the console page, extracted from the former Python string blob into real, lintable files inlined into one self-contained document at serve time. The client drives all operation state from the server `ops` (no optimistic toast state to corrupt): one transient toast per lane that morphs running → ok/failed in place and self-dismisses on success; a `pending` flag disables a lane's buttons immediately on click so a same-target action can't be double-fired; and a poll-sequence guard drops stale/overlapping `/api/status` responses.
- `waypointctl/pyproject.toml` — ship `control_assets/*` as package data so the installed wheel can serve the page.
- `waypointctl/tests/test_control.py` — cover the per-lane semantics (same lane → `409`, the other lane still runs; an `all` op blocked by a single held lane) and the keyed `ops` payload.
- `waypointctl/README.md` — document per-lane concurrency and the `ops` status field.

## Design

Operation state lives on the server as `ops` keyed by lane and is the single source of truth; the client renders from it rather than inventing optimistic state, which is what eliminates the stuck, undismissable banner and the toast corruption (a rejected duplicate or request error can no longer flip a genuinely-running op's toast). Lanes are the natural concurrency unit because the only conflict is shared services: `backend` and `frontend` are independent, while `all`/redeploy needs both. Extracting the page into `control_assets/` keeps the served output byte-for-byte a single self-contained document (no static-file route, so it still loads when the app is down) while making the HTML/CSS/JS editable and lintable; they ship as package data and are inlined via sentinel substitution at import.

## Test Plan

- `cd waypointctl && uv run pytest`
- `cd waypointctl && uvx ruff check src/ tests/`, `uvx black --check`, `uvx isort --check-only` (and the pre-commit hook's black/ruff/isort/codespell/mypy on commit)
- `cd waypointctl && uv build --wheel` and confirmed `control_assets/{html,css,js}` are inside the wheel.
- Deployed to the running stack (`uv tool install --reinstall ./waypointctl` + `waypointctl daemon restart`) and verified on a phone: frontend and backend restart concurrently (each with its own toast), a same-target action can't be double-fired, and the operation toast is transient (no stuck popup, nothing stale on reload).

## Test Result

`cd waypointctl && uv run pytest` — 160 passed. ruff/black/isort clean; codespell and mypy clean via the commit hook; the built wheel contains the `control_assets` files. On-device behavior confirmed: concurrent frontend/backend ops, per-target blocking, transient toasts.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run pre-commit and fixed any issues — change is under `waypointctl/`; the commit hook's black/ruff/isort/codespell/mypy passed.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd waypointctl && uv run pytest` — 160 passed).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — not touched.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` — the Next.js frontend is not touched (the console is waypointctl-served HTML).
- [ ] If this is a breaking change, I marked the title and described migration steps above — not a breaking change.
- [x] I have updated documentation or config examples (`waypointctl/README.md`, `pyproject.toml` package data).

</details>