### PR TITLE
feat: make the Claude model & effort catalogue CLI-version aware

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -95,6 +95,18 @@ class BackendPlugin(Protocol):
     # parse their own ``notes`` into ``(account_key, account_label)`` here;
     # plugins that omit it fall back to a session-scoped dashboard bucket.
     # Kept off the Protocol surface for the same predating-plugin reason.
+    #
+    # ``validate_new_session_selection(runtime, model, effort, launch_target_id)
+    # -> None`` is another optional method, mixed in via
+    # :class:`DefaultLaunchContract` and read defensively by
+    # ``SessionRuntime.create_session`` (via
+    # ``getattr(plugin, "validate_new_session_selection", None)``). It is a
+    # new-session preflight: agents that can prove a model/effort combination
+    # the installed CLI won't honor raise ``ValueError`` to reject the
+    # launch; anything they can't judge (an unrecognized or free-text model)
+    # must return ``None`` and let the launch proceed. The default is a
+    # no-op. Never consulted for resume / set-model / set-effort — only for
+    # brand-new sessions.
     # Pydantic model used by the dispatcher in api.py to validate the
     # JSON body of POST /api/backends/{id}/sessions/import. ``None`` for
     # plugins that don't accept thread imports — the dispatcher gates on
@@ -580,4 +592,25 @@ class DefaultLaunchContract:
         since: datetime,
         launch_target: "SshLaunchTargetConfig | None",
     ) -> None:
+        return None
+
+    def validate_new_session_selection(
+        self,
+        runtime: "SessionRuntime",
+        model: str | None,
+        effort: str | None,
+        launch_target_id: str | None,
+    ) -> None:
+        """New-session preflight: raise to reject a model/effort combo.
+
+        Called once by ``SessionRuntime.create_session``, before the process
+        is spawned, so a combination the installed CLI is known not to
+        support (e.g. an effort level too new for the detected binary)
+        fails fast with a clear message instead of the CLI silently
+        rejecting or downgrading the flag. Must raise ``ValueError`` to
+        reject; anything else -- including a model this agent doesn't
+        recognize (free text is allowed) -- returns ``None`` and lets the
+        launch proceed. The default is a no-op: agents override this only
+        when they can prove a combination is unsupported.
+        """
         return None

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -319,6 +319,12 @@ class ClaudeSessionState:
     last_plan_content: str | None = None
     closing: bool = False
     model: str | None = None
+    # The raw concrete model id the CLI last reported resolving to (e.g.
+    # ``claude-sonnet-5``), mirrored from the persisted
+    # ``SessionRecord.resolved_model`` so repeated ``system.init`` events for
+    # the same model don't trigger redundant storage writes. Unlike ``model``
+    # (normalized to a family, e.g. ``sonnet``), this is never normalized.
+    resolved_model: str | None = None
     context_usage_snapshot: SessionContextUsage | None = None
     context_usage_signature: tuple[int, int | None] | None = None
     rate_limit_usage_snapshot: SessionRateLimitUsage | None = None
@@ -1539,6 +1545,17 @@ class ClaudeCliAdapter:
                 if state.model is None or current_family != incoming_family:
                     state.model = model
                     await self._refresh_context_usage(state)
+            raw_model = event.get("model")
+            if (
+                isinstance(raw_model, str)
+                and raw_model
+                and raw_model != state.resolved_model
+            ):
+                state.resolved_model = raw_model
+                if self._on_session_update is not None:
+                    await self._on_session_update(
+                        state.session_id, {"resolved_model": raw_model}, False
+                    )
             if self._on_init is not None:
                 self._on_init(state.session_id, event)
             # Claude's stream-json mode emits `init` at the start of every

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -5,21 +5,30 @@ binary; bumped manually when a new alias ships. Codex has a runtime
 ``model/list`` RPC, Claude does not.
 """
 
+from collections.abc import Callable
+
 from waypoint.schemas import BackendModelOption
 
-# Effort levels gated by the binary's per-model checks (`vy`/`L4_`/`k4_`):
-# opus-4-6/4-7/4-8 and sonnet-4-6 expose the full set; haiku and older
-# opus/sonnet don't accept --effort at all. Fable 5 adds `max`.
-CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh")
-CLAUDE_FABLE_EFFORT_LEVELS: tuple[str, ...] = CLAUDE_EFFORT_LEVELS + ("max",)
+# Effort levels the CLI accepts per model (verified against v2.1.197's
+# gate functions: `Jw` for effort at all, `Rne` for xhigh, `c0e` for max).
+# opus-4-8, sonnet-5, and fable-5 accept the full set; haiku and pre-4.6
+# opus/sonnet don't accept --effort at all. The server can still clamp a
+# request at runtime via the account's `max_effort_level` entitlement.
+CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 # Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
 # see either the human-facing alias (``opus[1m]``) or a resolved API model id
 # (``claude-opus-4-8``); normalize both to the same family so the context window
 # lookup stays stable.
+#
+# Append-only: entries must never be removed, even after a concrete model id
+# is superseded. Resumed sessions persist historical concrete ids (e.g.
+# claude-sonnet-4-5), and those ids must keep resolving for display and usage
+# tracking for as long as such sessions can be resumed.
 CLAUDE_MODEL_ALIASES: dict[str, str] = {
     "claude-opus-4-8": "opus",
     "claude-opus-4-7": "opus",
+    "claude-sonnet-5": "sonnet",
     "claude-sonnet-4-6": "sonnet",
     "claude-sonnet-4-5": "sonnet",
     "claude-haiku-4-5": "haiku",
@@ -46,7 +55,7 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     ),
     BackendModelOption(
         id="sonnet",
-        label="Sonnet 4.6",
+        label="Sonnet 5",
         description="Best for everyday tasks",
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
@@ -66,7 +75,7 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     ),
     BackendModelOption(
         id="sonnet[1m]",
-        label="Sonnet 4.6 (1M context)",
+        label="Sonnet 5 (1M context)",
         description="Long sessions with large codebases",
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
@@ -75,14 +84,14 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         id="fable",
         label="Fable 5",
         description="Most capable for the hardest, longest-running tasks",
-        supported_efforts=list(CLAUDE_FABLE_EFFORT_LEVELS),
+        supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
     ),
     BackendModelOption(
         id="fable[1m]",
         label="Fable 5 (1M context)",
         description="Longest sessions with very large codebases",
-        supported_efforts=list(CLAUDE_FABLE_EFFORT_LEVELS),
+        supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
     ),
 )
@@ -107,6 +116,13 @@ def normalize_claude_model_id(model: str | None) -> str | None:
         return "haiku"
     if candidate.startswith("claude-fable-"):
         return "fable"
+    # Backward-compat safety net: any historical or unknown model id that
+    # merely mentions a family name still resolves to that family, so
+    # resumed sessions with concrete ids we've never seen keep working.
+    lowered = candidate.lower()
+    for family in ("opus", "sonnet", "haiku", "fable"):
+        if family in lowered:
+            return family
     return candidate
 
 
@@ -124,9 +140,14 @@ def claude_context_window_for_model(model: str | None) -> int | None:
     if normalized in CLAUDE_CONTEXT_WINDOWS:
         return CLAUDE_CONTEXT_WINDOWS[normalized]
     family = claude_model_family(normalized)
-    if family is None:
+    if family is None or family not in CLAUDE_CONTEXT_WINDOWS:
+        # No family could be inferred at all (genuine garbage) -- don't
+        # fabricate a window.
         return None
-    return CLAUDE_CONTEXT_WINDOWS.get(family)
+    candidate = model.strip() if isinstance(model, str) else ""
+    if normalized.endswith("[1m]") or candidate.endswith("[1m]"):
+        return 1_000_000
+    return CLAUDE_CONTEXT_WINDOWS[family]
 
 
 def claude_default_model_id() -> str | None:
@@ -134,3 +155,78 @@ def claude_default_model_id() -> str | None:
         if option.is_default:
             return option.id
     return None
+
+
+# CLI version milestones, from the official changelog (anthropics/claude-code):
+#   2.1.154  Opus 4.8 introduced (defaults high; accepts xhigh + max)
+#   2.1.170  Fable 5 introduced (accepts xhigh + max; 1M context)
+#   2.1.197  Sonnet 5 introduced as the `sonnet` alias (native 1M context)
+#
+# 2.1.197 is the offering boundary we gate on: it swaps the `sonnet` alias from
+# Sonnet 4.6 to Sonnet 5. Sonnet 5 accepts `xhigh` where Sonnet 4.6 did not
+# (4.6 accepts `max` but not `xhigh`); Opus 4.8 and Fable 5 already accept the
+# full set on both sides of the boundary. Verified against the 2.1.175 /
+# 2.1.195 / 2.1.196 / 2.1.197 binaries installed on this host.
+SONNET5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 197)
+
+# Labels pre-Sonnet-5 CLI builds use for the sonnet ids.
+_LEGACY_SONNET_LABELS: dict[str, str] = {
+    "sonnet": "Sonnet 4.6",
+    "sonnet[1m]": "Sonnet 4.6 (1M context)",
+}
+
+
+def _pre_sonnet5_offering() -> tuple[BackendModelOption, ...]:
+    """The catalogue offered by CLI builds older than SONNET5_MIN_CLI_VERSION.
+
+    On these builds the ``sonnet`` alias resolves to Sonnet 4.6, which accepts
+    ``max`` but not ``xhigh`` (verified in the 2.1.175 / 2.1.195 / 2.1.196
+    binaries: Sonnet 4.6's capabilities carry ``max_effort`` but not
+    ``xhigh_effort``). Opus 4.8, Fable 5, and Haiku are identical to the
+    current catalogue across this boundary, so only the sonnet family is
+    transformed. Derived from ``DEFAULT_CLAUDE_MODELS`` via ``model_copy`` so
+    unrelated catalogue edits (wording, descriptions, new fields) stay in sync
+    automatically.
+    """
+    sonnet_efforts = [level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"]
+    offering: list[BackendModelOption] = []
+    for option in DEFAULT_CLAUDE_MODELS:
+        if option.id.split("[", 1)[0] != "sonnet":
+            offering.append(option)
+            continue
+        offering.append(
+            option.model_copy(
+                update={
+                    "label": _LEGACY_SONNET_LABELS.get(option.id, option.label),
+                    "supported_efforts": sonnet_efforts,
+                }
+            )
+        )
+    return tuple(offering)
+
+
+# Ordered by descending minimum version so adding a future epoch is a small,
+# obvious edit: prepend a new ``(min_version, builder)`` pair at the front.
+_CLAUDE_MODEL_EPOCHS: tuple[
+    tuple[tuple[int, ...], Callable[[], tuple[BackendModelOption, ...]]], ...
+] = (
+    (SONNET5_MIN_CLI_VERSION, lambda: DEFAULT_CLAUDE_MODELS),
+    ((0,), _pre_sonnet5_offering),
+)
+
+
+def claude_models_for_version(
+    version: tuple[int, ...] | None,
+) -> tuple[BackendModelOption, ...]:
+    """The model catalogue to offer a CLI at ``version``.
+
+    ``version=None`` means detection failed (remote launch target, missing
+    binary, unparsable output, ...) -- callers should treat that as "assume
+    latest" and get the current catalogue.
+    """
+    if version is None:
+        return DEFAULT_CLAUDE_MODELS
+    for min_version, builder in _CLAUDE_MODEL_EPOCHS:
+        if version >= min_version:
+            return builder()
+    return DEFAULT_CLAUDE_MODELS

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -35,6 +35,7 @@ from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
+    claude_models_for_version,
 )
 from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_PERMISSION_MODE_SPECS,
@@ -64,6 +65,7 @@ from waypoint.backends.claude_code.threads import (
     list_local_claude_threads,
 )
 from waypoint.backends.claude_code.threads_remote import RemoteClaudeThreadEnumerator
+from waypoint.backends.claude_code.version import detect_claude_cli_version
 from waypoint.backends.claude_tty.pane_dialog import (
     composer_is_empty,
     composer_ready,
@@ -563,6 +565,64 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             ) from exc
         return True
 
+    def _offered_models_with_version(
+        self, runtime: "SessionRuntime", launch_target_id: str | None
+    ) -> tuple[list[BackendModelOption], tuple[int, ...] | None]:
+        """The model catalogue offered for a new session on this target.
+
+        A deployment that explicitly configured ``models`` (even to a list
+        identical to the built-in default) opted out of the version-gated
+        catalogue; honor it verbatim (version is ``None`` in that case).
+        Otherwise gate the built-in catalogue on the target's installed CLI
+        version -- ``None`` when undetectable (missing binary, remote
+        target) means "assume latest".
+
+        Synchronous (spawns a subprocess on a cache miss): callers on the
+        event loop should run it via ``asyncio.to_thread``.
+        """
+        config = self._config(runtime)
+        if "models" in config.model_fields_set:
+            return list(config.models), None
+        launch_target = (
+            runtime._find_launch_target(launch_target_id) if launch_target_id else None
+        )
+        version = detect_claude_cli_version(
+            config.local_bin or self.capabilities.cli_binary or "claude",
+            launch_target,
+        )
+        return list(claude_models_for_version(version)), version
+
+    def validate_new_session_selection(
+        self,
+        runtime: "SessionRuntime",
+        model: str | None,
+        effort: str | None,
+        launch_target_id: str | None,
+    ) -> None:
+        """Reject a model/effort combo the detected CLI can't honor.
+
+        Looks the selection up in the same version-gated catalogue
+        ``list_models`` would offer for this target. A model that isn't in
+        that catalogue is free text (or an id from a newer/unknown CLI) --
+        there's nothing to check it against, so it passes through
+        unrejected. Only a *recognized* model paired with an effort level
+        that catalogue entry doesn't list is provably unsupported.
+        """
+        if effort is None:
+            return None
+        options, version = self._offered_models_with_version(runtime, launch_target_id)
+        option = next((opt for opt in options if opt.id == model), None)
+        if option is None or effort in option.supported_efforts:
+            return None
+        version_label = (
+            ".".join(str(part) for part in version) if version else "unknown"
+        )
+        supported = ", ".join(option.supported_efforts) or "none"
+        raise ValueError(
+            f"model '{model}' does not support effort '{effort}' on the "
+            f"detected Claude CLI (v{version_label}); supported efforts: {supported}"
+        )
+
     async def list_models(
         self,
         runtime: "SessionRuntime",
@@ -572,10 +632,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         config = self._config(runtime)
         default_model = config.default_model_id
         default_effort = config.default_effort
-        options = [opt.model_dump(mode="json") for opt in config.models]
+        models, _version = await asyncio.to_thread(
+            self._offered_models_with_version, runtime, launch_target_id
+        )
+        options = [opt.model_dump(mode="json") for opt in models]
         default_model_id: str | None = None
         if default_model is None:
-            for opt in config.models:
+            for opt in models:
                 if opt.is_default:
                     default_model_id = opt.id
                     break
@@ -583,7 +646,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             default_model_id = default_model
         default_model_label: str | None = None
         if default_model_id:
-            for opt in config.models:
+            for opt in models:
                 if opt.id == default_model_id:
                     default_model_label = opt.label
                     break

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -15,7 +15,7 @@ import uuid
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel, Field
@@ -110,6 +110,74 @@ def _find_prefixed(notes: list[str], prefix: str) -> str | None:
             if value:
                 return value
     return None
+
+
+class ClaudeCatalogueConfig(Protocol):
+    """The config surface :func:`offered_claude_models` reads.
+
+    Satisfied structurally by both ``ClaudeCodePluginConfig`` and
+    ``ClaudeTtyPluginConfig`` (the two transports of the same agent), whose
+    ``models`` field the base ``PluginConfig`` does not carry.
+    """
+
+    models: list[BackendModelOption]
+    local_bin: str | None
+
+    @property
+    def model_fields_set(self) -> set[str]: ...
+
+
+def offered_claude_models(
+    config: ClaudeCatalogueConfig,
+    cli_binary: str,
+    launch_target: SshLaunchTargetConfig | None,
+) -> tuple[list[BackendModelOption], tuple[int, ...] | None]:
+    """The Claude model catalogue to offer for a new session on a target.
+
+    Shared by claude_code and its claude_tty transport -- the offered models
+    are an agent concern, identical across transports. A deployment that
+    explicitly configured ``models`` (even to a list identical to the built-in
+    default) opted out of the version gate; honor it verbatim (version is
+    ``None`` then). Otherwise gate the built-in catalogue on the target's
+    installed CLI version -- ``None`` when undetectable (missing binary, remote
+    target) means "assume latest".
+
+    Synchronous (spawns a subprocess on a cache miss): callers on the event
+    loop should run it via ``asyncio.to_thread``.
+    """
+    if "models" in config.model_fields_set:
+        return list(config.models), None
+    version = detect_claude_cli_version(
+        config.local_bin or cli_binary or "claude", launch_target
+    )
+    return list(claude_models_for_version(version)), version
+
+
+def raise_for_unsupported_selection(
+    models: list[BackendModelOption],
+    version: tuple[int, ...] | None,
+    model: str | None,
+    effort: str | None,
+) -> None:
+    """Reject a model/effort combo the detected CLI can't honor.
+
+    ``model`` is looked up in the version-gated catalogue ``list_models`` would
+    offer for the target. A model that isn't in it is free text (or an id from
+    a newer/unknown CLI) -- nothing to check it against, so it passes through
+    unrejected. Only a *recognized* model paired with an effort that catalogue
+    entry doesn't list is provably unsupported.
+    """
+    if effort is None:
+        return None
+    option = next((opt for opt in models if opt.id == model), None)
+    if option is None or effort in option.supported_efforts:
+        return None
+    version_label = ".".join(str(part) for part in version) if version else "unknown"
+    supported = ", ".join(option.supported_efforts) or "none"
+    raise ValueError(
+        f"model '{model}' does not support effort '{effort}' on the "
+        f"detected Claude CLI (v{version_label}); supported efforts: {supported}"
+    )
 
 
 class ClaudeCodePluginConfig(PluginConfig):
@@ -568,29 +636,14 @@ class ClaudeCodePlugin(DefaultLaunchContract):
     def _offered_models_with_version(
         self, runtime: "SessionRuntime", launch_target_id: str | None
     ) -> tuple[list[BackendModelOption], tuple[int, ...] | None]:
-        """The model catalogue offered for a new session on this target.
-
-        A deployment that explicitly configured ``models`` (even to a list
-        identical to the built-in default) opted out of the version-gated
-        catalogue; honor it verbatim (version is ``None`` in that case).
-        Otherwise gate the built-in catalogue on the target's installed CLI
-        version -- ``None`` when undetectable (missing binary, remote
-        target) means "assume latest".
-
-        Synchronous (spawns a subprocess on a cache miss): callers on the
-        event loop should run it via ``asyncio.to_thread``.
-        """
-        config = self._config(runtime)
-        if "models" in config.model_fields_set:
-            return list(config.models), None
         launch_target = (
             runtime._find_launch_target(launch_target_id) if launch_target_id else None
         )
-        version = detect_claude_cli_version(
-            config.local_bin or self.capabilities.cli_binary or "claude",
+        return offered_claude_models(
+            self._config(runtime),
+            self.capabilities.cli_binary or "claude",
             launch_target,
         )
-        return list(claude_models_for_version(version)), version
 
     def validate_new_session_selection(
         self,
@@ -599,29 +652,10 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         effort: str | None,
         launch_target_id: str | None,
     ) -> None:
-        """Reject a model/effort combo the detected CLI can't honor.
-
-        Looks the selection up in the same version-gated catalogue
-        ``list_models`` would offer for this target. A model that isn't in
-        that catalogue is free text (or an id from a newer/unknown CLI) --
-        there's nothing to check it against, so it passes through
-        unrejected. Only a *recognized* model paired with an effort level
-        that catalogue entry doesn't list is provably unsupported.
-        """
         if effort is None:
             return None
         options, version = self._offered_models_with_version(runtime, launch_target_id)
-        option = next((opt for opt in options if opt.id == model), None)
-        if option is None or effort in option.supported_efforts:
-            return None
-        version_label = (
-            ".".join(str(part) for part in version) if version else "unknown"
-        )
-        supported = ", ".join(option.supported_efforts) or "none"
-        raise ValueError(
-            f"model '{model}' does not support effort '{effort}' on the "
-            f"detected Claude CLI (v{version_label}); supported efforts: {supported}"
-        )
+        raise_for_unsupported_selection(options, version, model, effort)
 
     async def list_models(
         self,

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -17,6 +17,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from waypoint.backends.claude_code.version import claude_cli_version_string
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.perf import debug_timer
 from waypoint.schemas import SessionRateLimitUsage, UsageWindow
@@ -37,8 +38,6 @@ _WINDOWS: tuple[tuple[str, str, int], ...] = (
 # Windows the account-wide plan always carries; the per-model windows are
 # gated in parse_claude_usage_payload.
 _PRIMARY_WINDOW_KEYS = frozenset({"five_hour", "seven_day"})
-_CLAUDE_USER_AGENT: str | None = None
-_CLAUDE_USER_AGENT_RESOLVED = False
 
 
 def parse_claude_usage_payload(
@@ -578,33 +577,8 @@ def parse_claude_rate_limit_headers(
 
 
 def _claude_user_agent() -> str:
-    global _CLAUDE_USER_AGENT
-    global _CLAUDE_USER_AGENT_RESOLVED
-    if _CLAUDE_USER_AGENT_RESOLVED:
-        return _CLAUDE_USER_AGENT or "claude-code/2.1.5"
-    _CLAUDE_USER_AGENT_RESOLVED = True
-    try:
-        completed = subprocess.run(
-            ["claude", "--version"],
-            capture_output=True,
-            text=True,
-            timeout=3,
-            check=False,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        _CLAUDE_USER_AGENT = "claude-code/2.1.5"
-        return _CLAUDE_USER_AGENT
-    if completed.returncode != 0:
-        _CLAUDE_USER_AGENT = "claude-code/2.1.5"
-        return _CLAUDE_USER_AGENT
-    match = re.search(r"\d+(?:\.\d+)+(?:[-+][A-Za-z0-9.-]+)?", completed.stdout)
-    version = (
-        match.group(0)
-        if match is not None
-        else completed.stdout.strip().split()[0] if completed.stdout.strip() else ""
-    )
-    _CLAUDE_USER_AGENT = f"claude-code/{version}" if version else "claude-code/2.1.5"
-    return _CLAUDE_USER_AGENT
+    version = claude_cli_version_string()
+    return f"claude-code/{version}" if version else "claude-code/2.1.5"
 
 
 def _fetch_claude_oauth_usage(access_token: str) -> _ClaudeHTTPResponse | None:

--- a/backend/src/waypoint/backends/claude_code/version.py
+++ b/backend/src/waypoint/backends/claude_code/version.py
@@ -1,0 +1,108 @@
+"""Claude CLI version detection.
+
+The model catalogue Claude offers for a new session depends on which CLI
+build is actually installed: older binaries lack models/effort levels that
+newer ones ship, and advertising an option the binary doesn't recognize means
+it either rejects the flag or silently downgrades. This module probes the
+local ``claude --version`` output, with a short TTL cache so repeated
+model-list requests don't re-spawn the binary.
+
+Version detection over SSH is out of scope: every function here accepts an
+optional launch target and returns ``None`` (unknown) whenever one is given,
+without touching the network. Callers should treat ``None`` as "assume
+latest".
+"""
+
+import re
+import subprocess
+import time
+
+from waypoint.launch_targets import SshLaunchTargetConfig
+
+# How long a probed version stays valid before we re-run the binary. Long
+# enough to avoid spawning a subprocess on every model-list request; short
+# enough that an in-place CLI upgrade is picked up without a server restart.
+_VERSION_CACHE_TTL_SECONDS = 300.0
+
+# Raw version-string cache, keyed by binary path. Shared by
+# ``claude_cli_version_string`` and ``detect_claude_cli_version`` so both
+# callers (the rate-limit User-Agent and the model-catalogue gate) pay for at
+# most one subprocess spawn per binary per TTL window.
+_VERSION_STRING_CACHE: dict[str, tuple[float, str | None]] = {}
+
+_VERSION_SEGMENT_RE = re.compile(r"\d+(?:\.\d+)+")
+
+
+def _probe_claude_version_string(binary: str) -> str | None:
+    """Run ``<binary> --version`` and extract the raw version substring.
+
+    Prefers a dotted-numeric version, optionally with a ``-``/``+``
+    pre-release or build suffix (e.g. ``2.1.197-beta.1``); falls back to the
+    first whitespace-separated token of stdout when that regex doesn't
+    match. Returns ``None`` on any failure (missing binary, non-zero exit,
+    timeout) or empty output.
+    """
+    try:
+        completed = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if completed.returncode != 0:
+        return None
+    match = re.search(r"\d+(?:\.\d+)+(?:[-+][A-Za-z0-9.-]+)?", completed.stdout)
+    if match is not None:
+        return match.group(0)
+    stripped = completed.stdout.strip()
+    return stripped.split()[0] if stripped else None
+
+
+def _cached_version_string(binary: str) -> str | None:
+    now = time.monotonic()
+    cached = _VERSION_STRING_CACHE.get(binary)
+    if cached is not None and now - cached[0] < _VERSION_CACHE_TTL_SECONDS:
+        return cached[1]
+    value = _probe_claude_version_string(binary)
+    _VERSION_STRING_CACHE[binary] = (now, value)
+    return value
+
+
+def claude_cli_version_string(
+    binary: str = "claude",
+    launch_target: SshLaunchTargetConfig | None = None,
+) -> str | None:
+    """TTL-cached raw ``claude --version`` string, or ``None`` if undetectable.
+
+    Remote (SSH) targets are out of scope for version detection: passing a
+    ``launch_target`` always returns ``None`` without spawning a process.
+    """
+    if launch_target is not None:
+        return None
+    return _cached_version_string(binary)
+
+
+def detect_claude_cli_version(
+    binary: str = "claude",
+    launch_target: SshLaunchTargetConfig | None = None,
+) -> tuple[int, ...] | None:
+    """Best-effort ``claude --version``, parsed into an int tuple (e.g. ``(2, 1, 197)``).
+
+    Returns ``None`` when the binary can't be probed or its output doesn't
+    parse — including for any non-``None`` ``launch_target``, since version
+    detection over SSH is out of scope. Callers should treat ``None`` as
+    "assume latest".
+    """
+    raw = claude_cli_version_string(binary, launch_target)
+    if raw is None:
+        return None
+    match = _VERSION_SEGMENT_RE.match(raw)
+    if match is None:
+        return None
+    try:
+        return tuple(int(part) for part in match.group(0).split("."))
+    except ValueError:
+        return None

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -41,7 +41,11 @@ from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
 )
-from waypoint.backends.claude_code.plugin import ClaudeCodePlugin
+from waypoint.backends.claude_code.plugin import (
+    ClaudeCodePlugin,
+    offered_claude_models,
+    raise_for_unsupported_selection,
+)
 from waypoint.backends.claude_code.schemas import (
     ClaudeThreadImportRequest,
     ClaudeThreadSummary,
@@ -300,10 +304,19 @@ class ClaudeTtyPlugin:
     ) -> dict[str, Any]:
         config = self._config(runtime)
         default_model = config.default_model_id
-        options = [opt.model_dump(mode="json") for opt in config.models]
+        launch_target = (
+            runtime._find_launch_target(launch_target_id) if launch_target_id else None
+        )
+        models, _version = await asyncio.to_thread(
+            offered_claude_models,
+            config,
+            self._claude.capabilities.cli_binary or "claude",
+            launch_target,
+        )
+        options = [opt.model_dump(mode="json") for opt in models]
         default_model_id: str | None = None
         if default_model is None:
-            for opt in config.models:
+            for opt in models:
                 if opt.is_default:
                     default_model_id = opt.id
                     break
@@ -311,7 +324,7 @@ class ClaudeTtyPlugin:
             default_model_id = default_model
         default_model_label: str | None = None
         if default_model_id:
-            for opt in config.models:
+            for opt in models:
                 if opt.id == default_model_id:
                     default_model_label = opt.label
                     break
@@ -323,6 +336,27 @@ class ClaudeTtyPlugin:
             "default_effort": config.default_effort,
             "supports_free_text": True,
         }
+
+    def validate_new_session_selection(
+        self,
+        runtime: "SessionRuntime",
+        model: str | None,
+        effort: str | None,
+        launch_target_id: str | None,
+    ) -> None:
+        # Same agent as claude_code, so the same version-gated preflight
+        # applies over the TUI transport.
+        if effort is None:
+            return None
+        launch_target = (
+            runtime._find_launch_target(launch_target_id) if launch_target_id else None
+        )
+        models, version = offered_claude_models(
+            self._config(runtime),
+            self._claude.capabilities.cli_binary or "claude",
+            launch_target,
+        )
+        raise_for_unsupported_selection(models, version, model, effort)
 
     async def list_command_completions(
         self,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -395,6 +395,26 @@ class SessionRuntime:
                     "cannot be requested as the target backend"
                 ),
             )
+        # New-session preflight: an agent that can prove the installed CLI
+        # won't honor this model/effort combo raises ValueError here. Not
+        # consulted for resume / set-model / set-effort — only brand-new
+        # sessions. Optional method (see BackendPlugin's docstring), read
+        # defensively so agents that don't implement it (or predate it)
+        # still launch unimpeded.
+        preflight = getattr(plugin, "validate_new_session_selection", None)
+        if preflight is not None:
+            try:
+                await asyncio.to_thread(
+                    preflight,
+                    self,
+                    resolved_model,
+                    resolved_effort,
+                    request.launch_target_id,
+                )
+            except ValueError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+                ) from exc
         launch_mode = request.launch_mode
         # An omitted transport under AUTO launch resolves to the agent's
         # declared default transport, so every spawn path (UI, CLI, spawned

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -204,6 +204,13 @@ class SessionRecord(BaseModel):
     worktree_path: str | None = None
     permission_mode: str | None = None
     model: str | None = None
+    # The concrete model id the backend actually resolved and ran (e.g.
+    # ``claude-sonnet-5``), as reported by the CLI/API at launch time.
+    # Distinct from ``model``, which is the user's *selection* (e.g. the
+    # alias ``sonnet``) and is what relaunch/set-model uses. Display should
+    # prefer this field so a session's shown model doesn't drift when a
+    # catalogue update changes what an alias currently resolves to.
+    resolved_model: str | None = None
     effort: str | None = None
     args: list[str] = Field(default_factory=list)
     # Backend-specific structured overrides distinct from raw ``args``.

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -141,6 +141,7 @@ class Storage:
                 pinned_at TEXT,
                 permission_mode TEXT,
                 model TEXT,
+                resolved_model TEXT,
                 effort TEXT,
                 args TEXT NOT NULL DEFAULT '[]',
                 config_overrides TEXT NOT NULL DEFAULT '[]',
@@ -237,6 +238,7 @@ class Storage:
         self._ensure_column("sessions", "rate_limit_usage", "TEXT")
         self._ensure_column("sessions", "spawner_session_id", "TEXT")
         self._ensure_column("sessions", "worktree_path", "TEXT")
+        self._ensure_column("sessions", "resolved_model", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -266,8 +268,9 @@ class Storage:
                 launch_mode, repo_name, branch, status, created_at, updated_at,
                 last_event_at, raw_log_path, structured_log_path, transport_state,
                 pinned_at, spawner_session_id, worktree_path, permission_mode, model,
-                effort, args, config_overrides, context_usage, rate_limit_usage
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                resolved_model, effort, args, config_overrides, context_usage,
+                rate_limit_usage
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -292,6 +295,7 @@ class Storage:
                 session.worktree_path,
                 session.permission_mode,
                 session.model,
+                session.resolved_model,
                 session.effort,
                 json.dumps(list(session.args)),
                 json.dumps(list(session.config_overrides)),

--- a/backend/tests/golden/backends_payload.json
+++ b/backend/tests/golden/backends_payload.json
@@ -77,7 +77,8 @@
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
       "model_source": "static",
       "slash_commands": [
@@ -183,7 +184,8 @@
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
       "slash_commands": [
         {
@@ -348,7 +350,8 @@
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
       "model_source": "static",
       "slash_commands": [
@@ -454,7 +457,8 @@
         "low",
         "medium",
         "high",
-        "xhigh"
+        "xhigh",
+        "max"
       ],
       "slash_commands": [
         {

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -448,6 +448,56 @@ async def test_dispatch_system_init_refreshes_context_window_on_family_change() 
 
 
 @pytest.mark.asyncio
+async def test_dispatch_system_init_persists_resolved_model() -> None:
+    emitted: list = []
+    session_updates: list[tuple[str, dict[str, Any], bool]] = []
+    adapter = _make_adapter(emitted, session_updates)
+    state, _ = _attach_state(adapter)
+
+    await adapter._dispatch(
+        state,
+        {
+            "type": "system",
+            "subtype": "init",
+            "model": "claude-sonnet-5",
+            "session_id": "claude-uuid",
+        },
+    )
+
+    assert state.resolved_model == "claude-sonnet-5"
+    resolved_updates = [
+        update for update in session_updates if "resolved_model" in update[1]
+    ]
+    assert resolved_updates == [("sess", {"resolved_model": "claude-sonnet-5"}, False)]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_system_init_does_not_repersist_unchanged_resolved_model() -> (
+    None
+):
+    emitted: list = []
+    session_updates: list[tuple[str, dict[str, Any], bool]] = []
+    adapter = _make_adapter(emitted, session_updates)
+    state, _ = _attach_state(adapter)
+    state.resolved_model = "claude-sonnet-5"
+
+    await adapter._dispatch(
+        state,
+        {
+            "type": "system",
+            "subtype": "init",
+            "model": "claude-sonnet-5",
+            "session_id": "claude-uuid",
+        },
+    )
+
+    resolved_updates = [
+        update for update in session_updates if "resolved_model" in update[1]
+    ]
+    assert resolved_updates == []
+
+
+@pytest.mark.asyncio
 async def test_dispatch_assistant_emits_context_usage_snapshot() -> None:
     emitted: list = []
     session_updates: list[tuple[str, dict[str, Any], bool]] = []

--- a/backend/tests/test_claude_cli_version.py
+++ b/backend/tests/test_claude_cli_version.py
@@ -1,0 +1,130 @@
+"""Unit tests for backends/claude_code/version.py's ``claude --version`` probe."""
+
+from typing import Any
+
+import pytest
+
+from waypoint.backends.claude_code import version as version_module
+from waypoint.backends.claude_code.version import (
+    claude_cli_version_string,
+    detect_claude_cli_version,
+)
+from waypoint.launch_targets import SshLaunchTargetConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_version_cache() -> None:
+    # The TTL cache is keyed by binary path; clear it so one test's fake
+    # subprocess result can't leak into the next.
+    version_module._VERSION_STRING_CACHE.clear()
+
+
+class _FakeCompleted:
+    def __init__(self, stdout: str, returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _patch_run(monkeypatch: pytest.MonkeyPatch, result: Any) -> None:
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        if isinstance(result, BaseException):
+            raise result
+        return result
+
+    monkeypatch.setattr(version_module.subprocess, "run", fake_run)
+
+
+def test_claude_cli_version_string_strips_trailing_label(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, _FakeCompleted("2.1.197 (Claude Code)\n"))
+    assert claude_cli_version_string("claude") == "2.1.197"
+
+
+def test_detect_claude_cli_version_parses_labeled_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, _FakeCompleted("2.1.197 (Claude Code)\n"))
+    assert detect_claude_cli_version("claude") == (2, 1, 197)
+
+
+def test_detect_claude_cli_version_parses_plain_semver(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, _FakeCompleted("2.1.5\n"))
+    assert detect_claude_cli_version("claude") == (2, 1, 5)
+
+
+def test_detect_claude_cli_version_none_on_empty_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, _FakeCompleted(""))
+    assert detect_claude_cli_version("claude") is None
+
+
+def test_detect_claude_cli_version_none_on_non_numeric_junk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, _FakeCompleted("command not found"))
+    # The raw string falls back to the first whitespace token (matching the
+    # historical User-Agent behavior), but it doesn't parse as a version.
+    assert claude_cli_version_string("claude") == "command"
+    assert detect_claude_cli_version("claude") is None
+
+
+def test_detect_claude_cli_version_none_on_nonzero_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, _FakeCompleted("2.1.197", returncode=1))
+    assert detect_claude_cli_version("claude") is None
+
+
+def test_detect_claude_cli_version_none_on_missing_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_run(monkeypatch, FileNotFoundError())
+    assert detect_claude_cli_version("claude") is None
+
+
+def test_detect_claude_cli_version_none_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess
+
+    _patch_run(monkeypatch, subprocess.TimeoutExpired(cmd="claude", timeout=3))
+    assert detect_claude_cli_version("claude") is None
+
+
+def test_detect_claude_cli_version_short_circuits_for_remote_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        nonlocal called
+        called = True
+        return _FakeCompleted("2.1.197")
+
+    monkeypatch.setattr(version_module.subprocess, "run", fake_run)
+    target = SshLaunchTargetConfig(id="t", name="t", ssh_destination="remote")
+
+    assert detect_claude_cli_version("claude", target) is None
+    assert claude_cli_version_string("claude", target) is None
+    assert not called
+
+
+def test_detect_claude_cli_version_caches_within_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def fake_run(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return _FakeCompleted("2.1.197")
+
+    monkeypatch.setattr(version_module.subprocess, "run", fake_run)
+
+    assert detect_claude_cli_version("claude") == (2, 1, 197)
+    assert detect_claude_cli_version("claude") == (2, 1, 197)
+    assert calls == 1

--- a/backend/tests/test_claude_code_list_models.py
+++ b/backend/tests/test_claude_code_list_models.py
@@ -1,0 +1,128 @@
+"""Unit tests for ClaudeCodePlugin.list_models's version-gated offering."""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from waypoint.backends.claude_code.models import DEFAULT_CLAUDE_MODELS
+from waypoint.backends.claude_code.plugin import (
+    ClaudeCodePlugin,
+    ClaudeCodePluginConfig,
+)
+from waypoint.launch_targets import SshLaunchTargetConfig
+
+
+def _fake_runtime(
+    config: ClaudeCodePluginConfig | None = None,
+    launch_target: SshLaunchTargetConfig | None = None,
+) -> Any:
+    resolved_config = config or ClaudeCodePluginConfig()
+    return SimpleNamespace(
+        settings=SimpleNamespace(plugin_config=lambda plugin_id: resolved_config),
+        _find_launch_target=lambda launch_target_id: launch_target,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_models_uses_current_catalogue_for_recent_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 197),
+    )
+
+    result = await plugin.list_models(cast(Any, _fake_runtime()))
+
+    sonnet = next(m for m in result["models"] if m["id"] == "sonnet")
+    assert sonnet["label"] == "Sonnet 5"
+    assert "max" in sonnet["supported_efforts"]
+    assert result["default_model_id"] == "opus[1m]"
+
+
+@pytest.mark.asyncio
+async def test_list_models_uses_legacy_catalogue_for_older_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 100),
+    )
+
+    result = await plugin.list_models(cast(Any, _fake_runtime()))
+
+    sonnet = next(m for m in result["models"] if m["id"] == "sonnet")
+    assert sonnet["label"] == "Sonnet 4.6"
+    # Sonnet 4.6 accepts `max` but not `xhigh`.
+    assert "xhigh" not in sonnet["supported_efforts"]
+    assert "max" in sonnet["supported_efforts"]
+    # opus[1m] stays the default across both epochs.
+    assert result["default_model_id"] == "opus[1m]"
+    opus_1m = next(m for m in result["models"] if m["id"] == "opus[1m]")
+    assert opus_1m["is_default"] is True
+
+
+@pytest.mark.asyncio
+async def test_list_models_treats_undetectable_version_as_latest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: None,
+    )
+
+    result = await plugin.list_models(cast(Any, _fake_runtime()))
+
+    sonnet = next(m for m in result["models"] if m["id"] == "sonnet")
+    assert sonnet["label"] == "Sonnet 5"
+
+
+@pytest.mark.asyncio
+async def test_list_models_passes_resolved_launch_target_to_detector(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    target = SshLaunchTargetConfig(id="t", name="t", ssh_destination="remote")
+    seen: dict[str, Any] = {}
+
+    def fake_detect(binary: str, launch_target: Any) -> tuple[int, ...] | None:
+        seen["binary"] = binary
+        seen["launch_target"] = launch_target
+        return None
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fake_detect
+    )
+    runtime = _fake_runtime(launch_target=target)
+
+    await plugin.list_models(cast(Any, runtime), launch_target_id="remote-1")
+
+    assert seen["launch_target"] is target
+
+
+@pytest.mark.asyncio
+async def test_list_models_honors_explicit_models_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    custom = [DEFAULT_CLAUDE_MODELS[0]]
+    config = ClaudeCodePluginConfig(models=custom)
+    called = False
+
+    def fake_detect(binary: str, launch_target: Any) -> tuple[int, ...] | None:
+        nonlocal called
+        called = True
+        return (2, 0, 0)
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fake_detect
+    )
+
+    result = await plugin.list_models(cast(Any, _fake_runtime(config=config)))
+
+    assert not called
+    assert [m["id"] for m in result["models"]] == [custom[0].id]

--- a/backend/tests/test_claude_code_preflight.py
+++ b/backend/tests/test_claude_code_preflight.py
@@ -1,0 +1,177 @@
+"""Unit tests for ClaudeCodePlugin.validate_new_session_selection.
+
+The new-session preflight only rejects combinations it can *prove* the
+installed CLI won't honor (a recognized model paired with an effort that
+model's catalogue entry doesn't list). Free-text/unrecognized models always
+pass through, since claude_code advertises supports_free_text=True and users
+may type an arbitrary model string.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from waypoint.backends.claude_code.models import DEFAULT_CLAUDE_MODELS
+from waypoint.backends.claude_code.plugin import (
+    ClaudeCodePlugin,
+    ClaudeCodePluginConfig,
+)
+
+
+def _fake_runtime(config: ClaudeCodePluginConfig | None = None) -> Any:
+    resolved_config = config or ClaudeCodePluginConfig()
+    return SimpleNamespace(
+        settings=SimpleNamespace(plugin_config=lambda plugin_id: resolved_config),
+        _find_launch_target=lambda launch_target_id: None,
+    )
+
+
+def test_rejects_xhigh_effort_on_sonnet_under_old_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Pre-2.1.197 the `sonnet` alias is Sonnet 4.6, which accepts `max` but
+    # not `xhigh`.
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 190),
+    )
+
+    with pytest.raises(ValueError) as exc:
+        plugin.validate_new_session_selection(
+            cast(Any, _fake_runtime()), "sonnet", "xhigh", None
+        )
+
+    message = str(exc.value)
+    assert "sonnet" in message
+    assert "xhigh" in message
+    assert "2.1.190" in message
+    assert "max" in message  # the supported-efforts list is named
+
+
+def test_accepts_max_effort_on_sonnet_under_old_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Sonnet 4.6 does accept `max` -- only `xhigh` is unsupported pre-2.1.197.
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 190),
+    )
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime()), "sonnet", "max", None
+    )
+
+
+def test_rejects_any_effort_on_haiku(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 197),
+    )
+
+    with pytest.raises(ValueError) as exc:
+        plugin.validate_new_session_selection(
+            cast(Any, _fake_runtime()), "haiku", "low", None
+        )
+
+    assert "haiku" in str(exc.value)
+
+
+@pytest.mark.parametrize("version", [(2, 1, 197), (2, 2, 0)])
+def test_accepts_max_effort_on_sonnet_under_recent_cli(
+    monkeypatch: pytest.MonkeyPatch, version: tuple[int, ...]
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: version,
+    )
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime()), "sonnet", "max", None
+    )
+
+
+def test_accepts_max_effort_on_sonnet_when_version_undetectable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: None,
+    )
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime()), "sonnet", "max", None
+    )
+
+
+def test_passes_through_unknown_free_text_model_with_any_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    called = False
+
+    def fake_detect(binary: str, launch_target: Any) -> tuple[int, ...] | None:
+        nonlocal called
+        called = True
+        return (2, 1, 100)
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fake_detect
+    )
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime()), "claude-sonnet-9000", "max", None
+    )
+    # Free text is looked up in the catalogue (miss) but never rejected --
+    # the detector still runs since we can't skip resolving the catalogue.
+    assert called is True
+
+
+def test_effort_none_never_raises_and_skips_version_detection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+
+    def fail_detect(binary: str, launch_target: Any) -> tuple[int, ...] | None:
+        raise AssertionError("should not detect CLI version when effort is None")
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fail_detect
+    )
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime()), "haiku", None, None
+    )
+
+
+def test_honors_explicit_models_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ClaudeCodePlugin()
+    # A deployment-overridden catalogue where sonnet is deliberately capped
+    # at "low" -- the preflight should judge against this list, not the
+    # built-in default, and never touch version detection.
+    custom_sonnet = next(
+        opt for opt in DEFAULT_CLAUDE_MODELS if opt.id == "sonnet"
+    ).model_copy(update={"supported_efforts": ["low"]})
+    config = ClaudeCodePluginConfig(models=[custom_sonnet])
+
+    def fail_detect(binary: str, launch_target: Any) -> tuple[int, ...] | None:
+        raise AssertionError("should not detect CLI version for an explicit override")
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fail_detect
+    )
+
+    with pytest.raises(ValueError) as exc:
+        plugin.validate_new_session_selection(
+            cast(Any, _fake_runtime(config=config)), "sonnet", "high", None
+        )
+    assert "unknown" in str(exc.value)
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime(config=config)), "sonnet", "low", None
+    )

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -1,0 +1,63 @@
+"""Unit tests for the version-gated claude_code model offering.
+
+Distinct from test_claude_models_resolution.py, which covers the
+Phase 1 resolution layer (normalize/family/context-window) that stays full
+and version-independent. This file covers claude_models_for_version, which
+decides which *offering* (subset/labels) a given CLI build should see.
+"""
+
+import pytest
+
+from waypoint.backends.claude_code.models import (
+    DEFAULT_CLAUDE_MODELS,
+    SONNET5_MIN_CLI_VERSION,
+    claude_models_for_version,
+)
+
+
+def _by_id(models: tuple, model_id: str):
+    return next(opt for opt in models if opt.id == model_id)
+
+
+@pytest.mark.parametrize("version", [None, SONNET5_MIN_CLI_VERSION, (2, 2, 0)])
+def test_current_offering_for_none_or_recent_version(version) -> None:
+    models = claude_models_for_version(version)
+    assert models == DEFAULT_CLAUDE_MODELS
+    sonnet = _by_id(models, "sonnet")
+    assert sonnet.label == "Sonnet 5"
+    assert "max" in sonnet.supported_efforts
+
+
+def test_legacy_offering_below_sonnet5_min_version() -> None:
+    models = claude_models_for_version((2, 1, 190))
+
+    # Sonnet 4.6 accepts `max` but not `xhigh` (only the sonnet family differs
+    # across the 2.1.197 boundary).
+    sonnet = _by_id(models, "sonnet")
+    assert sonnet.label == "Sonnet 4.6"
+    assert sonnet.supported_efforts == ["low", "medium", "high", "max"]
+
+    sonnet_1m = _by_id(models, "sonnet[1m]")
+    assert sonnet_1m.label == "Sonnet 4.6 (1M context)"
+    assert sonnet_1m.supported_efforts == ["low", "medium", "high", "max"]
+
+    # Opus 4.8 and Fable 5 are unchanged across the boundary: full set incl. max.
+    opus = _by_id(models, "opus")
+    assert opus.label == "Opus 4.8"
+    assert "xhigh" in opus.supported_efforts and "max" in opus.supported_efforts
+
+    fable = _by_id(models, "fable")
+    assert "xhigh" in fable.supported_efforts and "max" in fable.supported_efforts
+
+    haiku = _by_id(models, "haiku")
+    assert haiku.supported_efforts == []
+
+    opus_1m = _by_id(models, "opus[1m]")
+    assert opus_1m.is_default is True
+    assert "xhigh" in opus_1m.supported_efforts and "max" in opus_1m.supported_efforts
+
+
+def test_legacy_offering_has_same_model_ids_as_default() -> None:
+    legacy = claude_models_for_version((2, 0, 0))
+    assert {opt.id for opt in legacy} == {opt.id for opt in DEFAULT_CLAUDE_MODELS}
+    assert sum(opt.is_default for opt in legacy) == 1

--- a/backend/tests/test_claude_models_resolution.py
+++ b/backend/tests/test_claude_models_resolution.py
@@ -1,0 +1,54 @@
+import pytest
+
+from waypoint.backends.claude_code.models import (
+    CLAUDE_MODEL_ALIASES,
+    claude_context_window_for_model,
+    claude_model_family,
+    normalize_claude_model_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("model", "family"),
+    [
+        ("claude-sonnet-4-5", "sonnet"),
+        ("claude-sonnet-4-6", "sonnet"),
+        ("claude-opus-4-7", "opus"),
+    ],
+)
+def test_legacy_concrete_ids_resolve_to_family(model: str, family: str) -> None:
+    assert claude_model_family(model) == family
+    assert claude_context_window_for_model(model) == 200_000
+
+
+@pytest.mark.parametrize(
+    ("alias", "window"),
+    [
+        ("sonnet", 200_000),
+        ("sonnet[1m]", 1_000_000),
+        ("opus[1m]", 1_000_000),
+        ("haiku", 200_000),
+    ],
+)
+def test_bare_aliases(alias: str, window: int) -> None:
+    assert claude_context_window_for_model(alias) == window
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["claude-sonnet-9", "some-sonnet-thing"],
+)
+def test_forward_unknown_but_familyish_ids_infer_family(model: str) -> None:
+    assert claude_model_family(model) == "sonnet"
+    assert claude_context_window_for_model(model) == 200_000
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "random"])
+def test_genuine_garbage_passes_through_unresolved(model: str) -> None:
+    assert normalize_claude_model_id(model) == model
+    assert claude_context_window_for_model(model) is None
+
+
+def test_every_alias_normalizes_to_its_mapped_family() -> None:
+    for concrete_id, family in CLAUDE_MODEL_ALIASES.items():
+        assert normalize_claude_model_id(concrete_id) == family

--- a/backend/tests/test_claude_tty_catalogue.py
+++ b/backend/tests/test_claude_tty_catalogue.py
@@ -1,0 +1,76 @@
+"""claude_tty shares claude_code's version-gated offering and preflight.
+
+claude_tty is the same Claude agent over the tmux/TUI transport, so the model
+catalogue it offers and the new-session preflight must track the installed CLI
+exactly as claude_code does.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin, ClaudeTtyPluginConfig
+
+# The gate lives in claude_code.plugin.offered_claude_models, so both plugins
+# resolve the version through this one symbol.
+_DETECT = "waypoint.backends.claude_code.plugin.detect_claude_cli_version"
+
+
+def _fake_runtime(config: ClaudeTtyPluginConfig | None = None) -> Any:
+    resolved = config or ClaudeTtyPluginConfig()
+    return SimpleNamespace(
+        settings=SimpleNamespace(plugin_config=lambda plugin_id: resolved),
+        _find_launch_target=lambda launch_target_id: None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_models_is_version_gated(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ClaudeTtyPlugin()
+    monkeypatch.setattr(_DETECT, lambda binary, launch_target: (2, 1, 190))
+
+    result = await plugin.list_models(cast(Any, _fake_runtime()))
+
+    sonnet = next(m for m in result["models"] if m["id"] == "sonnet")
+    assert sonnet["label"] == "Sonnet 4.6"
+    assert "xhigh" not in sonnet["supported_efforts"]
+    assert "max" in sonnet["supported_efforts"]
+
+
+@pytest.mark.asyncio
+async def test_list_models_current_catalogue_for_recent_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeTtyPlugin()
+    monkeypatch.setattr(_DETECT, lambda binary, launch_target: (2, 1, 197))
+
+    result = await plugin.list_models(cast(Any, _fake_runtime()))
+
+    sonnet = next(m for m in result["models"] if m["id"] == "sonnet")
+    assert sonnet["label"] == "Sonnet 5"
+    assert "xhigh" in sonnet["supported_efforts"]
+    assert result["default_model_id"] == "opus[1m]"
+
+
+def test_preflight_rejects_xhigh_on_sonnet_under_old_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeTtyPlugin()
+    monkeypatch.setattr(_DETECT, lambda binary, launch_target: (2, 1, 190))
+
+    with pytest.raises(ValueError) as exc:
+        plugin.validate_new_session_selection(
+            cast(Any, _fake_runtime()), "sonnet", "xhigh", None
+        )
+
+    assert "sonnet" in str(exc.value) and "xhigh" in str(exc.value)
+
+
+def test_preflight_accepts_supported_combo(monkeypatch: pytest.MonkeyPatch) -> None:
+    plugin = ClaudeTtyPlugin()
+    monkeypatch.setattr(_DETECT, lambda binary, launch_target: (2, 1, 197))
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime()), "sonnet", "xhigh", None
+    )

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1975,6 +1975,39 @@ async def test_create_session_rejects_tmux_backend(tmp_path) -> None:
     assert exc.value.status_code == 400
 
 
+@pytest.mark.asyncio
+async def test_create_session_rejects_unsupported_model_effort_combo(
+    monkeypatch, tmp_path
+) -> None:
+    """The new-session preflight fires before any transport/launch work --
+    a combo the detected CLI can't honor 400s without spawning anything."""
+    runtime, _, _ = make_runtime(tmp_path)
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 100),
+    )
+
+    # Pre-2.1.197 the `sonnet` alias is Sonnet 4.6, which accepts `max` but
+    # not `xhigh` -- so `xhigh` is the combo the preflight must reject before
+    # spawning anything. (A supported combo would fall through to a real
+    # launch and hang the suite, so this must stay an unsupported one.)
+    with pytest.raises(HTTPException) as exc:
+        await runtime.create_session(
+            SessionCreateRequest(
+                backend="claude_code",
+                cwd="~/workspace",
+                args=[],
+                model="sonnet",
+                effort="xhigh",
+                source_mode=SessionSource.MANAGED,
+            )
+        )
+
+    assert exc.value.status_code == 400
+    assert "sonnet" in exc.value.detail
+    assert "xhigh" in exc.value.detail
+
+
 def _fake_plugin_create_session(
     storage: Storage,
     settings: Settings,
@@ -2010,6 +2043,87 @@ def _fake_plugin_create_session(
         return session
 
     return _create
+
+
+@pytest.mark.asyncio
+async def test_create_session_accepts_supported_model_effort_combo(
+    monkeypatch, tmp_path
+) -> None:
+    """A combo the detected CLI does support sails through the preflight
+    and reaches the transport-resolved plugin's create_session unchanged."""
+    runtime, storage, settings = make_runtime(tmp_path)
+    claude = runtime.registry.get("claude_code")
+    tty = runtime.registry.get("claude_tty")
+    calls: list[tuple[str, str, str | None]] = []
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 197),
+    )
+    monkeypatch.setattr(tty, "is_available_for_managed_launch", lambda _runtime: True)
+    monkeypatch.setattr(
+        tty,
+        "create_session",
+        _fake_plugin_create_session(
+            storage, settings, transport="claude_tty", calls=calls
+        ),
+    )
+    monkeypatch.setattr(
+        claude,
+        "create_session",
+        lambda *args, **kwargs: pytest.fail("structured adapter is no longer default"),
+    )
+    monkeypatch.setattr(
+        runtime, "_warm_command_completions", lambda *_args, **_kwargs: None
+    )
+
+    session = await runtime.create_session(
+        SessionCreateRequest(
+            backend="claude_code",
+            cwd="~/workspace",
+            args=[],
+            model="sonnet",
+            effort="max",
+            source_mode=SessionSource.MANAGED,
+        )
+    )
+
+    assert calls == [(session.id, "claude_code", None)]
+
+
+@pytest.mark.asyncio
+async def test_apply_model_and_apply_effort_never_consult_preflight(tmp_path) -> None:
+    """set-model / set-effort mid-session never run the new-session
+    preflight -- it only gates create_session, per the resume/set contract."""
+    runtime, storage, settings = make_runtime(tmp_path)
+    claude = _claude_plugin(runtime)
+    calls: list[Any] = []
+    original = claude.validate_new_session_selection
+
+    def spy(*args: Any, **kwargs: Any) -> None:
+        calls.append((args, kwargs))
+        return original(*args, **kwargs)
+
+    claude.validate_new_session_selection = spy
+
+    class FakeAdapter:
+        async def set_model(self, session_id: str, model: str | None) -> None:
+            return None
+
+        async def set_effort(self, session_id: str, effort: str | None) -> None:
+            return None
+
+    claude.adapter = cast(Any, FakeAdapter())
+
+    session = make_session(
+        settings, id="s1", backend="claude_code", transport="claude_cli"
+    )
+    storage.create_session(session)
+
+    await claude.apply_model(runtime, session, "sonnet")
+    await claude.apply_effort(runtime, session, "max")
+
+    assert calls == []
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -189,6 +189,42 @@ def test_session_round_trip_persists_spawner_session_id(tmp_path) -> None:
     assert updated.spawner_session_id == "parent-2"
 
 
+def test_session_round_trip_persists_resolved_model(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="session-resolved-model",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        title="Claude session",
+        cwd="/tmp",
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/events.jsonl",
+        model="sonnet",
+    )
+    storage.create_session(session)
+
+    loaded = storage.get_session("session-resolved-model")
+    assert loaded is not None
+    assert loaded.model == "sonnet"
+    assert loaded.resolved_model is None
+
+    updated = storage.update_session(
+        "session-resolved-model", resolved_model="claude-sonnet-5"
+    )
+    assert updated.resolved_model == "claude-sonnet-5"
+    # The user's selection is untouched by the resolved-model update.
+    assert updated.model == "sonnet"
+
+    reloaded = storage.get_session("session-resolved-model")
+    assert reloaded is not None
+    assert reloaded.resolved_model == "claude-sonnet-5"
+
+
 def test_schedule_round_trip_persists_launch_mode(tmp_path) -> None:
     storage = Storage(tmp_path / "waypoint.db")
     now = datetime.now(UTC)
@@ -1009,6 +1045,60 @@ def test_storage_legacy_db_gets_launch_mode_column(tmp_path) -> None:
         assert row[0] == LaunchMode.AUTO.value
     finally:
         conn.close()
+
+
+def test_storage_legacy_db_gets_resolved_model_column(tmp_path) -> None:
+    """A pre-resolved_model SQLite file gains the column, reading null safely."""
+    import sqlite3
+
+    db_path = tmp_path / "legacy_resolved_model.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript("""
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            backend TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'managed',
+            title TEXT NOT NULL,
+            cwd TEXT NOT NULL,
+            launch_target_id TEXT,
+            status TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            last_event_at TEXT NOT NULL,
+            raw_log_path TEXT NOT NULL,
+            structured_log_path TEXT NOT NULL,
+            transport_state TEXT NOT NULL DEFAULT '{}',
+            permission_mode TEXT,
+            model TEXT,
+            effort TEXT,
+            transport TEXT
+        );
+        """)
+    conn.commit()
+    now = datetime.now(UTC).isoformat()
+    conn.execute(
+        "INSERT INTO sessions (id, backend, title, cwd, status, created_at, "
+        "updated_at, last_event_at, raw_log_path, structured_log_path, model, "
+        "transport) "
+        "VALUES (?, 'claude_code', 't', '/tmp', 'idle', ?, ?, ?, '/tmp/raw.log', "
+        "'/tmp/events.jsonl', 'sonnet', 'tmux')",
+        ("legacy-1", now, now, now),
+    )
+    conn.commit()
+    conn.close()
+
+    storage = Storage(db_path)
+
+    cols = {row[1] for row in storage.connection.execute("PRAGMA table_info(sessions)")}
+    assert "resolved_model" in cols
+
+    loaded = storage.get_session("legacy-1")
+    assert loaded is not None
+    assert loaded.model == "sonnet"
+    assert loaded.resolved_model is None
+
+    updated = storage.update_session("legacy-1", resolved_model="claude-sonnet-5")
+    assert updated.resolved_model == "claude-sonnet-5"
 
 
 # ── board history / author_label / keep_last ────────────────────────────────

--- a/frontend/src/components/EffortPicker.tsx
+++ b/frontend/src/components/EffortPicker.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { effortLabel } from "@/lib/modelDisplay";
+
 interface EffortPickerProps {
   options: string[];
   value: string;
@@ -7,20 +9,6 @@ interface EffortPickerProps {
   disabled?: boolean;
   label?: string;
   hint?: string;
-}
-
-const EFFORT_LABELS: Record<string, string> = {
-  none: "None",
-  minimal: "Minimal",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra high",
-  max: "Max",
-};
-
-function effortLabel(value: string): string {
-  return EFFORT_LABELS[value] ?? value;
 }
 
 export function EffortPicker({

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -107,6 +107,7 @@ import {
 import { TaskProgressDock } from "@/components/TaskProgressDock";
 import { SideQuestionDock } from "@/components/SideQuestionDock";
 import { readTodoEntries, summarizeTodos } from "@/lib/todos";
+import { effortLabel, formatResolvedModelLabel } from "@/lib/modelDisplay";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
   Backend,
@@ -225,17 +226,6 @@ function isSafariFamily(): boolean {
 function wrapBracketedPaste(text: string): string {
   return `\x1b[200~${text.replace(/\r\n?/g, "\n")}\x1b[201~`;
 }
-
-const EFFORT_LABEL: Record<string, string> = {
-  none: "None",
-  minimal: "Minimal",
-  low: "Low",
-  medium: "Medium",
-  high: "High",
-  xhigh: "Extra high",
-  max: "Max",
-};
-
 
 // An existing backend-native thread the assistant can adopt.
 export interface AssistantThreadOption {
@@ -2800,7 +2790,7 @@ const ReplyComposer = memo(function ReplyComposer({
        parts.push(matched?.label ?? (currentModel || (defaultModelLabel ? `Default (${defaultModelLabel})` : "Default")));
     }
     if (hasEffortPicker) {
-      parts.push(currentEffort ? EFFORT_LABEL[currentEffort] ?? currentEffort : "Default");
+      parts.push(currentEffort ? effortLabel(currentEffort) : "Default");
     }
     return parts.join(" · ") || "Settings";
   })();
@@ -2980,13 +2970,11 @@ const ReplyComposer = memo(function ReplyComposer({
                       disabled={effortBusy || disabled}
                     >
                       <option value="">
-                        {defaultEffort
-                          ? `Default (${EFFORT_LABEL[defaultEffort] ?? defaultEffort})`
-                          : "Default"}
+                        {defaultEffort ? `Default (${effortLabel(defaultEffort)})` : "Default"}
                       </option>
                       {effortOptions.map((option) => (
                         <option key={option} value={option}>
-                          {EFFORT_LABEL[option] ?? option}
+                          {effortLabel(option)}
                         </option>
                       ))}
                       {currentEffort && !effortOptions.includes(currentEffort) ? (
@@ -2999,7 +2987,7 @@ const ReplyComposer = memo(function ReplyComposer({
                   <div className="composer-tune-restart">
                     <p>
                       Restart Claude with{" "}
-                      <strong>{EFFORT_LABEL[pendingEffort] ?? pendingEffort}</strong> effort?
+                      <strong>{effortLabel(pendingEffort)}</strong> effort?
                       The current turn is interrupted and the session resumes at the new
                       level.
                     </p>
@@ -3916,6 +3904,19 @@ function SessionHeader({
     headerAgentDefault !== null && session.transport !== headerAgentDefault;
   const sourceLabel = session.source === "managed" ? "Managed" : "Attached";
   const pinned = Boolean(session.pinned_at);
+  // Prefer the concrete model the backend actually ran (session.resolved_model)
+  // for display, so the badge doesn't drift when a catalogue update changes
+  // what the user's selection (session.model) currently resolves to. Relaunch
+  // / set-model / the picker all stay keyed off session.model, unchanged.
+  const resolvedModelLabel = formatResolvedModelLabel(
+    session.resolved_model,
+    session.model,
+    modelOptions,
+  );
+  const selectionModelLabel =
+    modelOptions.find((opt) => opt.id === session.model)?.label ?? session.model;
+  const modelBadgeLabel = resolvedModelLabel ?? selectionModelLabel;
+  const modelBadgeTitle = session.resolved_model ?? session.model;
   const [isEditing, setIsEditing] = useState(false);
   const [draftTitle, setDraftTitle] = useState("");
 
@@ -4020,8 +4021,8 @@ function SessionHeader({
           </span>
         ) : null}
         {session.model ? (
-          <span className="badge model" title={`Model: ${session.model}`}>
-            {modelOptions.find((opt) => opt.id === session.model)?.label ?? session.model}
+          <span className="badge model" title={`Model: ${modelBadgeTitle}`}>
+            {modelBadgeLabel}
           </span>
         ) : null}
         {session.effort ? (

--- a/frontend/src/lib/modelDisplay.ts
+++ b/frontend/src/lib/modelDisplay.ts
@@ -1,0 +1,70 @@
+/**
+ * Display helpers for model/effort values shared across the launch panel,
+ * the effort picker, and the session header badge. Single-sourced so the
+ * label maps can't drift between call sites.
+ */
+
+import type { BackendModelOption } from "@/lib/types";
+
+const EFFORT_LABELS: Record<string, string> = {
+  none: "None",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "Extra high",
+  max: "Max",
+};
+
+export function effortLabel(value: string): string {
+  return EFFORT_LABELS[value] ?? value;
+}
+
+// Family ids as they appear in a concrete claude-<family>-<version> id,
+// title-cased for display (e.g. "opus" -> "Opus").
+const CLAUDE_MODEL_FAMILY_LABELS: Record<string, string> = {
+  opus: "Opus",
+  sonnet: "Sonnet",
+  haiku: "Haiku",
+  fable: "Fable",
+};
+
+// Best-effort "claude-<family>-<version segments>" -> "<Family> <version>"
+// (e.g. "claude-opus-4-8" -> "Opus 4.8", "claude-sonnet-5" -> "Sonnet 5").
+// Returns null when the id doesn't look like a claude concrete id.
+function parseClaudeConcreteModelId(id: string): string | null {
+  if (!id.startsWith("claude-")) {
+    return null;
+  }
+  const segments = id.slice("claude-".length).split("-");
+  const family = segments[0];
+  const familyLabel = CLAUDE_MODEL_FAMILY_LABELS[family];
+  if (!familyLabel || segments.length < 2) {
+    return null;
+  }
+  const version = segments.slice(1).join(".");
+  return `${familyLabel} ${version}`;
+}
+
+/**
+ * Label for a session's resolved (concrete) model, for display only.
+ *
+ * `resolvedModel` is the concrete id the backend actually ran (e.g.
+ * "claude-opus-4-8"); `selectionId` is the user's selection (e.g.
+ * "opus[1m]"), used only to reattach the context-window variant the
+ * resolved id itself doesn't carry. Returns null when there's no resolved
+ * model to show — callers should fall back to their existing
+ * selection-label logic.
+ */
+export function formatResolvedModelLabel(
+  resolvedModel: string | null | undefined,
+  selectionId: string | null | undefined,
+  modelOptions: BackendModelOption[],
+): string | null {
+  if (!resolvedModel) {
+    return null;
+  }
+  const catalogLabel = modelOptions.find((opt) => opt.id === resolvedModel)?.label;
+  const base = catalogLabel ?? parseClaudeConcreteModelId(resolvedModel) ?? resolvedModel;
+  return selectionId?.endsWith("[1m]") ? `${base} (1M context)` : base;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -90,6 +90,11 @@ export interface SessionRecord {
   pinned_at?: string | null;
   permission_mode?: string | null;
   model?: string | null;
+  // The concrete model id the backend actually resolved and ran (e.g.
+  // "claude-sonnet-5"), as reported at launch time. Distinct from `model`,
+  // which is the user's selection (e.g. the alias "sonnet") and is what
+  // relaunch/set-model send. Prefer this for display when present.
+  resolved_model?: string | null;
   effort?: string | null;
   context_usage?: SessionContextUsage | null;
   rate_limit_usage?: SessionRateLimitUsage | null;


### PR DESCRIPTION
## Purpose

The `claude_code` model catalogue was a hand-maintained mirror of the latest CLI, with no awareness of which `claude` binary is actually installed and no safety net for sessions created against an older catalogue. This adds Claude Sonnet 5 and universal `max` effort, then makes the catalogue version-aware and backward-compatible: the offered models/efforts track the installed CLI, historical model ids still resolve for display and usage tracking, and each session records the concrete model it actually ran.

## Changes

### Backend

- `backends/claude_code/models.py` — add Sonnet 5 and `max` effort; make normalization and context-window resolution total, so any historical or family-ish model id still resolves (resumed sessions keep working); add a version-gated offering (`claude_models_for_version`) with documented CLI epochs.
- `backends/claude_code/version.py` (new) — detect the installed `claude --version`, TTL-cached; `rate_limits.py` now sources its User-Agent from it.
- `backends/claude_code/plugin.py` — shared `offered_claude_models` / `raise_for_unsupported_selection` helpers: `list_models` returns the version-appropriate catalogue, and `validate_new_session_selection` preflights a new session and rejects a model/effort the detected CLI can't honor.
- `backends/claude_tty/plugin.py` — the TUI transport is the same agent, so it routes through the same version gate and preflight (previously it served the catalogue ungated and had no preflight).
- `backends/base.py`, `runtime.py` — the optional preflight contract hook and its `create_session` call site (new sessions only; resume/set stay pass-through).
- `schemas.py`, `storage.py`, `backends/claude_code/adapter.py` — persist the concrete model the CLI reports via a new nullable `resolved_model` column (idempotent migration; written from the init event).
- Tests — resolution, version-gated offering (both transports), version detection, `list_models` gating, preflight, resolved-model persistence, and the column migration.

### Frontend

- `lib/modelDisplay.ts` (new), `EffortPicker.tsx`, `SessionDetail.tsx`, `lib/types.ts` — single-source the effort labels, and show the session's resolved concrete model in the header badge (relaunch and set-model still use the user's selection).

## Design

The core split is **offering vs. resolution**. The `sonnet` alias is version-relative — the CLI resolves it to a different concrete model across versions — so the *offering* (what a new session may pick) is gated on the detected CLI version, while *resolution* (interpreting a persisted selection) is total and never rejects. The offering gate and preflight are shared helpers routed through by both Claude transports (`claude_code` and `claude_tty`). The preflight only rejects a *recognized* model paired with an effort that model can't accept on the detected CLI; free-text models pass through, and resume / set-model / set-effort are never gated. Older epochs derive from the current `DEFAULT_CLAUDE_MODELS` via `model_copy`, keeping "latest" as the single source of truth. Effort gating was verified against the 2.1.175 / 2.1.195 / 2.1.196 / 2.1.197 binaries on disk and the changelog: Sonnet 4.6 accepts `max` but not `xhigh`, whereas Opus 4.8 and Fable 5 always accepted both; 2.1.197 swaps the `sonnet` alias to Sonnet 5, which adds `xhigh`.

## Test Plan

```
cd backend && uv run pytest
cd backend && uv run pre-commit run --all-files
cd frontend && npm run lint && npx tsc --noEmit && npm run build
```

## Test Result

- `uv run pytest` — **1268 passed**.
- `pre-commit run --all-files` — isort / black / ruff / codespell / mypy all clean.
- frontend `npm run lint`, `tsc --noEmit`, and `npm run build` — clean.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (resolution, offering for both transports, version detection, preflight, persistence, migration).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest` — 1268 passed; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends still work — the preflight hook is an optional no-op default on the launch contract; only the two Claude transports (`claude_code`, `claude_tty`) override the offering/preflight, and the regenerated golden payload changes only their effort levels; codex, opencode, and tmux are unaffected.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` (plus `tsc --noEmit`) and kept dark/light theme parity — no new hardcoded colors; the badge reuses existing classes.
- [x] Not a breaking change — additive: `resolved_model` is nullable with a migration, the offering is version-gated additively, and the preflight only rejects new-session combos the CLI would already reject.
- [ ] Docs/config: no `.env`/`waypoint.example.yaml` surface changed. The launch contract gained an optional `validate_new_session_selection` hook, documented inline in `backends/base.py`; `docs/coding_agent_plugins.md` was not updated (backend-internal optional hook) — flag if a contract-doc note is wanted.

</details>