### PR TITLE
feat: polish the session list layout and add a top pager

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9716,6 +9716,31 @@ html[data-theme="light"] .term-compose-input {
   min-width: 0;
 }
 
+/* Card header: badges as one group on the left, last-activity time on the right.
+   space-between keeps the time in the right gutter when it fits, and — because a
+   lone flex item on a wrapped line sits at the start — drops it to its own
+   left-aligned line only when it can't fit. Works the same on every viewport, so
+   a short "8:20 PM" stays inline-right while a long "Jun 30 at 1:36 AM" wraps
+   left. */
+.session-card .session-row {
+  justify-content: space-between;
+}
+
+.session-card-badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.session-card-when {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
 .schedule-panel {
   border-color: var(--line);
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10134,6 +10134,47 @@ html[data-theme="light"] .msg-sched-count {
   padding: 0 2px;
 }
 
+/* Compact pager (top of a long list): controls only, separated from the list by
+   a bottom rule rather than the standard top rule, and right-aligned on wide
+   screens. */
+.pager.pager-compact {
+  justify-content: flex-end;
+  margin-top: 0;
+  margin-bottom: 8px;
+  padding-top: 0;
+  padding-bottom: 10px;
+  border-top: none;
+  border-bottom: 1px solid var(--line);
+}
+
+/* Inlined into a section header (beside "Recent"): sit right-aligned next to the
+   title with no separator; when the header wraps on mobile, drop below the title
+   as a full-width controls row (space-between via the rule above), like the
+   bottom pager. */
+.session-section-header .pager.pager-compact {
+  margin: 0 0 0 auto;
+  padding: 0;
+  border: none;
+  align-self: center;
+}
+
+@media (max-width: 720px) {
+  .session-section-header .pager.pager-compact {
+    width: 100%;
+    margin-left: 0;
+  }
+}
+
+/* On mobile the range readout wraps above the controls; span the controls the
+   full width so Prev / Next sit at the thumb-reachable edges instead of bunching
+   at the left. Applies to every pager — top compact and bottom full. */
+@media (max-width: 720px) {
+  .pager-controls {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
 html[data-theme="light"] .schedule-row.schedule-sent {
   border-color: rgba(37, 122, 80, 0.25);
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13031,6 +13031,10 @@ html[data-theme="light"]
   background: rgba(14, 17, 24, 0.98);
   border-right: 1px solid var(--line-strong);
   box-shadow: 4px 0 32px rgba(0, 0, 0, 0.36);
+  /* Inset the top too, not just the left: as a wide side-dock (iPad/desktop) the
+     header — and its pinned close button — would otherwise sit under the status
+     bar. The ≤640px full-screen-sheet rule already pads all four insets. */
+  padding-top: env(safe-area-inset-top);
   padding-left: env(safe-area-inset-left);
   animation: wp-dock-in 200ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }

--- a/frontend/src/components/Pager.tsx
+++ b/frontend/src/components/Pager.tsx
@@ -8,6 +8,10 @@ interface PagerProps {
   pageEnd: number;
   onPage: (page: number) => void;
   label?: string;
+  // Compact drops the range readout and keeps only the controls — for a second
+  // pager at the top of a long list, where the section header already shows the
+  // count and the full range would be redundant.
+  compact?: boolean;
 }
 
 // Shared list paginator: a range readout plus Prev / page-indicator / Next.
@@ -21,15 +25,18 @@ export function Pager({
   pageEnd,
   onPage,
   label = "items",
+  compact = false,
 }: PagerProps) {
   if (totalPages <= 1) {
     return null;
   }
   return (
-    <div className="pager">
-      <span className="pager-range">
-        {pageStart}–{pageEnd} of {total} {label}
-      </span>
+    <div className={`pager${compact ? " pager-compact" : ""}`}>
+      {compact ? null : (
+        <span className="pager-range">
+          {pageStart}–{pageEnd} of {total} {label}
+        </span>
+      )}
       <div className="pager-controls">
         <button
           type="button"

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -11,6 +11,7 @@ import {
   type BackendCatalog,
 } from "@/lib/backends";
 import { matchesQuery, parseQuery } from "@/lib/search";
+import { formatClock } from "@/lib/scheduleTime";
 import { SessionRecord } from "@/lib/types";
 
 import { SearchInput } from "./SearchInput";
@@ -198,19 +199,27 @@ export function SessionList({
     return (
       <Link className="panel session-card" href={`/session/${session.id}`} key={session.id}>
         <div className="session-row">
-          <span className={`badge ${agent}`}>
-            {humaniseBackend(agent, catalog)}
-          </span>
-          {showTransport ? (
-            <span className={`badge transport ${session.transport}`}>
-              {transportLabel(session.transport, catalog)}
+          <div className="session-card-badges">
+            <span className={`badge ${agent}`}>
+              {humaniseBackend(agent, catalog)}
             </span>
-          ) : null}
-          {session.launch_target_id ? (
-            <span className="badge neutral">{session.launch_target_id}</span>
-          ) : null}
-          <span className={`status ${session.status}`}>
-            {session.status.replace("_", " ")}
+            {showTransport ? (
+              <span className={`badge transport ${session.transport}`}>
+                {transportLabel(session.transport, catalog)}
+              </span>
+            ) : null}
+            {session.launch_target_id ? (
+              <span className="badge neutral">{session.launch_target_id}</span>
+            ) : null}
+            <span className={`status ${session.status}`}>
+              {session.status.replace("_", " ")}
+            </span>
+          </div>
+          <span
+            className="session-card-when"
+            title={new Date(session.last_event_at).toLocaleString()}
+          >
+            {formatClock(new Date(session.last_event_at))}
           </span>
         </div>
         <div className="session-card-title-row">
@@ -253,9 +262,6 @@ export function SessionList({
             {session.repo_name ?? "No repo"}
             {session.branch ? ` · ${session.branch}` : null}
             {session.source === "managed" ? " · managed" : " · attached"}
-          </p>
-          <p className="meta">
-            Last activity {new Date(session.last_event_at).toLocaleString()}
           </p>
         </div>
         <div className="session-card-actions">

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -325,6 +325,18 @@ export function SessionList({
       {flatSearchResults !== null ? (
         <section className="session-section">
           {flatSearchResults.length > 0 ? (
+            <Pager
+              page={page}
+              totalPages={totalPages}
+              total={flatSearchResults.length}
+              pageStart={showingFrom}
+              pageEnd={showingTo}
+              onPage={setPage}
+              label="sessions"
+              compact
+            />
+          ) : null}
+          {flatSearchResults.length > 0 ? (
             <div className="stack">{visibleItems.map(renderCard)}</div>
           ) : (
             <p className="muted" style={{ textAlign: "center", padding: "20px 0" }}>
@@ -360,6 +372,18 @@ export function SessionList({
               <h4>Recent</h4>
               {recentSessions.length > 0 ? (
                 <span className="meta">{recentSessions.length}</span>
+              ) : null}
+              {recentSessions.length > 0 ? (
+                <Pager
+                  page={page}
+                  totalPages={totalPages}
+                  total={recentSessions.length}
+                  pageStart={showingFrom}
+                  pageEnd={showingTo}
+                  onPage={setPage}
+                  label="sessions"
+                  compact
+                />
               ) : null}
             </header>
             {visibleItems.length > 0 ? (


### PR DESCRIPTION
## Purpose

Polish the session views' layout and make the long session list easier to page through: surface each session's last-activity time in the card header, add a second paginator at the top of the list, and fix the workspace files dock's close button hiding under the status bar on iPad.

## Changes

### Frontend

- `SessionList.tsx`, `globals.css` — move the last-activity time into the session-card header as a concise clock (full value kept in the tooltip) and drop the verbose bottom line; grouping the badges lets it sit right-aligned beside them when it fits and wrap to its own line only when it can't.
- `SessionList.tsx`, `Pager.tsx`, `globals.css` — add a compact, controls-only top pager inline with the "Recent" header (right-aligned on wide screens, a full-width control row on mobile) alongside the existing bottom pager; every pager's controls now span the width on mobile so Prev / Next sit at the thumb edges.
- `globals.css` — inset the workspace files dock's top safe area so its header and pinned close button clear the status bar when it renders as a wide side-dock on iPad.

## Design

The card header groups its badges as one flex item under `justify-content: space-between`, so a lone wrapped time lands at the start of its line — giving "right-aligned when it fits, wrap-left when it doesn't" with no media query or JS. The dock fix mirrors the top inset the narrow full-screen-sheet layout already applied. New styles resolve through CSS variables / `currentColor`, so both themes work with no separate light-mode override.

## Test Plan

- `cd frontend && npm run lint && npm run build`
- `cd backend && uv run pre-commit run --all-files`
- Manual: deployed via `waypointctl restart frontend`; verified the session cards, the top and bottom pagers, and the files-dock close button on desktop and mobile (iPad + phone) in both themes.

## Test Result

- frontend `npm run lint` and `npm run build` — clean (TypeScript OK, all pages generated).
- `pre-commit run --all-files` — isort / black / ruff / codespell / mypy all passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable) — N/A: layout-only frontend change and the repo has no frontend test harness.
- [x] I have verified the relevant suites pass locally — backend and `waypointctl` are untouched, so neither pytest suite applies; ran the frontend lint + build gate instead.
- [x] If I touched the coding-agent plugin/transport contract or dispatch code, I checked the backends — N/A: frontend-only, no plugin/transport or dispatch code touched.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (new rules use CSS variables / `currentColor`, so no separate light override was needed).
- [x] Not a breaking change — additive/cosmetic layout only.
- [x] No user-facing config or docs surface changed (`.env.example`, `waypoint.example.yaml`, `docs/`), so none updated.

</details>
