### PR TITLE
docs: document scheduling CLI in the waypoint skill

### DIFF
--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: waypoint
-description: Use when managing Waypoint coding sessions through the `waypoint` CLI, including listing sessions, reading transcripts, launching agents, discovering available models, sending messages, approvals, answering questions, interrupts, termination, doctor output, auth, or runtime reset decisions.
+description: Use when managing Waypoint coding sessions through the `waypoint` CLI, including listing sessions, reading transcripts, launching agents, discovering available models, sending messages, scheduling session launches or messages, approvals, answering questions, interrupts, termination, doctor output, auth, or runtime reset decisions.
 ---
 
 # Waypoint Sessions
@@ -24,6 +24,8 @@ trusting any flag list reproduced in this skill.
   backends` and `waypoint models [backend]` (see `references/sessions-launch.md`).
 - Send messages, interrupt running work, or terminate sessions: see
   `references/sessions-steer.md`.
+- Schedule a session launch or a message for later (deferred, server-side): see
+  `references/scheduling.md`.
 - Respond to approval requests or answer a session's question: see
   `references/sessions-approvals.md`.
 - Handle destructive operations such as reset or termination: see

--- a/.agents/skills/waypoint/references/scheduling.md
+++ b/.agents/skills/waypoint/references/scheduling.md
@@ -8,13 +8,16 @@ created them can exit.
 
 ## Timing (both groups)
 
-Every schedule needs exactly one of:
+Every schedule needs at least one of:
 
-- `--scheduled-at <iso8601>` — absolute time; must be in the future. A datetime
-  without a timezone is read as UTC.
+- `--scheduled-at <iso8601>` — absolute time. A datetime without a timezone is
+  read as UTC.
 - `--delay-seconds <n>` — relative to now; must be non-negative.
 
-If both are given, `--scheduled-at` wins. Omitting both is an error.
+If both are given, `--scheduled-at` wins and `--delay-seconds` is ignored;
+omitting both is an error. A `schedule message` with a past `--scheduled-at` is
+rejected, but a `schedule` (session) with a past time is accepted and fires on
+the next poll rather than erroring.
 
 ## Scheduled sessions
 
@@ -23,15 +26,17 @@ waypoint schedule list
 waypoint schedule create --backend <agent-id> --cwd <path> --delay-seconds 300
 waypoint schedule create --backend <agent-id> --cwd <path> --scheduled-at 2026-07-02T09:00:00Z --prompt "start the migration"
 waypoint schedule delete <schedule-id>
-waypoint schedule clear-history          # drop launched/cancelled records
+waypoint schedule clear-history          # drop launched/cancelled/failed records
 ```
 
 `schedule create` takes the same launch options as `waypoint sessions start`
 (`--backend`, `--cwd`, `--transport`, `--title`, `--model`, `--effort`,
-`--permission-mode`, `--prompt`, and trailing `args`); see
-`references/sessions-launch.md` for what they mean and how to pick a
-transport. A record moves `pending → launched | cancelled | failed`; once
-launched it carries the new `session_id`, and a `failure_reason` on failure.
+`--permission-mode`, and trailing `args`); see `references/sessions-launch.md`
+for what they mean and how to pick a transport. `--prompt` is specific to
+`schedule create` — it sets the session's initial prompt on launch, which a
+manual `sessions start` has no flag for. A record moves `pending → launched |
+cancelled | failed`; once launched it carries the new `session_id`, and a
+`failure_reason` on failure.
 
 ## Scheduled messages
 

--- a/.agents/skills/waypoint/references/scheduling.md
+++ b/.agents/skills/waypoint/references/scheduling.md
@@ -1,0 +1,61 @@
+# Scheduling Launches and Messages
+
+Two deferred-action command groups run against a live server. `waypoint
+schedule ...` launches a **session** later; `waypoint schedule message ...`
+sends a **message** to an existing session later. Both persist across restarts
+and fire from the server's scheduler, not the CLI process — the shell that
+created them can exit.
+
+## Timing (both groups)
+
+Every schedule needs exactly one of:
+
+- `--scheduled-at <iso8601>` — absolute time; must be in the future. A datetime
+  without a timezone is read as UTC.
+- `--delay-seconds <n>` — relative to now; must be non-negative.
+
+If both are given, `--scheduled-at` wins. Omitting both is an error.
+
+## Scheduled sessions
+
+```bash
+waypoint schedule list
+waypoint schedule create --backend <agent-id> --cwd <path> --delay-seconds 300
+waypoint schedule create --backend <agent-id> --cwd <path> --scheduled-at 2026-07-02T09:00:00Z --prompt "start the migration"
+waypoint schedule delete <schedule-id>
+waypoint schedule clear-history          # drop launched/cancelled records
+```
+
+`schedule create` takes the same launch options as `waypoint sessions start`
+(`--backend`, `--cwd`, `--transport`, `--title`, `--model`, `--effort`,
+`--permission-mode`, `--prompt`, and trailing `args`); see
+`references/sessions-launch.md` for what they mean and how to pick a
+transport. A record moves `pending → launched | cancelled | failed`; once
+launched it carries the new `session_id`, and a `failure_reason` on failure.
+
+## Scheduled messages
+
+```bash
+waypoint schedule message list
+waypoint schedule message list --session-id <session-id>
+waypoint schedule message create <session-id> "ping the reviewer" --delay-seconds 600
+waypoint schedule message create <session-id> "run the suite" --scheduled-at 2026-07-02T09:00:00Z
+waypoint schedule message create <session-id> "draft only" --no-submit
+waypoint schedule message delete <schedule-id>
+waypoint schedule message clear-history [--session-id <session-id>]
+```
+
+The target session must already exist. `--no-submit` queues the text into the
+session's input without auto-submitting it (the default submits). A record moves
+`pending → sent | cancelled | failed`.
+
+## Notes
+
+- Prefer JSON output and read back the assigned schedule id from the response
+  rather than assuming it.
+- `clear-history` only removes terminal records (launched/sent/cancelled/
+  failed); it never cancels a pending one — use `delete` for that.
+- `waypoint reset` wipes schedules along with other runtime data (see
+  `references/destructive-ops.md`).
+- Run `waypoint help` for the exact installed flag surface rather than trusting
+  the lists here.


### PR DESCRIPTION
## Purpose

The `waypoint` skill covered immediate session actions (launch, send, interrupt, terminate) but said nothing about the deferred `schedule` and `schedule message` command groups — the second of which #192 just added. An agent scanning the skill description had no signal that scheduling was in scope, so the skill might not fire on a scheduling ask. This documents both command groups so they're discoverable and correctly used.

## Changes

- `.agents/skills/waypoint/references/scheduling.md` (new) — reference for the `schedule` (deferred session launch) and `schedule message` (deferred message to an existing session) groups: the shared timing rule (exactly one of `--scheduled-at`/`--delay-seconds`, future-only, naive datetimes read as UTC, `scheduled-at` wins), the status lifecycles, `--no-submit`, the `clear-history` vs `delete` distinction, and a pointer to `sessions-launch.md` for the launch flags `schedule create` shares. Defers to `waypoint help` for the exact installed flag surface rather than duplicating it.
- `.agents/skills/waypoint/SKILL.md` — add "scheduling session launches or messages" to the skill description so the skill fires on scheduling asks, and a Common Routing bullet pointing at the new reference.

## Test Plan

```
uv run --with codespell codespell .agents/skills/waypoint/SKILL.md .agents/skills/waypoint/references/scheduling.md
```

## Test Result

- `codespell` — clean. Docs-only change to skill markdown; no Python/frontend surface, so the backend pre-commit hooks (black/isort/ruff/mypy) and the pytest suite don't apply.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `codespell` on the changed docs; the full backend `pre-commit`/`pytest` suites don't apply to this markdown-only change.
- [x] Tests: not applicable — documentation only.
- [x] No plugin/transport contract or plugin-id dispatch code touched.
- [x] No frontend change.
- [x] Not a breaking change — documentation only.
- [x] This *is* the documentation update; no `.env`/`waypoint.example.yaml` surface changed.

</details>