### PR TITLE
feat: add password SSH auth for remote coding sessions

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -38,6 +38,8 @@ from waypoint.schemas import (
     AssistantSummary,
     BoardEntryUpdateRequest,
     BoardPostRequest,
+    LaunchTargetConnectRequest,
+    LaunchTargetConnectResponse,
     LoginRequest,
     MeResponse,
     ScheduleCreateRequest,
@@ -173,6 +175,49 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             assistant=context.runtime.assistant_summary(),
         )
 
+    @app.post(
+        "/api/launch-targets/{target_id}/connect",
+        response_model=LaunchTargetConnectResponse,
+    )
+    async def connect_launch_target(
+        target_id: str,
+        body: LaunchTargetConnectRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> LaunchTargetConnectResponse:
+        # The password is used once to seed the ControlMaster socket and is
+        # never logged or persisted; do not echo ``body`` anywhere.
+        result = await context.runtime.connect_launch_target(target_id, body.password)
+        return LaunchTargetConnectResponse(
+            target_id=result.target_id,
+            connected=result.connected,
+            detail=result.detail,
+        )
+
+    @app.get(
+        "/api/launch-targets/{target_id}/status",
+        response_model=LaunchTargetConnectResponse,
+    )
+    async def launch_target_status(
+        target_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> LaunchTargetConnectResponse:
+        result = await context.runtime.launch_target_status(target_id)
+        return LaunchTargetConnectResponse(
+            target_id=result.target_id,
+            connected=result.connected,
+            detail=result.detail,
+        )
+
+    @app.post(
+        "/api/launch-targets/{target_id}/disconnect",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def disconnect_launch_target(
+        target_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> None:
+        await context.runtime.disconnect_launch_target(target_id)
+
     @app.post("/api/assistant/reset", response_model=AssistantSummary)
     async def assistant_reset(
         body: AssistantResetRequest,
@@ -260,6 +305,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"thread discovery is not supported for {backend}",
             )
+        # A password-auth target with no live master can't be reached; skip the
+        # remote enumeration instead of letting it fail/stall the picker.
+        if context.runtime.remote_probe_blocked(launch_target_id):
+            return {"threads": []}
         threads = [
             thread.model_dump(mode="json")
             for thread in await plugin.list_threads(context.runtime, launch_target_id)
@@ -957,6 +1006,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"unknown backend: {backend}",
             )
+        # Fall back to the local catalogue when the password-auth target isn't
+        # connected, rather than SSHing to an unreachable host for model probes.
+        if context.runtime.remote_probe_blocked(launch_target_id):
+            launch_target_id = None
         return await context.runtime.list_backend_models(
             backend,
             launch_target_id=launch_target_id,

--- a/backend/src/waypoint/launch_targets.py
+++ b/backend/src/waypoint/launch_targets.py
@@ -254,14 +254,15 @@ class SshLaunchTargetConfig(BaseModel):
 
         ``ConnectTimeout`` bounds the call so a probe against an unreachable
         host (or a password-auth target whose ControlMaster has dropped) fails
-        within seconds instead of stalling the caller; ssh first-value-wins, so
-        an explicit ``ssh_args`` value still takes precedence.
+        within seconds instead of stalling the caller. The default is spliced
+        *after* ``ssh_args`` so an explicit ``ConnectTimeout`` there wins
+        (ssh first-value-wins); absent one, this 15s default applies.
         """
         proc = await asyncio.create_subprocess_exec(
             self.ssh_bin,
+            *self.ssh_args,
             "-o",
             "ConnectTimeout=15",
-            *self.ssh_args,
             self.ssh_destination,
             remote_cmd,
             stdout=asyncio.subprocess.PIPE,

--- a/backend/src/waypoint/launch_targets.py
+++ b/backend/src/waypoint/launch_targets.py
@@ -19,9 +19,9 @@ import re
 import shlex
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from waypoint.backends.plugin_config import PluginLaunchTargetConfig
 from waypoint.backends.registry import get_registry
@@ -65,6 +65,14 @@ class SshLaunchTargetConfig(BaseModel):
     # codex/claude's stream protocols, so keep rcfile output on stderr only.
     remote_shell: str = "bash -ilc"
     remote_env: dict[str, str] = Field(default_factory=dict)
+    # SSH authentication method. ``key`` (the default) delegates entirely to
+    # the local ``ssh`` binary's key/agent discovery, exactly as before.
+    # ``password`` opts the target into UI-prompted password auth: the password
+    # is used once to seed a multiplexed ControlMaster connection (see
+    # ``ssh_master.py``) and never stored. Password auth therefore requires the
+    # ``ssh_args`` to enable connection multiplexing so every later call can
+    # reuse the authenticated socket without a password.
+    ssh_auth: Literal["key", "password"] = "key"
     # Per-plugin per-target config blocks keyed by plugin id. Presence
     # of a key means "this target supports the plugin"; an empty
     # mapping means "supports every non-fallback registered plugin
@@ -91,6 +99,52 @@ class SshLaunchTargetConfig(BaseModel):
                 raw if isinstance(raw, schema) else schema.model_validate(raw or {})
             )
         return dispatched
+
+    @model_validator(mode="after")
+    def _require_multiplexing_for_password(self) -> Self:
+        """Password auth reuses one ControlMaster socket, so the target must
+        configure connection multiplexing. Fail loud at config load (matching
+        ``_dispatch_plugin_configs``) rather than discovering it at connect time.
+        """
+        if self.ssh_auth != "password":
+            return self
+        options = self._parsed_ssh_options()
+        missing: list[str] = []
+        if options.get("controlmaster", "").lower() not in {"auto", "yes"}:
+            missing.append("ControlMaster=auto")
+        if not options.get("controlpath"):
+            missing.append("ControlPath=<path>")
+        if not options.get("controlpersist"):
+            missing.append("ControlPersist=<duration>")
+        if missing:
+            raise ValueError(
+                f"ssh target {self.id!r} uses password auth and must configure "
+                f"connection multiplexing; missing ssh_args: {', '.join(missing)}"
+            )
+        return self
+
+    def _parsed_ssh_options(self) -> dict[str, str]:
+        """Extract ``-o KEY=VALUE`` options from ``ssh_args`` keyed by lowercased
+        name. Accepts both the split (``["-o", "ControlMaster=auto"]``) and
+        glued (``["-oControlMaster=auto"]``) forms OpenSSH allows.
+        """
+        options: dict[str, str] = {}
+        args = iter(self.ssh_args)
+        for arg in args:
+            spec: str | None = None
+            if arg == "-o":
+                spec = next(args, None)
+            elif arg.startswith("-o") and len(arg) > 2:
+                spec = arg[2:]
+            if not spec or "=" not in spec:
+                continue
+            key, _, value = spec.partition("=")
+            options[key.strip().lower()] = value.strip()
+        return options
+
+    @property
+    def requires_password(self) -> bool:
+        return self.ssh_auth == "password"
 
     def supported_plugins(self) -> list[str]:
         """Plugin ids this target accepts managed launches for.
@@ -196,9 +250,17 @@ class SshLaunchTargetConfig(BaseModel):
         return f"{shell} {shlex.quote(command)}"
 
     async def ssh_capture(self, remote_cmd: str) -> str:
-        """``ssh <host> <cmd>`` — returns stdout (empty on non-zero exit)."""
+        """``ssh <host> <cmd>`` — returns stdout (empty on non-zero exit).
+
+        ``ConnectTimeout`` bounds the call so a probe against an unreachable
+        host (or a password-auth target whose ControlMaster has dropped) fails
+        within seconds instead of stalling the caller; ssh first-value-wins, so
+        an explicit ``ssh_args`` value still takes precedence.
+        """
         proc = await asyncio.create_subprocess_exec(
             self.ssh_bin,
+            "-o",
+            "ConnectTimeout=15",
             *self.ssh_args,
             self.ssh_destination,
             remote_cmd,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -56,6 +56,7 @@ from waypoint.schemas import (
     SessionStatus,
 )
 from waypoint.settings import Settings
+from waypoint.ssh_master import SshMasterManager, SshMasterStatus
 from waypoint.storage import Storage
 from waypoint.transports import TransportAdapter
 
@@ -173,6 +174,9 @@ class SessionRuntime:
         self.ssh_targets = {
             target.id: target for target in self.settings.ssh_targets if target.enabled
         }
+        # Owns the password-authenticated ControlMaster sockets for
+        # ``ssh_auth == "password"`` targets. Key-auth targets never touch it.
+        self.ssh_master = SshMasterManager()
         self.monitor_tasks: dict[str, asyncio.Task[None]] = {}
         # Per-session helpers that capture the agent's native thread id once
         # the underlying CLI has materialized it on disk (Codex writes its
@@ -237,6 +241,17 @@ class SessionRuntime:
             # EXITED stays skipped: that's a terminal user choice.
             if session.status == SessionStatus.EXITED:
                 continue
+            # A password-auth target has no live ControlMaster at boot, so a
+            # restore would block on an unanswerable password prompt. Leave the
+            # session in its stored state for the user to reconnect (prompting
+            # for the password) and /reattach.
+            launch_target = self._find_launch_target(session.launch_target_id)
+            if (
+                launch_target is not None
+                and launch_target.requires_password
+                and not self.ssh_master.is_connected_cached(launch_target)
+            ):
+                continue
             plugin = self.registry.plugin_for(session)
             task = asyncio.create_task(
                 self._restore_session_and_warm_completions(plugin, session),
@@ -300,6 +315,7 @@ class SessionRuntime:
         self._structured_log_handles.clear()
         for plugin in self.registry.all():
             await plugin.shutdown(self)
+        await self.ssh_master.disconnect_all(list(self.ssh_targets.values()))
         self.storage.close()
 
     def list_sessions(self) -> list[SessionRecord]:
@@ -339,6 +355,7 @@ class SessionRuntime:
         launch_target = self._resolve_launch_target(
             request.launch_target_id, request.backend
         )
+        await self._require_live_master(launch_target)
         # Local cwd is fed to subprocess.Popen / tmux new-session, neither of
         # which expand `~`. Resolve it before storing/launching. The remote
         # cwd is left verbatim so the remote shell can do its own expansion.
@@ -1331,6 +1348,9 @@ class SessionRuntime:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="this session cannot be reattached after exit",
             )
+        await self._require_live_master(
+            self._find_launch_target(session.launch_target_id)
+        )
         await plugin.terminate_session(self, session)
         await self._cancel_context_usage_source(session.id)
         # User-initiated retry: bypass any per-target cooldown / circuit
@@ -1733,9 +1753,50 @@ class SessionRuntime:
                         self.settings.default_backend
                     ),
                     "default_cwd": target.default_cwd,
+                    "auth": target.ssh_auth,
+                    "connected": self.ssh_master.is_connected_cached(target),
                 }
             )
         return summaries
+
+    async def connect_launch_target(
+        self, target_id: str, password: str
+    ) -> SshMasterStatus:
+        target = self._find_launch_target(target_id)
+        if target is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="unknown launch target"
+            )
+        if not target.requires_password:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="launch target does not use password auth",
+            )
+        return await self.ssh_master.connect(target, password)
+
+    async def launch_target_status(self, target_id: str) -> SshMasterStatus:
+        target = self._find_launch_target(target_id)
+        if target is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="unknown launch target"
+            )
+        connected = (
+            await self.ssh_master.is_connected(target)
+            if target.requires_password
+            else True
+        )
+        return SshMasterStatus(
+            target_id=target.id, auth=target.ssh_auth, connected=connected
+        )
+
+    async def disconnect_launch_target(self, target_id: str) -> None:
+        target = self._find_launch_target(target_id)
+        if target is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="unknown launch target"
+            )
+        if target.requires_password:
+            await self.ssh_master.disconnect(target)
 
     def _resolve_launch_target(
         self,
@@ -1762,6 +1823,35 @@ class SessionRuntime:
         if not launch_target_id:
             return None
         return self.ssh_targets.get(launch_target_id)
+
+    def remote_probe_blocked(self, launch_target_id: str | None) -> bool:
+        """True when a pre-launch SSH probe (thread/model enumeration) must be
+        skipped because the target needs a password and its ControlMaster is not
+        up. Otherwise the picker SSHes to an unreachable host on every load —
+        codex fails with ``Permission denied`` and opencode blocks on its
+        server-start timeout, both surfacing as "load failed" in the UI.
+        """
+        target = self._find_launch_target(launch_target_id)
+        return bool(
+            target
+            and target.requires_password
+            and not self.ssh_master.is_connected_cached(target)
+        )
+
+    async def _require_live_master(
+        self, launch_target: SshLaunchTargetConfig | None
+    ) -> None:
+        """Reject a launch on a password-auth target whose ControlMaster is not
+        up. The frontend matches the ``ssh-master-required`` detail to prompt
+        for the password (via ``/api/launch-targets/{id}/connect``) and retry.
+        """
+        if launch_target is None or not launch_target.requires_password:
+            return
+        if not await self.ssh_master.is_connected(launch_target):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="ssh-master-required",
+            )
 
     async def _record_user_event(
         self,

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -283,6 +283,19 @@ class LaunchTargetSummary(BaseModel):
     supported_backends: list[BackendId] = Field(default_factory=list)
     default_backend: BackendId = "codex"
     default_cwd: str | None = None
+    auth: Literal["key", "password"] = "key"
+    # Live ControlMaster state; only meaningful when ``auth == "password"``.
+    connected: bool = False
+
+
+class LaunchTargetConnectRequest(BaseModel):
+    password: str
+
+
+class LaunchTargetConnectResponse(BaseModel):
+    target_id: str
+    connected: bool
+    detail: str | None = None
 
 
 class AssistantSummary(BaseModel):

--- a/backend/src/waypoint/ssh_askpass.py
+++ b/backend/src/waypoint/ssh_askpass.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""SSH_ASKPASS helper for password-authenticated launch targets.
+
+OpenSSH invokes this program (with the prompt text as ``argv[1]``) to obtain a
+password non-interactively when ``SSH_ASKPASS`` points at it and
+``SSH_ASKPASS_REQUIRE=force`` is set. It carries no secret of its own — it only
+echoes the password the parent process placed in the environment for the
+lifetime of a single ``ssh`` invocation. See ``ssh_master.py``.
+"""
+
+import os
+import sys
+
+PASSWORD_ENV_VAR = "WAYPOINT_SSH_PASSWORD"
+
+
+def main() -> None:
+    sys.stdout.write(os.environ.get(PASSWORD_ENV_VAR, ""))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/waypoint/ssh_master.py
+++ b/backend/src/waypoint/ssh_master.py
@@ -28,23 +28,24 @@ log = logging.getLogger(__name__)
 
 _ASKPASS_HELPER_PATH = Path(__file__).with_name("ssh_askpass.py")
 
-# Options layered on top of ``target.ssh_args`` only when seeding the master.
-# ``ControlMaster=yes`` overrides the ``auto`` already in ssh_args (OpenSSH
-# last-value-wins) so this invocation owns the socket; ``ControlPersist=yes``
-# keeps it alive after the backgrounded ``-f -N`` process exits.
+# Mandatory seed options. OpenSSH uses the *first* value obtained for each
+# parameter, so these are spliced ahead of ``target.ssh_args`` (see ``connect``)
+# to guarantee they win even if the user set a conflicting value: ``BatchMode=no``
+# keeps interactive auth — and thus SSH_ASKPASS — enabled (a ``BatchMode=yes`` in
+# ssh_args would otherwise silently disable the password prompt), ``ControlMaster=yes``
+# makes this invocation own the socket, ``NumberOfPasswordPrompts=1`` fails a wrong
+# password fast, and ``ConnectTimeout`` bounds the seed. ``ControlPath`` and
+# ``ControlPersist`` are taken from the user's ssh_args (the validator requires
+# them) rather than overridden here, so the master's lifetime stays user-configured.
 #
 # Auth methods are intentionally NOT forced. The prompted password is supplied
 # via SSH_ASKPASS, and each hop negotiates whatever it accepts: a ProxyJump can
 # use a password (askpass-fed) while the destination uses a key, or vice versa.
 # Pinning ``PreferredAuthentications=password`` here would whitelist away
-# publickey and break any key-authenticated hop in the chain. ``BatchMode=no``
-# keeps interactive auth (and thus askpass) enabled; ``NumberOfPasswordPrompts=1``
-# makes a wrong password fail fast instead of retrying.
+# publickey and break any key-authenticated hop in the chain.
 _SEED_OPTIONS: tuple[str, ...] = (
     "-o",
     "ControlMaster=yes",
-    "-o",
-    "ControlPersist=yes",
     "-o",
     "BatchMode=no",
     "-o",
@@ -117,8 +118,8 @@ class SshMasterManager:
                 return self._status(target, True)
             argv = (
                 _resolve_local_binary(target.ssh_bin),
-                *target.ssh_args,
                 *_SEED_OPTIONS,
+                *target.ssh_args,
                 "-f",
                 "-N",
                 target.ssh_destination,

--- a/backend/src/waypoint/ssh_master.py
+++ b/backend/src/waypoint/ssh_master.py
@@ -1,0 +1,198 @@
+"""Password-authenticated SSH ControlMaster lifecycle.
+
+The whole stack streams each agent's protocol over a non-interactive ``ssh``
+subprocess, so ``ssh`` itself can never prompt for a password. Instead, a
+password-auth launch target (``ssh_auth == "password"``) reuses one multiplexed
+ControlMaster connection: this manager opens that master exactly once using the
+UI-prompted password, fed to ``ssh`` via OpenSSH's ``SSH_ASKPASS`` mechanism
+(``sshpass`` is intentionally not required). Every other SSH call on the target
+already splices ``*target.ssh_args`` — which carry the same ``ControlPath`` — so
+they transparently reuse the authenticated socket with no password.
+
+The password lives only in the child process environment for the duration of
+the seeding ``ssh`` invocation; it is never persisted, logged, or stored on the
+manager.
+"""
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from waypoint.launch_targets import SshLaunchTargetConfig, _resolve_local_binary
+from waypoint.ssh_askpass import PASSWORD_ENV_VAR
+
+log = logging.getLogger(__name__)
+
+_ASKPASS_HELPER_PATH = Path(__file__).with_name("ssh_askpass.py")
+
+# Options layered on top of ``target.ssh_args`` only when seeding the master.
+# ``ControlMaster=yes`` overrides the ``auto`` already in ssh_args (OpenSSH
+# last-value-wins) so this invocation owns the socket; ``ControlPersist=yes``
+# keeps it alive after the backgrounded ``-f -N`` process exits.
+#
+# Auth methods are intentionally NOT forced. The prompted password is supplied
+# via SSH_ASKPASS, and each hop negotiates whatever it accepts: a ProxyJump can
+# use a password (askpass-fed) while the destination uses a key, or vice versa.
+# Pinning ``PreferredAuthentications=password`` here would whitelist away
+# publickey and break any key-authenticated hop in the chain. ``BatchMode=no``
+# keeps interactive auth (and thus askpass) enabled; ``NumberOfPasswordPrompts=1``
+# makes a wrong password fail fast instead of retrying.
+_SEED_OPTIONS: tuple[str, ...] = (
+    "-o",
+    "ControlMaster=yes",
+    "-o",
+    "ControlPersist=yes",
+    "-o",
+    "BatchMode=no",
+    "-o",
+    "ConnectTimeout=15",
+    "-o",
+    "NumberOfPasswordPrompts=1",
+)
+
+
+class SshMasterStatus(BaseModel):
+    target_id: str
+    auth: str
+    connected: bool
+    detail: str | None = None
+
+
+class SshMasterManager:
+    """Opens, checks, and tears down ControlMaster sockets for password targets."""
+
+    def __init__(self) -> None:
+        self._connected: dict[str, bool] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._ensure_helper_executable()
+
+    @staticmethod
+    def _ensure_helper_executable() -> None:
+        if not _ASKPASS_HELPER_PATH.exists():
+            raise RuntimeError(f"ssh askpass helper missing: {_ASKPASS_HELPER_PATH}")
+        if not os.access(_ASKPASS_HELPER_PATH, os.X_OK):
+            # A wheel install or lost git exec bit can strip the bit; restore it
+            # best-effort and fail loud if even that is impossible.
+            try:
+                _ASKPASS_HELPER_PATH.chmod(0o755)
+            except OSError as exc:
+                raise RuntimeError(
+                    f"ssh askpass helper is not executable and could not be made "
+                    f"executable: {_ASKPASS_HELPER_PATH} ({exc})"
+                ) from exc
+
+    def _lock(self, target_id: str) -> asyncio.Lock:
+        lock = self._locks.get(target_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[target_id] = lock
+        return lock
+
+    def is_connected_cached(self, target: SshLaunchTargetConfig) -> bool:
+        """Last-known master state without spawning ``ssh``. Safe for hot paths
+        like ``/api/me`` that must not block on a per-target ``-O check``."""
+        return self._connected.get(target.id, False)
+
+    async def is_connected(self, target: SshLaunchTargetConfig) -> bool:
+        """Live ``ssh -O check`` against the master socket; updates the cache."""
+        argv = (
+            _resolve_local_binary(target.ssh_bin),
+            *target.ssh_args,
+            "-O",
+            "check",
+            target.ssh_destination,
+        )
+        connected = await self._run_quiet(argv)
+        self._connected[target.id] = connected
+        return connected
+
+    async def connect(
+        self, target: SshLaunchTargetConfig, password: str
+    ) -> SshMasterStatus:
+        async with self._lock(target.id):
+            if await self.is_connected(target):
+                return self._status(target, True)
+            argv = (
+                _resolve_local_binary(target.ssh_bin),
+                *target.ssh_args,
+                *_SEED_OPTIONS,
+                "-f",
+                "-N",
+                target.ssh_destination,
+            )
+            env = {
+                **os.environ,
+                "SSH_ASKPASS": str(_ASKPASS_HELPER_PATH),
+                "SSH_ASKPASS_REQUIRE": "force",
+                "DISPLAY": os.environ.get("DISPLAY", ":0"),
+                PASSWORD_ENV_VAR: password,
+            }
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                env=env,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+            )
+            _, stderr = await proc.communicate()
+            detail = stderr.decode("utf-8", errors="ignore").strip() or None
+            if proc.returncode != 0:
+                log.warning(
+                    "ssh master seed failed for %s (rc=%s): %s",
+                    target.id,
+                    proc.returncode,
+                    detail,
+                )
+                self._connected[target.id] = False
+                return self._status(target, False, detail)
+            connected = await self.is_connected(target)
+            return self._status(
+                target,
+                connected,
+                None if connected else "master socket did not come up",
+            )
+
+    async def disconnect(self, target: SshLaunchTargetConfig) -> None:
+        argv = (
+            _resolve_local_binary(target.ssh_bin),
+            *target.ssh_args,
+            "-O",
+            "exit",
+            target.ssh_destination,
+        )
+        await self._run_quiet(argv)
+        self._connected[target.id] = False
+
+    async def disconnect_all(self, targets: list[SshLaunchTargetConfig]) -> None:
+        for target in targets:
+            if target.requires_password and self._connected.get(target.id):
+                await self.disconnect(target)
+
+    @staticmethod
+    async def _run_quiet(argv: tuple[str, ...]) -> bool:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *argv,
+                stdin=asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+        except OSError:
+            return False
+        await proc.wait()
+        return proc.returncode == 0
+
+    @staticmethod
+    def _status(
+        target: SshLaunchTargetConfig, connected: bool, detail: str | None = None
+    ) -> SshMasterStatus:
+        return SshMasterStatus(
+            target_id=target.id,
+            auth=target.ssh_auth,
+            connected=connected,
+            detail=detail,
+        )

--- a/backend/tests/test_launch_target_connect.py
+++ b/backend/tests/test_launch_target_connect.py
@@ -1,0 +1,158 @@
+"""Route-level tests for password-auth launch-target connect + the launch gate.
+
+Exercised through the real FastAPI app over an in-process ASGI transport;
+``asyncio.create_subprocess_exec`` is monkeypatched so no real ``ssh`` runs.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from waypoint.api import create_app
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.settings import Settings
+
+_MULTIPLEX_ARGS = [
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPath=~/.ssh/cm-%C",
+    "-o",
+    "ControlPersist=600s",
+]
+
+
+class _FakeProc:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return b"", b""
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+def _make_recorder(connected: bool):
+    async def recorder(*argv: str, **kwargs: Any) -> _FakeProc:
+        if "-O" in argv and "check" in argv:
+            return _FakeProc(0 if connected else 1)
+        return _FakeProc(0)
+
+    return recorder
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    settings = Settings(
+        data_dir=tmp_path / "data",
+        ssh_targets=[
+            SshLaunchTargetConfig(
+                id="pw",
+                name="pw",
+                ssh_destination="host",
+                ssh_auth="password",
+                ssh_args=_MULTIPLEX_ARGS,
+            ),
+            SshLaunchTargetConfig(id="keyed", name="keyed", ssh_destination="host"),
+        ],
+    )
+    app = create_app(settings)
+    token = app.state.context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_connect_unknown_target_404(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/launch-targets/nope/connect",
+            json={"password": "x"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 404
+
+
+async def test_connect_rejects_key_auth_target_400(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/launch-targets/keyed/connect",
+            json={"password": "x"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 400
+
+
+async def test_connect_success_reports_connected(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "waypoint.launch_targets.shutil.which", lambda _: "/usr/bin/ssh"
+    )
+    monkeypatch.setattr(
+        "waypoint.ssh_master.asyncio.create_subprocess_exec",
+        _make_recorder(connected=True),
+    )
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/launch-targets/pw/connect",
+            json={"password": "s3cret"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 200
+    assert resp.json()["connected"] is True
+
+
+async def test_threads_probe_skipped_when_master_down(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # No SSH must be attempted; if the gate misses, this would raise loudly.
+    async def boom(*argv: str, **kwargs: Any):
+        raise AssertionError(f"unexpected ssh probe: {argv}")
+
+    monkeypatch.setattr("waypoint.ssh_master.asyncio.create_subprocess_exec", boom)
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/backends/codex/threads",
+            params={"launch_target_id": "pw"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 200
+    assert resp.json()["threads"] == []
+
+
+async def test_create_session_requires_live_master_409(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.launch_targets.shutil.which", lambda _: "/usr/bin/ssh"
+    )
+    monkeypatch.setattr(
+        "waypoint.ssh_master.asyncio.create_subprocess_exec",
+        _make_recorder(connected=False),
+    )
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions",
+            json={
+                "backend": "codex",
+                "cwd": "~/work",
+                "launch_target_id": "pw",
+                "source_mode": "managed",
+            },
+            headers=_auth(token),
+        )
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "ssh-master-required"

--- a/backend/tests/test_launch_targets.py
+++ b/backend/tests/test_launch_targets.py
@@ -1,8 +1,71 @@
 import os
 from pathlib import Path
 
+import pytest
+
 from waypoint.launch_targets import SshLaunchTargetConfig, quote_remote_path
 from waypoint.settings import load_settings
+
+_MULTIPLEX_ARGS = [
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPath=~/.ssh/cm-%C",
+    "-o",
+    "ControlPersist=600s",
+]
+
+
+def test_password_auth_requires_multiplexing_args() -> None:
+    target = SshLaunchTargetConfig(
+        id="pw",
+        name="pw",
+        ssh_destination="host",
+        ssh_auth="password",
+        ssh_args=_MULTIPLEX_ARGS,
+    )
+    assert target.requires_password is True
+
+
+def test_password_auth_accepts_glued_option_form() -> None:
+    target = SshLaunchTargetConfig(
+        id="pw",
+        name="pw",
+        ssh_destination="host",
+        ssh_auth="password",
+        ssh_args=[
+            "-oControlMaster=auto",
+            "-oControlPath=~/.ssh/cm-%C",
+            "-oControlPersist=yes",
+        ],
+    )
+    assert target._parsed_ssh_options()["controlmaster"] == "auto"
+
+
+@pytest.mark.parametrize(
+    "drop, expected",
+    [
+        ("ControlMaster", "ControlMaster=auto"),
+        ("ControlPath", "ControlPath"),
+        ("ControlPersist", "ControlPersist"),
+    ],
+)
+def test_password_auth_rejects_missing_multiplexing(drop: str, expected: str) -> None:
+    args = [a for a in _MULTIPLEX_ARGS if not a.startswith(drop)]
+    with pytest.raises(ValueError, match=expected):
+        SshLaunchTargetConfig(
+            id="pw",
+            name="pw",
+            ssh_destination="host",
+            ssh_auth="password",
+            ssh_args=args,
+        )
+
+
+def test_key_auth_skips_multiplexing_requirement() -> None:
+    target = SshLaunchTargetConfig(id="k", name="k", ssh_destination="host")
+    assert target.ssh_auth == "key"
+    assert target.requires_password is False
 
 
 def test_quote_remote_path_preserves_leading_tilde() -> None:

--- a/backend/tests/test_ssh_master.py
+++ b/backend/tests/test_ssh_master.py
@@ -1,0 +1,125 @@
+"""Unit tests for the password-auth ControlMaster manager.
+
+These never spawn a real ``ssh``; ``asyncio.create_subprocess_exec`` is
+monkeypatched so the argv and environment the manager builds can be asserted
+directly.
+"""
+
+import os
+from pathlib import Path
+from typing import Any
+
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.ssh_askpass import PASSWORD_ENV_VAR
+from waypoint.ssh_master import _ASKPASS_HELPER_PATH, SshMasterManager
+
+_MULTIPLEX_ARGS = [
+    "-o",
+    "ControlMaster=auto",
+    "-o",
+    "ControlPath=~/.ssh/cm-%C",
+    "-o",
+    "ControlPersist=600s",
+]
+
+
+def _password_target() -> SshLaunchTargetConfig:
+    return SshLaunchTargetConfig(
+        id="pw",
+        name="pw",
+        ssh_destination="host",
+        ssh_auth="password",
+        ssh_args=_MULTIPLEX_ARGS,
+    )
+
+
+class _FakeProc:
+    def __init__(self, returncode: int) -> None:
+        self.returncode = returncode
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return b"", b""
+
+    async def wait(self) -> int:
+        return self.returncode
+
+
+class _Recorder:
+    """Stateful ``create_subprocess_exec`` stand-in.
+
+    The master is reported absent on the first ``-O check`` and present after
+    the seed runs, mirroring a successful connect.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._seeded = False
+
+    async def __call__(self, *argv: str, **kwargs: Any) -> _FakeProc:
+        self.calls.append({"argv": argv, "env": kwargs.get("env")})
+        if "-O" in argv and "check" in argv:
+            return _FakeProc(0 if self._seeded else 1)
+        if "ControlMaster=yes" in argv:
+            self._seeded = True
+            return _FakeProc(0)
+        return _FakeProc(0)
+
+
+def _patch(monkeypatch, recorder: _Recorder) -> None:
+    monkeypatch.setattr(
+        "waypoint.launch_targets.shutil.which", lambda _: "/usr/bin/ssh"
+    )
+    monkeypatch.setattr("waypoint.ssh_master.asyncio.create_subprocess_exec", recorder)
+
+
+async def test_connect_builds_seed_argv_and_env(monkeypatch) -> None:
+    recorder = _Recorder()
+    _patch(monkeypatch, recorder)
+    target = _password_target()
+
+    status = await SshMasterManager().connect(target, "s3cret")
+
+    assert status.connected is True
+    seed = next(c for c in recorder.calls if "ControlMaster=yes" in c["argv"])
+    argv = seed["argv"]
+    assert argv[0] == "/usr/bin/ssh"
+    for token in _MULTIPLEX_ARGS:
+        assert token in argv
+    assert "-N" in argv and "-f" in argv
+    assert argv[-1] == "host"
+    # Auth methods must NOT be whitelisted, or a key-authenticated hop (e.g. a
+    # key dest behind a password ProxyJump) would be unable to offer its key.
+    assert not any("PreferredAuthentications" in token for token in argv)
+    assert not any("PubkeyAuthentication=no" in token for token in argv)
+    env = seed["env"]
+    assert env["SSH_ASKPASS"] == str(_ASKPASS_HELPER_PATH)
+    assert env["SSH_ASKPASS_REQUIRE"] == "force"
+    assert env[PASSWORD_ENV_VAR] == "s3cret"
+    # The password must never leak into the parent process environment.
+    assert PASSWORD_ENV_VAR not in os.environ
+
+
+async def test_connect_idempotent_when_already_live(monkeypatch) -> None:
+    recorder = _Recorder()
+    recorder._seeded = True  # master already up
+    _patch(monkeypatch, recorder)
+
+    status = await SshMasterManager().connect(_password_target(), "pw")
+
+    assert status.connected is True
+    assert not any("ControlMaster=yes" in c["argv"] for c in recorder.calls)
+
+
+async def test_disconnect_issues_control_exit(monkeypatch) -> None:
+    recorder = _Recorder()
+    _patch(monkeypatch, recorder)
+
+    await SshMasterManager().disconnect(_password_target())
+
+    exit_call = recorder.calls[-1]["argv"]
+    assert "-O" in exit_call and "exit" in exit_call
+
+
+def test_askpass_helper_is_executable() -> None:
+    assert Path(_ASKPASS_HELPER_PATH).exists()
+    assert os.access(_ASKPASS_HELPER_PATH, os.X_OK)

--- a/backend/tests/test_ssh_master.py
+++ b/backend/tests/test_ssh_master.py
@@ -87,6 +87,11 @@ async def test_connect_builds_seed_argv_and_env(monkeypatch) -> None:
         assert token in argv
     assert "-N" in argv and "-f" in argv
     assert argv[-1] == "host"
+    # Seed options must precede ssh_args so they win under OpenSSH's
+    # first-value-wins rule (e.g. seed BatchMode=no can't be defeated by a
+    # BatchMode=yes in ssh_args).
+    assert argv.index("ControlMaster=yes") < argv.index("ControlMaster=auto")
+    assert "BatchMode=no" in argv
     # Auth methods must NOT be whitelisted, or a key-authenticated hop (e.g. a
     # key dest behind a password ProxyJump) would be unable to offer its key.
     assert not any("PreferredAuthentications" in token for token in argv)

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -117,3 +117,10 @@ ssh_targets:
     remote_shell: bash -ilc
     remote_env:
       OPENAI_API_KEY: sk-your-key
+    # SSH authentication. `key` (the default) delegates to the local ssh
+    # binary's key/agent discovery. Set to `password` to have Waypoint prompt
+    # for the SSH password in the UI when connecting; the password seeds the
+    # ControlMaster connection above and is never stored or written to disk.
+    # Password auth REQUIRES the ControlMaster/ControlPath/ControlPersist args
+    # above (config load fails otherwise) and OpenSSH >= 8.4 on the host.
+    # ssh_auth: password

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -540,6 +540,35 @@ If your agent needs SSH-launched sessions, three pieces are involved:
    The plugin's `remote_executable(launch_target)` reads
    `launch_target.remote_bin_for(self.id, self.capabilities.cli_binary)`.
 
+### Password-based SSH targets
+
+By default an SSH target authenticates with whatever the local `ssh` binary
+discovers (keys / agent). A target can instead opt into UI-prompted password
+auth with `ssh_auth: password`. Because the agent protocol streams over a
+non-interactive `ssh` subprocess, the password is never handed to those calls;
+instead it seeds a single multiplexed **ControlMaster** connection once, and
+every later call (the agent launch, the Codex SDK's own `ssh`, OpenCode's serve
+tunnel, all background probes) reuses that authenticated socket with no
+password — they already splice `*target.ssh_args`, which carry the shared
+`ControlPath`.
+
+- A `password` target **must** configure `ControlMaster`/`ControlPath`/
+  `ControlPersist` in `ssh_args`; config load fails loudly otherwise.
+- The host needs **OpenSSH >= 8.4** (for `SSH_ASKPASS_REQUIRE=force`). The
+  password is fed to the one-time master seed via the committed, secret-free
+  [`ssh_askpass.py`](../backend/src/waypoint/ssh_askpass.py) helper and is never
+  stored, logged, or persisted to a session record.
+- Flow: the frontend prompts when a `password` target is selected (or on a `409
+  ssh-master-required` from a launch), `POST /api/launch-targets/{id}/connect`
+  seeds the master via [`SshMasterManager`](../backend/src/waypoint/ssh_master.py),
+  and the launch retries. `GET .../status` reports liveness; `POST .../disconnect`
+  closes the socket.
+- **Drop / reconnect:** when the master dies (`ControlPersist` timeout, network
+  drop, backend `stop()`), its multiplexed sessions drop and background probes
+  go stale rather than hang (`ssh_capture` is bounded by `ConnectTimeout`).
+  Boot restore skips `password` targets with no live master. The user
+  reconnects (re-entering the password) and uses `/reattach` to revive sessions.
+
 ## Adding a new transport
 
 A transport is "how an agent is driven". There are two shapes.

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13745,3 +13745,155 @@ html[data-theme="light"] .wp-hl {
     height: 38px;
   }
 }
+
+/* ─── SSH password-auth connect control + modal ─── */
+/* Inline auth control, rendered inside the backend selector (collapsed pill
+   and expanded panel) so it stays attached to where the SSH target is chosen. */
+.ssh-auth-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.84rem;
+  color: var(--muted);
+}
+
+.ssh-auth-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--warn);
+  flex: none;
+}
+
+.ssh-auth-row.is-connected .ssh-auth-dot {
+  background: var(--success);
+}
+
+.ssh-auth-label {
+  white-space: nowrap;
+}
+
+.ssh-auth-connect {
+  min-height: 28px;
+  padding: 0 12px;
+  font-size: 0.82rem;
+}
+
+/* In the collapsed pill the control sits after the "change" link; nudge it
+   apart so the two concerns (host vs. SSH auth) read as distinct. */
+.backend-pill .ssh-auth-row {
+  margin-left: auto;
+}
+
+.ssh-connect-backdrop {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  padding: 16px;
+}
+
+.ssh-connect-modal {
+  width: 100%;
+  max-width: min(28rem, calc(100vw - 32px));
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 1.4rem;
+  background: rgba(14, 17, 24, 0.96);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  animation: ssh-connect-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+}
+
+html[data-theme="light"] .ssh-connect-modal {
+  background: rgba(252, 249, 242, 0.98);
+  box-shadow: 0 16px 48px rgba(60, 45, 20, 0.2);
+}
+
+@keyframes ssh-connect-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ssh-connect-modal {
+    animation: none;
+  }
+}
+
+.ssh-connect-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.ssh-connect-head strong {
+  font-size: 1.05rem;
+  color: var(--text-strong);
+}
+
+/* iOS Safari zooms the viewport for inputs under 16px; keep it at 16px. */
+.ssh-connect-modal .field input {
+  font-size: 16px;
+}
+
+/* Password field with a trailing show/hide toggle. */
+.input-reveal {
+  position: relative;
+  display: flex;
+}
+
+.input-reveal input {
+  flex: 1;
+  padding-right: 44px;
+}
+
+.input-reveal-toggle {
+  position: absolute;
+  top: 50%;
+  right: 6px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.input-reveal-toggle:hover,
+.input-reveal-toggle:focus-visible {
+  color: var(--text);
+}
+
+.ssh-connect-error {
+  font-size: 0.82rem;
+  color: var(--danger);
+}
+
+.ssh-connect-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -11,6 +11,7 @@ import { LaunchPanel } from "@/components/LaunchPanel";
 import { LoginForm } from "@/components/LoginForm";
 import { ScheduledSessionsPanel } from "@/components/ScheduledSessionsPanel";
 import { SessionList } from "@/components/SessionList";
+import { SshConnectModal } from "@/components/SshConnectModal";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UsageDashboardSection } from "@/components/UsageDashboardSection";
 import { useTheme } from "@/lib/theme";
@@ -18,10 +19,13 @@ import {
   attachTmux,
   cancelSchedule as cancelScheduleRequest,
   clearScheduleHistory as clearScheduleHistoryRequest,
+  connectLaunchTarget,
   connectSessionsSocket,
   createSchedule as createScheduleRequest,
   createSession,
   deleteSession as deleteSessionRequest,
+  disconnectLaunchTarget,
+  fetchLaunchTargetStatus,
   fetchBackendThreads,
   fetchBoardChannels,
   fetchMe,
@@ -33,6 +37,7 @@ import {
   postAction,
   setSessionPinned,
   setSessionTitle,
+  SSH_MASTER_REQUIRED_DETAIL,
 } from "@/lib/api";
 import {
   clearToken,
@@ -121,6 +126,14 @@ export default function HomePage() {
   const [defaultCwd, setDefaultCwd] = useState("~/");
   const [launchTargets, setLaunchTargets] = useState<LaunchTargetSummary[]>([]);
   const [activeLaunchTargetId, setActiveLaunchTargetId] = useState("");
+  // Password-auth SSH connect prompt. ``retry`` re-runs the launch that hit a
+  // 409 once the ControlMaster is up; ``null`` when the prompt was opened
+  // proactively from the connection banner.
+  const [connectPrompt, setConnectPrompt] = useState<{
+    target: LaunchTargetSummary;
+    retry: (() => Promise<void>) | null;
+  } | null>(null);
+  const [connectError, setConnectError] = useState("");
   const [schedules, setSchedules] = useState<ScheduledSession[]>([]);
   const [boardChannels, setBoardChannels] = useState<BoardChannel[]>([]);
   const [recentCwds, setRecentCwds] = useState<string[]>([]);
@@ -153,6 +166,7 @@ export default function HomePage() {
 
   const activeLaunchTarget =
     launchTargets.find((target) => target.id === activeLaunchTargetId) ?? null;
+  const activeTargetAuth = activeLaunchTarget?.auth ?? null;
   const supportedBackends = activeLaunchTarget?.supported_backends.length
     ? activeLaunchTarget.supported_backends
     : registeredBackends;
@@ -191,6 +205,28 @@ export default function HomePage() {
   useEffect(() => {
     setRecentCwds(readRecentCwds(host, activeLaunchTargetId));
   }, [activeLaunchTargetId, host]);
+
+  // The `connected` flag from /api/me is a cached snapshot; the master may have
+  // dropped since. When a password-auth target becomes active, re-validate it
+  // live so the strip reflects reality instead of a stale "connected". Keyed on
+  // the auth kind (a stable primitive) — depending on `launchTargets` would loop
+  // since `markTargetConnected` rewrites that array.
+  useEffect(() => {
+    if (!host || !token || !activeLaunchTargetId || activeTargetAuth !== "password") {
+      return;
+    }
+    let cancelled = false;
+    fetchLaunchTargetStatus(host, token, activeLaunchTargetId)
+      .then((status) => {
+        if (!cancelled) {
+          markTargetConnected(activeLaunchTargetId, status.connected);
+        }
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [activeLaunchTargetId, host, token, activeTargetAuth]);
 
   useEffect(() => {
     if (!host || !token) {
@@ -418,6 +454,66 @@ export default function HomePage() {
     setError("");
   }
 
+  function markTargetConnected(targetId: string, connected: boolean) {
+    setLaunchTargets((current) => {
+      const target = current.find((t) => t.id === targetId);
+      if (!target || target.connected === connected) {
+        return current; // no change → keep the same array (avoids refetch churn)
+      }
+      return current.map((t) => (t.id === targetId ? { ...t, connected } : t));
+    });
+  }
+
+  async function handleConnectTarget(password: string) {
+    const prompt = connectPrompt;
+    if (!prompt) {
+      return;
+    }
+    setConnectError("");
+    try {
+      const result = await connectLaunchTarget(
+        host,
+        token,
+        prompt.target.id,
+        password,
+      );
+      markTargetConnected(prompt.target.id, result.connected);
+      if (!result.connected) {
+        setConnectError(result.detail ?? "authentication failed");
+        return;
+      }
+      setConnectPrompt(null);
+      if (prompt.retry) {
+        await prompt.retry();
+      }
+    } catch (connectErr) {
+      if (isAuthError(connectErr)) {
+        resetAuthState("Session expired. Log in again.");
+        return;
+      }
+      setConnectError(
+        connectErr instanceof Error ? connectErr.message : "failed to connect",
+      );
+    }
+  }
+
+  async function handleDisconnectTarget(targetId: string) {
+    try {
+      await disconnectLaunchTarget(host, token, targetId);
+      markTargetConnected(targetId, false);
+    } catch (disconnectErr) {
+      if (isAuthError(disconnectErr)) {
+        resetAuthState("Session expired. Log in again.");
+        return;
+      }
+      setError(
+        disconnectErr instanceof Error
+          ? disconnectErr.message
+          : "failed to disconnect",
+      );
+    }
+  }
+
   async function handleCreate(
     backend: Backend,
     cwd: string,
@@ -452,6 +548,31 @@ export default function HomePage() {
     } catch (createError) {
       if (isAuthError(createError)) {
         resetAuthState("Session expired. Log in again.");
+        return;
+      }
+      if (
+        createError instanceof Error &&
+        createError.message === SSH_MASTER_REQUIRED_DETAIL &&
+        activeLaunchTarget
+      ) {
+        // The target needs its password-auth ControlMaster opened first;
+        // prompt, then retry this exact launch on success.
+        setConnectError("");
+        setConnectPrompt({
+          target: activeLaunchTarget,
+          retry: () =>
+            handleCreate(
+              backend,
+              cwd,
+              title,
+              model,
+              effort,
+              transport,
+              args,
+              configOverrides,
+              permissionMode,
+            ),
+        });
         return;
       }
       setError(
@@ -758,6 +879,11 @@ export default function HomePage() {
           launchTargets={launchTargets}
           targetId={activeLaunchTargetId}
           onSwitch={handleSwitchBackend}
+          onConnectTarget={(target) => {
+            setConnectError("");
+            setConnectPrompt({ target, retry: null });
+          }}
+          onDisconnectTarget={handleDisconnectTarget}
           onAuthFailure={handleAuthFailure}
         />
       ) : null}
@@ -822,6 +948,17 @@ export default function HomePage() {
           </span>
           <span className="assistant-fab-label">Assistant</span>
         </Link>
+      ) : null}
+      {connectPrompt ? (
+        <SshConnectModal
+          targetName={connectPrompt.target.name}
+          error={connectError || null}
+          onSubmit={handleConnectTarget}
+          onCancel={() => {
+            setConnectPrompt(null);
+            setConnectError("");
+          }}
+        />
       ) : null}
     </main>
   );

--- a/frontend/src/components/BackendSwitcher.tsx
+++ b/frontend/src/components/BackendSwitcher.tsx
@@ -20,6 +20,8 @@ interface BackendSwitcherProps {
   launchTargets: LaunchTargetSummary[];
   targetId: string;
   onSwitch: (nextHost: string, nextTargetId: string) => void;
+  onConnectTarget: (target: LaunchTargetSummary) => void;
+  onDisconnectTarget: (targetId: string) => void;
   onAuthFailure?: () => void;
 }
 
@@ -33,7 +35,7 @@ interface PickerOption {
   hint: string | null;
 }
 
-export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch, onAuthFailure }: BackendSwitcherProps) {
+export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch, onConnectTarget, onDisconnectTarget, onAuthFailure }: BackendSwitcherProps) {
   const [open, setOpen] = useState(false);
   const [snapshot, setSnapshot] = useState<TailnetSnapshot | null>(null);
   const [snapshotLoading, setSnapshotLoading] = useState(false);
@@ -112,6 +114,7 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
   }, [open, hostOptions, host, targetId, launchTargets]);
 
   const selectedTargetId = selection.startsWith(TARGET_PREFIX) ? selection.slice(TARGET_PREFIX.length) : "";
+  const selectedTarget = launchTargets.find((target) => target.id === selectedTargetId) ?? null;
   const activeHost = selection === CUSTOM_VALUE || selection.startsWith(TARGET_PREFIX) ? customOrCurrentHost(selection, customHost, host) : selection;
   const dirty = !sameBackendUrl(activeHost, host) || selectedTargetId !== targetId;
 
@@ -140,12 +143,21 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
 
   if (!open) {
     return (
-      <p className="meta backend-pill">
-        Connected: <strong>{currentLabel}</strong>
+      <div className="meta backend-pill">
+        <span>
+          Connected: <strong>{currentLabel}</strong>
+        </span>
         <button type="button" className="link-button" onClick={() => setOpen(true)}>
           change
         </button>
-      </p>
+        {activeTarget?.auth === "password" ? (
+          <SshAuthControl
+            target={activeTarget}
+            onConnect={onConnectTarget}
+            onDisconnect={onDisconnectTarget}
+          />
+        ) : null}
+      </div>
     );
   }
 
@@ -193,6 +205,13 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
         </label>
       ) : null}
       {activeHost ? <ProbeIndicator status={probe} url={activeHost} /> : null}
+      {selectedTarget?.auth === "password" ? (
+        <SshAuthControl
+          target={selectedTarget}
+          onConnect={onConnectTarget}
+          onDisconnect={onDisconnectTarget}
+        />
+      ) : null}
       <div className="action-row">
         <button
           type="button"
@@ -204,6 +223,43 @@ export function BackendSwitcher({ host, token, launchTargets, targetId, onSwitch
         </button>
       </div>
     </section>
+  );
+}
+
+function SshAuthControl({
+  target,
+  onConnect,
+  onDisconnect,
+}: {
+  target: LaunchTargetSummary;
+  onConnect: (target: LaunchTargetSummary) => void;
+  onDisconnect: (targetId: string) => void;
+}) {
+  const connected = Boolean(target.connected);
+  return (
+    <div className={`ssh-auth-row${connected ? " is-connected" : ""}`}>
+      <span className="ssh-auth-dot" aria-hidden="true" />
+      <span className="ssh-auth-label">
+        {connected ? "SSH connected" : "SSH password required"}
+      </span>
+      {connected ? (
+        <button
+          type="button"
+          className="link-button"
+          onClick={() => onDisconnect(target.id)}
+        >
+          Disconnect
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="secondary ssh-auth-connect"
+          onClick={() => onConnect(target)}
+        >
+          Connect
+        </button>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 
+import { PasswordInput } from "@/components/PasswordInput";
 import { probeBackend } from "@/lib/api";
 import {
   backendPortFromUrl,
@@ -174,8 +175,7 @@ export function LoginForm({ defaultHost, onSubmit }: LoginFormProps) {
       {activeHost ? <ProbeIndicator status={probe} url={activeHost} /> : null}
       <label className="field">
         <span>Password</span>
-        <input
-          type="password"
+        <PasswordInput
           value={password}
           onChange={(event) => setPassword(event.target.value)}
           placeholder="Waypoint password"

--- a/frontend/src/components/PasswordInput.tsx
+++ b/frontend/src/components/PasswordInput.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { forwardRef, InputHTMLAttributes, useState } from "react";
+
+type PasswordInputProps = Omit<InputHTMLAttributes<HTMLInputElement>, "type">;
+
+// A password field with a trailing show/hide toggle. The icon reflects the
+// current visibility: an open eye when the password is revealed, a struck-through
+// eye when concealed. Forwards its ref and any input props to the underlying
+// <input> so callers can manage focus, validation, and value as usual.
+export const PasswordInput = forwardRef<HTMLInputElement, PasswordInputProps>(
+  function PasswordInput(props, ref) {
+    const [revealed, setRevealed] = useState(false);
+    return (
+      <div className="input-reveal">
+        <input ref={ref} type={revealed ? "text" : "password"} {...props} />
+        <button
+          type="button"
+          className="input-reveal-toggle"
+          aria-label={revealed ? "Hide password" : "Show password"}
+          aria-pressed={revealed}
+          onClick={() => setRevealed((value) => !value)}
+        >
+          {revealed ? <EyeIcon /> : <EyeOffIcon />}
+        </button>
+      </div>
+    );
+  },
+);
+
+function EyeIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  );
+}
+
+function EyeOffIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10.7 6.2A9.8 9.8 0 0 1 12 5c6.5 0 10 7 10 7a17.6 17.6 0 0 1-3.4 4.3M6.6 6.7A17.6 17.6 0 0 0 2 12s3.5 7 10 7a9.6 9.6 0 0 0 4.1-.9" />
+      <path d="m3 3 18 18" />
+    </svg>
+  );
+}

--- a/frontend/src/components/SshConnectModal.tsx
+++ b/frontend/src/components/SshConnectModal.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { PasswordInput } from "@/components/PasswordInput";
+
+interface SshConnectModalProps {
+  targetName: string;
+  error?: string | null;
+  onSubmit: (password: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+// Prompts for an SSH password to seed a password-auth target's ControlMaster
+// connection. The password is held in local component state only and is never
+// written to the store or localStorage — it vanishes when the modal unmounts
+// (on success or cancel). On a failed attempt the field is kept so the user
+// can correct a typo without retyping from scratch.
+export function SshConnectModal({
+  targetName,
+  error,
+  onSubmit,
+  onCancel,
+}: SshConnectModalProps) {
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const modalRef = useRef<HTMLFormElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Restore focus to whatever opened the modal (the Connect button) on close.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    inputRef.current?.focus();
+    return () => previouslyFocused?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCancel();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const root = modalRef.current;
+      if (!root) {
+        return;
+      }
+      const focusable = root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) {
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !root.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onCancel]);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    if (!password || busy) {
+      return;
+    }
+    setBusy(true);
+    try {
+      await onSubmit(password);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return createPortal(
+    <div
+      className="ssh-connect-backdrop"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onCancel();
+        }
+      }}
+    >
+      <form
+        ref={modalRef}
+        className="ssh-connect-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="ssh-connect-title"
+        onSubmit={handleSubmit}
+      >
+        <div className="ssh-connect-head">
+          <strong id="ssh-connect-title">Connect to {targetName}</strong>
+          <span className="muted">SSH password · never stored</span>
+        </div>
+        <label className="field">
+          <span>SSH password</span>
+          <PasswordInput
+            ref={inputRef}
+            // Intentionally off: this is an ephemeral connection secret we never
+            // persist, so we don't invite a password manager to save it.
+            autoComplete="off"
+            value={password}
+            disabled={busy}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? "ssh-connect-error" : undefined}
+            onChange={(event) => setPassword(event.target.value)}
+          />
+        </label>
+        {error ? (
+          <span id="ssh-connect-error" className="ssh-connect-error" role="alert">
+            {error}
+          </span>
+        ) : null}
+        <div className="ssh-connect-actions">
+          <button
+            type="button"
+            className="secondary"
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button type="submit" className="primary" disabled={busy || !password}>
+            {busy ? "Connecting…" : "Connect"}
+          </button>
+        </div>
+      </form>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -254,6 +254,68 @@ export async function createSession(
   return body.session as SessionRecord;
 }
 
+// Detail token the backend returns (HTTP 409) when a launch targets a
+// password-auth SSH host whose ControlMaster is not connected yet.
+export const SSH_MASTER_REQUIRED_DETAIL = "ssh-master-required";
+
+export interface LaunchTargetConnectResult {
+  target_id: string;
+  connected: boolean;
+  detail?: string | null;
+}
+
+export async function connectLaunchTarget(
+  host: string,
+  token: string,
+  targetId: string,
+  password: string,
+): Promise<LaunchTargetConnectResult> {
+  const response = await fetch(
+    `${host}/api/launch-targets/${encodeURIComponent(targetId)}/connect`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ password }),
+    },
+  );
+  await ensureOk(response, "failed to connect launch target");
+  return (await response.json()) as LaunchTargetConnectResult;
+}
+
+export async function fetchLaunchTargetStatus(
+  host: string,
+  token: string,
+  targetId: string,
+): Promise<LaunchTargetConnectResult> {
+  const response = await fetch(
+    `${host}/api/launch-targets/${encodeURIComponent(targetId)}/status`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch launch target status");
+  return (await response.json()) as LaunchTargetConnectResult;
+}
+
+export async function disconnectLaunchTarget(
+  host: string,
+  token: string,
+  targetId: string,
+): Promise<void> {
+  const response = await fetch(
+    `${host}/api/launch-targets/${encodeURIComponent(targetId)}/disconnect`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to disconnect launch target");
+}
+
 export async function forkSession(
   host: string,
   token: string,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -309,6 +309,8 @@ export interface LaunchTargetSummary {
   supported_backends: Backend[];
   default_backend: Backend;
   default_cwd?: string | null;
+  auth?: "key" | "password";
+  connected?: boolean;
 }
 
 export type ScheduleStatus = "pending" | "launched" | "cancelled" | "failed";


### PR DESCRIPTION
## Purpose

Remote launch targets only supported key-based SSH. The agent protocol streams over a non-interactive `ssh` subprocess, so `ssh` can never prompt for a password, and the Codex SDK hard-codes `subprocess.Popen`, so a pure-Python SSH client (asyncssh/paramiko) can't drive it without forking a pinned dependency. This PR adds opt-in password authentication for Claude Code, Codex, and OpenCode targets, with the password prompted in the UI and never stored.

## Changes

### Backend

- `backend/src/waypoint/launch_targets.py` — add `ssh_auth: Literal["key", "password"]` (default `key`, so existing targets are unchanged) with a validator that requires `ControlMaster`/`ControlPath`/`ControlPersist` in `ssh_args` for password targets; bound `ssh_capture` with `ConnectTimeout` so probes can't stall.
- `backend/src/waypoint/ssh_master.py` (new) + `ssh_askpass.py` (new) — `SshMasterManager` opens/checks/tears down the multiplexed master via OpenSSH's `SSH_ASKPASS` mechanism (no `sshpass`); the committed, secret-free askpass helper echoes the password from the seed process's environment only.
- `backend/src/waypoint/runtime.py` — own the manager (created at init, `disconnect_all` at stop); gate launches on a live master (`409 ssh-master-required`) for create/reattach; skip boot-restore for disconnected password targets; `remote_probe_blocked` short-circuit for pre-launch probes.
- `backend/src/waypoint/api.py` + `schemas.py` — `connect`/`status`/`disconnect` endpoints, `auth`/`connected` on the launch-target summary, and the probe gate on `/threads` (returns empty) and `/models` (falls back to the local catalogue).

### Frontend

- `frontend/src/components/BackendSwitcher.tsx` — surface password-auth targets inline (panel + collapsed pill) with a connected/disconnected status control and Connect/Disconnect actions, attached to where the target is chosen.
- `frontend/src/components/SshConnectModal.tsx` (new) — portaled password prompt (focus trap, Escape, `aria-live` error) that retries a launch which hit a 409; `PasswordInput.tsx` (new) — shared show/hide field reused by the modal and the login form.
- `frontend/src/app/page.tsx`, `lib/api.ts`, `lib/types.ts`, `app/globals.css`, `components/LoginForm.tsx` — connect/disconnect wiring, live status re-validation on target switch, and styles.

### Docs / config

- `docs/coding_agent_plugins.md`, `backend/waypoint.example.yaml` — document the `ssh_auth: password` flow, the multiplexing requirement, the OpenSSH 8.4 prerequisite, and drop/reconnect behavior.

## Design

The password is used exactly once to seed an OpenSSH ControlMaster connection; because every SSH call site already splices `*target.ssh_args` (which carry the shared `ControlPath`), all later calls — the agent launch, the Codex SDK's own `ssh`, OpenCode's serve tunnel, and every background probe — transparently reuse the authenticated socket with no password and no per-backend code. The seed deliberately does not pin `PreferredAuthentications`, so mixed ProxyJump chains negotiate per hop (e.g. a password jump host fronting a key-auth destination). The password lives only in the seed subprocess's environment and is never written to config, a session record, or `localStorage`. When the master drops, multiplexed sessions end and probes fail fast rather than hang; the user reconnects and reattaches.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- Manual: deployed via `waypointctl restart`; verified the `SSH_ASKPASS` seed reaches a live host's password auth, that the `/threads` probe returns empty in ~10ms for a disconnected password target across codex/opencode/claude_code, and the end-to-end connect → launch flow in the UI.

## Test Result

- pre-commit — all passed; `uv run pytest` — 1191 passed.
- frontend lint / `tsc` / `npm run build` — clean.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (validator, manager argv/env, connect/gate/probe endpoints).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). (`waypointctl` not touched.)
- [x] If I touched code that dispatches by plugin id, I checked the affected backends — the SSH layer is backend-agnostic; verified the thread probe for all three and live-tested the claude_code launch over password SSH.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (CSS variables + shared `.field`/`.primary`/`.secondary` classes).
- [x] Not a breaking change — `ssh_auth` defaults to `key`.
- [x] I have updated documentation and config examples (`docs/coding_agent_plugins.md`, `backend/waypoint.example.yaml`).

</details>