### PR TITLE
fix: unify row actions and dock expand behavior

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9930,12 +9930,10 @@ html[data-theme="light"] .schedule-msg-preview {
     gap: 12px;
   }
 
+  /* Keep the text actions right-aligned when the bottomline stacks, matching
+     the desktop alignment. */
   .import-thread-cta {
-    align-self: stretch;
-  }
-
-  .import-thread-cta button.secondary {
-    width: 100%;
+    align-self: flex-end;
   }
 
   .import-thread-footer {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -471,22 +471,9 @@ html[data-theme="light"] .import-thread-chip {
   margin-left: auto;
 }
 
-.import-thread-cta button.secondary {
-  min-height: 32px;
-  padding: 0 14px;
+.import-thread-cta .link-button {
   font-family: var(--font-mono);
-  font-size: 0.76rem;
-  letter-spacing: 0.06em;
-  text-transform: lowercase;
-}
-
-/* The delete action is a danger-styled sibling of Import; keep the row-hover
-   accent recolor off it so it stays in its danger hue. */
-.import-thread-row:hover
-  .import-thread-cta
-  button.secondary:not(.danger):not(:disabled) {
-  border-color: rgba(200, 169, 106, 0.5);
-  color: var(--accent-strong);
+  font-size: 0.78rem;
 }
 
 .import-thread-footer {
@@ -3565,8 +3552,8 @@ html[data-theme="light"] .task-dock-scrim {
   }
 
   .task-dock.expanded .task-dock-strip {
-    border-top-left-radius: var(--radius);
-    border-top-right-radius: var(--radius);
+    border-top-left-radius: var(--radius-glass);
+    border-top-right-radius: var(--radius-glass);
   }
 }
 
@@ -3822,8 +3809,8 @@ html[data-theme="light"] .sq-dock-scrim {
   }
 
   .sq-dock.expanded .sq-dock-strip {
-    border-top-left-radius: var(--radius);
-    border-top-right-radius: var(--radius);
+    border-top-left-radius: var(--radius-glass);
+    border-top-right-radius: var(--radius-glass);
   }
 }
 
@@ -8791,7 +8778,7 @@ html[data-theme="light"] .term-compose-send {
    the touch target without drawing a chip around it. */
 .session-card-actions .link-button.pin-link,
 .session-card-actions .link-button.danger-link,
-.link-button.danger-link.action-chip {
+.link-button.action-chip {
   align-self: center;
   margin-top: 0;
   padding: 6px 10px;
@@ -8802,7 +8789,7 @@ html[data-theme="light"] .term-compose-send {
 
 .session-card-actions .link-button.pin-link:hover:not(:disabled),
 .session-card-actions .link-button.danger-link:hover:not(:disabled),
-.link-button.danger-link.action-chip:hover:not(:disabled) {
+.link-button.action-chip:hover:not(:disabled) {
   background: color-mix(in srgb, currentColor 10%, transparent);
 }
 

--- a/frontend/src/components/ResumeThreadPanel.tsx
+++ b/frontend/src/components/ResumeThreadPanel.tsx
@@ -371,16 +371,16 @@ export function ResumeThreadPanel({
                     <div className="import-thread-cta">
                       {canDelete ? (
                         <button
-                          className="secondary danger"
+                          className="link-button danger-link action-chip"
                           disabled={busy}
                           type="button"
                           onClick={() => void handleDelete(thread)}
                         >
-                          {isDeleting ? "deleting…" : "delete"}
+                          {isDeleting ? "Deleting…" : "Delete"}
                         </button>
                       ) : null}
                       <button
-                        className="secondary"
+                        className="link-button action-chip"
                         disabled={busy}
                         type="button"
                         onClick={() => void handleImport(thread)}


### PR DESCRIPTION
## Purpose

Two consistency gaps from the design-system restyle (#203). The resume/import panel's per-row Delete and Import buttons were still boxed `.secondary` buttons (with lowercase labels) while every sibling row action — session-card Pin/Terminate/Delete, scheduled-row Cancel — uses quiet text actions. And expanding the task or side-question dock on desktop visibly reshaped the strip's corners from 16px to 4px while the scheduled-messages dock kept its capsule, so the three docks disagreed about whether expanding "morphs" the strip.

## Changes

### Frontend

- `ResumeThreadPanel.tsx`, `globals.css` — the import rows' Delete/Import become `link-button` row actions sharing the (now generalized) `action-chip` recipe: bare mono text in danger red / accent gold with a soft fill on hover, consistent capitalization. The boxed-button overrides and the row-hover recolor rule are gone.
- `globals.css` — the desktop-expanded task/side-question dock strips restore `--radius-glass` instead of `--radius`, matching the scheduled dock.

## Design

Row-level actions are quiet text; real buttons are reserved for panel-level controls — one altitude rule across lists. For the docks: the capsule-fusing-into-a-sheet morph is the *mobile* behavior, where the panel genuinely joins the strip at a seam (all three docks already shared it); on desktop the panel is a detached popover, so nothing joins the strip and its shape must not change. The 4px snap was a leftover from the seam-join rules being un-done with the wrong radius token.

## Test Plan

- `cd frontend && npm run lint && npx tsc --noEmit && npm run build`
- Manual: deployed via `waypointctl restart frontend`; verified the resume rows' new actions on the home page and both dock states (collapsed/expanded) at desktop and phone widths in dark theme via Playwright captures.

## Test Result

- Lint, type-check, and production build — clean.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues — hooks ran at commit time; backend untouched so the python hooks had no files to check.
- [x] I have added or updated tests covering my changes (if applicable) — N/A: styling-only frontend change; no frontend test harness.
- [x] I have verified the relevant suites pass locally — backend and `waypointctl` untouched; ran the frontend lint + type-check + build gate instead.
- [x] If I touched the coding-agent plugin/transport contract or dispatch code, I checked the backends — N/A.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (all changed rules resolve from tokens / `currentColor`).
- [x] Not a breaking change — visual consistency fixes only.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)