### PR TITLE
fix: keep the task dock visible for out-of-window todos

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1761,7 +1761,16 @@ class SessionRuntime:
             has_more = self.storage.has_events_before_sequence(
                 session_id, oldest_in_window
             )
-        return EventsPageResponse(events=events, has_more=has_more)
+        # Only the tail request carries the sticky todo snapshot; older pages
+        # leave it None so the client never clobbers a valid pre-window todo.
+        latest_todo = (
+            self.storage.latest_todo_event(session_id)
+            if before_sequence is None
+            else None
+        )
+        return EventsPageResponse(
+            events=events, has_more=has_more, latest_todo=latest_todo
+        )
 
     def launch_target_summaries(self) -> list[dict[str, Any]]:
         summaries: list[dict[str, Any]] = []

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -359,6 +359,11 @@ class MeResponse(BaseModel):
 class EventsPageResponse(BaseModel):
     events: list[EventRecord] = Field(default_factory=list)
     has_more: bool = False
+    # The session's most recent todo/task snapshot, populated only in tail
+    # mode so the frontend's task dock stays visible even when the latest
+    # todo predates the loaded transcript window. ``None`` when the session
+    # has no todos or when paginating older pages.
+    latest_todo: EventRecord | None = None
 
 
 class SessionCreateRequest(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -832,6 +832,32 @@ class Storage:
         return row is not None
 
     @_synchronized
+    def latest_todo_event(self, session_id: str) -> EventRecord | None:
+        """Return the most recent todo/task event, or ``None``.
+
+        Every todo event is a full snapshot of the current list, so the
+        single latest one drives the frontend's task dock regardless of
+        which transcript window the client has paginated into. The
+        predicate mirrors :func:`waypoint.events.is_todo_list_event`
+        (``item_type == "todo_list"`` or a ``TodoWrite`` tool name, with
+        the ``default_api:`` prefix); running it in SQL avoids
+        deserializing every row of a long, todo-less session on each load.
+        """
+        row = self.connection.execute(
+            """
+            SELECT * FROM events
+            WHERE session_id = ?
+              AND (json_extract(metadata, '$.item_type') = 'todo_list'
+                   OR lower(json_extract(metadata, '$.tool_name'))
+                      IN ('todowrite', 'default_api:todowrite'))
+            ORDER BY sequence DESC, id DESC
+            LIMIT 1
+            """,
+            [session_id],
+        ).fetchone()
+        return self._event_from_row(row) if row is not None else None
+
+    @_synchronized
     def insert_token(self, token: str, expires_at: datetime) -> None:
         now = datetime.now(UTC)
         self.connection.execute(

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -387,6 +387,40 @@ def test_effective_permission_mode_no_spawner_is_none(tmp_path) -> None:
     assert runtime._effective_permission_mode(request) is None
 
 
+def test_session_events_page_surfaces_latest_todo_in_tail_mode(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    storage.create_session(make_session(settings, id="sess"))
+    now = datetime.now(UTC)
+    # An early todo followed by more messages than a tail window would hold.
+    storage.append_event(
+        EventRecord(
+            session_id="sess",
+            ts=now,
+            kind=EventKind.TOOL_RESULT,
+            text="todos",
+            metadata={"item_type": "todo_list"},
+            sequence=1,
+        )
+    )
+    for i in range(2, 12):
+        storage.append_event(
+            EventRecord(
+                session_id="sess",
+                ts=now + timedelta(seconds=i),
+                kind=EventKind.AGENT_OUTPUT,
+                text=f"chunk-{i}",
+                sequence=i,
+            )
+        )
+
+    tail = runtime.session_events_page("sess", message_limit=1)
+    assert tail.latest_todo is not None
+    assert tail.latest_todo.sequence == 1
+
+    older = runtime.session_events_page("sess", message_limit=1, before_sequence=5)
+    assert older.latest_todo is None
+
+
 @pytest.mark.asyncio
 async def test_post_board_entry_persists_and_broadcasts(tmp_path) -> None:
     runtime, storage, _ = make_runtime(tmp_path)

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -288,8 +288,9 @@ def _append(
     text: str,
     ts: datetime,
     item_id: str | None = None,
+    metadata: dict[str, object] | None = None,
 ) -> None:
-    metadata: dict[str, object] = {}
+    metadata = dict(metadata or {})
     if item_id is not None:
         metadata["item_id"] = item_id
     storage.append_event(
@@ -656,6 +657,71 @@ def test_has_events_before_sequence(tmp_path) -> None:
     assert storage.has_events_before_sequence("sess", 1) is False
     assert storage.has_events_before_sequence("sess", 2) is True
     assert storage.has_events_before_sequence("sess", 99) is True
+
+
+def test_latest_todo_event_returns_highest_sequence_todo(tmp_path) -> None:
+    storage, now = _seed_session(tmp_path)
+    _append(
+        storage,
+        "sess",
+        sequence=1,
+        kind=EventKind.TOOL_RESULT,
+        text="old todos",
+        ts=now,
+        metadata={"item_type": "todo_list"},
+    )
+    _append(
+        storage,
+        "sess",
+        sequence=2,
+        kind=EventKind.TOOL_RESULT,
+        text="newer todos",
+        ts=now + timedelta(seconds=1),
+        metadata={"tool_name": "TodoWrite"},
+    )
+    # A later non-todo event must not shadow the latest todo snapshot.
+    _append(
+        storage,
+        "sess",
+        sequence=3,
+        kind=EventKind.AGENT_OUTPUT,
+        text="reply",
+        ts=now + timedelta(seconds=2),
+    )
+    latest = storage.latest_todo_event("sess")
+    assert latest is not None
+    assert latest.sequence == 2
+
+
+def test_latest_todo_event_matches_default_api_tool_name(tmp_path) -> None:
+    storage, now = _seed_session(tmp_path)
+    _append(
+        storage,
+        "sess",
+        sequence=1,
+        kind=EventKind.TOOL_RESULT,
+        text="todos",
+        ts=now,
+        metadata={"tool_name": "default_api:todowrite"},
+    )
+    latest = storage.latest_todo_event("sess")
+    assert latest is not None
+    assert latest.sequence == 1
+
+
+def test_latest_todo_event_returns_none_without_todos(tmp_path) -> None:
+    storage, now = _seed_session(tmp_path)
+    for i in range(3):
+        _append(
+            storage,
+            "sess",
+            sequence=i + 1,
+            kind=EventKind.AGENT_OUTPUT,
+            text=f"d{i}",
+            ts=now + timedelta(seconds=i),
+            metadata={"tool_name": "Bash"},
+        )
+    assert storage.latest_todo_event("sess") is None
 
 
 def test_storage_serializes_concurrent_threads(tmp_path) -> None:

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -306,6 +306,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   );
   const [session, setSession] = useState<SessionRecord | null>(null);
   const [events, setEvents] = useState<EventRecord[]>([]);
+  // The session's latest todo/task snapshot as of the initial load, carried on
+  // the tail events page. It keeps the task dock visible when the most recent
+  // todo predates the loaded transcript window; live/newer todos arrive through
+  // `events` and win the max-sequence comparison in `currentTaskEvent`.
+  const [loadedTodoEvent, setLoadedTodoEvent] = useState<EventRecord | null>(null);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | undefined>(undefined);
   const [workspaceInitialDir, setWorkspaceInitialDir] = useState<string | undefined>(undefined);
@@ -745,6 +750,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         setEvents(coalesced);
         setHasOlderEvents(loadedPage.has_more);
         setOldestRawSequence(minRawSequence(sanitized));
+        setLoadedTodoEvent(
+          loadedPage.latest_todo ? sanitizeEvent(loadedPage.latest_todo) : null,
+        );
       } catch (loadError) {
         if (active) {
           if (isAuthError(loadError)) {
@@ -1336,15 +1344,26 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // endpoints.
   const workspacePreviewEnabled = Boolean(session && !session.launch_target_id);
   // Latest task group, read off the raw event stream so the dock reflects the
-  // true current state regardless of the transcript's event filter.
+  // true current state regardless of the transcript's event filter. Fall back
+  // to `loadedTodoEvent` (the tail-page snapshot) when the latest todo predates
+  // the loaded window; the higher sequence wins so a live update always beats
+  // the load-time snapshot.
   const currentTaskEvent = useMemo(() => {
+    let windowTodo: EventRecord | null = null;
     for (let i = events.length - 1; i >= 0; i -= 1) {
       if (isTodoListEvent(events[i])) {
-        return events[i];
+        windowTodo = events[i];
+        break;
       }
     }
-    return null;
-  }, [events]);
+    if (!windowTodo) {
+      return loadedTodoEvent;
+    }
+    if (loadedTodoEvent && loadedTodoEvent.sequence > windowTodo.sequence) {
+      return loadedTodoEvent;
+    }
+    return windowTodo;
+  }, [events, loadedTodoEvent]);
   const taskProgress = useMemo(
     () => summarizeTodos(readTodoEntries(currentTaskEvent)),
     [currentTaskEvent],

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -234,6 +234,7 @@ export async function fetchEvents(
   return {
     events: (payload.events ?? []) as EventRecord[],
     has_more: Boolean(payload.has_more),
+    latest_todo: (payload.latest_todo as EventRecord | null) ?? null,
   };
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -307,6 +307,9 @@ export interface MeResponse {
 export interface EventsPage {
   events: EventRecord[];
   has_more: boolean;
+  // The session's latest todo/task snapshot, sent only for the tail page so
+  // the task dock survives a todo update that predates the loaded window.
+  latest_todo: EventRecord | null;
 }
 
 export interface LaunchTargetSummary {


### PR DESCRIPTION
## Purpose

The task/TODO progress dock disappeared whenever a session's most recent todo update predated the loaded transcript window. The dock's visibility is derived by scanning the in-memory `events` array for the latest todo event, but the initial fetch only returns the newest page of logical messages and older events page in lazily on scroll. So opening (or reloading, or navigating into) a session whose last todo update was old showed no dock until the user scrolled up far enough to page the todo event back in. Live sessions were unaffected because new todo events stream in over the websocket.

## Changes

### Backend

- `storage.py` — add `latest_todo_event(session_id)`, which returns the single most recent todo/task event via an SQL predicate mirroring `is_todo_list_event` (`item_type == "todo_list"` or a `TodoWrite` tool name, `default_api:` prefix included). Filtering in SQL avoids deserializing every row of a long, todo-less session on each load.
- `runtime.py` — populate the new field in `session_events_page` only for tail-mode requests (`before_sequence is None`); older pages leave it `None` so the client never clobbers a valid pre-window todo.
- `schemas.py` — add `latest_todo: EventRecord | None` to `EventsPageResponse` (optional, backward compatible with the CLI/client consumers of the model).

### Frontend

- `lib/types.ts`, `lib/api.ts` — carry `latest_todo` on the events page; no new endpoint or client function.
- `components/SessionDetail.tsx` — read the tail page's `latest_todo` into state and fold it into `currentTaskEvent`: when the loaded window has no todo event, fall back to the snapshot; otherwise pick whichever of the window todo and the snapshot has the higher `sequence`. A live update always wins (it lands in `events` with a higher sequence), and dismissal-by-sequence still sticks.

### Tests

- `tests/test_storage.py`, `tests/test_runtime.py` — cover `latest_todo_event` (highest-sequence todo wins, `default_api:` tool name matches, `None` without todos) and that `session_events_page` surfaces the snapshot in tail mode while leaving it `None` for older pages.

## Design

Every todo event a backend emits is already a full snapshot of the current list — claude_code Task-tool snapshots, legacy `TodoWrite`, Codex `update_plan`/`todo_list`, and opencode's `todowrite` tool call all carry the complete list in a single event — so surfacing the one latest matching event is sufficient; no range coalescing is needed. The backend already owns the exact cross-backend predicate (`waypoint.events.is_todo_list_event`), so the fix adds no per-backend branching. Rather than add a dedicated endpoint and a second round trip, the latest todo rides the existing tail events response, since that is exactly when the client needs it. The frontend keeps owning todo parsing (`readTodoEntries`); the backend only locates the event.

opencode was checked and needs no change: its todos already reach the dock through the `todowrite` tool call (matched by the predicate, full `tool_input.todos` on the event), and the `latest_todo_event` predicate covers it too. Its `todo.updated` SSE event is a deliberate lightweight breadcrumb, not the dock source.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- End-to-end against the live stack (`waypointctl restart`, real DB): confirmed via the HTTP events API that sessions whose latest todo predates the tail window now return `latest_todo` with parseable todos, and that an in-window todo is still detected in-window (no regression). Spot-checked all three backends' stored todo events (claude_code, codex, opencode).

## Test Result

- `pre-commit run --all-files` — all hooks passed (isort, black, ruff, codespell, mypy).
- `uv run pytest` — 1310 passed.
- `npm run lint` + `npm run build` — clean (all pages generated).
- Live API: `codex-34d7f2e1` tail window seq 10706–11360, `latest_todo` seq 10642 (4 todos) → out-of-window, now surfaced; `claude_code-…64` window 5209–5305, `latest_todo` seq 4247 (11 todos) → surfaced; `opencode-…bb9d8` `latest_todo` seq 16584 inside window 15875–16622 → in-window, consistent.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes — new storage and runtime tests for `latest_todo_event` / tail-mode population.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest` — 1310 passed; `waypointctl` untouched).
- [x] If I touched code that dispatches by plugin id, I checked the backends — the fix reuses the shared `is_todo_list_event` predicate (no per-backend branch); verified claude_code, codex, and opencode todo events against the live DB.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity — no new styles, logic-only change.
- [x] Not a breaking change — `latest_todo` is an additive, optional response field.
- [x] No documentation or config examples needed — no user-facing config or contract change.

</details>
