### PR TITLE
docs: update skills to prefer sessions output

### DIFF
--- a/.agents/skills/waypoint-comms/references/send-and-reply.md
+++ b/.agents/skills/waypoint-comms/references/send-and-reply.md
@@ -44,17 +44,12 @@ waypoint sessions show <target-id>     # poll until idle / waiting_input / exite
 waypoint sessions output <target-id> --messages 20 --text
 ```
 
-Use `sessions output` for normal replies because it coalesces streaming deltas
-into readable assistant text. If the reply seems missing, or the target is
-blocked on an approval/question, inspect
-`waypoint sessions events <target-id> --messages 20 --coalesce`; this preserves
-`approval_request` and `tool_call` records while making long assistant/tool
-result output readable. Drop to raw `events` only when you need exact event
-mechanics such as delta boundaries, overwritten metadata, paging/duplicate
-diagnosis, or transport/TUI artifacts. For sessions on the `tmux` (Terminal)
-transport, event kinds are inferred heuristically — also check
-`raw_terminal_chunk` if structured output is incomplete. This path does not
-disturb your own turn: you choose when to look.
+Use `sessions output` for normal replies. If the reply seems missing, or the
+target is blocked on an approval/question, inspect
+`waypoint sessions events <target-id> --messages 20 --coalesce`. Use raw
+`events` only for exact stream debugging or transport/TUI artifacts such as
+`raw_terminal_chunk`. This path does not disturb your own turn: you choose when
+to look.
 
 ## Push: the answer arrives in your input (you set `reply-to`)
 

--- a/.agents/skills/waypoint-comms/references/send-and-reply.md
+++ b/.agents/skills/waypoint-comms/references/send-and-reply.md
@@ -37,18 +37,21 @@ waypoint sessions send <target-id> "[wp-msg from=$ME] Run the backend test suite
 
 ## Pull: read the target's stream (you omitted `reply-to`)
 
-Poll the target to a settled status, then read its `agent_output`:
+Poll the target to a settled status, then read its conversational output:
 
 ```bash
 waypoint sessions show <target-id>     # poll until idle / waiting_input / exited
-waypoint sessions events <target-id> --messages 20
+waypoint sessions output <target-id> --messages 20 --text
 ```
 
-Filter events for `kind == "agent_output"` to get the reply; skip
-`system_note`, `tool_call`, and `tool_result`. (For sessions on the `tmux`
-(Terminal) transport, kinds are heuristic — also check `raw_terminal_chunk`.)
-This path does not disturb your
-own turn: you choose when to look.
+Use `sessions output` for normal replies because it coalesces streaming deltas
+into readable assistant text. If the reply seems missing, or you need approvals,
+tool calls, tool results, questions, or transport debugging details, inspect
+`waypoint sessions events <target-id> --messages 20 --coalesce` and then raw
+`events` if needed. For sessions on the `tmux` (Terminal) transport, event kinds
+are inferred heuristically — also check `raw_terminal_chunk` if structured output
+is incomplete. This path does not disturb your own turn: you choose when to
+look.
 
 ## Push: the answer arrives in your input (you set `reply-to`)
 

--- a/.agents/skills/waypoint-comms/references/send-and-reply.md
+++ b/.agents/skills/waypoint-comms/references/send-and-reply.md
@@ -45,13 +45,16 @@ waypoint sessions output <target-id> --messages 20 --text
 ```
 
 Use `sessions output` for normal replies because it coalesces streaming deltas
-into readable assistant text. If the reply seems missing, or you need approvals,
-tool calls, tool results, questions, or transport debugging details, inspect
-`waypoint sessions events <target-id> --messages 20 --coalesce` and then raw
-`events` if needed. For sessions on the `tmux` (Terminal) transport, event kinds
-are inferred heuristically — also check `raw_terminal_chunk` if structured output
-is incomplete. This path does not disturb your own turn: you choose when to
-look.
+into readable assistant text. If the reply seems missing, or the target is
+blocked on an approval/question, inspect
+`waypoint sessions events <target-id> --messages 20 --coalesce`; this preserves
+`approval_request` and `tool_call` records while making long assistant/tool
+result output readable. Drop to raw `events` only when you need exact event
+mechanics such as delta boundaries, overwritten metadata, paging/duplicate
+diagnosis, or transport/TUI artifacts. For sessions on the `tmux` (Terminal)
+transport, event kinds are inferred heuristically — also check
+`raw_terminal_chunk` if structured output is incomplete. This path does not
+disturb your own turn: you choose when to look.
 
 ## Push: the answer arrives in your input (you set `reply-to`)
 

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -12,16 +12,11 @@ waypoint sessions events <session-id> --messages 40 --coalesce       # structure
 waypoint sessions events <session-id> --before-sequence <sequence>   # page back JSON
 ```
 
-Use `sessions output` for the child's normal answer; it coalesces streaming
-deltas into readable assistant messages. Use `--text` when you only need the
-concatenated assistant text. Use `events --coalesce` for settled structured JSON
-inspection, including normal tool-call/result context and pending
-approvals/questions: coalescing leaves `approval_request`, `tool_call`, and
-question records intact. Drop to raw `events` only for exact stream debugging,
-such as delta boundaries, per-chunk sequence/timestamp checks, overwritten
-metadata, paging/duplicate diagnosis, or transport/TUI artifacts. For sessions
-on the `tmux` (Terminal) transport, event kinds are inferred heuristically —
-also check `raw_terminal_chunk` if structured output is incomplete.
+Use `sessions output` for the child's normal answer, and add `--text` when you
+only need assistant text. Use `events --coalesce` for structured JSON reads,
+including tool context and pending approvals/questions. Use raw `events` only
+for exact stream debugging or transport/TUI artifacts such as
+`raw_terminal_chunk`.
 
 Quote only the minimum transcript text needed to justify your conclusion;
 summarize the rest. Distinguish the reported `status` from your interpretation of

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -14,11 +14,14 @@ waypoint sessions events <session-id> --before-sequence <sequence>   # page back
 
 Use `sessions output` for the child's normal answer; it coalesces streaming
 deltas into readable assistant messages. Use `--text` when you only need the
-concatenated assistant text. Use `events --coalesce` for structured JSON
-transcript inspection, and raw `events` for approvals, tool calls/results,
-questions, or debugging missing output. For sessions on the `tmux` (Terminal)
-transport, event kinds are inferred heuristically — also check
-`raw_terminal_chunk` if structured output is incomplete.
+concatenated assistant text. Use `events --coalesce` for settled structured JSON
+inspection, including normal tool-call/result context and pending
+approvals/questions: coalescing leaves `approval_request`, `tool_call`, and
+question records intact. Drop to raw `events` only for exact stream debugging,
+such as delta boundaries, per-chunk sequence/timestamp checks, overwritten
+metadata, paging/duplicate diagnosis, or transport/TUI artifacts. For sessions
+on the `tmux` (Terminal) transport, event kinds are inferred heuristically —
+also check `raw_terminal_chunk` if structured output is incomplete.
 
 Quote only the minimum transcript text needed to justify your conclusion;
 summarize the rest. Distinguish the reported `status` from your interpretation of

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -6,15 +6,19 @@ decide whether it is done or needs another turn.
 ## Read output
 
 ```bash
-waypoint sessions events <session-id> --messages 40
-waypoint sessions events <session-id> --before-sequence <sequence>   # page back
+waypoint sessions output <session-id> --messages 40
+waypoint sessions output <session-id> --messages 40 --text
+waypoint sessions events <session-id> --messages 40 --coalesce       # structured JSON
+waypoint sessions events <session-id> --before-sequence <sequence>   # page back JSON
 ```
 
-`events` returns JSON. Filter for `kind == "agent_output"` to read the agent's
-replies; skip the verbose `system_note` init payload and the `tool_call` /
-`tool_result` chatter. For sessions on the `tmux` (Terminal) transport, event
-kinds are inferred heuristically — also check `raw_terminal_chunk` if a reply
-seems missing.
+Use `sessions output` for the child's normal answer; it coalesces streaming
+deltas into readable assistant messages. Use `--text` when you only need the
+concatenated assistant text. Use `events --coalesce` for structured JSON
+transcript inspection, and raw `events` for approvals, tool calls/results,
+questions, or debugging missing output. For sessions on the `tmux` (Terminal)
+transport, event kinds are inferred heuristically — also check
+`raw_terminal_chunk` if structured output is incomplete.
 
 Quote only the minimum transcript text needed to justify your conclusion;
 summarize the rest. Distinguish the reported `status` from your interpretation of

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -82,12 +82,16 @@ for those, reap and respawn remains the only path.
 ## Service a child's approvals
 
 When a child sits in `waiting_input`, it may be blocked on an approval. Read it
-from the child's events, then decide:
+from the child's coalesced events, then decide:
 
 ```bash
-waypoint sessions events <child-id> --messages 10   # find the approval_request
+waypoint sessions events <child-id> --messages 20 --coalesce   # find the approval_request
 waypoint sessions approve <child-id> <decision> [--approval-id <id>]
 ```
+
+Coalescing preserves `approval_request` records and keeps surrounding
+assistant/tool output readable. Use raw `events` only if you need exact event
+ordering, duplicate diagnosis, or per-chunk metadata.
 
 The `approval_request` event metadata tells you the kind:
 
@@ -116,7 +120,7 @@ surfaces in the child's events as a `tool_call` whose metadata has
 will not release it.
 
 ```bash
-waypoint sessions events <child-id> --messages 10   # find the AskUserQuestion tool_call
+waypoint sessions events <child-id> --messages 20 --coalesce   # find the AskUserQuestion tool_call
 waypoint sessions answer-question <child-id> --answer "<your answer>"
 ```
 

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -89,9 +89,8 @@ waypoint sessions events <child-id> --messages 20 --coalesce   # find the approv
 waypoint sessions approve <child-id> <decision> [--approval-id <id>]
 ```
 
-Coalescing preserves `approval_request` records and keeps surrounding
-assistant/tool output readable. Use raw `events` only if you need exact event
-ordering, duplicate diagnosis, or per-chunk metadata.
+Use raw `events` only if you need exact event ordering, duplicate diagnosis, or
+per-chunk metadata.
 
 The `approval_request` event metadata tells you the kind:
 

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -95,11 +95,9 @@ waypoint sessions wait "$sid" --until exited,error --timeout 600 \
 ```
 
 After `wait`, use `sessions output` for the child's normal answer. If the child
-stopped in `waiting_input`, inspect `sessions events "$sid" --coalesce` for the
-pending `approval_request` or question `tool_call`; coalescing keeps those
-records intact while making assistant/tool result output readable. Use raw
-`events` only when diagnosing exact event-stream mechanics, missing output,
-transport/TUI artifacts, paging, or duplicates.
+stopped in `waiting_input`, inspect `sessions events "$sid" --coalesce` for a
+pending approval or question. Use raw `events` only for exact stream debugging,
+missing output, or transport/TUI artifacts.
 
 To watch a child's transcript live instead of blocking silently, stream events
 as NDJSON (one compact JSON object per line) until a terminal status or Ctrl+C:

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -94,10 +94,12 @@ waypoint sessions wait "$sid" --until exited,error --timeout 600 \
   && waypoint sessions output "$sid" --messages 40
 ```
 
-After `wait`, use `sessions output` for the child's normal answer. Use
-`sessions events "$sid" --coalesce` when you need structured JSON, and raw
-`events` when diagnosing approvals, tool calls/results, questions, or missing
-output.
+After `wait`, use `sessions output` for the child's normal answer. If the child
+stopped in `waiting_input`, inspect `sessions events "$sid" --coalesce` for the
+pending `approval_request` or question `tool_call`; coalescing keeps those
+records intact while making assistant/tool result output readable. Use raw
+`events` only when diagnosing exact event-stream mechanics, missing output,
+transport/TUI artifacts, paging, or duplicates.
 
 To watch a child's transcript live instead of blocking silently, stream events
 as NDJSON (one compact JSON object per line) until a terminal status or Ctrl+C:

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -87,7 +87,7 @@ Statuses that mean keep waiting: `starting`, `running`, `interrupted`.
 
 It maps the outcome to a process exit code so it composes in `&&` chains:
 `error` → 1, timeout → 124, everything else → 0. Narrow the set with `--until`
-(comma-separated), e.g. wait only for the process to end, then dump events:
+(comma-separated), e.g. wait only for the process to end, then dump its output:
 
 ```bash
 waypoint sessions wait "$sid" --until exited,error --timeout 600 \

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -91,8 +91,13 @@ It maps the outcome to a process exit code so it composes in `&&` chains:
 
 ```bash
 waypoint sessions wait "$sid" --until exited,error --timeout 600 \
-  && waypoint sessions events "$sid"
+  && waypoint sessions output "$sid" --messages 40
 ```
+
+After `wait`, use `sessions output` for the child's normal answer. Use
+`sessions events "$sid" --coalesce` when you need structured JSON, and raw
+`events` when diagnosing approvals, tool calls/results, questions, or missing
+output.
 
 To watch a child's transcript live instead of blocking silently, stream events
 as NDJSON (one compact JSON object per line) until a terminal status or Ctrl+C:

--- a/.agents/skills/waypoint/references/sessions-approvals.md
+++ b/.agents/skills/waypoint/references/sessions-approvals.md
@@ -8,9 +8,12 @@ waypoint sessions approve <session-id> <decision> --approval-id <id>
 waypoint sessions approve <session-id> <decision> --text <message>
 ```
 
-Read the pending request from `waypoint sessions events <session-id>` before
-approving. If multiple approvals are pending, pass `--approval-id` when the
-transcript exposes one.
+Read the pending request from
+`waypoint sessions events <session-id> --messages 20 --coalesce` before
+approving. Coalescing preserves `approval_request` records and keeps surrounding
+assistant/tool output readable. If multiple approvals are pending, pass
+`--approval-id` when the transcript exposes one. Use raw `events` only if you
+need exact event ordering, duplicate diagnosis, or per-chunk metadata.
 
 Do not approve destructive, privileged, or unclear requests without user
 confirmation.
@@ -18,9 +21,9 @@ confirmation.
 ## Questions
 
 A session can also block on a question (an `AskUserQuestion` prompt), which is
-not an approval. It surfaces as a `tool_call` event with
-`tool_name: AskUserQuestion` rather than an `approval_request`, so `approve`
-does not release it — answer it instead:
+not an approval. It surfaces in coalesced or raw events as a `tool_call` event
+with `tool_name: AskUserQuestion` rather than an `approval_request`, so
+`approve` does not release it — answer it instead:
 
 ```bash
 waypoint sessions answer-question <session-id> --answer "<your answer>"

--- a/.agents/skills/waypoint/references/sessions-approvals.md
+++ b/.agents/skills/waypoint/references/sessions-approvals.md
@@ -10,10 +10,9 @@ waypoint sessions approve <session-id> <decision> --text <message>
 
 Read the pending request from
 `waypoint sessions events <session-id> --messages 20 --coalesce` before
-approving. Coalescing preserves `approval_request` records and keeps surrounding
-assistant/tool output readable. If multiple approvals are pending, pass
-`--approval-id` when the transcript exposes one. Use raw `events` only if you
-need exact event ordering, duplicate diagnosis, or per-chunk metadata.
+approving. If multiple approvals are pending, pass `--approval-id` when the
+transcript exposes one. Use raw `events` only if you need exact event ordering,
+duplicate diagnosis, or per-chunk metadata.
 
 Do not approve destructive, privileged, or unclear requests without user
 confirmation.
@@ -21,9 +20,9 @@ confirmation.
 ## Questions
 
 A session can also block on a question (an `AskUserQuestion` prompt), which is
-not an approval. It surfaces in coalesced or raw events as a `tool_call` event
-with `tool_name: AskUserQuestion` rather than an `approval_request`, so
-`approve` does not release it — answer it instead:
+not an approval. It surfaces as a `tool_call` with
+`tool_name: AskUserQuestion`, so `approve` does not release it — answer it
+instead:
 
 ```bash
 waypoint sessions answer-question <session-id> --answer "<your answer>"

--- a/.agents/skills/waypoint/references/sessions-read.md
+++ b/.agents/skills/waypoint/references/sessions-read.md
@@ -7,10 +7,10 @@ waypoint sessions list
 waypoint sessions show <session-id>
 waypoint sessions output <session-id> --messages 40
 waypoint sessions output <session-id> --messages 40 --text
-waypoint sessions events <session-id>
-waypoint sessions events <session-id> --coalesce
-waypoint sessions events <session-id> --messages 40
-waypoint sessions events <session-id> --before-sequence <sequence>
+waypoint sessions events <session-id> --messages 40 --coalesce
+waypoint sessions events <session-id> --before-sequence <sequence> --coalesce
+waypoint sessions events <session-id> --messages 40              # raw events
+waypoint sessions events <session-id> --follow
 ```
 
 `list` is the starting point for broad questions. Use `show` for one session's
@@ -18,10 +18,17 @@ metadata. Use `output` for the conversational transcript or the agent's answer;
 `--text` is best when you want only the concatenated assistant text for shell
 piping or quick reading.
 
-Use `events --coalesce` when you need structured JSON transcript inspection
-without streaming deltas split across many events. Use raw `events` for
-control-plane details such as approvals, tool calls/results, questions,
-debugging missing output, or live `--follow` streams.
+Use `events --coalesce` for settled structured JSON inspection. Coalescing
+combines streaming `agent_output` and `tool_result` deltas that share an
+`item_id`; it leaves other event kinds, including `approval_request`,
+`tool_call`, and question events, as their own records. That makes coalesced
+events the right default for checking what happened in a finished turn,
+including normal tool-call/result context or pending approvals/questions.
+
+Switch to raw `events` only when exact event-stream mechanics matter: delta
+boundaries, original per-chunk `sequence`/`ts`, intermediate metadata that a
+merged event may overwrite, paging or duplicate-event diagnosis, transport/TUI
+artifacts such as `raw_terminal_chunk`, or live `--follow` streams.
 
 When summarizing, distinguish status (`running`, `waiting_input`, `idle`,
 `exited`, `error`) from your interpretation of progress. Quote only the minimum

--- a/.agents/skills/waypoint/references/sessions-read.md
+++ b/.agents/skills/waypoint/references/sessions-read.md
@@ -18,17 +18,14 @@ metadata. Use `output` for the conversational transcript or the agent's answer;
 `--text` is best when you want only the concatenated assistant text for shell
 piping or quick reading.
 
-Use `events --coalesce` for settled structured JSON inspection. Coalescing
-combines streaming `agent_output` and `tool_result` deltas that share an
-`item_id`; it leaves other event kinds, including `approval_request`,
-`tool_call`, and question events, as their own records. That makes coalesced
-events the right default for checking what happened in a finished turn,
-including normal tool-call/result context or pending approvals/questions.
+Use `events --coalesce` for settled structured JSON reads, including tool
+context, approvals, and questions. Coalescing only merges streaming
+`agent_output` and `tool_result` deltas with the same `item_id`;
+`approval_request` and `tool_call` records stay visible.
 
-Switch to raw `events` only when exact event-stream mechanics matter: delta
-boundaries, original per-chunk `sequence`/`ts`, intermediate metadata that a
-merged event may overwrite, paging or duplicate-event diagnosis, transport/TUI
-artifacts such as `raw_terminal_chunk`, or live `--follow` streams.
+Use raw `events` or `--follow` only when exact stream mechanics matter: delta
+boundaries, original sequence/timestamps, overwritten metadata, duplicate or
+paging diagnosis, or transport artifacts such as `raw_terminal_chunk`.
 
 When summarizing, distinguish status (`running`, `waiting_input`, `idle`,
 `exited`, `error`) from your interpretation of progress. Quote only the minimum

--- a/.agents/skills/waypoint/references/sessions-read.md
+++ b/.agents/skills/waypoint/references/sessions-read.md
@@ -5,13 +5,23 @@ Use these commands to ground answers in live Waypoint state:
 ```bash
 waypoint sessions list
 waypoint sessions show <session-id>
+waypoint sessions output <session-id> --messages 40
+waypoint sessions output <session-id> --messages 40 --text
 waypoint sessions events <session-id>
+waypoint sessions events <session-id> --coalesce
 waypoint sessions events <session-id> --messages 40
 waypoint sessions events <session-id> --before-sequence <sequence>
 ```
 
 `list` is the starting point for broad questions. Use `show` for one session's
-metadata and `events` for transcript details.
+metadata. Use `output` for the conversational transcript or the agent's answer;
+`--text` is best when you want only the concatenated assistant text for shell
+piping or quick reading.
+
+Use `events --coalesce` when you need structured JSON transcript inspection
+without streaming deltas split across many events. Use raw `events` for
+control-plane details such as approvals, tool calls/results, questions,
+debugging missing output, or live `--follow` streams.
 
 When summarizing, distinguish status (`running`, `waiting_input`, `idle`,
 `exited`, `error`) from your interpretation of progress. Quote only the minimum


### PR DESCRIPTION
## Purpose

PR #183 added CLI-side event coalescing and `waypoint sessions output`, so agents no longer need to manually filter raw event streams for normal replies. This follow-up updates the local Waypoint skills to use those reader surfaces consistently and keeps the raw-event fallback narrowly scoped.

## Changes

- Prefer `sessions output` for conversational replies and child-session results.
- Prefer `sessions events --coalesce` for settled structured reads, including tool context, approvals, and questions.
- Reserve raw `events` / `--follow` for exact stream debugging: delta boundaries, original sequence/timestamps, overwritten metadata, duplicate or paging diagnosis, and transport/TUI artifacts.
- Align approval and question examples in both the base Waypoint and subagent skill references.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`

## Test Result

pre-commit all passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable) — docs-only skill guidance update.
- [ ] I have verified the relevant suites pass locally (`cd backend && uv run pytest`) — not rerun for the final docs-only wording trim.
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — not touched.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity — no frontend changes.
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above — not a breaking change.
- [x] I have updated documentation or config examples — updated local skill documentation.

</details>