### PR TITLE
feat: add `update --check` to report available updates without applying

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ curl -fsSL https://raw.githubusercontent.com/kaiitunnz/waypoint/main/scripts/ins
 
 or set `WAYPOINT_VERSION=v0.1.0` in the environment before running. To track the bleeding edge instead of a release, pass `--nightly` (the tip of `main`). Prerequisites: git and Node.js ≥ 20 (npm included); `uv` is installed automatically if absent.
 
-Bring the stack up with `waypointctl start`. Use `waypointctl update` to upgrade to the latest release, `waypointctl update --ref vX.Y.Z` to pin a specific version, or `waypointctl update --nightly` to track `main`; `update` leaves the stack untouched, so run `waypointctl restart` afterward to apply the new code.
+Bring the stack up with `waypointctl start`. Use `waypointctl update` to upgrade to the latest release, `waypointctl update --ref vX.Y.Z` to pin a specific version, or `waypointctl update --nightly` to track `main`; `update` leaves the stack untouched, so run `waypointctl restart` afterward to apply the new code. Add `--check` to any of these to report whether an update is available without applying it (handy on a schedule).
 
 To remove Waypoint, run `waypointctl uninstall` (add `--purge` to also delete the state and data directories). It stops the stack, strips the `WAYPOINT_HOME` shell-profile entry, removes the managed checkout, and uninstalls `waypointctl`; `curl`-based installs can instead run `scripts/uninstall.sh` directly.
 

--- a/waypointctl/src/waypointctl/cli.py
+++ b/waypointctl/src/waypointctl/cli.py
@@ -309,9 +309,16 @@ def update(
             "--nightly", help="Update to the tip of main instead of a release."
         ),
     ] = False,
+    check: Annotated[
+        bool,
+        typer.Option(
+            "--check",
+            help="Report whether an update is available without applying it.",
+        ),
+    ] = False,
 ) -> None:
     """Update Waypoint to the latest release; run `waypointctl restart` to apply."""
-    run_update(_ctx_home(ctx), ref=ref, nightly=nightly)
+    run_update(_ctx_home(ctx), ref=ref, nightly=nightly, check=check)
 
 
 @app.command("uninstall")

--- a/waypointctl/src/waypointctl/update.py
+++ b/waypointctl/src/waypointctl/update.py
@@ -70,7 +70,7 @@ def _latest_tag(home: Path) -> str:
 
 def _target_ref(home: Path, ref: str) -> str:
     # Branch refs track the remote tip (so nightly / --ref main actually
-    # advance); tags and SHAs resolve as-is. Either way the caller detaches.
+    # advance); tags and SHAs resolve as-is.
     remote = subprocess.run(
         [
             "git",
@@ -119,6 +119,15 @@ def _checkout(home: Path, ref: str) -> None:
     )
 
 
+def _apply_command(ref: str | None, nightly: bool) -> str:
+    """The command that would apply this check's target, matching its mode."""
+    if nightly:
+        return "waypointctl update --nightly"
+    if ref is not None:
+        return f"waypointctl update --ref {ref}"
+    return "waypointctl update"
+
+
 def _check(home: Path, ref: str | None, nightly: bool) -> None:
     """Report whether a newer revision is available, without changing anything."""
     _fetch(home)
@@ -128,7 +137,10 @@ def _check(home: Path, ref: str | None, nightly: bool) -> None:
     if _rev(home, "HEAD") == _rev(home, f"{_target_ref(home, target)}^{{commit}}"):
         typer.echo(f"Up to date ({target}).")
     else:
-        typer.echo(f"Update available ({target}). Run 'waypointctl update' to apply.")
+        typer.echo(
+            f"Update available ({target}). "
+            f"Run '{_apply_command(ref, nightly)}' to apply."
+        )
 
 
 def run(

--- a/waypointctl/src/waypointctl/update.py
+++ b/waypointctl/src/waypointctl/update.py
@@ -68,9 +68,9 @@ def _latest_tag(home: Path) -> str:
     raise RuntimeError(f"no tags found in {home}")
 
 
-def _checkout(home: Path, ref: str) -> None:
+def _target_ref(home: Path, ref: str) -> str:
     # Branch refs track the remote tip (so nightly / --ref main actually
-    # advance); tags and SHAs detach. Either way we land in a detached HEAD.
+    # advance); tags and SHAs resolve as-is. Either way the caller detaches.
     remote = subprocess.run(
         [
             "git",
@@ -85,21 +85,74 @@ def _checkout(home: Path, ref: str) -> None:
         capture_output=True,
         text=True,
     )
-    target = f"origin/{ref}" if remote.returncode == 0 else ref
-    subprocess.run(["git", "-C", str(home), "checkout", "--detach", target], check=True)
+    return f"origin/{ref}" if remote.returncode == 0 else ref
+
+
+def _rev(home: Path, rev: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(home), "rev-parse", rev],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _select_target(home: Path, ref: str | None, nightly: bool) -> str:
+    if nightly:
+        return DEFAULT_BRANCH
+    if ref is not None:
+        return ref
+    return _latest_tag(home)
+
+
+def _fetch(home: Path) -> None:
+    subprocess.run(
+        ["git", "-C", str(home), "fetch", "--force", "--tags", "origin"], check=True
+    )
+
+
+def _checkout(home: Path, ref: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(home), "checkout", "--detach", _target_ref(home, ref)],
+        check=True,
+    )
+
+
+def _check(home: Path, ref: str | None, nightly: bool) -> None:
+    """Report whether a newer revision is available, without changing anything."""
+    _fetch(home)
+    target = _select_target(home, ref, nightly)
+    # `^{commit}` dereferences annotated tags to the commit they point at, so
+    # the comparison matches HEAD (always a commit) regardless of tag kind.
+    if _rev(home, "HEAD") == _rev(home, f"{_target_ref(home, target)}^{{commit}}"):
+        typer.echo(f"Up to date ({target}).")
+    else:
+        typer.echo(f"Update available ({target}). Run 'waypointctl update' to apply.")
 
 
 def run(
-    home: Path | None = None, ref: str | None = None, nightly: bool = False
+    home: Path | None = None,
+    ref: str | None = None,
+    nightly: bool = False,
+    check: bool = False,
 ) -> None:
     """Update Waypoint to the latest release (or --ref / --nightly).
 
     The stack is left untouched; run `waypointctl restart` afterward to apply.
+    With check=True, only report whether an update is available and return.
     """
     if nightly and ref is not None:
         raise typer.BadParameter("--nightly cannot be combined with --ref")
 
     resolved = _resolve_home(home)
+
+    # A check is read-only, so it runs before the managed-drift and dirty-tree
+    # guards that only matter when we are about to rewrite the working tree.
+    if check:
+        _check(resolved, ref, nightly)
+        return
+
     # In an installer-managed checkout, clear build-generated drift first so a
     # prior start/restart doesn't block the update on "uncommitted changes".
     if _is_managed(resolved):
@@ -111,16 +164,9 @@ def run(
         )
 
     typer.echo(f"Updating {resolved}")
-    subprocess.run(
-        ["git", "-C", str(resolved), "fetch", "--force", "--tags", "origin"], check=True
-    )
+    _fetch(resolved)
 
-    if nightly:
-        target = DEFAULT_BRANCH
-    elif ref is not None:
-        target = ref
-    else:
-        target = _latest_tag(resolved)
+    target = _select_target(resolved, ref, nightly)
 
     typer.echo(f"Checking out {target}")
     _checkout(resolved, target)

--- a/waypointctl/tests/test_update.py
+++ b/waypointctl/tests/test_update.py
@@ -31,6 +31,33 @@ def _fake_run(
     return run
 
 
+def _fake_check_run(
+    *,
+    head: str,
+    target: str,
+    tags: str = "v1.0.0\n",
+    remote_has=lambda ref: False,
+):
+    """A subprocess.run stub for the read-only `--check` path.
+
+    A `--verify` rev-parse probes existence (returncode); a plain rev-parse
+    resolves a SHA (stdout): HEAD -> head, anything else -> target.
+    """
+
+    def run(argv, **kwargs):
+        if "tag" in argv and "--list" in argv:
+            return MagicMock(returncode=0, stdout=tags)
+        if "rev-parse" in argv and "--verify" in argv:
+            ref = argv[-1].rsplit("/", 1)[-1]
+            return MagicMock(returncode=0 if remote_has(ref) else 1, stdout="")
+        if "rev-parse" in argv:
+            sha = head if argv[-1] == "HEAD" else target
+            return MagicMock(returncode=0, stdout=f"{sha}\n")
+        return MagicMock(returncode=0, stdout="")
+
+    return run
+
+
 def _argvs(mock_run) -> list[list[str]]:
     return [c.args[0] for c in mock_run.call_args_list]
 
@@ -225,3 +252,53 @@ def test_resolve_home_reraises_when_default_missing(tmp_path: Path) -> None:
         pytest.raises(RuntimeError),
     ):
         update._resolve_home(None)
+
+
+def test_check_reports_up_to_date(tmp_path: Path, capsys) -> None:
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run",
+            side_effect=_fake_check_run(head="abc123", target="abc123"),
+        ) as mock_run,
+    ):
+        update.run(tmp_path, check=True)
+
+    assert "Up to date" in capsys.readouterr().out
+    argvs = _argvs(mock_run)
+    assert ["git", "-C", str(tmp_path), "fetch", "--force", "--tags", "origin"] in argvs
+    # a check never rewrites the working tree or reinstalls the tool
+    assert not any("checkout" in a for a in argvs)
+    assert not any(a and a[0] == "uv" for a in argvs)
+
+
+def test_check_reports_update_available(tmp_path: Path, capsys) -> None:
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run",
+            side_effect=_fake_check_run(head="abc123", target="def456"),
+        ) as mock_run,
+    ):
+        update.run(tmp_path, check=True)
+
+    out = capsys.readouterr().out
+    assert "Update available" in out
+    assert "v1.0.0" in out  # the resolved target tag
+    argvs = _argvs(mock_run)
+    assert not any("checkout" in a for a in argvs)
+    assert not any(a and a[0] == "uv" for a in argvs)
+
+
+def test_check_skips_dirty_guard(tmp_path: Path) -> None:
+    # A check is read-only, so a dirty working tree must not block it.
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run",
+            side_effect=_fake_check_run(head="abc123", target="abc123"),
+        ) as mock_run,
+    ):
+        update.run(tmp_path, check=True)
+
+    assert not any("status" in a and "--porcelain" in a for a in _argvs(mock_run))

--- a/waypointctl/tests/test_update.py
+++ b/waypointctl/tests/test_update.py
@@ -285,9 +285,37 @@ def test_check_reports_update_available(tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "Update available" in out
     assert "v1.0.0" in out  # the resolved target tag
+    # default mode suggests the bare apply command
+    assert "Run 'waypointctl update' to apply." in out
     argvs = _argvs(mock_run)
     assert not any("checkout" in a for a in argvs)
     assert not any(a and a[0] == "uv" for a in argvs)
+
+
+def test_check_apply_command_matches_nightly_mode(tmp_path: Path, capsys) -> None:
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run",
+            side_effect=_fake_check_run(head="abc123", target="def456"),
+        ),
+    ):
+        update.run(tmp_path, check=True, nightly=True)
+
+    assert "Run 'waypointctl update --nightly' to apply." in capsys.readouterr().out
+
+
+def test_check_apply_command_matches_ref_mode(tmp_path: Path, capsys) -> None:
+    with (
+        patch("waypointctl.update.resolve_waypoint_home", return_value=tmp_path),
+        patch(
+            "waypointctl.update.subprocess.run",
+            side_effect=_fake_check_run(head="abc123", target="def456"),
+        ),
+    ):
+        update.run(tmp_path, check=True, ref="v2.0.0")
+
+    assert "Run 'waypointctl update --ref v2.0.0' to apply." in capsys.readouterr().out
 
 
 def test_check_skips_dirty_guard(tmp_path: Path) -> None:


### PR DESCRIPTION
## Purpose

Add `waypointctl update --check`: a read-only mode that reports whether a newer
revision is available without changing anything. This makes it safe to run on a
schedule (e.g. a weekly cron) as an update notifier — today there is no way to
ask "is there an update?" without `update` actually checking out and reinstalling.

## Changes

- `waypointctl/src/waypointctl/update.py` — add `--check` handling. `run()` gains
  a `check` flag that short-circuits to a new `_check()` (which fetches, resolves
  the target, and compares HEAD to it) before the managed-drift and dirty-tree
  guards, since a check never rewrites the working tree. The target selection,
  fetch, and remote-ref resolution previously inlined in `run()` are factored into
  `_select_target`, `_fetch`, and `_target_ref` so the check and apply paths share
  one implementation.
- `waypointctl/src/waypointctl/cli.py` — expose the `--check` option on `update`.
- `waypointctl/tests/test_update.py` — cover up-to-date, update-available, and the
  read-only (skips the dirty-tree guard) behavior.
- `README.md` — document `--check`.

## Design

`--check` reuses the exact target-resolution logic as a real update (latest
release tag by default, or `--ref` / `--nightly`), so what it reports is exactly
what `update` would apply. It compares `git rev-parse HEAD` against the target
dereferenced with `^{commit}` — the dereference keeps the comparison correct for
annotated tags (whose `rev-parse` yields the tag-object SHA, not the commit) as
well as lightweight tags, branches, and SHAs.

## Test Plan

```
cd waypointctl
uv run pytest                 # full suite
uvx ruff check src tests
uvx black --check src tests
uvx isort --check-only --profile black src tests
uv run --with mypy mypy src/waypointctl/update.py src/waypointctl/cli.py
```
Also smoke-tested the real git path: `update.run(home=..., check=True)` against a
working checkout prints `Update available (v0.2.0). Run 'waypointctl update' to apply.`

## Test Result

- `uv run pytest` — 163 passed (15 in `test_update.py`, including 3 new `--check` cases).
- ruff / black / isort / mypy — clean.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [ ] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. (N/A — change is `waypointctl`-only, no backend files touched.)
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd waypointctl && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends. (N/A.)
- [x] If I changed the frontend, I ran lint + build. (N/A — no frontend changes.)
- [x] If this is a breaking change, I marked the title and described migration steps. (N/A — additive flag.)
- [x] I have updated documentation or config examples if user-facing behavior changed. (`README.md`.)

</details>
