### PR TITLE
fix: replay thread history into imported sessions

### DIFF
--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -18,7 +18,7 @@ trusting any flag list reproduced in this skill.
 
 ## Common Routing
 
-- Read session state or transcript: see `references/sessions-read.md`; list importable threads with `waypoint backends threads <backend>`, import one with `waypoint sessions import <backend> --json ...`, or pipe just the assistant text with `waypoint sessions output <session-id> --text`.
+- Read session state or transcript: see `references/sessions-read.md`; list importable threads with `waypoint backends threads <backend>`, import one with `waypoint sessions import <backend> --thread-id <id>` (replays the thread's prior conversation into the new session by default; pass `--no-import-history` to start empty), or pipe just the assistant text with `waypoint sessions output <session-id> --text`.
 - Launch a new coding agent: see `references/sessions-launch.md`.
 - Discover the backend ids and the models/efforts each offers: `waypoint
   backends` and `waypoint models [backend]` (see `references/sessions-launch.md`).

--- a/backend/src/waypoint/backends/claude_code/history.py
+++ b/backend/src/waypoint/backends/claude_code/history.py
@@ -1,0 +1,181 @@
+"""Historical transcript -> EventRecord conversion for thread-history import.
+
+Feeds the ``reader`` callable ``runtime.seed_thread_history`` expects for both
+the claude_code (direct SDK) and claude_tty transports, which persist and
+resume the same on-disk ``~/.claude/projects/<enc-cwd>/<uuid>.jsonl``
+transcript. Reuses the pure block helpers from ``normalize.py`` so seeded
+events carry metadata shaped like the live normalizers' output
+(``item_id``/``tool_use_id``/``tool_name``) — what ``parseEvent`` /
+``TranscriptCard`` on the frontend key off of to render and pair
+tool_call/tool_result cards.
+
+Unlike the live normalizers (``adapter.py``'s ``_handle_user`` and
+``claude_tty/normalize.py``'s ``_process_user``), which intentionally skip
+plain user text because it is already recorded at the input boundary
+(``runtime._record_user_event``), historical replay has no such live input
+boundary: user turns are reconstructed here or they vanish from the imported
+transcript entirely.
+"""
+
+import asyncio
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from waypoint.backends.claude_code.normalize import (
+    is_injected_user_turn,
+    iter_content_blocks,
+    stringify_tool_result,
+)
+from waypoint.backends.claude_code.threads import (
+    parse_iso_timestamp,
+    read_local_claude_transcript,
+)
+from waypoint.schemas import EventKind, EventRecord, SessionStatus
+
+
+async def read_local_claude_history(
+    session_id: str, thread_id: str
+) -> list[EventRecord]:
+    """Read and convert a local Claude transcript for thread-history import."""
+    records = await asyncio.to_thread(read_local_claude_transcript, thread_id)
+    return convert_transcript_records(session_id, records)
+
+
+def convert_transcript_records(
+    session_id: str, records: list[dict[str, Any]]
+) -> list[EventRecord]:
+    """Convert ordered raw transcript records into ordered EventRecords.
+
+    Only ``assistant`` text/tool_use and ``user`` text/tool_result records
+    produce events; other record types (system notes, compact boundaries,
+    summaries) carry no chat content worth replaying and are dropped.
+    """
+    events: list[EventRecord] = []
+    last_ts = datetime.now(UTC)
+    for record in records:
+        ts = _record_timestamp(record) or last_ts
+        last_ts = ts
+        rec_type = record.get("type")
+        if rec_type == "assistant":
+            events.extend(_convert_assistant(session_id, record, ts))
+        elif rec_type == "user":
+            events.extend(_convert_user(session_id, record, ts))
+    return events
+
+
+def _convert_assistant(
+    session_id: str, record: dict[str, Any], ts: datetime
+) -> list[EventRecord]:
+    message: dict[str, Any] = record.get("message") or {}
+    message_id = str(message.get("id") or "")
+    events: list[EventRecord] = []
+    for block in iter_content_blocks(message.get("content")):
+        block_type = block.get("type")
+        if block_type == "text":
+            text = str(block.get("text") or "")
+            if not text:
+                continue
+            events.append(
+                _event(
+                    session_id,
+                    ts,
+                    EventKind.AGENT_OUTPUT,
+                    text,
+                    {
+                        "method": "assistant.text",
+                        "item_id": message_id,
+                        "payload": block,
+                    },
+                )
+            )
+        elif block_type == "tool_use":
+            tool_use_id = str(block.get("id") or "")
+            tool_name = str(block.get("name") or "tool")
+            input_text = json.dumps(block.get("input") or {}, indent=2)
+            events.append(
+                _event(
+                    session_id,
+                    ts,
+                    EventKind.TOOL_CALL,
+                    f"{tool_name}\n{input_text}",
+                    {
+                        "method": "assistant.tool_use",
+                        "item_id": tool_use_id,
+                        "tool_name": tool_name,
+                        "tool_use_id": tool_use_id,
+                        "payload": block,
+                    },
+                )
+            )
+        # "thinking" and other block types render no card live either.
+    return events
+
+
+def _convert_user(
+    session_id: str, record: dict[str, Any], ts: datetime
+) -> list[EventRecord]:
+    message: dict[str, Any] = record.get("message") or {}
+    content = message.get("content")
+    if is_injected_user_turn(content):
+        return []
+    blocks = iter_content_blocks(content)
+    tool_result_blocks = [b for b in blocks if b.get("type") == "tool_result"]
+    if tool_result_blocks:
+        # A tool_result record never mixes in genuine human text (the CLI
+        # only echoes the tool verdict here), matching the live normalizers'
+        # assumption in ``_handle_user``/``_process_user``.
+        return [
+            _event(
+                session_id,
+                ts,
+                EventKind.TOOL_RESULT,
+                stringify_tool_result(block.get("content")),
+                {
+                    "method": "user.tool_result",
+                    "item_id": str(block.get("tool_use_id") or ""),
+                    "tool_use_id": str(block.get("tool_use_id") or ""),
+                    "is_error": bool(block.get("is_error")),
+                    "payload": block,
+                },
+            )
+            for block in tool_result_blocks
+        ]
+    text = "\n".join(
+        str(block.get("text") or "")
+        for block in blocks
+        if block.get("type") == "text" and block.get("text")
+    ).strip()
+    if not text:
+        return []
+    return [
+        _event(
+            session_id,
+            ts,
+            EventKind.USER_INPUT,
+            text,
+            {"method": "user.text", "submit": True, "imported": True},
+        )
+    ]
+
+
+def _event(
+    session_id: str,
+    ts: datetime,
+    kind: EventKind,
+    text: str,
+    metadata: dict[str, Any],
+) -> EventRecord:
+    return EventRecord(
+        session_id=session_id,
+        ts=ts,
+        kind=kind,
+        text=text,
+        metadata={**metadata, "status": SessionStatus.RUNNING},
+        sequence=0,  # storage.seed_events reassigns sequences from list order.
+    )
+
+
+def _record_timestamp(record: dict[str, Any]) -> datetime | None:
+    raw = record.get("timestamp")
+    return parse_iso_timestamp(raw) if isinstance(raw, str) else None

--- a/backend/src/waypoint/backends/claude_code/normalize.py
+++ b/backend/src/waypoint/backends/claude_code/normalize.py
@@ -114,6 +114,20 @@ def iter_content_blocks(content: Any) -> list[dict[str, Any]]:
     return blocks
 
 
+def is_injected_user_turn(content: Any) -> bool:
+    """Return True for harness-injected user turns that must not surface as chat.
+
+    Shared by the live tty-tail normalizer and the historical thread-import
+    converter, both of which read the same on-disk transcript records.
+    """
+    if isinstance(content, str):
+        stripped = content.lstrip()
+        return stripped.startswith("<task-notification>") or stripped.startswith(
+            "This session is being continued"
+        )
+    return False
+
+
 def stringify_tool_result(content: Any) -> str:
     if content is None:
         return ""

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -31,6 +31,7 @@ from waypoint.backends.claude_code.commands import (
     CLAUDE_BUILTIN_SLASH_COMMANDS,
     list_claude_command_completions,
 )
+from waypoint.backends.claude_code.history import read_local_claude_history
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
@@ -81,6 +82,7 @@ from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
     EventKind,
+    EventRecord,
     LaunchMode,
     SessionCreateRequest,
     SessionEnvelope,
@@ -1549,6 +1551,23 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             self.thread_enumerator.invalidate(launch_target.id)
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
         await self._register_rate_limit_probe(runtime, session.id, launch_target)
+
+        async def _read_thread_history() -> list[EventRecord]:
+            if launch_target is not None:
+                # Remote transcripts aren't fetched today: RemoteClaudeThread-
+                # Enumerator only surfaces thread-list metadata (via
+                # claude_thread_enumerator.sh), not the full JSONL transcript,
+                # and there's no existing remote-file-read primitive cheap
+                # enough to reuse here. Degrade to a plain resume — an empty
+                # read is a no-op for seed_thread_history, not a failure.
+                return []
+            return await read_local_claude_history(session.id, info.id)
+
+        await runtime.seed_thread_history(
+            session.id,
+            reader=_read_thread_history,
+            enabled=request.import_history,
+        )
         await runtime._record_system_event(
             session.id,
             self.format_import_message(cwd, launch_target),

--- a/backend/src/waypoint/backends/claude_code/schemas.py
+++ b/backend/src/waypoint/backends/claude_code/schemas.py
@@ -43,3 +43,7 @@ class ClaudeThreadImportRequest(BaseModel):
     # thread under the tty-tail driver while still persisting
     # ``backend=claude_code``.
     transport: SessionTransportId | None = None
+    # When true (default), the prior conversation is replayed into the new
+    # session's transcript at import time; when false the transcript starts
+    # empty and only the underlying agent resumes its own context.
+    import_history: bool = True

--- a/backend/src/waypoint/backends/claude_code/threads.py
+++ b/backend/src/waypoint/backends/claude_code/threads.py
@@ -24,6 +24,7 @@ import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 log = logging.getLogger("waypoint.claude_threads")
 
@@ -259,12 +260,65 @@ def _fallback_title(preview: str | None, cwd: str, session_id: str) -> str:
 
 
 def _parse_iso_timestamp(value: str) -> float | None:
+    parsed = parse_iso_timestamp(value)
+    return parsed.timestamp() if parsed is not None else None
+
+
+def parse_iso_timestamp(value: str) -> datetime | None:
+    """Parse a transcript record's ISO-8601 ``timestamp`` field.
+
+    Shared with the history converter so seeded events preserve the
+    source timestamp rather than the import time.
+    """
     text = value.strip()
     if not text:
         return None
     if text.endswith("Z"):
         text = text[:-1] + "+00:00"
     try:
-        return datetime.fromisoformat(text).timestamp()
+        return datetime.fromisoformat(text)
     except ValueError:
         return None
+
+
+def read_local_claude_transcript(thread_id: str) -> list[dict[str, Any]]:
+    """Read every record of a local Claude transcript, in file order.
+
+    Unlike ``_read_thread_info`` (which stops after ``MAX_LINES_SCANNED``
+    once it has enough metadata for a thread-list entry), this reads the
+    transcript in full: thread-history import needs every user/assistant/
+    tool record the CLI wrote, not just the first ones.
+    """
+    if not UUID_RE.match(thread_id):
+        return []
+    root = claude_projects_root()
+    if not root.is_dir():
+        return []
+    for project_dir in root.iterdir():
+        if not project_dir.is_dir():
+            continue
+        candidate = project_dir / f"{thread_id}.jsonl"
+        if not candidate.is_file():
+            continue
+        return _read_all_records(candidate)
+    return []
+
+
+def _read_all_records(path: Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    try:
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(record, dict):
+                    records.append(record)
+    except OSError as exc:
+        log.warning("failed to read claude transcript %s: %s", path, exc)
+        return []
+    return records

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -37,6 +37,7 @@ from waypoint.backends.claude_code.normalize import (
     TaskListTracker,
     extract_created_task_id,
     format_task_snapshot,
+    is_injected_user_turn,
     iter_content_blocks,
     stringify_tool_result,
 )
@@ -345,7 +346,7 @@ class TranscriptNormalizer:
         message: dict[str, Any] = record.get("message") or {}
         content = message.get("content")
 
-        if _is_injected_turn(content):
+        if is_injected_user_turn(content):
             return []
 
         turn_aborted = _is_user_rejection(record)
@@ -474,16 +475,6 @@ def _strip_local_command_output(content: Any) -> str:
     if len(text) > _LOCAL_COMMAND_MAX_LEN:
         text = text[: _LOCAL_COMMAND_MAX_LEN - 1].rstrip() + "…"
     return text
-
-
-def _is_injected_turn(content: Any) -> bool:
-    """Return True for harness-injected user turns that must not surface as chat."""
-    if isinstance(content, str):
-        stripped = content.lstrip()
-        return stripped.startswith("<task-notification>") or stripped.startswith(
-            "This session is being continued"
-        )
-    return False
 
 
 def _is_user_rejection(record: dict[str, Any]) -> bool:

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -37,6 +37,7 @@ from pydantic import BaseModel, Field
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.claude_code import side_question as _sq
 from waypoint.backends.claude_code.commands import list_claude_command_completions
+from waypoint.backends.claude_code.history import read_local_claude_history
 from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
@@ -69,6 +70,7 @@ from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
     EventKind,
+    EventRecord,
     SessionCreateRequest,
     SessionRateLimitUsage,
     SessionRecord,
@@ -1301,6 +1303,15 @@ class ClaudeTtyPlugin:
             },
         )
         runtime.storage.create_session(session)
+
+        async def _read_thread_history() -> list[EventRecord]:
+            return await read_local_claude_history(session.id, request.thread_id)
+
+        await runtime.seed_thread_history(
+            session.id,
+            reader=_read_thread_history,
+            enabled=request.import_history,
+        )
         await runtime._record_system_event(
             session.id,
             f"Imported stored Claude thread ({cwd})",
@@ -1308,7 +1319,9 @@ class ClaudeTtyPlugin:
             metadata={"imported_thread_id": request.thread_id},
         )
         # The resumed thread reopens an already-populated transcript; tail from
-        # the end so records already on disk are not replayed into the DB.
+        # the end so records already on disk are not replayed into the DB (the
+        # seed above has already replayed them, from the on-disk transcript
+        # directly rather than the live tail).
         self._start_tailer(
             runtime, session.id, request.thread_id, cwd, start_at_end=True
         )

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -18,6 +18,7 @@ from waypoint.backends.codex.normalize import (
     diff_preview_for_notification,
     extract_item,
     extract_item_id,
+    extract_tool_name,
     format_approval_text,
     map_notification,
     payload_to_dict,
@@ -41,29 +42,6 @@ ApprovalDecisionHandler = Callable[
 ApprovalCallback = Callable[[str, dict[str, Any] | None], dict[str, Any]]
 ClientFactory = Callable[[str, ApprovalCallback], CodexClient]
 SessionUpdateCallback = Callable[[str, dict[str, Any], bool], Awaitable[Any]]
-
-
-def _extract_tool_name(item_type: str | None, item: dict[str, Any]) -> str | None:
-    """Return a canonical tool name for metadata["tool_name"] given a Codex item."""
-    if item_type == "commandExecution":
-        return "Bash"
-    if item_type == "fileChange":
-        return "Edit"
-    if item_type == "mcpToolCall":
-        server = item.get("server", "")
-        tool = item.get("tool", "")
-        if server and tool:
-            return f"{server}:{tool}"
-        return str(tool or server) or None
-    if item_type in {"dynamicToolCall", "collabAgentToolCall"}:
-        ns = item.get("namespace", "")
-        tool = item.get("tool", "")
-        if ns and tool:
-            return f"{ns}:{tool}"
-        return str(tool) if tool else None
-    if item_type == "webSearch":
-        return "WebSearch"
-    return None
 
 
 def default_client_factory(cwd: str, approval_handler: ApprovalCallback) -> CodexClient:
@@ -641,7 +619,7 @@ class CodexAppServerAdapter:
                         item_type = item.get("type")
                         if isinstance(item_type, str) and item_type:
                             metadata["item_type"] = item_type
-                        tool_name = _extract_tool_name(item_type, item)
+                        tool_name = extract_tool_name(item_type, item)
                         if tool_name:
                             metadata["tool_name"] = tool_name
                         plan_envelope = plan_metadata_for_item(item)

--- a/backend/src/waypoint/backends/codex/history.py
+++ b/backend/src/waypoint/backends/codex/history.py
@@ -1,0 +1,135 @@
+"""Historical Codex thread -> ``EventRecord`` conversion.
+
+Feeds ``runtime.seed_thread_history`` when importing a Codex thread with
+``import_history=True``. Converts each ``Turn``'s ``ThreadItem``s (from
+``client.thread_read(thread_id, include_turns=True)``) into ``EventRecord``s,
+reusing ``codex/normalize.py``'s per-item-type formatters so a synthesized
+historical tool item carries the same metadata envelope (``item_id``,
+``item_type``, ``tool_name``, ``payload.item``, diff-preview keys) that the
+live adapter builds for ``item/started``/``item/completed`` notifications —
+the frontend pairs tool cards solely on ``metadata.item_id``, and Codex items
+carry no ``tool_use_id`` to fall back on.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from openai_codex.generated.v2_all import Turn
+
+from waypoint.backends.codex.normalize import (
+    _format_item_completed,
+    _format_item_started,
+    diff_preview_for_notification,
+    extract_tool_name,
+    plan_metadata_for_item,
+)
+from waypoint.backends.diff_preview import preview_to_metadata
+from waypoint.schemas import EventKind, EventRecord
+
+
+def turns_to_events(turns: list[Turn], session_id: str) -> list[EventRecord]:
+    """Replay a Codex thread's turns into ``EventRecord``s in sequence order."""
+    events: list[EventRecord] = []
+    for turn in turns:
+        started_at = _turn_timestamp(turn.started_at, turn.completed_at)
+        completed_at = _turn_timestamp(turn.completed_at, turn.started_at)
+        for item in turn.items:
+            events.extend(
+                _item_to_events(item.root, session_id, started_at, completed_at)
+            )
+    return events
+
+
+def _turn_timestamp(primary: int | None, fallback: int | None) -> datetime:
+    epoch = primary if primary is not None else fallback
+    return datetime.fromtimestamp(epoch or 0, UTC)
+
+
+def _item_to_events(
+    item: Any, session_id: str, started_at: datetime, completed_at: datetime
+) -> list[EventRecord]:
+    item_type = getattr(item, "type", None)
+    if item_type == "userMessage":
+        text = _user_message_text(item)
+        if not text:
+            return []
+        return [_event(session_id, started_at, EventKind.USER_INPUT, text, metadata={})]
+
+    item_dict = item.model_dump(mode="json", by_alias=True)
+    call_kind, call_text, call_status = _format_item_started(item_dict)
+    if call_kind is None or not call_text:
+        return []
+
+    item_id = item_dict.get("id")
+    tool_name = extract_tool_name(item_type, item_dict)
+    call_metadata = _envelope(
+        "item/started", item_dict, item_id, item_type, tool_name, call_status
+    )
+    call_event = _event(session_id, started_at, call_kind, call_text, call_metadata)
+    if call_kind != EventKind.TOOL_CALL:
+        return [call_event]
+
+    events = [call_event]
+    result_kind, result_text, result_status = _format_item_completed(item_dict)
+    if result_kind is not None and result_text:
+        result_metadata = _envelope(
+            "item/completed", item_dict, item_id, item_type, tool_name, result_status
+        )
+        events.append(
+            _event(session_id, completed_at, result_kind, result_text, result_metadata)
+        )
+    return events
+
+
+def _envelope(
+    method: str,
+    item_dict: dict[str, Any],
+    item_id: Any,
+    item_type: str | None,
+    tool_name: str | None,
+    status: Any,
+) -> dict[str, Any]:
+    payload = {"item": item_dict}
+    metadata: dict[str, Any] = {
+        "method": method,
+        "payload": payload,
+        "status": status,
+    }
+    if isinstance(item_id, str) and item_id:
+        metadata["item_id"] = item_id
+    if isinstance(item_type, str) and item_type:
+        metadata["item_type"] = item_type
+    if tool_name:
+        metadata["tool_name"] = tool_name
+    plan_envelope = plan_metadata_for_item(item_dict)
+    if plan_envelope is not None:
+        metadata["plan"] = plan_envelope
+    diff_preview = diff_preview_for_notification(method, payload)
+    metadata.update(preview_to_metadata(diff_preview))
+    return metadata
+
+
+def _user_message_text(item: Any) -> str:
+    parts: list[str] = []
+    for part in item.content:
+        text = getattr(part.root, "text", None)
+        if isinstance(text, str) and text:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def _event(
+    session_id: str,
+    ts: datetime,
+    kind: EventKind,
+    text: str,
+    metadata: dict[str, Any],
+) -> EventRecord:
+    return EventRecord(
+        session_id=session_id,
+        ts=ts,
+        kind=kind,
+        text=text,
+        metadata=metadata,
+        sequence=0,
+    )

--- a/backend/src/waypoint/backends/codex/normalize.py
+++ b/backend/src/waypoint/backends/codex/normalize.py
@@ -287,6 +287,29 @@ def extract_item(payload: dict[str, Any]) -> dict[str, Any]:
     return item if isinstance(item, dict) else {}
 
 
+def extract_tool_name(item_type: str | None, item: dict[str, Any]) -> str | None:
+    """Return a canonical tool name for metadata["tool_name"] given a Codex item."""
+    if item_type == "commandExecution":
+        return "Bash"
+    if item_type == "fileChange":
+        return "Edit"
+    if item_type == "mcpToolCall":
+        server = item.get("server", "")
+        tool = item.get("tool", "")
+        if server and tool:
+            return f"{server}:{tool}"
+        return str(tool or server) or None
+    if item_type in {"dynamicToolCall", "collabAgentToolCall"}:
+        ns = item.get("namespace", "")
+        tool = item.get("tool", "")
+        if ns and tool:
+            return f"{ns}:{tool}"
+        return str(tool) if tool else None
+    if item_type == "webSearch":
+        return "WebSearch"
+    return None
+
+
 _PLAN_DECISIONS: tuple[str, ...] = ("accept", "acceptForSession", "decline", "cancel")
 
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -34,6 +34,7 @@ from waypoint.backends.codex.adapter import (
     CodexAppServerAdapter,
     default_client_factory,
 )
+from waypoint.backends.codex.history import turns_to_events
 from waypoint.backends.codex.pane import composer_ready, composer_submitted
 from waypoint.backends.codex.permission_modes import (
     CODEX_PERMISSION_MODE_IDS,
@@ -1294,11 +1295,15 @@ class CodexPlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None,
+        *,
+        include_turns: bool = False,
     ) -> Any:
         runtime._resolve_launch_target(launch_target_id, self.id)
 
         async def operation(client: CodexClient) -> Any:
-            response = await asyncio.to_thread(client.thread_read, thread_id, False)
+            response = await asyncio.to_thread(
+                client.thread_read, thread_id, include_turns
+            )
             return response.thread
 
         try:
@@ -1479,7 +1484,10 @@ class CodexPlugin(DefaultLaunchContract):
                 detail="codex thread already imported",
             )
         thread = await self._read_thread(
-            runtime, request.thread_id, request.launch_target_id
+            runtime,
+            request.thread_id,
+            request.launch_target_id,
+            include_turns=request.import_history,
         )
         if thread.ephemeral:
             raise HTTPException(
@@ -1581,6 +1589,13 @@ class CodexPlugin(DefaultLaunchContract):
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"failed to import codex thread: {exc}",
             ) from exc
+
+        async def read_history() -> list[EventRecord]:
+            return turns_to_events(thread.turns, session.id)
+
+        await runtime.seed_thread_history(
+            session.id, read_history, enabled=request.import_history
+        )
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
         await self._register_rate_limit_probe(runtime, session.id, cwd, launch_target)
         await runtime._record_system_event(

--- a/backend/src/waypoint/backends/codex/schemas.py
+++ b/backend/src/waypoint/backends/codex/schemas.py
@@ -41,3 +41,7 @@ class CodexThreadImportRequest(BaseModel):
     # ``launch_mode`` and must be one the agent declares (the runtime
     # rejects mismatches with 400).
     transport: SessionTransportId | None = None
+    # When true (default), the prior conversation is replayed into the new
+    # session's transcript at import time; when false the transcript starts
+    # empty and only the underlying agent resumes its own context.
+    import_history: bool = True

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -1220,6 +1220,24 @@ class OpenCodeAdapter:
         except Exception:
             return None
 
+    async def get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
+        """Fetch the full message history for a session (thread import).
+
+        Unlike ``get_session``/``list_sessions``, failures are raised rather
+        than swallowed: ``runtime.seed_thread_history``'s reader contract
+        expects a raise to signal "history unavailable" so it can degrade to
+        a plain resume with a system note instead of silently seeding an
+        empty transcript.
+        """
+        if not self._started:
+            await self.start()
+        client = self._require_client()
+        try:
+            result = await client.get(f"/session/{session_id}/message")
+        except Exception as exc:
+            raise OpenCodeError(f"failed to fetch session messages: {exc}") from exc
+        return result if isinstance(result, list) else []
+
     async def delete_session(self, session_id: str) -> bool:
         if not self._started:
             await self.start()

--- a/backend/src/waypoint/backends/opencode/normalize.py
+++ b/backend/src/waypoint/backends/opencode/normalize.py
@@ -1,4 +1,5 @@
 import json
+from datetime import UTC, datetime
 from typing import Any
 
 from waypoint.backends.diff_preview import (
@@ -409,6 +410,137 @@ def _map_tool_event(
         )
 
     return (EventKind.SYSTEM_NOTE, "", {})
+
+
+def historical_events_from_messages(
+    messages: list[dict[str, Any]],
+) -> list[tuple[datetime, EventKind, str, dict[str, Any]]]:
+    """Convert a ``GET /session/{id}/message`` response into ordered events.
+
+    Each entry is ``{"info": Message, "parts": Part[]}``. The live SSE path
+    streams assistant text/reasoning via ``message.part.delta`` and never
+    surfaces ``message.updated`` for user turns (see ``map_event`` above);
+    neither has a REST equivalent, so historical replay reads the full body
+    straight off each part snapshot and synthesizes the user turn from the
+    message itself. Tool parts reuse ``_map_tool_event`` directly — the
+    message-history endpoint already returns each tool part's terminal
+    state, so a lone ``TOOL_RESULT`` (or ``TOOL_CALL`` for a part that never
+    finished) is enough for the frontend to render a complete tool card.
+    """
+    events: list[tuple[datetime, EventKind, str, dict[str, Any]]] = []
+    for entry in messages:
+        if not isinstance(entry, dict):
+            continue
+        info = entry.get("info")
+        parts = entry.get("parts")
+        if not isinstance(info, dict) or not isinstance(parts, list):
+            continue
+        role = info.get("role")
+        if role == "user":
+            user_event = _map_historical_user_turn(info, parts)
+            if user_event is not None:
+                events.append(user_event)
+        elif role == "assistant":
+            events.extend(_map_historical_assistant_parts(info, parts))
+    return events
+
+
+def _map_historical_user_turn(
+    info: dict[str, Any], parts: list[dict[str, Any]]
+) -> tuple[datetime, EventKind, str, dict[str, Any]] | None:
+    segments = [
+        part["text"]
+        for part in parts
+        if isinstance(part, dict)
+        and part.get("type") == "text"
+        and isinstance(part.get("text"), str)
+        and part["text"]
+    ]
+    text = "\n".join(segments)
+    if not text:
+        return None
+    ts = _timestamp_from_ms(_as_dict(info.get("time")), "created") or datetime.now(UTC)
+    return (
+        ts,
+        EventKind.USER_INPUT,
+        text,
+        {"submit": True, "status": SessionStatus.RUNNING},
+    )
+
+
+def _map_historical_assistant_parts(
+    info: dict[str, Any], parts: list[dict[str, Any]]
+) -> list[tuple[datetime, EventKind, str, dict[str, Any]]]:
+    session_id = info.get("sessionID", "")
+    fallback_ts = (
+        _timestamp_from_ms(_as_dict(info.get("time")), "completed")
+        or _timestamp_from_ms(_as_dict(info.get("time")), "created")
+        or datetime.now(UTC)
+    )
+    events: list[tuple[datetime, EventKind, str, dict[str, Any]]] = []
+    for part in parts:
+        if not isinstance(part, dict):
+            continue
+        part_type = part.get("type")
+        if part_type in ("text", "reasoning"):
+            mapped = _map_historical_text_part(part, fallback_ts)
+            if mapped is not None:
+                events.append(mapped)
+        elif part_type == "tool":
+            kind, text, metadata = _map_tool_event(part, session_id)
+            if not text and not metadata:
+                continue
+            ts = _tool_part_timestamp(part) or fallback_ts
+            events.append((ts, kind, text, metadata))
+    return events
+
+
+def _map_historical_text_part(
+    part: dict[str, Any], fallback_ts: datetime
+) -> tuple[datetime, EventKind, str, dict[str, Any]] | None:
+    text = part.get("text")
+    if not isinstance(text, str) or not text:
+        return None
+    part_type = part.get("type")
+    part_id = part.get("id")
+    time_field = _as_dict(part.get("time"))
+    ts = (
+        _timestamp_from_ms(time_field, "end")
+        or _timestamp_from_ms(time_field, "start")
+        or fallback_ts
+    )
+    method = (
+        "message.part.delta.reasoning"
+        if part_type == "reasoning"
+        else "message.part.delta.text"
+    )
+    metadata: dict[str, Any] = {
+        "method": method,
+        "payload": {"partID": part_id, "field": "text", "delta": text},
+        "status": SessionStatus.RUNNING,
+    }
+    if isinstance(part_id, str) and part_id:
+        metadata["item_id"] = part_id
+    if part_type == "reasoning":
+        metadata["item_kind"] = "reasoning"
+    return (ts, EventKind.AGENT_OUTPUT, text, metadata)
+
+
+def _tool_part_timestamp(part: dict[str, Any]) -> datetime | None:
+    state = _as_dict(part.get("state")) or {}
+    time_field = _as_dict(state.get("time"))
+    return _timestamp_from_ms(time_field, "end") or _timestamp_from_ms(
+        time_field, "start"
+    )
+
+
+def _timestamp_from_ms(time_field: dict[str, Any] | None, key: str) -> datetime | None:
+    if time_field is None:
+        return None
+    value = time_field.get(key)
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    return datetime.fromtimestamp(value / 1000, tz=UTC)
 
 
 def _diff_preview_from_opencode_properties(

--- a/backend/src/waypoint/backends/opencode/normalize.py
+++ b/backend/src/waypoint/backends/opencode/normalize.py
@@ -487,11 +487,47 @@ def _map_historical_assistant_parts(
             if mapped is not None:
                 events.append(mapped)
         elif part_type == "tool":
-            kind, text, metadata = _map_tool_event(part, session_id)
-            if not text and not metadata:
-                continue
-            ts = _tool_part_timestamp(part) or fallback_ts
-            events.append((ts, kind, text, metadata))
+            events.extend(_map_historical_tool_part(part, session_id, fallback_ts))
+    return events
+
+
+def _map_historical_tool_part(
+    part: dict[str, Any], session_id: str, fallback_ts: datetime
+) -> list[tuple[datetime, EventKind, str, dict[str, Any]]]:
+    # A REST message snapshot carries only a tool part's terminal state, but
+    # the live SSE path emits a TOOL_CALL (pending/running) before the
+    # TOOL_RESULT (completed/error). Synthesize the missing call half from the
+    # terminal snapshot so an imported tool renders as a paired card (the
+    # frontend pairs on call_id/tool_use_id) instead of a lone result.
+    events: list[tuple[datetime, EventKind, str, dict[str, Any]]] = []
+    state = _as_dict(part.get("state")) or {}
+    end_ts = _tool_part_timestamp(part) or fallback_ts
+    if state.get("status") in ("completed", "error"):
+        call_id = part.get("callID", "")
+        tool_name = part.get("tool", "tool")
+        tool_input = state.get("input", {})
+        start_ts = _timestamp_from_ms(_as_dict(state.get("time")), "start") or end_ts
+        events.append(
+            (
+                start_ts,
+                EventKind.TOOL_CALL,
+                f"{tool_name}({json.dumps(tool_input, indent=2)})",
+                {
+                    "method": "tool.pending",
+                    "item_id": call_id,
+                    "item_type": "tool_use",
+                    "call_id": call_id,
+                    "tool_name": tool_name,
+                    "tool_input": tool_input,
+                    "tool_use_id": call_id,
+                    "payload": part,
+                    "status": SessionStatus.RUNNING,
+                },
+            )
+        )
+    kind, text, metadata = _map_tool_event(part, session_id)
+    if text or metadata:
+        events.append((end_ts, kind, text, metadata))
     return events
 
 

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1607,7 +1607,7 @@ class OpenCodePlugin(DefaultLaunchContract):
         await runtime.seed_thread_history(
             session.id,
             reader=read_history,
-            enabled=getattr(request, "import_history", True),
+            enabled=request.import_history,
         )
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
         await runtime._record_system_event(

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -122,6 +122,10 @@ class OpenCodeThreadImportRequest(BaseModel):
     # transport (e.g. the tmux wrapper) is rejected with 400 since there is no
     # resume-via-tmux path for OpenCode. ``None`` keeps the native behavior.
     transport: SessionTransportId | None = None
+    # When true (default), the prior conversation is replayed into the new
+    # session's transcript at import time; when false the transcript starts
+    # empty and only the underlying agent resumes its own context.
+    import_history: bool = True
 
 
 class OpenCodeThreadSummary(BaseModel):

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -18,6 +18,7 @@ from waypoint.backends.capabilities import (
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.opencode.adapter import OpenCodeAdapter, OpenCodeError
 from waypoint.backends.opencode.health import AdapterHealth
+from waypoint.backends.opencode.normalize import historical_events_from_messages
 from waypoint.backends.opencode.pane import composer_ready, composer_submitted
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.git_meta import GitMeta
@@ -26,6 +27,7 @@ from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
     EventKind,
+    EventRecord,
     SessionCreateRequest,
     SessionEnvelope,
     SessionInputRequest,
@@ -1585,6 +1587,28 @@ class OpenCodePlugin(DefaultLaunchContract):
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"failed to restore session: {exc}",
             ) from exc
+
+        async def read_history() -> list[EventRecord]:
+            messages = await adapter.get_session_messages(opencode_session_id)
+            return [
+                EventRecord(
+                    session_id=session.id,
+                    ts=ts,
+                    kind=kind,
+                    text=text,
+                    metadata=metadata,
+                    sequence=0,
+                )
+                for ts, kind, text, metadata in historical_events_from_messages(
+                    messages
+                )
+            ]
+
+        await runtime.seed_thread_history(
+            session.id,
+            reader=read_history,
+            enabled=getattr(request, "import_history", True),
+        )
         runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
         await runtime._record_system_event(
             session.id,

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1454,16 +1454,41 @@ def sessions_import(
     ctx: typer.Context,
     backend: Annotated[str, typer.Argument()],
     json_source: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--json",
             help="Path to a JSON object body, or - to read it from stdin.",
             metavar="FILE|-",
         ),
-    ],
+    ] = None,
+    thread_id: Annotated[
+        str | None,
+        typer.Option("--thread-id", help="Backend-native thread id to import."),
+    ] = None,
+    import_history: Annotated[
+        bool | None,
+        typer.Option(
+            "--import-history/--no-import-history",
+            help=(
+                "Replay the thread's prior conversation into the new session's "
+                "transcript (default). --no-import-history starts empty and only "
+                "resumes the agent's own context."
+            ),
+        ),
+    ] = None,
 ) -> None:
-    """Import a backend-native thread into Waypoint."""
-    body = _parse_json_object(json_source)
+    """Import a backend-native thread into Waypoint.
+
+    Provide the request body via ``--json`` and/or the individual flags; an
+    explicit flag overrides the same field in the JSON body.
+    """
+    body = _parse_json_object(json_source) if json_source is not None else {}
+    if thread_id is not None:
+        body["thread_id"] = thread_id
+    if import_history is not None:
+        body["import_history"] = import_history
+    if not body.get("thread_id"):
+        raise typer.BadParameter("pass --thread-id or a --json body with thread_id")
     _emit(
         _settings_from_ctx(ctx),
         lambda c: {"session": c.import_thread(backend, body)},

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1935,6 +1935,48 @@ class SessionRuntime:
         self._append_structured_log(session_id, persisted)
         await self._publish_event(persisted)
 
+    async def seed_thread_history(
+        self,
+        session_id: str,
+        reader: Callable[[], Awaitable[list[EventRecord]]],
+        *,
+        enabled: bool,
+    ) -> int:
+        """Replay imported thread history into a freshly-created session.
+
+        Agent plugins call this from ``import_thread`` after ``create_session``
+        and before recording the "Imported…" note, passing a ``reader`` that
+        reads the native thread and converts it into ``EventRecord``s. The
+        converter is agent-specific (it shares helpers with, but is not, the
+        live ``normalize.py`` — historical snapshots must re-add the user turns
+        and full assistant text the live path streams on other channels); this
+        method owns the transport-agnostic seed and its failure handling.
+
+        When ``enabled`` is false this is a no-op (the transcript stays empty and
+        the agent merely resumes its own context). Any failure to read or
+        convert history is swallowed: the import still succeeds as a plain
+        resume, with a system note explaining history was unavailable. Returns
+        the number of events seeded.
+        """
+        if not enabled:
+            return 0
+        try:
+            events = await reader()
+        except Exception:
+            log.exception("failed to import thread history for %s", session_id)
+            await self._record_system_event(
+                session_id,
+                "Prior conversation history could not be imported; "
+                "the session resumes without it.",
+            )
+            return 0
+        if not events:
+            return 0
+        persisted = self.storage.seed_events(session_id, events)
+        for event in persisted:
+            self._append_structured_log(session_id, event)
+        return len(persisted)
+
     async def _record_system_event(
         self,
         session_id: str,

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -729,6 +729,78 @@ class Storage:
         ).fetchone()[0]
 
     @_synchronized
+    def seed_events(
+        self, session_id: str, events: list[EventRecord]
+    ) -> list[EventRecord]:
+        """Bulk-append externally-sourced events (e.g. imported thread history).
+
+        Unlike ``clone_events`` (which copies another session's rows verbatim),
+        the caller supplies freshly-built ``EventRecord``s whose ``sequence`` is
+        ignored: sequences are (re)assigned ascending from
+        ``MAX(sequence) + 1`` for the target so seeded history slots after any
+        events already present. Each row is stamped with the canonical envelope
+        ``version`` like ``append_event``, but the session's
+        ``last_event_at``/``updated_at``/``status`` are updated once at the end
+        rather than per row. Returns the persisted rows (with assigned ``id`` and
+        ``sequence``) in order, so callers can mirror them to the structured log.
+        """
+        if not events:
+            return []
+        base = int(
+            self.connection.execute(
+                "SELECT COALESCE(MAX(sequence), 0) AS max_sequence FROM events WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()["max_sequence"]
+        )
+        rows: list[tuple[str, str, str, str, str, int]] = []
+        last_ts_iso: str | None = None
+        last_status: str | None = None
+        for offset, event in enumerate(events, start=1):
+            metadata = event.metadata
+            if "version" not in metadata:
+                metadata = {**metadata, "version": 1}
+            ts_iso = event.ts.isoformat()
+            rows.append(
+                (
+                    session_id,
+                    ts_iso,
+                    event.kind,
+                    event.text,
+                    json.dumps(metadata),
+                    base + offset,
+                )
+            )
+            last_ts_iso = ts_iso
+            status = metadata.get("status")
+            if status is not None:
+                last_status = status
+        self.connection.executemany(
+            """
+            INSERT INTO events (session_id, ts, kind, text, metadata, sequence)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        self.connection.execute(
+            """
+            UPDATE sessions
+            SET last_event_at = ?, updated_at = ?, status = COALESCE(?, status)
+            WHERE id = ?
+            """,
+            (last_ts_iso, last_ts_iso, last_status, session_id),
+        )
+        self.connection.commit()
+        persisted = self.connection.execute(
+            """
+            SELECT * FROM events
+            WHERE session_id = ? AND sequence > ?
+            ORDER BY sequence ASC, id ASC
+            """,
+            (session_id, base),
+        ).fetchall()
+        return [self._event_from_row(row) for row in persisted]
+
+    @_synchronized
     def list_events(
         self,
         session_id: str,

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -603,6 +603,7 @@ async def test_import_thread_resumes_and_starts_tailer(
     runtime.storage.list_sessions.return_value = []
     runtime.storage.create_session = MagicMock()
     runtime._record_system_event = AsyncMock()
+    runtime.seed_thread_history = AsyncMock(return_value=0)
     created_holder: dict[str, SessionRecord] = {}
 
     def _create(session: SessionRecord) -> None:
@@ -652,6 +653,7 @@ async def test_import_thread_persists_resolving_agent_backend(
     )
     runtime.get_session.side_effect = lambda sid: created_holder["session"]
     runtime._record_system_event = AsyncMock()
+    runtime.seed_thread_history = AsyncMock(return_value=0)
 
     request = ClaudeThreadImportRequest(thread_id="imp-2")
     result = await plugin.import_thread(runtime, request, agent="claude_code")

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -2,10 +2,10 @@
 
 import pytest
 
+from waypoint.backends.claude_code.normalize import is_injected_user_turn
 from waypoint.backends.claude_tty.normalize import (
     NormalizedEvent,
     TranscriptNormalizer,
-    _is_injected_turn,
 )
 from waypoint.schemas import EventKind, SessionStatus
 
@@ -66,29 +66,29 @@ def _edit_result_record(
 
 
 def test_is_injected_task_notification() -> None:
-    assert _is_injected_turn("<task-notification>foo</task-notification>")
+    assert is_injected_user_turn("<task-notification>foo</task-notification>")
 
 
 def test_is_injected_task_notification_leading_whitespace() -> None:
-    assert _is_injected_turn("  \n<task-notification>bar</task-notification>")
+    assert is_injected_user_turn("  \n<task-notification>bar</task-notification>")
 
 
 def test_is_injected_context_summary() -> None:
-    assert _is_injected_turn(
+    assert is_injected_user_turn(
         "This session is being continued from a previous conversation."
     )
 
 
 def test_not_injected_plain_text() -> None:
-    assert not _is_injected_turn("Hello, world!")
+    assert not is_injected_user_turn("Hello, world!")
 
 
 def test_not_injected_list_content() -> None:
-    assert not _is_injected_turn([{"type": "tool_result", "content": "ok"}])
+    assert not is_injected_user_turn([{"type": "tool_result", "content": "ok"}])
 
 
 def test_not_injected_none() -> None:
-    assert not _is_injected_turn(None)
+    assert not is_injected_user_turn(None)
 
 
 # ── TranscriptNormalizer: assistant records ────────────────────────────────────

--- a/backend/tests/test_import_history_claude.py
+++ b/backend/tests/test_import_history_claude.py
@@ -1,0 +1,191 @@
+import json
+from datetime import UTC, datetime
+
+from waypoint.backends.claude_code.history import (
+    convert_transcript_records,
+    read_local_claude_history,
+)
+from waypoint.backends.claude_code.threads import read_local_claude_transcript
+from waypoint.schemas import EventKind
+
+
+def _assistant_text(
+    msg_id: str,
+    text: str,
+    stop_reason: str = "tool_use",
+    ts: str = "2026-04-29T15:47:09.826Z",
+) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "id": msg_id,
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": stop_reason,
+        },
+    }
+
+
+def _assistant_tool_use(
+    msg_id: str,
+    tool_use_id: str,
+    name: str,
+    inp: dict,
+    ts: str = "2026-04-29T15:47:10.000Z",
+) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "id": msg_id,
+            "content": [
+                {"type": "tool_use", "id": tool_use_id, "name": name, "input": inp}
+            ],
+            "stop_reason": "tool_use",
+        },
+    }
+
+
+def _user_text(text: str, ts: str = "2026-04-29T15:47:08.000Z") -> dict:
+    return {"type": "user", "timestamp": ts, "message": {"content": text}}
+
+
+def _user_tool_result(
+    tool_use_id: str,
+    result: str,
+    is_error: bool = False,
+    ts: str = "2026-04-29T15:47:11.000Z",
+) -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": tool_use_id,
+                    "content": result,
+                    "is_error": is_error,
+                }
+            ]
+        },
+    }
+
+
+def _injected_notification(ts: str = "2026-04-29T15:47:12.000Z") -> dict:
+    return {
+        "type": "user",
+        "timestamp": ts,
+        "message": {"content": "<task-notification>ping</task-notification>"},
+    }
+
+
+def test_convert_transcript_records_orders_and_pairs_tool_use() -> None:
+    records = [
+        _user_text("Please fix the bug"),
+        _assistant_tool_use("msg1", "tu1", "Bash", {"command": "ls"}),
+        _user_tool_result("tu1", "file1\nfile2"),
+        _assistant_text("msg2", "Done", stop_reason="end_turn"),
+    ]
+
+    events = convert_transcript_records("sess-1", records)
+
+    assert [e.kind for e in events] == [
+        EventKind.USER_INPUT,
+        EventKind.TOOL_CALL,
+        EventKind.TOOL_RESULT,
+        EventKind.AGENT_OUTPUT,
+    ]
+    assert events[0].text == "Please fix the bug"
+
+    call, result = events[1], events[2]
+    assert call.metadata["tool_use_id"] == "tu1"
+    assert call.metadata["item_id"] == "tu1"
+    assert call.metadata["tool_name"] == "Bash"
+    assert result.metadata["tool_use_id"] == "tu1"
+    assert result.metadata["item_id"] == "tu1"
+    assert result.text == "file1\nfile2"
+
+    assert events[3].text == "Done"
+    assert all(e.session_id == "sess-1" for e in events)
+
+
+def test_convert_transcript_records_skips_injected_turns() -> None:
+    records = [
+        _injected_notification(),
+        _assistant_text("msg1", "hi", stop_reason="end_turn"),
+    ]
+
+    events = convert_transcript_records("sess-1", records)
+
+    assert [e.kind for e in events] == [EventKind.AGENT_OUTPUT]
+
+
+def test_convert_transcript_records_preserves_source_timestamps() -> None:
+    records = [_user_text("hello", ts="2026-01-01T00:00:00Z")]
+
+    events = convert_transcript_records("sess-1", records)
+
+    assert events[0].ts == datetime(2026, 1, 1, tzinfo=UTC)
+
+
+def test_convert_transcript_records_marks_tool_error() -> None:
+    records = [
+        _assistant_tool_use("msg1", "tu1", "Bash", {"command": "false"}),
+        _user_tool_result("tu1", "boom", is_error=True),
+    ]
+
+    events = convert_transcript_records("sess-1", records)
+
+    result = events[1]
+    assert result.kind == EventKind.TOOL_RESULT
+    assert result.metadata["is_error"] is True
+
+
+def test_convert_transcript_records_skips_non_chat_record_types() -> None:
+    records = [
+        {"type": "summary", "summary": "prior context"},
+        {"type": "system", "subtype": "compact_boundary"},
+        _assistant_text("msg1", "hi", stop_reason="end_turn"),
+    ]
+
+    events = convert_transcript_records("sess-1", records)
+
+    assert [e.kind for e in events] == [EventKind.AGENT_OUTPUT]
+
+
+def test_read_local_claude_transcript_reads_entire_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    thread_id = "11111111-1111-1111-1111-111111111111"
+    project_dir = tmp_path / "claude" / "projects" / "-home-user-project"
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / f"{thread_id}.jsonl"
+    records = [_user_text(f"turn {i}") for i in range(250)]
+    transcript.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+    )
+
+    read_records = read_local_claude_transcript(thread_id)
+
+    # Longer than the 200-line cap `_read_thread_info` uses for metadata
+    # sniffing — history import must not inherit that cap.
+    assert len(read_records) == 250
+
+
+async def test_read_local_claude_history_converts_full_file(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    thread_id = "22222222-2222-2222-2222-222222222222"
+    project_dir = tmp_path / "claude" / "projects" / "-home-user-project"
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / f"{thread_id}.jsonl"
+    records = [_user_text(f"turn {i}") for i in range(210)]
+    transcript.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+    )
+
+    events = await read_local_claude_history("sess-1", thread_id)
+
+    assert len(events) == 210
+    assert all(event.kind == EventKind.USER_INPUT for event in events)

--- a/backend/tests/test_import_history_codex.py
+++ b/backend/tests/test_import_history_codex.py
@@ -1,0 +1,108 @@
+from openai_codex.generated.v2_all import Turn
+
+from waypoint.backends.codex.history import turns_to_events
+from waypoint.schemas import EventKind
+
+
+def _turn(**overrides: object) -> Turn:
+    base: dict[str, object] = {
+        "id": "turn1",
+        "status": "completed",
+        "startedAt": 1_700_000_000,
+        "completedAt": 1_700_000_010,
+        "items": [],
+    }
+    base.update(overrides)
+    return Turn.model_validate(base)
+
+
+def test_user_message_becomes_user_input_event() -> None:
+    turn = _turn(
+        items=[
+            {
+                "type": "userMessage",
+                "id": "item-u1",
+                "content": [
+                    {"type": "text", "text": "please fix the bug"},
+                ],
+            }
+        ]
+    )
+    events = turns_to_events([turn], "sess-1")
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == EventKind.USER_INPUT
+    assert event.text == "please fix the bug"
+    assert event.session_id == "sess-1"
+
+
+def test_agent_message_becomes_full_agent_output_event() -> None:
+    turn = _turn(
+        items=[
+            {
+                "type": "agentMessage",
+                "id": "item-a1",
+                "text": "Here is the full assistant reply.",
+            }
+        ]
+    )
+    events = turns_to_events([turn], "sess-1")
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == EventKind.AGENT_OUTPUT
+    assert event.text == "Here is the full assistant reply."
+    assert event.metadata["item_id"] == "item-a1"
+    assert event.metadata["item_type"] == "agentMessage"
+
+
+def test_command_execution_item_synthesizes_paired_tool_call_and_result() -> None:
+    turn = _turn(
+        items=[
+            {
+                "type": "commandExecution",
+                "id": "item-c1",
+                "command": "ls -la",
+                "commandActions": [],
+                "cwd": "/tmp",
+                "status": "completed",
+                "aggregatedOutput": "file1\nfile2",
+            }
+        ]
+    )
+    events = turns_to_events([turn], "sess-1")
+    assert len(events) == 2
+
+    call, result = events
+    assert call.kind == EventKind.TOOL_CALL
+    assert call.text == "$ ls -la"
+    assert result.kind == EventKind.TOOL_RESULT
+    assert result.text == "$ ls -la\nfile1\nfile2"
+
+    for event in (call, result):
+        assert event.metadata["item_id"] == "item-c1"
+        assert event.metadata["item_type"] == "commandExecution"
+        assert event.metadata["tool_name"] == "Bash"
+        assert event.metadata["payload"]["item"]["id"] == "item-c1"
+        assert event.metadata["payload"]["item"]["command"] == "ls -la"
+
+    assert call.metadata["method"] == "item/started"
+    assert result.metadata["method"] == "item/completed"
+
+
+def test_multiple_turns_preserve_sequence_order() -> None:
+    first = _turn(
+        id="turn1",
+        items=[
+            {
+                "type": "userMessage",
+                "id": "item-u1",
+                "content": [{"type": "text", "text": "hi"}],
+            }
+        ],
+    )
+    second = _turn(
+        id="turn2",
+        items=[{"type": "agentMessage", "id": "item-a1", "text": "hello back"}],
+    )
+    events = turns_to_events([first, second], "sess-1")
+    assert [event.text for event in events] == ["hi", "hello back"]

--- a/backend/tests/test_import_history_opencode.py
+++ b/backend/tests/test_import_history_opencode.py
@@ -1,0 +1,415 @@
+from datetime import UTC, datetime
+from typing import Any, cast
+
+import pytest
+
+from waypoint.backends.opencode.adapter import OpenCodeAdapter, OpenCodeError
+from waypoint.backends.opencode.normalize import historical_events_from_messages
+from waypoint.backends.opencode.plugin import OpenCodePlugin
+from waypoint.schemas import EventKind, EventRecord, SessionRecord
+
+
+def _build_adapter() -> OpenCodeAdapter:
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    return OpenCodeAdapter(emit_event=_emit)
+
+
+# ─── adapter.get_session_messages ───
+
+
+@pytest.mark.asyncio
+async def test_get_session_messages_returns_the_list() -> None:
+    adapter = _build_adapter()
+    adapter._started = True
+
+    class _FakeClient:
+        async def get(self, path: str, params: dict[str, str] | None = None) -> Any:
+            assert path == "/session/ses_1/message"
+            return [{"info": {"role": "user"}, "parts": []}]
+
+    adapter._client = cast(Any, _FakeClient())
+
+    messages = await adapter.get_session_messages("ses_1")
+
+    assert messages == [{"info": {"role": "user"}, "parts": []}]
+
+
+@pytest.mark.asyncio
+async def test_get_session_messages_raises_on_client_failure() -> None:
+    adapter = _build_adapter()
+    adapter._started = True
+
+    class _FailingClient:
+        async def get(self, path: str, params: dict[str, str] | None = None) -> Any:
+            raise RuntimeError("connection refused")
+
+    adapter._client = cast(Any, _FailingClient())
+
+    with pytest.raises(OpenCodeError):
+        await adapter.get_session_messages("ses_1")
+
+
+# ─── normalize.historical_events_from_messages ───
+
+
+def test_user_turn_becomes_user_input_event() -> None:
+    messages = [
+        {
+            "info": {"role": "user", "sessionID": "ses_1", "time": {"created": 1000}},
+            "parts": [
+                {"id": "p_user", "type": "text", "text": "fix the bug"},
+            ],
+        }
+    ]
+
+    events = historical_events_from_messages(messages)
+
+    assert len(events) == 1
+    ts, kind, text, metadata = events[0]
+    assert kind == EventKind.USER_INPUT
+    assert text == "fix the bug"
+    assert ts == datetime.fromtimestamp(1.0, tz=UTC)
+    assert metadata["submit"] is True
+
+
+def test_user_turn_with_no_text_parts_is_skipped() -> None:
+    messages = [
+        {
+            "info": {"role": "user", "sessionID": "ses_1", "time": {"created": 1000}},
+            "parts": [
+                {"id": "p_file", "type": "file", "mime": "image/png", "url": "data:..."}
+            ],
+        }
+    ]
+
+    assert historical_events_from_messages(messages) == []
+
+
+def test_assistant_text_part_carries_full_body_and_item_id() -> None:
+    messages = [
+        {
+            "info": {
+                "role": "assistant",
+                "sessionID": "ses_1",
+                "time": {"created": 1000, "completed": 2000},
+            },
+            "parts": [
+                {
+                    "id": "p_text",
+                    "sessionID": "ses_1",
+                    "type": "text",
+                    "text": "here is the fix",
+                    "time": {"start": 1200, "end": 1800},
+                },
+            ],
+        }
+    ]
+
+    events = historical_events_from_messages(messages)
+
+    assert len(events) == 1
+    ts, kind, text, metadata = events[0]
+    assert kind == EventKind.AGENT_OUTPUT
+    assert text == "here is the fix"
+    assert ts == datetime.fromtimestamp(1.8, tz=UTC)
+    assert metadata["item_id"] == "p_text"
+    assert metadata["method"] == "message.part.delta.text"
+    assert "item_kind" not in metadata
+
+
+def test_assistant_reasoning_part_is_tagged_distinctly_from_text() -> None:
+    messages = [
+        {
+            "info": {
+                "role": "assistant",
+                "sessionID": "ses_1",
+                "time": {"created": 1000},
+            },
+            "parts": [
+                {
+                    "id": "p_reason",
+                    "sessionID": "ses_1",
+                    "type": "reasoning",
+                    "text": "thinking it through",
+                    "time": {"start": 1000, "end": 1100},
+                },
+            ],
+        }
+    ]
+
+    events = historical_events_from_messages(messages)
+
+    assert len(events) == 1
+    _, kind, text, metadata = events[0]
+    assert kind == EventKind.AGENT_OUTPUT
+    assert text == "thinking it through"
+    assert metadata["method"] == "message.part.delta.reasoning"
+    assert metadata["item_kind"] == "reasoning"
+
+
+def test_assistant_tool_part_reuses_map_tool_event_and_keeps_tool_use_id() -> None:
+    messages = [
+        {
+            "info": {
+                "role": "assistant",
+                "sessionID": "ses_1",
+                "time": {"created": 1000},
+            },
+            "parts": [
+                {
+                    "id": "p_tool",
+                    "sessionID": "ses_1",
+                    "type": "tool",
+                    "tool": "Read",
+                    "callID": "call_1",
+                    "state": {
+                        "status": "completed",
+                        "input": {"path": "/etc/hosts"},
+                        "output": "127.0.0.1 localhost",
+                        "time": {"start": 1000, "end": 1500},
+                    },
+                },
+            ],
+        }
+    ]
+
+    events = historical_events_from_messages(messages)
+
+    assert len(events) == 1
+    ts, kind, text, metadata = events[0]
+    assert kind == EventKind.TOOL_RESULT
+    assert text.startswith("Result for Read:")
+    assert metadata["tool_use_id"] == "call_1"
+    assert metadata["item_id"] == "call_1"
+    assert ts == datetime.fromtimestamp(1.5, tz=UTC)
+
+
+def test_ordered_thread_preserves_user_then_assistant_order() -> None:
+    messages = [
+        {
+            "info": {"role": "user", "sessionID": "ses_1", "time": {"created": 1000}},
+            "parts": [{"id": "p1", "type": "text", "text": "hello"}],
+        },
+        {
+            "info": {
+                "role": "assistant",
+                "sessionID": "ses_1",
+                "time": {"created": 2000},
+            },
+            "parts": [
+                {
+                    "id": "p2",
+                    "sessionID": "ses_1",
+                    "type": "tool",
+                    "tool": "Bash",
+                    "callID": "call_1",
+                    "state": {"status": "completed", "input": {}, "output": "ok"},
+                },
+                {
+                    "id": "p3",
+                    "sessionID": "ses_1",
+                    "type": "text",
+                    "text": "done",
+                    "time": {"start": 2500},
+                },
+            ],
+        },
+    ]
+
+    events = historical_events_from_messages(messages)
+
+    kinds = [kind for _, kind, _, _ in events]
+    assert kinds == [
+        EventKind.USER_INPUT,
+        EventKind.TOOL_RESULT,
+        EventKind.AGENT_OUTPUT,
+    ]
+
+
+# ─── plugin.import_thread wiring ───
+
+
+@pytest.mark.asyncio
+async def test_import_thread_seeds_history_before_the_imported_note() -> None:
+    plugin = OpenCodePlugin()
+
+    class FakeAdapter:
+        async def get_session(self, session_id: str) -> dict[str, object] | None:
+            return {"id": session_id, "title": "Imported", "directory": "/repo"}
+
+        async def restore_session(
+            self, session_id, cwd, opencode_session_id, **kwargs
+        ) -> None:
+            return None
+
+        async def get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
+            return [
+                {
+                    "info": {
+                        "role": "user",
+                        "sessionID": session_id,
+                        "time": {"created": 1000},
+                    },
+                    "parts": [{"id": "p1", "type": "text", "text": "hi"}],
+                }
+            ]
+
+    fake_adapter = FakeAdapter()
+
+    async def fake_get_or_create_adapter(
+        runtime, launch_target_id, cwd, custom_args=(), **kw
+    ):
+        return fake_adapter
+
+    plugin._get_or_create_adapter = fake_get_or_create_adapter  # type: ignore[method-assign]
+
+    class FakeStorage:
+        def __init__(self) -> None:
+            self.sessions: list[SessionRecord] = []
+
+        def list_sessions(self) -> list[SessionRecord]:
+            return list(self.sessions)
+
+        def create_session(self, session: SessionRecord) -> None:
+            self.sessions.append(session)
+
+        def update_session(self, session_id: str, **kwargs: Any) -> SessionRecord:
+            session = self.sessions[-1]
+            for key, value in kwargs.items():
+                setattr(session, key, value)
+            return session
+
+    calls: list[str] = []
+
+    class FakeRuntime:
+        def __init__(self) -> None:
+            self.storage = FakeStorage()
+            self.seeded_events: list[EventRecord] = []
+
+        def _generate_session_id(self, backend_id: str) -> str:
+            return f"{backend_id}-1"
+
+        def _session_dir(self, session_id: str):
+            from pathlib import Path
+
+            path = Path("/tmp") / session_id
+            path.mkdir(parents=True, exist_ok=True)
+            return path
+
+        async def _record_system_event(self, *args: Any, **kwargs: Any) -> None:
+            calls.append("note")
+
+        async def seed_thread_history(self, session_id, reader, *, enabled) -> int:
+            assert enabled is True
+            events = await reader()
+            self.seeded_events.extend(events)
+            calls.append("seed")
+            return len(events)
+
+        def get_session(self, session_id: str) -> SessionRecord:
+            return self.storage.sessions[-1]
+
+    runtime: Any = FakeRuntime()
+    request = type(
+        "Req",
+        (),
+        {
+            "thread_id": "ses_1",
+            "launch_target_id": None,
+            "cwd": "/repo",
+            "import_history": True,
+        },
+    )()
+
+    result = await plugin.import_thread(runtime, request)
+
+    assert calls == ["seed", "note"]
+    assert len(runtime.seeded_events) == 1
+    seeded = runtime.seeded_events[0]
+    assert seeded.session_id == result.id
+    assert seeded.kind == EventKind.USER_INPUT
+    assert seeded.text == "hi"
+
+
+@pytest.mark.asyncio
+async def test_import_thread_skips_history_when_disabled() -> None:
+    plugin = OpenCodePlugin()
+
+    class FakeAdapter:
+        async def get_session(self, session_id: str) -> dict[str, object] | None:
+            return {"id": session_id, "title": "Imported", "directory": "/repo"}
+
+        async def restore_session(
+            self, session_id, cwd, opencode_session_id, **kwargs
+        ) -> None:
+            return None
+
+        async def get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
+            raise AssertionError("history should not be read when import_history=False")
+
+    fake_adapter = FakeAdapter()
+
+    async def fake_get_or_create_adapter(
+        runtime, launch_target_id, cwd, custom_args=(), **kw
+    ):
+        return fake_adapter
+
+    plugin._get_or_create_adapter = fake_get_or_create_adapter  # type: ignore[method-assign]
+
+    class FakeStorage:
+        def __init__(self) -> None:
+            self.sessions: list[SessionRecord] = []
+
+        def list_sessions(self) -> list[SessionRecord]:
+            return list(self.sessions)
+
+        def create_session(self, session: SessionRecord) -> None:
+            self.sessions.append(session)
+
+        def update_session(self, session_id: str, **kwargs: Any) -> SessionRecord:
+            session = self.sessions[-1]
+            for key, value in kwargs.items():
+                setattr(session, key, value)
+            return session
+
+    class FakeRuntime:
+        def __init__(self) -> None:
+            self.storage = FakeStorage()
+
+        def _generate_session_id(self, backend_id: str) -> str:
+            return f"{backend_id}-1"
+
+        def _session_dir(self, session_id: str):
+            from pathlib import Path
+
+            path = Path("/tmp") / session_id
+            path.mkdir(parents=True, exist_ok=True)
+            return path
+
+        async def _record_system_event(self, *args: Any, **kwargs: Any) -> None:
+            return None
+
+        async def seed_thread_history(self, session_id, reader, *, enabled) -> int:
+            assert enabled is False
+            return 0
+
+        def get_session(self, session_id: str) -> SessionRecord:
+            return self.storage.sessions[-1]
+
+    runtime: Any = FakeRuntime()
+    request = type(
+        "Req",
+        (),
+        {
+            "thread_id": "ses_1",
+            "launch_target_id": None,
+            "cwd": "/repo",
+            "import_history": False,
+        },
+    )()
+
+    result = await plugin.import_thread(runtime, request)
+
+    assert result.id == "opencode-1"

--- a/backend/tests/test_import_history_opencode.py
+++ b/backend/tests/test_import_history_opencode.py
@@ -177,13 +177,21 @@ def test_assistant_tool_part_reuses_map_tool_event_and_keeps_tool_use_id() -> No
 
     events = historical_events_from_messages(messages)
 
-    assert len(events) == 1
-    ts, kind, text, metadata = events[0]
-    assert kind == EventKind.TOOL_RESULT
-    assert text.startswith("Result for Read:")
-    assert metadata["tool_use_id"] == "call_1"
-    assert metadata["item_id"] == "call_1"
-    assert ts == datetime.fromtimestamp(1.5, tz=UTC)
+    # A completed tool snapshot is replayed as a paired TOOL_CALL + TOOL_RESULT
+    # (the live SSE path emits both across state updates), sharing tool_use_id.
+    assert [kind for _, kind, _, _ in events] == [
+        EventKind.TOOL_CALL,
+        EventKind.TOOL_RESULT,
+    ]
+    call_ts, _, call_text, call_meta = events[0]
+    assert call_text.startswith("Read(")
+    assert call_meta["tool_use_id"] == "call_1"
+    assert call_ts == datetime.fromtimestamp(1.0, tz=UTC)
+    result_ts, _, result_text, result_meta = events[1]
+    assert result_text.startswith("Result for Read:")
+    assert result_meta["tool_use_id"] == "call_1"
+    assert result_meta["item_id"] == "call_1"
+    assert result_ts == datetime.fromtimestamp(1.5, tz=UTC)
 
 
 def test_ordered_thread_preserves_user_then_assistant_order() -> None:
@@ -223,6 +231,7 @@ def test_ordered_thread_preserves_user_then_assistant_order() -> None:
     kinds = [kind for _, kind, _, _ in events]
     assert kinds == [
         EventKind.USER_INPUT,
+        EventKind.TOOL_CALL,
         EventKind.TOOL_RESULT,
         EventKind.AGENT_OUTPUT,
     ]

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -1139,7 +1139,12 @@ async def test_import_thread_preserves_launch_target_id() -> None:
     request = type(
         "Req",
         (),
-        {"thread_id": "ses_1", "launch_target_id": "ssh-1", "cwd": "/repo"},
+        {
+            "thread_id": "ses_1",
+            "launch_target_id": "ssh-1",
+            "cwd": "/repo",
+            "import_history": False,
+        },
     )()
 
     result = await plugin.import_thread(runtime, request)
@@ -1238,6 +1243,7 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
             "thread_id": "ses_1",
             "launch_target_id": "ssh-1",
             "cwd": "/repo/requested",
+            "import_history": False,
         },
     )()
 

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -1123,6 +1123,15 @@ async def test_import_thread_preserves_launch_target_id() -> None:
         async def _record_system_event(self, *args, **kwargs) -> None:
             return None
 
+        async def seed_thread_history(self, session_id, reader, *, enabled) -> int:
+            if not enabled:
+                return 0
+            try:
+                events = await reader()
+            except Exception:
+                return 0
+            return len(events)
+
         def get_session(self, session_id: str) -> SessionRecord:
             return self.storage.sessions[-1]
 
@@ -1208,6 +1217,15 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
 
         async def _record_system_event(self, *args, **kwargs) -> None:
             return None
+
+        async def seed_thread_history(self, session_id, reader, *, enabled) -> int:
+            if not enabled:
+                return 0
+            try:
+                events = await reader()
+            except Exception:
+                return 0
+            return len(events)
 
         def get_session(self, session_id: str) -> SessionRecord:
             return self.storage.sessions[-1]

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -626,6 +626,7 @@ def make_thread(**overrides: Any) -> Any:
         updated_at=overrides.pop("updated_at", 1_700_000_300),
         ephemeral=overrides.pop("ephemeral", False),
         git_info=git_info,
+        turns=overrides.pop("turns", []),
     )
 
 
@@ -2571,7 +2572,13 @@ async def test_import_codex_thread_for_remote_target_uses_thread_cwd(
         ),
     )
 
-    async def fake_read(_runtime, thread_id: str, launch_target_id: str | None) -> Any:
+    async def fake_read(
+        _runtime,
+        thread_id: str,
+        launch_target_id: str | None,
+        *,
+        include_turns: bool = False,
+    ) -> Any:
         assert thread_id == "thread-9"
         assert launch_target_id == "devbox"
         return thread

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -319,6 +319,68 @@ def test_list_events_returns_full_history_in_ascending_order(tmp_path) -> None:
     assert [event.sequence for event in storage.list_events("sess")] == [1, 2, 3, 4, 5]
 
 
+def test_seed_events_assigns_sequences_and_stamps_version(tmp_path) -> None:
+    storage, now = _seed_session(tmp_path)
+    seeded = storage.seed_events(
+        "sess",
+        [
+            EventRecord(
+                session_id="sess",
+                ts=now,
+                kind=EventKind.USER_INPUT,
+                text="hello",
+                metadata={},
+                sequence=0,  # ignored; reassigned from MAX(sequence)+1
+            ),
+            EventRecord(
+                session_id="sess",
+                ts=now + timedelta(seconds=1),
+                kind=EventKind.AGENT_OUTPUT,
+                text="hi there",
+                metadata={"item_id": "a1"},
+                sequence=0,
+            ),
+        ],
+    )
+    assert [e.sequence for e in seeded] == [1, 2]
+    assert all(e.metadata["version"] == 1 for e in seeded)
+    stored = storage.list_events("sess")
+    assert [e.kind for e in stored] == [EventKind.USER_INPUT, EventKind.AGENT_OUTPUT]
+    assert [e.text for e in stored] == ["hello", "hi there"]
+
+
+def test_seed_events_appends_after_existing_events(tmp_path) -> None:
+    storage, now = _seed_session(tmp_path)
+    _append(
+        storage,
+        "sess",
+        sequence=1,
+        kind=EventKind.SYSTEM_NOTE,
+        text="existing",
+        ts=now,
+    )
+    storage.seed_events(
+        "sess",
+        [
+            EventRecord(
+                session_id="sess",
+                ts=now + timedelta(seconds=1),
+                kind=EventKind.USER_INPUT,
+                text="imported",
+                metadata={},
+                sequence=99,
+            )
+        ],
+    )
+    assert [e.sequence for e in storage.list_events("sess")] == [1, 2]
+
+
+def test_seed_events_empty_is_noop(tmp_path) -> None:
+    storage, _ = _seed_session(tmp_path)
+    assert storage.seed_events("sess", []) == []
+    assert storage.list_events("sess") == []
+
+
 def test_list_events_with_cursor_returns_only_newer_rows(tmp_path) -> None:
     # Cursor-after semantics is the legacy reconnect/catch-up path: return
     # everything strictly newer than the supplied id, no clamp.

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -332,6 +332,26 @@ serves to the frontend (`{models, default_model_id, default_model_label,
 default_effort, supports_free_text}`). `list_threads` returns plugin-specific
 summary objects; the API serialises via `model_dump`.
 
+`import_thread` adopts an externally-created native thread into a brand-new
+session. When the import request's `import_history` flag is set (it defaults to
+`True` on every backend's import-request schema), the plugin also **replays the
+thread's prior conversation into the new session's transcript** so an imported
+thread reads as continuous rather than starting empty. The plugin does this by
+reading the native history (Claude's `~/.claude/projects` transcript JSONL,
+Codex's `thread_read(include_turns=True)`, OpenCode's `GET /session/{id}/message`)
+and converting each record into `EventRecord`s, then calling
+`runtime.seed_thread_history(session_id, reader, enabled=request.import_history)`
+after `create_session` and before the "Imported…" system note. Two caveats make
+this a purpose-built converter rather than a call into the live `normalize.py`:
+the live normalizers **suppress user turns** (they arrive at the input boundary
+live) and **delta-streamed assistant text** (no snapshot equivalent), so the
+converter must re-add both from the historical snapshot; and Codex tool metadata
+lives in the adapter, not the normalizer, so its converter reproduces the full
+`item_id`/`item_type`/`tool_name`/`payload.item` envelope and synthesizes the
+tool_call+tool_result pair. `seed_thread_history` swallows read/convert failures
+and degrades to a plain resume with a note, so history import never blocks the
+import. The generic `tmux`-wrapper import path does not seed history today.
+
 ### Slash routing & per-event hooks
 
 ```python

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -466,6 +466,9 @@ html[data-theme="light"] .import-thread-chip {
   display: flex;
   align-items: center;
   gap: 12px;
+  /* Keep the actions right-aligned even when the bottomline wraps them onto
+     their own row — space-between alone would left-align a lone wrapped item. */
+  margin-left: auto;
 }
 
 .import-thread-cta button.secondary {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -537,6 +537,79 @@ html[data-theme="light"] .import-thread-chip {
   min-width: 0;
 }
 
+/* Import-history toggle: an in-flow instrument, so flat token surfaces and a
+   solid hairline — no glass. The capsule track and round thumb are the one
+   sanctioned use of --radius-pill for a true capsule/circle. */
+.import-history-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.import-history-copy {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.import-history-label {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.import-history-hint {
+  font-size: 0.75rem;
+  color: var(--muted-soft);
+}
+
+.switch {
+  flex: none;
+  width: 42px;
+  height: 24px;
+  padding: 0;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--line-strong);
+  background: var(--bg-input);
+  cursor: pointer;
+  position: relative;
+  transition:
+    background 140ms ease,
+    border-color 140ms ease;
+}
+
+.switch[aria-checked="true"] {
+  background: color-mix(in srgb, var(--accent) 30%, transparent);
+  border-color: var(--accent);
+}
+
+.switch-thumb {
+  position: absolute;
+  top: 50%;
+  left: 3px;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-pill);
+  background: var(--muted);
+  transform: translateY(-50%);
+  transition:
+    transform 140ms ease,
+    background 140ms ease;
+}
+
+.switch[aria-checked="true"] .switch-thumb {
+  transform: translate(18px, -50%);
+  background: var(--accent-strong);
+}
+
+.switch:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
 .resume-panel-loading,
 .resume-panel-empty {
   margin: 0;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -608,6 +608,21 @@ html[data-theme="light"] .import-thread-chip {
   background: var(--accent-strong);
 }
 
+/* Slight hover feedback: a hint of accent on the track and a brighter thumb —
+   no lift, in keeping with the flat in-flow instrument. */
+.switch:hover {
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line-strong));
+}
+
+.switch:not([aria-checked="true"]):hover .switch-thumb {
+  background: color-mix(in srgb, var(--muted) 55%, var(--text));
+}
+
+.switch[aria-checked="true"]:hover {
+  background: color-mix(in srgb, var(--accent) 42%, transparent);
+  border-color: var(--accent-strong);
+}
+
 .switch:focus-visible {
   outline: none;
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -649,6 +649,7 @@ export default function HomePage() {
     threadId: string,
     cwd: string,
     transport: SessionTransport | null,
+    importHistory: boolean,
   ) {
     try {
       const payload = {
@@ -659,6 +660,9 @@ export default function HomePage() {
         // pin the chosen transport and leave the launch mode on "auto".
         launch_mode: "auto",
         transport: transport || null,
+        // Replay the thread's prior conversation into the new session's
+        // transcript; false starts empty and only resumes the agent's context.
+        import_history: importHistory,
       };
       const session = await importBackendThread(host, token, backend, payload);
       setSessions((current) => [

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -68,6 +68,7 @@ interface LaunchPanelProps {
     threadId: string,
     cwd: string,
     transport: SessionTransport | null,
+    importHistory: boolean,
   ) => Promise<void>;
   onDeleteThread?: (
     backend: Backend,

--- a/frontend/src/components/ResumeThreadPanel.tsx
+++ b/frontend/src/components/ResumeThreadPanel.tsx
@@ -39,6 +39,7 @@ interface ResumeThreadPanelProps {
     threadId: string,
     cwd: string,
     transport: SessionTransport | null,
+    importHistory: boolean,
   ) => Promise<void>;
   onDeleteThread?: (
     backend: Backend,
@@ -114,6 +115,9 @@ export function ResumeThreadPanel({
   const [importingId, setImportingId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  // Replay the prior conversation into the new session's transcript on import.
+  // On by default: an imported thread should look continuous, not empty.
+  const [importHistory, setImportHistory] = useState(true);
 
   // The transport picker only applies to a single-agent view. Feed the hook a
   // concrete agent (the filtered one, or the preferred fallback while "All" is
@@ -189,7 +193,13 @@ export function ResumeThreadPanel({
         : defaultTransportFor(thread.backend, catalog);
     setImportingId(thread.id);
     try {
-      await onImportThread(thread.backend, thread.id, thread.cwd, chosen);
+      await onImportThread(
+        thread.backend,
+        thread.id,
+        thread.cwd,
+        chosen,
+        importHistory,
+      );
     } finally {
       setImportingId(null);
     }
@@ -259,6 +269,25 @@ export function ResumeThreadPanel({
           catalog={catalog}
         />
       ) : null}
+
+      <div className="import-history-row">
+        <div className="import-history-copy">
+          <span className="import-history-label">Import history</span>
+          <span className="import-history-hint">
+            Replay the prior conversation into the new session
+          </span>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={importHistory}
+          aria-label="Import prior conversation history"
+          className="switch"
+          onClick={() => setImportHistory((value) => !value)}
+        >
+          <span className="switch-thumb" />
+        </button>
+      </div>
 
       <div className="resume-filters">
         <div className="resume-filters-search">


### PR DESCRIPTION
## Purpose

Importing an existing Claude Code / Codex / OpenCode thread previously created a session whose transcript started empty — only an "Imported…" note. The underlying agent resumed its own context, but the Waypoint transcript showed nothing prior, so the feature felt incomplete. This replays the thread's prior conversation (user turns, assistant output, tool calls/results) into the new session's transcript so an imported thread reads as continuous, and adds a Resume-panel toggle (default on) to opt out.

## Changes

### Backend

- `storage.py`, `runtime.py` — a bulk `seed_events` that appends externally-sourced events with reassigned sequences and a stamped envelope version, and a transport-agnostic `seed_thread_history` helper that agent plugins call after `create_session`; it guards the read/convert/seed and degrades to a plain resume (with a note) on any failure, so history never blocks the import.
- `backends/*/schemas.py`, `backends/opencode/plugin.py` — an `import_history: bool = True` field on each backend's import-request schema.
- `backends/claude_code`, `backends/claude_tty` — a full-transcript reader plus a converter that reuses the shared block/tool helpers and re-adds the user turns the live normalizer drops; wired into both the direct SDK and tty-tail import paths. Remote Claude degrades to resume-only (the enumerator surfaces only thread metadata today).
- `backends/codex` — reads history via `thread_read(include_turns=True)` and reproduces the adapter envelope (`item_id`/`item_type`/`tool_name`/`payload.item`), synthesizing the tool_call + tool_result pair Codex only pairs on `item_id`.
- `backends/opencode` — a `GET /session/{id}/message` fetch plus a converter that reuses the tool mapping and writes the fresh text/reasoning + user paths the SSE normalizer suppresses; a completed tool snapshot is replayed as a paired call + result.
- `cli.py` — `waypoint sessions import` gains first-class `--thread-id` and `--import-history/--no-import-history` flags (`--json` is now optional; explicit flags override it).

### Frontend

- `ResumeThreadPanel.tsx`, `LaunchPanel.tsx`, `page.tsx`, `globals.css` — an "Import history" switch (default on) in the Resume panel, threaded into the import request. The switch is a flat token-surfaced instrument (capsule track, accent fill when on) consistent with the design language, verified in both themes.

### Docs

- `docs/coding_agent_plugins.md`, `.agents/skills/waypoint/SKILL.md` — document the `import_history` field, the read→convert→seed replay pattern (and why converters share helpers with but are not the live `normalize.py`), and the new CLI flag.

## Design

The live `normalize.py` modules deliberately suppress exactly the content replay must show — user turns (they arrive at the input boundary) and delta-streamed assistant text (no snapshot equivalent) — so each backend gets a purpose-built historical converter that shares the pure block/tool helpers but re-adds those from the snapshot. Fidelity is enforced by routing through those helpers so replayed events carry the same metadata `parseEvent`/`TranscriptCard` key off of, and by per-backend fixture tests asserting user turns, assistant text, and tool pairing all survive. The personal-assistant "Resume thread" flow (`attach_assistant`) is a separate path and is intentionally left unchanged.

## Test Plan

- `cd backend && uv run pre-commit run --all-files` and `cd backend && uv run pytest` — full suite.
- `cd frontend && npm run lint && npx tsc --noEmit && npm run build`.
- Manual end-to-end on a running stack: imported a real Claude, Codex, and OpenCode thread with the toggle on and confirmed the transcript replayed user turns, assistant output, and paired tool_call/tool_result cards; imported with `--no-import-history` and confirmed the transcript stays empty apart from the note.

## Test Result

- pre-commit (isort, black, ruff, codespell, mypy) — passed; `uv run pytest` — 1338 passed.
- frontend lint, `tsc --noEmit`, and `npm run build` — clean.
- Live import: Claude replayed 6 agent_output / 13 tool_call / 13 tool_result / 1 user_input; Codex replayed 3 user_input / 17 agent_output; OpenCode replayed 9 tool_call / 9 tool_result / 2 user_input; `--no-import-history` produced only the system note.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes — new `test_import_history_{claude,codex,opencode}.py` plus `seed_events` tests.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`); `waypointctl` untouched.
- [x] I touched code that dispatches by plugin id — verified claude_code, codex, and opencode import-with-history live on a running stack.
- [x] I changed the frontend — ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (the switch resolves from tokens / `color-mix`).
- [x] Not a breaking change — import defaults to the new replay behavior; `--no-import-history` reproduces the prior empty-transcript resume.
- [x] I updated documentation (`docs/coding_agent_plugins.md`, waypoint skill) for the user-facing behavior change.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
