### PR TITLE
feat: add /btw side-questions to the Claude agent

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 import mimetypes
-import shutil
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -932,29 +931,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         sqid: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        session = context.runtime.get_session(session_id)
-        plugin = context.runtime.registry.plugin_for(session)
-        new_session_id = context.runtime._generate_session_id(session.backend)
-        session_dir = context.runtime._session_dir(new_session_id)
-        raw_log = session_dir / "raw.log"
-        structured_log = session_dir / "events.jsonl"
-        for src, dst in [
-            (Path(session.raw_log_path), raw_log),
-            (Path(session.structured_log_path), structured_log),
-        ]:
-            if src.exists():
-                shutil.copy2(src, dst)
-        title = f"{session.title or session.id} (btw)"
-        new_session = await plugin.fork_side_question(
-            context.runtime,
-            session,
-            sqid,
-            new_session_id=new_session_id,
-            title=title,
-            raw_log=raw_log,
-            structured_log=structured_log,
-        )
-        await context.runtime._broadcast_session_list()
+        new_session = await context.runtime.fork_side_question(session_id, sqid)
         return {"session": new_session.model_dump(mode="json")}
 
     @app.delete("/api/sessions/{session_id}/side-questions/{sqid}")

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import mimetypes
+import shutil
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager, suppress
 from pathlib import Path
@@ -925,6 +926,48 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session = await context.runtime.set_effort(session_id, body.effort)
         return {"session": session.model_dump(mode="json")}
 
+    @app.post("/api/sessions/{session_id}/side-questions/{sqid}/fork")
+    async def fork_side_question(
+        session_id: str,
+        sqid: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        session = context.runtime.get_session(session_id)
+        plugin = context.runtime.registry.plugin_for(session)
+        new_session_id = context.runtime._generate_session_id(session.backend)
+        session_dir = context.runtime._session_dir(new_session_id)
+        raw_log = session_dir / "raw.log"
+        structured_log = session_dir / "events.jsonl"
+        for src, dst in [
+            (Path(session.raw_log_path), raw_log),
+            (Path(session.structured_log_path), structured_log),
+        ]:
+            if src.exists():
+                shutil.copy2(src, dst)
+        title = f"{session.title or session.id} (btw)"
+        new_session = await plugin.fork_side_question(
+            context.runtime,
+            session,
+            sqid,
+            new_session_id=new_session_id,
+            title=title,
+            raw_log=raw_log,
+            structured_log=structured_log,
+        )
+        await context.runtime._broadcast_session_list()
+        return {"session": new_session.model_dump(mode="json")}
+
+    @app.delete("/api/sessions/{session_id}/side-questions/{sqid}")
+    async def dismiss_side_question(
+        session_id: str,
+        sqid: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        session = context.runtime.get_session(session_id)
+        plugin = context.runtime.registry.plugin_for(session)
+        await plugin.dismiss_side_question(context.runtime, session, sqid)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
     @app.get("/api/backends/{backend}/models")
     async def list_backend_models(
         backend: str,
@@ -1077,6 +1120,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     payload={"session": session.model_dump(mode="json")},
                 ).model_dump(mode="json")
             )
+            # Hydrate pending side-questions so a fresh-load client sees open cards
+            for sq in session.transport_state.get("pending_side_questions", []):
+                if isinstance(sq, dict):
+                    await websocket.send_json(
+                        SessionEnvelope(
+                            type="side_question",
+                            payload={"side_question": sq},
+                        ).model_dump(mode="json")
+                    )
             while True:
                 message = await queue.get()
                 await websocket.send_json(message)

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1097,13 +1097,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     payload={"session": session.model_dump(mode="json")},
                 ).model_dump(mode="json")
             )
-            # Hydrate pending side-questions so a fresh-load client sees open cards
+            # Hydrate pending side-questions so a fresh-load client sees open
+            # cards. Tag them ``hydrated`` so the client can tell a replay-on-
+            # connect from a live push and avoid auto-expanding old asides.
             for sq in session.transport_state.get("pending_side_questions", []):
                 if isinstance(sq, dict):
                     await websocket.send_json(
                         SessionEnvelope(
                             type="side_question",
-                            payload={"side_question": sq},
+                            payload={"side_question": sq, "hydrated": True},
                         ).model_dump(mode="json")
                     )
             while True:

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -301,6 +301,37 @@ class BackendPlugin(Protocol):
         """
         ...
 
+    async def fork_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        """Promote an open ``/btw`` side-question into a real session.
+
+        Adopts the aside's forked thread as a new managed session (handing off
+        the thread, not deleting it) and drops the side-question record.
+        Backends without side-question support raise ``HTTPException(400)``.
+        """
+        ...
+
+    async def dismiss_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+    ) -> None:
+        """Resolve a ``/btw`` side-question: drop its record, delete its forked
+        thread, and broadcast the removal. Backends without side-question
+        support raise ``HTTPException(400)``.
+        """
+        ...
+
     def setup(self, runtime: "SessionRuntime") -> None:
         """One-shot initialisation hook called from ``SessionRuntime.__init__``.
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import shlex
 import uuid
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -24,6 +25,7 @@ from waypoint.backends.capabilities import (
     BackendCapabilities,
     ModelSource,
 )
+from waypoint.backends.claude_code import side_question as _sq
 from waypoint.backends.claude_code.adapter import ClaudeCliAdapter, ClaudeCliError
 from waypoint.backends.claude_code.commands import (
     CLAUDE_BUILTIN_SLASH_COMMANDS,
@@ -183,6 +185,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         self.adapter: ClaudeCliAdapter | None = None
         self.support: ClaudeSupportBundle | None = None
         self.thread_enumerator: RemoteClaudeThreadEnumerator | None = None
+        self._sq_tasks: dict[str, asyncio.Task[None]] = {}
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
         # Imported lazily to avoid the cycle: transport → adapter →
@@ -233,11 +236,23 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         )
 
     async def shutdown(self, runtime: "SessionRuntime") -> None:
+        for task in list(self._sq_tasks.values()):
+            task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await task
+        self._sq_tasks.clear()
         if self.adapter is not None:
             await self.adapter.shutdown()
             self.adapter = None
         self.support = None
         self.thread_enumerator = None
+
+    async def start_background_tasks(self, runtime: "SessionRuntime") -> None:
+        task = asyncio.create_task(
+            _sq.recover_pending_side_questions(runtime, self),
+            name="claude-sq-recovery",
+        )
+        self._sq_tasks["__recovery__"] = task
 
     def _require_adapter(self) -> ClaudeCliAdapter:
         if self.adapter is None:
@@ -584,11 +599,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         runtime_commands = _session_slash_commands(
             self.adapter, session.id
         ) or _session_transport_slash_commands(session)
-        completions = (
-            []
-            if _commands_include_name(runtime_commands, "status")
-            else _claude_waypoint_completions(prefix)
-        )
+        waypoint_completions = _claude_waypoint_completions(prefix)
+        # /status: drop our version when Claude has it natively; /btw is always ours
+        if _commands_include_name(runtime_commands, "status"):
+            waypoint_completions = [
+                c for c in waypoint_completions if c.name != "status"
+            ]
+        completions = waypoint_completions
         completions.extend(_claude_runtime_slash_completions(runtime_commands, prefix))
         # Curated built-ins as a baseline for sessions with no live slash-command
         # stream (tmux transport), deduped against anything the runtime reported.
@@ -641,6 +658,11 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         request: SessionInputRequest,
     ) -> SessionRecord | None:
         command = _first_slash_command(request.text)
+        if command == "/btw":
+            question = request.text.strip()[len("/btw") :].strip()
+            if question:
+                await _sq.start_side_question(runtime, self, session, question)
+            return runtime.get_session(session.id)
         runtime_commands = _session_slash_commands(
             self.adapter, session.id
         ) or _session_transport_slash_commands(session)
@@ -709,11 +731,15 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         raw_log: Path,
         structured_log: Path,
     ) -> SessionRecord:
-        # T0 placeholder — implemented in the backend-wiring task (W2),
-        # delegating to side_question.fork_aside.
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="side-questions are not yet wired",
+        return await _sq.fork_aside(
+            runtime,
+            self,
+            session,
+            side_question_id,
+            new_session_id=new_session_id,
+            title=title,
+            raw_log=raw_log,
+            structured_log=structured_log,
         )
 
     async def dismiss_side_question(
@@ -722,12 +748,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         session: SessionRecord,
         side_question_id: str,
     ) -> None:
-        # T0 placeholder — implemented in the backend-wiring task (W2),
-        # delegating to side_question.dismiss_aside.
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="side-questions are not yet wired",
-        )
+        await _sq.dismiss_aside(runtime, self, session, side_question_id)
 
     async def answer_question(
         self,
@@ -1398,21 +1419,34 @@ def _claude_effort_swap_message(effort: str | None) -> str:
 
 
 def _claude_waypoint_completions(prefix: str) -> list[CommandCompletion]:
-    command = "/status"
-    if not _slash_prefix_matches(command, prefix):
-        return []
+    specs = [
+        (
+            "/status",
+            "status",
+            "Show Waypoint session status",
+            "claude_code:waypoint:status",
+        ),
+        (
+            "/btw",
+            "btw",
+            "Ask a side-question without interrupting the session",
+            "claude_code:waypoint:btw",
+        ),
+    ]
     return [
         CommandCompletion(
-            id="claude_code:waypoint:status",
+            id=cid,
             trigger="/",
-            replacement="/status ",
-            name="status",
-            description="Show Waypoint session status",
+            replacement=f"{command} ",
+            name=name,
+            description=description,
             kind="command",
             source="waypoint",
             dispatch=CompletionDispatch.PLAIN_TEXT,
-            metadata={"builtin_command": "/status"},
+            metadata={"builtin_command": command},
         )
+        for command, name, description, cid in specs
+        if _slash_prefix_matches(command, prefix)
     ]
 
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -740,9 +740,6 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         adapter = self._require_adapter()
 
         async def _bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
-            # The structured adapter resumes the thread without replaying its
-            # transcript, so seed the new session from the parent's events.
-            runtime.storage.clone_events(session.id, new_session.id)
             await adapter.restore_session(
                 new_session.id,
                 session.cwd,

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -698,6 +698,37 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return runtime.get_session(session.id)
         return None
 
+    async def fork_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        # T0 placeholder — implemented in the backend-wiring task (W2),
+        # delegating to side_question.fork_aside.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are not yet wired",
+        )
+
+    async def dismiss_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+    ) -> None:
+        # T0 placeholder — implemented in the backend-wiring task (W2),
+        # delegating to side_question.dismiss_aside.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are not yet wired",
+        )
+
     async def answer_question(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -257,8 +257,10 @@ class ClaudeCodePlugin(DefaultLaunchContract):
     async def cleanup_side_questions_on_delete(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        if session.transport_state.get("pending_side_questions"):
-            await _sq.delete_session_side_questions(runtime, self, session)
+        # No stale-snapshot guard: the helper re-reads fresh state under the
+        # per-session lock (and returns cheaply when there is nothing to clean),
+        # so a /btw persisted after this snapshot is still cleaned up.
+        await _sq.delete_session_side_questions(runtime, self, session)
 
     def _require_adapter(self) -> ClaudeCliAdapter:
         if self.adapter is None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -737,15 +737,29 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         raw_log: Path,
         structured_log: Path,
     ) -> SessionRecord:
+        adapter = self._require_adapter()
+
+        async def _bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
+            await adapter.restore_session(
+                new_session.id,
+                session.cwd,
+                fork_thread_id,
+                self.launch_factory(runtime, session.launch_target_id),
+                permission_mode=session.permission_mode,
+                model=session.model,
+                effort=session.effort,
+            )
+
         return await _sq.fork_aside(
             runtime,
-            self,
             session,
             side_question_id,
             new_session_id=new_session_id,
+            transport_id=self.transport_id,
             title=title,
             raw_log=raw_log,
             structured_log=structured_log,
+            bring_up=_bring_up,
         )
 
     async def dismiss_side_question(

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -740,6 +740,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         adapter = self._require_adapter()
 
         async def _bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
+            # The structured adapter resumes the thread without replaying its
+            # transcript, so seed the new session from the parent's events.
+            runtime.storage.clone_events(session.id, new_session.id)
             await adapter.restore_session(
                 new_session.id,
                 session.cwd,

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -254,6 +254,12 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         )
         self._sq_tasks["__recovery__"] = task
 
+    async def cleanup_side_questions_on_delete(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        if session.transport_state.get("pending_side_questions"):
+            await _sq.delete_session_side_questions(runtime, self, session)
+
     def _require_adapter(self) -> ClaudeCliAdapter:
         if self.adapter is None:
             raise HTTPException(

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -51,6 +51,7 @@ from waypoint.launch_targets import (
     quote_remote_path,
 )
 from waypoint.schemas import (
+    EventKind,
     SessionEnvelope,
     SessionRecord,
     SessionSource,
@@ -498,13 +499,13 @@ async def claim_fork_thread(
     runtime: "SessionRuntime",
     session: SessionRecord,
     side_question_id: str,
-) -> str:
+) -> SideQuestion:
     """Hand an answered aside's forked thread off to a new owner.
 
     Drops the record **without** deleting ``<E>.jsonl`` (the new session adopts
     it — the one exception to the cleanup invariant) and broadcasts the removal.
-    Returns the forked ``thread_id``. Raises if the id is unknown or the aside
-    has no retained thread yet.
+    Returns the claimed record (its ``fork_thread_id`` is guaranteed set). Raises
+    if the id is unknown or the aside has no retained thread yet.
     """
     async with _lock_for(session.id):
         fresh = runtime.storage.get_session(session.id)
@@ -524,12 +525,11 @@ async def claim_fork_thread(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="side question has no retained thread; wait for an answer first",
             )
-        fork_thread_id = sq.fork_thread_id
         qs = [q for q in qs if q.id != side_question_id]
         _write_side_questions(runtime, session.id, qs)
 
     await _broadcast_remove(runtime, session.id, side_question_id)
-    return fork_thread_id
+    return sq
 
 
 async def fork_aside(
@@ -547,15 +547,18 @@ async def fork_aside(
     """Promote an answered aside into a managed session on ``transport_id``.
 
     Claims the aside's forked thread (see :func:`claim_fork_thread`), persists a
-    new session record that resumes it, then hands the actual launch to
-    ``bring_up`` — the transport-specific step (a structured adapter restore for
-    ``claude_cli``, a resumed tmux pane for ``claude_tty``). ``bring_up`` also
-    owns populating the new session's transcript, since how the aside's Q&A is
-    surfaced differs by transport. Transport-agnostic on purpose: it never
-    touches the structured adapter, so it works for any transport that can resume
-    a thread.
+    new session record that resumes it, seeds the transcript, then hands the
+    launch to ``bring_up`` — the transport-specific step (a structured adapter
+    restore for ``claude_cli``, a resumed tmux pane for ``claude_tty``).
+
+    Transcript seeding is length-independent: the parent's events are bulk-cloned
+    and the aside's question/answer are injected from the (durable) record, rather
+    than re-reading and re-emitting the whole forked thread. Transport-agnostic on
+    purpose — it never touches the structured adapter — so it works for any
+    transport that can resume a thread.
     """
-    fork_thread_id = await claim_fork_thread(runtime, session, side_question_id)
+    sq = await claim_fork_thread(runtime, session, side_question_id)
+    fork_thread_id = sq.fork_thread_id or ""
 
     now = datetime.now(UTC)
     raw_log.touch(exist_ok=True)
@@ -583,6 +586,8 @@ async def fork_aside(
         config_overrides=session.config_overrides,
     )
     runtime.storage.create_session(new_session)
+    runtime.storage.clone_events(session.id, new_session_id)
+    await _ingest_aside_qa(runtime, new_session_id, sq)
 
     try:
         await bring_up(new_session, fork_thread_id)
@@ -594,6 +599,29 @@ async def fork_aside(
         ) from exc
 
     return runtime.get_session(new_session_id)
+
+
+async def _ingest_aside_qa(
+    runtime: "SessionRuntime", session_id: str, sq: SideQuestion
+) -> None:
+    """Append the aside's question and answer to the promoted session.
+
+    The forked thread already holds these turns, but the new session's event DB
+    only carries the cloned parent transcript. Injecting the stored text appends
+    them after the parent without re-reading the thread — O(1) regardless of how
+    long the conversation is.
+    """
+    await runtime._record_user_event(
+        session_id, sq.question, True, status=SessionStatus.IDLE
+    )
+    if sq.answer:
+        await runtime._emit_adapter_event(
+            session_id,
+            EventKind.AGENT_OUTPUT,
+            sq.answer,
+            {"method": "assistant.text"},
+            SessionStatus.IDLE,
+        )
 
 
 async def dismiss_aside(

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -33,14 +33,404 @@ wiring (``/btw`` interception, the runtime-dispatched fork/dismiss methods, and
 scheduling :func:`recover_pending_side_questions` from ``setup``).
 """
 
+import asyncio
+import json
+import logging
+import shlex
+import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from waypoint.schemas import SessionRecord
+from fastapi import HTTPException, status
+
+from waypoint.launch_targets import (
+    SshLaunchTargetConfig,
+    _resolve_local_binary,
+    quote_remote_path,
+)
+from waypoint.schemas import (
+    SessionEnvelope,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+    SideQuestion,
+    SideQuestionStatus,
+)
 
 if TYPE_CHECKING:
     from waypoint.backends.claude_code.plugin import ClaudeCodePlugin
     from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.claude_code.side_question")
+
+MAX_ATTEMPTS = 3
+_ONE_SHOT_TIMEOUT = 120.0
+
+# Per-session asyncio locks for transport_state["pending_side_questions"] mutations.
+_session_locks: dict[str, asyncio.Lock] = {}
+
+# Live background tasks kept in a set to prevent GC before completion.
+_background_tasks: set[asyncio.Task[None]] = set()
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _lock_for(session_id: str) -> asyncio.Lock:
+    lock = _session_locks.get(session_id)
+    if lock is None:
+        lock = asyncio.Lock()
+        _session_locks[session_id] = lock
+    return lock
+
+
+def _read_side_questions(session: SessionRecord) -> list[SideQuestion]:
+    raw = session.transport_state.get("pending_side_questions")
+    if not isinstance(raw, list):
+        return []
+    out: list[SideQuestion] = []
+    for item in raw:
+        if isinstance(item, dict):
+            try:
+                out.append(SideQuestion.model_validate(item))
+            except Exception:  # noqa: BLE001
+                pass
+    return out
+
+
+def _write_side_questions(
+    runtime: "SessionRuntime",
+    session_id: str,
+    questions: list[SideQuestion],
+) -> SessionRecord:
+    session = runtime.storage.get_session(session_id)
+    if session is None:
+        raise KeyError(session_id)
+    state = {
+        **session.transport_state,
+        "pending_side_questions": [q.model_dump(mode="json") for q in questions],
+    }
+    return runtime.storage.update_session(session_id, transport_state=state)
+
+
+async def _broadcast_upsert(
+    runtime: "SessionRuntime",
+    session_id: str,
+    sq: SideQuestion,
+) -> None:
+    await runtime.broadcast.publish(
+        SessionEnvelope(
+            type="side_question",
+            payload={"side_question": sq.model_dump(mode="json")},
+        ),
+        session_id=session_id,
+    )
+
+
+async def _broadcast_remove(
+    runtime: "SessionRuntime",
+    session_id: str,
+    sqid: str,
+) -> None:
+    await runtime.broadcast.publish(
+        SessionEnvelope(
+            type="side_question",
+            payload={"removed_id": sqid},
+        ),
+        session_id=session_id,
+    )
+
+
+def _delete_fork_file_local(fork_thread_id: str) -> None:
+    """Delete ``<fork_thread_id>.jsonl`` from ``~/.claude/projects/``."""
+    projects = Path.home() / ".claude" / "projects"
+    if not projects.is_dir():
+        return
+    for p in projects.glob(f"*/{fork_thread_id}.jsonl"):
+        try:
+            p.unlink(missing_ok=True)
+        except OSError:
+            log.warning("could not delete fork thread file %s", p)
+        return  # UUID is unique; stop after the first match
+
+
+async def _delete_fork_file(
+    fork_thread_id: str,
+    launch_target_id: str | None,
+    runtime: "SessionRuntime",
+) -> None:
+    """Delete the forked thread file locally or via SSH."""
+    if launch_target_id is None:
+        await asyncio.to_thread(_delete_fork_file_local, fork_thread_id)
+        return
+    launch_target = runtime._find_launch_target(launch_target_id)
+    if launch_target is None:
+        return
+    needle = shlex.quote(f"{fork_thread_id}.jsonl")
+    # ssh_capture runs the command in the remote shell; glob and find both work.
+    await launch_target.ssh_capture(
+        f"find $HOME/.claude/projects -maxdepth 2 -name {needle}"
+        f" -exec rm -f {{}} \\; 2>/dev/null || true"
+    )
+
+
+def _parse_one_shot_output(raw: bytes) -> str:
+    """Parse ``--output-format json`` stdout and return the result text."""
+    text = raw.decode("utf-8", errors="replace").strip()
+    try:
+        data: dict = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"claude output is not valid JSON: {text[:200]!r}") from exc
+    if data.get("is_error"):
+        raise RuntimeError(f"claude error: {data.get('subtype', 'unknown')}")
+    result = data.get("result")
+    if not isinstance(result, str):
+        raise RuntimeError(f"claude result missing or not a string: {text[:200]!r}")
+    return result
+
+
+async def _run_one_shot_local(
+    question: str,
+    thread_id: str,
+    fork_id: str,
+    cwd: str,
+) -> str:
+    """Run a one-shot fork-query locally and return the answer text."""
+    binary = shutil.which("claude")
+    if binary is None:
+        raise RuntimeError("claude binary not found on PATH")
+    args = [
+        binary,
+        "-p",
+        question,
+        "--resume",
+        thread_id,
+        "--fork-session",
+        "--session-id",
+        fork_id,
+        "--output-format",
+        "json",
+    ]
+    cwd_path = Path(cwd).expanduser()
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        cwd=str(cwd_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=_ONE_SHOT_TIMEOUT
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise RuntimeError("side-question one-shot timed out") from None
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude exited with rc={proc.returncode}")
+    return _parse_one_shot_output(stdout)
+
+
+async def _run_one_shot_remote(
+    question: str,
+    thread_id: str,
+    fork_id: str,
+    cwd: str,
+    launch_target: SshLaunchTargetConfig,
+    claude_bin: str,
+) -> str:
+    """Run a one-shot fork-query on a remote SSH host and return the answer."""
+    claude_args = [
+        claude_bin,
+        "-p",
+        question,
+        "--resume",
+        thread_id,
+        "--fork-session",
+        "--session-id",
+        fork_id,
+        "--output-format",
+        "json",
+    ]
+    remote_parts = [
+        f"cd {quote_remote_path(cwd)}",
+        "&&",
+        "exec",
+        shlex.join(claude_args),
+    ]
+    remote_cmd = " ".join(remote_parts)
+    wrapped = launch_target.wrap_remote_command(remote_cmd)
+    ssh_args = [
+        _resolve_local_binary(launch_target.ssh_bin),
+        *launch_target.ssh_args,
+        launch_target.ssh_destination,
+        wrapped,
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        *ssh_args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=_ONE_SHOT_TIMEOUT
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.communicate()
+        raise RuntimeError("side-question one-shot timed out (remote)") from None
+    if proc.returncode != 0:
+        raise RuntimeError(f"claude (remote) exited with rc={proc.returncode}")
+    return _parse_one_shot_output(stdout)
+
+
+async def _mark_error(
+    runtime: "SessionRuntime",
+    session_id: str,
+    sqid: str,
+    error_msg: str,
+) -> None:
+    """Update a side-question to ``error`` status and broadcast the change."""
+    updated: SideQuestion | None = None
+    async with _lock_for(session_id):
+        fresh = runtime.storage.get_session(session_id)
+        if fresh is None:
+            return
+        questions = _read_side_questions(fresh)
+        sq = next((q for q in questions if q.id == sqid), None)
+        if sq is None:
+            return
+        updated = sq.model_copy(
+            update={
+                "status": SideQuestionStatus.ERROR,
+                "error": error_msg,
+                "fork_thread_id": None,
+            }
+        )
+        questions = [updated if q.id == sqid else q for q in questions]
+        _write_side_questions(runtime, session_id, questions)
+    if updated is not None:
+        await _broadcast_upsert(runtime, session_id, updated)
+
+
+def _schedule_bg_task(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+    session_id: str,
+    sqid: str,
+) -> None:
+    task = asyncio.create_task(
+        _run_side_question_bg(runtime, plugin, session_id, sqid),
+        name=f"side-question-{sqid}",
+    )
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+
+
+async def _run_side_question_bg(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+    session_id: str,
+    sqid: str,
+) -> None:
+    """Background worker: run the one-shot and update the side-question record."""
+    try:
+        session = runtime.storage.get_session(session_id)
+        if session is None:
+            return
+
+        thread_id = session.transport_state.get("thread_id")
+        if not isinstance(thread_id, str) or not thread_id:
+            await _mark_error(
+                runtime, session_id, sqid, "Session has no conversation thread."
+            )
+            return
+
+        # Read the question from the persisted record.
+        questions_now = _read_side_questions(session)
+        sq_now = next((q for q in questions_now if q.id == sqid), None)
+        if sq_now is None:
+            return  # dismissed before we started
+        question = sq_now.question
+
+        launch_target_id = session.launch_target_id
+        launch_target = (
+            runtime._find_launch_target(launch_target_id) if launch_target_id else None
+        )
+        fork_id = plugin.generate_session_id()
+
+        try:
+            if launch_target is None:
+                answer = await _run_one_shot_local(
+                    question, thread_id, fork_id, session.cwd
+                )
+            else:
+                claude_bin = plugin.remote_executable(launch_target) or "claude"
+                answer = await _run_one_shot_remote(
+                    question,
+                    thread_id,
+                    fork_id,
+                    session.cwd,
+                    launch_target,
+                    claude_bin,
+                )
+        except Exception as exc:  # noqa: BLE001
+            log.warning(
+                "side-question one-shot failed: %s",
+                exc,
+                extra={"session_id": session_id, "sqid": sqid},
+            )
+            # The one-shot may have created <E>.jsonl before failing; clean it up.
+            await _delete_fork_file(fork_id, launch_target_id, runtime)
+            await _mark_error(runtime, session_id, sqid, str(exc))
+            return
+
+        # Persist the answer under the per-session lock.
+        fork_file_to_cleanup: str | None = None
+        updated: SideQuestion | None = None
+
+        async with _lock_for(session_id):
+            fresh = runtime.storage.get_session(session_id)
+            if fresh is None:
+                # Session deleted while running; abandon, clean up the fork file.
+                fork_file_to_cleanup = fork_id
+            else:
+                qs = _read_side_questions(fresh)
+                sq = next((q for q in qs if q.id == sqid), None)
+                if sq is None:
+                    # Dismissed while running; clean up the fork file.
+                    fork_file_to_cleanup = fork_id
+                else:
+                    updated = sq.model_copy(
+                        update={
+                            "status": SideQuestionStatus.ANSWERED,
+                            "answer": answer,
+                            "fork_thread_id": fork_id,
+                        }
+                    )
+                    qs = [updated if q.id == sqid else q for q in qs]
+                    _write_side_questions(runtime, session_id, qs)
+
+        if fork_file_to_cleanup is not None:
+            await _delete_fork_file(fork_file_to_cleanup, launch_target_id, runtime)
+            return
+
+        if updated is not None:
+            await _broadcast_upsert(runtime, session_id, updated)
+
+    except Exception:  # noqa: BLE001
+        log.exception(
+            "side-question bg task crashed",
+            extra={"session_id": session_id, "sqid": sqid},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 async def start_side_question(
@@ -59,7 +449,44 @@ async def start_side_question(
     spawned. Registered against ``plugin`` so the task can be cancelled on
     shutdown.
     """
-    raise NotImplementedError
+    thread_id = session.transport_state.get("thread_id")
+    now = datetime.now(UTC)
+
+    if not isinstance(thread_id, str) or not thread_id:
+        sq = SideQuestion(
+            id=plugin.generate_session_id(),
+            question=question,
+            status=SideQuestionStatus.ERROR,
+            error="Send a message first — there is no conversation to read.",
+            attempts=1,
+            created_at=now,
+        )
+        async with _lock_for(session.id):
+            fresh = runtime.storage.get_session(session.id)
+            if fresh is None:
+                return
+            qs = _read_side_questions(fresh)
+            qs.append(sq)
+            _write_side_questions(runtime, session.id, qs)
+        await _broadcast_upsert(runtime, session.id, sq)
+        return
+
+    sq = SideQuestion(
+        id=plugin.generate_session_id(),
+        question=question,
+        status=SideQuestionStatus.PENDING,
+        attempts=1,
+        created_at=now,
+    )
+    async with _lock_for(session.id):
+        fresh = runtime.storage.get_session(session.id)
+        if fresh is None:
+            return
+        qs = _read_side_questions(fresh)
+        qs.append(sq)
+        _write_side_questions(runtime, session.id, qs)
+    await _broadcast_upsert(runtime, session.id, sq)
+    _schedule_bg_task(runtime, plugin, session.id, sq.id)
 
 
 async def fork_aside(
@@ -79,7 +506,86 @@ async def fork_aside(
     and broadcasts the removal. Raises if the side-question is unknown or has no
     retained thread.
     """
-    raise NotImplementedError
+    if plugin.adapter is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="claude adapter is not initialized",
+        )
+
+    fork_thread_id: str = ""
+
+    async with _lock_for(session.id):
+        fresh = runtime.storage.get_session(session.id)
+        if fresh is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="session not found"
+            )
+        qs = _read_side_questions(fresh)
+        sq = next((q for q in qs if q.id == side_question_id), None)
+        if sq is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="side question not found",
+            )
+        if not sq.fork_thread_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="side question has no retained thread; wait for an answer first",
+            )
+        fork_thread_id = sq.fork_thread_id
+        # Drop the record WITHOUT deleting the thread — the new session owns it.
+        qs = [q for q in qs if q.id != side_question_id]
+        _write_side_questions(runtime, session.id, qs)
+
+    await _broadcast_remove(runtime, session.id, side_question_id)
+
+    # Build the new session record resuming the fork thread directly.
+    now = datetime.now(UTC)
+    raw_log.touch(exist_ok=True)
+    new_session = SessionRecord(
+        id=new_session_id,
+        backend=session.backend,
+        source=SessionSource.MANAGED,
+        transport=plugin.transport_id,
+        title=title,
+        cwd=session.cwd,
+        launch_target_id=session.launch_target_id,
+        repo_name=session.repo_name,
+        branch=session.branch,
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(raw_log),
+        structured_log_path=str(structured_log),
+        transport_state={"thread_id": fork_thread_id},
+        permission_mode=session.permission_mode,
+        model=session.model,
+        effort=session.effort,
+        args=session.args,
+        config_overrides=session.config_overrides,
+    )
+    runtime.storage.create_session(new_session)
+    runtime.storage.clone_events(session.id, new_session_id)
+
+    try:
+        await plugin.adapter.restore_session(
+            new_session_id,
+            session.cwd,
+            fork_thread_id,
+            plugin.launch_factory(runtime, session.launch_target_id),
+            permission_mode=session.permission_mode,
+            model=session.model,
+            effort=session.effort,
+        )
+    except Exception as exc:  # noqa: BLE001
+        runtime.storage.update_session(new_session_id, status=SessionStatus.ERROR)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"failed to restore forked session: {exc}",
+        ) from exc
+
+    return runtime.get_session(new_session_id)
 
 
 async def dismiss_aside(
@@ -90,7 +596,23 @@ async def dismiss_aside(
 ) -> None:
     """Resolve a side-question: drop its record, delete its forked thread, and
     broadcast the removal. No-op if the id is unknown."""
-    raise NotImplementedError
+    fork_thread_id: str | None = None
+
+    async with _lock_for(session.id):
+        fresh = runtime.storage.get_session(session.id)
+        if fresh is None:
+            return
+        qs = _read_side_questions(fresh)
+        sq = next((q for q in qs if q.id == side_question_id), None)
+        if sq is None:
+            return  # no-op
+        fork_thread_id = sq.fork_thread_id
+        qs = [q for q in qs if q.id != side_question_id]
+        _write_side_questions(runtime, session.id, qs)
+
+    if fork_thread_id:
+        await _delete_fork_file(fork_thread_id, session.launch_target_id, runtime)
+    await _broadcast_remove(runtime, session.id, side_question_id)
 
 
 async def recover_pending_side_questions(
@@ -106,4 +628,77 @@ async def recover_pending_side_questions(
     are simply re-broadcast so the overlay reappears. Records on dead/exited
     sessions are cleaned up (thread deleted, record dropped) so nothing leaks.
     """
-    raise NotImplementedError
+    for session in runtime.storage.list_sessions():
+        if session.backend != plugin.id:
+            continue
+        questions = _read_side_questions(session)
+        if not questions:
+            continue
+
+        # Dead/exited sessions: clean up all fork files and drop all records.
+        if session.status in (SessionStatus.EXITED, SessionStatus.ERROR):
+            for sq in questions:
+                if sq.fork_thread_id:
+                    await _delete_fork_file(
+                        sq.fork_thread_id, session.launch_target_id, runtime
+                    )
+            async with _lock_for(session.id):
+                fresh = runtime.storage.get_session(session.id)
+                if fresh is not None:
+                    state = {
+                        **fresh.transport_state,
+                        "pending_side_questions": [],
+                    }
+                    runtime.storage.update_session(session.id, transport_state=state)
+            continue
+
+        for sq in questions:
+            if sq.status == SideQuestionStatus.ANSWERED:
+                # Thread survived the restart; re-broadcast so the overlay reappears.
+                await _broadcast_upsert(runtime, session.id, sq)
+
+            elif sq.status == SideQuestionStatus.PENDING:
+                # The in-flight one-shot was killed by the restart.
+                # Delete the stale fork file (it may be corrupt/incomplete).
+                if sq.fork_thread_id:
+                    await _delete_fork_file(
+                        sq.fork_thread_id, session.launch_target_id, runtime
+                    )
+
+                if sq.attempts >= MAX_ATTEMPTS:
+                    # Attempt cap: mark error, keep record visible for the user to dismiss.
+                    updated = sq.model_copy(
+                        update={
+                            "status": SideQuestionStatus.ERROR,
+                            "error": "Max attempts reached after backend restart.",
+                            "fork_thread_id": None,
+                        }
+                    )
+                    async with _lock_for(session.id):
+                        fresh = runtime.storage.get_session(session.id)
+                        if fresh is None:
+                            continue
+                        qs = _read_side_questions(fresh)
+                        qs = [updated if q.id == sq.id else q for q in qs]
+                        _write_side_questions(runtime, session.id, qs)
+                    await _broadcast_upsert(runtime, session.id, updated)
+                else:
+                    # Re-issue with a fresh fork id and bumped attempt counter.
+                    resumed = sq.model_copy(
+                        update={
+                            "attempts": sq.attempts + 1,
+                            "resumed": True,
+                            "fork_thread_id": None,
+                        }
+                    )
+                    async with _lock_for(session.id):
+                        fresh = runtime.storage.get_session(session.id)
+                        if fresh is None:
+                            continue
+                        qs = _read_side_questions(fresh)
+                        qs = [resumed if q.id == sq.id else q for q in qs]
+                        _write_side_questions(runtime, session.id, qs)
+                    await _broadcast_upsert(runtime, session.id, resumed)
+                    _schedule_bg_task(runtime, plugin, session.id, sq.id)
+
+            # ERROR records: leave as-is; user can dismiss them.

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -355,18 +355,37 @@ async def _run_side_question_bg(
             )
             return
 
-        # Read the question from the persisted record.
-        questions_now = _read_side_questions(session)
-        sq_now = next((q for q in questions_now if q.id == sqid), None)
-        if sq_now is None:
-            return  # dismissed before we started
-        question = sq_now.question
-
         launch_target_id = session.launch_target_id
         launch_target = (
             runtime._find_launch_target(launch_target_id) if launch_target_id else None
         )
         fork_id = plugin.generate_session_id()
+
+        # Read the question and persist the fork id on the record under one lock,
+        # BEFORE launching the one-shot. ``--fork-session`` creates
+        # ``<fork_id>.jsonl`` on disk; recording the id first means a restart
+        # mid-flight can find that orphan via the record so recovery deletes it,
+        # rather than leaking it — the record and its fork file stay
+        # born-and-die-together as the cleanup invariant requires.
+        question: str
+        async with _lock_for(session_id):
+            fresh = runtime.storage.get_session(session_id)
+            if fresh is None:
+                return
+            qs = _read_side_questions(fresh)
+            sq_now = next((q for q in qs if q.id == sqid), None)
+            if sq_now is None or sq_now.status != SideQuestionStatus.PENDING:
+                return  # dismissed or already resolved before we started
+            question = sq_now.question
+            qs = [
+                (
+                    sq_now.model_copy(update={"fork_thread_id": fork_id})
+                    if q.id == sqid
+                    else q
+                )
+                for q in qs
+            ]
+            _write_side_questions(runtime, session_id, qs)
 
         try:
             if launch_target is None:
@@ -520,7 +539,10 @@ async def claim_fork_thread(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="side question not found",
             )
-        if not sq.fork_thread_id:
+        if sq.status != SideQuestionStatus.ANSWERED or not sq.fork_thread_id:
+            # A pending record now also carries a fork id (so a mid-flight restart
+            # can clean it up), so presence of the id is no longer enough — only an
+            # answered aside owns a complete, idle thread that is safe to adopt.
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="side question has no retained thread; wait for an answer first",
@@ -560,45 +582,82 @@ async def fork_aside(
     sq = await claim_fork_thread(runtime, session, side_question_id)
     fork_thread_id = sq.fork_thread_id or ""
 
-    now = datetime.now(UTC)
-    raw_log.touch(exist_ok=True)
-    new_session = SessionRecord(
-        id=new_session_id,
-        backend=session.backend,
-        source=SessionSource.MANAGED,
-        transport=transport_id,
-        title=title,
-        cwd=session.cwd,
-        launch_target_id=session.launch_target_id,
-        repo_name=session.repo_name,
-        branch=session.branch,
-        status=SessionStatus.IDLE,
-        created_at=now,
-        updated_at=now,
-        last_event_at=now,
-        raw_log_path=str(raw_log),
-        structured_log_path=str(structured_log),
-        transport_state={"thread_id": fork_thread_id},
-        permission_mode=session.permission_mode,
-        model=session.model,
-        effort=session.effort,
-        args=session.args,
-        config_overrides=session.config_overrides,
-    )
-    runtime.storage.create_session(new_session)
-    runtime.storage.clone_events(session.id, new_session_id)
-    await _ingest_aside_qa(runtime, new_session_id, sq)
-
+    # Everything after the claim runs under one rollback: record creation, event
+    # cloning, transcript seeding, and launch can each fail, and any failure must
+    # restore the source card and re-home or delete the handed-off fork thread —
+    # never leave the aside swallowed or ``<E>.jsonl`` orphaned.
+    created = False
     try:
+        now = datetime.now(UTC)
+        raw_log.touch(exist_ok=True)
+        new_session = SessionRecord(
+            id=new_session_id,
+            backend=session.backend,
+            source=SessionSource.MANAGED,
+            transport=transport_id,
+            title=title,
+            cwd=session.cwd,
+            launch_target_id=session.launch_target_id,
+            repo_name=session.repo_name,
+            branch=session.branch,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"thread_id": fork_thread_id},
+            permission_mode=session.permission_mode,
+            model=session.model,
+            effort=session.effort,
+            args=session.args,
+            config_overrides=session.config_overrides,
+        )
+        runtime.storage.create_session(new_session)
+        created = True
+        runtime.storage.clone_events(session.id, new_session_id)
+        await _ingest_aside_qa(runtime, new_session_id, sq)
         await bring_up(new_session, fork_thread_id)
     except Exception as exc:  # noqa: BLE001
-        runtime.storage.update_session(new_session_id, status=SessionStatus.ERROR)
+        # ``claim_fork_thread`` only hands the thread off — it never deletes
+        # ``<E>.jsonl`` — so a restored record still owns its fork file. If the
+        # source session vanished mid-promotion, no record can own the fork
+        # again, so delete it to keep the record-and-fork-file invariant.
+        if created:
+            runtime.storage.delete_session(new_session_id)
+        restored = await _restore_claimed_aside(runtime, session.id, sq)
+        if not restored and fork_thread_id:
+            await _delete_fork_file(fork_thread_id, session.launch_target_id, runtime)
+        if isinstance(exc, HTTPException):
+            raise
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"failed to bring up forked session: {exc}",
+            detail=f"failed to promote side question: {exc}",
         ) from exc
 
     return runtime.get_session(new_session_id)
+
+
+async def _restore_claimed_aside(
+    runtime: "SessionRuntime", session_id: str, sq: SideQuestion
+) -> bool:
+    """Re-insert an aside claimed by a fork that then failed to launch, and
+    re-broadcast it so the dismissed card returns.
+
+    Returns ``True`` if the record now lives on the source session (restored, or
+    already re-added), ``False`` if the source session is gone — in which case
+    the caller owns cleaning up the orphaned fork thread."""
+    async with _lock_for(session_id):
+        fresh = runtime.storage.get_session(session_id)
+        if fresh is None:
+            return False
+        qs = _read_side_questions(fresh)
+        if any(q.id == sq.id for q in qs):
+            return True
+        qs.append(sq)
+        _write_side_questions(runtime, session_id, qs)
+    await _broadcast_upsert(runtime, session_id, sq)
+    return True
 
 
 async def _ingest_aside_qa(
@@ -654,8 +713,15 @@ async def dismiss_aside(
 async def recover_pending_side_questions(
     runtime: "SessionRuntime",
     plugin: "ClaudeCodePlugin",
+    *,
+    backend_ids: set[str] | None = None,
 ) -> None:
     """Post-restart sweep over every Claude-agent session's pending records.
+
+    Sweeps sessions whose ``backend`` is in ``backend_ids`` (default: just
+    ``plugin.id``). The legacy ``claude_tty`` alias backend drives the same
+    one-shot mechanism, so it schedules this with ``backend_ids={"claude_tty"}``
+    to cover its own rows — which ``plugin.id``-only filtering would skip.
 
     ``pending`` records had their one-shot killed by the restart: delete the
     orphaned ``<E>``, re-issue with a fresh ``<E>`` (bump ``attempts``; on cap,
@@ -664,8 +730,9 @@ async def recover_pending_side_questions(
     are simply re-broadcast so the overlay reappears. Records on dead/exited
     sessions are cleaned up (thread deleted, record dropped) so nothing leaks.
     """
+    target_ids = backend_ids if backend_ids is not None else {plugin.id}
     for session in runtime.storage.list_sessions():
-        if session.backend != plugin.id:
+        if session.backend not in target_ids:
             continue
         questions = _read_side_questions(session)
         if not questions:
@@ -766,22 +833,21 @@ async def delete_session_side_questions(
 ) -> None:
     """Clean up all side-question fork files when a session is being deleted.
 
-    Reads fork ids from the passed ``session`` snapshot (storage may already be
-    gone by the time this is called). Clears ``pending_side_questions`` from
-    storage if the row is still present, then deletes every ``<E>.jsonl`` fork
-    file.  Called from ``plugin.on_session_deleted`` before the session row is
-    removed.
+    Reads fork ids under the per-session lock, preferring the **fresh** storage
+    state so a fork-promotion that concurrently claimed an aside (and now owns
+    its ``<E>.jsonl``) is honored — its fork file is not deleted out from under
+    the promoted session. Falls back to the passed ``session`` snapshot only when
+    the storage row is already gone. Clears ``pending_side_questions`` and then
+    deletes every retained ``<E>.jsonl``. Runs before the session row is removed
+    (see ``SessionRuntime.delete``).
     """
-    questions = _read_side_questions(session)
-    if not questions:
-        return
-
-    # Collect fork ids from the passed snapshot before touching storage so we
-    # can clean up files even if the storage row is already gone.
-    fork_ids = [sq.fork_thread_id for sq in questions if sq.fork_thread_id]
-
     async with _lock_for(session.id):
         fresh = runtime.storage.get_session(session.id)
+        source = fresh if fresh is not None else session
+        questions = _read_side_questions(source)
+        if not questions:
+            return
+        fork_ids = [sq.fork_thread_id for sq in questions if sq.fork_thread_id]
         if fresh is not None:
             state = {**fresh.transport_state, "pending_side_questions": []}
             runtime.storage.update_session(session.id, transport_state=state)

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -547,11 +547,13 @@ async def fork_aside(
     """Promote an answered aside into a managed session on ``transport_id``.
 
     Claims the aside's forked thread (see :func:`claim_fork_thread`), persists a
-    new session record that resumes it, clones the parent transcript, then hands
-    the actual launch to ``bring_up`` — the transport-specific step (a structured
-    adapter restore for ``claude_cli``, a resumed tmux pane for ``claude_tty``).
-    Transport-agnostic on purpose: it never touches the structured adapter, so it
-    works for any transport that can resume a thread.
+    new session record that resumes it, then hands the actual launch to
+    ``bring_up`` — the transport-specific step (a structured adapter restore for
+    ``claude_cli``, a resumed tmux pane for ``claude_tty``). ``bring_up`` also
+    owns populating the new session's transcript, since how the aside's Q&A is
+    surfaced differs by transport. Transport-agnostic on purpose: it never
+    touches the structured adapter, so it works for any transport that can resume
+    a thread.
     """
     fork_thread_id = await claim_fork_thread(runtime, session, side_question_id)
 
@@ -581,7 +583,6 @@ async def fork_aside(
         config_overrides=session.config_overrides,
     )
     runtime.storage.create_session(new_session)
-    runtime.storage.clone_events(session.id, new_session_id)
 
     try:
         await bring_up(new_session, fork_thread_id)

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -38,6 +38,7 @@ import json
 import logging
 import shlex
 import shutil
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -493,31 +494,18 @@ async def start_side_question(
     _schedule_bg_task(runtime, plugin, session.id, sq.id)
 
 
-async def fork_aside(
+async def claim_fork_thread(
     runtime: "SessionRuntime",
-    plugin: "ClaudeCodePlugin",
     session: SessionRecord,
     side_question_id: str,
-    *,
-    new_session_id: str,
-    title: str,
-    raw_log: Path,
-    structured_log: Path,
-) -> SessionRecord:
-    """Adopt the aside's forked thread as a new managed Claude session.
+) -> str:
+    """Hand an answered aside's forked thread off to a new owner.
 
-    Hands off ``fork_thread_id`` (does **not** delete it), drops the record,
-    and broadcasts the removal. Raises if the side-question is unknown or has no
-    retained thread.
+    Drops the record **without** deleting ``<E>.jsonl`` (the new session adopts
+    it — the one exception to the cleanup invariant) and broadcasts the removal.
+    Returns the forked ``thread_id``. Raises if the id is unknown or the aside
+    has no retained thread yet.
     """
-    if plugin.adapter is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="claude adapter is not initialized",
-        )
-
-    fork_thread_id: str = ""
-
     async with _lock_for(session.id):
         fresh = runtime.storage.get_session(session.id)
         if fresh is None:
@@ -537,20 +525,43 @@ async def fork_aside(
                 detail="side question has no retained thread; wait for an answer first",
             )
         fork_thread_id = sq.fork_thread_id
-        # Drop the record WITHOUT deleting the thread — the new session owns it.
         qs = [q for q in qs if q.id != side_question_id]
         _write_side_questions(runtime, session.id, qs)
 
     await _broadcast_remove(runtime, session.id, side_question_id)
+    return fork_thread_id
 
-    # Build the new session record resuming the fork thread directly.
+
+async def fork_aside(
+    runtime: "SessionRuntime",
+    session: SessionRecord,
+    side_question_id: str,
+    *,
+    new_session_id: str,
+    transport_id: str,
+    title: str,
+    raw_log: Path,
+    structured_log: Path,
+    bring_up: Callable[[SessionRecord, str], Awaitable[None]],
+) -> SessionRecord:
+    """Promote an answered aside into a managed session on ``transport_id``.
+
+    Claims the aside's forked thread (see :func:`claim_fork_thread`), persists a
+    new session record that resumes it, clones the parent transcript, then hands
+    the actual launch to ``bring_up`` — the transport-specific step (a structured
+    adapter restore for ``claude_cli``, a resumed tmux pane for ``claude_tty``).
+    Transport-agnostic on purpose: it never touches the structured adapter, so it
+    works for any transport that can resume a thread.
+    """
+    fork_thread_id = await claim_fork_thread(runtime, session, side_question_id)
+
     now = datetime.now(UTC)
     raw_log.touch(exist_ok=True)
     new_session = SessionRecord(
         id=new_session_id,
         backend=session.backend,
         source=SessionSource.MANAGED,
-        transport=plugin.transport_id,
+        transport=transport_id,
         title=title,
         cwd=session.cwd,
         launch_target_id=session.launch_target_id,
@@ -573,20 +584,12 @@ async def fork_aside(
     runtime.storage.clone_events(session.id, new_session_id)
 
     try:
-        await plugin.adapter.restore_session(
-            new_session_id,
-            session.cwd,
-            fork_thread_id,
-            plugin.launch_factory(runtime, session.launch_target_id),
-            permission_mode=session.permission_mode,
-            model=session.model,
-            effort=session.effort,
-        )
+        await bring_up(new_session, fork_thread_id)
     except Exception as exc:  # noqa: BLE001
         runtime.storage.update_session(new_session_id, status=SessionStatus.ERROR)
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"failed to restore forked session: {exc}",
+            detail=f"failed to bring up forked session: {exc}",
         ) from exc
 
     return runtime.get_session(new_session_id)

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -213,6 +213,8 @@ async def _run_one_shot_local(
         fork_id,
         "--output-format",
         "json",
+        "--tools",
+        "",
     ]
     cwd_path = Path(cwd).expanduser()
     proc = await asyncio.create_subprocess_exec(
@@ -254,6 +256,8 @@ async def _run_one_shot_remote(
         fork_id,
         "--output-format",
         "json",
+        "--tools",
+        "",
     ]
     remote_parts = [
         f"cd {quote_remote_path(cwd)}",
@@ -654,51 +658,101 @@ async def recover_pending_side_questions(
 
         for sq in questions:
             if sq.status == SideQuestionStatus.ANSWERED:
-                # Thread survived the restart; re-broadcast so the overlay reappears.
-                await _broadcast_upsert(runtime, session.id, sq)
+                # Thread survived the restart.  Re-read under lock to get the
+                # current state before broadcasting (dismiss may have raced us).
+                sq_current: SideQuestion | None = None
+                async with _lock_for(session.id):
+                    fresh = runtime.storage.get_session(session.id)
+                    if fresh is None:
+                        continue
+                    qs_fresh = _read_side_questions(fresh)
+                    sq_current = next((q for q in qs_fresh if q.id == sq.id), None)
+                if (
+                    sq_current is not None
+                    and sq_current.status == SideQuestionStatus.ANSWERED
+                ):
+                    await _broadcast_upsert(runtime, session.id, sq_current)
 
             elif sq.status == SideQuestionStatus.PENDING:
-                # The in-flight one-shot was killed by the restart.
-                # Delete the stale fork file (it may be corrupt/incomplete).
-                if sq.fork_thread_id:
-                    await _delete_fork_file(
-                        sq.fork_thread_id, session.launch_target_id, runtime
-                    )
+                # Re-read the record list FRESH inside the lock so a completion
+                # that landed during recovery (between the stale snapshot and
+                # the lock) is never clobbered and its fork file never orphaned.
+                stale_fork_id: str | None = None
+                to_broadcast: SideQuestion | None = None
+                schedule_task = False
 
-                if sq.attempts >= MAX_ATTEMPTS:
-                    # Attempt cap: mark error, keep record visible for the user to dismiss.
-                    updated = sq.model_copy(
-                        update={
-                            "status": SideQuestionStatus.ERROR,
-                            "error": "Max attempts reached after backend restart.",
-                            "fork_thread_id": None,
-                        }
+                async with _lock_for(session.id):
+                    fresh = runtime.storage.get_session(session.id)
+                    if fresh is None:
+                        continue
+                    qs_fresh = _read_side_questions(fresh)
+                    sq_fresh = next((q for q in qs_fresh if q.id == sq.id), None)
+                    if (
+                        sq_fresh is None
+                        or sq_fresh.status != SideQuestionStatus.PENDING
+                    ):
+                        # Completed or dismissed while we were iterating — leave it alone.
+                        continue
+                    stale_fork_id = sq_fresh.fork_thread_id
+                    if sq_fresh.attempts >= MAX_ATTEMPTS:
+                        to_broadcast = sq_fresh.model_copy(
+                            update={
+                                "status": SideQuestionStatus.ERROR,
+                                "error": "Max attempts reached after backend restart.",
+                                "fork_thread_id": None,
+                            }
+                        )
+                    else:
+                        to_broadcast = sq_fresh.model_copy(
+                            update={
+                                "attempts": sq_fresh.attempts + 1,
+                                "resumed": True,
+                                "fork_thread_id": None,
+                            }
+                        )
+                        schedule_task = True
+                    qs_fresh = [to_broadcast if q.id == sq.id else q for q in qs_fresh]
+                    _write_side_questions(runtime, session.id, qs_fresh)
+
+                # Async I/O and task scheduling outside the lock.
+                if stale_fork_id:
+                    await _delete_fork_file(
+                        stale_fork_id, session.launch_target_id, runtime
                     )
-                    async with _lock_for(session.id):
-                        fresh = runtime.storage.get_session(session.id)
-                        if fresh is None:
-                            continue
-                        qs = _read_side_questions(fresh)
-                        qs = [updated if q.id == sq.id else q for q in qs]
-                        _write_side_questions(runtime, session.id, qs)
-                    await _broadcast_upsert(runtime, session.id, updated)
-                else:
-                    # Re-issue with a fresh fork id and bumped attempt counter.
-                    resumed = sq.model_copy(
-                        update={
-                            "attempts": sq.attempts + 1,
-                            "resumed": True,
-                            "fork_thread_id": None,
-                        }
-                    )
-                    async with _lock_for(session.id):
-                        fresh = runtime.storage.get_session(session.id)
-                        if fresh is None:
-                            continue
-                        qs = _read_side_questions(fresh)
-                        qs = [resumed if q.id == sq.id else q for q in qs]
-                        _write_side_questions(runtime, session.id, qs)
-                    await _broadcast_upsert(runtime, session.id, resumed)
+                if to_broadcast is not None:
+                    await _broadcast_upsert(runtime, session.id, to_broadcast)
+                if schedule_task:
                     _schedule_bg_task(runtime, plugin, session.id, sq.id)
 
             # ERROR records: leave as-is; user can dismiss them.
+
+
+async def delete_session_side_questions(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+    session: SessionRecord,
+) -> None:
+    """Clean up all side-question fork files when a session is being deleted.
+
+    Reads fork ids from the passed ``session`` snapshot (storage may already be
+    gone by the time this is called). Clears ``pending_side_questions`` from
+    storage if the row is still present, then deletes every ``<E>.jsonl`` fork
+    file.  Called from ``plugin.on_session_deleted`` before the session row is
+    removed.
+    """
+    questions = _read_side_questions(session)
+    if not questions:
+        return
+
+    # Collect fork ids from the passed snapshot before touching storage so we
+    # can clean up files even if the storage row is already gone.
+    fork_ids = [sq.fork_thread_id for sq in questions if sq.fork_thread_id]
+
+    async with _lock_for(session.id):
+        fresh = runtime.storage.get_session(session.id)
+        if fresh is not None:
+            state = {**fresh.transport_state, "pending_side_questions": []}
+            runtime.storage.update_session(session.id, transport_state=state)
+
+    for fork_thread_id in fork_ids:
+        await _delete_fork_file(fork_thread_id, session.launch_target_id, runtime)

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -1,0 +1,109 @@
+"""Ephemeral, read-only ``/btw`` side-questions for the Claude agent.
+
+A side-question is answered from the current conversation with **no tools**, is
+**never written to the transcript**, runs **non-blocking** beside any in-flight
+turn, is **session-scoped**, and **survives a backend restart while pending**.
+It leaves **no native Claude thread behind** once resolved.
+
+Mechanism (swappable behind this module's public functions): a one-shot
+``claude -p "<question>" --resume <thread> --fork-session --session-id <E>
+--output-format json`` with tools disabled. ``--fork-session`` copies the live
+thread into ``<E>.jsonl`` and never mutates the original. The forked thread is
+retained while the aside's card is open (so it can be promoted into a real
+session) and deleted the moment its record leaves the session.
+
+Cleanup invariant — the load-bearing guarantee:
+    A durable record (an entry in
+    ``SessionRecord.transport_state["pending_side_questions"]``) and its forked
+    thread ``<E>.jsonl`` are born and die together. ``<E>.jsonl`` is deleted
+    **iff** its record leaves ``pending_side_questions`` *without being adopted
+    by a fork* — i.e. on dismiss, fork-handoff is the one exception (the new
+    session owns the thread), session-delete, a restart re-issue (the stale
+    ``<E>``), or attempt-cap failure. Deletion targets the exact, globally
+    unique ``<E>.jsonl`` filename, so it can never touch another session's fork.
+
+Concurrency: every read-modify-write of ``pending_side_questions`` runs under a
+per-session lock, reading the record list **fresh inside the lock**, so
+simultaneous asks, a completion landing during the recovery sweep, or two client
+windows can never clobber the list. Records are keyed by side-question id;
+different sessions and different ids are fully independent.
+
+This module owns the mechanism and the durable state; ``plugin.py`` owns the
+wiring (``/btw`` interception, the runtime-dispatched fork/dismiss methods, and
+scheduling :func:`recover_pending_side_questions` from ``setup``).
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from waypoint.schemas import SessionRecord
+
+if TYPE_CHECKING:
+    from waypoint.backends.claude_code.plugin import ClaudeCodePlugin
+    from waypoint.runtime import SessionRuntime
+
+
+async def start_side_question(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+    session: SessionRecord,
+    question: str,
+) -> None:
+    """Begin a side-question: persist a ``pending`` record, broadcast it, and
+    launch the background fork-query.
+
+    Non-blocking — returns once the record is persisted and the task is
+    scheduled; the answer is delivered later via the ``side_question``
+    broadcast. On an empty conversation (nothing to read) the record resolves
+    straight to ``error`` with a "send a message first" note and no fork is
+    spawned. Registered against ``plugin`` so the task can be cancelled on
+    shutdown.
+    """
+    raise NotImplementedError
+
+
+async def fork_aside(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+    session: SessionRecord,
+    side_question_id: str,
+    *,
+    new_session_id: str,
+    title: str,
+    raw_log: Path,
+    structured_log: Path,
+) -> SessionRecord:
+    """Adopt the aside's forked thread as a new managed Claude session.
+
+    Hands off ``fork_thread_id`` (does **not** delete it), drops the record,
+    and broadcasts the removal. Raises if the side-question is unknown or has no
+    retained thread.
+    """
+    raise NotImplementedError
+
+
+async def dismiss_aside(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+    session: SessionRecord,
+    side_question_id: str,
+) -> None:
+    """Resolve a side-question: drop its record, delete its forked thread, and
+    broadcast the removal. No-op if the id is unknown."""
+    raise NotImplementedError
+
+
+async def recover_pending_side_questions(
+    runtime: "SessionRuntime",
+    plugin: "ClaudeCodePlugin",
+) -> None:
+    """Post-restart sweep over every Claude-agent session's pending records.
+
+    ``pending`` records had their one-shot killed by the restart: delete the
+    orphaned ``<E>``, re-issue with a fresh ``<E>`` (bump ``attempts``; on cap,
+    mark ``error`` and drop), set ``resumed=True``, and re-broadcast.
+    ``answered`` records keep their on-disk thread (it survived the restart) and
+    are simply re-broadcast so the overlay reappears. Records on dead/exited
+    sessions are cleaned up (thread deleted, record dropped) so nothing leaks.
+    """
+    raise NotImplementedError

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -177,6 +177,14 @@ class ClaudeTtyPlugin:
     def setup(self, runtime: "SessionRuntime") -> None:
         return None
 
+    async def start_background_tasks(self, runtime: "SessionRuntime") -> None:
+        # claude_code's recovery sweep only covers its own backend id, so legacy
+        # backend=claude_tty rows (this alias) would be skipped. Recover ours via
+        # the shared Claude one-shot machinery, scoped to this backend id.
+        await _sq.recover_pending_side_questions(
+            runtime, self._claude, backend_ids={self.id}
+        )
+
     async def shutdown(self, runtime: "SessionRuntime") -> None:
         return None
 
@@ -930,8 +938,10 @@ class ClaudeTtyPlugin:
     async def cleanup_side_questions_on_delete(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:
-        if session.transport_state.get("pending_side_questions"):
-            await _sq.delete_session_side_questions(runtime, self._claude, session)
+        # No stale-snapshot guard: the helper re-reads fresh state under the
+        # per-session lock (and returns cheaply when there is nothing to clean),
+        # so a /btw persisted after this snapshot is still cleaned up.
+        await _sq.delete_session_side_questions(runtime, self._claude, session)
 
     async def fork_side_question(
         self,
@@ -999,32 +1009,41 @@ class ClaudeTtyPlugin:
         target = await runtime.tmux.start_managed_session(
             new_session.id, new_session.cwd, command
         )
-        await runtime.tmux.pipe_output(target.pane, raw_log)
-        with suppress(TmuxError):
-            await runtime.tmux.resize_window(target.session, 120, 50)
-        runtime.storage.update_session(
-            new_session.id,
-            transport_state={
-                "tmux_session": target.session,
-                "tmux_window": target.window,
-                "tmux_pane": target.pane,
-                "pid": target.pane_pid,
-                "thread_id": thread_id,
-                "launch_args": launch_args,
-            },
-            status=SessionStatus.STARTING,
-        )
-        await runtime._record_system_event(
-            new_session.id,
-            f"Promoted side question to a session (resumed thread {thread_id})",
-            status=SessionStatus.IDLE,
-        )
-        # The transcript (parent + aside Q&A) is already seeded in the event DB by
-        # fork_aside, so tail from the end and only pick up turns added from here.
-        self._start_tailer(
-            runtime, new_session.id, thread_id, new_session.cwd, start_at_end=True
-        )
-        self._spawn_rate_limit_watcher(runtime, new_session)
+        # Once the pane (a live `claude --resume`) exists, any later failure must
+        # kill it before re-raising — otherwise fork_aside's rollback restores the
+        # source aside while an unmanaged process still holds the same fork thread.
+        try:
+            await runtime.tmux.pipe_output(target.pane, raw_log)
+            with suppress(TmuxError):
+                await runtime.tmux.resize_window(target.session, 120, 50)
+            runtime.storage.update_session(
+                new_session.id,
+                transport_state={
+                    "tmux_session": target.session,
+                    "tmux_window": target.window,
+                    "tmux_pane": target.pane,
+                    "pid": target.pane_pid,
+                    "thread_id": thread_id,
+                    "launch_args": launch_args,
+                },
+                status=SessionStatus.STARTING,
+            )
+            await runtime._record_system_event(
+                new_session.id,
+                f"Promoted side question to a session (resumed thread {thread_id})",
+                status=SessionStatus.IDLE,
+            )
+            # The transcript (parent + aside Q&A) is already seeded in the event
+            # DB by fork_aside, so tail from the end and only pick up turns added
+            # from here.
+            self._start_tailer(
+                runtime, new_session.id, thread_id, new_session.cwd, start_at_end=True
+            )
+            self._spawn_rate_limit_watcher(runtime, new_session)
+        except Exception:
+            with suppress(TmuxError):
+                await runtime.tmux.kill_session(target.session)
+            raise
 
     async def dismiss_side_question(
         self,

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -927,6 +927,12 @@ class ClaudeTtyPlugin:
 
     # ── AskUserQuestion ──────────────────────────────────────────────────────
 
+    async def cleanup_side_questions_on_delete(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        if session.transport_state.get("pending_side_questions"):
+            await _sq.delete_session_side_questions(runtime, self._claude, session)
+
     async def fork_side_question(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1019,10 +1019,11 @@ class ClaudeTtyPlugin:
             f"Promoted side question to a session (resumed thread {thread_id})",
             status=SessionStatus.IDLE,
         )
-        # The resumed thread's transcript is already cloned into the event DB, so
-        # tail from the end to avoid replaying it.
+        # The forked thread file already holds the whole conversation up to and
+        # including the aside's Q&A, and none of it is in this new session's
+        # event DB yet, so tail from byte 0 to ingest the full transcript.
         self._start_tailer(
-            runtime, new_session.id, thread_id, new_session.cwd, start_at_end=True
+            runtime, new_session.id, thread_id, new_session.cwd, start_at_end=False
         )
         self._spawn_rate_limit_watcher(runtime, new_session)
 

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -35,6 +35,7 @@ from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
+from waypoint.backends.claude_code import side_question as _sq
 from waypoint.backends.claude_code.commands import list_claude_command_completions
 from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
@@ -62,6 +63,7 @@ from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
     BackendModelOption,
     CommandCompletion,
+    CompletionDispatch,
     EventKind,
     SessionCreateRequest,
     SessionRateLimitUsage,
@@ -211,6 +213,12 @@ class ClaudeTtyPlugin:
     async def maybe_handle_input(
         self, runtime: "SessionRuntime", session: SessionRecord, request: Any
     ) -> SessionRecord | None:
+        text = request.text.strip()
+        if text == "/btw" or text.startswith("/btw "):
+            question = text[len("/btw") :].strip()
+            if question:
+                await _sq.start_side_question(runtime, self._claude, session, question)
+            return runtime.get_session(session.id)
         return None
 
     async def approve_plan(
@@ -322,6 +330,24 @@ class ClaudeTtyPlugin:
         completions = static_slash_completions(
             self.id, self.capabilities, prefix=prefix
         )
+        # /btw is a Waypoint-owned command; always add it
+        norm_prefix = (
+            prefix if prefix.startswith("/") else f"/{prefix}" if prefix else "/"
+        )
+        if "/btw".startswith(norm_prefix) or norm_prefix == "/":
+            completions.append(
+                CommandCompletion(
+                    id="claude_tty:waypoint:btw",
+                    trigger="/",
+                    replacement="/btw ",
+                    name="btw",
+                    description="Ask a side-question without interrupting the session",
+                    kind="command",
+                    source="waypoint",
+                    dispatch=CompletionDispatch.PLAIN_TEXT,
+                    metadata={"builtin_command": "/btw"},
+                )
+            )
         # Custom commands and skills come from the same on-disk discovery
         # claude_code uses; both wrap the ``claude`` binary in the same cwd.
         launch_target = (
@@ -912,11 +938,15 @@ class ClaudeTtyPlugin:
         raw_log: Path,
         structured_log: Path,
     ) -> SessionRecord:
-        # T0 placeholder — implemented in the backend-wiring task (W2),
-        # delegating to self._claude / side_question.fork_aside.
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="side-questions are not yet wired",
+        return await _sq.fork_aside(
+            runtime,
+            self._claude,
+            session,
+            side_question_id,
+            new_session_id=new_session_id,
+            title=title,
+            raw_log=raw_log,
+            structured_log=structured_log,
         )
 
     async def dismiss_side_question(
@@ -925,12 +955,7 @@ class ClaudeTtyPlugin:
         session: SessionRecord,
         side_question_id: str,
     ) -> None:
-        # T0 placeholder — implemented in the backend-wiring task (W2),
-        # delegating to self._claude / side_question.dismiss_aside.
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="side-questions are not yet wired",
-        )
+        await _sq.dismiss_aside(runtime, self._claude, session, side_question_id)
 
     async def answer_question(
         self,

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -944,16 +944,87 @@ class ClaudeTtyPlugin:
         raw_log: Path,
         structured_log: Path,
     ) -> SessionRecord:
+        async def _bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
+            await self._launch_resumed_pane(
+                runtime, session, new_session, fork_thread_id
+            )
+
         return await _sq.fork_aside(
             runtime,
-            self._claude,
             session,
             side_question_id,
             new_session_id=new_session_id,
+            transport_id=self.transport_id,
             title=title,
             raw_log=raw_log,
             structured_log=structured_log,
+            bring_up=_bring_up,
         )
+
+    async def _launch_resumed_pane(
+        self,
+        runtime: "SessionRuntime",
+        parent: SessionRecord,
+        new_session: SessionRecord,
+        thread_id: str,
+    ) -> None:
+        """Bring up a managed tmux pane resuming ``thread_id`` for a forked aside.
+
+        The aside already forked a self-contained thread off the parent, so we
+        resume it directly (no second ``--fork-session``); the new session owns
+        it. Launch flags are inherited from ``parent`` so model/permission carry
+        over, mirroring :meth:`fork_session` minus the re-fork.
+        """
+        launch_target = (
+            runtime._find_launch_target(parent.launch_target_id)
+            if parent.launch_target_id
+            else None
+        )
+        stored_args = parent.transport_state.get("launch_args")
+        base_args = _scrub_session_args(
+            stored_args if isinstance(stored_args, list) else []
+        )
+        launch_args = ["--resume", thread_id, *base_args]
+        command = runtime._command_for_backend(
+            self.id,
+            launch_args,
+            launch_target,
+            new_session.cwd,
+            allocate_tty=True,
+            session_id=new_session.id,
+        )
+        raw_log = Path(new_session.raw_log_path)
+        raw_log.parent.mkdir(parents=True, exist_ok=True)
+        raw_log.touch(exist_ok=True)
+        target = await runtime.tmux.start_managed_session(
+            new_session.id, new_session.cwd, command
+        )
+        await runtime.tmux.pipe_output(target.pane, raw_log)
+        with suppress(TmuxError):
+            await runtime.tmux.resize_window(target.session, 120, 50)
+        runtime.storage.update_session(
+            new_session.id,
+            transport_state={
+                "tmux_session": target.session,
+                "tmux_window": target.window,
+                "tmux_pane": target.pane,
+                "pid": target.pane_pid,
+                "thread_id": thread_id,
+                "launch_args": launch_args,
+            },
+            status=SessionStatus.STARTING,
+        )
+        await runtime._record_system_event(
+            new_session.id,
+            f"Promoted side question to a session (resumed thread {thread_id})",
+            status=SessionStatus.IDLE,
+        )
+        # The resumed thread's transcript is already cloned into the event DB, so
+        # tail from the end to avoid replaying it.
+        self._start_tailer(
+            runtime, new_session.id, thread_id, new_session.cwd, start_at_end=True
+        )
+        self._spawn_rate_limit_watcher(runtime, new_session)
 
     async def dismiss_side_question(
         self,

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -901,6 +901,37 @@ class ClaudeTtyPlugin:
 
     # ── AskUserQuestion ──────────────────────────────────────────────────────
 
+    async def fork_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        # T0 placeholder — implemented in the backend-wiring task (W2),
+        # delegating to self._claude / side_question.fork_aside.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are not yet wired",
+        )
+
+    async def dismiss_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+    ) -> None:
+        # T0 placeholder — implemented in the backend-wiring task (W2),
+        # delegating to self._claude / side_question.dismiss_aside.
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are not yet wired",
+        )
+
     async def answer_question(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1019,11 +1019,10 @@ class ClaudeTtyPlugin:
             f"Promoted side question to a session (resumed thread {thread_id})",
             status=SessionStatus.IDLE,
         )
-        # The forked thread file already holds the whole conversation up to and
-        # including the aside's Q&A, and none of it is in this new session's
-        # event DB yet, so tail from byte 0 to ingest the full transcript.
+        # The transcript (parent + aside Q&A) is already seeded in the event DB by
+        # fork_aside, so tail from the end and only pick up turns added from here.
         self._start_tailer(
-            runtime, new_session.id, thread_id, new_session.cwd, start_at_end=False
+            runtime, new_session.id, thread_id, new_session.cwd, start_at_end=True
         )
         self._spawn_rate_limit_watcher(runtime, new_session)
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -510,6 +510,33 @@ class CodexPlugin(DefaultLaunchContract):
     def effort_swap_message(self, effort: str | None) -> str:
         return ""  # never published; apply_effort returns False
 
+    async def fork_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are only supported for Claude sessions",
+        )
+
+    async def dismiss_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+    ) -> None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are only supported for Claude sessions",
+        )
+
     async def answer_question(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1143,6 +1143,33 @@ class OpenCodePlugin(DefaultLaunchContract):
 
         return None
 
+    async def fork_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are only supported for Claude sessions",
+        )
+
+    async def dismiss_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+    ) -> None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="side-questions are only supported for Claude sessions",
+        )
+
     async def answer_question(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -260,6 +260,27 @@ class TmuxPlugin:
     ) -> SessionRecord | None:
         return None
 
+    async def fork_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Path,
+        structured_log: Path,
+    ) -> SessionRecord:
+        _unsupported("side-questions")
+
+    async def dismiss_side_question(
+        self,
+        runtime: "SessionRuntime",
+        session: SessionRecord,
+        side_question_id: str,
+    ) -> None:
+        _unsupported("side-questions")
+
     async def answer_question(
         self,
         runtime: "SessionRuntime",

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -251,6 +251,13 @@ class SessionRuntime:
             await self._ensure_assistant_session()
         except Exception:
             log.exception("failed to ensure the assistant session")
+        for plugin in self.registry.all():
+            hook = getattr(plugin, "start_background_tasks", None)
+            if callable(hook):
+                asyncio.create_task(
+                    hook(self),
+                    name=f"plugin-bg-{plugin.id}",
+                )
         await self.scheduler.start()
 
     async def stop(self) -> None:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -252,6 +252,7 @@ class SessionRuntime:
         except Exception:
             log.exception("failed to ensure the assistant session")
         for plugin in self.registry.all():
+            # Optional lifecycle hook; not part of the BackendPlugin protocol.
             hook = getattr(plugin, "start_background_tasks", None)
             if callable(hook):
                 asyncio.create_task(
@@ -825,6 +826,37 @@ class SessionRuntime:
             )
         await self.reattach(session_id)
         return self._require_assistant_summary()
+
+    async def fork_side_question(
+        self, session_id: str, side_question_id: str
+    ) -> SessionRecord:
+        session = self.get_session(session_id)
+        plugin = self.registry.plugin_for(session)
+
+        new_session_id = self._generate_session_id(session.backend)
+        session_dir = self._session_dir(new_session_id)
+        raw_log = session_dir / "raw.log"
+        structured_log = session_dir / "events.jsonl"
+
+        for src, dst in [
+            (Path(session.raw_log_path), raw_log),
+            (Path(session.structured_log_path), structured_log),
+        ]:
+            if src.exists():
+                shutil.copy2(src, dst)
+
+        title = f"{session.title or session.id} (btw)"
+        new_session = await plugin.fork_side_question(
+            self,
+            session,
+            side_question_id,
+            new_session_id=new_session_id,
+            title=title,
+            raw_log=raw_log,
+            structured_log=structured_log,
+        )
+        await self._broadcast_session_list()
+        return new_session
 
     async def fork_session(self, session_id: str) -> SessionRecord:
         session = self.get_session(session_id)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1377,6 +1377,14 @@ class SessionRuntime:
         # case (natural exit never called terminate()) here.
         await self._cancel_context_usage_source(session_id)
         self._close_structured_log(session_id)
+        plugin = self.registry.plugin_for(session)
+        # Optional async cleanup hook; not part of the BackendPlugin protocol.
+        # Run it BEFORE deleting the row so it can read fresh side-question state
+        # under lock and honor a concurrent fork-promotion that claimed an aside
+        # (and now owns its fork thread) rather than deleting that fork file.
+        cleanup = getattr(plugin, "cleanup_side_questions_on_delete", None)
+        if cleanup is not None and asyncio.iscoroutinefunction(cleanup):
+            await cleanup(self, session)
         self.storage.delete_session(session_id)
         if session.worktree_path is not None:
             self._remove_worktree(session.worktree_path, prune_branches=prune_branches)
@@ -1384,11 +1392,6 @@ class SessionRuntime:
         self.attachments.discard(session_id)
         # Drop this session's blackboard posts along with its record.
         pruned = self.storage.prune_board_for_session(session_id)
-        plugin = self.registry.plugin_for(session)
-        # Optional async cleanup hook; not part of the BackendPlugin protocol.
-        cleanup = getattr(plugin, "cleanup_side_questions_on_delete", None)
-        if cleanup is not None and asyncio.iscoroutinefunction(cleanup):
-            await cleanup(self, session)
         plugin.on_session_deleted(self, session)
         await self._broadcast_session_list()
         if pruned:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1384,7 +1384,12 @@ class SessionRuntime:
         self.attachments.discard(session_id)
         # Drop this session's blackboard posts along with its record.
         pruned = self.storage.prune_board_for_session(session_id)
-        self.registry.plugin_for(session).on_session_deleted(self, session)
+        plugin = self.registry.plugin_for(session)
+        # Optional async cleanup hook; not part of the BackendPlugin protocol.
+        cleanup = getattr(plugin, "cleanup_side_questions_on_delete", None)
+        if cleanup is not None and asyncio.iscoroutinefunction(cleanup):
+            await cleanup(self, session)
+        plugin.on_session_deleted(self, session)
         await self._broadcast_session_list()
         if pruned:
             await self._publish_board_update(None)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -501,3 +501,34 @@ class ScheduleCreateRequest(BaseModel):
 class SessionEnvelope(BaseModel):
     type: str
     payload: Mapping[str, Any]
+
+
+class SideQuestionStatus(StrEnum):
+    PENDING = "pending"
+    ANSWERED = "answered"
+    ERROR = "error"
+
+
+class SideQuestion(BaseModel):
+    """An ephemeral ``/btw`` side-question on a Claude session.
+
+    Answered from the current conversation with no tools, never written to the
+    transcript, session-scoped. The same shape is the durable record persisted
+    under ``SessionRecord.transport_state["pending_side_questions"]`` and the
+    body of the ``side_question`` broadcast envelope.
+
+    ``fork_thread_id`` is the forked Claude thread retained while the card is
+    open so the aside can be promoted into a real session; it is ``None`` once
+    the thread has been cleaned up. ``resumed`` is set when a pending aside was
+    re-issued by the post-restart recovery sweep.
+    """
+
+    id: str
+    question: str
+    status: SideQuestionStatus
+    answer: str | None = None
+    error: str | None = None
+    fork_thread_id: str | None = None
+    attempts: int = 1
+    resumed: bool = False
+    created_at: datetime

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -119,6 +119,24 @@ class _StubPlugin:
     async def post_approval(self, runtime: Any, session: Any) -> None:
         return None
 
+    async def fork_side_question(
+        self,
+        runtime: Any,
+        session: Any,
+        side_question_id: str,
+        *,
+        new_session_id: str,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+    ) -> Any:
+        raise NotImplementedError
+
+    async def dismiss_side_question(
+        self, runtime: Any, session: Any, side_question_id: str
+    ) -> None:
+        raise NotImplementedError
+
     def setup(self, runtime: Any) -> None:
         return None
 

--- a/backend/tests/test_btw_routing.py
+++ b/backend/tests/test_btw_routing.py
@@ -13,6 +13,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import httpx
+from starlette.testclient import TestClient
 
 from waypoint.api import create_app
 from waypoint.backends.claude_code.plugin import (
@@ -344,8 +345,6 @@ async def test_dismiss_side_question_404_unknown_session(tmp_path: Path) -> None
 
 def test_ws_session_hydrates_pending_side_questions(tmp_path: Path) -> None:
     """WS handler sends a side_question envelope for each pending side-question."""
-    from starlette.testclient import TestClient
-
     sq = {
         "id": "sq-hydrate-001",
         "question": "Are we done yet?",
@@ -363,15 +362,24 @@ def test_ws_session_hydrates_pending_side_questions(tmp_path: Path) -> None:
     )
     app, token = _make_app(tmp_path, session)
 
-    with TestClient(app) as client:
-        with client.websocket_connect(f"/ws/sessions/{session.id}?token={token}") as ws:
-            # First message: session_state
-            first = ws.receive_json()
-            assert first["type"] == "session_state"
-            # Second message: side_question hydration envelope
-            second = ws.receive_json()
-            assert second["type"] == "side_question"
-            assert second["payload"]["side_question"]["id"] == "sq-hydrate-001"
+    # Hydration is what's under test; mock the startup recovery sweep so it
+    # doesn't race in and re-issue/mutate the pending record (it runs as a
+    # background task on the TestClient lifespan startup).
+    with patch(
+        "waypoint.backends.claude_code.side_question.recover_pending_side_questions",
+        new=AsyncMock(return_value=None),
+    ):
+        with TestClient(app) as client:
+            with client.websocket_connect(
+                f"/ws/sessions/{session.id}?token={token}"
+            ) as ws:
+                # First message: session_state
+                first = ws.receive_json()
+                assert first["type"] == "session_state"
+                # Second message: side_question hydration envelope
+                second = ws.receive_json()
+                assert second["type"] == "side_question"
+                assert second["payload"]["side_question"]["id"] == "sq-hydrate-001"
 
 
 # ── Recovery task scheduling ──────────────────────────────────────────────────

--- a/backend/tests/test_btw_routing.py
+++ b/backend/tests/test_btw_routing.py
@@ -1,0 +1,422 @@
+"""Routing tests for the /btw side-question feature.
+
+Verifies that /btw interception, slash completions, API endpoints, and
+WebSocket hydration are wired correctly.  Side-question logic bodies
+(start_side_question, fork_aside, dismiss_aside) are mocked so these
+tests are decoupled from the W1 implementation.
+"""
+
+import asyncio
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from waypoint.api import create_app
+from waypoint.backends.claude_code.plugin import (
+    ClaudeCodePlugin,
+    _claude_waypoint_completions,
+)
+from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import (
+    SessionInputRequest,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _make_session(
+    tmp_path: Path,
+    backend: str = "claude_code",
+    transport: str = "claude_cli",
+    transport_state: dict[str, Any] | None = None,
+) -> tuple[SessionRecord, str, str]:
+    now = datetime.now(UTC)
+    session_id = "test-session-001"
+    raw_log = tmp_path / "raw.log"
+    structured_log = tmp_path / "events.jsonl"
+    raw_log.touch()
+    structured_log.touch()
+    session = SessionRecord(
+        id=session_id,
+        backend=backend,
+        transport=transport,
+        source=SessionSource.MANAGED,
+        title="Test Session",
+        cwd=str(tmp_path),
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(raw_log),
+        structured_log_path=str(structured_log),
+        transport_state=transport_state or {},
+    )
+    return session, str(raw_log), str(structured_log)
+
+
+def _make_app(
+    tmp_path: Path,
+    session: SessionRecord,
+) -> tuple[Any, str]:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    context = app.state.context
+    context.storage.create_session(session)
+    token = context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _make_runtime(tmp_path: Path) -> tuple[SessionRuntime, Storage, Settings]:
+    settings = Settings(data_dir=tmp_path / "data")
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+    return runtime, storage, settings
+
+
+# ── /btw completions ─────────────────────────────────────────────────────────
+
+
+def test_claude_waypoint_completions_includes_btw() -> None:
+    completions = _claude_waypoint_completions("")
+    names = [c.name for c in completions]
+    assert "btw" in names
+    assert "status" in names
+
+
+def test_claude_waypoint_completions_btw_prefix_match() -> None:
+    completions = _claude_waypoint_completions("/bt")
+    assert any(c.name == "btw" for c in completions)
+    assert not any(c.name == "status" for c in completions)
+
+
+def test_claude_waypoint_completions_no_match() -> None:
+    completions = _claude_waypoint_completions("/xyz")
+    assert completions == []
+
+
+async def test_claude_code_completions_include_btw(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeCodePlugin()
+    completions = await plugin.list_command_completions(runtime, session, prefix="")
+    assert any(c.name == "btw" for c in completions)
+
+
+async def test_claude_tty_completions_include_btw(tmp_path: Path) -> None:
+    session, _, _ = _make_session(
+        tmp_path, backend="claude_tty", transport="claude_tty"
+    )
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeTtyPlugin()
+    completions = await plugin.list_command_completions(runtime, session, prefix="")
+    assert any(c.name == "btw" for c in completions)
+
+
+async def test_claude_tty_completions_btw_prefix_match(tmp_path: Path) -> None:
+    session, _, _ = _make_session(
+        tmp_path, backend="claude_tty", transport="claude_tty"
+    )
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeTtyPlugin()
+    completions = await plugin.list_command_completions(runtime, session, prefix="/bt")
+    assert any(c.name == "btw" for c in completions)
+
+
+# ── /btw maybe_handle_input (claude_code) ────────────────────────────────────
+
+
+async def test_claude_code_btw_interception_calls_start_side_question(
+    tmp_path: Path,
+) -> None:
+    session, _, _ = _make_session(tmp_path)
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeCodePlugin()
+    request = SessionInputRequest(text="/btw What is the status?", submit=True)
+
+    with patch(
+        "waypoint.backends.claude_code.plugin._sq.start_side_question",
+        new_callable=AsyncMock,
+    ) as mock_start:
+        result = await plugin.maybe_handle_input(runtime, session, request)
+
+    assert result is not None
+    mock_start.assert_called_once_with(runtime, plugin, session, "What is the status?")
+
+
+async def test_claude_code_btw_no_question_short_circuits_without_start(
+    tmp_path: Path,
+) -> None:
+    session, _, _ = _make_session(tmp_path)
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeCodePlugin()
+    request = SessionInputRequest(text="/btw", submit=True)
+
+    with patch(
+        "waypoint.backends.claude_code.plugin._sq.start_side_question",
+        new_callable=AsyncMock,
+    ) as mock_start:
+        result = await plugin.maybe_handle_input(runtime, session, request)
+
+    assert result is not None
+    mock_start.assert_not_called()
+
+
+async def test_claude_code_btw_does_not_flip_to_running(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeCodePlugin()
+    request = SessionInputRequest(text="/btw Are you busy?", submit=True)
+
+    with patch(
+        "waypoint.backends.claude_code.plugin._sq.start_side_question",
+        new_callable=AsyncMock,
+    ):
+        await plugin.maybe_handle_input(runtime, session, request)
+
+    updated = storage.get_session(session.id)
+    assert updated is not None
+    assert updated.status == SessionStatus.IDLE
+
+
+async def test_claude_code_non_btw_input_not_intercepted(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeCodePlugin()
+    request = SessionInputRequest(text="Hello world", submit=True)
+
+    result = await plugin.maybe_handle_input(runtime, session, request)
+    assert result is None
+
+
+# ── /btw maybe_handle_input (claude_tty) ─────────────────────────────────────
+
+
+async def test_claude_tty_btw_interception_calls_start_side_question(
+    tmp_path: Path,
+) -> None:
+    session, _, _ = _make_session(
+        tmp_path, backend="claude_tty", transport="claude_tty"
+    )
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeTtyPlugin()
+    request = SessionInputRequest(text="/btw How far along?", submit=True)
+
+    with patch(
+        "waypoint.backends.claude_tty.plugin._sq.start_side_question",
+        new_callable=AsyncMock,
+    ) as mock_start:
+        result = await plugin.maybe_handle_input(runtime, session, request)
+
+    assert result is not None
+    mock_start.assert_called_once_with(
+        runtime, plugin._claude, session, "How far along?"
+    )
+
+
+async def test_claude_tty_btw_no_question_short_circuits_without_start(
+    tmp_path: Path,
+) -> None:
+    session, _, _ = _make_session(
+        tmp_path, backend="claude_tty", transport="claude_tty"
+    )
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeTtyPlugin()
+    request = SessionInputRequest(text="/btw  ", submit=True)
+
+    with patch(
+        "waypoint.backends.claude_tty.plugin._sq.start_side_question",
+        new_callable=AsyncMock,
+    ) as mock_start:
+        result = await plugin.maybe_handle_input(runtime, session, request)
+
+    assert result is not None
+    mock_start.assert_not_called()
+
+
+async def test_claude_tty_non_btw_returns_none(tmp_path: Path) -> None:
+    session, _, _ = _make_session(
+        tmp_path, backend="claude_tty", transport="claude_tty"
+    )
+    runtime, storage, _ = _make_runtime(tmp_path)
+    storage.create_session(session)
+    plugin = ClaudeTtyPlugin()
+    request = SessionInputRequest(text="/status", submit=True)
+    result = await plugin.maybe_handle_input(runtime, session, request)
+    assert result is None
+
+
+# ── API endpoint routing ──────────────────────────────────────────────────────
+
+
+async def test_fork_side_question_endpoint_routes_to_plugin(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    app, token = _make_app(tmp_path, session)
+    context = app.state.context
+
+    fake_new_session = session.model_copy(update={"id": "new-session-fork"})
+    plugin = context.runtime.registry.plugin_for(session)
+    plugin.fork_side_question = AsyncMock(return_value=fake_new_session)
+
+    async with _client(app) as client:
+        resp = await client.post(
+            f"/api/sessions/{session.id}/side-questions/sq-001/fork",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "session" in data
+    plugin.fork_side_question.assert_called_once()
+    call_kwargs = plugin.fork_side_question.call_args
+    assert call_kwargs.args[2] == "sq-001"  # side_question_id is 3rd positional arg
+
+
+async def test_dismiss_side_question_endpoint_routes_to_plugin(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    app, token = _make_app(tmp_path, session)
+    context = app.state.context
+
+    plugin = context.runtime.registry.plugin_for(session)
+    plugin.dismiss_side_question = AsyncMock()
+
+    async with _client(app) as client:
+        resp = await client.delete(
+            f"/api/sessions/{session.id}/side-questions/sq-002",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 204
+    plugin.dismiss_side_question.assert_called_once()
+    call_kwargs = plugin.dismiss_side_question.call_args
+    assert call_kwargs.args[2] == "sq-002"  # side_question_id is 3rd positional arg
+
+
+async def test_fork_side_question_404_unknown_session(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    app, token = _make_app(tmp_path, session)
+
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/no-such-session/side-questions/sq-001/fork",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 404
+
+
+async def test_dismiss_side_question_404_unknown_session(tmp_path: Path) -> None:
+    session, _, _ = _make_session(tmp_path)
+    app, token = _make_app(tmp_path, session)
+
+    async with _client(app) as client:
+        resp = await client.delete(
+            "/api/sessions/no-such-session/side-questions/sq-001",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 404
+
+
+# ── WebSocket hydration ───────────────────────────────────────────────────────
+
+
+async def test_ws_session_hydrates_pending_side_questions(tmp_path: Path) -> None:
+    sq = {
+        "id": "sq-hydrate-001",
+        "question": "Are we done yet?",
+        "status": "pending",
+        "answer": None,
+        "error": None,
+        "fork_thread_id": None,
+        "attempts": 1,
+        "resumed": False,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    session, _, _ = _make_session(
+        tmp_path,
+        transport_state={"pending_side_questions": [sq]},
+    )
+    app, token = _make_app(tmp_path, session)
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        async with client.stream(
+            "GET",
+            f"/ws/sessions/{session.id}?token={token}",
+            headers={"upgrade": "websocket", "connection": "upgrade"},
+        ) as resp:
+            # WebSocket upgrade; collect initial messages
+            with suppress(Exception):
+                async for _chunk in resp.aiter_bytes():
+                    pass
+
+    # Since httpx doesn't natively handle WS frames, use a websockets client
+    # approach via the ASGI transport indirectly. Instead, verify the hydration
+    # logic directly by inspecting the broadcast hub after a subscribe.
+    context = app.state.context
+    queue = context.runtime.broadcast.subscribe_session(session.id)
+    # Simulate what the WS handler does: get session and check transport_state
+    reloaded = context.runtime.get_session(session.id)
+    pending = reloaded.transport_state.get("pending_side_questions", [])
+    assert len(pending) == 1
+    assert pending[0]["id"] == "sq-hydrate-001"
+    context.runtime.broadcast.unsubscribe_session(session.id, queue)
+
+
+# ── Recovery task scheduling ──────────────────────────────────────────────────
+
+
+async def test_claude_code_start_background_tasks_schedules_recovery(
+    tmp_path: Path,
+) -> None:
+    runtime, storage, _ = _make_runtime(tmp_path)
+    plugin = ClaudeCodePlugin()
+
+    with patch(
+        "waypoint.backends.claude_code.plugin._sq.recover_pending_side_questions",
+        new_callable=AsyncMock,
+    ) as mock_recover:
+        await plugin.start_background_tasks(runtime)
+        # Let the task run
+        await asyncio.sleep(0)
+
+    mock_recover.assert_called_once_with(runtime, plugin)
+
+
+async def test_claude_code_shutdown_cancels_sq_tasks(tmp_path: Path) -> None:
+    runtime, storage, _ = _make_runtime(tmp_path)
+    plugin = ClaudeCodePlugin()
+
+    async def _long_running() -> None:
+        await asyncio.sleep(9999)
+
+    task = asyncio.create_task(_long_running())
+    plugin._sq_tasks["test-sq"] = task
+    await asyncio.sleep(0)  # let task start and suspend at its first await
+    await plugin.shutdown(runtime)
+    assert task.cancelled()
+    assert plugin._sq_tasks == {}

--- a/backend/tests/test_btw_routing.py
+++ b/backend/tests/test_btw_routing.py
@@ -7,7 +7,6 @@ tests are decoupled from the W1 implementation.
 """
 
 import asyncio
-from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -343,7 +342,10 @@ async def test_dismiss_side_question_404_unknown_session(tmp_path: Path) -> None
 # ── WebSocket hydration ───────────────────────────────────────────────────────
 
 
-async def test_ws_session_hydrates_pending_side_questions(tmp_path: Path) -> None:
+def test_ws_session_hydrates_pending_side_questions(tmp_path: Path) -> None:
+    """WS handler sends a side_question envelope for each pending side-question."""
+    from starlette.testclient import TestClient
+
     sq = {
         "id": "sq-hydrate-001",
         "question": "Are we done yet?",
@@ -361,30 +363,15 @@ async def test_ws_session_hydrates_pending_side_questions(tmp_path: Path) -> Non
     )
     app, token = _make_app(tmp_path, session)
 
-    async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://test"
-    ) as client:
-        async with client.stream(
-            "GET",
-            f"/ws/sessions/{session.id}?token={token}",
-            headers={"upgrade": "websocket", "connection": "upgrade"},
-        ) as resp:
-            # WebSocket upgrade; collect initial messages
-            with suppress(Exception):
-                async for _chunk in resp.aiter_bytes():
-                    pass
-
-    # Since httpx doesn't natively handle WS frames, use a websockets client
-    # approach via the ASGI transport indirectly. Instead, verify the hydration
-    # logic directly by inspecting the broadcast hub after a subscribe.
-    context = app.state.context
-    queue = context.runtime.broadcast.subscribe_session(session.id)
-    # Simulate what the WS handler does: get session and check transport_state
-    reloaded = context.runtime.get_session(session.id)
-    pending = reloaded.transport_state.get("pending_side_questions", [])
-    assert len(pending) == 1
-    assert pending[0]["id"] == "sq-hydrate-001"
-    context.runtime.broadcast.unsubscribe_session(session.id, queue)
+    with TestClient(app) as client:
+        with client.websocket_connect(f"/ws/sessions/{session.id}?token={token}") as ws:
+            # First message: session_state
+            first = ws.receive_json()
+            assert first["type"] == "session_state"
+            # Second message: side_question hydration envelope
+            second = ws.receive_json()
+            assert second["type"] == "side_question"
+            assert second["payload"]["side_question"]["id"] == "sq-hydrate-001"
 
 
 # ── Recovery task scheduling ──────────────────────────────────────────────────

--- a/backend/tests/test_btw_routing.py
+++ b/backend/tests/test_btw_routing.py
@@ -394,6 +394,47 @@ async def test_claude_code_start_background_tasks_schedules_recovery(
     mock_recover.assert_called_once_with(runtime, plugin)
 
 
+async def test_delete_session_calls_cleanup_side_questions(tmp_path: Path) -> None:
+    """Deleting a session with pending side-questions awaits the cleanup hook."""
+    sq = {
+        "id": "sq-del-001",
+        "question": "Will this be cleaned up?",
+        "status": "pending",
+        "answer": None,
+        "error": None,
+        "fork_thread_id": "fork-thread-abc",
+        "attempts": 1,
+        "resumed": False,
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    session, _, _ = _make_session(
+        tmp_path,
+        transport_state={"pending_side_questions": [sq]},
+    )
+    app, token = _make_app(tmp_path, session)
+    context = app.state.context
+    # Mark session as already EXITED so delete skips terminate()
+    context.storage.update_session(session.id, status=SessionStatus.EXITED)
+
+    mock_cleanup = AsyncMock()
+    with patch(
+        "waypoint.backends.claude_code.side_question.delete_session_side_questions",
+        mock_cleanup,
+        create=True,
+    ):
+        async with _client(app) as client:
+            resp = await client.delete(
+                f"/api/sessions/{session.id}",
+                headers={"Authorization": f"Bearer {token}"},
+            )
+
+    assert resp.status_code == 200
+    mock_cleanup.assert_called_once()
+    call_args = mock_cleanup.call_args
+    # (runtime, plugin, session) positional args
+    assert call_args.args[2].id == session.id
+
+
 async def test_claude_code_shutdown_cancels_sq_tasks(tmp_path: Path) -> None:
     runtime, storage, _ = _make_runtime(tmp_path)
     plugin = ClaudeCodePlugin()

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -309,6 +309,27 @@ async def test_restart_clears_pending_approval_and_tailer() -> None:
     assert "sess-1" not in plugin._pending_approvals
 
 
+# ── _launch_resumed_pane (fork promotion) ─────────────────────────────────────
+
+
+async def test_launch_resumed_pane_kills_pane_on_post_start_failure() -> None:
+    """A failure after the pane is started must kill it, so fork_aside's rollback
+    doesn't leave an unmanaged claude process holding the fork thread."""
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+    runtime, target = _restart_runtime()
+    # A step after start_managed_session raises.
+    runtime.tmux.pipe_output = AsyncMock(side_effect=TmuxError("pipe failed"))
+    parent = _make_session(session_id="parent-1")
+    new_session = _make_session(session_id="new-1", thread_id=None)
+
+    with pytest.raises(TmuxError):
+        await plugin._launch_resumed_pane(runtime, parent, new_session, "fork-thread")
+
+    runtime.tmux.start_managed_session.assert_awaited_once()
+    runtime.tmux.kill_session.assert_awaited_once_with(target.session)
+
+
 # ── apply_effort return contract ──────────────────────────────────────────────
 
 

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -1064,7 +1064,12 @@ async def test_one_shot_local_argv_disables_tools(
 
         return _FakeProc()
 
-    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+    # Patch the binary lookup so the test does not depend on `claude` being
+    # installed on PATH (it isn't on CI runners), only on the argv we build.
+    with (
+        patch("shutil.which", return_value="/usr/bin/claude"),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+    ):
         await sq_module._run_side_question_bg(runtime, plugin, session.id, "sq-tools")
 
     assert captured_args, "subprocess was never called"

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -482,7 +482,7 @@ async def test_fork_aside_drops_record_and_brings_up_new_session(
     assert any("removed_id" in m.payload for m in msgs if m.type == "side_question")
 
 
-async def test_fork_aside_marks_error_and_raises_400_when_bring_up_fails(
+async def test_fork_aside_rolls_back_when_bring_up_fails(
     runtime: Any,
     tmp_path: Path,
 ) -> None:
@@ -519,9 +519,128 @@ async def test_fork_aside_marks_error_and_raises_400_when_bring_up_fails(
         )
     assert exc_info.value.status_code == 400
 
-    errored = runtime.storage.get_session("new-sess")
-    assert errored is not None
-    assert errored.status == SessionStatus.ERROR
+    # The half-created target is deleted, not left behind as an ERROR row.
+    assert runtime.storage.get_session("new-sess") is None
+
+    # The source aside is restored so the card returns and can be retried.
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    restored = _read_side_questions(fresh)
+    assert [q.id for q in restored] == ["sq-ready"]
+    assert restored[0].fork_thread_id == "fork-uuid"
+
+    # The card was broadcast removed (claim) then re-broadcast (rollback).
+    sq_msgs = [m for m, _ in runtime.broadcast.published if m.type == "side_question"]
+    assert any("removed_id" in m.payload for m in sq_msgs)
+    assert any(m.payload.get("side_question") for m in sq_msgs)
+
+
+async def test_fork_aside_deletes_orphan_fork_when_source_gone_on_rollback(
+    runtime: Any,
+    tmp_path: Path,
+) -> None:
+    """If the source session is deleted mid-promotion and the launch then fails,
+    the fork thread has no owner to return to, so rollback must delete it."""
+    from fastapi import HTTPException
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-ready",
+        question="x?",
+        status=SideQuestionStatus.ANSWERED,
+        answer="y.",
+        fork_thread_id="fork-uuid",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+    session_dir = tmp_path / "new"
+    session_dir.mkdir()
+
+    async def _boom(new_session: SessionRecord, fork_thread_id: str) -> None:
+        # The source session vanishes while the launch is in flight.
+        runtime.storage.delete_session(session.id)
+        raise RuntimeError("launch failed")
+
+    deleted_forks: list[str] = []
+    with (
+        pytest.raises(HTTPException),
+        patch.object(
+            sq_module,
+            "_delete_fork_file",
+            new=AsyncMock(side_effect=lambda fid, *a, **kw: deleted_forks.append(fid)),
+        ),
+    ):
+        await fork_aside(
+            runtime,
+            session,
+            "sq-ready",
+            new_session_id="new-sess",
+            transport_id="claude_cli",
+            title="F",
+            raw_log=session_dir / "raw.log",
+            structured_log=session_dir / "events.jsonl",
+            bring_up=_boom,
+        )
+
+    # Orphaned fork thread was deleted; neither session row survives.
+    assert "fork-uuid" in deleted_forks
+    assert runtime.storage.get_session(session.id) is None
+    assert runtime.storage.get_session("new-sess") is None
+
+
+async def test_fork_aside_rolls_back_on_pre_launch_failure(
+    runtime: Any,
+    tmp_path: Path,
+) -> None:
+    """A failure in post-claim setup (before bring_up) rolls back too: the target
+    is deleted and the source aside restored, and bring_up never runs."""
+    from fastapi import HTTPException
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-ready",
+        question="x?",
+        status=SideQuestionStatus.ANSWERED,
+        answer="y.",
+        fork_thread_id="fork-uuid",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+    session_dir = tmp_path / "new"
+    session_dir.mkdir()
+
+    bring_up_called: list[bool] = []
+
+    async def _bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
+        bring_up_called.append(True)
+
+    with (
+        pytest.raises(HTTPException),
+        patch.object(
+            sq_module,
+            "_ingest_aside_qa",
+            new=AsyncMock(side_effect=RuntimeError("seed failed")),
+        ),
+    ):
+        await fork_aside(
+            runtime,
+            session,
+            "sq-ready",
+            new_session_id="new-sess",
+            transport_id="claude_cli",
+            title="F",
+            raw_log=session_dir / "raw.log",
+            structured_log=session_dir / "events.jsonl",
+            bring_up=_bring_up,
+        )
+
+    assert bring_up_called == []  # failed before launch
+    assert runtime.storage.get_session("new-sess") is None  # target rolled back
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    assert [q.id for q in _read_side_questions(fresh)] == ["sq-ready"]
 
 
 # ---------------------------------------------------------------------------
@@ -557,6 +676,42 @@ async def test_bg_task_success_updates_record(
     assert qs[0].status == SideQuestionStatus.ANSWERED
     assert qs[0].answer == "All green!"
     assert qs[0].fork_thread_id is not None
+
+
+async def test_bg_task_persists_fork_id_before_one_shot(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """The fork id is recorded before the one-shot runs, so a restart mid-flight
+    can find and delete the orphaned <E>.jsonl rather than leaking it."""
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-pre",
+        question="q?",
+        status=SideQuestionStatus.PENDING,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    seen: dict[str, Any] = {}
+
+    async def fake_one_shot(
+        question: str, thread_id: str, fork_id: str, cwd: str, *a: Any, **kw: Any
+    ) -> str:
+        fresh = runtime.storage.get_session(session.id)
+        seen["recorded"] = _read_side_questions(fresh)[0].fork_thread_id
+        seen["arg"] = fork_id
+        return "answer"
+
+    with patch.object(
+        sq_module, "_run_one_shot_local", new=AsyncMock(side_effect=fake_one_shot)
+    ):
+        await sq_module._run_side_question_bg(runtime, plugin, session.id, "sq-pre")
+
+    # While the one-shot was still running, the record already carried the fork id.
+    assert seen["recorded"] is not None
+    assert seen["recorded"] == seen["arg"]
 
 
 async def test_bg_task_marks_error_on_failure(
@@ -811,6 +966,57 @@ async def test_recover_skips_non_claude_sessions(
 
     # Nothing touched.
     assert cleanup_calls == []
+
+
+async def test_recover_covers_extra_backend_ids(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """Legacy backend=claude_tty rows are skipped by the default claude_code
+    sweep but recovered when their id is passed in ``backend_ids``."""
+    session = _make_session(
+        runtime.storage,
+        session_id="claude_tty-x",
+        backend="claude_tty",
+        thread_id="t1",
+    )
+    sq = SideQuestion(
+        id="sq-tty",
+        question="q?",
+        status=SideQuestionStatus.PENDING,
+        fork_thread_id="fork-tty",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    state = {
+        **session.transport_state,
+        "pending_side_questions": [sq.model_dump(mode="json")],
+    }
+    runtime.storage.update_session(session.id, transport_state=state)
+
+    # Default sweep (claude_code only) ignores the claude_tty row.
+    with (
+        patch.object(sq_module, "_schedule_bg_task") as sched_default,
+        patch.object(sq_module, "_delete_fork_file", new=AsyncMock()),
+    ):
+        await recover_pending_side_questions(runtime, plugin)
+    sched_default.assert_not_called()
+
+    # Scoped to claude_tty it re-issues: deletes the stale fork and reschedules.
+    cleanup: list[str] = []
+    with (
+        patch.object(sq_module, "_schedule_bg_task") as sched_tty,
+        patch.object(
+            sq_module,
+            "_delete_fork_file",
+            new=AsyncMock(side_effect=lambda fid, *a, **kw: cleanup.append(fid)),
+        ),
+    ):
+        await recover_pending_side_questions(
+            runtime, plugin, backend_ids={"claude_tty"}
+        )
+    sched_tty.assert_called_once()
+    assert "fork-tty" in cleanup
 
 
 # ---------------------------------------------------------------------------
@@ -1070,3 +1276,81 @@ async def test_delete_session_side_questions_uses_passed_snapshot(
         await delete_session_side_questions(runtime, plugin, session_with_fork)
 
     assert "fork-snap" in deleted_files
+
+
+async def test_delete_session_side_questions_prefers_fresh_state(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """If an aside was claimed by a concurrent fork-promotion (so the live row no
+    longer lists it) the delete sweep must NOT delete its handed-off fork file,
+    even though the passed snapshot still has it."""
+    from waypoint.backends.claude_code.side_question import (
+        delete_session_side_questions,
+    )
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-claimed",
+        question="Q?",
+        status=SideQuestionStatus.ANSWERED,
+        fork_thread_id="fork-handed-off",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+    # Snapshot still lists the aside...
+    stale_snapshot = runtime.storage.get_session(session.id)
+    assert stale_snapshot is not None
+    # ...but a concurrent fork-promotion has since claimed it (row now empty).
+    _write_side_questions(runtime, session.id, [])
+
+    deleted_files: list[str] = []
+    with patch.object(
+        sq_module,
+        "_delete_fork_file",
+        new=AsyncMock(side_effect=lambda fid, *a, **kw: deleted_files.append(fid)),
+    ):
+        await delete_session_side_questions(runtime, plugin, stale_snapshot)
+
+    # The handed-off fork file must survive — the promoted session owns it now.
+    assert deleted_files == []
+
+
+async def test_delete_session_side_questions_cleans_aside_absent_from_snapshot(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """A /btw persisted after the delete-time snapshot (snapshot empty, live row
+    has it) is still cleaned up — cleanup keys off fresh state, not the snapshot,
+    so the plugin hook can safely call it unconditionally."""
+    from waypoint.backends.claude_code.side_question import (
+        delete_session_side_questions,
+    )
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    empty_snapshot = runtime.storage.get_session(session.id)  # no asides yet
+    assert empty_snapshot is not None
+    # A /btw lands after the snapshot was captured.
+    sq = SideQuestion(
+        id="sq-late",
+        question="late?",
+        status=SideQuestionStatus.ANSWERED,
+        fork_thread_id="fork-late",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    deleted_files: list[str] = []
+    with patch.object(
+        sq_module,
+        "_delete_fork_file",
+        new=AsyncMock(side_effect=lambda fid, *a, **kw: deleted_files.append(fid)),
+    ):
+        await delete_session_side_questions(runtime, plugin, empty_snapshot)
+
+    assert "fork-late" in deleted_files
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    assert _read_side_questions(fresh) == []

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -768,3 +768,262 @@ async def test_recover_skips_non_claude_sessions(
 
     # Nothing touched.
     assert cleanup_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: --tools "" disables tools in one-shot argv
+# ---------------------------------------------------------------------------
+
+
+async def test_one_shot_local_argv_disables_tools(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """The local one-shot must pass --tools "" so Claude cannot call any tool."""
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    _write_side_questions(
+        runtime,
+        session.id,
+        [
+            SideQuestion(
+                id="sq-tools",
+                question="What is 2+2?",
+                status=SideQuestionStatus.PENDING,
+                attempts=1,
+                created_at=datetime.now(UTC),
+            )
+        ],
+    )
+
+    captured_args: list[list[str]] = []
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> Any:
+        captured_args.append(list(args))
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                import json as _json
+
+                return (
+                    _json.dumps(
+                        {"is_error": False, "result": "4", "subtype": "success"}
+                    ).encode(),
+                    b"",
+                )
+
+        return _FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await sq_module._run_side_question_bg(runtime, plugin, session.id, "sq-tools")
+
+    assert captured_args, "subprocess was never called"
+    argv = captured_args[0]
+    # --tools must appear in the argv and the next element must be the empty string.
+    assert "--tools" in argv, f"--tools not in argv: {argv}"
+    tools_idx = argv.index("--tools")
+    assert (
+        argv[tools_idx + 1] == ""
+    ), f"--tools value is not empty: {argv[tools_idx + 1]!r}"
+
+
+async def test_one_shot_remote_argv_disables_tools() -> None:
+    """The remote one-shot command string must include --tools ''."""
+    from waypoint.launch_targets import SshLaunchTargetConfig
+
+    target = SshLaunchTargetConfig(id="box", name="Box", ssh_destination="user@host")
+    captured_args: list[list[str]] = []
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> Any:
+        captured_args.append(list(args))
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                import json as _json
+
+                return (
+                    _json.dumps(
+                        {"is_error": False, "result": "ok", "subtype": "success"}
+                    ).encode(),
+                    b"",
+                )
+
+        return _FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        await sq_module._run_one_shot_remote(
+            "What branch?", "thread-1", "fork-1", "~/project", target, "claude"
+        )
+
+    assert captured_args, "subprocess was never called"
+    # The remote command is the last arg passed to ssh; the claude args are
+    # embedded in it.  Check the full command string contains --tools.
+    full_cmd = " ".join(captured_args[0])
+    assert "--tools" in full_cmd, f"--tools not in remote command: {full_cmd!r}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: recovery does not clobber a completion that lands mid-sweep
+# ---------------------------------------------------------------------------
+
+
+async def test_recover_does_not_clobber_mid_sweep_completion(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """A bg-task completion that lands while recover_pending_side_questions is
+    running (between the stale snapshot and the lock) must not be overwritten,
+    and the completed fork file must not be deleted."""
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-race",
+        question="Will race?",
+        status=SideQuestionStatus.PENDING,
+        fork_thread_id="stale-E",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    deleted_files: list[str] = []
+
+    async def fake_delete(fid: str, *args: Any, **kwargs: Any) -> None:
+        # Simulate the bg task completing sq-race to ANSWERED just before
+        # the recovery writes its update.
+        if fid == "stale-E":
+            completed = sq.model_copy(
+                update={
+                    "status": SideQuestionStatus.ANSWERED,
+                    "answer": "Race answer.",
+                    "fork_thread_id": "live-E",
+                }
+            )
+            _write_side_questions(runtime, session.id, [completed])
+        deleted_files.append(fid)
+
+    with (
+        patch.object(
+            sq_module, "_delete_fork_file", new=AsyncMock(side_effect=fake_delete)
+        ),
+        patch.object(sq_module, "_schedule_bg_task"),
+    ):
+        await recover_pending_side_questions(runtime, plugin)
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1, "record was dropped"
+    # The record must remain ANSWERED — NOT overwritten with pending/error.
+    assert (
+        qs[0].status == SideQuestionStatus.ANSWERED
+    ), f"record was clobbered: {qs[0].status}"
+    assert qs[0].fork_thread_id == "live-E", "live fork thread id was lost"
+    # The live fork file must NOT have been deleted.
+    assert "live-E" not in deleted_files, "live fork file was wrongly deleted"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: delete_session_side_questions
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_session_side_questions_clears_records_and_fork_files(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """delete_session_side_questions must delete every fork file and clear the
+    pending_side_questions list from storage."""
+    from waypoint.backends.claude_code.side_question import (
+        delete_session_side_questions,
+    )
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    qs_init = [
+        SideQuestion(
+            id="sq-a",
+            question="A?",
+            status=SideQuestionStatus.ANSWERED,
+            fork_thread_id="fork-A",
+            attempts=1,
+            created_at=datetime.now(UTC),
+        ),
+        SideQuestion(
+            id="sq-b",
+            question="B?",
+            status=SideQuestionStatus.PENDING,
+            fork_thread_id="fork-B",
+            attempts=1,
+            created_at=datetime.now(UTC),
+        ),
+        SideQuestion(
+            id="sq-c",
+            question="C?",
+            status=SideQuestionStatus.ERROR,
+            fork_thread_id=None,
+            attempts=1,
+            created_at=datetime.now(UTC),
+        ),
+    ]
+    _write_side_questions(runtime, session.id, qs_init)
+    # Re-read so the snapshot passed to the function has the questions embedded.
+    session_with_qs = runtime.storage.get_session(session.id)
+    assert session_with_qs is not None
+
+    deleted_files: list[str] = []
+    with patch.object(
+        sq_module,
+        "_delete_fork_file",
+        new=AsyncMock(side_effect=lambda fid, *a, **kw: deleted_files.append(fid)),
+    ):
+        await delete_session_side_questions(runtime, plugin, session_with_qs)
+
+    # Both fork files must be deleted; sq-c had no fork file.
+    assert set(deleted_files) == {"fork-A", "fork-B"}
+
+    # Storage must have an empty pending_side_questions list.
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    assert _read_side_questions(fresh) == []
+
+
+async def test_delete_session_side_questions_uses_passed_snapshot(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """Fork ids must be read from the passed session snapshot, not re-fetched
+    from storage (storage may already be gone when called)."""
+    from waypoint.backends.claude_code.side_question import (
+        delete_session_side_questions,
+    )
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq_snap = SideQuestion(
+        id="sq-snap",
+        question="Snap?",
+        status=SideQuestionStatus.ANSWERED,
+        fork_thread_id="fork-snap",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    # Write to storage so the session exists there.
+    _write_side_questions(runtime, session.id, [sq_snap])
+    # Re-read the session snapshot with the fork id embedded.
+    session_with_fork = runtime.storage.get_session(session.id)
+    assert session_with_fork is not None
+
+    # Now remove the session from storage (simulating post-delete call).
+    runtime.storage.delete_session(session.id)
+
+    deleted_files: list[str] = []
+    with patch.object(
+        sq_module,
+        "_delete_fork_file",
+        new=AsyncMock(side_effect=lambda fid, *a, **kw: deleted_files.append(fid)),
+    ):
+        # The session row is already gone; must still clean up the fork file.
+        await delete_session_side_questions(runtime, plugin, session_with_fork)
+
+    assert "fork-snap" in deleted_files

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -58,6 +58,8 @@ class _FakeRuntime:
         self.storage = storage
         self.broadcast = _FakeBroadcast()
         self._launch_targets: dict[str, Any] = {}
+        # (session_id, kind, text) for events emitted via the runtime hooks.
+        self.emitted: list[tuple[str, str, str]] = []
 
     def get_session(self, session_id: str) -> SessionRecord:
         session = self.storage.get_session(session_id)
@@ -69,6 +71,27 @@ class _FakeRuntime:
         if not launch_target_id:
             return None
         return self._launch_targets.get(launch_target_id)
+
+    async def _record_user_event(
+        self,
+        session_id: str,
+        text: str,
+        submit: bool,
+        status: SessionStatus = SessionStatus.RUNNING,
+        extra_metadata: dict | None = None,
+        attachments: Any = None,
+    ) -> None:
+        self.emitted.append((session_id, "user_input", text))
+
+    async def _emit_adapter_event(
+        self,
+        session_id: str,
+        kind: Any,
+        text: str,
+        metadata: dict,
+        status: SessionStatus,
+    ) -> None:
+        self.emitted.append((session_id, str(kind), text))
 
 
 class _FakeAdapter:
@@ -446,6 +469,13 @@ async def test_fork_aside_drops_record_and_brings_up_new_session(
 
     # bring_up received the new record and the fork thread id.
     assert bring_up_calls == [("new-sess", "fork-uuid-xyz")]
+
+    # The aside's question and answer were injected into the new transcript.
+    injected = [
+        (kind, text) for sid, kind, text in runtime.emitted if sid == "new-sess"
+    ]
+    assert ("user_input", "What files changed?") in injected
+    assert ("agent_output", "Only foo.py.") in injected
 
     # Removal broadcast was sent.
     msgs = [m for m, _ in runtime.broadcast.published]

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -336,9 +336,12 @@ async def test_dismiss_aside_noop_for_unknown_id(
 # ---------------------------------------------------------------------------
 
 
+async def _noop_bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
+    return None
+
+
 async def test_fork_aside_raises_404_for_unknown_question(
     runtime: Any,
-    plugin: Any,
     tmp_path: Path,
 ) -> None:
     from fastapi import HTTPException
@@ -350,20 +353,20 @@ async def test_fork_aside_raises_404_for_unknown_question(
     with pytest.raises(HTTPException) as exc_info:
         await fork_aside(
             runtime,
-            plugin,
             session,
             "nonexistent",
             new_session_id="new-sess",
+            transport_id="claude_cli",
             title="Fork",
             raw_log=session_dir / "raw.log",
             structured_log=session_dir / "events.jsonl",
+            bring_up=_noop_bring_up,
         )
     assert exc_info.value.status_code == 404
 
 
 async def test_fork_aside_raises_400_when_no_fork_thread(
     runtime: Any,
-    plugin: Any,
     tmp_path: Path,
 ) -> None:
     from fastapi import HTTPException
@@ -384,20 +387,20 @@ async def test_fork_aside_raises_400_when_no_fork_thread(
     with pytest.raises(HTTPException) as exc_info:
         await fork_aside(
             runtime,
-            plugin,
             session,
             "sq-pending",
             new_session_id="new-sess",
+            transport_id="claude_cli",
             title="Fork",
             raw_log=session_dir / "raw.log",
             structured_log=session_dir / "events.jsonl",
+            bring_up=_noop_bring_up,
         )
     assert exc_info.value.status_code == 400
 
 
-async def test_fork_aside_drops_record_and_creates_new_session(
+async def test_fork_aside_drops_record_and_brings_up_new_session(
     runtime: Any,
-    plugin: Any,
     tmp_path: Path,
 ) -> None:
     session = _make_session(runtime.storage, thread_id="thread-abc")
@@ -414,18 +417,21 @@ async def test_fork_aside_drops_record_and_creates_new_session(
 
     session_dir = tmp_path / "new-sess"
     session_dir.mkdir()
-    adapter = plugin.adapter
-    assert adapter is not None
+    bring_up_calls: list[tuple[str, str]] = []
+
+    async def _record(new_session: SessionRecord, fork_thread_id: str) -> None:
+        bring_up_calls.append((new_session.id, fork_thread_id))
 
     new_sess = await fork_aside(
         runtime,
-        plugin,
         session,
         "sq-ready",
         new_session_id="new-sess",
+        transport_id="claude_cli",
         title="Forked question",
         raw_log=session_dir / "raw.log",
         structured_log=session_dir / "events.jsonl",
+        bring_up=_record,
     )
 
     # Original record was dropped.
@@ -433,21 +439,21 @@ async def test_fork_aside_drops_record_and_creates_new_session(
     assert fresh is not None
     assert _read_side_questions(fresh) == []
 
-    # New session was created resuming fork-uuid-xyz.
+    # New session was created on the requested transport, resuming fork-uuid-xyz.
     assert new_sess.id == "new-sess"
+    assert new_sess.transport == "claude_cli"
     assert new_sess.transport_state.get("thread_id") == "fork-uuid-xyz"
 
-    # Adapter received restore call with the fork thread id.
-    assert adapter.restore_calls[0][2] == "fork-uuid-xyz"
+    # bring_up received the new record and the fork thread id.
+    assert bring_up_calls == [("new-sess", "fork-uuid-xyz")]
 
     # Removal broadcast was sent.
     msgs = [m for m, _ in runtime.broadcast.published]
     assert any("removed_id" in m.payload for m in msgs if m.type == "side_question")
 
 
-async def test_fork_aside_raises_503_when_adapter_none(
+async def test_fork_aside_marks_error_and_raises_400_when_bring_up_fails(
     runtime: Any,
-    plugin: Any,
     tmp_path: Path,
 ) -> None:
     from fastapi import HTTPException
@@ -463,22 +469,29 @@ async def test_fork_aside_raises_503_when_adapter_none(
         created_at=datetime.now(UTC),
     )
     _write_side_questions(runtime, session.id, [sq])
-    plugin.adapter = None
     session_dir = tmp_path / "new"
     session_dir.mkdir()
+
+    async def _boom(new_session: SessionRecord, fork_thread_id: str) -> None:
+        raise RuntimeError("launch failed")
 
     with pytest.raises(HTTPException) as exc_info:
         await fork_aside(
             runtime,
-            plugin,
             session,
             "sq-ready",
             new_session_id="new-sess",
+            transport_id="claude_cli",
             title="F",
             raw_log=session_dir / "raw.log",
             structured_log=session_dir / "events.jsonl",
+            bring_up=_boom,
         )
-    assert exc_info.value.status_code == 503
+    assert exc_info.value.status_code == 400
+
+    errored = runtime.storage.get_session("new-sess")
+    assert errored is not None
+    assert errored.status == SessionStatus.ERROR
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -1,0 +1,770 @@
+"""Tests for backends/claude_code/side_question.py.
+
+Covers the durable-state helpers, public API functions, background worker
+logic, and the post-restart recovery sweep.  The tests are unit-level: they
+replace the actual ``claude`` process calls with synchronous or async fakes
+and verify the side-effects on storage and the broadcast hub.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import waypoint.backends.claude_code.side_question as sq_module
+from waypoint.backends.claude_code.side_question import (
+    MAX_ATTEMPTS,
+    _parse_one_shot_output,
+    _read_side_questions,
+    _write_side_questions,
+    dismiss_aside,
+    fork_aside,
+    recover_pending_side_questions,
+    start_side_question,
+)
+from waypoint.schemas import (
+    SessionEnvelope,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+    SideQuestion,
+    SideQuestionStatus,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+# ---------------------------------------------------------------------------
+# Minimal fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeBroadcast:
+    def __init__(self) -> None:
+        self.published: list[tuple[SessionEnvelope, str | None]] = []
+
+    async def publish(
+        self, message: SessionEnvelope, session_id: str | None = None
+    ) -> None:
+        self.published.append((message, session_id))
+
+
+class _FakeRuntime:
+    """Minimal SessionRuntime stub: real Storage, fake broadcast."""
+
+    def __init__(self, storage: Storage) -> None:
+        self.storage = storage
+        self.broadcast = _FakeBroadcast()
+        self._launch_targets: dict[str, Any] = {}
+
+    def get_session(self, session_id: str) -> SessionRecord:
+        session = self.storage.get_session(session_id)
+        if session is None:
+            raise KeyError(session_id)
+        return session
+
+    def _find_launch_target(self, launch_target_id: str | None) -> Any:
+        if not launch_target_id:
+            return None
+        return self._launch_targets.get(launch_target_id)
+
+
+class _FakeAdapter:
+    def __init__(self) -> None:
+        self.restore_calls: list[tuple[str, str, str]] = []
+        self.raise_on_restore: Exception | None = None
+
+    async def restore_session(
+        self,
+        session_id: str,
+        cwd: str,
+        thread_id: str,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        if self.raise_on_restore is not None:
+            raise self.raise_on_restore
+        self.restore_calls.append((session_id, cwd, thread_id))
+
+
+class _FakePlugin:
+    id = "claude_code"
+    transport_id = "claude_cli"
+    _counter = 0
+
+    def __init__(self) -> None:
+        self.adapter: _FakeAdapter | None = _FakeAdapter()
+
+    def generate_session_id(self) -> str:
+        _FakePlugin._counter += 1
+        return f"fake-uuid-{_FakePlugin._counter}"
+
+    def remote_executable(self, launch_target: Any) -> str:
+        return "claude"
+
+    def launch_factory(self, runtime: Any, launch_target_id: str | None) -> Any:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_storage(tmp_path: Path) -> Storage:
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    return Storage(settings.database_path)
+
+
+@pytest.fixture
+def runtime(tmp_storage: Storage) -> Any:
+    return _FakeRuntime(tmp_storage)
+
+
+@pytest.fixture
+def plugin() -> Any:
+    _FakePlugin._counter = 0
+    return _FakePlugin()
+
+
+def _make_session(
+    storage: Storage,
+    *,
+    session_id: str = "sess-1",
+    backend: str = "claude_code",
+    thread_id: str | None = "thread-abc",
+    status: SessionStatus = SessionStatus.IDLE,
+    launch_target_id: str | None = None,
+    transport_state_extra: dict | None = None,
+) -> SessionRecord:
+    settings_dir = storage.database_path.parent / "sessions" / session_id
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    state: dict = {}
+    if thread_id is not None:
+        state["thread_id"] = thread_id
+    if transport_state_extra:
+        state.update(transport_state_extra)
+    session = SessionRecord(
+        id=session_id,
+        backend=backend,
+        source=SessionSource.MANAGED,
+        transport="claude_cli",
+        title="Test Session",
+        cwd="/tmp/project",
+        launch_target_id=launch_target_id,
+        status=status,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        transport_state=state,
+        raw_log_path=str(settings_dir / "raw.log"),
+        structured_log_path=str(settings_dir / "events.jsonl"),
+    )
+    return storage.create_session(session)
+
+
+# ---------------------------------------------------------------------------
+# _parse_one_shot_output
+# ---------------------------------------------------------------------------
+
+
+def test_parse_one_shot_success() -> None:
+    raw = json.dumps(
+        {"type": "result", "subtype": "success", "is_error": False, "result": "Hello!"}
+    ).encode()
+    assert _parse_one_shot_output(raw) == "Hello!"
+
+
+def test_parse_one_shot_error_flag() -> None:
+    raw = json.dumps(
+        {"type": "result", "subtype": "error_max_turns", "is_error": True}
+    ).encode()
+    with pytest.raises(RuntimeError, match="claude error"):
+        _parse_one_shot_output(raw)
+
+
+def test_parse_one_shot_invalid_json() -> None:
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        _parse_one_shot_output(b"not json at all")
+
+
+def test_parse_one_shot_missing_result_field() -> None:
+    raw = json.dumps({"type": "result", "is_error": False}).encode()
+    with pytest.raises(RuntimeError, match="missing or not a string"):
+        _parse_one_shot_output(raw)
+
+
+# ---------------------------------------------------------------------------
+# _read_side_questions / _write_side_questions
+# ---------------------------------------------------------------------------
+
+
+def test_read_side_questions_empty(runtime: Any) -> None:
+    session = _make_session(runtime.storage)
+    assert _read_side_questions(session) == []
+
+
+def test_write_and_read_round_trip(runtime: Any) -> None:
+    session = _make_session(runtime.storage)
+    sq = SideQuestion(
+        id="sq-1",
+        question="What is the plan?",
+        status=SideQuestionStatus.PENDING,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    loaded = _read_side_questions(fresh)
+    assert len(loaded) == 1
+    assert loaded[0].id == "sq-1"
+    assert loaded[0].status == SideQuestionStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# start_side_question
+# ---------------------------------------------------------------------------
+
+
+async def test_start_side_question_creates_pending_record(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+
+    await start_side_question(runtime, plugin, session, "What branch am I on?")
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1
+    assert qs[0].status == SideQuestionStatus.PENDING
+    assert qs[0].question == "What branch am I on?"
+    assert qs[0].attempts == 1
+
+
+async def test_start_side_question_broadcasts_upsert(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+
+    await start_side_question(runtime, plugin, session, "Quick q?")
+
+    # Cancel the spawned bg task so it doesn't linger.
+    for task in list(sq_module._background_tasks):
+        task.cancel()
+
+    messages = [m for m, _ in runtime.broadcast.published]
+    assert any(m.type == "side_question" for m in messages)
+    upsert = next(m for m in messages if m.type == "side_question")
+    assert "side_question" in upsert.payload
+
+
+async def test_start_side_question_no_thread_resolves_to_error(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id=None)
+
+    await start_side_question(runtime, plugin, session, "What?")
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1
+    assert qs[0].status == SideQuestionStatus.ERROR
+    assert qs[0].error is not None
+    # No background task should have been scheduled.
+    assert not any(
+        t.get_name().startswith("side-question") for t in sq_module._background_tasks
+    )
+
+
+# ---------------------------------------------------------------------------
+# dismiss_aside
+# ---------------------------------------------------------------------------
+
+
+async def test_dismiss_aside_drops_record_and_broadcasts(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-del",
+        question="Old?",
+        status=SideQuestionStatus.ANSWERED,
+        answer="Yes.",
+        fork_thread_id=None,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    await dismiss_aside(runtime, plugin, session, "sq-del")
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    assert _read_side_questions(fresh) == []
+
+    messages = [m for m, _ in runtime.broadcast.published]
+    remove_msgs = [m for m in messages if m.type == "side_question"]
+    assert any("removed_id" in m.payload for m in remove_msgs)
+
+
+async def test_dismiss_aside_noop_for_unknown_id(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+
+    # Should not raise
+    await dismiss_aside(runtime, plugin, session, "nonexistent-id")
+
+    assert runtime.broadcast.published == []
+
+
+# ---------------------------------------------------------------------------
+# fork_aside
+# ---------------------------------------------------------------------------
+
+
+async def test_fork_aside_raises_404_for_unknown_question(
+    runtime: Any,
+    plugin: Any,
+    tmp_path: Path,
+) -> None:
+    from fastapi import HTTPException
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    session_dir = tmp_path / "new-sess"
+    session_dir.mkdir()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fork_aside(
+            runtime,
+            plugin,
+            session,
+            "nonexistent",
+            new_session_id="new-sess",
+            title="Fork",
+            raw_log=session_dir / "raw.log",
+            structured_log=session_dir / "events.jsonl",
+        )
+    assert exc_info.value.status_code == 404
+
+
+async def test_fork_aside_raises_400_when_no_fork_thread(
+    runtime: Any,
+    plugin: Any,
+    tmp_path: Path,
+) -> None:
+    from fastapi import HTTPException
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-pending",
+        question="Not answered yet?",
+        status=SideQuestionStatus.PENDING,
+        fork_thread_id=None,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+    session_dir = tmp_path / "new-sess"
+    session_dir.mkdir()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fork_aside(
+            runtime,
+            plugin,
+            session,
+            "sq-pending",
+            new_session_id="new-sess",
+            title="Fork",
+            raw_log=session_dir / "raw.log",
+            structured_log=session_dir / "events.jsonl",
+        )
+    assert exc_info.value.status_code == 400
+
+
+async def test_fork_aside_drops_record_and_creates_new_session(
+    runtime: Any,
+    plugin: Any,
+    tmp_path: Path,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-ready",
+        question="What files changed?",
+        status=SideQuestionStatus.ANSWERED,
+        answer="Only foo.py.",
+        fork_thread_id="fork-uuid-xyz",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    session_dir = tmp_path / "new-sess"
+    session_dir.mkdir()
+    adapter = plugin.adapter
+    assert adapter is not None
+
+    new_sess = await fork_aside(
+        runtime,
+        plugin,
+        session,
+        "sq-ready",
+        new_session_id="new-sess",
+        title="Forked question",
+        raw_log=session_dir / "raw.log",
+        structured_log=session_dir / "events.jsonl",
+    )
+
+    # Original record was dropped.
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    assert _read_side_questions(fresh) == []
+
+    # New session was created resuming fork-uuid-xyz.
+    assert new_sess.id == "new-sess"
+    assert new_sess.transport_state.get("thread_id") == "fork-uuid-xyz"
+
+    # Adapter received restore call with the fork thread id.
+    assert adapter.restore_calls[0][2] == "fork-uuid-xyz"
+
+    # Removal broadcast was sent.
+    msgs = [m for m, _ in runtime.broadcast.published]
+    assert any("removed_id" in m.payload for m in msgs if m.type == "side_question")
+
+
+async def test_fork_aside_raises_503_when_adapter_none(
+    runtime: Any,
+    plugin: Any,
+    tmp_path: Path,
+) -> None:
+    from fastapi import HTTPException
+
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-ready",
+        question="x?",
+        status=SideQuestionStatus.ANSWERED,
+        answer="y.",
+        fork_thread_id="fork-uuid",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+    plugin.adapter = None
+    session_dir = tmp_path / "new"
+    session_dir.mkdir()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await fork_aside(
+            runtime,
+            plugin,
+            session,
+            "sq-ready",
+            new_session_id="new-sess",
+            title="F",
+            raw_log=session_dir / "raw.log",
+            structured_log=session_dir / "events.jsonl",
+        )
+    assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# _run_side_question_bg (via monkeypatching _run_one_shot_local)
+# ---------------------------------------------------------------------------
+
+
+async def test_bg_task_success_updates_record(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-bg",
+        question="What's the status?",
+        status=SideQuestionStatus.PENDING,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    with patch.object(
+        sq_module,
+        "_run_one_shot_local",
+        new=AsyncMock(return_value="All green!"),
+    ):
+        await sq_module._run_side_question_bg(runtime, plugin, session.id, "sq-bg")
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1
+    assert qs[0].status == SideQuestionStatus.ANSWERED
+    assert qs[0].answer == "All green!"
+    assert qs[0].fork_thread_id is not None
+
+
+async def test_bg_task_marks_error_on_failure(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-fail",
+        question="Will fail?",
+        status=SideQuestionStatus.PENDING,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    with (
+        patch.object(
+            sq_module,
+            "_run_one_shot_local",
+            new=AsyncMock(side_effect=RuntimeError("claude not found")),
+        ),
+        patch.object(sq_module, "_delete_fork_file", new=AsyncMock()),
+    ):
+        await sq_module._run_side_question_bg(runtime, plugin, session.id, "sq-fail")
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1
+    assert qs[0].status == SideQuestionStatus.ERROR
+    assert "claude not found" in (qs[0].error or "")
+
+
+async def test_bg_task_cleans_up_fork_file_when_dismissed_mid_run(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    """If the side-question is dismissed while the bg task is running, the
+    completed fork file must be cleaned up."""
+    session = _make_session(runtime.storage, thread_id="thread-abc")
+    sq = SideQuestion(
+        id="sq-race",
+        question="Race?",
+        status=SideQuestionStatus.PENDING,
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    cleanup_calls: list[str] = []
+
+    async def fake_delete(fork_thread_id: str, *args: Any, **kwargs: Any) -> None:
+        cleanup_calls.append(fork_thread_id)
+
+    async def fake_one_shot(*args: Any, **kwargs: Any) -> str:
+        # Dismiss the record while the "one-shot" is running.
+        _write_side_questions(runtime, session.id, [])
+        return "answer"
+
+    with (
+        patch.object(
+            sq_module, "_run_one_shot_local", new=AsyncMock(side_effect=fake_one_shot)
+        ),
+        patch.object(
+            sq_module, "_delete_fork_file", new=AsyncMock(side_effect=fake_delete)
+        ),
+    ):
+        await sq_module._run_side_question_bg(runtime, plugin, session.id, "sq-race")
+
+    # The fork file must have been cleaned up (dismissed-while-running path).
+    assert len(cleanup_calls) == 1
+
+
+async def test_bg_task_noop_when_session_gone(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    # Session never stored — bg task must silently exit.
+    with patch.object(
+        sq_module, "_run_one_shot_local", new=AsyncMock(return_value="x")
+    ):
+        await sq_module._run_side_question_bg(
+            runtime, plugin, "nonexistent-sess", "sq-x"
+        )
+
+
+# ---------------------------------------------------------------------------
+# recover_pending_side_questions
+# ---------------------------------------------------------------------------
+
+
+async def test_recover_re_issues_pending_records(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="t1")
+    sq = SideQuestion(
+        id="sq-pend",
+        question="Pending?",
+        status=SideQuestionStatus.PENDING,
+        fork_thread_id="stale-fork",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    cleanup_calls: list[str] = []
+
+    with (
+        patch.object(
+            sq_module,
+            "_delete_fork_file",
+            new=AsyncMock(side_effect=lambda fid, *a, **kw: cleanup_calls.append(fid)),
+        ),
+        patch.object(sq_module, "_schedule_bg_task"),
+    ):
+        await recover_pending_side_questions(runtime, plugin)
+
+    # Stale fork file deleted.
+    assert "stale-fork" in cleanup_calls
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1
+    assert qs[0].attempts == 2
+    assert qs[0].resumed is True
+    assert qs[0].fork_thread_id is None
+    assert qs[0].status == SideQuestionStatus.PENDING
+
+
+async def test_recover_caps_at_max_attempts(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="t1")
+    sq = SideQuestion(
+        id="sq-cap",
+        question="Capped?",
+        status=SideQuestionStatus.PENDING,
+        fork_thread_id=None,
+        attempts=MAX_ATTEMPTS,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    with patch.object(sq_module, "_delete_fork_file", new=AsyncMock()):
+        await recover_pending_side_questions(runtime, plugin)
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    qs = _read_side_questions(fresh)
+    assert len(qs) == 1
+    assert qs[0].status == SideQuestionStatus.ERROR
+
+
+async def test_recover_rebroadcasts_answered_records(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(runtime.storage, thread_id="t1")
+    sq = SideQuestion(
+        id="sq-ans",
+        question="Done?",
+        status=SideQuestionStatus.ANSWERED,
+        answer="Yes.",
+        fork_thread_id="survived-fork",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    await recover_pending_side_questions(runtime, plugin)
+
+    # No deletion for answered records.
+    msgs = [m for m, _ in runtime.broadcast.published]
+    upserts = [
+        m for m in msgs if m.type == "side_question" and "side_question" in m.payload
+    ]
+    assert len(upserts) == 1
+    assert upserts[0].payload["side_question"]["id"] == "sq-ans"
+
+
+async def test_recover_cleans_up_dead_sessions(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    session = _make_session(
+        runtime.storage, thread_id="t1", status=SessionStatus.EXITED
+    )
+    sq = SideQuestion(
+        id="sq-dead",
+        question="Dead?",
+        status=SideQuestionStatus.ANSWERED,
+        fork_thread_id="dangling-fork",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    _write_side_questions(runtime, session.id, [sq])
+
+    cleanup_calls: list[str] = []
+
+    with patch.object(
+        sq_module,
+        "_delete_fork_file",
+        new=AsyncMock(side_effect=lambda fid, *a, **kw: cleanup_calls.append(fid)),
+    ):
+        await recover_pending_side_questions(runtime, plugin)
+
+    assert "dangling-fork" in cleanup_calls
+
+    fresh = runtime.storage.get_session(session.id)
+    assert fresh is not None
+    assert _read_side_questions(fresh) == []
+
+
+async def test_recover_skips_non_claude_sessions(
+    runtime: Any,
+    plugin: Any,
+) -> None:
+    # A codex session — the plugin id doesn't match; should be ignored.
+    session = _make_session(
+        runtime.storage,
+        session_id="codex-sess",
+        backend="codex",
+        thread_id="t1",
+    )
+    sq = SideQuestion(
+        id="sq-x",
+        question="Ignored?",
+        status=SideQuestionStatus.PENDING,
+        fork_thread_id="fork-x",
+        attempts=1,
+        created_at=datetime.now(UTC),
+    )
+    # Manually inject the record (bypasses _write_side_questions so we avoid
+    # having to set the transport correctly for codex).
+    state = {
+        **session.transport_state,
+        "pending_side_questions": [sq.model_dump(mode="json")],
+    }
+    runtime.storage.update_session(session.id, transport_state=state)
+
+    cleanup_calls: list[str] = []
+    with patch.object(
+        sq_module,
+        "_delete_fork_file",
+        new=AsyncMock(side_effect=lambda fid, *a, **kw: cleanup_calls.append(fid)),
+    ):
+        await recover_pending_side_questions(runtime, plugin)
+
+    # Nothing touched.
+    assert cleanup_calls == []

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3808,9 +3808,10 @@ html[data-theme="light"] .task-dock-panel {
 }
 
 /* ────────────────────────────────────────────────────────────────────────
- * Side-question dock — marginalia overlay that surfaces /btw answers above
- * the composer. Desktop: a right-anchored floating card stack. Mobile: a
- * slim bar that opens a bottom sheet.
+ * Side-question dock — /btw answers, unified with the task-progress dock: a
+ * collapsed strip above the composer that expands into a panel (a bottom sheet
+ * on mobile, a floating popover on desktop) listing the aside cards. Mirrors
+ * the .task-dock-* structure and surface so the two docks read as one family.
  * ──────────────────────────────────────────────────────────────────────── */
 .sq-dock {
   position: sticky;
@@ -3820,128 +3821,100 @@ html[data-theme="light"] .task-dock-panel {
   pointer-events: none;
 }
 
-.sq-dock.sq-dock-expanded {
+.sq-dock.expanded {
   z-index: 50;
 }
 
-/* ── Mobile slim bar ── */
-.sq-bar {
+.sq-dock-strip {
   pointer-events: auto;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  width: 100%;
-  padding: 8px 14px;
-  background: linear-gradient(180deg, rgba(20, 24, 33, 0.92), rgba(12, 15, 22, 0.96));
+  overflow: hidden;
   border: 1px solid var(--line-strong);
   border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.92), rgba(12, 15, 22, 0.96));
   box-shadow:
     0 12px 30px rgba(0, 0, 0, 0.36),
     0 0 0 1px rgba(200, 169, 106, 0.05) inset;
   backdrop-filter: blur(22px) saturate(1.2);
-  font: inherit;
-  color: var(--text);
-  cursor: pointer;
-  text-align: left;
 }
 
-html[data-theme="light"] .sq-bar {
+html[data-theme="light"] .sq-dock-strip {
   background: linear-gradient(180deg, rgba(248, 245, 238, 0.96), rgba(240, 236, 226, 0.98));
   box-shadow:
     0 12px 30px rgba(60, 50, 30, 0.14),
     0 0 0 1px rgba(200, 169, 106, 0.12) inset;
 }
 
-.sq-bar-icon {
-  flex: none;
-  color: var(--accent);
-  font-size: 1rem;
-  font-weight: 700;
-}
-
-.sq-bar-label {
-  flex: 1;
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  letter-spacing: 0.06em;
-  color: var(--text);
-}
-
-.sq-bar-chevron {
-  flex: none;
-  color: var(--muted-soft);
-  font-size: 0.9rem;
-  transition: transform 160ms ease;
-}
-
-.sq-dock-expanded .sq-bar .sq-bar-chevron {
-  transform: rotate(180deg);
-}
-
-/* ── Mobile scrim ── */
-.sq-scrim {
-  position: fixed;
-  inset: 0;
-  z-index: 6;
-  border: none;
-  background: rgba(0, 0, 0, 0.4);
-  cursor: default;
-  pointer-events: auto;
-}
-
-html[data-theme="light"] .sq-scrim {
-  background: rgba(20, 16, 8, 0.22);
-}
-
-/* ── Mobile bottom sheet ── */
-.sq-sheet {
-  position: relative;
-  z-index: 7;
-  margin-bottom: 0;
-  max-height: 60vh;
-  overflow-y: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  border: 1px solid var(--line-strong);
-  border-bottom: none;
-  border-radius: var(--radius) var(--radius) 0 0;
-  background: linear-gradient(180deg, rgba(20, 24, 33, 0.96), rgba(12, 15, 22, 0.98));
-  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.4);
-  backdrop-filter: blur(22px) saturate(1.2);
-  pointer-events: auto;
-}
-
-html[data-theme="light"] .sq-sheet {
-  background: linear-gradient(180deg, rgba(248, 245, 238, 0.98), rgba(240, 236, 226, 0.99));
-  box-shadow: 0 -10px 30px rgba(60, 50, 30, 0.16);
-}
-
-.sq-sheet-head {
+.sq-dock-row {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 12px 14px 10px;
-  border-bottom: 1px solid var(--line);
-  position: sticky;
-  top: 0;
-  background: inherit;
-  z-index: 1;
+  padding: 6px 8px 6px 12px;
 }
 
-.sq-sheet-title {
+.sq-dock-toggle {
   flex: 1;
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted-soft);
-  font-weight: 600;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
-.sq-sheet-close {
+.sq-dock-glyph {
   flex: none;
-  padding: 4px 7px;
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.sq-dock.active .sq-dock-glyph {
+  animation: sq-dock-pulse 2.8s ease-in-out infinite;
+}
+
+@keyframes sq-dock-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.sq-dock-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sq-dock-count {
+  flex: none;
+  color: var(--muted);
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+}
+
+.sq-dock-chevron {
+  flex: none;
+  display: inline-flex;
+  color: var(--muted-soft);
+  transition: transform 160ms ease;
+}
+
+.sq-dock-toggle[aria-expanded="true"] .sq-dock-chevron {
+  transform: rotate(180deg);
+}
+
+.sq-dock-dismiss {
+  flex: none;
+  padding: 4px 6px;
   background: none;
   border: none;
   border-radius: var(--radius-sm);
@@ -3951,27 +3924,127 @@ html[data-theme="light"] .sq-sheet {
   cursor: pointer;
 }
 
-.sq-sheet-close:hover {
+.sq-dock-dismiss:hover {
   color: var(--text);
 }
 
-.sq-sheet-cards {
+.sq-dock-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 6;
+  border: none;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: default;
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .sq-dock-scrim {
+  background: rgba(20, 16, 8, 0.22);
+}
+
+.sq-dock-panel {
+  position: relative;
+  z-index: 7;
+  margin-bottom: 8px;
+  max-height: 50vh;
+  overflow-y: auto;
+  display: grid;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.96), rgba(12, 15, 22, 0.98));
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(22px) saturate(1.2);
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .sq-dock-panel {
+  background: linear-gradient(180deg, rgba(248, 245, 238, 0.98), rgba(240, 236, 226, 0.99));
+  box-shadow: 0 -10px 30px rgba(60, 50, 30, 0.16);
+}
+
+/* Mobile: join the panel to the strip into one surface. */
+.sq-dock.expanded .sq-dock-panel {
+  margin-bottom: 0;
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  box-shadow: none;
+}
+
+.sq-dock.expanded .sq-dock-strip {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.sq-dock-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sq-dock-panel-title {
+  flex: 1;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.sq-dock-collapse {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 6px;
+  background: none;
+  border: none;
+  color: var(--muted-soft);
+  cursor: pointer;
+}
+
+/* The collapse control always points down ("close"). */
+.sq-dock-collapse svg {
+  transform: rotate(180deg);
+}
+
+.sq-dock-cards {
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  padding: 10px 12px 12px;
 }
 
-/* ── Desktop floating panel ── */
-.sq-panel {
-  display: none;
+@media (min-width: 768px) {
+  .sq-dock-scrim,
+  html[data-theme="light"] .sq-dock-scrim {
+    background: transparent;
+  }
+
+  .sq-dock-panel {
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 8px);
+    width: min(440px, 92vw);
+    margin-bottom: 0;
+  }
+
+  .sq-dock.expanded .sq-dock-panel {
+    border-bottom: 1px solid var(--line-strong);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  }
+
+  html[data-theme="light"] .sq-dock.expanded .sq-dock-panel {
+    box-shadow: 0 12px 30px rgba(60, 50, 30, 0.16);
+  }
+
+  .sq-dock.expanded .sq-dock-strip {
+    border-top-left-radius: var(--radius);
+    border-top-right-radius: var(--radius);
+  }
 }
 
-/* ── Clear-all button (shared mobile sheet + desktop panel) ── */
+/* Clear-all (panel head) */
 .sq-clear-all {
   flex: none;
   font-family: var(--font-mono);
-  font-size: 0.64rem;
+  font-size: 0.62rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--muted);
@@ -3988,43 +4061,24 @@ html[data-theme="light"] .sq-sheet {
   border-color: var(--accent);
 }
 
-/* ── Side-question card ── */
+/* ── Aside card: a marginalia list item inside the panel ── */
 .sq-card {
   position: relative;
-  /* Opaque surface (blur as fallback) so a long answer never lets the
-     transcript bleed through and collide with the card's own text. The gold
-     left rule is the card's defining edge — the "ink in the margin". */
-  background: linear-gradient(180deg, rgba(22, 26, 35, 0.985), rgba(14, 17, 24, 0.99));
-  backdrop-filter: blur(20px) saturate(1.2);
-  border: 1px solid var(--line);
   border-left: 3px solid var(--accent);
-  border-radius: var(--radius-sm);
-  padding: 15px 17px 14px 18px;
-  box-shadow: 0 18px 44px -28px rgba(0, 0, 0, 0.9);
-  animation: sq-slidein 0.34s cubic-bezier(0.16, 1, 0.3, 1) both;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  padding: 10px 4px 12px 14px;
 }
 
-html[data-theme="light"] .sq-card {
-  background: linear-gradient(180deg, rgba(255, 253, 247, 0.985), rgba(248, 244, 236, 0.99));
-  box-shadow: 0 10px 28px -18px rgba(60, 45, 20, 0.34);
+.sq-card + .sq-card {
+  margin-top: 12px;
+  border-top: 1px solid var(--line);
+  padding-top: 14px;
 }
 
 .sq-card.sq-error {
   border-left-color: var(--danger);
 }
 
-@keyframes sq-slidein {
-  from {
-    opacity: 0;
-    transform: translateY(8px) scale(0.99);
-  }
-  to {
-    opacity: 1;
-    transform: none;
-  }
-}
-
-/* Card meta row */
 .sq-card-meta {
   display: flex;
   align-items: center;
@@ -4034,7 +4088,7 @@ html[data-theme="light"] .sq-card {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 11px;
+  margin-bottom: 9px;
   flex-wrap: nowrap;
 }
 
@@ -4117,15 +4171,13 @@ html[data-theme="light"] .sq-card {
   cursor: default;
 }
 
-/* Question text in serif with curly quotes */
 .sq-card-q {
   font-family: var(--font-display);
-  font-size: 1.04rem;
+  font-size: 1.02rem;
   line-height: 1.32;
   color: var(--text-strong);
   margin: 0 0 8px;
   text-wrap: pretty;
-  /* Clamp a long question — it's the user's own text, so a few lines suffice. */
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -4143,12 +4195,9 @@ html[data-theme="light"] .sq-card {
   color: var(--accent);
 }
 
-/* Answer text. A long answer is clamped to a few lines with a fade rather than
- * trapped in a scroll window; "Read full aside" expands it in place, bounded by
- * the viewport so it can never grow the card to fill the screen. */
 .sq-card-a {
   font-family: var(--font-display);
-  font-size: 0.94rem;
+  font-size: 0.92rem;
   line-height: 1.5;
   color: var(--text);
   margin: 0;
@@ -4165,9 +4214,15 @@ html[data-theme="light"] .sq-card {
 }
 
 .sq-card-a-expanded {
-  max-height: min(46vh, calc(100dvh - var(--composer-height, 220px) - 220px));
+  max-height: 34vh;
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.sq-card.sq-error .sq-card-a {
+  font-family: var(--font-sans);
+  font-size: 0.86rem;
+  color: var(--muted);
 }
 
 .sq-card-more {
@@ -4187,13 +4242,6 @@ html[data-theme="light"] .sq-card {
   color: var(--text-strong);
 }
 
-.sq-card.sq-error .sq-card-a {
-  font-family: var(--font-sans);
-  font-size: 0.86rem;
-  color: var(--muted);
-}
-
-/* Shimmer skeleton while asking */
 .sq-shimmer-lines {
   display: flex;
   flex-direction: column;
@@ -4233,19 +4281,12 @@ html[data-theme="light"] .sq-card {
   width: 62%;
 }
 
-/* Card footer */
 .sq-card-foot {
   display: flex;
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
   margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid var(--line);
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  letter-spacing: 0.08em;
-  color: var(--muted-soft);
 }
 
 .sq-card-fork {
@@ -4272,90 +4313,14 @@ html[data-theme="light"] .sq-card {
   cursor: default;
 }
 
-/* ── Desktop layout: right-anchored floating column ── */
-@media (min-width: 768px) {
-  .sq-bar {
-    display: none;
-  }
-
-  .sq-scrim,
-  .sq-sheet {
-    display: none;
-  }
-
-  /* In-flow, right-aligned above the composer (the sticky .sq-dock rides the
-     composer band). NOT absolute against the zero-height dock — that floated
-     it mid-transcript. margin-left:auto right-aligns the fixed-width block. */
-  .sq-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    width: min(380px, 46%);
-    margin-left: auto;
-    pointer-events: auto;
-  }
-
-  .sq-panel-head {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-family: var(--font-mono);
-    font-size: 0.64rem;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: var(--muted-soft);
-    padding: 0 4px 4px;
-  }
-
-  .sq-panel-label {
-    flex: 1;
-  }
-
-  .sq-panel-cards {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    /* Bound the stack so several asides never climb the page; scroll past it. */
-    max-height: min(64vh, calc(100dvh - var(--composer-height, 220px) - 96px));
-    overflow-y: auto;
-    padding-right: 2px;
-  }
-}
-
-/* Older-asides summary toggle (desktop stack) */
-.sq-older-toggle {
-  width: 100%;
-  font-family: var(--font-mono);
-  font-size: 0.66rem;
-  letter-spacing: 0.06em;
-  color: var(--muted);
-  background: none;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  padding: 7px 11px;
-  cursor: pointer;
-  text-align: left;
-  transition: color 0.14s, border-color 0.14s;
-}
-
-.sq-older-toggle:hover {
-  color: var(--accent);
-  border-color: var(--accent);
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .sq-card {
-    animation: none;
-  }
-
-  .sq-card-pulse {
-    animation: none;
-  }
-
+  .sq-dock.active .sq-dock-glyph,
+  .sq-card-pulse,
   .sq-shimmer {
     animation: none;
   }
 }
+
 
 /* ────────────────────────────────────────────────────────────────────────
  * Composer — sticky reply deck pinned to the viewport bottom so the user

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4273,7 +4273,11 @@ html[data-theme="light"] .sq-dock-panel {
     color-mix(in srgb, var(--muted) 16%, transparent) 75%
   );
   background-size: 220% 100%;
-  animation: sq-sweep 1.5s linear infinite;
+  /* `alternate` + `ease-in-out` ping-pongs the sweep instead of snapping from
+     the end position back to the start — the gradient's ends aren't identical,
+     so a one-way loop showed a visible discontinuity at the reset. Easing the
+     turn keeps the band's motion continuous. */
+  animation: sq-sweep 1.2s ease-in-out infinite alternate;
 }
 
 @keyframes sq-sweep {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3819,6 +3819,11 @@ html[data-theme="light"] .task-dock-panel {
   z-index: 5;
   margin-top: -8px;
   pointer-events: none;
+  /* The parent `.stack` is a grid with an `auto` column, which sizes to its
+     widest child's max-content. Every other `.stack` child sets this; without
+     it the dock's answer paragraph (max-content = the whole answer on one line)
+     blew the grid — and the page — wider than the viewport. */
+  min-width: 0;
 }
 
 .sq-dock.expanded {
@@ -3949,6 +3954,11 @@ html[data-theme="light"] .sq-dock-scrim {
   max-height: 50vh;
   overflow-y: auto;
   display: grid;
+  /* minmax(0, 1fr) — NOT a default `auto` column, which sizes to the answer
+     paragraph's max-content (the whole answer on one line) and blows the dock
+     wider than the viewport, scrolling the page sideways. The 0 floor lets the
+     column shrink so text wraps. */
+  grid-template-columns: minmax(0, 1fr);
   gap: 10px;
   padding: 12px 14px;
   border: 1px solid var(--line-strong);
@@ -4006,6 +4016,7 @@ html[data-theme="light"] .sq-dock-panel {
 }
 
 .sq-dock-cards {
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }
@@ -4064,6 +4075,7 @@ html[data-theme="light"] .sq-dock-panel {
 /* ── Aside card: a marginalia list item inside the panel ── */
 .sq-card {
   position: relative;
+  min-width: 0;
   border-left: 3px solid var(--accent);
   border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
   padding: 10px 4px 12px 14px;
@@ -4178,6 +4190,7 @@ html[data-theme="light"] .sq-dock-panel {
   color: var(--text-strong);
   margin: 0 0 8px;
   text-wrap: pretty;
+  overflow-wrap: anywhere;
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -4201,6 +4214,7 @@ html[data-theme="light"] .sq-dock-panel {
   line-height: 1.5;
   color: var(--text);
   margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .sq-card-a-clamped {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3948,9 +3948,14 @@ html[data-theme="light"] .sq-dock-scrim {
 }
 
 .sq-dock-panel {
-  position: relative;
+  /* Absolute (not in flow) so expanding it overlays the transcript instead of
+     growing the sticky dock's box and reflowing content upward — mobile sits
+     flush atop the strip as a full-width sheet; desktop re-anchors below. */
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
   z-index: 7;
-  margin-bottom: 8px;
   max-height: 50vh;
   overflow-y: auto;
   display: grid;
@@ -4028,11 +4033,10 @@ html[data-theme="light"] .sq-dock-panel {
   }
 
   .sq-dock-panel {
-    position: absolute;
+    left: auto;
     right: 0;
     bottom: calc(100% + 8px);
     width: min(440px, 92vw);
-    margin-bottom: 0;
   }
 
   .sq-dock.expanded .sq-dock-panel {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3808,6 +3808,494 @@ html[data-theme="light"] .task-dock-panel {
 }
 
 /* ────────────────────────────────────────────────────────────────────────
+ * Side-question dock — marginalia overlay that surfaces /btw answers above
+ * the composer. Desktop: a right-anchored floating card stack. Mobile: a
+ * slim bar that opens a bottom sheet.
+ * ──────────────────────────────────────────────────────────────────────── */
+.sq-dock {
+  position: sticky;
+  bottom: calc(var(--composer-height, 220px) + 12px);
+  z-index: 5;
+  margin-top: -8px;
+  pointer-events: none;
+}
+
+.sq-dock.sq-dock-expanded {
+  z-index: 50;
+}
+
+/* ── Mobile slim bar ── */
+.sq-bar {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  padding: 8px 14px;
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.92), rgba(12, 15, 22, 0.96));
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.36),
+    0 0 0 1px rgba(200, 169, 106, 0.05) inset;
+  backdrop-filter: blur(22px) saturate(1.2);
+  font: inherit;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+}
+
+html[data-theme="light"] .sq-bar {
+  background: linear-gradient(180deg, rgba(248, 245, 238, 0.96), rgba(240, 236, 226, 0.98));
+  box-shadow:
+    0 12px 30px rgba(60, 50, 30, 0.14),
+    0 0 0 1px rgba(200, 169, 106, 0.12) inset;
+}
+
+.sq-bar-icon {
+  flex: none;
+  color: var(--accent);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.sq-bar-label {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  color: var(--text);
+}
+
+.sq-bar-chevron {
+  flex: none;
+  color: var(--muted-soft);
+  font-size: 0.9rem;
+  transition: transform 160ms ease;
+}
+
+.sq-dock-expanded .sq-bar .sq-bar-chevron {
+  transform: rotate(180deg);
+}
+
+/* ── Mobile scrim ── */
+.sq-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 6;
+  border: none;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: default;
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .sq-scrim {
+  background: rgba(20, 16, 8, 0.22);
+}
+
+/* ── Mobile bottom sheet ── */
+.sq-sheet {
+  position: relative;
+  z-index: 7;
+  margin-bottom: 0;
+  max-height: 60vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border: 1px solid var(--line-strong);
+  border-bottom: none;
+  border-radius: var(--radius) var(--radius) 0 0;
+  background: linear-gradient(180deg, rgba(20, 24, 33, 0.96), rgba(12, 15, 22, 0.98));
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(22px) saturate(1.2);
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .sq-sheet {
+  background: linear-gradient(180deg, rgba(248, 245, 238, 0.98), rgba(240, 236, 226, 0.99));
+  box-shadow: 0 -10px 30px rgba(60, 50, 30, 0.16);
+}
+
+.sq-sheet-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px 10px;
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  background: inherit;
+  z-index: 1;
+}
+
+.sq-sheet-title {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+  font-weight: 600;
+}
+
+.sq-sheet-close {
+  flex: none;
+  padding: 4px 7px;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--muted-soft);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.sq-sheet-close:hover {
+  color: var(--text);
+}
+
+.sq-sheet-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px 12px 12px;
+}
+
+/* ── Desktop floating panel ── */
+.sq-panel {
+  display: none;
+}
+
+/* ── Clear-all button (shared mobile sheet + desktop panel) ── */
+.sq-clear-all {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  padding: 3px 9px;
+  cursor: pointer;
+  transition: color 0.14s, border-color 0.14s;
+}
+
+.sq-clear-all:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+/* ── Side-question card ── */
+.sq-card {
+  position: relative;
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-left: 2px solid var(--accent);
+  border-radius: var(--radius-sm);
+  padding: 13px 15px 13px 16px;
+  box-shadow: 0 18px 44px -30px rgba(0, 0, 0, 0.85);
+  animation: sq-slidein 0.34s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+html[data-theme="light"] .sq-card {
+  box-shadow: 0 8px 24px -16px rgba(60, 45, 20, 0.3);
+}
+
+.sq-card.sq-error {
+  border-left-color: var(--danger);
+}
+
+@keyframes sq-slidein {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Card meta row */
+.sq-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 9px;
+}
+
+.sq-card.sq-error .sq-card-meta {
+  color: var(--danger);
+}
+
+.sq-card-asking {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sq-card-pulse {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: sq-pulse 1.3s ease-in-out infinite;
+}
+
+@keyframes sq-pulse {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.1);
+  }
+}
+
+.sq-chip-resumed {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 1px solid color-mix(in srgb, var(--accent-cool) 45%, transparent);
+  color: var(--accent-cool);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+  text-transform: none;
+}
+
+.sq-card-ts {
+  margin-left: auto;
+  color: var(--muted-soft);
+  letter-spacing: 0.06em;
+  font-variant-numeric: tabular-nums;
+  text-transform: none;
+}
+
+.sq-card-dismiss {
+  flex: none;
+  color: var(--muted-soft);
+  cursor: pointer;
+  font-size: 0.9rem;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 6px;
+  margin: -2px -4px -2px 2px;
+  background: none;
+  border: none;
+}
+
+.sq-card-dismiss:hover {
+  color: var(--text-strong);
+  background: var(--bg-card-soft);
+}
+
+.sq-card-dismiss:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Question text in serif with curly quotes */
+.sq-card-q {
+  font-family: var(--font-display);
+  font-size: 1.04rem;
+  line-height: 1.32;
+  color: var(--text-strong);
+  margin: 0 0 8px;
+  text-wrap: pretty;
+}
+
+.sq-card-q::before {
+  content: "\201C";
+  color: var(--accent);
+  margin-right: 1px;
+}
+
+.sq-card-q::after {
+  content: "\201D";
+  color: var(--accent);
+}
+
+/* Answer text */
+.sq-card-a {
+  font-family: var(--font-display);
+  font-size: 0.94rem;
+  line-height: 1.46;
+  color: var(--text);
+  margin: 0;
+}
+
+.sq-card.sq-error .sq-card-a {
+  font-family: var(--font-sans);
+  font-size: 0.86rem;
+  color: var(--muted);
+}
+
+/* Shimmer skeleton while asking */
+.sq-shimmer-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  margin-top: 2px;
+}
+
+.sq-shimmer {
+  height: 9px;
+  border-radius: 5px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--muted) 16%, transparent) 25%,
+    color-mix(in srgb, var(--accent) 22%, transparent) 50%,
+    color-mix(in srgb, var(--muted) 16%, transparent) 75%
+  );
+  background-size: 220% 100%;
+  animation: sq-sweep 1.5s linear infinite;
+}
+
+@keyframes sq-sweep {
+  from {
+    background-position: 120% 0;
+  }
+  to {
+    background-position: -120% 0;
+  }
+}
+
+.sq-shimmer-full {
+  width: 100%;
+}
+.sq-shimmer-wide {
+  width: 86%;
+}
+.sq-shimmer-mid {
+  width: 62%;
+}
+
+/* Card footer */
+.sq-card-foot {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 11px;
+  padding-top: 9px;
+  border-top: 1px dashed var(--line);
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  color: var(--muted-soft);
+}
+
+.sq-card-foot-state {
+  color: var(--success);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.sq-card-foot-state.sq-foot-pending {
+  color: var(--accent);
+}
+
+.sq-card-foot-state.sq-foot-error {
+  color: var(--danger);
+}
+
+.sq-card-fork {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  color: var(--accent-cool);
+  background: none;
+  border: 1px solid color-mix(in srgb, var(--accent-cool) 40%, transparent);
+  border-radius: var(--radius-pill);
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: color 0.14s, border-color 0.14s;
+}
+
+.sq-card-fork:hover {
+  color: var(--text-strong);
+  border-color: var(--accent-cool);
+}
+
+.sq-card-fork:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* ── Desktop layout: right-anchored floating column ── */
+@media (min-width: 768px) {
+  .sq-bar {
+    display: none;
+  }
+
+  .sq-scrim,
+  .sq-sheet {
+    display: none;
+  }
+
+  .sq-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: min(360px, 78%);
+    pointer-events: auto;
+  }
+
+  .sq-panel-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--muted-soft);
+    padding: 0 4px 4px;
+  }
+
+  .sq-panel-label {
+    flex: 1;
+  }
+
+  .sq-panel-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sq-card {
+    animation: none;
+  }
+
+  .sq-card-pulse {
+    animation: none;
+  }
+
+  .sq-shimmer {
+    animation: none;
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────────
  * Composer — sticky reply deck pinned to the viewport bottom so the user
  * never has to scroll to find the input. The transcript section reserves
  * `--composer-height` worth of bottom padding so the last message can scroll

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4115,6 +4115,11 @@ html[data-theme="light"] .sq-card {
   color: var(--text-strong);
   margin: 0 0 8px;
   text-wrap: pretty;
+  /* Clamp a long question — it's the user's own text, so a few lines suffice. */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .sq-card-q::before {
@@ -4128,13 +4133,17 @@ html[data-theme="light"] .sq-card {
   color: var(--accent);
 }
 
-/* Answer text */
+/* Answer text — capped with internal scroll so a long answer never grows the
+ * card to fill the viewport. */
 .sq-card-a {
   font-family: var(--font-display);
   font-size: 0.94rem;
   line-height: 1.46;
   color: var(--text);
   margin: 0;
+  max-height: 220px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .sq-card.sq-error .sq-card-a {
@@ -4196,20 +4205,6 @@ html[data-theme="light"] .sq-card {
   font-size: 0.62rem;
   letter-spacing: 0.08em;
   color: var(--muted-soft);
-}
-
-.sq-card-foot-state {
-  color: var(--success);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-
-.sq-card-foot-state.sq-foot-pending {
-  color: var(--accent);
-}
-
-.sq-card-foot-state.sq-foot-error {
-  color: var(--danger);
 }
 
 .sq-card-fork {
@@ -4278,6 +4273,10 @@ html[data-theme="light"] .sq-card {
     display: flex;
     flex-direction: column;
     gap: 10px;
+    /* Never let the stack climb the whole viewport; scroll past the cap. */
+    max-height: min(60vh, calc(100dvh - var(--composer-height, 220px) - 120px));
+    overflow-y: auto;
+    padding-right: 2px;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3991,17 +3991,22 @@ html[data-theme="light"] .sq-sheet {
 /* ── Side-question card ── */
 .sq-card {
   position: relative;
-  background: var(--bg-card);
+  /* Opaque surface (blur as fallback) so a long answer never lets the
+     transcript bleed through and collide with the card's own text. The gold
+     left rule is the card's defining edge — the "ink in the margin". */
+  background: linear-gradient(180deg, rgba(22, 26, 35, 0.985), rgba(14, 17, 24, 0.99));
+  backdrop-filter: blur(20px) saturate(1.2);
   border: 1px solid var(--line);
-  border-left: 2px solid var(--accent);
+  border-left: 3px solid var(--accent);
   border-radius: var(--radius-sm);
-  padding: 13px 15px 13px 16px;
-  box-shadow: 0 18px 44px -30px rgba(0, 0, 0, 0.85);
+  padding: 15px 17px 14px 18px;
+  box-shadow: 0 18px 44px -28px rgba(0, 0, 0, 0.9);
   animation: sq-slidein 0.34s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 html[data-theme="light"] .sq-card {
-  box-shadow: 0 8px 24px -16px rgba(60, 45, 20, 0.3);
+  background: linear-gradient(180deg, rgba(255, 253, 247, 0.985), rgba(248, 244, 236, 0.99));
+  box-shadow: 0 10px 28px -18px rgba(60, 45, 20, 0.34);
 }
 
 .sq-card.sq-error {
@@ -4029,7 +4034,12 @@ html[data-theme="light"] .sq-card {
   letter-spacing: 0.16em;
   text-transform: uppercase;
   color: var(--accent);
-  margin-bottom: 9px;
+  margin-bottom: 11px;
+  flex-wrap: nowrap;
+}
+
+.sq-card-mark {
+  white-space: nowrap;
 }
 
 .sq-card.sq-error .sq-card-meta {
@@ -4133,17 +4143,48 @@ html[data-theme="light"] .sq-card {
   color: var(--accent);
 }
 
-/* Answer text — capped with internal scroll so a long answer never grows the
- * card to fill the viewport. */
+/* Answer text. A long answer is clamped to a few lines with a fade rather than
+ * trapped in a scroll window; "Read full aside" expands it in place, bounded by
+ * the viewport so it can never grow the card to fill the screen. */
 .sq-card-a {
   font-family: var(--font-display);
   font-size: 0.94rem;
-  line-height: 1.46;
+  line-height: 1.5;
   color: var(--text);
   margin: 0;
-  max-height: 220px;
+}
+
+.sq-card-a-clamped {
+  max-height: 9em;
+  overflow: hidden;
+}
+
+.sq-card-a-fade {
+  -webkit-mask-image: linear-gradient(180deg, #000 72%, transparent);
+  mask-image: linear-gradient(180deg, #000 72%, transparent);
+}
+
+.sq-card-a-expanded {
+  max-height: min(46vh, calc(100dvh - var(--composer-height, 220px) - 220px));
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.sq-card-more {
+  display: block;
+  margin-top: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  color: var(--accent-cool);
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.sq-card-more:hover {
+  color: var(--text-strong);
 }
 
 .sq-card.sq-error .sq-card-a {
@@ -4198,9 +4239,9 @@ html[data-theme="light"] .sq-card {
   align-items: center;
   gap: 8px;
   flex-wrap: wrap;
-  margin-top: 11px;
-  padding-top: 9px;
-  border-top: 1px dashed var(--line);
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
   font-family: var(--font-mono);
   font-size: 0.62rem;
   letter-spacing: 0.08em;
@@ -4242,14 +4283,15 @@ html[data-theme="light"] .sq-card {
     display: none;
   }
 
+  /* In-flow, right-aligned above the composer (the sticky .sq-dock rides the
+     composer band). NOT absolute against the zero-height dock — that floated
+     it mid-transcript. margin-left:auto right-aligns the fixed-width block. */
   .sq-panel {
     display: flex;
     flex-direction: column;
-    gap: 10px;
-    position: absolute;
-    right: 0;
-    bottom: 0;
-    width: min(360px, 78%);
+    gap: 8px;
+    width: min(380px, 46%);
+    margin-left: auto;
     pointer-events: auto;
   }
 
@@ -4273,11 +4315,32 @@ html[data-theme="light"] .sq-card {
     display: flex;
     flex-direction: column;
     gap: 10px;
-    /* Never let the stack climb the whole viewport; scroll past the cap. */
-    max-height: min(60vh, calc(100dvh - var(--composer-height, 220px) - 120px));
+    /* Bound the stack so several asides never climb the page; scroll past it. */
+    max-height: min(64vh, calc(100dvh - var(--composer-height, 220px) - 96px));
     overflow-y: auto;
     padding-right: 2px;
   }
+}
+
+/* Older-asides summary toggle (desktop stack) */
+.sq-older-toggle {
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  padding: 7px 11px;
+  cursor: pointer;
+  text-align: left;
+  transition: color 0.14s, border-color 0.14s;
+}
+
+.sq-older-toggle:hover {
+  color: var(--accent);
+  border-color: var(--accent);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -105,6 +105,7 @@ import {
   type ToolPair,
 } from "@/components/TranscriptCard";
 import { TaskProgressDock } from "@/components/TaskProgressDock";
+import { SideQuestionDock } from "@/components/SideQuestionDock";
 import { readTodoEntries, summarizeTodos } from "@/lib/todos";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
@@ -117,6 +118,7 @@ import {
   SessionEnvelope,
   SessionRecord,
   SessionTransport,
+  SideQuestion,
 } from "@/lib/types";
 
 // iOS Safari rejects ``navigator.clipboard.writeText`` even from inside a
@@ -350,6 +352,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       setDismissedTaskSequence(null);
     }
   }, [sessionId]);
+  useEffect(() => {
+    setSideQuestions(new Map());
+  }, [sessionId]);
   const [view, setView] = useState<ViewMode>("chat");
   const [filterMode, setFilterMode] = useState<FilterMode>("important");
   const [toolRunsExpanded, setToolRunsExpanded] = useState(false);
@@ -375,6 +380,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // the pill and send straight through.
   const [pendingPaste, setPendingPaste] = useState<string | null>(null);
   const [pasteSeq, setPasteSeq] = useState(0);
+  const [sideQuestions, setSideQuestions] = useState<Map<string, SideQuestion>>(new Map());
   const [connection, setConnection] = useState<ConnectionState>("connecting");
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
@@ -806,6 +812,19 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
               } else {
                 setPendingClipboard(text);
               }
+            }
+          }
+          if (message.type === "side_question") {
+            const payload = message.payload as { side_question?: SideQuestion; removed_id?: string };
+            if (payload.side_question) {
+              const sq = payload.side_question;
+              setSideQuestions((prev) => new Map(prev).set(sq.id, sq));
+            } else if (payload.removed_id) {
+              setSideQuestions((prev) => {
+                const next = new Map(prev);
+                next.delete(payload.removed_id as string);
+                return next;
+              });
             }
           }
           if (message.type === "auth_revoked") {
@@ -2142,6 +2161,14 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
             ×
           </button>
         </div>
+      ) : null}
+      {sideQuestions.size > 0 ? (
+        <SideQuestionDock
+          questions={[...sideQuestions.values()]}
+          host={host}
+          token={token}
+          sessionId={sessionId}
+        />
       ) : null}
       {showTaskDock && taskProgress ? (
         <TaskProgressDock

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -354,6 +354,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   }, [sessionId]);
   useEffect(() => {
     setSideQuestions(new Map());
+    sqLiveSeenRef.current = new Set();
+    setSqExpandSignal(0);
   }, [sessionId]);
   const [view, setView] = useState<ViewMode>("chat");
   const [filterMode, setFilterMode] = useState<FilterMode>("important");
@@ -381,6 +383,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [pendingPaste, setPendingPaste] = useState<string | null>(null);
   const [pasteSeq, setPasteSeq] = useState(0);
   const [sideQuestions, setSideQuestions] = useState<Map<string, SideQuestion>>(new Map());
+  // Bumped when a *live* (non-hydrated) side-question first arrives, so the dock
+  // auto-expands a just-sent /btw but not asides replayed on page load. The ref
+  // tracks ids already accounted for — including hydrated ones, so a later live
+  // update to a rehydrated aside doesn't pop the dock open.
+  const [sqExpandSignal, setSqExpandSignal] = useState(0);
+  const sqLiveSeenRef = useRef<Set<string>>(new Set());
   const [connection, setConnection] = useState<ConnectionState>("connecting");
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [showScrollToTop, setShowScrollToTop] = useState(false);
@@ -815,10 +823,19 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
             }
           }
           if (message.type === "side_question") {
-            const payload = message.payload as { side_question?: SideQuestion; removed_id?: string };
+            const payload = message.payload as {
+              side_question?: SideQuestion;
+              removed_id?: string;
+              hydrated?: boolean;
+            };
             if (payload.side_question) {
               const sq = payload.side_question;
               setSideQuestions((prev) => new Map(prev).set(sq.id, sq));
+              if (!sqLiveSeenRef.current.has(sq.id)) {
+                sqLiveSeenRef.current.add(sq.id);
+                // Live (non-hydrated) first appearance → ask the dock to open.
+                if (!payload.hydrated) setSqExpandSignal((n) => n + 1);
+              }
             } else if (payload.removed_id) {
               setSideQuestions((prev) => {
                 const next = new Map(prev);
@@ -2168,6 +2185,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           host={host}
           token={token}
           sessionId={sessionId}
+          expandSignal={sqExpandSignal}
         />
       ) : null}
       {showTaskDock && taskProgress ? (

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -156,19 +156,24 @@ export function SideQuestionDock({
   const [dismissingIds, setDismissingIds] = useState<Set<string>>(new Set());
   const seenIdsRef = useRef<Set<string>>(new Set());
 
-  // Auto-expand when a new side-question appears — e.g. right after the user
-  // sends /btw — so the asked question and its "asking…" shimmer are visible
-  // immediately (the newest sorts to the top). A manual collapse sticks until
-  // the next new question, since this only fires on a previously-unseen id.
+  // Auto-expand when the user sends a /btw, so the asked question and its
+  // "asking…" shimmer show immediately (the newest sorts to the top). We key
+  // off freshness, not just a new id: a just-sent aside is created ~now, while
+  // ones replayed on page load/refresh are older — so a reload no longer
+  // re-expands old asides. A manual collapse sticks (this only fires once per
+  // previously-unseen, freshly-created id).
   useEffect(() => {
-    let added = false;
+    const now = Date.now();
+    let openFor = false;
     for (const q of questions) {
-      if (!seenIdsRef.current.has(q.id)) {
-        seenIdsRef.current.add(q.id);
-        added = true;
+      if (seenIdsRef.current.has(q.id)) continue;
+      seenIdsRef.current.add(q.id);
+      const created = new Date(q.created_at).getTime();
+      if (Number.isFinite(created) && now - created < 8000) {
+        openFor = true;
       }
     }
-    if (added) setExpanded(true);
+    if (openFor) setExpanded(true);
   }, [questions]);
 
   useEffect(() => {

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -6,6 +6,26 @@ import { useRouter } from "next/navigation";
 import { dismissSideQuestion, forkSideQuestion } from "@/lib/api";
 import { type SideQuestion } from "@/lib/types";
 
+// Single up-chevron; orientation handled with a CSS rotation, matching the
+// task-progress dock so the two docks read as one family.
+function ChevronIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M4 10l4-4 4 4" />
+    </svg>
+  );
+}
+
 function fmtTime(iso: string): string {
   try {
     const d = new Date(iso);
@@ -35,8 +55,7 @@ function SideQuestionCard({
   const answerRef = useRef<HTMLParagraphElement>(null);
 
   // A long answer is clamped to a few lines with a fade; only then do we offer
-  // "Read full aside". Measure against the clamped box (collapsed only) so a
-  // short answer never shows a needless toggle or a fade over its last line.
+  // "Read full aside". Measure against the clamped box (collapsed only).
   useLayoutEffect(() => {
     const el = answerRef.current;
     if (!el || isPending || expanded) return;
@@ -132,19 +151,18 @@ export function SideQuestionDock({
   sessionId: string;
 }) {
   const router = useRouter();
-  const [sheetOpen, setSheetOpen] = useState(false);
-  const [showOlder, setShowOlder] = useState(false);
+  const [expanded, setExpanded] = useState(false);
   const [forkingId, setForkingId] = useState<string | null>(null);
   const [dismissingIds, setDismissingIds] = useState<Set<string>>(new Set());
 
   useEffect(() => {
-    if (!sheetOpen) return;
+    if (!expanded) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setSheetOpen(false);
+      if (e.key === "Escape") setExpanded(false);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [sheetOpen]);
+  }, [expanded]);
 
   const handleDismiss = useCallback(
     async (sqid: string) => {
@@ -176,7 +194,7 @@ export function SideQuestionDock({
     [forkingId, host, token, sessionId, router],
   );
 
-  const handleClearAll = useCallback(async () => {
+  const handleClearAll = useCallback(() => {
     for (const sq of questions) {
       void handleDismiss(sq.id);
     }
@@ -187,120 +205,84 @@ export function SideQuestionDock({
   const sorted = [...questions].sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
-
-  const renderCard = (sq: SideQuestion) => (
-    <SideQuestionCard
-      key={sq.id}
-      sq={sq}
-      onDismiss={() => handleDismiss(sq.id)}
-      onFork={() => handleFork(sq.id)}
-      forking={forkingId === sq.id}
-      dismissing={dismissingIds.has(sq.id)}
-    />
-  );
-
-  // Desktop keeps a small footprint: the most recent aside is expanded, older
-  // ones fold behind a one-line summary so the stack never climbs the page.
-  const [newest, ...older] = sorted;
-  const desktopStack = (
-    <>
-      {renderCard(newest)}
-      {older.length > 0 ? (
-        showOlder ? (
-          <>
-            {older.map(renderCard)}
-            <button
-              type="button"
-              className="sq-older-toggle"
-              onClick={() => setShowOlder(false)}
-            >
-              Show fewer
-            </button>
-          </>
-        ) : (
-          <button
-            type="button"
-            className="sq-older-toggle"
-            onClick={() => setShowOlder(true)}
-          >
-            ¶ {older.length} earlier aside{older.length !== 1 ? "s" : ""}
-          </button>
-        )
-      ) : null}
-    </>
-  );
+  const pendingCount = sorted.filter((s) => s.status === "pending").length;
+  const count = questions.length;
+  const label = pendingCount > 0 ? "Asking…" : sorted[0].question;
 
   return (
-    <div className={`sq-dock${sheetOpen ? " sq-dock-expanded" : ""}`}>
-      {/* Mobile bottom sheet (expanded) */}
-      {sheetOpen ? (
+    <div className={`sq-dock${pendingCount > 0 ? " active" : ""}${expanded ? " expanded" : ""}`}>
+      {expanded ? (
         <>
           <button
             type="button"
-            className="sq-scrim"
+            className="sq-dock-scrim"
             aria-label="Close side questions"
-            onClick={() => setSheetOpen(false)}
+            onClick={() => setExpanded(false)}
           />
-          <div className="sq-sheet" role="dialog" aria-label="Side questions">
-            <div className="sq-sheet-head">
-              <span className="sq-sheet-title">Side questions</span>
-              {questions.length >= 2 ? (
-                <button
-                  type="button"
-                  className="sq-clear-all"
-                  onClick={() => {
-                    void handleClearAll();
-                    setSheetOpen(false);
-                  }}
-                >
+          <div className="sq-dock-panel" role="dialog" aria-label="Side questions">
+            <div className="sq-dock-panel-head">
+              <span className="sq-dock-panel-title">Side questions</span>
+              <span className="sq-dock-count">{count}</span>
+              {count >= 2 ? (
+                <button type="button" className="sq-clear-all" onClick={handleClearAll}>
                   Clear all
                 </button>
               ) : null}
               <button
                 type="button"
-                className="sq-sheet-close"
-                aria-label="Close"
-                onClick={() => setSheetOpen(false)}
+                className="sq-dock-collapse"
+                aria-label="Collapse side questions"
+                onClick={() => setExpanded(false)}
               >
-                ×
+                <ChevronIcon />
               </button>
             </div>
-            <div className="sq-sheet-cards">{sorted.map(renderCard)}</div>
+            <div className="sq-dock-cards">
+              {sorted.map((sq) => (
+                <SideQuestionCard
+                  key={sq.id}
+                  sq={sq}
+                  onDismiss={() => handleDismiss(sq.id)}
+                  onFork={() => handleFork(sq.id)}
+                  forking={forkingId === sq.id}
+                  dismissing={dismissingIds.has(sq.id)}
+                />
+              ))}
+            </div>
           </div>
         </>
       ) : null}
 
-      {/* Mobile slim bar */}
-      <button
-        type="button"
-        className="sq-bar"
-        onClick={() => setSheetOpen(true)}
-        aria-label={`${questions.length} side question${questions.length !== 1 ? "s" : ""} — tap to view`}
-        aria-expanded={sheetOpen}
-      >
-        <span className="sq-bar-icon" aria-hidden="true">
-          ¶
-        </span>
-        <span className="sq-bar-label">
-          {questions.length} side question{questions.length !== 1 ? "s" : ""}
-        </span>
-        <span className="sq-bar-chevron" aria-hidden="true">
-          ↑
-        </span>
-      </button>
-
-      {/* Desktop in-flow panel, right-aligned above the composer */}
-      <div className="sq-panel" aria-label="Side questions">
-        <div className="sq-panel-head">
-          <span className="sq-panel-label">Side questions</span>
-          {questions.length >= 2 ? (
-            <button type="button" className="sq-clear-all" onClick={() => void handleClearAll()}>
-              Clear all
-            </button>
-          ) : null}
+      <div className="sq-dock-strip">
+        <div className="sq-dock-row">
+          <button
+            type="button"
+            className="sq-dock-toggle"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((v) => !v)}
+          >
+            <span className="sq-dock-glyph" aria-hidden>
+              ¶
+            </span>
+            <span className="sq-dock-label">{label}</span>
+            <span className="sq-dock-count">{count}</span>
+            <span className="sq-dock-chevron" aria-hidden>
+              <ChevronIcon />
+            </span>
+          </button>
+          <button
+            type="button"
+            className="sq-dock-dismiss"
+            aria-label="Clear side questions"
+            onClick={handleClearAll}
+          >
+            ×
+          </button>
         </div>
-        <div className="sq-panel-cards">{desktopStack}</div>
       </div>
+      <span className="sr-only" aria-live="polite">
+        {label}
+      </span>
     </div>
   );
 }

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -71,31 +71,19 @@ function SideQuestionCard({
         <p className="sq-card-a">{sq.answer ?? sq.error}</p>
       )}
 
-      <div className="sq-card-foot">
-        <span
-          className={`sq-card-foot-state${isPending ? " sq-foot-pending" : isError ? " sq-foot-error" : ""}`}
-        >
-          {isPending ? "running independently" : isError ? "couldn't answer" : "answered"}
-        </span>
-        {isPending ? (
-          <span className="sq-card-foot-note">no tools</span>
-        ) : (
-          <>
-            <span className="sq-card-foot-note">won&apos;t be saved</span>
-            {!isError ? (
-              <button
-                type="button"
-                className="sq-card-fork"
-                aria-label="Open side question as a new session"
-                disabled={forking}
-                onClick={onFork}
-              >
-                {forking ? "opening…" : "Open as session →"}
-              </button>
-            ) : null}
-          </>
-        )}
-      </div>
+      {!isPending && !isError ? (
+        <div className="sq-card-foot">
+          <button
+            type="button"
+            className="sq-card-fork"
+            aria-label="Open side question as a new session"
+            disabled={forking}
+            onClick={onFork}
+          >
+            {forking ? "opening…" : "Open as session →"}
+          </button>
+        </div>
+      ) : null}
     </article>
   );
 }

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -154,6 +154,22 @@ export function SideQuestionDock({
   const [expanded, setExpanded] = useState(false);
   const [forkingId, setForkingId] = useState<string | null>(null);
   const [dismissingIds, setDismissingIds] = useState<Set<string>>(new Set());
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  // Auto-expand when a new side-question appears — e.g. right after the user
+  // sends /btw — so the asked question and its "asking…" shimmer are visible
+  // immediately (the newest sorts to the top). A manual collapse sticks until
+  // the next new question, since this only fires on a previously-unseen id.
+  useEffect(() => {
+    let added = false;
+    for (const q of questions) {
+      if (!seenIdsRef.current.has(q.id)) {
+        seenIdsRef.current.add(q.id);
+        added = true;
+      }
+    }
+    if (added) setExpanded(true);
+  }, [questions]);
 
   useEffect(() => {
     if (!expanded) return;

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { dismissSideQuestion, forkSideQuestion } from "@/lib/api";
@@ -30,6 +30,20 @@ function SideQuestionCard({
 }) {
   const isPending = sq.status === "pending";
   const isError = sq.status === "error";
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const answerRef = useRef<HTMLParagraphElement>(null);
+
+  // A long answer is clamped to a few lines with a fade; only then do we offer
+  // "Read full aside". Measure against the clamped box (collapsed only) so a
+  // short answer never shows a needless toggle or a fade over its last line.
+  useLayoutEffect(() => {
+    const el = answerRef.current;
+    if (!el || isPending || expanded) return;
+    setOverflowing(el.scrollHeight - el.clientHeight > 4);
+  }, [sq.answer, sq.error, isPending, expanded]);
+
+  const answerText = sq.answer ?? sq.error ?? "";
 
   return (
     <article className={`sq-card${isError ? " sq-error" : ""}`}>
@@ -40,13 +54,11 @@ function SideQuestionCard({
             asking…
           </span>
         ) : isError ? (
-          <span>✕ Aside</span>
+          <span className="sq-card-mark">✕ Aside</span>
         ) : (
-          <span>¶ Aside</span>
+          <span className="sq-card-mark">¶ Aside</span>
         )}
-        {sq.resumed ? (
-          <span className="sq-chip-resumed">↻ resumed</span>
-        ) : null}
+        {sq.resumed ? <span className="sq-chip-resumed">↻ resumed</span> : null}
         <span className="sq-card-ts">{fmtTime(sq.created_at)}</span>
         <button
           type="button"
@@ -68,8 +80,28 @@ function SideQuestionCard({
           <span className="sq-shimmer sq-shimmer-mid" />
         </div>
       ) : (
-        <p className="sq-card-a">{sq.answer ?? sq.error}</p>
+        <p
+          ref={answerRef}
+          className={`sq-card-a${
+            expanded
+              ? " sq-card-a-expanded"
+              : ` sq-card-a-clamped${overflowing ? " sq-card-a-fade" : ""}`
+          }`}
+        >
+          {answerText}
+        </p>
       )}
+
+      {!isPending && !isError && (overflowing || expanded) ? (
+        <button
+          type="button"
+          className="sq-card-more"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? "Show less" : "Read full aside"}
+        </button>
+      ) : null}
 
       {!isPending && !isError ? (
         <div className="sq-card-foot">
@@ -101,6 +133,7 @@ export function SideQuestionDock({
 }) {
   const router = useRouter();
   const [sheetOpen, setSheetOpen] = useState(false);
+  const [showOlder, setShowOlder] = useState(false);
   const [forkingId, setForkingId] = useState<string | null>(null);
   const [dismissingIds, setDismissingIds] = useState<Set<string>>(new Set());
 
@@ -155,7 +188,7 @@ export function SideQuestionDock({
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
   );
 
-  const cards = sorted.map((sq) => (
+  const renderCard = (sq: SideQuestion) => (
     <SideQuestionCard
       key={sq.id}
       sq={sq}
@@ -164,7 +197,38 @@ export function SideQuestionDock({
       forking={forkingId === sq.id}
       dismissing={dismissingIds.has(sq.id)}
     />
-  ));
+  );
+
+  // Desktop keeps a small footprint: the most recent aside is expanded, older
+  // ones fold behind a one-line summary so the stack never climbs the page.
+  const [newest, ...older] = sorted;
+  const desktopStack = (
+    <>
+      {renderCard(newest)}
+      {older.length > 0 ? (
+        showOlder ? (
+          <>
+            {older.map(renderCard)}
+            <button
+              type="button"
+              className="sq-older-toggle"
+              onClick={() => setShowOlder(false)}
+            >
+              Show fewer
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="sq-older-toggle"
+            onClick={() => setShowOlder(true)}
+          >
+            ¶ {older.length} earlier aside{older.length !== 1 ? "s" : ""}
+          </button>
+        )
+      ) : null}
+    </>
+  );
 
   return (
     <div className={`sq-dock${sheetOpen ? " sq-dock-expanded" : ""}`}>
@@ -201,7 +265,7 @@ export function SideQuestionDock({
                 ×
               </button>
             </div>
-            <div className="sq-sheet-cards">{cards}</div>
+            <div className="sq-sheet-cards">{sorted.map(renderCard)}</div>
           </div>
         </>
       ) : null}
@@ -225,7 +289,7 @@ export function SideQuestionDock({
         </span>
       </button>
 
-      {/* Desktop floating card panel */}
+      {/* Desktop in-flow panel, right-aligned above the composer */}
       <div className="sq-panel" aria-label="Side questions">
         <div className="sq-panel-head">
           <span className="sq-panel-label">Side questions</span>
@@ -235,7 +299,7 @@ export function SideQuestionDock({
             </button>
           ) : null}
         </div>
-        <div className="sq-panel-cards">{cards}</div>
+        <div className="sq-panel-cards">{desktopStack}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -144,37 +144,30 @@ export function SideQuestionDock({
   host,
   token,
   sessionId,
+  expandSignal,
 }: {
   questions: SideQuestion[];
   host: string;
   token: string;
   sessionId: string;
+  expandSignal: number;
 }) {
   const router = useRouter();
   const [expanded, setExpanded] = useState(false);
   const [forkingId, setForkingId] = useState<string | null>(null);
   const [dismissingIds, setDismissingIds] = useState<Set<string>>(new Set());
-  const seenIdsRef = useRef<Set<string>>(new Set());
+  const lastExpandSignalRef = useRef(0);
 
-  // Auto-expand when the user sends a /btw, so the asked question and its
-  // "asking…" shimmer show immediately (the newest sorts to the top). We key
-  // off freshness, not just a new id: a just-sent aside is created ~now, while
-  // ones replayed on page load/refresh are older — so a reload no longer
-  // re-expands old asides. A manual collapse sticks (this only fires once per
-  // previously-unseen, freshly-created id).
+  // Auto-expand when the parent reports a *live* /btw (a non-hydrated aside) by
+  // advancing expandSignal — so a just-sent question opens immediately, but
+  // asides replayed on page load/refresh (which never advance the signal) stay
+  // collapsed. A manual collapse sticks until the next live /btw.
   useEffect(() => {
-    const now = Date.now();
-    let openFor = false;
-    for (const q of questions) {
-      if (seenIdsRef.current.has(q.id)) continue;
-      seenIdsRef.current.add(q.id);
-      const created = new Date(q.created_at).getTime();
-      if (Number.isFinite(created) && now - created < 8000) {
-        openFor = true;
-      }
+    if (expandSignal > lastExpandSignalRef.current) {
+      lastExpandSignalRef.current = expandSignal;
+      setExpanded(true);
     }
-    if (openFor) setExpanded(true);
-  }, [questions]);
+  }, [expandSignal]);
 
   useEffect(() => {
     if (!expanded) return;

--- a/frontend/src/components/SideQuestionDock.tsx
+++ b/frontend/src/components/SideQuestionDock.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { dismissSideQuestion, forkSideQuestion } from "@/lib/api";
+import { type SideQuestion } from "@/lib/types";
+
+function fmtTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return `${d.getHours().toString().padStart(2, "0")}:${d.getMinutes().toString().padStart(2, "0")}`;
+  } catch {
+    return "";
+  }
+}
+
+function SideQuestionCard({
+  sq,
+  onDismiss,
+  onFork,
+  forking,
+  dismissing,
+}: {
+  sq: SideQuestion;
+  onDismiss: () => void;
+  onFork: () => void;
+  forking: boolean;
+  dismissing: boolean;
+}) {
+  const isPending = sq.status === "pending";
+  const isError = sq.status === "error";
+
+  return (
+    <article className={`sq-card${isError ? " sq-error" : ""}`}>
+      <div className="sq-card-meta">
+        {isPending ? (
+          <span className="sq-card-asking">
+            <span className="sq-card-pulse" aria-hidden="true" />
+            asking…
+          </span>
+        ) : isError ? (
+          <span>✕ Aside</span>
+        ) : (
+          <span>¶ Aside</span>
+        )}
+        {sq.resumed ? (
+          <span className="sq-chip-resumed">↻ resumed</span>
+        ) : null}
+        <span className="sq-card-ts">{fmtTime(sq.created_at)}</span>
+        <button
+          type="button"
+          className="sq-card-dismiss"
+          aria-label="Dismiss side question"
+          disabled={dismissing}
+          onClick={onDismiss}
+        >
+          ✕
+        </button>
+      </div>
+
+      <p className="sq-card-q">{sq.question}</p>
+
+      {isPending ? (
+        <div className="sq-shimmer-lines" aria-label="Generating answer">
+          <span className="sq-shimmer sq-shimmer-full" />
+          <span className="sq-shimmer sq-shimmer-wide" />
+          <span className="sq-shimmer sq-shimmer-mid" />
+        </div>
+      ) : (
+        <p className="sq-card-a">{sq.answer ?? sq.error}</p>
+      )}
+
+      <div className="sq-card-foot">
+        <span
+          className={`sq-card-foot-state${isPending ? " sq-foot-pending" : isError ? " sq-foot-error" : ""}`}
+        >
+          {isPending ? "running independently" : isError ? "couldn't answer" : "answered"}
+        </span>
+        {isPending ? (
+          <span className="sq-card-foot-note">no tools</span>
+        ) : (
+          <>
+            <span className="sq-card-foot-note">won&apos;t be saved</span>
+            {!isError ? (
+              <button
+                type="button"
+                className="sq-card-fork"
+                aria-label="Open side question as a new session"
+                disabled={forking}
+                onClick={onFork}
+              >
+                {forking ? "opening…" : "Open as session →"}
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+    </article>
+  );
+}
+
+export function SideQuestionDock({
+  questions,
+  host,
+  token,
+  sessionId,
+}: {
+  questions: SideQuestion[];
+  host: string;
+  token: string;
+  sessionId: string;
+}) {
+  const router = useRouter();
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [forkingId, setForkingId] = useState<string | null>(null);
+  const [dismissingIds, setDismissingIds] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!sheetOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setSheetOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [sheetOpen]);
+
+  const handleDismiss = useCallback(
+    async (sqid: string) => {
+      setDismissingIds((prev) => new Set(prev).add(sqid));
+      try {
+        await dismissSideQuestion(host, token, sessionId, sqid);
+      } catch {
+        setDismissingIds((prev) => {
+          const next = new Set(prev);
+          next.delete(sqid);
+          return next;
+        });
+      }
+    },
+    [host, token, sessionId],
+  );
+
+  const handleFork = useCallback(
+    async (sqid: string) => {
+      if (forkingId) return;
+      setForkingId(sqid);
+      try {
+        const sess = await forkSideQuestion(host, token, sessionId, sqid);
+        router.push(`/session/${sess.id}`);
+      } catch {
+        setForkingId(null);
+      }
+    },
+    [forkingId, host, token, sessionId, router],
+  );
+
+  const handleClearAll = useCallback(async () => {
+    for (const sq of questions) {
+      void handleDismiss(sq.id);
+    }
+  }, [questions, handleDismiss]);
+
+  if (questions.length === 0) return null;
+
+  const sorted = [...questions].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+
+  const cards = sorted.map((sq) => (
+    <SideQuestionCard
+      key={sq.id}
+      sq={sq}
+      onDismiss={() => handleDismiss(sq.id)}
+      onFork={() => handleFork(sq.id)}
+      forking={forkingId === sq.id}
+      dismissing={dismissingIds.has(sq.id)}
+    />
+  ));
+
+  return (
+    <div className={`sq-dock${sheetOpen ? " sq-dock-expanded" : ""}`}>
+      {/* Mobile bottom sheet (expanded) */}
+      {sheetOpen ? (
+        <>
+          <button
+            type="button"
+            className="sq-scrim"
+            aria-label="Close side questions"
+            onClick={() => setSheetOpen(false)}
+          />
+          <div className="sq-sheet" role="dialog" aria-label="Side questions">
+            <div className="sq-sheet-head">
+              <span className="sq-sheet-title">Side questions</span>
+              {questions.length >= 2 ? (
+                <button
+                  type="button"
+                  className="sq-clear-all"
+                  onClick={() => {
+                    void handleClearAll();
+                    setSheetOpen(false);
+                  }}
+                >
+                  Clear all
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="sq-sheet-close"
+                aria-label="Close"
+                onClick={() => setSheetOpen(false)}
+              >
+                ×
+              </button>
+            </div>
+            <div className="sq-sheet-cards">{cards}</div>
+          </div>
+        </>
+      ) : null}
+
+      {/* Mobile slim bar */}
+      <button
+        type="button"
+        className="sq-bar"
+        onClick={() => setSheetOpen(true)}
+        aria-label={`${questions.length} side question${questions.length !== 1 ? "s" : ""} — tap to view`}
+        aria-expanded={sheetOpen}
+      >
+        <span className="sq-bar-icon" aria-hidden="true">
+          ¶
+        </span>
+        <span className="sq-bar-label">
+          {questions.length} side question{questions.length !== 1 ? "s" : ""}
+        </span>
+        <span className="sq-bar-chevron" aria-hidden="true">
+          ↑
+        </span>
+      </button>
+
+      {/* Desktop floating card panel */}
+      <div className="sq-panel" aria-label="Side questions">
+        <div className="sq-panel-head">
+          <span className="sq-panel-label">Side questions</span>
+          {questions.length >= 2 ? (
+            <button type="button" className="sq-clear-all" onClick={() => void handleClearAll()}>
+              Clear all
+            </button>
+          ) : null}
+        </div>
+        <div className="sq-panel-cards">{cards}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1209,6 +1209,40 @@ export function isAuthError(error: unknown): error is AuthError {
   return error instanceof AuthError;
 }
 
+export async function forkSideQuestion(
+  host: string,
+  token: string,
+  sessionId: string,
+  sqid: string,
+): Promise<SessionRecord> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/side-questions/${sqid}/fork`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to fork side question");
+  const body = await response.json();
+  return body.session as SessionRecord;
+}
+
+export async function dismissSideQuestion(
+  host: string,
+  token: string,
+  sessionId: string,
+  sqid: string,
+): Promise<void> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/side-questions/${sqid}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to dismiss side question");
+}
+
 async function ensureOk(response: Response, fallbackMessage: string): Promise<void> {
   if (response.ok) {
     return;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -397,6 +397,24 @@ export interface SessionEnvelope {
     | "auth_revoked"
     | "schedule_list_update"
     | "board_update"
-    | "clipboard_copy";
+    | "clipboard_copy"
+    | "side_question";
   payload: Record<string, unknown>;
+}
+
+export type SideQuestionStatus = "pending" | "answered" | "error";
+
+// An ephemeral /btw side-question. Mirrors backend schemas.SideQuestion. The
+// `side_question` envelope carries either an upsert ({ side_question })
+// or a removal ({ removed_id }).
+export interface SideQuestion {
+  id: string;
+  question: string;
+  status: SideQuestionStatus;
+  answer?: string | null;
+  error?: string | null;
+  fork_thread_id?: string | null;
+  attempts: number;
+  resumed: boolean;
+  created_at: string;
 }


### PR DESCRIPTION
## Summary

Adds the `/btw` side-question to Waypoint's Claude agent (both the structured `claude_cli` transport and the `claude_tty` TUI-tail transport). A side-question is answered from the current conversation with no tools, never enters the transcript, runs non-blocking beside any in-flight turn, is session-scoped, survives a backend restart while pending, and leaves no native Claude thread behind once resolved. Open asides can be promoted ("forked") into a real session.

It surfaces in the session view as an ephemeral "marginalia" overlay (asking → answered/error, with a resumed chip after a restart), with per-card dismiss, Clear-all, and Open-as-session. On mobile the dock collapses to a slim bar that opens a bottom sheet so it never occludes the composer.

## How it works

`/btw` is intercepted in `maybe_handle_input` and short-circuits the normal turn (no history write, no RUNNING flip). The mechanism is a one-shot read-only fork-query (`claude -p --resume <thread> --fork-session --session-id <E>` with tools disabled) whose forked thread `<E>.jsonl` is retained while the card is open and deleted the moment its durable record leaves the session — on dismiss, session-delete, restart re-issue, or attempt-cap; a fork hands the thread off to the new session instead. Pending records live in `transport_state["pending_side_questions"]`; a startup sweep re-issues those still pending after a restart. The mechanism is isolated behind `backends/claude_code/side_question.py` so it can be swapped later.

## Changes

- Backend core: `side_question.py` — fork-query runner (local + SSH), exact-filename thread cleanup, per-session-locked durable records, and the restart-recovery sweep.
- Backend wiring: `/btw` interception on both Claude transports, `runtime.fork_side_question`, thin fork/dismiss API endpoints, an awaited session-delete cleanup hook, and WS hydration so a fresh load re-shows open asides. Non-Claude backends return a clean 400.
- Frontend: the side-question dock/overlay, fork + dismiss actions, mobile bottom-sheet, and dark/light parity.

## Testing

- `uv run pytest` (1162 passed), `uv run mypy src`, `uv run ruff check src tests` — all green.
- `npm run lint`, `npx tsc --noEmit`, `npm run build` — all green.
- Live E2E against the running stack: `/btw` answered from context with no tools and no transcript entry; the forked thread was retained while open and removed on session-delete (no residue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)