### PR TITLE
feat: patch board cell metadata with set-meta --merge

### DIFF
--- a/.agents/skills/waypoint-crew/references/coordination.md
+++ b/.agents/skills/waypoint-crew/references/coordination.md
@@ -170,12 +170,12 @@ waypoint board post org:<product> "lifecycle state" --key phase \
   is absorbed — move the entry to `jobs=` if the main lead keeps running the
   channel, or drop it on lift-to-org.
 
-Update the cell with `board set-meta ... --key phase` (it preserves the text), and
-**re-supply all metas every time** — `--meta` replaces the cell's metadata
-wholesale, so an update that passes only `jobs=` silently drops `current=`,
-`approved=`, and (under a hierarchy) `teams=`. This is the same keyed-cell hazard
-the work queue avoids with its two-cell split; here the `phase` cell has no text
-worth protecting, so one cell plus always-write-all-metas is enough.
+Update the cell with `board set-meta ... --key phase --merge` (it preserves the
+text). `--merge` patches only the keys you pass and leaves the rest intact, so an
+update that passes only `jobs=` keeps `current=`, `approved=`, and (under a
+hierarchy) `teams=` untouched; drop a stale key with `--unset <key>`. Without
+`--merge`, `--meta` replaces the cell's metadata wholesale — you must then
+re-supply every meta or silently lose the omitted ones.
 
 A lead restarting reads `phase`, then for each **self-run** channel in `jobs=`
 runs the work-queue resume procedure directly (done tasks skipped, `todo`
@@ -222,7 +222,8 @@ deleted, until its cells are read or migrated.**
   successor is stranded on a stale entry (a `teams=` channel with no team lead
   behind it): respawn → rewrite `teams=` with the new sid; absorb-and-keep-running
   → move the entry `teams=` → `jobs=`; absorb-and-lift-to-org → drop it from
-  `teams=`. All under the re-supply-all-metas rule.
+  `teams=`. Use `set-meta --merge` to patch just `teams=` (and `--unset teams` to
+  drop it) without disturbing the other metas.
 - **Double death.** If a team lead is *also* dead, its members were `--spawned-by`
   the dead team-lead sid (recorded in `teams=`), not by the old main lead, so the
   successor walks the spawn tree **tier by tier** — recover the team via the path

--- a/.agents/skills/waypoint-workqueue/references/org-template.md
+++ b/.agents/skills/waypoint-workqueue/references/org-template.md
@@ -33,7 +33,9 @@ Three kinds of cell, **all written only by the lead**:
   plus how to check it. Set once; never rewritten.
 - `status:<n>` — paired with each `task:<n>`. **Mutable status**: `--meta`
   carries `state=todo|doing|done|blocked` and `assignee=<sid>`. Text is a brief
-  label. Update with `waypoint board set-meta` to flip state without touching text.
+  label. Update with `waypoint board set-meta ... --merge` to flip one key without
+  touching text or the other metas (`--unset <key>` removes a key); plain `--meta`
+  without `--merge` replaces the whole blob.
 
 ```bash
 # plan — once

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1789,13 +1789,25 @@ def board_set_meta(
     channel: Annotated[str, typer.Argument()],
     meta: Annotated[
         list[str] | None,
-        typer.Option("--meta", help="Replace metadata with key=value. Repeatable."),
+        typer.Option("--meta", help="Set metadata key=value. Repeatable."),
     ] = None,
     key: Annotated[
         str | None, typer.Option("--key", help="Cell key to target.")
     ] = None,
     entry_id: Annotated[
         int | None, typer.Option("--entry-id", help="Entry id to target.")
+    ] = None,
+    merge: Annotated[
+        bool,
+        typer.Option(
+            "--merge/--replace",
+            help="Merge --meta into the existing metadata (patch) instead of "
+            "replacing the whole blob.",
+        ),
+    ] = False,
+    unset: Annotated[
+        list[str] | None,
+        typer.Option("--unset", help="Remove metadata key(s). Repeatable."),
     ] = None,
 ) -> None:
     """Update a keyed cell's metadata without changing its text."""
@@ -1816,7 +1828,14 @@ def board_set_meta(
             assert entry_id is not None
             eid = entry_id
         return {
-            "entry": c.update_board_entry(channel, eid, text=None, metadata=metadata)
+            "entry": c.update_board_entry(
+                channel,
+                eid,
+                text=None,
+                metadata=metadata,
+                merge=merge,
+                unset=unset,
+            )
         }
 
     _emit(_settings_from_ctx(ctx), _run)

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -461,10 +461,16 @@ class WaypointClient:
         entry_id: int,
         text: str | None = None,
         metadata: dict[str, Any] | None = None,
+        merge: bool = False,
+        unset: list[str] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"metadata": metadata or {}}
         if text is not None:
             body["text"] = text
+        if merge:
+            body["merge"] = True
+        if unset:
+            body["unset"] = list(unset)
         data: dict[str, Any] = self._request(
             "PATCH", f"/api/board/{channel}/entries/{entry_id}", json=body
         ).json()["entry"]

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1565,7 +1565,12 @@ class SessionRuntime:
         self, channel: str, entry_id: int, request: BoardEntryUpdateRequest
     ) -> BoardEntry | None:
         entry = self.storage.update_board_entry(
-            channel, entry_id, request.text, request.metadata
+            channel,
+            entry_id,
+            request.text,
+            request.metadata,
+            merge=request.merge,
+            unset=request.unset,
         )
         if entry is not None:
             await self._publish_board_update(channel)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -272,6 +272,11 @@ class BoardPostRequest(BaseModel):
 class BoardEntryUpdateRequest(BaseModel):
     text: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
+    # When True, merge ``metadata`` into the entry's existing metadata (patch
+    # semantics) instead of replacing the whole blob. Keys in ``unset`` are
+    # removed from the result in either mode.
+    merge: bool = False
+    unset: list[str] = Field(default_factory=list)
 
 
 class LoginRequest(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -632,8 +632,10 @@ class Storage:
         now = datetime.now(UTC)
         patch = metadata or {}
         unset = unset or []
-        # Merge/unset need the current blob; the SELECT and UPDATE share this
-        # method's ``@_synchronized`` lock, so the read-modify-write is atomic.
+        # Merge/unset both patch the current blob rather than replacing it, so
+        # they read it first; the SELECT and UPDATE share this method's
+        # ``@_synchronized`` lock, so the read-modify-write is atomic. ``unset``
+        # implies patch semantics too — removing a key must not drop the others.
         if merge or unset:
             existing_row = self.connection.execute(
                 "SELECT metadata FROM board_entries WHERE id = ? AND channel = ?",
@@ -642,7 +644,7 @@ class Storage:
             if existing_row is None:
                 return None
             existing = json.loads(existing_row["metadata"] or "{}")
-            final_meta = {**existing, **patch} if merge else dict(patch)
+            final_meta = {**existing, **patch}
             for removed_key in unset:
                 final_meta.pop(removed_key, None)
         else:

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -626,19 +626,38 @@ class Storage:
         entry_id: int,
         text: str | None,
         metadata: dict[str, Any] | None = None,
+        merge: bool = False,
+        unset: list[str] | None = None,
     ) -> BoardEntry | None:
         now = datetime.now(UTC)
+        patch = metadata or {}
+        unset = unset or []
+        # Merge/unset need the current blob; the SELECT and UPDATE share this
+        # method's ``@_synchronized`` lock, so the read-modify-write is atomic.
+        if merge or unset:
+            existing_row = self.connection.execute(
+                "SELECT metadata FROM board_entries WHERE id = ? AND channel = ?",
+                (entry_id, channel),
+            ).fetchone()
+            if existing_row is None:
+                return None
+            existing = json.loads(existing_row["metadata"] or "{}")
+            final_meta = {**existing, **patch} if merge else dict(patch)
+            for removed_key in unset:
+                final_meta.pop(removed_key, None)
+        else:
+            final_meta = patch
         if text is None:
             cursor = self.connection.execute(
                 "UPDATE board_entries SET metadata = ?, edited_at = ? "
                 "WHERE id = ? AND channel = ?",
-                (json.dumps(metadata or {}), now.isoformat(), entry_id, channel),
+                (json.dumps(final_meta), now.isoformat(), entry_id, channel),
             )
         else:
             cursor = self.connection.execute(
                 "UPDATE board_entries SET text = ?, metadata = ?, edited_at = ? "
                 "WHERE id = ? AND channel = ?",
-                (text, json.dumps(metadata or {}), now.isoformat(), entry_id, channel),
+                (text, json.dumps(final_meta), now.isoformat(), entry_id, channel),
             )
         self.connection.commit()
         if not (cursor.rowcount or 0):

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1094,6 +1094,61 @@ def test_board_update_entry_missing_returns_none(tmp_path) -> None:
     assert storage.list_board_entries("topic:a")[0].text == "hi"
 
 
+def test_board_update_entry_replace_drops_omitted_keys(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry(
+        "topic:a", "cell", key="status", metadata={"state": "todo", "assignee": "x"}
+    )
+    updated = storage.update_board_entry(
+        "topic:a", entry.id, None, metadata={"state": "done"}
+    )
+    assert updated is not None
+    # Default (replace) semantics: omitted keys vanish.
+    assert updated.metadata == {"state": "done"}
+
+
+def test_board_update_entry_merge_preserves_untouched_keys(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry(
+        "topic:a",
+        "cell",
+        key="phase",
+        metadata={"current": "build", "approved": "no", "teams": "1,2"},
+    )
+    updated = storage.update_board_entry(
+        "topic:a", entry.id, None, metadata={"approved": "yes"}, merge=True
+    )
+    assert updated is not None
+    assert updated.metadata == {"current": "build", "approved": "yes", "teams": "1,2"}
+
+
+def test_board_update_entry_unset_removes_keys(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry(
+        "topic:a", "cell", key="k", metadata={"a": "1", "b": "2", "c": "3"}
+    )
+    updated = storage.update_board_entry(
+        "topic:a", entry.id, None, metadata={"a": "9"}, merge=True, unset=["b"]
+    )
+    assert updated is not None
+    assert updated.metadata == {"a": "9", "c": "3"}
+
+
+def test_board_update_entry_merge_missing_returns_none(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry("topic:a", "hi", key="k", metadata={"a": "1"})
+    assert (
+        storage.update_board_entry("topic:a", 99999, None, {"a": "2"}, merge=True)
+        is None
+    )
+    # Wrong channel with merge is a clean no-op, not a partial write.
+    assert (
+        storage.update_board_entry("topic:b", entry.id, None, {"a": "2"}, merge=True)
+        is None
+    )
+    assert storage.list_board_entries("topic:a", key="k")[0].metadata == {"a": "1"}
+
+
 def test_storage_legacy_db_gets_launch_mode_column(tmp_path) -> None:
     """A pre-launch_mode SQLite file gains the column with default 'auto'."""
     import sqlite3

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1134,6 +1134,31 @@ def test_board_update_entry_unset_removes_keys(tmp_path) -> None:
     assert updated.metadata == {"a": "9", "c": "3"}
 
 
+def test_board_update_entry_unset_without_merge_keeps_other_keys(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry(
+        "topic:a", "cell", key="k", metadata={"current": "build", "stale": "x"}
+    )
+    # unset alone (no merge, no metadata) must remove only the named key, not
+    # wipe the whole blob back to {}.
+    updated = storage.update_board_entry("topic:a", entry.id, None, unset=["stale"])
+    assert updated is not None
+    assert updated.metadata == {"current": "build"}
+
+
+def test_board_update_entry_merge_with_text_updates_both(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    entry = storage.add_board_entry(
+        "topic:a", "old", key="k", metadata={"a": "1", "b": "2"}
+    )
+    updated = storage.update_board_entry(
+        "topic:a", entry.id, "new", metadata={"b": "9"}, merge=True
+    )
+    assert updated is not None
+    assert updated.text == "new"
+    assert updated.metadata == {"a": "1", "b": "9"}
+
+
 def test_board_update_entry_merge_missing_returns_none(tmp_path) -> None:
     storage = Storage(tmp_path / "waypoint.db")
     entry = storage.add_board_entry("topic:a", "hi", key="k", metadata={"a": "1"})


### PR DESCRIPTION
## Purpose

Grounded wishlist item #1 from the PR #210 review. `board set-meta` replaced a cell's entire metadata blob, so every update had to re-supply every key or silently drop the omitted ones — a footgun documented in three skills. This adds patch semantics so an update touches only the keys it names. Relates to #210.

## Changes

### Backend

- `backend/src/waypoint/schemas.py` — `BoardEntryUpdateRequest` gains `merge: bool` and `unset: list[str]`.
- `backend/src/waypoint/storage.py` — `update_board_entry` performs the read-modify-write under the existing `@_synchronized` lock when `merge`/`unset` is set, so the patch is atomic against concurrent posters; default behavior (full replace) is unchanged.
- `backend/src/waypoint/runtime.py`, `backend/src/waypoint/client.py` — thread `merge`/`unset` through the update path.
- `backend/src/waypoint/cli.py` — `board set-meta` gains `--merge/--replace` (default replace, for back-compat) and repeatable `--unset <key>`.
- `backend/tests/test_storage.py` — cover replace-drops-omitted, merge-preserves-untouched, unset-removes, and merge-on-missing-entry no-op.

### Docs

- `.agents/skills/waypoint-crew/references/coordination.md`, `.agents/skills/waypoint-workqueue/references/org-template.md` — point the phase/status cell update guidance at `--merge`/`--unset` instead of the re-supply-all-metas rule.

## Design

The merge runs server-side in storage rather than client-side because a client read-modify-write would race concurrent updates to the same cell; the storage method already holds the connection lock, so the SELECT + UPDATE there is atomic. Key deletion is an explicit `--unset` rather than overloading an empty value, since `--meta` requires `key=value`. `--merge` is opt-in so existing `set-meta` callers keep replace semantics. The larger two-cell workqueue simplification the patch unlocks is left as a follow-up.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1342 passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — N/A: board storage is plugin-agnostic.
- [x] If I changed the frontend, I ran the frontend gate — N/A: no frontend change.
- [x] Not a breaking change — `--merge` is opt-in; default `set-meta` behavior is unchanged.
- [x] I have updated documentation — skill references updated; no `.env`/config surface changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)