### PR TITLE
fix: reject a nonexistent working directory at session launch

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -75,9 +75,31 @@ SESSION_BROADCAST_DEBOUNCE_SECONDS = 0.25
 # close). A crash can lose at most the last few un-flushed lines, all of which
 # are still durable in SQLite.
 STRUCTURED_LOG_FLUSH_EVERY = 16
+# Stable sentinel returned when a launch's working directory does not exist.
+# The frontend matches it (like ``ssh-master-required``) to surface an inline
+# error on the working-directory field instead of the generic banner.
+CWD_NOT_FOUND_DETAIL = "cwd-not-found"
 
 
 log = logging.getLogger("waypoint.runtime")
+
+
+def require_existing_local_dir(cwd: str) -> str:
+    """Expand ``~`` and return the resolved local cwd, raising 400 if it is not
+    an existing directory.
+
+    An unchecked missing cwd is handed to tmux / ``Popen``, which silently fall
+    back to ``$HOME``; the agent then runs in the wrong directory and — for the
+    tty-tail transport — writes its transcript where the tailer is not watching,
+    leaving an empty transcript. Failing fast surfaces the typo instead.
+    """
+    resolved = str(Path(cwd).expanduser())
+    if not Path(resolved).is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=CWD_NOT_FOUND_DETAIL,
+        )
+    return resolved
 
 
 @dataclass
@@ -362,7 +384,7 @@ class SessionRuntime:
         if launch_target is not None:
             local_cwd = request.cwd or launch_target.default_cwd
         else:
-            local_cwd = str(Path(request.cwd).expanduser())
+            local_cwd = require_existing_local_dir(request.cwd)
         request = request.model_copy(update={"cwd": local_cwd})
         title = (
             request.title

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -17,7 +17,12 @@ from waypoint.backends.codex.permission_modes import (
 )
 from waypoint.backends.codex.schemas import CodexThreadImportRequest
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.runtime import STRUCTURED_LOG_FLUSH_EVERY, SessionRuntime
+from waypoint.runtime import (
+    CWD_NOT_FOUND_DETAIL,
+    STRUCTURED_LOG_FLUSH_EVERY,
+    SessionRuntime,
+    require_existing_local_dir,
+)
 from waypoint.schemas import (
     BoardEntryUpdateRequest,
     BoardPostRequest,
@@ -385,6 +390,39 @@ def test_effective_permission_mode_no_spawner_is_none(tmp_path) -> None:
     runtime, _, _ = make_runtime(tmp_path)
     request = SessionCreateRequest(backend="claude_code", cwd="/tmp")
     assert runtime._effective_permission_mode(request) is None
+
+
+def test_require_existing_local_dir_accepts_dir_and_expands(tmp_path) -> None:
+    assert require_existing_local_dir(str(tmp_path)) == str(tmp_path)
+    # ``~`` expands to the (existing) home directory.
+    assert require_existing_local_dir("~") == str(Path.home())
+
+
+def test_require_existing_local_dir_rejects_missing(tmp_path) -> None:
+    with pytest.raises(HTTPException) as exc:
+        require_existing_local_dir(str(tmp_path / "nope"))
+    assert exc.value.status_code == 400
+    assert exc.value.detail == CWD_NOT_FOUND_DETAIL
+
+
+def test_require_existing_local_dir_rejects_file(tmp_path) -> None:
+    target = tmp_path / "regular.txt"
+    target.write_text("x")
+    with pytest.raises(HTTPException) as exc:
+        require_existing_local_dir(str(target))
+    assert exc.value.detail == CWD_NOT_FOUND_DETAIL
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_missing_cwd(tmp_path) -> None:
+    runtime, _, _ = make_runtime(tmp_path)
+    request = SessionCreateRequest(
+        backend="claude_code", cwd=str(tmp_path / "does-not-exist")
+    )
+    with pytest.raises(HTTPException) as exc:
+        await runtime.create_session(request)
+    assert exc.value.status_code == 400
+    assert exc.value.detail == CWD_NOT_FOUND_DETAIL
 
 
 def test_session_events_page_surfaces_latest_todo_in_tail_mode(tmp_path) -> None:
@@ -1852,7 +1890,7 @@ async def test_create_session_direct_mode_uses_requested_backend(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="codex",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             launch_mode=LaunchMode.DIRECT,
             title="Direct launch",
             args=[],
@@ -1863,7 +1901,7 @@ async def test_create_session_direct_mode_uses_requested_backend(
     assert create_calls == [(session.id, LaunchMode.DIRECT)]
     assert session.backend == "codex"
     assert session.transport == "codex_app_server"
-    assert session.cwd == str(Path.home() / "workspace")
+    assert session.cwd == str(tmp_path)
 
 
 @pytest.mark.asyncio
@@ -1915,7 +1953,7 @@ async def test_create_session_tmux_wrapper_mode_routes_through_tmux(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="codex",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             launch_mode=LaunchMode.TMUX_WRAPPER,
             title="Wrapper launch",
             args=[],
@@ -1926,7 +1964,7 @@ async def test_create_session_tmux_wrapper_mode_routes_through_tmux(
     assert create_calls == [(session.id, "codex", LaunchMode.TMUX_WRAPPER)]
     assert session.backend == "codex"
     assert session.transport == "tmux"
-    assert session.cwd == str(Path.home() / "workspace")
+    assert session.cwd == str(tmp_path)
 
 
 @pytest.mark.asyncio
@@ -1981,7 +2019,7 @@ async def test_create_session_auto_mode_falls_back_to_tmux_when_backend_unavaila
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="codex",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             title="Auto fallback",
             args=[],
             source_mode=SessionSource.MANAGED,
@@ -2029,7 +2067,7 @@ async def test_create_session_rejects_unsupported_model_effort_combo(
         await runtime.create_session(
             SessionCreateRequest(
                 backend="claude_code",
-                cwd="~/workspace",
+                cwd=str(tmp_path),
                 args=[],
                 model="sonnet",
                 effort="xhigh",
@@ -2114,7 +2152,7 @@ async def test_create_session_accepts_supported_model_effort_combo(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             args=[],
             model="sonnet",
             effort="max",
@@ -2188,7 +2226,7 @@ async def test_create_session_explicit_transport_routes_to_tty_driver(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             transport="claude_tty",
             title="TUI",
             args=[],
@@ -2231,7 +2269,7 @@ async def test_create_session_explicit_transport_takes_precedence_over_launch_mo
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             launch_mode=LaunchMode.TMUX_WRAPPER,
             transport="claude_tty",
             args=[],
@@ -2271,7 +2309,7 @@ async def test_create_session_explicit_cli_transport_uses_structured_adapter(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             transport="claude_cli",
             args=[],
             source_mode=SessionSource.MANAGED,
@@ -2290,7 +2328,7 @@ async def test_create_session_rejects_unsupported_transport(tmp_path) -> None:
         await runtime.create_session(
             SessionCreateRequest(
                 backend="claude_code",
-                cwd="~/workspace",
+                cwd=str(tmp_path),
                 transport="codex_app_server",
                 args=[],
                 source_mode=SessionSource.MANAGED,
@@ -2333,7 +2371,7 @@ async def test_create_session_legacy_claude_tty_backend_routes_to_tty(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_tty",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             args=[],
             source_mode=SessionSource.MANAGED,
         )
@@ -2376,7 +2414,7 @@ async def test_create_session_local_claude_defaults_to_tty_transport(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             args=[],
             source_mode=SessionSource.MANAGED,
         )
@@ -2418,7 +2456,7 @@ async def test_create_session_default_transport_falls_back_when_driver_unavailab
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             args=[],
             source_mode=SessionSource.MANAGED,
         )
@@ -2461,7 +2499,7 @@ async def test_create_session_explicit_transport_skips_unavailable_fallback(
     session = await runtime.create_session(
         SessionCreateRequest(
             backend="claude_code",
-            cwd="~/workspace",
+            cwd=str(tmp_path),
             transport="claude_tty",
             args=[],
             source_mode=SessionSource.MANAGED,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -691,6 +691,10 @@ html[data-theme="light"] .field select {
   .field input[aria-invalid="true"] {
     animation: field-shake 220ms ease-in-out;
   }
+
+  .field-error {
+    animation: field-error-in 140ms ease-out both;
+  }
 }
 
 /* Inline validation message beneath a field. Leads with a currentColor lamp
@@ -704,7 +708,6 @@ html[data-theme="light"] .field select {
   font-size: 0.8rem;
   line-height: 1.4;
   overflow-wrap: anywhere;
-  animation: field-error-in 140ms ease-out both;
 }
 
 .field-error::before {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -692,41 +692,39 @@ html[data-theme="light"] .field select {
     animation: field-shake 220ms ease-in-out;
   }
 
-  .field-error {
+  .field .field-error {
     animation: field-error-in 140ms ease-out both;
   }
 }
 
-/* Inline validation message beneath a field. Leads with a currentColor lamp
-   dot — the same status vocabulary as badges — and wraps long paths so it can
-   never overflow the launch card. */
-.field-error {
-  display: flex;
-  align-items: baseline;
-  gap: 7px;
+/* Inline validation message beneath a field. The `.field .field-error`
+   specificity (and the resets below) override `.field span`, which otherwise
+   styles this as an uppercase mono label. Leads with a currentColor lamp dot —
+   the same status vocabulary as badges — and wraps long paths naturally. */
+.field .field-error {
+  display: block;
   color: var(--danger);
+  font-family: var(--font-sans);
   font-size: 0.8rem;
   line-height: 1.4;
+  letter-spacing: normal;
+  text-transform: none;
   overflow-wrap: anywhere;
 }
 
-.field-error::before {
+.field .field-error::before {
   content: "";
-  flex: none;
+  display: inline-block;
   width: 6px;
   height: 6px;
-  margin-top: 0.35em;
+  margin-right: 7px;
   border-radius: var(--radius-pill);
   background: currentColor;
+  vertical-align: middle;
 }
 
-.field-error code {
+.field .field-error code {
   font-family: var(--font-mono);
-}
-
-.field-error-hint {
-  color: color-mix(in srgb, var(--danger) 70%, var(--muted));
-  margin-left: 6px;
 }
 
 @keyframes field-error-in {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -676,6 +676,81 @@ html[data-theme="light"] .field select {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
+/* Invalid field: the same instrument reading, in the danger hue. Mirrors the
+   accent focus ring above so the treatment reads as one system. */
+.field input[aria-invalid="true"] {
+  border-color: var(--danger);
+}
+
+.field input[aria-invalid="true"]:focus {
+  border-color: var(--danger);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger) 20%, transparent);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .field input[aria-invalid="true"] {
+    animation: field-shake 220ms ease-in-out;
+  }
+}
+
+/* Inline validation message beneath a field. Leads with a currentColor lamp
+   dot — the same status vocabulary as badges — and wraps long paths so it can
+   never overflow the launch card. */
+.field-error {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  color: var(--danger);
+  font-size: 0.8rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+  animation: field-error-in 140ms ease-out both;
+}
+
+.field-error::before {
+  content: "";
+  flex: none;
+  width: 6px;
+  height: 6px;
+  margin-top: 0.35em;
+  border-radius: var(--radius-pill);
+  background: currentColor;
+}
+
+.field-error code {
+  font-family: var(--font-mono);
+}
+
+.field-error-hint {
+  color: color-mix(in srgb, var(--danger) 70%, var(--muted));
+  margin-left: 6px;
+}
+
+@keyframes field-error-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes field-shake {
+  10%,
+  90% {
+    transform: translateX(-1px);
+  }
+  30%,
+  70% {
+    transform: translateX(2px);
+  }
+  50% {
+    transform: translateX(-2px);
+  }
+}
+
 .primary,
 .secondary,
 .danger {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -43,6 +43,7 @@ import {
   setSessionPinned,
   setSessionTitle,
   SSH_MASTER_REQUIRED_DETAIL,
+  CWD_NOT_FOUND_DETAIL,
 } from "@/lib/api";
 import {
   clearToken,
@@ -127,6 +128,9 @@ export default function HomePage() {
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
   const [assistant, setAssistant] = useState<AssistantSummary | null>(null);
   const [error, setError] = useState("");
+  // The working directory the last New launch was rejected for (400
+  // cwd-not-found), surfaced inline on the launch form's cwd field.
+  const [cwdError, setCwdError] = useState<string | null>(null);
   const [connection, setConnection] = useState<ConnectionState>("idle");
   const [defaultBackend, setDefaultBackend] = useState<Backend>("codex");
   const [defaultCwd, setDefaultCwd] = useState("~/");
@@ -211,6 +215,9 @@ export default function HomePage() {
 
   useEffect(() => {
     setRecentCwds(readRecentCwds(host, activeLaunchTargetId));
+    // A cwd rejection is target-specific ("not found on <target>"), so drop it
+    // when the target changes to avoid showing a now-irrelevant error.
+    setCwdError(null);
   }, [activeLaunchTargetId, host]);
 
   // The `connected` flag from /api/me is a cached snapshot; the master may have
@@ -539,6 +546,7 @@ export default function HomePage() {
     configOverrides: string[] = [],
     permissionMode: string | null = null,
   ) {
+    setCwdError(null);
     try {
       const session = await createSession(host, token, {
         backend,
@@ -562,6 +570,15 @@ export default function HomePage() {
     } catch (createError) {
       if (isAuthError(createError)) {
         resetAuthState("Session expired. Log in again.");
+        return;
+      }
+      if (
+        createError instanceof Error &&
+        createError.message === CWD_NOT_FOUND_DETAIL
+      ) {
+        // A field-level validation error: surface it inline on the working
+        // directory input rather than the global banner.
+        setCwdError(cwd);
         return;
       }
       if (
@@ -982,6 +999,8 @@ export default function HomePage() {
           onImportThread={handleImportThread}
           onCreateSchedule={handleCreateSchedule}
           onAuthFailure={handleAuthFailure}
+          cwdError={cwdError}
+          onClearCwdError={() => setCwdError(null)}
         />
       ) : null}
       {token ? (

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -212,6 +212,8 @@ interface LaunchFormFieldsProps {
   catalog: BackendCatalog;
   busy: boolean;
   onAuthFailure?: () => void;
+  cwdError?: string | null;
+  onClearCwdError?: () => void;
 }
 
 // The shared input block for New and Schedule: agent/transport picker, the
@@ -228,6 +230,8 @@ export function LaunchFormFields({
   catalog,
   busy,
   onAuthFailure,
+  cwdError,
+  onClearCwdError,
 }: LaunchFormFieldsProps) {
   return (
     <>
@@ -245,6 +249,8 @@ export function LaunchFormFields({
           onChange={form.setCwd}
           targetLabel={targetLabel}
           recentCwds={recentCwds}
+          error={cwdError}
+          onClearError={onClearCwdError}
         />
         <label className="field">
           <span>Title</span>

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -76,6 +76,9 @@ interface LaunchPanelProps {
   ) => Promise<void>;
   onCreateSchedule: (payload: ScheduleCreateRequest) => Promise<void>;
   onAuthFailure?: () => void;
+  // The cwd the backend rejected as nonexistent on the last New launch, or null.
+  cwdError?: string | null;
+  onClearCwdError?: () => void;
 }
 
 export function LaunchPanel({
@@ -96,6 +99,8 @@ export function LaunchPanel({
   onDeleteThread,
   onCreateSchedule,
   onAuthFailure,
+  cwdError,
+  onClearCwdError,
 }: LaunchPanelProps) {
   const [mode, setMode] = useState<PanelMode>("new");
   const form = useLaunchForm({ defaultBackend, defaultCwd, launchTargetId, catalog });
@@ -212,6 +217,8 @@ export function LaunchPanel({
             catalog={catalog}
             busy={formBusy}
             onAuthFailure={onAuthFailure}
+            cwdError={cwdError}
+            onClearCwdError={onClearCwdError}
           />
           <div className="launch-actions">
             <span className="grow" />

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -201,7 +201,15 @@ export function LaunchPanel({
           <h3>Start a session</h3>
           <p className="muted">{subhead}</p>
         </div>
-        <LaunchModeChooser mode={mode} onChange={setMode} />
+        <LaunchModeChooser
+          mode={mode}
+          onChange={(next) => {
+            // The cwd field is shared across modes; a rejection from the New
+            // form is stale once we leave it, so clear it on any mode switch.
+            onClearCwdError?.();
+            setMode(next);
+          }}
+        />
       </div>
 
       {mode === "new" ? (

--- a/frontend/src/components/WorkingDirectoryField.tsx
+++ b/frontend/src/components/WorkingDirectoryField.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useId } from "react";
+import { useEffect, useId, useRef } from "react";
 
 interface WorkingDirectoryFieldProps {
   cwd: string;
   onChange: (cwd: string) => void;
   targetLabel: string | null;
   recentCwds: string[];
+  // The path the backend rejected as nonexistent, or null. When set, the field
+  // shows an inline error and takes focus; editing clears it via onClearError.
+  error?: string | null;
+  onClearError?: () => void;
 }
 
 export function WorkingDirectoryField({
@@ -14,22 +18,57 @@ export function WorkingDirectoryField({
   onChange,
   targetLabel,
   recentCwds,
+  error,
+  onClearError,
 }: WorkingDirectoryFieldProps) {
   const listId = useId();
+  const errorId = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
   const label = targetLabel
     ? `Working directory on ${targetLabel}`
     : "Working directory";
   const hasRecents = recentCwds.length > 0;
 
+  // Pull focus to the offending field when a launch fails on the cwd, so the
+  // fix is immediate even if the launch card scrolled out of view.
+  useEffect(() => {
+    if (!error) {
+      return;
+    }
+    const input = inputRef.current;
+    input?.focus();
+    input?.scrollIntoView({ block: "nearest" });
+  }, [error]);
+
   return (
     <label className="field">
       <span>{label}</span>
       <input
+        ref={inputRef}
         value={cwd}
-        onChange={(event) => onChange(event.target.value)}
+        onChange={(event) => {
+          onChange(event.target.value);
+          if (error) {
+            onClearError?.();
+          }
+        }}
         placeholder={targetLabel ? "~" : undefined}
         list={hasRecents ? listId : undefined}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
       />
+      {error ? (
+        <span className="field-error" id={errorId} role="alert">
+          <span className="field-error-msg">
+            Working directory not found: <code>{error}</code>
+            <span className="field-error-hint">
+              {targetLabel
+                ? `Check the path exists on ${targetLabel}.`
+                : "Check the path exists on this machine."}
+            </span>
+          </span>
+        </span>
+      ) : null}
       {hasRecents ? (
         <datalist id={listId}>
           {recentCwds.map((recent) => (

--- a/frontend/src/components/WorkingDirectoryField.tsx
+++ b/frontend/src/components/WorkingDirectoryField.tsx
@@ -59,14 +59,7 @@ export function WorkingDirectoryField({
       />
       {error ? (
         <span className="field-error" id={errorId} role="alert">
-          <span className="field-error-msg">
-            Working directory not found: <code>{error}</code>
-            <span className="field-error-hint">
-              {targetLabel
-                ? `Check the path exists on ${targetLabel}.`
-                : "Check the path exists on this machine."}
-            </span>
-          </span>
+          Directory not found: <code>{error}</code>
         </span>
       ) : null}
       {hasRecents ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -260,6 +260,10 @@ export async function createSession(
 // password-auth SSH host whose ControlMaster is not connected yet.
 export const SSH_MASTER_REQUIRED_DETAIL = "ssh-master-required";
 
+// Detail token the backend returns (HTTP 400) when a launch's working
+// directory does not exist; the client surfaces it inline on the cwd field.
+export const CWD_NOT_FOUND_DETAIL = "cwd-not-found";
+
 export interface LaunchTargetConnectResult {
   target_id: string;
   connected: boolean;


### PR DESCRIPTION
## Purpose

Launching a session with a working directory that doesn't exist produced a broken, silent session: `create_session` only expanded `~` and never checked the path, so the missing cwd was handed to tmux / `Popen`, which fall back to `$HOME`. The agent then ran in the wrong directory, and — for the tty-tail (`claude_tty`) transport — Claude wrote its transcript JSONL under the `$HOME`-derived project folder while the tailer watched the path derived from the *requested* cwd. The watched file never appeared, so the structured transcript stayed empty even though the terminal pane mirrored everything. This is exactly how a `~/.agent/skills` typo (for `~/.agents/skills`) produced a session with no agent output. This fails the launch fast instead and surfaces the mistake inline on the field that caused it.

## Changes

### Backend

- `runtime.py` — add `require_existing_local_dir(cwd)`: expands `~`, and if the result isn't a directory raises `HTTPException(400, detail=CWD_NOT_FOUND_DETAIL)`. `create_session` calls it on the local branch (`launch_target is None`), before transport/plugin dispatch, so every transport (tty-tail, native structured, tmux) fail-fasts. `CWD_NOT_FOUND_DETAIL` (`"cwd-not-found"`) is a stable sentinel, mirroring the existing `ssh-master-required` contract.

### Frontend

- `lib/api.ts` — export `CWD_NOT_FOUND_DETAIL`, matching the backend sentinel (beside `SSH_MASTER_REQUIRED_DETAIL`).
- `app/page.tsx` — intercept the sentinel in `handleCreate`: set an inline `cwdError` instead of the global banner, and clear it on a fresh launch, on launch-target change, and on edit.
- `components/WorkingDirectoryField.tsx` — render an invalid state (`aria-invalid`, danger border/ring) and a `role="alert"` message naming the path, and move focus to the input so the fix is immediate.
- `components/LaunchFormFields.tsx`, `components/LaunchPanel.tsx` — thread `cwdError`/`onClearCwdError` through to the field. The error is gated to the New form only; the Schedule form shares the component but never inherits the error.
- `app/globals.css` — flat, token-derived styles for the invalid field and `.field-error` (danger hue via `--danger`, a `currentColor` lamp dot, mono path, fade-in, and a reduced-motion-gated shake), consistent with the flat-instruments design language.

### Tests

- `tests/test_runtime.py` — cover `require_existing_local_dir` (dir passes and expands `~`; missing and file-path both 400 with the sentinel) and `create_session` rejecting a missing cwd. Existing local-launch routing tests now use `tmp_path` (an existing dir) rather than the never-created `~/workspace`.

## Design

The validation lives at the single local-launch choke point in `create_session`, so it can't be bypassed per-transport, and it uses `is_dir()` to fold "missing" and "exists-but-is-a-file" into one symlink-transparent check. Rejecting (rather than auto-creating) is deliberate: a nonexistent cwd is almost always a typo, and silently `mkdir`-ing it would mask the mistake. On the client, this is a field-level validation error, so it belongs on the field, not the page-level banner — mirroring the app's existing pattern of intercepting a specific backend sentinel (`ssh-master-required`) for contextual handling.

Deliberately out of scope: restore/reattach and resume-restart relaunch into the *stored* `session.cwd` without re-validation (their cwd was validated at create; boot-time restore would need graceful per-session degradation rather than a hard 400) — a follow-up. Remote launches pass cwd verbatim to the remote shell and never derive a local tailer path, so they can't hit this bug. The import/resume paths already validate their cwd. As a pre-existing behavior (unchanged here), a failed launch still clears the typed title.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- Manual, against the live stack: originally reproduced the empty-transcript bug on a real session launched with a nonexistent cwd (`~/.agent/skills`); confirmed the backend now rejects a missing cwd with the sentinel via the runtime path.

## Test Result

- `pre-commit run --all-files` — all hooks passed (isort, black, ruff, codespell, mypy).
- `uv run pytest` — 1314 passed.
- `npm run lint` + `npm run build` — clean (all pages generated).

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes — new `require_existing_local_dir` / `create_session` cwd tests.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest` — 1314 passed; `waypointctl` untouched).
- [x] If I touched code that dispatches by plugin id, I checked the backends — the guard is a single transport-agnostic check reusing no per-backend branch; claude_code, codex, and opencode all launch through the same `create_session` path.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity — the new styles resolve from `--danger` / `color-mix`, no per-theme override needed.
- [x] Not a breaking change — additive validation + a new optional error field on the launch form. Note: the structured `claude_code` create path previously tolerated a missing cwd (silent server-cwd fallback); it now returns a 400, which is the intended fail-fast.
- [x] No documentation or config examples needed — no user-facing config or contract change.

</details>
