### PR TITLE
feat: add scheduled messages for sessions

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -43,6 +43,7 @@ from waypoint.schemas import (
     LoginRequest,
     MeResponse,
     ScheduleCreateRequest,
+    ScheduledMessageCreateRequest,
     SessionAnswerQuestionRequest,
     SessionApprovalRequest,
     SessionAttachRequest,
@@ -1111,6 +1112,44 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         removed = context.runtime.scheduler.clear_history()
+        return {"removed": removed}
+
+    @app.get("/api/message-schedules")
+    async def list_message_schedules(
+        _: Annotated[str, Depends(token_dependency())],
+        session_id: str | None = Query(default=None),
+    ) -> Any:
+        schedules = [
+            s.model_dump(mode="json")
+            for s in context.runtime.scheduler.list_message_schedules(
+                session_id=session_id
+            )
+        ]
+        return {"message_schedules": schedules}
+
+    @app.post("/api/sessions/{session_id}/message-schedules")
+    async def create_message_schedule(
+        session_id: str,
+        body: ScheduledMessageCreateRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        record = context.runtime.scheduler.create_message_schedule(session_id, body)
+        return {"message_schedule": record.model_dump(mode="json")}
+
+    @app.delete("/api/message-schedules/{schedule_id}")
+    async def cancel_message_schedule(
+        schedule_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        record = context.runtime.scheduler.cancel_message_schedule(schedule_id)
+        return {"message_schedule": record.model_dump(mode="json")}
+
+    @app.post("/api/message-schedules/clear-history")
+    async def clear_message_schedule_history(
+        _: Annotated[str, Depends(token_dependency())],
+        session_id: str | None = Query(default=None),
+    ) -> Any:
+        removed = context.runtime.scheduler.clear_message_history(session_id=session_id)
         return {"removed": removed}
 
     @app.get("/api/sessions/{session_id}/events")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -125,6 +125,10 @@ schedule_app = typer.Typer(
     help="Manage scheduled session launches on a running Waypoint server.",
     no_args_is_help=True,
 )
+schedule_message_app = typer.Typer(
+    help="Manage scheduled messages on a running Waypoint server.",
+    no_args_is_help=True,
+)
 maintenance_app = typer.Typer(
     help="Maintenance commands for the Waypoint server data.",
     no_args_is_help=True,
@@ -134,6 +138,7 @@ app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
 app.add_typer(board_app, name="board")
 app.add_typer(schedule_app, name="schedule")
+schedule_app.add_typer(schedule_message_app, name="message")
 app.add_typer(maintenance_app, name="maintenance")
 
 
@@ -1871,6 +1876,83 @@ def schedule_delete(
 def schedule_clear_history(ctx: typer.Context) -> None:
     """Remove completed/cancelled schedule records."""
     _emit(_settings_from_ctx(ctx), lambda c: c.clear_schedule_history())
+
+
+@schedule_message_app.command("list")
+def schedule_message_list(
+    ctx: typer.Context,
+    session_id: Annotated[
+        str | None,
+        typer.Option(help="Filter by target session id."),
+    ] = None,
+) -> None:
+    """List all scheduled messages."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "message_schedules": c.list_message_schedules(session_id=session_id)
+        },
+    )
+
+
+@schedule_message_app.command("create")
+def schedule_message_create(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument(help="Target session id.")],
+    text: Annotated[str, typer.Argument(help="Message text to send.")],
+    delay_seconds: Annotated[
+        int | None,
+        typer.Option(help="Send this many seconds from now."),
+    ] = None,
+    scheduled_at: Annotated[
+        str | None,
+        typer.Option(help="ISO 8601 datetime at which to send the message."),
+    ] = None,
+    no_submit: Annotated[
+        bool,
+        typer.Option("--no-submit", help="Do not auto-submit the message."),
+    ] = False,
+) -> None:
+    """Schedule a message to be sent to a session."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "message_schedule": c.create_message_schedule(
+                session_id,
+                text,
+                submit=not no_submit,
+                delay_seconds=delay_seconds,
+                scheduled_at=scheduled_at,
+            )
+        },
+    )
+
+
+@schedule_message_app.command("delete")
+def schedule_message_delete(
+    ctx: typer.Context,
+    schedule_id: Annotated[str, typer.Argument(help="Message schedule id to cancel.")],
+) -> None:
+    """Cancel and remove a scheduled message."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {"message_schedule": c.delete_message_schedule(schedule_id)},
+    )
+
+
+@schedule_message_app.command("clear-history")
+def schedule_message_clear_history(
+    ctx: typer.Context,
+    session_id: Annotated[
+        str | None,
+        typer.Option(help="Only clear history for this target session."),
+    ] = None,
+) -> None:
+    """Remove completed/cancelled/failed message schedule records."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: c.clear_message_schedule_history(session_id=session_id),
+    )
 
 
 @maintenance_app.command("stats")

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -532,6 +532,60 @@ class WaypointClient:
         ).json()
         return data
 
+    # ── message schedules ────────────────────────────────────────────────
+
+    def list_message_schedules(
+        self, session_id: str | None = None
+    ) -> list[dict[str, Any]]:
+        params: dict[str, str] = {}
+        if session_id is not None:
+            params["session_id"] = session_id
+        data: list[dict[str, Any]] = self._request(
+            "GET", "/api/message-schedules", params=params if params else None
+        ).json()["message_schedules"]
+        return data
+
+    def create_message_schedule(
+        self,
+        session_id: str,
+        text: str,
+        *,
+        submit: bool = True,
+        delay_seconds: int | None = None,
+        scheduled_at: str | None = None,
+        attachments: list[str] | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {"text": text, "submit": submit}
+        if delay_seconds is not None:
+            body["delay_seconds"] = delay_seconds
+        if scheduled_at is not None:
+            body["scheduled_at"] = scheduled_at
+        if attachments:
+            body["attachments"] = attachments
+        data: dict[str, Any] = self._request(
+            "POST",
+            f"/api/sessions/{session_id}/message-schedules",
+            json=body,
+        ).json()["message_schedule"]
+        return data
+
+    def delete_message_schedule(self, schedule_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "DELETE", f"/api/message-schedules/{schedule_id}"
+        ).json()["message_schedule"]
+        return data
+
+    def clear_message_schedule_history(
+        self, session_id: str | None = None
+    ) -> dict[str, Any]:
+        params: dict[str, str] = {}
+        if session_id is not None:
+            params["session_id"] = session_id
+        data: dict[str, Any] = self._request(
+            "POST", "/api/message-schedules/clear-history", params=params or None
+        ).json()
+        return data
+
     # ── usage ────────────────────────────────────────────────────────────
 
     def get_usage(self) -> dict[str, Any]:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1432,6 +1432,9 @@ class SessionRuntime:
         self.attachments.discard(session_id)
         # Drop this session's blackboard posts along with its record.
         pruned = self.storage.prune_board_for_session(session_id)
+        # Drop any scheduled messages queued for the now-deleted session; the
+        # scheduled_messages FK is declarative only (foreign_keys pragma is off).
+        await self.scheduler.purge_session_messages(session_id)
         plugin.on_session_deleted(self, session)
         await self._broadcast_session_list()
         if pruned:

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -148,7 +148,7 @@ class Scheduler:
     def create_message_schedule(
         self, session_id: str, request: ScheduledMessageCreateRequest
     ) -> ScheduledMessageRecord:
-        session = self._runtime.get_session(session_id)
+        session = self._runtime.storage.get_session(session_id)
         if session is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -204,6 +204,12 @@ class Scheduler:
         self._runtime.storage.delete_scheduled_message(message_id)
         asyncio.create_task(self._publish_update())
         return existing
+
+    async def purge_session_messages(self, session_id: str) -> int:
+        removed = self._runtime.storage.delete_scheduled_messages_by_session(session_id)
+        if removed:
+            await self._publish_update()
+        return removed
 
     def clear_message_history(self, session_id: str | None = None) -> int:
         removed = self._runtime.storage.delete_scheduled_messages_by_status(
@@ -277,7 +283,7 @@ class Scheduler:
 
     async def _fire_message(self, record: ScheduledMessageRecord) -> None:
         try:
-            session = self._runtime.get_session(record.session_id)
+            session = self._runtime.storage.get_session(record.session_id)
             if session is None:
                 self._runtime.storage.update_scheduled_message(
                     record.id,

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -2,13 +2,16 @@ import asyncio
 import logging
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 
 from waypoint.backends.registry import get_registry
 from waypoint.schemas import (
     ScheduleCreateRequest,
+    ScheduledMessageCreateRequest,
+    ScheduledMessageRecord,
+    ScheduledMessageStatus,
     ScheduledSessionRecord,
     ScheduleStatus,
     SessionCreateRequest,
@@ -137,6 +140,84 @@ class Scheduler:
         asyncio.create_task(self._publish_update())
         return existing
 
+    def list_message_schedules(
+        self, session_id: str | None = None
+    ) -> list[ScheduledMessageRecord]:
+        return self._runtime.storage.list_scheduled_messages(session_id=session_id)
+
+    def create_message_schedule(
+        self, session_id: str, request: ScheduledMessageCreateRequest
+    ) -> ScheduledMessageRecord:
+        session = self._runtime.get_session(session_id)
+        if session is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"session {session_id} not found",
+            )
+        if (
+            request.text == ""
+            and request.command is None
+            and not request.items
+            and not request.attachments
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="message schedule must have text, command, items, or attachments",
+            )
+        scheduled_at = self._resolve_scheduled_at(request)
+        now = datetime.now(UTC)
+        if request.scheduled_at is not None and scheduled_at <= now:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="scheduled_at must be in the future",
+            )
+        record = ScheduledMessageRecord(
+            id=self._generate_id(),
+            session_id=session_id,
+            text=request.text,
+            submit=request.submit,
+            command=request.command,
+            items=request.items,
+            attachments=list(request.attachments),
+            scheduled_at=scheduled_at,
+            created_at=now,
+            status=ScheduledMessageStatus.PENDING,
+        )
+        self._runtime.storage.create_scheduled_message(record)
+        self._wakeup.set()
+        asyncio.create_task(self._publish_update())
+        return record
+
+    def cancel_message_schedule(self, message_id: str) -> ScheduledMessageRecord:
+        existing = self._runtime.storage.get_scheduled_message(message_id)
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="message schedule not found",
+            )
+        if existing.status == ScheduledMessageStatus.PENDING:
+            updated = self._runtime.storage.update_scheduled_message(
+                message_id, status=ScheduledMessageStatus.CANCELLED
+            )
+            asyncio.create_task(self._publish_update())
+            return updated
+        self._runtime.storage.delete_scheduled_message(message_id)
+        asyncio.create_task(self._publish_update())
+        return existing
+
+    def clear_message_history(self, session_id: str | None = None) -> int:
+        removed = self._runtime.storage.delete_scheduled_messages_by_status(
+            [
+                ScheduledMessageStatus.SENT,
+                ScheduledMessageStatus.CANCELLED,
+                ScheduledMessageStatus.FAILED,
+            ],
+            session_id=session_id,
+        )
+        if removed:
+            asyncio.create_task(self._publish_update())
+        return removed
+
     def clear_history(self) -> int:
         removed = self._runtime.storage.delete_schedules_by_status(
             [
@@ -166,9 +247,14 @@ class Scheduler:
 
     def _compute_wait_seconds(self) -> float:
         pending = self._runtime.storage.list_schedules([ScheduleStatus.PENDING])
-        if not pending:
+        pending_msgs = self._runtime.storage.list_scheduled_messages(
+            [ScheduledMessageStatus.PENDING]
+        )
+        if not pending and not pending_msgs:
             return 60.0
-        soonest = min(item.scheduled_at for item in pending)
+        all_times = [item.scheduled_at for item in pending]
+        all_times.extend(item.scheduled_at for item in pending_msgs)
+        soonest = min(all_times)
         delta = (soonest - datetime.now(UTC)).total_seconds()
         if delta <= 0:
             return 0.5
@@ -181,6 +267,50 @@ class Scheduler:
             if schedule.scheduled_at > now:
                 continue
             await self._fire(schedule)
+        pending_msgs = self._runtime.storage.list_scheduled_messages(
+            [ScheduledMessageStatus.PENDING]
+        )
+        for msg in pending_msgs:
+            if msg.scheduled_at > now:
+                continue
+            await self._fire_message(msg)
+
+    async def _fire_message(self, record: ScheduledMessageRecord) -> None:
+        try:
+            session = self._runtime.get_session(record.session_id)
+            if session is None:
+                self._runtime.storage.update_scheduled_message(
+                    record.id,
+                    status=ScheduledMessageStatus.FAILED,
+                    failure_reason="session not found",
+                )
+                return
+            await self._runtime.handle_input(
+                record.session_id,
+                SessionInputRequest(
+                    text=record.text,
+                    submit=record.submit,
+                    command=record.command,
+                    items=record.items,
+                    attachments=(
+                        list(record.attachments) if record.attachments else None
+                    ),
+                ),
+            )
+            self._runtime.storage.update_scheduled_message(
+                record.id, status=ScheduledMessageStatus.SENT
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.exception(
+                "scheduled message fire failed",
+                extra={"msg_id": record.id},
+            )
+            self._runtime.storage.update_scheduled_message(
+                record.id,
+                status=ScheduledMessageStatus.FAILED,
+                failure_reason=str(exc),
+            )
+        await self._publish_update()
 
     async def _fire(self, schedule: ScheduledSessionRecord) -> None:
         try:
@@ -232,7 +362,11 @@ class Scheduler:
                 payload={
                     "schedules": [
                         item.model_dump(mode="json") for item in self.list_schedules()
-                    ]
+                    ],
+                    "message_schedules": [
+                        item.model_dump(mode="json")
+                        for item in self.list_message_schedules()
+                    ],
                 },
             )
         )
@@ -244,7 +378,7 @@ class Scheduler:
         )
 
     @staticmethod
-    def _resolve_scheduled_at(request: ScheduleCreateRequest) -> datetime:
+    def _resolve_scheduled_at(request: Any) -> datetime:
         if request.scheduled_at is not None:
             scheduled_at = request.scheduled_at
             if scheduled_at.tzinfo is None:

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import secrets
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 
@@ -378,7 +378,9 @@ class Scheduler:
         )
 
     @staticmethod
-    def _resolve_scheduled_at(request: Any) -> datetime:
+    def _resolve_scheduled_at(
+        request: ScheduleCreateRequest | ScheduledMessageCreateRequest,
+    ) -> datetime:
         if request.scheduled_at is not None:
             scheduled_at = request.scheduled_at
             if scheduled_at.tzinfo is None:

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -523,6 +523,37 @@ class SessionEnvelope(BaseModel):
     payload: Mapping[str, Any]
 
 
+class ScheduledMessageStatus(StrEnum):
+    PENDING = "pending"
+    SENT = "sent"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class ScheduledMessageRecord(BaseModel):
+    id: str
+    session_id: str
+    text: str = ""
+    submit: bool = True
+    command: SessionCommandInvocation | None = None
+    items: list[SessionInputItem] | None = None
+    attachments: list[str] = Field(default_factory=list)
+    scheduled_at: datetime
+    created_at: datetime
+    status: ScheduledMessageStatus = ScheduledMessageStatus.PENDING
+    failure_reason: str | None = None
+
+
+class ScheduledMessageCreateRequest(BaseModel):
+    text: str = ""
+    submit: bool = True
+    command: SessionCommandInvocation | None = None
+    items: list[SessionInputItem] | None = None
+    attachments: list[str] = Field(default_factory=list)
+    delay_seconds: int | None = None
+    scheduled_at: datetime | None = None
+
+
 class SideQuestionStatus(StrEnum):
     PENDING = "pending"
     ANSWERED = "answered"

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1069,6 +1069,14 @@ class Storage:
         return (cursor.rowcount or 0) > 0
 
     @_synchronized
+    def delete_scheduled_messages_by_session(self, session_id: str) -> int:
+        cursor = self.connection.execute(
+            "DELETE FROM scheduled_messages WHERE session_id = ?", (session_id,)
+        )
+        self.connection.commit()
+        return cursor.rowcount or 0
+
+    @_synchronized
     def delete_scheduled_messages_by_status(
         self,
         statuses: list[ScheduledMessageStatus],

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from waypoint.perf import debug_timer
 from waypoint.schemas import (
@@ -20,6 +20,8 @@ from waypoint.schemas import (
     ScheduledMessageStatus,
     ScheduledSessionRecord,
     ScheduleStatus,
+    SessionCommandInvocation,
+    SessionInputItem,
     SessionRecord,
     SessionStatus,
 )
@@ -245,9 +247,6 @@ class Storage:
         self._ensure_column("scheduled_sessions", "permission_mode", "TEXT")
         self._ensure_column("scheduled_sessions", "model", "TEXT")
         self._ensure_column("scheduled_sessions", "effort", "TEXT")
-        self._ensure_column(
-            "scheduled_messages", "submit", "INTEGER NOT NULL DEFAULT 1"
-        )
         self._ensure_column(
             "scheduled_sessions", "launch_mode", "TEXT NOT NULL DEFAULT 'auto'"
         )
@@ -1300,13 +1299,12 @@ class Storage:
         if raw_command:
             try:
                 cmd_data = json.loads(raw_command)
-                if isinstance(cmd_data, dict):
-                    from waypoint.schemas import SessionCommandInvocation
-
-                    payload["command"] = SessionCommandInvocation.model_validate(
-                        cmd_data
-                    )
-            except (json.JSONDecodeError, Exception):
+                payload["command"] = (
+                    SessionCommandInvocation.model_validate(cmd_data)
+                    if isinstance(cmd_data, dict)
+                    else None
+                )
+            except (json.JSONDecodeError, ValidationError):
                 payload["command"] = None
         else:
             payload["command"] = None
@@ -1314,13 +1312,12 @@ class Storage:
         if raw_items:
             try:
                 items_data = json.loads(raw_items)
-                if isinstance(items_data, list):
-                    from waypoint.schemas import SessionInputItem
-
-                    payload["items"] = [
-                        SessionInputItem.model_validate(i) for i in items_data
-                    ]
-            except (json.JSONDecodeError, Exception):
+                payload["items"] = (
+                    [SessionInputItem.model_validate(i) for i in items_data]
+                    if isinstance(items_data, list)
+                    else None
+                )
+            except (json.JSONDecodeError, ValidationError):
                 payload["items"] = None
         else:
             payload["items"] = None
@@ -1358,17 +1355,6 @@ class Storage:
             return value.isoformat()
         if isinstance(value, BaseModel):
             return json.dumps(value.model_dump(mode="json"))
-        if isinstance(value, list):
-            return json.dumps(
-                [
-                    (
-                        item.model_dump(mode="json")
-                        if isinstance(item, BaseModel)
-                        else item
-                    )
-                    for item in value
-                ]
-            )
         if isinstance(value, dict):
             return json.dumps(value)
         return value

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -16,6 +16,8 @@ from waypoint.schemas import (
     BoardEntry,
     EventKind,
     EventRecord,
+    ScheduledMessageRecord,
+    ScheduledMessageStatus,
     ScheduledSessionRecord,
     ScheduleStatus,
     SessionRecord,
@@ -191,6 +193,24 @@ class Storage:
                 failure_reason TEXT
             );
 
+            CREATE TABLE IF NOT EXISTS scheduled_messages (
+                id TEXT PRIMARY KEY,
+                session_id TEXT NOT NULL,
+                text TEXT NOT NULL DEFAULT '',
+                submit INTEGER NOT NULL DEFAULT 1,
+                command TEXT,
+                items TEXT,
+                attachments TEXT NOT NULL DEFAULT '[]',
+                scheduled_at TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                failure_reason TEXT,
+                FOREIGN KEY (session_id) REFERENCES sessions(id)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_scheduled_messages_status
+                ON scheduled_messages(status);
+
             CREATE TABLE IF NOT EXISTS board_entries (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 channel TEXT NOT NULL,
@@ -225,6 +245,9 @@ class Storage:
         self._ensure_column("scheduled_sessions", "permission_mode", "TEXT")
         self._ensure_column("scheduled_sessions", "model", "TEXT")
         self._ensure_column("scheduled_sessions", "effort", "TEXT")
+        self._ensure_column(
+            "scheduled_messages", "submit", "INTEGER NOT NULL DEFAULT 1"
+        )
         self._ensure_column(
             "scheduled_sessions", "launch_mode", "TEXT NOT NULL DEFAULT 'auto'"
         )
@@ -951,6 +974,120 @@ class Storage:
         return cursor.rowcount or 0
 
     @_synchronized
+    def create_scheduled_message(
+        self, record: ScheduledMessageRecord
+    ) -> ScheduledMessageRecord:
+        self.connection.execute(
+            """
+            INSERT INTO scheduled_messages (
+                id, session_id, text, submit, command, items, attachments,
+                scheduled_at, created_at, status, failure_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record.id,
+                record.session_id,
+                record.text,
+                1 if record.submit else 0,
+                (
+                    json.dumps(record.command.model_dump(mode="json"))
+                    if record.command
+                    else None
+                ),
+                (
+                    json.dumps([item.model_dump(mode="json") for item in record.items])
+                    if record.items
+                    else None
+                ),
+                json.dumps(list(record.attachments)),
+                record.scheduled_at.isoformat(),
+                record.created_at.isoformat(),
+                record.status,
+                record.failure_reason,
+            ),
+        )
+        self.connection.commit()
+        return record
+
+    @_synchronized
+    def list_scheduled_messages(
+        self,
+        statuses: list[ScheduledMessageStatus] | None = None,
+        session_id: str | None = None,
+    ) -> list[ScheduledMessageRecord]:
+        query = "SELECT * FROM scheduled_messages"
+        params: list[Any] = []
+        conditions: list[str] = []
+        if statuses:
+            placeholders = ",".join(["?"] * len(statuses))
+            conditions.append(f"status IN ({placeholders})")
+            params.extend(status.value for status in statuses)
+        if session_id:
+            conditions.append("session_id = ?")
+            params.append(session_id)
+        if conditions:
+            query += " WHERE " + " AND ".join(conditions)
+        query += " ORDER BY scheduled_at ASC, created_at ASC"
+        rows = self.connection.execute(query, params).fetchall()
+        return [self._scheduled_message_from_row(row) for row in rows]
+
+    @_synchronized
+    def get_scheduled_message(self, message_id: str) -> ScheduledMessageRecord | None:
+        row = self.connection.execute(
+            "SELECT * FROM scheduled_messages WHERE id = ?", (message_id,)
+        ).fetchone()
+        if row is None:
+            return None
+        return self._scheduled_message_from_row(row)
+
+    @_synchronized
+    def update_scheduled_message(
+        self, message_id: str, **fields: Any
+    ) -> ScheduledMessageRecord:
+        if not fields:
+            current = self.get_scheduled_message(message_id)
+            if current is None:
+                raise KeyError(message_id)
+            return current
+        assignments = ", ".join(f"{name} = ?" for name in fields)
+        values = [self._serialize_field(value) for value in fields.values()]
+        values.append(message_id)
+        self.connection.execute(
+            f"UPDATE scheduled_messages SET {assignments} WHERE id = ?", values
+        )
+        self.connection.commit()
+        updated = self.get_scheduled_message(message_id)
+        if updated is None:
+            raise KeyError(message_id)
+        return updated
+
+    @_synchronized
+    def delete_scheduled_message(self, message_id: str) -> bool:
+        cursor = self.connection.execute(
+            "DELETE FROM scheduled_messages WHERE id = ?", (message_id,)
+        )
+        self.connection.commit()
+        return (cursor.rowcount or 0) > 0
+
+    @_synchronized
+    def delete_scheduled_messages_by_status(
+        self,
+        statuses: list[ScheduledMessageStatus],
+        session_id: str | None = None,
+    ) -> int:
+        if not statuses:
+            return 0
+        placeholders = ",".join(["?"] * len(statuses))
+        query = f"DELETE FROM scheduled_messages WHERE status IN ({placeholders})"
+        params = [item.value for item in statuses]
+        if session_id:
+            query += " AND session_id = ?"
+            params.append(session_id)
+        cursor = self.connection.execute(query, params)
+        self.connection.commit()
+        return cursor.rowcount or 0
+
+    @_synchronized
     def next_sequence(self, session_id: str) -> int:
         row = self.connection.execute(
             "SELECT COALESCE(MAX(sequence), 0) AS max_sequence FROM events WHERE session_id = ?",
@@ -1153,6 +1290,50 @@ class Storage:
         )
         return ScheduledSessionRecord.model_validate(payload)
 
+    def _scheduled_message_from_row(self, row: sqlite3.Row) -> ScheduledMessageRecord:
+        payload = dict(row)
+        for field_name in ("scheduled_at", "created_at"):
+            payload[field_name] = datetime.fromisoformat(payload[field_name])
+        payload["status"] = ScheduledMessageStatus(payload.get("status", "pending"))
+        payload["submit"] = bool(payload.get("submit", 1))
+        raw_command = payload.pop("command", None)
+        if raw_command:
+            try:
+                cmd_data = json.loads(raw_command)
+                if isinstance(cmd_data, dict):
+                    from waypoint.schemas import SessionCommandInvocation
+
+                    payload["command"] = SessionCommandInvocation.model_validate(
+                        cmd_data
+                    )
+            except (json.JSONDecodeError, Exception):
+                payload["command"] = None
+        else:
+            payload["command"] = None
+        raw_items = payload.pop("items", None)
+        if raw_items:
+            try:
+                items_data = json.loads(raw_items)
+                if isinstance(items_data, list):
+                    from waypoint.schemas import SessionInputItem
+
+                    payload["items"] = [
+                        SessionInputItem.model_validate(i) for i in items_data
+                    ]
+            except (json.JSONDecodeError, Exception):
+                payload["items"] = None
+        else:
+            payload["items"] = None
+        raw_attachments = payload.get("attachments") or "[]"
+        try:
+            parsed_attachments = json.loads(raw_attachments)
+        except json.JSONDecodeError:
+            parsed_attachments = []
+        payload["attachments"] = (
+            parsed_attachments if isinstance(parsed_attachments, list) else []
+        )
+        return ScheduledMessageRecord.model_validate(payload)
+
     def _event_from_row(self, row: sqlite3.Row) -> EventRecord:
         payload = dict(row)
         payload["ts"] = datetime.fromisoformat(payload["ts"])
@@ -1177,6 +1358,17 @@ class Storage:
             return value.isoformat()
         if isinstance(value, BaseModel):
             return json.dumps(value.model_dump(mode="json"))
+        if isinstance(value, list):
+            return json.dumps(
+                [
+                    (
+                        item.model_dump(mode="json")
+                        if isinstance(item, BaseModel)
+                        else item
+                    )
+                    for item in value
+                ]
+            )
         if isinstance(value, dict):
             return json.dumps(value)
         return value

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -2158,3 +2158,279 @@ def test_start_warns_on_unknown_model(
     # Warning, not rejection: the session is still created.
     assert result.exit_code == 0
     assert "is not among" in result.output
+
+
+# ── schedule message CLI tests ─────────────────────────────────────────────────
+
+
+def test_schedule_message_help_lists_commands(tmp_path: Path) -> None:
+    result = runner.invoke(app, ["schedule", "message", "--help"])
+    assert result.exit_code == 0
+    for name in ("list", "create", "delete", "clear-history"):
+        assert name in result.stdout
+
+
+def _message_schedule_handler(
+    request: httpx.Request,
+) -> httpx.Response:
+    path = request.url.path
+    if path == "/api/message-schedules" and request.method == "GET":
+        return httpx.Response(
+            200,
+            json={
+                "message_schedules": [
+                    {"id": "ms1", "session_id": "s1", "text": "hello"}
+                ]
+            },
+        )
+    if path == "/api/sessions/s1/message-schedules" and request.method == "POST":
+        payload = json.loads(request.content)
+        return httpx.Response(200, json={"message_schedule": {"id": "ms1", **payload}})
+    if path.startswith("/api/message-schedules/") and request.method == "DELETE":
+        schedule_id = path.rsplit("/", 1)[-1]
+        return httpx.Response(200, json={"message_schedule": {"id": schedule_id}})
+    if path == "/api/message-schedules/clear-history" and request.method == "POST":
+        return httpx.Response(200, json={"removed": 2})
+    return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+
+def test_schedule_message_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(_message_schedule_handler),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "schedule", "message", "list"],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["message_schedules"] == [
+        {"id": "ms1", "session_id": "s1", "text": "hello"}
+    ]
+
+
+def test_schedule_message_list_with_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/message-schedules" and request.method == "GET":
+            state["params"] = dict(request.url.params)
+            return httpx.Response(
+                200, json={"message_schedules": [{"id": "ms1", "session_id": "s1"}]}
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "list",
+            "--session-id",
+            "s1",
+        ],
+    )
+    assert result.exit_code == 0
+    assert state["params"]["session_id"] == "s1"
+
+
+def test_schedule_message_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(_message_schedule_handler),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "create",
+            "s1",
+            "hello world",
+            "--delay-seconds",
+            "30",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["message_schedule"]["id"] == "ms1"
+    assert out["message_schedule"]["text"] == "hello world"
+    assert out["message_schedule"]["delay_seconds"] == 30
+
+
+def test_schedule_message_create_with_scheduled_at(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(_message_schedule_handler),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "create",
+            "s1",
+            "hello",
+            "--scheduled-at",
+            "2026-07-01T12:00:00Z",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["message_schedule"]["scheduled_at"] == "2026-07-01T12:00:00Z"
+
+
+def test_schedule_message_create_no_submit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/sessions/s1/message-schedules"
+            and request.method == "POST"
+        ):
+            state["body"] = json.loads(request.content)
+            return httpx.Response(
+                200, json={"message_schedule": {"id": "ms1", **state["body"]}}
+            )
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "create",
+            "s1",
+            "hello",
+            "--no-submit",
+        ],
+    )
+    assert result.exit_code == 0
+    assert state["body"]["submit"] is False
+
+
+def test_schedule_message_delete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(_message_schedule_handler),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "delete",
+            "ms1",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out["message_schedule"] == {"id": "ms1"}
+
+
+def test_schedule_message_clear_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(
+            transport=httpx.MockTransport(_message_schedule_handler),
+            base_url="http://t",
+        )
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "clear-history",
+        ],
+    )
+    assert result.exit_code == 0
+    out = json.loads(result.stdout)
+    assert out == {"removed": 2}
+
+
+def test_schedule_message_clear_history_with_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/message-schedules/clear-history"
+            and request.method == "POST"
+        ):
+            state["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"removed": 1})
+        return httpx.Response(404, json={"detail": "unexpected"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "message",
+            "clear-history",
+            "--session-id",
+            "s1",
+        ],
+    )
+    assert result.exit_code == 0
+    assert state["params"]["session_id"] == "s1"

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -191,6 +191,32 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
         ):
             schedule_id = request.url.path.rsplit("/", 1)[-1]
             return httpx.Response(200, json={"schedule": {"id": schedule_id}})
+        if request.url.path == "/api/message-schedules" and request.method == "GET":
+            state["msg_schedule_params"] = dict(request.url.params)
+            return httpx.Response(
+                200, json={"message_schedules": [{"id": "ms1", "session_id": "s1"}]}
+            )
+        if (
+            request.url.path == "/api/message-schedules/clear-history"
+            and request.method == "POST"
+        ):
+            state["msg_clear_params"] = dict(request.url.params)
+            return httpx.Response(200, json={"removed": 2})
+        if (
+            request.url.path.startswith("/api/message-schedules/")
+            and request.method == "DELETE"
+        ):
+            schedule_id = request.url.path.rsplit("/", 1)[-1]
+            return httpx.Response(200, json={"message_schedule": {"id": schedule_id}})
+        if (
+            request.url.path == "/api/sessions/s1/message-schedules"
+            and request.method == "POST"
+        ):
+            payload = json.loads(request.content)
+            state["msg_schedule_create"] = payload
+            return httpx.Response(
+                200, json={"message_schedule": {"id": "ms1", **payload}}
+            )
         if request.url.path == "/api/sessions/missing":
             return httpx.Response(404, json={"detail": "session not found"})
         return httpx.Response(200, json={"session": {"id": "ok"}})
@@ -793,3 +819,115 @@ def test_clear_board_no_keep_last_omits_param(
     with _client(_settings(tmp_path), state) as client:
         client.clear_board("topic:x")
     assert state.get("clear_params", {}).get("keep_last") is None
+
+
+def test_list_message_schedules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedules = client.list_message_schedules()
+    assert schedules == [{"id": "ms1", "session_id": "s1"}]
+
+
+def test_list_message_schedules_passes_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.list_message_schedules(session_id="s1")
+    assert state["msg_schedule_params"]["session_id"] == "s1"
+
+
+def test_list_message_schedules_omits_session_id_when_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.list_message_schedules()
+    assert "session_id" not in state.get("msg_schedule_params", {})
+
+
+def test_create_message_schedule_posts_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedule = client.create_message_schedule(
+            "s1",
+            "hello",
+            delay_seconds=30,
+        )
+    assert schedule["id"] == "ms1"
+    assert state["msg_schedule_create"]["text"] == "hello"
+    assert state["msg_schedule_create"]["submit"] is True
+    assert state["msg_schedule_create"]["delay_seconds"] == 30
+
+
+def test_create_message_schedule_scheduled_at(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedule = client.create_message_schedule(
+            "s1",
+            "hello",
+            scheduled_at="2026-07-01T12:00:00Z",
+        )
+    assert schedule["id"] == "ms1"
+    assert state["msg_schedule_create"]["scheduled_at"] == "2026-07-01T12:00:00Z"
+
+
+def test_create_message_schedule_with_submit_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.create_message_schedule("s1", "hello", submit=False)
+    assert state["msg_schedule_create"]["submit"] is False
+
+
+def test_create_message_schedule_with_attachments(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.create_message_schedule("s1", "hello", attachments=["att1", "att2"])
+    assert state["msg_schedule_create"]["attachments"] == ["att1", "att2"]
+
+
+def test_delete_message_schedule(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        schedule = client.delete_message_schedule("ms1")
+    assert schedule == {"id": "ms1"}
+
+
+def test_clear_message_schedule_history(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        result = client.clear_message_schedule_history()
+    assert result == {"removed": 2}
+
+
+def test_clear_message_schedule_history_passes_session_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.clear_message_schedule_history(session_id="s1")
+    assert state["msg_clear_params"]["session_id"] == "s1"

--- a/backend/tests/test_scheduled_messages.py
+++ b/backend/tests/test_scheduled_messages.py
@@ -1,0 +1,428 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import (
+    ScheduledMessageCreateRequest,
+    ScheduledMessageRecord,
+    ScheduledMessageStatus,
+    SessionInputItem,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def make_runtime(tmp_path) -> SessionRuntime:
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    return SessionRuntime(settings, storage)
+
+
+def make_session(settings: Settings, session_id: str) -> SessionRecord:
+    session_dir = settings.sessions_dir / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=session_id,
+        backend="codex",
+        source=SessionSource.MANAGED,
+        transport="codex_app_server",
+        title="Test session",
+        cwd="/tmp/project",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        transport_state={"thread_id": "thread-1"},
+        raw_log_path=str(session_dir / "raw.log"),
+        structured_log_path=str(session_dir / "events.jsonl"),
+    )
+
+
+# ── Storage tests ────────────────────────────────────────────────────────────
+
+
+def test_scheduled_message_round_trip(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    item = SessionInputItem(type="text", text="hello")
+    record = ScheduledMessageRecord(
+        id="msg-1",
+        session_id="sess-1",
+        text="ship it",
+        items=[item],
+        attachments=["att-1"],
+        scheduled_at=now + timedelta(minutes=5),
+        created_at=now,
+        status=ScheduledMessageStatus.PENDING,
+    )
+    storage.create_scheduled_message(record)
+
+    loaded = storage.get_scheduled_message("msg-1")
+    assert loaded is not None
+    assert loaded.text == "ship it"
+    assert loaded.items == [item]
+    assert loaded.attachments == ["att-1"]
+    assert loaded.status == ScheduledMessageStatus.PENDING
+
+
+def test_scheduled_message_stores_command(tmp_path) -> None:
+    from waypoint.schemas import CompletionDispatch, SessionCommandInvocation
+
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    cmd = SessionCommandInvocation(
+        completion_id="cmd-1",
+        name="test",
+        arguments="--flag",
+        dispatch=CompletionDispatch.PLAIN_TEXT,
+    )
+    record = ScheduledMessageRecord(
+        id="msg-cmd",
+        session_id="sess-1",
+        command=cmd,
+        scheduled_at=now + timedelta(minutes=5),
+        created_at=now,
+    )
+    storage.create_scheduled_message(record)
+    loaded = storage.get_scheduled_message("msg-cmd")
+    assert loaded is not None
+    assert loaded.command is not None
+    assert loaded.command.completion_id == "cmd-1"
+    assert loaded.command.name == "test"
+    assert loaded.command.arguments == "--flag"
+
+
+def test_scheduled_message_list_filters_by_status(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    for status in ScheduledMessageStatus:
+        storage.create_scheduled_message(
+            ScheduledMessageRecord(
+                id=f"msg-{status.value}",
+                session_id="sess-1",
+                scheduled_at=now + timedelta(minutes=5),
+                created_at=now,
+                status=status,
+            )
+        )
+    pending = storage.list_scheduled_messages([ScheduledMessageStatus.PENDING])
+    assert len(pending) == 1
+    assert pending[0].id == "msg-pending"
+
+
+def test_scheduled_message_list_filters_by_session(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    for session_id in ("sess-1", "sess-2"):
+        storage.create_scheduled_message(
+            ScheduledMessageRecord(
+                id=f"msg-{session_id}",
+                session_id=session_id,
+                scheduled_at=now + timedelta(minutes=5),
+                created_at=now,
+                status=ScheduledMessageStatus.PENDING,
+            )
+        )
+    filtered = storage.list_scheduled_messages(session_id="sess-2")
+    assert [item.id for item in filtered] == ["msg-sess-2"]
+
+
+def test_scheduled_message_update(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    storage.create_scheduled_message(
+        ScheduledMessageRecord(
+            id="msg-upd",
+            session_id="sess-1",
+            scheduled_at=now + timedelta(minutes=5),
+            created_at=now,
+        )
+    )
+    updated = storage.update_scheduled_message(
+        "msg-upd", status=ScheduledMessageStatus.SENT
+    )
+    assert updated.status == ScheduledMessageStatus.SENT
+    loaded = storage.get_scheduled_message("msg-upd")
+    assert loaded is not None
+    assert loaded.status == ScheduledMessageStatus.SENT
+
+
+def test_scheduled_message_update_missing_raises(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    with pytest.raises(KeyError):
+        storage.update_scheduled_message(
+            "does-not-exist", status=ScheduledMessageStatus.SENT
+        )
+
+
+def test_scheduled_message_delete(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    storage.create_scheduled_message(
+        ScheduledMessageRecord(
+            id="msg-del",
+            session_id="sess-1",
+            scheduled_at=now + timedelta(minutes=5),
+            created_at=now,
+        )
+    )
+    assert storage.delete_scheduled_message("msg-del") is True
+    assert storage.get_scheduled_message("msg-del") is None
+    assert storage.delete_scheduled_message("msg-del") is False
+
+
+def test_scheduled_message_delete_by_status(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    for session_id, status in (
+        ("sess-1", ScheduledMessageStatus.SENT),
+        ("sess-1", ScheduledMessageStatus.FAILED),
+        ("sess-1", ScheduledMessageStatus.PENDING),
+        ("sess-2", ScheduledMessageStatus.SENT),
+    ):
+        storage.create_scheduled_message(
+            ScheduledMessageRecord(
+                id=f"msg-{session_id}-{status.value}",
+                session_id=session_id,
+                scheduled_at=now + timedelta(minutes=5),
+                created_at=now,
+                status=status,
+            )
+        )
+    removed = storage.delete_scheduled_messages_by_status(
+        [ScheduledMessageStatus.SENT, ScheduledMessageStatus.FAILED],
+        session_id="sess-1",
+    )
+    assert removed == 2
+    remaining = [r.id for r in storage.list_scheduled_messages()]
+    assert remaining == ["msg-sess-1-pending", "msg-sess-2-sent"]
+
+
+# ── Scheduler tests ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_message_schedule_persists(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    record = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(
+            text="hello world",
+            delay_seconds=60,
+        ),
+    )
+    assert record.status == ScheduledMessageStatus.PENDING
+    assert record.session_id == "sess-1"
+    assert record.text == "hello world"
+    assert record.scheduled_at > datetime.now(UTC)
+    stored = runtime.storage.list_scheduled_messages()
+    assert [r.id for r in stored] == [record.id]
+
+
+@pytest.mark.asyncio
+async def test_create_message_schedule_no_session_404(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_message_schedule(
+            "no-such-session",
+            ScheduledMessageCreateRequest(text="hi", delay_seconds=60),
+        )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_message_schedule_empty_body_400(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_message_schedule(
+            "sess-1",
+            ScheduledMessageCreateRequest(delay_seconds=60),
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_message_schedule_rejects_past_time(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_message_schedule(
+            "sess-1",
+            ScheduledMessageCreateRequest(
+                text="hi",
+                scheduled_at=(datetime.now(UTC) - timedelta(hours=1)),
+            ),
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_cancel_message_schedule(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    record = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="hi", delay_seconds=300),
+    )
+    cancelled = runtime.scheduler.cancel_message_schedule(record.id)
+    assert cancelled.status == ScheduledMessageStatus.CANCELLED
+
+    runtime.scheduler.cancel_message_schedule(record.id)
+    assert runtime.storage.get_scheduled_message(record.id) is None
+
+    with pytest.raises(HTTPException):
+        runtime.scheduler.cancel_message_schedule(record.id)
+
+
+@pytest.mark.asyncio
+async def test_clear_message_history(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    other_session = make_session(runtime.settings, "sess-2")
+    runtime.storage.create_session(session)
+    runtime.storage.create_session(other_session)
+
+    pending = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="keep", delay_seconds=600),
+    )
+    cancelled = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="cancel", delay_seconds=600),
+    )
+    runtime.scheduler.cancel_message_schedule(cancelled.id)
+    runtime.storage.update_scheduled_message(
+        runtime.scheduler.create_message_schedule(
+            "sess-2",
+            ScheduledMessageCreateRequest(text="sent", delay_seconds=600),
+        ).id,
+        status=ScheduledMessageStatus.SENT,
+    )
+
+    removed = runtime.scheduler.clear_message_history(session_id="sess-1")
+    assert removed == 1
+    remaining_sess_1 = [
+        r.id for r in runtime.storage.list_scheduled_messages(session_id="sess-1")
+    ]
+    assert remaining_sess_1 == [pending.id]
+    assert len(runtime.storage.list_scheduled_messages(session_id="sess-2")) == 1
+
+
+@pytest.mark.asyncio
+async def test_fire_due_message_schedule_sends_input(tmp_path, monkeypatch) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    record = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(
+            text="ship it",
+            submit=False,
+            delay_seconds=0,
+        ),
+    )
+    runtime.storage.update_scheduled_message(
+        record.id, scheduled_at=datetime.now(UTC) - timedelta(seconds=1)
+    )
+
+    inputs: list[tuple[str, str, bool]] = []
+
+    async def fake_handle_input(session_id: str, request) -> SessionRecord:
+        inputs.append((session_id, request.text, request.submit))
+        return session
+
+    monkeypatch.setattr(runtime, "handle_input", fake_handle_input)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    refreshed = runtime.storage.get_scheduled_message(record.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledMessageStatus.SENT
+    assert inputs == [("sess-1", "ship it", False)]
+
+
+@pytest.mark.asyncio
+async def test_fire_due_message_schedule_missing_session(tmp_path, monkeypatch) -> None:
+    runtime = make_runtime(tmp_path)
+    now = datetime.now(UTC)
+
+    # Insert directly via storage to bypass the scheduler's session check.
+    runtime.storage.create_scheduled_message(
+        ScheduledMessageRecord(
+            id="msg-orphan",
+            session_id="no-such-session",
+            text="hi",
+            scheduled_at=now - timedelta(seconds=1),
+            created_at=now,
+            status=ScheduledMessageStatus.PENDING,
+        )
+    )
+
+    await runtime.scheduler._fire_due_schedules()
+
+    refreshed = runtime.storage.get_scheduled_message("msg-orphan")
+    assert refreshed is not None
+    assert refreshed.status == ScheduledMessageStatus.FAILED
+    assert refreshed.failure_reason == "404: session not found"
+
+
+@pytest.mark.asyncio
+async def test_fire_due_message_schedule_records_failure(tmp_path, monkeypatch) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    record = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="hi", delay_seconds=0),
+    )
+    runtime.storage.update_scheduled_message(
+        record.id, scheduled_at=datetime.now(UTC) - timedelta(seconds=1)
+    )
+
+    async def fake_handle_input(_session_id, _request) -> SessionRecord:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(runtime, "handle_input", fake_handle_input)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    refreshed = runtime.storage.get_scheduled_message(record.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledMessageStatus.FAILED
+    assert refreshed.failure_reason == "boom"
+
+
+# ── API tests ────────────────────────────────────────────────────────────────
+
+
+def test_message_schedule_create_request_schema() -> None:
+    req = ScheduledMessageCreateRequest(
+        text="hello",
+        delay_seconds=60,
+    )
+    assert req.text == "hello"
+    assert req.delay_seconds == 60
+    assert req.scheduled_at is None
+    assert req.command is None
+    assert req.items is None
+    assert req.attachments == []
+    assert req.submit is True

--- a/backend/tests/test_scheduled_messages.py
+++ b/backend/tests/test_scheduled_messages.py
@@ -381,7 +381,35 @@ async def test_fire_due_message_schedule_missing_session(tmp_path, monkeypatch) 
     refreshed = runtime.storage.get_scheduled_message("msg-orphan")
     assert refreshed is not None
     assert refreshed.status == ScheduledMessageStatus.FAILED
-    assert refreshed.failure_reason == "404: session not found"
+    assert refreshed.failure_reason == "session not found"
+
+
+@pytest.mark.asyncio
+async def test_purge_session_messages_drops_only_that_session(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    now = datetime.now(UTC)
+    for msg_id, session_id, status in (
+        ("msg-a1", "sess-a", ScheduledMessageStatus.PENDING),
+        ("msg-a2", "sess-a", ScheduledMessageStatus.SENT),
+        ("msg-b1", "sess-b", ScheduledMessageStatus.PENDING),
+    ):
+        runtime.storage.create_scheduled_message(
+            ScheduledMessageRecord(
+                id=msg_id,
+                session_id=session_id,
+                text="hi",
+                scheduled_at=now + timedelta(minutes=5),
+                created_at=now,
+                status=status,
+            )
+        )
+
+    removed = await runtime.scheduler.purge_session_messages("sess-a")
+
+    assert removed == 2
+    assert runtime.storage.get_scheduled_message("msg-a1") is None
+    assert runtime.storage.get_scheduled_message("msg-a2") is None
+    assert runtime.storage.get_scheduled_message("msg-b1") is not None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9775,6 +9775,135 @@ html[data-theme="light"] .term-compose-input {
   text-transform: none;
 }
 
+/* ─── Message schedule rows ─── */
+
+.schedule-row.schedule-sent {
+  border-color: rgba(94, 210, 156, 0.28);
+}
+
+.badge.schedule-status.sent {
+  background: rgba(94, 210, 156, 0.12);
+  color: var(--success);
+  border-color: rgba(94, 210, 156, 0.22);
+}
+
+.schedule-title.msg-text {
+  font-size: 0.9rem;
+  font-family: var(--font-mono);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.45;
+}
+
+html[data-theme="light"] .schedule-row.schedule-sent {
+  border-color: rgba(37, 122, 80, 0.25);
+}
+
+html[data-theme="light"] .badge.schedule-status.sent {
+  background: rgba(37, 122, 80, 0.08);
+  color: var(--success);
+  border-color: rgba(37, 122, 80, 0.18);
+}
+
+/* ─── Schedule message dialog ─── */
+
+.schedule-msg-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 24px;
+}
+
+html[data-theme="light"] .schedule-msg-dialog-overlay {
+  background: rgba(0, 0, 0, 0.18);
+}
+
+.schedule-msg-dialog {
+  background: var(--bg-card);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 18px;
+  width: 100%;
+  max-width: 480px;
+  display: grid;
+  gap: 12px;
+  box-shadow: var(--shadow);
+}
+
+.schedule-msg-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.schedule-msg-dialog-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-strong);
+}
+
+.schedule-msg-dialog-close {
+  font-size: 1.2rem;
+  color: var(--muted);
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+}
+
+.schedule-msg-dialog-close:hover {
+  background: rgba(120, 138, 168, 0.12);
+}
+
+.schedule-msg-dialog-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  resize: vertical;
+  min-height: 64px;
+}
+
+.schedule-msg-dialog-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.schedule-msg-dialog-field {
+  display: grid;
+  gap: 4px;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.schedule-msg-dialog-number {
+  width: 100%;
+  padding: 7px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 0.88rem;
+}
+
+.schedule-msg-dialog-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 @media (max-width: 720px) {
   .page-shell {
     padding: calc(20px + env(safe-area-inset-top))

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9561,11 +9561,6 @@ html[data-theme="light"] .term-compose-input {
   letter-spacing: 0.04em;
 }
 
-.session-section-controls {
-  margin-left: auto;
-  flex-wrap: wrap;
-}
-
 .session-section-pinned .session-card {
   border-color: rgba(200, 169, 106, 0.32);
   box-shadow: inset 3px 0 0 var(--accent);
@@ -9592,10 +9587,6 @@ html[data-theme="light"] .term-compose-input {
 
 .pin-link.active {
   color: var(--accent);
-}
-
-.pagination-controls {
-  margin-left: auto;
 }
 
 .session-header-title-row,
@@ -9702,15 +9693,6 @@ html[data-theme="light"] .term-compose-input {
   font-size: 0.86rem;
 }
 
-.schedule-heading {
-  margin: 4px 0 0;
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--muted-soft);
-}
-
 .schedule-row {
   display: grid;
   gap: 6px;
@@ -9787,12 +9769,293 @@ html[data-theme="light"] .term-compose-input {
   border-color: rgba(94, 210, 156, 0.22);
 }
 
-.schedule-title.msg-text {
-  font-size: 0.9rem;
+/* ─── Unified schedule panel groups ─── */
+
+.msg-sched-head {
+  display: grid;
+  gap: 3px;
+}
+
+.msg-sched-head p {
+  margin: 0;
+}
+
+.sched-group {
+  gap: 8px;
+}
+
+.sched-group + .sched-group {
+  padding-top: 14px;
+  border-top: 1px solid var(--line);
+}
+
+.sched-group-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.sched-group-title {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.msg-sched-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 6px;
+  border-radius: var(--radius-pill);
+  background: rgba(200, 169, 106, 0.16);
+  color: var(--accent-strong);
+  font-size: 0.66rem;
+  letter-spacing: 0.02em;
+}
+
+html[data-theme="light"] .msg-sched-count {
+  background: rgba(184, 130, 14, 0.14);
+  color: #8a5d05;
+}
+
+/* ─── Message schedule rows ─── */
+
+.msg-row {
+  gap: 6px;
+  padding: 10px 12px;
+}
+
+.msg-row-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.msg-row-right {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.msg-row-top .msg-cancel {
+  margin-top: 0;
+  align-self: baseline;
+}
+
+.msg-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--muted);
+}
+
+.msg-status-dot.pending {
+  background: var(--accent-cool);
+  animation: msg-dot-pulse 2.4s ease-in-out infinite;
+}
+
+.msg-status-dot.sent {
+  background: var(--success);
+}
+
+.msg-status-dot.failed {
+  background: var(--danger);
+}
+
+.msg-status-dot.cancelled {
+  background: var(--muted-soft);
+}
+
+@keyframes msg-dot-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 3px rgba(143, 179, 214, 0.16);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(143, 179, 214, 0.04);
+  }
+}
+
+.msg-session-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 180px;
+  padding: 2px 9px;
+  border: 1px solid rgba(143, 179, 214, 0.22);
+  border-radius: var(--radius-pill);
+  background: rgba(143, 179, 214, 0.08);
+  color: var(--accent-cool);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.03em;
+  transition:
+    border-color 140ms ease,
+    background-color 140ms ease;
+}
+
+.msg-session-link:hover {
+  border-color: rgba(143, 179, 214, 0.45);
+  background: rgba(143, 179, 214, 0.14);
+}
+
+.msg-session-glyph {
+  flex: none;
+  opacity: 0.6;
+}
+
+.msg-session-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.msg-row-when {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 0.78rem;
+  white-space: nowrap;
+}
+
+.msg-countdown {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  color: var(--accent-strong);
+}
+
+.msg-text {
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--text);
   white-space: pre-wrap;
   word-break: break-word;
-  line-height: 1.45;
+}
+
+.schedule-row.schedule-sent .msg-text,
+.schedule-row.schedule-cancelled .msg-text {
+  color: var(--muted);
+}
+
+.msg-error {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+/* ─── Expandable clamped text (shared by rows + dock) ─── */
+
+.expandable-text {
+  margin: 0;
+}
+
+.expandable-text-clamped {
+  overflow: hidden;
+}
+
+.expandable-text-fade {
+  -webkit-mask-image: linear-gradient(180deg, #000 70%, transparent);
+  mask-image: linear-gradient(180deg, #000 70%, transparent);
+}
+
+.expandable-text-expanded {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.expandable-more {
+  display: inline-block;
+  justify-self: start;
+  margin-top: 5px;
+  padding: 0;
+  background: none;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  color: var(--accent-cool);
+  cursor: pointer;
+}
+
+.expandable-more:hover {
+  color: var(--text-strong);
+}
+
+/* ─── Shared list paginator ─── */
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 4px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+
+.pager-range {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--muted-soft);
+  font-variant-numeric: tabular-nums;
+}
+
+.pager-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pager-btn {
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    border-color 140ms ease,
+    color 140ms ease,
+    background-color 140ms ease;
+}
+
+.pager-btn:hover:not(:disabled) {
+  border-color: var(--line-strong);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.pager-btn:disabled {
+  color: var(--muted-soft);
+  opacity: 0.5;
+  cursor: default;
+}
+
+.pager-indicator {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+  font-variant-numeric: tabular-nums;
+  padding: 0 2px;
 }
 
 html[data-theme="light"] .schedule-row.schedule-sent {
@@ -9805,33 +10068,333 @@ html[data-theme="light"] .badge.schedule-status.sent {
   border-color: rgba(37, 122, 80, 0.18);
 }
 
+/* ─── In-session scheduled-messages dock ───
+ * Mirrors .task-dock / .sq-dock: a sticky strip floating above the composer
+ * that expands into a scrim + panel (bottom sheet on mobile, popover on
+ * desktop), so the three docks read and behave as one family. */
+
+.sched-dock {
+  position: sticky;
+  bottom: calc(var(--composer-height, 220px) + 12px);
+  z-index: 5;
+  margin-top: -8px;
+  pointer-events: none;
+  min-width: 0;
+}
+
+.sched-dock.expanded {
+  z-index: 50;
+}
+
+.sched-dock-strip {
+  pointer-events: auto;
+  overflow: hidden;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(
+    180deg,
+    rgba(20, 24, 33, 0.92),
+    rgba(12, 15, 22, 0.96)
+  );
+  box-shadow:
+    0 12px 30px rgba(0, 0, 0, 0.36),
+    0 0 0 1px rgba(200, 169, 106, 0.05) inset;
+  backdrop-filter: blur(22px) saturate(1.2);
+}
+
+html[data-theme="light"] .sched-dock-strip {
+  background: linear-gradient(
+    180deg,
+    rgba(248, 245, 238, 0.96),
+    rgba(240, 236, 226, 0.98)
+  );
+  box-shadow:
+    0 12px 30px rgba(60, 50, 30, 0.14),
+    0 0 0 1px rgba(200, 169, 106, 0.12) inset;
+}
+
+.sched-dock-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 12px;
+}
+
+.sched-dock-toggle {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 2px;
+  background: none;
+  border: none;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.sched-dock-glyph {
+  flex: none;
+  color: var(--accent-strong);
+  font-size: 0.95rem;
+}
+
+.sched-dock-label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  color: var(--text);
+}
+
+.sched-dock-when {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: var(--accent-strong);
+}
+
+.sched-dock-count {
+  flex: none;
+  color: var(--muted);
+  font-size: 0.9em;
+  font-variant-numeric: tabular-nums;
+}
+
+.sched-dock-chevron {
+  flex: none;
+  display: inline-flex;
+  color: var(--muted-soft);
+  transition: transform 160ms ease;
+}
+
+.sched-dock-toggle[aria-expanded="true"] .sched-dock-chevron {
+  transform: rotate(180deg);
+}
+
+.sched-dock-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 6;
+  border: none;
+  background: rgba(0, 0, 0, 0.4);
+  cursor: default;
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .sched-dock-scrim {
+  background: rgba(20, 16, 8, 0.22);
+}
+
+.sched-dock-panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 100%;
+  z-index: 7;
+  max-height: 50vh;
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: linear-gradient(
+    180deg,
+    rgba(20, 24, 33, 0.96),
+    rgba(12, 15, 22, 0.98)
+  );
+  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(22px) saturate(1.2);
+  pointer-events: auto;
+}
+
+html[data-theme="light"] .sched-dock-panel {
+  background: linear-gradient(
+    180deg,
+    rgba(248, 245, 238, 0.98),
+    rgba(240, 236, 226, 0.99)
+  );
+  box-shadow: 0 -10px 30px rgba(60, 50, 30, 0.16);
+}
+
+.sched-dock.expanded .sched-dock-panel {
+  border-bottom: none;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  box-shadow: none;
+}
+
+.sched-dock.expanded .sched-dock-strip {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.sched-dock-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sched-dock-panel-title {
+  flex: 1;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.sched-dock-collapse {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 6px;
+  background: none;
+  border: none;
+  color: var(--muted-soft);
+  cursor: pointer;
+}
+
+/* The collapse control always points down ("close"). */
+.sched-dock-collapse svg {
+  transform: rotate(180deg);
+}
+
+.sched-dock-list {
+  display: grid;
+  gap: 2px;
+}
+
+.sched-dock-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 10px;
+  padding: 8px 2px;
+}
+
+.sched-dock-item + .sched-dock-item {
+  border-top: 1px solid var(--line);
+}
+
+.sched-dock-item-when {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--accent-strong);
+  white-space: nowrap;
+}
+
+.sched-dock-item-body {
+  min-width: 0;
+}
+
+.sched-dock-item-text {
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1.45;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.sched-dock-item .sched-dock-cancel {
+  align-self: start;
+  white-space: nowrap;
+  margin-top: 0;
+}
+
+@media (min-width: 768px) {
+  .sched-dock-scrim,
+  html[data-theme="light"] .sched-dock-scrim {
+    background: transparent;
+  }
+
+  .sched-dock-panel {
+    left: auto;
+    right: 0;
+    bottom: calc(100% + 8px);
+    width: min(420px, 92vw);
+  }
+
+  .sched-dock.expanded .sched-dock-panel {
+    border-bottom: 1px solid var(--line-strong);
+    border-radius: var(--radius);
+    box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+  }
+
+  html[data-theme="light"] .sched-dock.expanded .sched-dock-panel {
+    box-shadow: 0 12px 30px rgba(60, 50, 30, 0.16);
+  }
+
+  .sched-dock.expanded .sched-dock-strip {
+    border-top-left-radius: var(--radius);
+    border-top-right-radius: var(--radius);
+  }
+}
+
 /* ─── Schedule message dialog ─── */
 
 .schedule-msg-dialog-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(4, 6, 10, 0.55);
+  backdrop-filter: blur(3px);
   z-index: 100;
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: center;
   padding: 24px;
+  animation: schedule-msg-fade 160ms ease;
 }
 
 html[data-theme="light"] .schedule-msg-dialog-overlay {
-  background: rgba(0, 0, 0, 0.18);
+  background: rgba(30, 26, 18, 0.28);
 }
 
 .schedule-msg-dialog {
   background: var(--bg-card);
-  border: 1px solid var(--line);
+  border: 1px solid var(--line-strong);
   border-radius: var(--radius);
-  padding: 18px;
+  padding: 20px;
   width: 100%;
-  max-width: 480px;
+  max-width: 460px;
   display: grid;
-  gap: 12px;
+  gap: 14px;
   box-shadow: var(--shadow);
+  animation: schedule-msg-pop 200ms cubic-bezier(0.2, 0.9, 0.3, 1.1);
+}
+
+@keyframes schedule-msg-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes schedule-msg-pop {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .schedule-msg-dialog-overlay,
+  .schedule-msg-dialog {
+    animation: none;
+  }
 }
 
 .schedule-msg-dialog-header {
@@ -9841,67 +10404,223 @@ html[data-theme="light"] .schedule-msg-dialog-overlay {
 }
 
 .schedule-msg-dialog-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-display);
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 1.1rem;
   color: var(--text-strong);
 }
 
+.schedule-msg-dialog-glyph {
+  color: var(--accent);
+  font-size: 1rem;
+}
+
 .schedule-msg-dialog-close {
-  font-size: 1.2rem;
+  font-size: 1.3rem;
+  line-height: 1;
   color: var(--muted);
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 6px;
+  border-radius: 8px;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
 }
 
 .schedule-msg-dialog-close:hover {
   background: rgba(120, 138, 168, 0.12);
+  color: var(--text);
 }
 
 .schedule-msg-dialog-input {
   width: 100%;
-  padding: 10px 12px;
+  padding: 11px 13px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-input);
   color: var(--text);
   font-family: var(--font-mono);
   font-size: 0.88rem;
-  line-height: 1.45;
+  line-height: 1.5;
   resize: vertical;
-  min-height: 64px;
+  min-height: 72px;
+  transition: border-color 140ms ease;
 }
 
-.schedule-msg-dialog-options {
+.schedule-msg-dialog-input:focus {
+  outline: none;
+  border-color: var(--line-strong);
+}
+
+.schedule-msg-modes {
+  width: 100%;
+}
+
+.schedule-msg-modes .segmented-item {
+  flex: 1;
+}
+
+.schedule-msg-delay {
   display: grid;
-  grid-template-columns: 1fr 1fr;
   gap: 10px;
 }
 
-.schedule-msg-dialog-field {
+.schedule-msg-presets {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.schedule-msg-preset {
+  padding: 5px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  transition:
+    border-color 140ms ease,
+    color 140ms ease,
+    background-color 140ms ease;
+}
+
+.schedule-msg-preset:hover {
+  color: var(--text);
+  border-color: var(--line-strong);
+}
+
+.schedule-msg-preset.active {
+  border-color: rgba(200, 169, 106, 0.4);
+  background: rgba(200, 169, 106, 0.12);
+  color: var(--accent-strong);
+}
+
+html[data-theme="light"] .schedule-msg-preset.active {
+  border-color: rgba(184, 130, 14, 0.38);
+  background: rgba(184, 130, 14, 0.12);
+  color: #8a5d05;
+}
+
+.schedule-msg-field {
   display: grid;
-  gap: 4px;
-  font-size: 0.82rem;
+  gap: 5px;
+}
+
+.schedule-msg-field-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.schedule-msg-field-inline {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.schedule-msg-field-inline .schedule-msg-dialog-number {
+  width: 96px;
+}
+
+.schedule-msg-field-suffix {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
   color: var(--muted);
 }
 
 .schedule-msg-dialog-number {
-  width: 100%;
-  padding: 7px 10px;
+  padding: 8px 11px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-input);
   color: var(--text);
+  font-family: var(--font-mono);
   font-size: 0.88rem;
+  transition: border-color 140ms ease;
+}
+
+.schedule-msg-dialog-number:focus {
+  outline: none;
+  border-color: var(--line-strong);
+}
+
+.schedule-msg-preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: rgba(200, 169, 106, 0.08);
+  border: 1px solid rgba(200, 169, 106, 0.18);
+  font-size: 0.84rem;
+  color: var(--text);
+}
+
+html[data-theme="light"] .schedule-msg-preview {
+  background: rgba(184, 130, 14, 0.08);
+  border-color: rgba(184, 130, 14, 0.2);
+}
+
+.schedule-msg-preview strong {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.schedule-msg-preview-glyph {
+  color: var(--accent);
+}
+
+.schedule-msg-preview-rel {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
+  color: var(--accent-strong);
+}
+
+.schedule-msg-submit-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.schedule-msg-submit-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.schedule-msg-submit .segmented-item {
+  min-height: 28px;
+  padding: 0 12px;
+  font-size: 0.7rem;
+}
+
+.schedule-msg-dialog-error {
+  margin: 0;
+  font-size: 0.82rem;
 }
 
 .schedule-msg-dialog-actions {
   display: flex;
   gap: 8px;
   justify-content: flex-end;
+  margin-top: 2px;
 }
 
 @media (max-width: 720px) {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,8 +9,7 @@ import { BackendSwitcher } from "@/components/BackendSwitcher";
 import { BoardPanel } from "@/components/BoardPanel";
 import { LaunchPanel } from "@/components/LaunchPanel";
 import { LoginForm } from "@/components/LoginForm";
-import { ScheduledMessagesPanel } from "@/components/ScheduledMessagesPanel";
-import { ScheduledSessionsPanel } from "@/components/ScheduledSessionsPanel";
+import { SchedulePanel } from "@/components/SchedulePanel";
 import { SessionList } from "@/components/SessionList";
 import { SshConnectModal } from "@/components/SshConnectModal";
 import { ThemeToggle } from "@/components/ThemeToggle";
@@ -985,20 +984,17 @@ export default function HomePage() {
         />
       ) : null}
       {token ? (
-        <ScheduledSessionsPanel
+        <SchedulePanel
           host={host}
           token={token}
           schedules={schedules}
-          catalog={catalog}
-          onCancel={handleCancelSchedule}
-          onClearHistory={handleClearScheduleHistory}
-        />
-      ) : null}
-      {token ? (
-        <ScheduledMessagesPanel
           messageSchedules={messageSchedules}
-          onDelete={handleDeleteMessageSchedule}
-          onClearHistory={handleClearMessageScheduleHistory}
+          sessions={sessions}
+          catalog={catalog}
+          onCancelSchedule={handleCancelSchedule}
+          onClearScheduleHistory={handleClearScheduleHistory}
+          onDeleteMessage={handleDeleteMessageSchedule}
+          onClearMessageHistory={handleClearMessageScheduleHistory}
         />
       ) : null}
       {token ? (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -31,6 +31,7 @@ import {
   disconnectLaunchTarget,
   fetchBackendThreads,
   fetchBoardChannels,
+  fetchLaunchTargetStatus,
   fetchMe,
   fetchMessageSchedules,
   fetchSchedules,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import { BackendSwitcher } from "@/components/BackendSwitcher";
 import { BoardPanel } from "@/components/BoardPanel";
 import { LaunchPanel } from "@/components/LaunchPanel";
 import { LoginForm } from "@/components/LoginForm";
+import { ScheduledMessagesPanel } from "@/components/ScheduledMessagesPanel";
 import { ScheduledSessionsPanel } from "@/components/ScheduledSessionsPanel";
 import { SessionList } from "@/components/SessionList";
 import { SshConnectModal } from "@/components/SshConnectModal";
@@ -18,18 +19,20 @@ import { useTheme } from "@/lib/theme";
 import {
   attachTmux,
   cancelSchedule as cancelScheduleRequest,
+  clearMessageScheduleHistory as clearMessageScheduleHistoryRequest,
   clearScheduleHistory as clearScheduleHistoryRequest,
   connectLaunchTarget,
   connectSessionsSocket,
   createSchedule as createScheduleRequest,
   createSession,
+  deleteMessageSchedule as deleteMessageScheduleRequest,
   deleteSession as deleteSessionRequest,
   deleteThread,
   disconnectLaunchTarget,
-  fetchLaunchTargetStatus,
   fetchBackendThreads,
   fetchBoardChannels,
   fetchMe,
+  fetchMessageSchedules,
   fetchSchedules,
   fetchSessions,
   importBackendThread,
@@ -59,6 +62,7 @@ import {
   BackendDescriptor,
   BoardChannel,
   LaunchTargetSummary,
+  MessageSchedule,
   ScheduleCreateRequest,
   ScheduledSession,
   SessionEnvelope,
@@ -136,6 +140,7 @@ export default function HomePage() {
   } | null>(null);
   const [connectError, setConnectError] = useState("");
   const [schedules, setSchedules] = useState<ScheduledSession[]>([]);
+  const [messageSchedules, setMessageSchedules] = useState<MessageSchedule[]>([]);
   const [boardChannels, setBoardChannels] = useState<BoardChannel[]>([]);
   const [recentCwds, setRecentCwds] = useState<string[]>([]);
   const [threadsByBackend, setThreadsByBackend] = useState<
@@ -241,9 +246,10 @@ export default function HomePage() {
       fetchSessions(host, token),
       fetchMe(host, token),
       fetchSchedules(host, token).catch(() => [] as ScheduledSession[]),
+      fetchMessageSchedules(host, token).catch(() => [] as MessageSchedule[]),
       fetchBoardChannels(host, token).catch(() => []),
     ])
-      .then(([items, me, scheduleItems, boardChannels]) => {
+      .then(([items, me, scheduleItems, messageItems, boardChannels]) => {
         if (!active) {
           return;
         }
@@ -257,6 +263,7 @@ export default function HomePage() {
           setBackendDescriptors(me.backends);
         }
         setSchedules(scheduleItems);
+        setMessageSchedules(messageItems);
         const storedTargetId = readLaunchTarget(host);
         const nextTargetId = me.launch_targets.some(
           (target) => target.id === storedTargetId,
@@ -311,6 +318,11 @@ export default function HomePage() {
           }
           if (message.type === "schedule_list_update") {
             setSchedules(message.payload.schedules as ScheduledSession[]);
+          }
+          if (message.type === "message_schedule_list_update") {
+            setMessageSchedules(
+              message.payload.message_schedules as MessageSchedule[],
+            );
           }
           if (message.type === "board_update") {
             scheduleBoardRefresh();
@@ -741,6 +753,36 @@ export default function HomePage() {
     }
   }
 
+  async function handleDeleteMessageSchedule(scheduleId: string) {
+    try {
+      await deleteMessageScheduleRequest(host, token, scheduleId);
+      setMessageSchedules((current) =>
+        current.filter((ms) => ms.id !== scheduleId),
+      );
+    } catch (deleteError) {
+      if (isAuthError(deleteError)) {
+        resetAuthState("Session expired. Log in again.");
+        return;
+      }
+      setError(deleteError instanceof Error ? deleteError.message : "failed to delete message schedule");
+    }
+  }
+
+  async function handleClearMessageScheduleHistory() {
+    try {
+      await clearMessageScheduleHistoryRequest(host, token);
+      setMessageSchedules((current) =>
+        current.filter((ms) => ms.status === "pending"),
+      );
+    } catch (clearError) {
+      if (isAuthError(clearError)) {
+        resetAuthState("Session expired. Log in again.");
+        return;
+      }
+      setError(clearError instanceof Error ? clearError.message : "failed to clear message schedule history");
+    }
+  }
+
   async function handleDelete(sessionId: string) {
     try {
       await deleteSessionRequest(host, token, sessionId);
@@ -949,6 +991,13 @@ export default function HomePage() {
           catalog={catalog}
           onCancel={handleCancelSchedule}
           onClearHistory={handleClearScheduleHistory}
+        />
+      ) : null}
+      {token ? (
+        <ScheduledMessagesPanel
+          messageSchedules={messageSchedules}
+          onDelete={handleDeleteMessageSchedule}
+          onClearHistory={handleClearMessageScheduleHistory}
         />
       ) : null}
       {token ? (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -318,11 +318,11 @@ export default function HomePage() {
           }
           if (message.type === "schedule_list_update") {
             setSchedules(message.payload.schedules as ScheduledSession[]);
-          }
-          if (message.type === "message_schedule_list_update") {
-            setMessageSchedules(
-              message.payload.message_schedules as MessageSchedule[],
-            );
+            if ("message_schedules" in message.payload) {
+              setMessageSchedules(
+                message.payload.message_schedules as MessageSchedule[],
+              );
+            }
           }
           if (message.type === "board_update") {
             scheduleBoardRefresh();

--- a/frontend/src/components/ExpandableText.tsx
+++ b/frontend/src/components/ExpandableText.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { CSSProperties, useLayoutEffect, useRef, useState } from "react";
+
+interface ExpandableTextProps {
+  text: string;
+  className?: string;
+  collapsedMaxHeight?: string;
+  expandedMaxHeight?: string;
+  moreLabel?: string;
+  lessLabel?: string;
+}
+
+// Text that clamps to a few lines with a fade and reveals a "Show more" toggle
+// only when it actually overflows — the same affordance the side-question dock
+// uses for long aside answers, so long scheduled messages read consistently.
+export function ExpandableText({
+  text,
+  className,
+  collapsedMaxHeight = "4.5em",
+  expandedMaxHeight = "34vh",
+  moreLabel = "Show more",
+  lessLabel = "Show less",
+}: ExpandableTextProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [overflowing, setOverflowing] = useState(false);
+  const ref = useRef<HTMLParagraphElement>(null);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || expanded) {
+      return;
+    }
+    setOverflowing(el.scrollHeight - el.clientHeight > 4);
+  }, [text, expanded]);
+
+  const style: CSSProperties = {
+    maxHeight: expanded ? expandedMaxHeight : collapsedMaxHeight,
+  };
+
+  return (
+    <>
+      <p
+        ref={ref}
+        style={style}
+        className={[
+          "expandable-text",
+          className ?? "",
+          expanded
+            ? "expandable-text-expanded"
+            : `expandable-text-clamped${overflowing ? " expandable-text-fade" : ""}`,
+        ]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {text}
+      </p>
+      {overflowing || expanded ? (
+        <button
+          type="button"
+          className="expandable-more"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? lessLabel : moreLabel}
+        </button>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/Pager.tsx
+++ b/frontend/src/components/Pager.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+interface PagerProps {
+  page: number;
+  totalPages: number;
+  total: number;
+  pageStart: number;
+  pageEnd: number;
+  onPage: (page: number) => void;
+  label?: string;
+}
+
+// Shared list paginator: a range readout plus Prev / page-indicator / Next.
+// Renders nothing for a single page. Used by the schedule panel and session
+// list so paginated panels read consistently.
+export function Pager({
+  page,
+  totalPages,
+  total,
+  pageStart,
+  pageEnd,
+  onPage,
+  label = "items",
+}: PagerProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+  return (
+    <div className="pager">
+      <span className="pager-range">
+        {pageStart}–{pageEnd} of {total} {label}
+      </span>
+      <div className="pager-controls">
+        <button
+          type="button"
+          className="pager-btn"
+          onClick={() => onPage(Math.max(1, page - 1))}
+          disabled={page === 1}
+        >
+          ← Prev
+        </button>
+        <span className="pager-indicator">
+          {page} / {totalPages}
+        </span>
+        <button
+          type="button"
+          className="pager-btn"
+          onClick={() => onPage(Math.min(totalPages, page + 1))}
+          disabled={page === totalPages}
+        >
+          Next →
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ScheduleMessageModal.tsx
+++ b/frontend/src/components/ScheduleMessageModal.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { createMessageSchedule } from "@/lib/api";
+
+interface ScheduleMessageModalProps {
+  host: string;
+  token: string;
+  sessionId: string;
+  initialDraft?: string;
+  onClose: () => void;
+  onScheduled?: () => void;
+  onError: (message: string) => void;
+}
+
+type Timing = "delay" | "datetime";
+
+const DELAY_PRESETS: { label: string; minutes: number }[] = [
+  { label: "5m", minutes: 5 },
+  { label: "15m", minutes: 15 },
+  { label: "30m", minutes: 30 },
+  { label: "1h", minutes: 60 },
+  { label: "3h", minutes: 180 },
+];
+
+// Small portaled form modal for queuing a message to the current session.
+// Follows the SshConnectModal conventions: rendered to document.body (so it
+// escapes the composer's backdrop-filtered ancestor), Escape to close, a focus
+// trap, and focus restored to the trigger on unmount.
+export function ScheduleMessageModal({
+  host,
+  token,
+  sessionId,
+  initialDraft = "",
+  onClose,
+  onScheduled,
+  onError,
+}: ScheduleMessageModalProps) {
+  const [draft, setDraft] = useState(initialDraft);
+  const [timing, setTiming] = useState<Timing>("delay");
+  const [delay, setDelay] = useState("15");
+  const [at, setAt] = useState(defaultScheduledAt);
+  const [submit, setSubmit] = useState(true);
+  const [error, setError] = useState("");
+  const [sending, setSending] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    textareaRef.current?.focus();
+    return () => previouslyFocused?.focus();
+  }, []);
+
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") {
+        return;
+      }
+      const root = modalRef.current;
+      if (!root) {
+        return;
+      }
+      const focusable = root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) {
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !root.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  async function handleSchedule() {
+    const text = draft.trim();
+    if (!text || sending) {
+      return;
+    }
+    setError("");
+    const options: {
+      submit: boolean;
+      delaySeconds?: number;
+      scheduledAt?: string;
+    } = { submit };
+    if (timing === "delay") {
+      const minutes = Number.parseFloat(delay);
+      if (!Number.isFinite(minutes) || minutes < 0) {
+        setError("Enter a non-negative delay in minutes.");
+        return;
+      }
+      options.delaySeconds = Math.round(minutes * 60);
+    } else {
+      const local = new Date(at);
+      if (Number.isNaN(local.getTime())) {
+        setError("Enter a valid scheduled time.");
+        return;
+      }
+      options.scheduledAt = local.toISOString();
+    }
+    setSending(true);
+    try {
+      await createMessageSchedule(host, token, sessionId, text, options);
+      onScheduled?.();
+      onClose();
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "failed to schedule message");
+    } finally {
+      setSending(false);
+    }
+  }
+
+  const preview = computeSchedulePreview(timing, delay, at);
+
+  return createPortal(
+    <div
+      className="schedule-msg-dialog-overlay"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+      role="presentation"
+    >
+      <div
+        ref={modalRef}
+        className="schedule-msg-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Schedule message"
+      >
+        <div className="schedule-msg-dialog-header">
+          <span className="schedule-msg-dialog-title">
+            <span className="schedule-msg-dialog-glyph" aria-hidden="true">
+              ◷
+            </span>
+            Schedule message
+          </span>
+          <button
+            type="button"
+            className="schedule-msg-dialog-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <textarea
+          ref={textareaRef}
+          className="schedule-msg-dialog-input"
+          rows={3}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="Message text…"
+          aria-label="Message text"
+        />
+        <div className="segmented schedule-msg-modes" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={timing === "delay"}
+            className={`segmented-item${timing === "delay" ? " active" : ""}`}
+            onClick={() => setTiming("delay")}
+          >
+            After delay
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={timing === "datetime"}
+            className={`segmented-item${timing === "datetime" ? " active" : ""}`}
+            onClick={() => setTiming("datetime")}
+          >
+            At a time
+          </button>
+        </div>
+        {timing === "delay" ? (
+          <div className="schedule-msg-delay">
+            <div className="schedule-msg-presets">
+              {DELAY_PRESETS.map((preset) => (
+                <button
+                  key={preset.minutes}
+                  type="button"
+                  className={`schedule-msg-preset${
+                    delay === String(preset.minutes) ? " active" : ""
+                  }`}
+                  onClick={() => setDelay(String(preset.minutes))}
+                >
+                  {preset.label}
+                </button>
+              ))}
+            </div>
+            <label className="schedule-msg-field-inline">
+              <input
+                type="number"
+                className="schedule-msg-dialog-number"
+                min={0}
+                step={1}
+                value={delay}
+                onChange={(e) => setDelay(e.target.value)}
+                placeholder="15"
+                aria-label="Delay in minutes"
+              />
+              <span className="schedule-msg-field-suffix">minutes</span>
+            </label>
+          </div>
+        ) : (
+          <label className="schedule-msg-field">
+            <span className="schedule-msg-field-label">Local time</span>
+            <input
+              type="datetime-local"
+              className="schedule-msg-dialog-number"
+              value={at}
+              onChange={(e) => setAt(e.target.value)}
+              aria-label="Scheduled local time"
+            />
+          </label>
+        )}
+        {preview ? (
+          <p className="schedule-msg-preview">
+            <span className="schedule-msg-preview-glyph" aria-hidden="true">
+              →
+            </span>
+            Sends&nbsp;<strong>{preview.absolute}</strong>
+            <span className="schedule-msg-preview-rel">{preview.relative}</span>
+          </p>
+        ) : null}
+        <div className="schedule-msg-submit-row">
+          <span className="schedule-msg-submit-label">On delivery</span>
+          <div className="segmented segmented-quiet schedule-msg-submit">
+            <button
+              type="button"
+              className={`segmented-item${submit ? " active" : ""}`}
+              onClick={() => setSubmit(true)}
+            >
+              Submit
+            </button>
+            <button
+              type="button"
+              className={`segmented-item${!submit ? " active" : ""}`}
+              onClick={() => setSubmit(false)}
+            >
+              Hold as draft
+            </button>
+          </div>
+        </div>
+        {error ? (
+          <p className="error schedule-msg-dialog-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        <div className="schedule-msg-dialog-actions">
+          <button type="button" className="secondary" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="primary"
+            onClick={() => void handleSchedule()}
+            disabled={!draft.trim() || sending}
+          >
+            {sending ? "Scheduling…" : "Schedule"}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function defaultScheduledAt(): string {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + 15);
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+function computeSchedulePreview(
+  timing: Timing,
+  delay: string,
+  at: string,
+): { absolute: string; relative: string } | null {
+  let target: Date;
+  if (timing === "delay") {
+    const minutes = Number.parseFloat(delay);
+    if (!Number.isFinite(minutes) || minutes < 0) {
+      return null;
+    }
+    target = new Date(Date.now() + minutes * 60_000);
+  } else {
+    target = new Date(at);
+    if (Number.isNaN(target.getTime())) {
+      return null;
+    }
+  }
+  const sameDay = new Date().toDateString() === target.toDateString();
+  const absolute = target.toLocaleString(undefined, {
+    weekday: sameDay ? undefined : "short",
+    month: sameDay ? undefined : "short",
+    day: sameDay ? undefined : "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return { absolute, relative: relativeFromNow(target) };
+}
+
+function relativeFromNow(target: Date): string {
+  const diff = target.getTime() - Date.now();
+  if (diff <= 0) {
+    return "now";
+  }
+  const minutes = Math.round(diff / 60_000);
+  if (minutes < 1) {
+    return "in under a minute";
+  }
+  if (minutes < 60) {
+    return `in ${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const rem = minutes % 60;
+  if (hours < 48) {
+    return rem ? `in ${hours}h ${rem}m` : `in ${hours}h`;
+  }
+  const days = Math.round(hours / 24);
+  return `in ${days} days`;
+}

--- a/frontend/src/components/SchedulePanel.tsx
+++ b/frontend/src/components/SchedulePanel.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import type { BackendCatalog } from "@/lib/backends";
+import { MessageSchedule, ScheduledSession, SessionRecord } from "@/lib/types";
+import { ScheduledMessagesGroup } from "@/components/ScheduledMessagesPanel";
+import { ScheduledSessionsGroup } from "@/components/ScheduledSessionsPanel";
+
+interface SchedulePanelProps {
+  host: string;
+  token: string;
+  schedules: ScheduledSession[];
+  messageSchedules: MessageSchedule[];
+  sessions: SessionRecord[];
+  catalog: BackendCatalog;
+  onCancelSchedule: (scheduleId: string) => Promise<void>;
+  onClearScheduleHistory: () => Promise<void>;
+  onDeleteMessage: (scheduleId: string) => Promise<void>;
+  onClearMessageHistory: () => Promise<void>;
+}
+
+// Single dashboard card for everything the scheduler will do: future session
+// launches and messages queued to existing sessions. Each group renders itself
+// and collapses when empty, so the card is hidden entirely when nothing is
+// queued.
+export function SchedulePanel({
+  host,
+  token,
+  schedules,
+  messageSchedules,
+  sessions,
+  catalog,
+  onCancelSchedule,
+  onClearScheduleHistory,
+  onDeleteMessage,
+  onClearMessageHistory,
+}: SchedulePanelProps) {
+  if (!schedules.length && !messageSchedules.length) {
+    return null;
+  }
+
+  const sessionsById: Record<string, SessionRecord> = {};
+  for (const session of sessions) {
+    sessionsById[session.id] = session;
+  }
+
+  return (
+    <section className="panel stack schedule-panel" aria-label="Scheduled">
+      <div className="msg-sched-head">
+        <h3>Scheduled</h3>
+        <p className="muted">
+          Upcoming session launches and messages queued to sessions.
+        </p>
+      </div>
+      <ScheduledSessionsGroup
+        host={host}
+        token={token}
+        schedules={schedules}
+        catalog={catalog}
+        onCancel={onCancelSchedule}
+        onClearHistory={onClearScheduleHistory}
+      />
+      <ScheduledMessagesGroup
+        messageSchedules={messageSchedules}
+        sessionsById={sessionsById}
+        onDelete={onDeleteMessage}
+        onClearHistory={onClearMessageHistory}
+      />
+    </section>
+  );
+}

--- a/frontend/src/components/ScheduledMessagesDock.tsx
+++ b/frontend/src/components/ScheduledMessagesDock.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { ExpandableText } from "@/components/ExpandableText";
+import { MessageSchedule } from "@/lib/types";
+
+// A single chevron glyph (pointing up); orientation handled with a CSS rotation,
+// matching the task-progress and side-question docks so the three read as one
+// family.
+function ChevronIcon() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M4 10l4-4 4 4" />
+    </svg>
+  );
+}
+
+interface ScheduledMessagesDockProps {
+  messages: MessageSchedule[];
+  onCancel: (scheduleId: string) => Promise<void> | void;
+}
+
+// A persistent, glanceable readout of this session's pending scheduled
+// messages, docked above the composer so it stays visible as the transcript
+// scrolls. Collapsed it shows the next delivery + countdown; tapping it expands
+// the full list (a bottom sheet on mobile, a popover on desktop). Mirrors the
+// TaskProgressDock structure and surface.
+export function ScheduledMessagesDock({
+  messages,
+  onCancel,
+}: ScheduledMessagesDockProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!messages.length) {
+      return;
+    }
+    const id = window.setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => window.clearInterval(id);
+  }, [messages.length]);
+
+  useEffect(() => {
+    if (!expanded) {
+      return;
+    }
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setExpanded(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  if (!messages.length) {
+    return null;
+  }
+
+  const next = messages[0];
+  const label = next.text || "(no text)";
+
+  return (
+    <div className={`sched-dock${expanded ? " expanded" : ""}`}>
+      {expanded ? (
+        <>
+          <button
+            type="button"
+            className="sched-dock-scrim"
+            aria-label="Close scheduled messages"
+            onClick={() => setExpanded(false)}
+          />
+          <div
+            className="sched-dock-panel"
+            role="dialog"
+            aria-label="Scheduled messages"
+          >
+            <div className="sched-dock-panel-head">
+              <span className="sched-dock-panel-title">Scheduled messages</span>
+              <span className="sched-dock-count">{messages.length}</span>
+              <button
+                type="button"
+                className="sched-dock-collapse"
+                aria-label="Collapse scheduled messages"
+                onClick={() => setExpanded(false)}
+              >
+                <ChevronIcon />
+              </button>
+            </div>
+            <div className="sched-dock-list">
+              {messages.map((m) => (
+                <div key={m.id} className="sched-dock-item">
+                  <span className="sched-dock-item-when">
+                    {relativeFromNow(m)}
+                  </span>
+                  <div className="sched-dock-item-body">
+                    <ExpandableText
+                      className="sched-dock-item-text"
+                      text={m.text || "(no text)"}
+                      collapsedMaxHeight="3em"
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    className="link-button danger-link sched-dock-cancel"
+                    onClick={() => void onCancel(m.id)}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      ) : null}
+      <div className="sched-dock-strip">
+        <div className="sched-dock-row">
+          <button
+            type="button"
+            className="sched-dock-toggle"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((value) => !value)}
+          >
+            <span className="sched-dock-glyph" aria-hidden>
+              ◷
+            </span>
+            <span className="sched-dock-label">{label}</span>
+            <span className="sched-dock-when">{relativeFromNow(next)}</span>
+            <span className="sched-dock-count">{messages.length}</span>
+            <span className="sched-dock-chevron" aria-hidden>
+              <ChevronIcon />
+            </span>
+          </button>
+        </div>
+      </div>
+      <span className="sr-only" aria-live="polite">
+        {messages.length} scheduled message{messages.length === 1 ? "" : "s"},
+        next {relativeFromNow(next)}
+      </span>
+    </div>
+  );
+}
+
+function relativeFromNow(schedule: MessageSchedule): string {
+  if (!schedule.scheduled_at) {
+    return "";
+  }
+  const diff = new Date(schedule.scheduled_at).getTime() - Date.now();
+  if (diff <= 0) {
+    return "any moment";
+  }
+  const minutes = Math.round(diff / 60_000);
+  if (minutes < 1) {
+    return "in <1m";
+  }
+  if (minutes < 60) {
+    return `in ${minutes}m`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `in ${hours}h`;
+  }
+  const days = Math.round(hours / 24);
+  return `in ${days}d`;
+}

--- a/frontend/src/components/ScheduledMessagesPanel.tsx
+++ b/frontend/src/components/ScheduledMessagesPanel.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { MessageSchedule } from "@/lib/types";
+
+interface ScheduledMessagesPanelProps {
+  messageSchedules: MessageSchedule[];
+  onDelete: (scheduleId: string) => Promise<void>;
+  onClearHistory: () => Promise<void>;
+}
+
+export function ScheduledMessagesPanel({
+  messageSchedules,
+  onDelete,
+  onClearHistory,
+}: ScheduledMessagesPanelProps) {
+  const pending = messageSchedules.filter((ms) => ms.status === "pending");
+  const recent = messageSchedules.filter((ms) => ms.status !== "pending").slice(0, 4);
+
+  if (!pending.length && !recent.length) {
+    return null;
+  }
+
+  return (
+    <section className="panel stack schedule-panel" aria-label="Scheduled messages">
+      <div>
+        <h3>Scheduled messages</h3>
+        <p className="muted">Messages queued to send to sessions.</p>
+      </div>
+      {pending.length ? (
+        <div className="stack">
+          <h4 className="schedule-heading">Pending</h4>
+          {pending.map((ms) => (
+            <MessageRow key={ms.id} schedule={ms} onDelete={onDelete} />
+          ))}
+        </div>
+      ) : null}
+      {recent.length ? (
+        <div className="stack">
+          <div className="field-row">
+            <h4 className="schedule-heading">Recent</h4>
+            <button
+              type="button"
+              className="link-button danger-link"
+              onClick={() => void onClearHistory()}
+            >
+              Clear history
+            </button>
+          </div>
+          {recent.map((ms) => (
+            <MessageRow key={ms.id} schedule={ms} onDelete={onDelete} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function MessageRow({
+  schedule,
+  onDelete,
+}: {
+  schedule: MessageSchedule;
+  onDelete: (id: string) => Promise<void>;
+}) {
+  const when = schedule.scheduled_at
+    ? new Date(schedule.scheduled_at)
+    : schedule.created_at
+      ? new Date(schedule.created_at)
+      : null;
+  const formatted = when ? when.toLocaleString() : "";
+  return (
+    <article className={`schedule-row schedule-${schedule.status}`}>
+      <div className="session-row">
+        <span className={`badge schedule-status ${schedule.status}`}>
+          {schedule.status}
+        </span>
+        <span className="badge model" title={`Session: ${schedule.session_id}`}>
+          {schedule.session_id.slice(0, 12)}…
+        </span>
+        <span className="muted">{formatted}</span>
+      </div>
+      <p className="schedule-title msg-text">{schedule.text}</p>
+      {schedule.failure_reason ? (
+        <p className="error">{schedule.failure_reason}</p>
+      ) : null}
+      <div className="action-row">
+        <button
+          type="button"
+          className="link-button danger-link"
+          onClick={() => void onDelete(schedule.id)}
+        >
+          {schedule.status === "pending" ? "Cancel" : "Dismiss"}
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/frontend/src/components/ScheduledMessagesPanel.tsx
+++ b/frontend/src/components/ScheduledMessagesPanel.tsx
@@ -1,65 +1,113 @@
 "use client";
 
-import { MessageSchedule } from "@/lib/types";
+import { useEffect, useState } from "react";
 
-interface ScheduledMessagesPanelProps {
+import { ExpandableText } from "@/components/ExpandableText";
+import { Pager } from "@/components/Pager";
+import { usePagination } from "@/lib/usePagination";
+import { MessageSchedule, SessionRecord } from "@/lib/types";
+
+const PAGE_SIZE = 5;
+
+interface ScheduledMessagesGroupProps {
   messageSchedules: MessageSchedule[];
+  sessionsById?: Record<string, SessionRecord>;
   onDelete: (scheduleId: string) => Promise<void>;
   onClearHistory: () => Promise<void>;
 }
 
-export function ScheduledMessagesPanel({
+// The "Messages" group inside the unified Scheduled panel: pending deliveries
+// first (with live countdowns), then recently sent/failed/cancelled ones.
+export function ScheduledMessagesGroup({
   messageSchedules,
+  sessionsById,
   onDelete,
   onClearHistory,
-}: ScheduledMessagesPanelProps) {
+}: ScheduledMessagesGroupProps) {
+  // Re-render on a slow cadence so the "in 14m" countdowns stay honest without
+  // hammering the main thread.
+  const [, setTick] = useState(0);
+  const [clearing, setClearing] = useState(false);
+
   const pending = messageSchedules.filter((ms) => ms.status === "pending");
-  const recent = messageSchedules.filter((ms) => ms.status !== "pending").slice(0, 4);
+  const recent = messageSchedules.filter((ms) => ms.status !== "pending");
+  // Pending first (with live countdowns), then recent history, paginated as one
+  // ordered list so the card stays a fixed height regardless of backlog.
+  const ordered = [...pending, ...recent];
+  const pager = usePagination(ordered, PAGE_SIZE);
+
+  useEffect(() => {
+    if (!pending.length) {
+      return;
+    }
+    const id = window.setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => window.clearInterval(id);
+  }, [pending.length]);
+
+  async function handleClearHistory() {
+    if (clearing) {
+      return;
+    }
+    setClearing(true);
+    try {
+      await onClearHistory();
+    } finally {
+      setClearing(false);
+    }
+  }
 
   if (!pending.length && !recent.length) {
     return null;
   }
 
   return (
-    <section className="panel stack schedule-panel" aria-label="Scheduled messages">
-      <div>
-        <h3>Scheduled messages</h3>
-        <p className="muted">Messages queued to send to sessions.</p>
+    <div className="stack sched-group msg-sched">
+      <div className="sched-group-head">
+        <h4 className="sched-group-title">
+          Messages
+          {pending.length ? (
+            <span className="msg-sched-count">{pending.length}</span>
+          ) : null}
+        </h4>
+        {recent.length ? (
+          <button
+            type="button"
+            className="link-button danger-link"
+            onClick={() => void handleClearHistory()}
+            disabled={clearing}
+          >
+            {clearing ? "Clearing…" : "Clear history"}
+          </button>
+        ) : null}
       </div>
-      {pending.length ? (
-        <div className="stack">
-          <h4 className="schedule-heading">Pending</h4>
-          {pending.map((ms) => (
-            <MessageRow key={ms.id} schedule={ms} onDelete={onDelete} />
-          ))}
-        </div>
-      ) : null}
-      {recent.length ? (
-        <div className="stack">
-          <div className="field-row">
-            <h4 className="schedule-heading">Recent</h4>
-            <button
-              type="button"
-              className="link-button danger-link"
-              onClick={() => void onClearHistory()}
-            >
-              Clear history
-            </button>
-          </div>
-          {recent.map((ms) => (
-            <MessageRow key={ms.id} schedule={ms} onDelete={onDelete} />
-          ))}
-        </div>
-      ) : null}
-    </section>
+      {pager.pageItems.map((ms) => (
+        <MessageRow
+          key={ms.id}
+          schedule={ms}
+          sessionTitle={sessionsById?.[ms.session_id]?.title ?? null}
+          onDelete={onDelete}
+        />
+      ))}
+      <Pager
+        page={pager.page}
+        totalPages={pager.totalPages}
+        total={pager.total}
+        pageStart={pager.pageStart}
+        pageEnd={pager.pageEnd}
+        onPage={pager.setPage}
+        label="messages"
+      />
+    </div>
   );
 }
 
 function MessageRow({
   schedule,
+  sessionTitle,
   onDelete,
 }: {
   schedule: MessageSchedule;
+  sessionTitle?: string | null;
   onDelete: (id: string) => Promise<void>;
 }) {
   const when = schedule.scheduled_at
@@ -67,31 +115,93 @@ function MessageRow({
     : schedule.created_at
       ? new Date(schedule.created_at)
       : null;
-  const formatted = when ? when.toLocaleString() : "";
+  const absolute = when ? formatClock(when) : "";
+  const isPending = schedule.status === "pending";
+  const relative = isPending && when ? formatRelative(when) : null;
+  const label = sessionTitle?.trim() || shortSessionId(schedule.session_id);
+
   return (
-    <article className={`schedule-row schedule-${schedule.status}`}>
-      <div className="session-row">
+    <article className={`schedule-row msg-row schedule-${schedule.status}`}>
+      <div className="msg-row-top">
+        <span className={`msg-status-dot ${schedule.status}`} aria-hidden="true" />
         <span className={`badge schedule-status ${schedule.status}`}>
           {schedule.status}
         </span>
-        <span className="badge model" title={`Session: ${schedule.session_id}`}>
-          {schedule.session_id.slice(0, 12)}…
-        </span>
-        <span className="muted">{formatted}</span>
-      </div>
-      <p className="schedule-title msg-text">{schedule.text}</p>
-      {schedule.failure_reason ? (
-        <p className="error">{schedule.failure_reason}</p>
-      ) : null}
-      <div className="action-row">
-        <button
-          type="button"
-          className="link-button danger-link"
-          onClick={() => void onDelete(schedule.id)}
+        <a
+          className="msg-session-link"
+          href={`/session/${schedule.session_id}`}
+          title={`Open session ${schedule.session_id}`}
         >
-          {schedule.status === "pending" ? "Cancel" : "Dismiss"}
-        </button>
+          <span className="msg-session-glyph" aria-hidden="true">
+            ⇢
+          </span>
+          <span className="msg-session-name">{label}</span>
+        </a>
+        <span className="msg-row-right">
+          <span className="msg-row-when">
+            {relative ? <span className="msg-countdown">{relative}</span> : null}
+            <span className="muted">{absolute}</span>
+          </span>
+          <button
+            type="button"
+            className="link-button danger-link msg-cancel"
+            onClick={() => void onDelete(schedule.id)}
+          >
+            {isPending ? "Cancel" : "Dismiss"}
+          </button>
+        </span>
       </div>
+      {schedule.text ? (
+        <ExpandableText
+          className="msg-text"
+          text={schedule.text}
+          collapsedMaxHeight="4.5em"
+        />
+      ) : (
+        <p className="msg-text">
+          <em className="muted">(no text)</em>
+        </p>
+      )}
+      {schedule.failure_reason ? (
+        <p className="error msg-error">{schedule.failure_reason}</p>
+      ) : null}
     </article>
   );
+}
+
+function shortSessionId(id: string): string {
+  // Session ids are "<backend>-<hex>"; the hex suffix is the unique part and
+  // reads as an intentional handle, unlike a blind prefix truncation.
+  const dash = id.lastIndexOf("-");
+  return dash >= 0 ? id.slice(dash + 1) : id;
+}
+
+function formatClock(target: Date): string {
+  const sameDay = new Date().toDateString() === target.toDateString();
+  return target.toLocaleString(undefined, {
+    month: sameDay ? undefined : "short",
+    day: sameDay ? undefined : "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function formatRelative(target: Date): string {
+  const diff = target.getTime() - Date.now();
+  if (diff <= 0) {
+    return "any moment";
+  }
+  const minutes = Math.round(diff / 60_000);
+  if (minutes < 1) {
+    return "in <1m";
+  }
+  if (minutes < 60) {
+    return `in ${minutes}m`;
+  }
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) {
+    return `in ${hours}h`;
+  }
+  const days = Math.round(hours / 24);
+  return `in ${days}d`;
 }

--- a/frontend/src/components/ScheduledSessionsPanel.tsx
+++ b/frontend/src/components/ScheduledSessionsPanel.tsx
@@ -8,13 +8,17 @@ import {
   permissionModeLabel,
 } from "@/lib/backends";
 import { fetchBackendModels } from "@/lib/api";
+import { Pager } from "@/components/Pager";
+import { usePagination } from "@/lib/usePagination";
 import {
   Backend,
   BackendModelOption,
   ScheduledSession,
 } from "@/lib/types";
 
-interface ScheduledSessionsPanelProps {
+const PAGE_SIZE = 5;
+
+interface ScheduledSessionsGroupProps {
   host: string;
   token: string;
   schedules: ScheduledSession[];
@@ -23,17 +27,18 @@ interface ScheduledSessionsPanelProps {
   onClearHistory: () => Promise<void>;
 }
 
-// The list of upcoming and recent scheduled sessions. The creation form now
-// lives under the Schedule tab of the launch panel; this panel is purely the
-// management view and renders nothing until at least one schedule exists.
-export function ScheduledSessionsPanel({
+// The "Sessions" group inside the unified Scheduled panel: upcoming launches
+// first, then recently-resolved schedules. The creation form lives under the
+// Schedule tab of the launch panel; this is purely the management view and
+// renders nothing until at least one schedule exists.
+export function ScheduledSessionsGroup({
   host,
   token,
   schedules,
   catalog,
   onCancel,
   onClearHistory,
-}: ScheduledSessionsPanelProps) {
+}: ScheduledSessionsGroupProps) {
   const [modelsByBackend, setModelsByBackend] = useState<Record<string, BackendModelOption[]>>({});
   const [clearing, setClearing] = useState(false);
 
@@ -59,7 +64,9 @@ export function ScheduledSessionsPanel({
   }, [host, token, schedules, modelsByBackend]);
 
   const upcoming = schedules.filter((schedule) => schedule.status === "pending");
-  const recent = schedules.filter((schedule) => schedule.status !== "pending").slice(0, 4);
+  const recent = schedules.filter((schedule) => schedule.status !== "pending");
+  const ordered = [...upcoming, ...recent];
+  const pager = usePagination(ordered, PAGE_SIZE);
 
   async function handleClearHistory() {
     if (clearing) {
@@ -81,50 +88,44 @@ export function ScheduledSessionsPanel({
   }
 
   return (
-    <section className="panel stack schedule-panel" aria-label="Scheduled sessions">
-      <div>
-        <h3>Scheduled sessions</h3>
-        <p className="muted">Sessions waiting to start, and recently completed schedules.</p>
+    <div className="stack sched-group">
+      <div className="sched-group-head">
+        <h4 className="sched-group-title">
+          Sessions
+          {upcoming.length ? (
+            <span className="msg-sched-count">{upcoming.length}</span>
+          ) : null}
+        </h4>
+        {recent.length ? (
+          <button
+            type="button"
+            className="link-button danger-link"
+            onClick={() => void handleClearHistory()}
+            disabled={clearing}
+          >
+            {clearing ? "Clearing…" : "Clear history"}
+          </button>
+        ) : null}
       </div>
-      {upcoming.length ? (
-        <div className="stack">
-          <h4 className="schedule-heading">Upcoming</h4>
-          {upcoming.map((schedule) => (
-            <ScheduleRow
-              key={schedule.id}
-              schedule={schedule}
-              onCancel={onCancel}
-              catalog={catalog}
-              modelsByBackend={modelsByBackend}
-            />
-          ))}
-        </div>
-      ) : null}
-      {recent.length ? (
-        <div className="stack">
-          <div className="field-row">
-            <h4 className="schedule-heading">Recent</h4>
-            <button
-              type="button"
-              className="link-button danger-link"
-              onClick={() => void handleClearHistory()}
-              disabled={clearing}
-            >
-              {clearing ? "Clearing…" : "Clear history"}
-            </button>
-          </div>
-          {recent.map((schedule) => (
-            <ScheduleRow
-              key={schedule.id}
-              schedule={schedule}
-              onCancel={onCancel}
-              catalog={catalog}
-              modelsByBackend={modelsByBackend}
-            />
-          ))}
-        </div>
-      ) : null}
-    </section>
+      {pager.pageItems.map((schedule) => (
+        <ScheduleRow
+          key={schedule.id}
+          schedule={schedule}
+          onCancel={onCancel}
+          catalog={catalog}
+          modelsByBackend={modelsByBackend}
+        />
+      ))}
+      <Pager
+        page={pager.page}
+        totalPages={pager.totalPages}
+        total={pager.total}
+        pageStart={pager.pageStart}
+        pageEnd={pager.pageEnd}
+        onPage={pager.setPage}
+        label="schedules"
+      />
+    </div>
   );
 }
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -22,7 +22,6 @@ import {
   approveSession,
   connectSessionSocket,
   connectTerminalSocket,
-  createMessageSchedule,
   createSession,
   deleteSession as deleteSessionRequest,
   fetchBackendModels,
@@ -77,6 +76,7 @@ import {
   type PlanViewModel,
 } from "@/lib/events";
 import { useTheme } from "@/lib/theme";
+import { useSessionScheduledMessages } from "@/lib/useSessionScheduledMessages";
 import { formatRelativeTime } from "@/lib/usage";
 import {
   AttachmentContextProvider,
@@ -85,6 +85,8 @@ import {
   PaperclipIcon,
   useAttachments,
 } from "@/components/AttachmentTray";
+import { ScheduleMessageModal } from "@/components/ScheduleMessageModal";
+import { ScheduledMessagesDock } from "@/components/ScheduledMessagesDock";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { WorkspaceFilesPanel } from "@/components/WorkspaceFilesPanel";
 import {
@@ -395,6 +397,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const { openSwitcher, setCurrentSession } = useSwitcher();
+  const scheduledMessages = useSessionScheduledMessages(host, token, sessionId);
   // Auto-dismiss the "Copied!" pill after a beat so it doesn't squat on
   // the toast slot. The fallback "Tap to copy" toast stays until the user
   // acts on it — clipboard access can't be reattempted programmatically
@@ -2181,11 +2184,18 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         />
       ) : null}
       {session && !terminalOnly ? (
+        <ScheduledMessagesDock
+          messages={scheduledMessages.messages}
+          onCancel={scheduledMessages.cancel}
+        />
+      ) : null}
+      {session && !terminalOnly ? (
         <ReplyComposer
           host={host}
           token={token}
           sessionId={sessionId}
           session={session}
+          onScheduled={scheduledMessages.refresh}
           permissionModeOptions={
             session ? permissionModesFor(session.backend, catalog) : []
           }
@@ -2278,6 +2288,7 @@ interface ReplyComposerProps {
   token: string;
   sessionId: string;
   session: SessionRecord | null;
+  onScheduled?: () => void;
   agentBusy: boolean;
   permissionModeOptions: readonly BackendPermissionMode[];
   hasToolRuns: boolean;
@@ -2335,6 +2346,7 @@ const ReplyComposer = memo(function ReplyComposer({
   token,
   sessionId,
   session,
+  onScheduled,
   agentBusy,
   permissionModeOptions,
   canDelete,
@@ -2384,13 +2396,6 @@ const ReplyComposer = memo(function ReplyComposer({
   const attachments = useAttachments({ host, token, sessionId, onError });
   const [filesOpen, setFilesOpen] = useState(false);
   const [scheduleMsgOpen, setScheduleMsgOpen] = useState(false);
-  const [scheduleMsgDraft, setScheduleMsgDraft] = useState("");
-  const [scheduleMsgTiming, setScheduleMsgTiming] =
-    useState<"delay" | "datetime">("delay");
-  const [scheduleMsgDelay, setScheduleMsgDelay] = useState("15");
-  const [scheduleMsgAt, setScheduleMsgAt] = useState(defaultMessageScheduledAt());
-  const [scheduleMsgError, setScheduleMsgError] = useState("");
-  const [scheduleMsgSending, setScheduleMsgSending] = useState(false);
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
@@ -2576,51 +2581,6 @@ const ReplyComposer = memo(function ReplyComposer({
     } finally {
       setSending(false);
     }
-  }
-
-  async function handleScheduleMessage() {
-    const text = scheduleMsgDraft.trim();
-    if (!text || !session || scheduleMsgSending) {
-      return;
-    }
-    setScheduleMsgError("");
-    const timing: {
-      delaySeconds?: number | null;
-      scheduledAt?: string | null;
-    } = {};
-    if (scheduleMsgTiming === "delay") {
-      const minutes = Number.parseFloat(scheduleMsgDelay);
-      if (!Number.isFinite(minutes) || minutes < 0) {
-        setScheduleMsgError("Enter a non-negative delay in minutes.");
-        return;
-      }
-      timing.delaySeconds = Math.round(minutes * 60);
-    } else {
-      const local = new Date(scheduleMsgAt);
-      if (Number.isNaN(local.getTime())) {
-        setScheduleMsgError("Enter a valid scheduled time.");
-        return;
-      }
-      timing.scheduledAt = local.toISOString();
-    }
-    setScheduleMsgSending(true);
-    try {
-      await createMessageSchedule(host, token, sessionId, text, timing);
-      closeScheduleMessageDialog();
-    } catch (err) {
-      onError(err instanceof Error ? err.message : "failed to schedule message");
-    } finally {
-      setScheduleMsgSending(false);
-    }
-  }
-
-  function closeScheduleMessageDialog() {
-    setScheduleMsgOpen(false);
-    setScheduleMsgDraft("");
-    setScheduleMsgTiming("delay");
-    setScheduleMsgDelay("15");
-    setScheduleMsgAt(defaultMessageScheduledAt());
-    setScheduleMsgError("");
   }
 
   const addFilesFromInput = (event: ChangeEvent<HTMLInputElement>) => {
@@ -3371,11 +3331,10 @@ const ReplyComposer = memo(function ReplyComposer({
                     className="composer-overflow-item"
                     onClick={() => {
                       setOverflowOpen(false);
-                      setScheduleMsgDraft((current) => current || draft);
                       setScheduleMsgOpen(true);
                     }}
                   >
-                    <span className="glyph">⏲</span>
+                    <span className="glyph">◷</span>
                     Schedule message…
                   </button>
                   {workspacePreviewEnabled ? (
@@ -3531,95 +3490,15 @@ const ReplyComposer = memo(function ReplyComposer({
         />
       ) : null}
       {scheduleMsgOpen ? (
-        <div className="schedule-msg-dialog-overlay" onClick={closeScheduleMessageDialog}>
-          <div className="schedule-msg-dialog" onClick={(e) => e.stopPropagation()}>
-            <div className="schedule-msg-dialog-header">
-              <span className="schedule-msg-dialog-title">Schedule message</span>
-              <button
-                type="button"
-                className="schedule-msg-dialog-close"
-                onClick={closeScheduleMessageDialog}
-                aria-label="Close"
-              >
-                ×
-              </button>
-            </div>
-            <textarea
-              className="schedule-msg-dialog-input"
-              rows={3}
-              value={scheduleMsgDraft}
-              onChange={(e) => setScheduleMsgDraft(e.target.value)}
-              placeholder="Message text…"
-              aria-label="Message text"
-            />
-            <div className="schedule-mode-row">
-              <button
-                type="button"
-                className={
-                  scheduleMsgTiming === "delay" ? "primary" : "secondary"
-                }
-                onClick={() => setScheduleMsgTiming("delay")}
-              >
-                After delay
-              </button>
-              <button
-                type="button"
-                className={
-                  scheduleMsgTiming === "datetime" ? "primary" : "secondary"
-                }
-                onClick={() => setScheduleMsgTiming("datetime")}
-              >
-                At specific time
-              </button>
-            </div>
-            <div className="schedule-msg-dialog-options">
-              {scheduleMsgTiming === "delay" ? (
-                <label className="schedule-msg-dialog-field">
-                  <span>Delay (minutes)</span>
-                  <input
-                    type="number"
-                    className="schedule-msg-dialog-number"
-                    min={0}
-                    step={1}
-                    value={scheduleMsgDelay}
-                    onChange={(e) => setScheduleMsgDelay(e.target.value)}
-                    placeholder="15"
-                    aria-label="Delay in minutes"
-                  />
-                </label>
-              ) : (
-                <label className="schedule-msg-dialog-field">
-                  <span>Local time</span>
-                  <input
-                    type="datetime-local"
-                    className="schedule-msg-dialog-number"
-                    value={scheduleMsgAt}
-                    onChange={(e) => setScheduleMsgAt(e.target.value)}
-                    aria-label="Scheduled local time"
-                  />
-                </label>
-              )}
-            </div>
-            {scheduleMsgError ? <p className="error">{scheduleMsgError}</p> : null}
-            <div className="schedule-msg-dialog-actions">
-              <button
-                type="button"
-                className="secondary"
-                onClick={closeScheduleMessageDialog}
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                className="primary"
-                onClick={() => void handleScheduleMessage()}
-                disabled={!scheduleMsgDraft.trim() || scheduleMsgSending}
-              >
-                {scheduleMsgSending ? "Scheduling…" : "Schedule"}
-              </button>
-            </div>
-          </div>
-        </div>
+        <ScheduleMessageModal
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          initialDraft={draft}
+          onClose={() => setScheduleMsgOpen(false)}
+          onScheduled={onScheduled}
+          onError={onError}
+        />
       ) : null}
     </section>
   );
@@ -4370,12 +4249,3 @@ function stripAnsi(text: string): string {
     .replace(/\u001B[@-_]/g, "");
 }
 
-function defaultMessageScheduledAt(): string {
-  const date = new Date();
-  date.setMinutes(date.getMinutes() + 15);
-  const pad = (value: number) => value.toString().padStart(2, "0");
-  return (
-    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
-    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
-  );
-}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -22,6 +22,7 @@ import {
   approveSession,
   connectSessionSocket,
   connectTerminalSocket,
+  createMessageSchedule,
   createSession,
   deleteSession as deleteSessionRequest,
   fetchBackendModels,
@@ -2382,6 +2383,10 @@ const ReplyComposer = memo(function ReplyComposer({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const attachments = useAttachments({ host, token, sessionId, onError });
   const [filesOpen, setFilesOpen] = useState(false);
+  const [scheduleMsgOpen, setScheduleMsgOpen] = useState(false);
+  const [scheduleMsgDraft, setScheduleMsgDraft] = useState("");
+  const [scheduleMsgDelay, setScheduleMsgDelay] = useState("");
+  const [scheduleMsgSending, setScheduleMsgSending] = useState(false);
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [tuneOpen, setTuneOpen] = useState(false);
@@ -2566,6 +2571,29 @@ const ReplyComposer = memo(function ReplyComposer({
       }
     } finally {
       setSending(false);
+    }
+  }
+
+  async function handleScheduleMessage() {
+    const text = scheduleMsgDraft.trim();
+    if (!text || !session || scheduleMsgSending) {
+      return;
+    }
+    setScheduleMsgSending(true);
+    try {
+      const delaySeconds = scheduleMsgDelay
+        ? Math.max(0, parseInt(scheduleMsgDelay, 10) * 60)
+        : undefined;
+      await createMessageSchedule(host, token, sessionId, text, {
+        delaySeconds: delaySeconds || null,
+      });
+      setScheduleMsgOpen(false);
+      setScheduleMsgDraft("");
+      setScheduleMsgDelay("");
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "failed to schedule message");
+    } finally {
+      setScheduleMsgSending(false);
     }
   }
 
@@ -3311,6 +3339,18 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">⇄</span>
                     Switch session…
                   </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="composer-overflow-item"
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      setScheduleMsgOpen(true);
+                    }}
+                  >
+                    <span className="glyph">⏲</span>
+                    Schedule message…
+                  </button>
                   {workspacePreviewEnabled ? (
                     <button
                       type="button"
@@ -3462,6 +3502,62 @@ const ReplyComposer = memo(function ReplyComposer({
           onReference={attachments.referenceExisting}
           referencedIds={attachments.attachedIds}
         />
+      ) : null}
+      {scheduleMsgOpen ? (
+        <div className="schedule-msg-dialog-overlay" onClick={() => setScheduleMsgOpen(false)}>
+          <div className="schedule-msg-dialog" onClick={(e) => e.stopPropagation()}>
+            <div className="schedule-msg-dialog-header">
+              <span className="schedule-msg-dialog-title">Schedule message</span>
+              <button
+                type="button"
+                className="schedule-msg-dialog-close"
+                onClick={() => { setScheduleMsgOpen(false); setScheduleMsgDraft(""); setScheduleMsgDelay(""); }}
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <textarea
+              className="schedule-msg-dialog-input"
+              rows={3}
+              value={scheduleMsgDraft}
+              onChange={(e) => setScheduleMsgDraft(e.target.value)}
+              placeholder="Message text…"
+              aria-label="Message text"
+            />
+            <div className="schedule-msg-dialog-options">
+              <label className="schedule-msg-dialog-field">
+                <span>Delay (minutes)</span>
+                <input
+                  type="number"
+                  className="schedule-msg-dialog-number"
+                  min={0}
+                  value={scheduleMsgDelay}
+                  onChange={(e) => setScheduleMsgDelay(e.target.value)}
+                  placeholder="0"
+                  aria-label="Delay in minutes"
+                />
+              </label>
+            </div>
+            <div className="schedule-msg-dialog-actions">
+              <button
+                type="button"
+                className="secondary"
+                onClick={() => { setScheduleMsgOpen(false); setScheduleMsgDraft(""); setScheduleMsgDelay(""); }}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="primary"
+                onClick={() => void handleScheduleMessage()}
+                disabled={!scheduleMsgDraft.trim() || scheduleMsgSending}
+              >
+                {scheduleMsgSending ? "Scheduling…" : "Schedule"}
+              </button>
+            </div>
+          </div>
+        </div>
       ) : null}
     </section>
   );

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2385,7 +2385,11 @@ const ReplyComposer = memo(function ReplyComposer({
   const [filesOpen, setFilesOpen] = useState(false);
   const [scheduleMsgOpen, setScheduleMsgOpen] = useState(false);
   const [scheduleMsgDraft, setScheduleMsgDraft] = useState("");
-  const [scheduleMsgDelay, setScheduleMsgDelay] = useState("");
+  const [scheduleMsgTiming, setScheduleMsgTiming] =
+    useState<"delay" | "datetime">("delay");
+  const [scheduleMsgDelay, setScheduleMsgDelay] = useState("15");
+  const [scheduleMsgAt, setScheduleMsgAt] = useState(defaultMessageScheduledAt());
+  const [scheduleMsgError, setScheduleMsgError] = useState("");
   const [scheduleMsgSending, setScheduleMsgSending] = useState(false);
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
@@ -2579,22 +2583,44 @@ const ReplyComposer = memo(function ReplyComposer({
     if (!text || !session || scheduleMsgSending) {
       return;
     }
+    setScheduleMsgError("");
+    const timing: {
+      delaySeconds?: number | null;
+      scheduledAt?: string | null;
+    } = {};
+    if (scheduleMsgTiming === "delay") {
+      const minutes = Number.parseFloat(scheduleMsgDelay);
+      if (!Number.isFinite(minutes) || minutes < 0) {
+        setScheduleMsgError("Enter a non-negative delay in minutes.");
+        return;
+      }
+      timing.delaySeconds = Math.round(minutes * 60);
+    } else {
+      const local = new Date(scheduleMsgAt);
+      if (Number.isNaN(local.getTime())) {
+        setScheduleMsgError("Enter a valid scheduled time.");
+        return;
+      }
+      timing.scheduledAt = local.toISOString();
+    }
     setScheduleMsgSending(true);
     try {
-      const delaySeconds = scheduleMsgDelay
-        ? Math.max(0, parseInt(scheduleMsgDelay, 10) * 60)
-        : undefined;
-      await createMessageSchedule(host, token, sessionId, text, {
-        delaySeconds: delaySeconds || null,
-      });
-      setScheduleMsgOpen(false);
-      setScheduleMsgDraft("");
-      setScheduleMsgDelay("");
+      await createMessageSchedule(host, token, sessionId, text, timing);
+      closeScheduleMessageDialog();
     } catch (err) {
       onError(err instanceof Error ? err.message : "failed to schedule message");
     } finally {
       setScheduleMsgSending(false);
     }
+  }
+
+  function closeScheduleMessageDialog() {
+    setScheduleMsgOpen(false);
+    setScheduleMsgDraft("");
+    setScheduleMsgTiming("delay");
+    setScheduleMsgDelay("15");
+    setScheduleMsgAt(defaultMessageScheduledAt());
+    setScheduleMsgError("");
   }
 
   const addFilesFromInput = (event: ChangeEvent<HTMLInputElement>) => {
@@ -3345,6 +3371,7 @@ const ReplyComposer = memo(function ReplyComposer({
                     className="composer-overflow-item"
                     onClick={() => {
                       setOverflowOpen(false);
+                      setScheduleMsgDraft((current) => current || draft);
                       setScheduleMsgOpen(true);
                     }}
                   >
@@ -3504,14 +3531,14 @@ const ReplyComposer = memo(function ReplyComposer({
         />
       ) : null}
       {scheduleMsgOpen ? (
-        <div className="schedule-msg-dialog-overlay" onClick={() => setScheduleMsgOpen(false)}>
+        <div className="schedule-msg-dialog-overlay" onClick={closeScheduleMessageDialog}>
           <div className="schedule-msg-dialog" onClick={(e) => e.stopPropagation()}>
             <div className="schedule-msg-dialog-header">
               <span className="schedule-msg-dialog-title">Schedule message</span>
               <button
                 type="button"
                 className="schedule-msg-dialog-close"
-                onClick={() => { setScheduleMsgOpen(false); setScheduleMsgDraft(""); setScheduleMsgDelay(""); }}
+                onClick={closeScheduleMessageDialog}
                 aria-label="Close"
               >
                 ×
@@ -3525,25 +3552,60 @@ const ReplyComposer = memo(function ReplyComposer({
               placeholder="Message text…"
               aria-label="Message text"
             />
-            <div className="schedule-msg-dialog-options">
-              <label className="schedule-msg-dialog-field">
-                <span>Delay (minutes)</span>
-                <input
-                  type="number"
-                  className="schedule-msg-dialog-number"
-                  min={0}
-                  value={scheduleMsgDelay}
-                  onChange={(e) => setScheduleMsgDelay(e.target.value)}
-                  placeholder="0"
-                  aria-label="Delay in minutes"
-                />
-              </label>
+            <div className="schedule-mode-row">
+              <button
+                type="button"
+                className={
+                  scheduleMsgTiming === "delay" ? "primary" : "secondary"
+                }
+                onClick={() => setScheduleMsgTiming("delay")}
+              >
+                After delay
+              </button>
+              <button
+                type="button"
+                className={
+                  scheduleMsgTiming === "datetime" ? "primary" : "secondary"
+                }
+                onClick={() => setScheduleMsgTiming("datetime")}
+              >
+                At specific time
+              </button>
             </div>
+            <div className="schedule-msg-dialog-options">
+              {scheduleMsgTiming === "delay" ? (
+                <label className="schedule-msg-dialog-field">
+                  <span>Delay (minutes)</span>
+                  <input
+                    type="number"
+                    className="schedule-msg-dialog-number"
+                    min={0}
+                    step={1}
+                    value={scheduleMsgDelay}
+                    onChange={(e) => setScheduleMsgDelay(e.target.value)}
+                    placeholder="15"
+                    aria-label="Delay in minutes"
+                  />
+                </label>
+              ) : (
+                <label className="schedule-msg-dialog-field">
+                  <span>Local time</span>
+                  <input
+                    type="datetime-local"
+                    className="schedule-msg-dialog-number"
+                    value={scheduleMsgAt}
+                    onChange={(e) => setScheduleMsgAt(e.target.value)}
+                    aria-label="Scheduled local time"
+                  />
+                </label>
+              )}
+            </div>
+            {scheduleMsgError ? <p className="error">{scheduleMsgError}</p> : null}
             <div className="schedule-msg-dialog-actions">
               <button
                 type="button"
                 className="secondary"
-                onClick={() => { setScheduleMsgOpen(false); setScheduleMsgDraft(""); setScheduleMsgDelay(""); }}
+                onClick={closeScheduleMessageDialog}
               >
                 Cancel
               </button>
@@ -4306,4 +4368,14 @@ function stripAnsi(text: string): string {
     .replace(/\u001B\][\s\S]*?(?:\u0007|\u001B\\)/g, "")
     .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "")
     .replace(/\u001B[@-_]/g, "");
+}
+
+function defaultMessageScheduledAt(): string {
+  const date = new Date();
+  date.setMinutes(date.getMinutes() + 15);
+  const pad = (value: number) => value.toString().padStart(2, "0");
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
 }

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -14,6 +14,7 @@ import { matchesQuery, parseQuery } from "@/lib/search";
 import { SessionRecord } from "@/lib/types";
 
 import { SearchInput } from "./SearchInput";
+import { Pager } from "@/components/Pager";
 
 interface SessionListProps {
   sessions: SessionRecord[];
@@ -324,28 +325,16 @@ export function SessionList({
               No sessions match your search.
             </p>
           )}
-          {totalPages > 1 && flatSearchResults.length > 0 ? (
-            <div className="action-row pagination-controls" style={{ marginTop: "12px", justifyContent: "flex-end" }}>
-              <button
-                className="secondary"
-                type="button"
-                onClick={() => setPage((current) => Math.max(1, current - 1))}
-                disabled={page === 1}
-              >
-                Previous
-              </button>
-              <span className="meta">
-                Page {page} of {totalPages}
-              </span>
-              <button
-                className="secondary"
-                type="button"
-                onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
-                disabled={page === totalPages}
-              >
-                Next
-              </button>
-            </div>
+          {flatSearchResults.length > 0 ? (
+            <Pager
+              page={page}
+              totalPages={totalPages}
+              total={flatSearchResults.length}
+              pageStart={showingFrom}
+              pageEnd={showingTo}
+              onPage={setPage}
+              label="sessions"
+            />
           ) : null}
         </section>
       ) : (
@@ -363,42 +352,26 @@ export function SessionList({
           <section className="session-section">
             <header className="session-section-header">
               <h4>Recent</h4>
-              <div className="action-row session-section-controls">
-                {recentSessions.length > 0 ? (
-                  <span className="meta">
-                    {showingFrom}–{showingTo} of {recentSessions.length}
-                  </span>
-                ) : null}
-                {totalPages > 1 ? (
-                  <div className="action-row pagination-controls">
-                    <button
-                      className="secondary"
-                      type="button"
-                      onClick={() => setPage((current) => Math.max(1, current - 1))}
-                      disabled={page === 1}
-                    >
-                      Previous
-                    </button>
-                    <span className="meta">
-                      Page {page} of {totalPages}
-                    </span>
-                    <button
-                      className="secondary"
-                      type="button"
-                      onClick={() => setPage((current) => Math.min(totalPages, current + 1))}
-                      disabled={page === totalPages}
-                    >
-                      Next
-                    </button>
-                  </div>
-                ) : null}
-              </div>
+              {recentSessions.length > 0 ? (
+                <span className="meta">{recentSessions.length}</span>
+              ) : null}
             </header>
             {visibleItems.length > 0 ? (
               <div className="stack">{visibleItems.map(renderCard)}</div>
             ) : (
               <p className="muted">All sessions are pinned.</p>
             )}
+            {recentSessions.length > 0 ? (
+              <Pager
+                page={page}
+                totalPages={totalPages}
+                total={recentSessions.length}
+                pageStart={showingFrom}
+                pageEnd={showingTo}
+                onPage={setPage}
+                label="sessions"
+              />
+            ) : null}
           </section>
         </>
       )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import {
   EventRecord,
   EventsPage,
   MeResponse,
+  MessageSchedule,
   ScheduleCreateRequest,
   ScheduledSession,
   SessionCompletionsResponse,
@@ -607,6 +608,86 @@ export async function clearScheduleHistory(host: string, token: string): Promise
     headers: { Authorization: `Bearer ${token}` },
   });
   await ensureOk(response, "failed to clear schedule history");
+  const payload = (await response.json()) as { removed?: number };
+  return payload.removed ?? 0;
+}
+
+export async function fetchMessageSchedules(
+  host: string,
+  token: string,
+  sessionId?: string,
+): Promise<MessageSchedule[]> {
+  const params = sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : "";
+  const response = await fetch(`${host}/api/message-schedules${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  await ensureOk(response, "failed to fetch message schedules");
+  const payload = await response.json();
+  return (payload.message_schedules ?? []) as MessageSchedule[];
+}
+
+export async function createMessageSchedule(
+  host: string,
+  token: string,
+  sessionId: string,
+  text: string,
+  options: {
+    submit?: boolean;
+    delaySeconds?: number | null;
+    scheduledAt?: string | null;
+  } = {},
+): Promise<MessageSchedule> {
+  const body: Record<string, unknown> = { text, submit: options.submit ?? true };
+  if (options.delaySeconds != null) body.delay_seconds = options.delaySeconds;
+  if (options.scheduledAt != null) body.scheduled_at = options.scheduledAt;
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/message-schedules`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  await ensureOk(response, "failed to create message schedule");
+  const payload = await response.json();
+  return payload.message_schedule as MessageSchedule;
+}
+
+export async function deleteMessageSchedule(
+  host: string,
+  token: string,
+  scheduleId: string,
+): Promise<MessageSchedule> {
+  const response = await fetch(
+    `${host}/api/message-schedules/${encodeURIComponent(scheduleId)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to delete message schedule");
+  const payload = await response.json();
+  return payload.message_schedule as MessageSchedule;
+}
+
+export async function clearMessageScheduleHistory(
+  host: string,
+  token: string,
+  sessionId?: string,
+): Promise<number> {
+  const params = sessionId ? `?session_id=${encodeURIComponent(sessionId)}` : "";
+  const response = await fetch(
+    `${host}/api/message-schedules/clear-history${params}`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  );
+  await ensureOk(response, "failed to clear message schedule history");
   const payload = (await response.json()) as { removed?: number };
   return payload.removed ?? 0;
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -405,6 +405,9 @@ export interface MessageSchedule {
   session_id: string;
   text: string;
   submit: boolean;
+  command?: SessionCommandInvocation | null;
+  items?: unknown[] | null;
+  attachments?: string[] | null;
   delay_seconds?: number | null;
   scheduled_at?: string | null;
   status: MessageScheduleStatus;
@@ -420,7 +423,6 @@ export interface SessionEnvelope {
     | "session_state"
     | "auth_revoked"
     | "schedule_list_update"
-    | "message_schedule_list_update"
     | "board_update"
     | "clipboard_copy"
     | "side_question";

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -408,11 +408,9 @@ export interface MessageSchedule {
   command?: SessionCommandInvocation | null;
   items?: unknown[] | null;
   attachments?: string[] | null;
-  delay_seconds?: number | null;
   scheduled_at?: string | null;
   status: MessageScheduleStatus;
   created_at: string;
-  sent_at?: string | null;
   failure_reason?: string | null;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -398,6 +398,21 @@ export interface BoardChannel {
   last_created_at: string;
 }
 
+export type MessageScheduleStatus = "pending" | "sent" | "cancelled" | "failed";
+
+export interface MessageSchedule {
+  id: string;
+  session_id: string;
+  text: string;
+  submit: boolean;
+  delay_seconds?: number | null;
+  scheduled_at?: string | null;
+  status: MessageScheduleStatus;
+  created_at: string;
+  sent_at?: string | null;
+  failure_reason?: string | null;
+}
+
 export interface SessionEnvelope {
   type:
     | "session_list_update"
@@ -405,6 +420,7 @@ export interface SessionEnvelope {
     | "session_state"
     | "auth_revoked"
     | "schedule_list_update"
+    | "message_schedule_list_update"
     | "board_update"
     | "clipboard_copy"
     | "side_question";

--- a/frontend/src/lib/usePagination.ts
+++ b/frontend/src/lib/usePagination.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// Client-side pagination over an in-memory list. Clamps the current page when
+// the list shrinks (e.g. a scheduled message fires and leaves the list) so the
+// view never strands on an empty page.
+export function usePagination<T>(items: T[], pageSize: number) {
+  const [page, setPage] = useState(1);
+  const total = items.length;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+
+  useEffect(() => {
+    if (page > totalPages) {
+      setPage(totalPages);
+    }
+  }, [page, totalPages]);
+
+  const clampedPage = Math.min(page, totalPages);
+  const start = (clampedPage - 1) * pageSize;
+  const pageItems = items.slice(start, start + pageSize);
+
+  return {
+    page: clampedPage,
+    setPage,
+    totalPages,
+    total,
+    pageItems,
+    pageStart: total ? start + 1 : 0,
+    pageEnd: Math.min(total, start + pageSize),
+  };
+}

--- a/frontend/src/lib/useSessionScheduledMessages.ts
+++ b/frontend/src/lib/useSessionScheduledMessages.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { deleteMessageSchedule, fetchMessageSchedules } from "@/lib/api";
+import { MessageSchedule } from "@/lib/types";
+
+// Live view of the *pending* scheduled messages for a single session, for the
+// in-session dock. The global schedule_list_update broadcast only reaches the
+// /ws/sessions socket (published with session_id=None), which the session page
+// doesn't hold — so we fetch on mount, poll on a slow cadence, apply an
+// optimistic cancel, and refresh after a create to keep the dock responsive.
+export function useSessionScheduledMessages(
+  host: string,
+  token: string,
+  sessionId: string,
+) {
+  const [messages, setMessages] = useState<MessageSchedule[]>([]);
+
+  const refresh = useCallback(async () => {
+    if (!host || !token || !sessionId) {
+      return;
+    }
+    try {
+      const all = await fetchMessageSchedules(host, token, sessionId);
+      const pending = all
+        .filter((m) => m.status === "pending")
+        // Soonest first, undated last, so the dock's messages[0] is a robust
+        // "next" regardless of backend ordering.
+        .sort((a, b) => scheduledAtMs(a) - scheduledAtMs(b));
+      // Keep the previous reference when nothing changed so the polling effect
+      // doesn't tear down its interval and no needless re-render fires.
+      setMessages((current) => (sameSchedules(current, pending) ? current : pending));
+    } catch {
+      // Transient fetch failures leave the last-known list in place.
+    }
+  }, [host, token, sessionId]);
+
+  // Fetch once on mount / when the target changes.
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Adaptive polling: a message fires server-side and leaves the pending list,
+  // but the session page never receives the schedule broadcast, so we poll to
+  // notice. Poll fast when the soonest delivery is imminent or already past
+  // (so a just-fired message clears within a few seconds instead of lingering
+  // on "any moment"), and slowly otherwise.
+  useEffect(() => {
+    const soonest = messages.reduce((min, m) => {
+      if (!m.scheduled_at) {
+        return min;
+      }
+      return Math.min(min, new Date(m.scheduled_at).getTime());
+    }, Number.POSITIVE_INFINITY);
+    const dueSoon = soonest - Date.now() <= 30_000;
+    const interval = dueSoon ? 4_000 : 15_000;
+    const id = window.setInterval(() => void refresh(), interval);
+    return () => window.clearInterval(id);
+  }, [refresh, messages]);
+
+  const cancel = useCallback(
+    async (scheduleId: string) => {
+      setMessages((current) => current.filter((m) => m.id !== scheduleId));
+      try {
+        await deleteMessageSchedule(host, token, scheduleId);
+      } catch {
+        // Re-sync from the server if the cancel didn't land.
+        void refresh();
+      }
+    },
+    [host, token, refresh],
+  );
+
+  return { messages, refresh, cancel };
+}
+
+function scheduledAtMs(m: MessageSchedule): number {
+  return m.scheduled_at
+    ? new Date(m.scheduled_at).getTime()
+    : Number.POSITIVE_INFINITY;
+}
+
+function sameSchedules(a: MessageSchedule[], b: MessageSchedule[]): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  return a.every((m, i) => {
+    const other = b[i];
+    return (
+      m.id === other.id &&
+      m.status === other.status &&
+      m.scheduled_at === other.scheduled_at
+    );
+  });
+}


### PR DESCRIPTION
## Purpose

Waypoint could schedule a *new session* to launch later, but there was no way to queue a message to an *existing* session. This adds scheduled messages: a message (or command / items / attachments) can be queued against a running session and delivered at a future time, either after a delay or at a specific instant. Records are persisted, survive restarts, and are driven by the same poll loop that fires scheduled sessions.

## Changes

### Backend

- `schemas.py` — add `ScheduledMessageRecord`, `ScheduledMessageCreateRequest`, and the `ScheduledMessageStatus` enum (pending/sent/failed/cancelled).
- `storage.py` — new `scheduled_messages` table (indexed on `status`) plus CRUD helpers (`create`/`list`/`get`/`update`/`delete`/`delete_by_status`); the row parser tolerates corrupt stored `command`/`items` blobs by catching only json/validation errors.
- `scheduler.py` — `create`/`cancel`/`list`/`clear_message_history` and a `_fire_message` path that calls `runtime.handle_input`, marking the record `sent` or `failed`; the poll loop and `_compute_wait_seconds` now fold pending messages into the wakeup schedule, and `schedule_list_update` carries `message_schedules`.
- `api.py` — `GET /api/message-schedules`, `POST /api/sessions/{session_id}/message-schedules`, `DELETE /api/message-schedules/{schedule_id}`, and `POST /api/message-schedules/clear-history`.
- `cli.py`, `client.py` — a `schedule message` command group (`list`/`create`/`delete`/`clear-history`) and the matching `WaypointClient` methods.

### Frontend

- `components/ScheduledMessagesPanel.tsx` (new) — pending/recent list with cancel/dismiss and clear-history.
- `components/SessionDetail.tsx` — a "Schedule message…" entry in the composer overflow menu opening a dialog with delay / specific-time modes.
- `app/page.tsx`, `lib/api.ts`, `lib/types.ts`, `app/globals.css` — fetch/create/delete/clear wiring, live `schedule_list_update` handling, the `MessageSchedule` type, and panel/dialog styles with dark/light parity.

### Tests

- `tests/test_scheduled_messages.py`, `tests/test_cli.py`, `tests/test_client.py` — storage CRUD, firing/cancel/clear behavior, the API endpoints, and the CLI/client surface.

## Design

Scheduled messages reuse the existing scheduler poll loop rather than a second timer: `_compute_wait_seconds` takes the minimum due time across both pending sessions and pending messages, and `_fire_due_schedules` fires each in turn. Firing routes through `runtime.handle_input`, so a scheduled message is indistinguishable from a live one; a missing session or an input failure transitions the record to `failed` with a reason instead of crashing the loop. `_resolve_scheduled_at` is shared between session and message requests (both expose `scheduled_at` / `delay_seconds`).

## Test Plan

```
cd backend && uv run pre-commit run --all-files
cd backend && uv run pytest
cd frontend && npm run lint && npx tsc --noEmit && npm run build
```

## Test Result

- `uv run pytest` — **1305 passed**.
- `pre-commit run --all-files` — isort / black / ruff / codespell / mypy all clean.
- frontend `npm run lint`, `tsc --noEmit`, and `npm run build` — clean.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (storage CRUD, firing/cancel/clear, API endpoints, CLI/client).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest` — 1305 passed; `waypointctl` untouched).
- [x] If I touched code that dispatches by plugin id, I checked the affected backends — firing routes through the generic `runtime.handle_input`, so there is no per-backend branch; claude_code, codex, and opencode are unaffected.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` (plus `tsc --noEmit`) and kept dark/light theme parity (panel/dialog light overrides co-located in `globals.css`).
- [x] Not a breaking change — additive tables, endpoints, and UI; existing scheduled-session behavior is unchanged.
- [ ] Docs/config: no `.env`/`waypoint.example.yaml` surface changed; no doc update needed.

</details>