### PR TITLE
feat: restyle session/schedule actions as chips and align scheduled rows

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9589,15 +9589,13 @@ html[data-theme="light"] .term-compose-input {
   color: var(--accent);
 }
 
-/* Outline the session-card pin / terminate (and the mutually-exclusive delete)
-   actions so they read as buttons. currentColor keeps each border in its own
-   action hue and adapts to both themes without a separate light override. */
+/* Underline the session-card pin / terminate / delete actions so they read as
+   tappable without the visual weight of a full button — they appear on every
+   card and carry no important state, so they stay deliberately low-key. */
 .session-card-actions .pin-link,
 .session-card-actions .danger-link {
-  border: 1px solid currentColor;
-  border-radius: 6px;
-  padding: 3px 10px;
-  margin-top: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .session-header-title-row,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9589,13 +9589,44 @@ html[data-theme="light"] .term-compose-input {
   color: var(--accent);
 }
 
-/* Underline the session-card pin / terminate / delete actions so they read as
-   tappable without the visual weight of a full button — they appear on every
-   card and carry no important state, so they stay deliberately low-key. */
-.session-card-actions .pin-link,
-.session-card-actions .danger-link {
-  text-decoration: underline;
-  text-underline-offset: 3px;
+/* Session-card actions (and the scheduled-panel row Cancel/Dismiss, via
+   .action-chip) echo the app's tinted-chip badge language but sit one rung
+   quieter: state badges are outlined, these are borderless soft-fill pills that
+   ignite to a deeper fill + hairline border and lift on hover/press. The
+   color-mix tints read off currentColor, so pin keeps its neutral→gold hue and
+   terminate/delete/cancel stay danger-red, adapting to both themes with no
+   override. */
+.session-card-actions .link-button.pin-link,
+.session-card-actions .link-button.danger-link,
+.link-button.danger-link.action-chip {
+  align-self: center;
+  margin-top: 0;
+  padding: 6px 13px;
+  border-radius: var(--radius-pill);
+  border: 1px solid transparent;
+  background: color-mix(in srgb, currentColor 9%, transparent);
+  transition: background 140ms ease, border-color 140ms ease,
+    transform 120ms ease, color 140ms ease;
+}
+
+.session-card-actions .link-button.pin-link:hover:not(:disabled),
+.session-card-actions .link-button.danger-link:hover:not(:disabled),
+.link-button.danger-link.action-chip:hover:not(:disabled) {
+  background: color-mix(in srgb, currentColor 17%, transparent);
+  border-color: color-mix(in srgb, currentColor 34%, transparent);
+  transform: translateY(-1px);
+}
+
+.session-card-actions .link-button.pin-link:active:not(:disabled),
+.session-card-actions .link-button.danger-link:active:not(:disabled),
+.link-button.danger-link.action-chip:active:not(:disabled) {
+  background: color-mix(in srgb, currentColor 23%, transparent);
+  transform: translateY(0);
+}
+
+.session-card-actions .link-button.pin-link.active {
+  background: color-mix(in srgb, currentColor 14%, transparent);
+  border-color: color-mix(in srgb, currentColor 30%, transparent);
 }
 
 .session-header-title-row,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9884,13 +9884,24 @@ html[data-theme="light"] .msg-sched-count {
 .msg-row-right {
   margin-left: auto;
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
 }
 
 .msg-row-top .msg-cancel {
   margin-top: 0;
-  align-self: baseline;
+  align-self: center;
+}
+
+/* On narrow screens the time + action group wraps below the badges; give it the
+   full row and split it (time at the left edge, action at the right) instead of
+   letting margin-left:auto jam both against the right margin. */
+@media (max-width: 720px) {
+  .msg-row-right {
+    width: 100%;
+    margin-left: 0;
+    justify-content: space-between;
+  }
 }
 
 .msg-status-dot {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9589,6 +9589,17 @@ html[data-theme="light"] .term-compose-input {
   color: var(--accent);
 }
 
+/* Outline the session-card pin / terminate (and the mutually-exclusive delete)
+   actions so they read as buttons. currentColor keeps each border in its own
+   action hue and adapts to both themes without a separate light override. */
+.session-card-actions .pin-link,
+.session-card-actions .danger-link {
+  border: 1px solid currentColor;
+  border-radius: 6px;
+  padding: 3px 10px;
+  margin-top: 0;
+}
+
 .session-header-title-row,
 .session-card-title-row {
   display: flex;

--- a/frontend/src/components/ScheduledMessagesPanel.tsx
+++ b/frontend/src/components/ScheduledMessagesPanel.tsx
@@ -144,7 +144,7 @@ function MessageRow({
           </span>
           <button
             type="button"
-            className="link-button danger-link msg-cancel"
+            className="link-button danger-link msg-cancel action-chip"
             onClick={() => void onDelete(schedule.id)}
           >
             {isPending ? "Cancel" : "Dismiss"}

--- a/frontend/src/components/ScheduledMessagesPanel.tsx
+++ b/frontend/src/components/ScheduledMessagesPanel.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { ExpandableText } from "@/components/ExpandableText";
 import { Pager } from "@/components/Pager";
 import { usePagination } from "@/lib/usePagination";
+import { formatClock, formatRelative } from "@/lib/scheduleTime";
 import { MessageSchedule, SessionRecord } from "@/lib/types";
 
 const PAGE_SIZE = 5;
@@ -176,32 +177,3 @@ function shortSessionId(id: string): string {
   return dash >= 0 ? id.slice(dash + 1) : id;
 }
 
-function formatClock(target: Date): string {
-  const sameDay = new Date().toDateString() === target.toDateString();
-  return target.toLocaleString(undefined, {
-    month: sameDay ? undefined : "short",
-    day: sameDay ? undefined : "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
-}
-
-function formatRelative(target: Date): string {
-  const diff = target.getTime() - Date.now();
-  if (diff <= 0) {
-    return "any moment";
-  }
-  const minutes = Math.round(diff / 60_000);
-  if (minutes < 1) {
-    return "in <1m";
-  }
-  if (minutes < 60) {
-    return `in ${minutes}m`;
-  }
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) {
-    return `in ${hours}h`;
-  }
-  const days = Math.round(hours / 24);
-  return `in ${days}d`;
-}

--- a/frontend/src/components/ScheduledSessionsPanel.tsx
+++ b/frontend/src/components/ScheduledSessionsPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { fetchBackendModels } from "@/lib/api";
 import { Pager } from "@/components/Pager";
 import { usePagination } from "@/lib/usePagination";
+import { formatClock, formatRelative } from "@/lib/scheduleTime";
 import {
   Backend,
   BackendModelOption,
@@ -141,8 +142,8 @@ function ScheduleRow({
   modelsByBackend: Record<string, BackendModelOption[]>;
 }) {
   const when = new Date(schedule.scheduled_at);
-  const formatted = when.toLocaleString();
-  const relative = formatRelative(when);
+  const formatted = formatClock(when);
+  const relative = schedule.status === "pending" ? formatRelative(when) : null;
   const modelCacheKey = scheduleModelCacheKey(
     schedule.backend,
     schedule.launch_target_id ?? null,
@@ -172,8 +173,19 @@ function ScheduleRow({
             {schedule.effort}
           </span>
         ) : null}
-        <span className="muted">{formatted}</span>
-        {schedule.status === "pending" ? <span className="muted">· {relative}</span> : null}
+        <span className="msg-row-right">
+          <span className="msg-row-when">
+            {relative ? <span className="msg-countdown">{relative}</span> : null}
+            <span className="muted">{formatted}</span>
+          </span>
+          <button
+            type="button"
+            className="link-button danger-link action-chip"
+            onClick={() => void onCancel(schedule.id)}
+          >
+            {schedule.status === "pending" ? "Cancel" : "Dismiss"}
+          </button>
+        </span>
       </div>
       <p className="schedule-title">
         {schedule.title || schedule.cwd}
@@ -187,41 +199,17 @@ function ScheduleRow({
       {schedule.failure_reason ? (
         <p className="error">{schedule.failure_reason}</p>
       ) : null}
-      <div className="action-row">
-        {schedule.session_id ? (
+      {schedule.session_id ? (
+        <div className="action-row">
           <a className="link-button" href={`/session/${schedule.session_id}`}>
             Open session →
           </a>
-        ) : null}
-        <button
-          type="button"
-          className="link-button danger-link"
-          onClick={() => void onCancel(schedule.id)}
-        >
-          {schedule.status === "pending" ? "Cancel" : "Dismiss"}
-        </button>
-      </div>
+        </div>
+      ) : null}
     </article>
   );
 }
 
 function scheduleModelCacheKey(backend: Backend, launchTargetId: string | null): string {
   return `${backend}::${launchTargetId ?? "local"}`;
-}
-
-function formatRelative(target: Date): string {
-  const diff = target.getTime() - Date.now();
-  if (diff <= 0) {
-    return "any moment";
-  }
-  const minutes = Math.round(diff / 60_000);
-  if (minutes < 60) {
-    return `in ${minutes}m`;
-  }
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) {
-    return `in ${hours}h`;
-  }
-  const days = Math.round(hours / 24);
-  return `in ${days}d`;
 }

--- a/frontend/src/lib/scheduleTime.ts
+++ b/frontend/src/lib/scheduleTime.ts
@@ -1,0 +1,34 @@
+/**
+ * Time formatting shared by the Scheduled Sessions and Messages panels, which
+ * render the same launch/send clock and countdown.
+ */
+
+export function formatClock(target: Date): string {
+  const sameDay = new Date().toDateString() === target.toDateString();
+  return target.toLocaleString(undefined, {
+    month: sameDay ? undefined : "short",
+    day: sameDay ? undefined : "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function formatRelative(target: Date): string {
+  const diff = target.getTime() - Date.now();
+  if (diff <= 0) {
+    return "any moment";
+  }
+  const minutes = Math.round(diff / 60_000);
+  if (minutes < 1) {
+    return "in <1m";
+  }
+  if (minutes < 60) {
+    return `in ${minutes}m`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `in ${hours}h`;
+  }
+  const days = Math.round(hours / 24);
+  return `in ${days}d`;
+}


### PR DESCRIPTION
## Summary

Restyles the low-key secondary actions on session cards and in the Scheduled panel (pin / terminate / delete / cancel) from bare text into "ghost chips" — borderless, `currentColor`-tinted pills that read as tappable while staying a rung quieter than the app's status badges — and brings the Scheduled *Sessions* row into visual parity with the *Messages* row.

## Changes

- Ghost-chip treatment for the session-card pin/terminate/delete actions and the scheduled-panel Cancel/Dismiss: borderless soft fills that deepen and lift on hover/press, tinted via `color-mix(… currentColor …)` so each action keeps its own hue (pin neutral/gold, destructive danger-red) and both themes work with no separate light-mode override. State badges stay outlined, so state and actions read as distinct tiers.
- Scheduled Sessions row restructured to mirror the Messages row: launch time, countdown, and Cancel now share one right-aligned group instead of an orphaned bottom action, the verbose full timestamp becomes the concise clock format the Messages panel already used (countdown gated to pending), and "Open session →" shows only for launched sessions.
- Mobile fix: on narrow screens the shared time + action group wraps to a full-width `space-between` line (time at the left edge, action at the right) instead of jamming both against the right margin.
- Extracted the duplicated `formatClock` / `formatRelative` helpers into a shared `frontend/src/lib/scheduleTime.ts` module.

## Design

Underline/border were both tried and rejected earlier as either too link-like or too heavy. A borderless tinted pill signals "tappable" with a real touch target, echoes the existing badge vocabulary without competing with it, and adapts to dark/light for free through `currentColor` + CSS variables.

## Test Plan / Result

- `cd frontend && npm run lint` — clean.
- Production build + deploy via `waypointctl restart frontend` — succeeded/healthy.
- Verified on desktop and mobile widths (session cards, scheduled Sessions and Messages rows, both themes).
