### PR TITLE
fix: keep wide tasks from overflowing the task dock past the viewport

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -2159,60 +2159,6 @@ html[data-theme="light"] .transcript.codex.user_input {
   opacity: 0.5;
 }
 
-.transcript.codex.user_input.pending-optimistic.persisted {
-  opacity: 1;
-}
-
-.transcript.codex.user_input.pending-optimistic.persisted::after {
-  content: "";
-  position: absolute;
-  top: 10px;
-  right: 0;
-  width: 4px;
-  height: calc(100% - 20px);
-  border-radius: 999px 0 0 999px;
-  background: linear-gradient(
-    180deg,
-    rgba(143, 179, 214, 0.15),
-    rgba(143, 179, 214, 0.72),
-    rgba(143, 179, 214, 0.15)
-  );
-  box-shadow:
-    0 0 0 1px rgba(143, 179, 214, 0.14),
-    0 0 18px rgba(143, 179, 214, 0.28);
-  animation: transcript-persisted-edge 5s ease-in-out infinite;
-  pointer-events: none;
-}
-
-html[data-theme="light"]
-  .transcript.codex.user_input.pending-optimistic.persisted::after {
-  background: linear-gradient(
-    180deg,
-    rgba(184, 130, 14, 0.12),
-    rgba(184, 130, 14, 0.65),
-    rgba(184, 130, 14, 0.12)
-  );
-  box-shadow:
-    0 0 0 1px rgba(184, 130, 14, 0.12),
-    0 0 18px rgba(184, 130, 14, 0.2);
-}
-
-@keyframes transcript-persisted-edge {
-  0%,
-  100% {
-    opacity: 0.28;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .transcript.codex.user_input.pending-optimistic.persisted::after {
-    animation: none;
-  }
-}
-
 .transcript.codex.user_input.ask-answer-summary {
   width: 100%;
   max-width: min(92%, 760px);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3483,6 +3483,10 @@ html[data-theme="light"] .code-copy.copied {
   z-index: 5;
   margin-top: -8px;
   pointer-events: none;
+  /* The parent `.stack` is a grid with an `auto` column, which sizes to its
+     widest child's max-content. Set this to prevent wide tasks from
+     blowing the grid — and the page — wider than the viewport. */
+  min-width: 0;
 }
 
 /* Expanded, the dock is a modal (full-screen scrim + task list) and must sit
@@ -3633,12 +3637,20 @@ html[data-theme="light"] .task-dock-scrim {
 }
 
 .task-dock-panel {
-  position: relative;
+  /* Absolute (not in flow) so expanding it overlays the transcript instead of
+     growing the sticky dock's box and reflowing content upward — mobile sits
+     flush atop the strip as a full-width sheet; desktop re-anchors below. */
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
   z-index: 7;
-  margin-bottom: 8px;
   max-height: 50vh;
   overflow-y: auto;
   display: grid;
+  /* minmax(0, 1fr) lets the grid column shrink so text wraps instead of
+     sizing to max-content and blowing the dock wider than the viewport. */
+  grid-template-columns: minmax(0, 1fr);
   gap: 10px;
   padding: 12px 14px;
   border: 1px solid var(--line-strong);
@@ -3659,7 +3671,6 @@ html[data-theme="light"] .task-dock-panel {
  * with the strip carrying the shadow. (Desktop overrides this below to float
  * the panel as a detached popover.) */
 .task-dock.expanded .task-dock-panel {
-  margin-bottom: 0;
   border-bottom: none;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
@@ -3705,11 +3716,10 @@ html[data-theme="light"] .task-dock-panel {
   }
 
   .task-dock-panel {
-    position: absolute;
+    left: auto;
     right: 0;
     bottom: calc(100% + 8px);
     width: min(420px, 92vw);
-    margin-bottom: 0;
   }
 
   /* The panel floats as a detached popover, so undo the mobile sheet join:
@@ -3927,7 +3937,6 @@ html[data-theme="light"] .sq-dock-panel {
 
 /* Mobile: join the panel to the strip into one surface. */
 .sq-dock.expanded .sq-dock-panel {
-  margin-bottom: 0;
   border-bottom: none;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -444,7 +444,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // this from the raw payload before coalescing.
   const [oldestRawSequence, setOldestRawSequence] = useState<number | null>(null);
   const [optimisticMessages, setOptimisticMessages] = useState<
-    { tempId: string; text: string; ts: string; confirmed: boolean }[]
+    { tempId: string; text: string; ts: string }[]
   >([]);
   const sectionRef = useRef<HTMLElement | null>(null);
   const nearBottomRef = useRef(true);
@@ -633,23 +633,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     const confirmedUserTexts = pending
       .filter((e) => e.kind === "user_input")
       .map((e) => e.text);
-    if (confirmedUserTexts.length > 0) {
-      setOptimisticMessages((prev) => {
-        let next = prev;
-        for (const text of confirmedUserTexts) {
-          const idx = next.findIndex((m) => !m.confirmed && m.text === text);
-          if (idx !== -1) {
-            next = [
-              ...next.slice(0, idx),
-              { ...next[idx], confirmed: true },
-              ...next.slice(idx + 1),
-            ];
-          }
-        }
-        return next;
-      });
-    }
     startTransition(() => {
+      if (confirmedUserTexts.length > 0) {
+        setOptimisticMessages((prev) =>
+          removeConfirmedOptimisticMessages(prev, confirmedUserTexts),
+        );
+      }
       setEvents((current) =>
         pending.reduce<EventRecord[]>((acc, event) => mergeEvents(acc, event), current),
       );
@@ -1073,7 +1062,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     ) => {
       const tempId = Math.random().toString(36).slice(2);
       const ts = new Date().toISOString();
-      setOptimisticMessages((prev) => [...prev, { tempId, text, ts, confirmed: false }]);
+      setOptimisticMessages((prev) => [...prev, { tempId, text, ts }]);
       try {
         // Sending a message to an exited session restarts it: the placeholder
         // "Session has exited — send a message to reattach…" promises this UX.
@@ -1322,13 +1311,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     [filterMode, displayEvents],
   );
   const hiddenEventCount = displayEvents.length - visibleEvents.length;
-  const transcriptEvents = useMemo(
-    () =>
-      optimisticMessages.length > 0
-        ? filterOptimisticTranscriptEvents(visibleEvents, optimisticMessages)
-        : visibleEvents,
-    [visibleEvents, optimisticMessages],
-  );
   const pendingPlanApprovalEvent = useMemo(
     () =>
       session?.permission_mode === "plan" &&
@@ -1344,9 +1326,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const transcriptEventsForDisplay = useMemo(
     () =>
       pendingPlanApprovalEvent
-        ? transcriptEvents.filter((event) => event !== pendingPlanApprovalEvent)
-        : transcriptEvents,
-    [pendingPlanApprovalEvent, transcriptEvents],
+        ? visibleEvents.filter((event) => event !== pendingPlanApprovalEvent)
+        : visibleEvents,
+    [pendingPlanApprovalEvent, visibleEvents],
   );
   const transcriptItems = useMemo(
     () => buildTranscriptItems(transcriptEventsForDisplay),
@@ -1930,7 +1912,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
                   key={msg.tempId}
                   text={msg.text}
                   ts={msg.ts}
-                  confirmed={msg.confirmed}
                 />
               ))
             : null}
@@ -3804,31 +3785,27 @@ function mergeToolResultEvent(existing: EventRecord, incoming: EventRecord): Eve
   };
 }
 
-function filterOptimisticTranscriptEvents(
-  events: EventRecord[],
-  optimisticMessages: { text: string }[],
-): EventRecord[] {
-  const pendingCounts = new Map<string, number>();
-  for (const message of optimisticMessages) {
-    pendingCounts.set(message.text, (pendingCounts.get(message.text) ?? 0) + 1);
+function removeConfirmedOptimisticMessages<T extends { text: string }>(
+  messages: T[],
+  confirmedTexts: string[],
+): T[] {
+  const confirmedCounts = new Map<string, number>();
+  for (const text of confirmedTexts) {
+    confirmedCounts.set(text, (confirmedCounts.get(text) ?? 0) + 1);
   }
-  if (pendingCounts.size === 0) {
-    return events;
+  if (confirmedCounts.size === 0) {
+    return messages;
   }
-  const filtered: EventRecord[] = [];
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const event = events[index];
-    if (event.kind === "user_input") {
-      const pendingCount = pendingCounts.get(event.text) ?? 0;
-      if (pendingCount > 0) {
-        pendingCounts.set(event.text, pendingCount - 1);
-        continue;
-      }
+  const next: T[] = [];
+  for (const message of messages) {
+    const count = confirmedCounts.get(message.text) ?? 0;
+    if (count > 0) {
+      confirmedCounts.set(message.text, count - 1);
+      continue;
     }
-    filtered.push(event);
+    next.push(message);
   }
-  filtered.reverse();
-  return filtered;
+  return next;
 }
 
 function isToolResultDelta(event: EventRecord): boolean {

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -87,16 +87,14 @@ function useMetaReserve(gap: number = 16) {
 export function PendingUserInputCard({
   text,
   ts,
-  confirmed = false,
 }: {
   text: string;
   ts: string;
-  confirmed?: boolean;
 }) {
   const { metaRef, style } = useMetaReserve();
   return (
     <article
-      className={`panel transcript codex user_input${confirmed ? " pending-optimistic persisted" : " pending-optimistic"}`}
+      className="panel transcript codex user_input pending-optimistic"
       aria-label="Message from you"
       style={style}
     >


### PR DESCRIPTION
## Purpose

A wide task title made the task dock — and the whole page — scroll sideways: the dock's grid column sized to the title's `max-content`, so a long single-line task blew past the viewport width. This floats the dock panel and constrains the grid so wide content wraps instead of overflowing. While here, it also finishes a half-done optimistic-message refactor that the dock CSS work sat on top of.

## Changes

### Task dock overflow fix

- `frontend/src/app/globals.css` — float `.task-dock-panel` absolutely (`position: absolute; left/right/bottom: 100%`) so expanding it overlays the transcript instead of growing the sticky dock and reflowing content upward, matching the existing `.sq-dock-panel` pattern; the desktop media query re-anchors it as a right-aligned popover. Constrain the panel's grid with `grid-template-columns: minmax(0, 1fr)` and add `min-width: 0` to `.task-dock` so long task titles wrap rather than sizing to `max-content`. Drops the now-redundant `margin-bottom` overrides on both the task and side-question docks.

### Optimistic-message refactor

- `frontend/src/components/SessionDetail.tsx` — replace the confirmed/persisted optimistic-message scheme with a remove-on-confirm one. An optimistic card is shown on send; when the real `user_input` event arrives it is removed (`removeConfirmedOptimisticMessages`) and the confirmed event renders in the transcript, instead of keeping the optimistic card and filtering the duplicate real event out. Removal and event-merge happen in the same `startTransition`, so there is no duplicate-display window.
- `frontend/src/components/TranscriptCard.tsx` — drop the now-unused `confirmed` prop from `PendingUserInputCard`.
- `frontend/src/app/globals.css` — remove the dead `.pending-optimistic.persisted` styles and `transcript-persisted-edge` keyframes orphaned by the refactor.

## Design

The dock fix mirrors the side-question dock, which already solved the same overflow with absolute positioning + `minmax(0, 1fr)`; bringing the task dock into parity keeps the two docks behaving identically. The optimistic refactor collapses two representations of an in-flight message (an optimistic card plus a filtered-out real event) into one: the optimistic card exists only until its confirming event lands, then the real event takes over. The unchanged `finally` cleanup still removes the optimistic card if the send fails, so a never-confirmed message can't linger.

## Test Plan

```
cd frontend
npm run lint
npm run build
```

No frontend automated-test harness exists in this repo. The changes were reviewed for theme parity: the removed `.persisted` rules covered both dark and light, and the dock positioning change adds no new hardcoded colors, so dark/light parity is preserved. Not manually exercised in a running app this session.

## Test Result

- `npm run lint` — clean.
- `npm run build` — compiled successfully, TypeScript clean, all routes generated.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [ ] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. (N/A — frontend-only.)
- [ ] I have added or updated tests covering my changes (if applicable). (N/A — no frontend test harness.)
- [ ] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). (N/A — frontend-only.)
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends. (N/A — no backend dispatch touched.)
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [x] If this is a breaking change, I marked the title and described migration steps. (N/A — not breaking.)
- [x] I have updated documentation or config examples if user-facing behavior changed. (N/A — no config/docs surface.)

</details>