### PR TITLE
feat: pin and manage session attachments from the CLI

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -11,6 +11,7 @@ from fastapi import (
     Depends,
     FastAPI,
     File,
+    Form,
     Header,
     HTTPException,
     Query,
@@ -421,6 +422,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session_id: str,
         _: Annotated[str, Depends(token_dependency())],
         file: Annotated[UploadFile, File()],
+        pin: Annotated[bool, Form()] = False,
     ) -> Any:
         # 404 on an unknown session before persisting anything.
         context.runtime.get_session(session_id)
@@ -437,6 +439,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             filename=file.filename or "file",
             content_type=file.content_type,
         )
+        if pin:
+            context.runtime.attachments.mark_pinned(session_id, [spec.id])
         return spec.model_dump(mode="json")
 
     @app.get("/api/sessions/{session_id}/attachments")
@@ -754,6 +758,34 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="attachment not found"
             )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @app.post("/api/sessions/{session_id}/attachments/{attachment_id}/pin")
+    async def pin_attachment(
+        session_id: str,
+        attachment_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        # Exempt the blob from the orphan sweep. 404 on an unknown attachment so
+        # a typo doesn't silently pin nothing.
+        context.runtime.get_session(session_id)
+        if context.runtime.attachments.resolve(session_id, attachment_id) is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="attachment not found"
+            )
+        context.runtime.attachments.mark_pinned(session_id, [attachment_id])
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @app.delete("/api/sessions/{session_id}/attachments/{attachment_id}/pin")
+    async def unpin_attachment(
+        session_id: str,
+        attachment_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        # Re-expose the blob to the orphan sweep. Idempotent: unpinning an
+        # already-unpinned (or unknown) id is a clean no-op.
+        context.runtime.get_session(session_id)
+        context.runtime.attachments.unmark_pinned(session_id, [attachment_id])
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @app.post("/api/sessions/{session_id}/interrupt")

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -452,8 +452,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         context.runtime.attachments.sweep(
             session_id, context.settings.attachment_orphan_ttl_seconds
         )
+        pinned = context.runtime.attachments.pinned_ids(session_id)
         return [
-            {**spec.model_dump(mode="json"), "uploaded_at": uploaded_at}
+            {
+                **spec.model_dump(mode="json"),
+                "uploaded_at": uploaded_at,
+                "pinned": spec.id in pinned,
+            }
             for spec, uploaded_at in context.runtime.attachments.entries(session_id)
         ]
 

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -19,6 +19,9 @@ _IMAGE_MIME_PREFIX = "image/"
 # Index of ids referenced by a sent message; its stem isn't a uuid so it's
 # transparent to entries()/sweep, which only consider sidecars.
 _SENT_INDEX = "_sent.json"
+# Index of ids the user explicitly pinned to survive the orphan sweep even
+# without being sent. Same transparent-to-sidecars shape as _SENT_INDEX.
+_PINNED_INDEX = "_pinned.json"
 
 
 def _sanitize_component(value: str, *, fallback: str) -> str:
@@ -195,31 +198,41 @@ class AttachmentStore:
     def mark_sent(self, session_id: str, attachment_ids: list[str]) -> None:
         """Record ids carried by a sent message so the sweep never reaps them
         (a sent file is referenced by the transcript and must survive)."""
-        ids = [aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)]
+        self._add_to_index(session_id, _SENT_INDEX, attachment_ids)
+
+    def mark_pinned(self, session_id: str, attachment_ids: list[str]) -> None:
+        """Pin ids so the sweep never reaps them, independent of being sent —
+        the user-intent "keep this durably" signal."""
+        self._add_to_index(session_id, _PINNED_INDEX, attachment_ids)
+
+    def unmark_pinned(self, session_id: str, attachment_ids: list[str]) -> None:
+        """Drop ids from the pin index, re-exposing them to the orphan sweep."""
+        ids = {aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)}
         if not ids:
             return
         session_dir = self._session_dir(session_id)
         if not session_dir.is_dir():
             return
-        current = self._sent_ids(session_dir)
-        current.update(ids)
-        (session_dir / _SENT_INDEX).write_text(
-            json.dumps(sorted(current)), encoding="utf-8"
+        remaining = self._read_id_index(session_dir, _PINNED_INDEX) - ids
+        (session_dir / _PINNED_INDEX).write_text(
+            json.dumps(sorted(remaining)), encoding="utf-8"
         )
 
     def sweep(self, session_id: str, ttl_seconds: float) -> int:
         """Reap eager uploads that were never sent — blobs older than
-        ``ttl_seconds`` that no sent message references. Returns the count
-        removed. Best-effort; never raises."""
+        ``ttl_seconds`` that no sent message references and the user hasn't
+        pinned. Returns the count removed. Best-effort; never raises."""
         session_dir = self._session_dir(session_id)
         if not session_dir.is_dir():
             return 0
-        sent = self._sent_ids(session_dir)
+        kept = self._read_id_index(session_dir, _SENT_INDEX) | self._read_id_index(
+            session_dir, _PINNED_INDEX
+        )
         cutoff = time.time() - ttl_seconds
         removed = 0
         for sidecar in session_dir.glob("*.json"):
             attachment_id = sidecar.stem
-            if not _ATTACHMENT_ID.fullmatch(attachment_id) or attachment_id in sent:
+            if not _ATTACHMENT_ID.fullmatch(attachment_id) or attachment_id in kept:
                 continue
             try:
                 if sidecar.stat().st_mtime >= cutoff:
@@ -230,9 +243,24 @@ class AttachmentStore:
                 removed += 1
         return removed
 
-    def _sent_ids(self, session_dir: Path) -> set[str]:
+    def _add_to_index(
+        self, session_id: str, index_name: str, attachment_ids: list[str]
+    ) -> None:
+        ids = [aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)]
+        if not ids:
+            return
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return
+        current = self._read_id_index(session_dir, index_name)
+        current.update(ids)
+        (session_dir / index_name).write_text(
+            json.dumps(sorted(current)), encoding="utf-8"
+        )
+
+    def _read_id_index(self, session_dir: Path, index_name: str) -> set[str]:
         try:
-            data = json.loads((session_dir / _SENT_INDEX).read_text(encoding="utf-8"))
+            data = json.loads((session_dir / index_name).read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             return set()
         return set(data) if isinstance(data, list) else set()

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -205,6 +205,10 @@ class AttachmentStore:
         the user-intent "keep this durably" signal."""
         self._add_to_index(session_id, _PINNED_INDEX, attachment_ids)
 
+    def pinned_ids(self, session_id: str) -> set[str]:
+        """Ids currently pinned in this session, for surfacing pin state."""
+        return self._read_id_index(self._session_dir(session_id), _PINNED_INDEX)
+
     def unmark_pinned(self, session_id: str, attachment_ids: list[str]) -> None:
         """Drop ids from the pin index, re-exposing them to the orphan sweep."""
         ids = {aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)}

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -117,6 +117,10 @@ sessions_app = typer.Typer(
     help="Manage sessions on a running Waypoint server over HTTP.",
     no_args_is_help=True,
 )
+attachments_app = typer.Typer(
+    help="Manage a session's file attachments on a running Waypoint server.",
+    no_args_is_help=True,
+)
 board_app = typer.Typer(
     help="Blackboard messaging shared across sessions.",
     no_args_is_help=True,
@@ -136,6 +140,7 @@ maintenance_app = typer.Typer(
 app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
+sessions_app.add_typer(attachments_app, name="attachments")
 app.add_typer(board_app, name="board")
 app.add_typer(schedule_app, name="schedule")
 schedule_app.add_typer(schedule_message_app, name="message")
@@ -1223,12 +1228,127 @@ def sessions_upload(
             help="File(s) to upload.",
         ),
     ],
+    pin: Annotated[
+        bool,
+        typer.Option(
+            "--pin",
+            help="Exempt the upload(s) from the orphan sweep so they persist "
+            "without being sent in a message.",
+        ),
+    ] = False,
 ) -> None:
     """Upload file attachment(s) to a session without sending a message."""
 
     def _run(c: WaypointClient) -> dict[str, Any]:
-        specs = [c.upload_attachment(session_id, path) for path in files]
+        specs = [c.upload_attachment(session_id, path, pin=pin) for path in files]
         return {"attachments": specs}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@attachments_app.command("list")
+def attachments_list(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+) -> None:
+    """List a session's attachments (newest first)."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        return {"attachments": c.list_attachments(session_id)}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@attachments_app.command("get")
+def attachments_get(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    attachment_id: Annotated[str, typer.Argument()],
+    out: Annotated[
+        Path | None,
+        typer.Option(
+            "--out",
+            "-o",
+            dir_okay=True,
+            help="Write to this path (a directory uses the original filename); "
+            "defaults to the original filename in the current directory.",
+        ),
+    ] = None,
+) -> None:
+    """Download an attachment to a local file."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        content, filename = c.download_attachment(session_id, attachment_id)
+        destination = out if out is not None else Path(filename)
+        if destination.is_dir():
+            destination = destination / filename
+        destination.write_bytes(content)
+        return {"attachment_id": attachment_id, "path": str(destination.resolve())}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@attachments_app.command("delete")
+def attachments_delete(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    attachment_id: Annotated[str, typer.Argument()],
+) -> None:
+    """Delete a single attachment."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        c.delete_attachment(session_id, attachment_id)
+        return {"attachment_id": attachment_id, "deleted": True}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@attachments_app.command("delete-all")
+def attachments_delete_all(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", "-y", help="Skip the confirmation prompt."),
+    ] = False,
+) -> None:
+    """Delete every attachment on a session."""
+    if not yes:
+        typer.confirm(f"Delete all attachments on {session_id}?", abort=True)
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        c.delete_all_attachments(session_id)
+        return {"session_id": session_id, "deleted_all": True}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@attachments_app.command("pin")
+def attachments_pin(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    attachment_id: Annotated[str, typer.Argument()],
+) -> None:
+    """Pin an existing attachment so the orphan sweep never reaps it."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        c.pin_attachment(session_id, attachment_id)
+        return {"attachment_id": attachment_id, "pinned": True}
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@attachments_app.command("unpin")
+def attachments_unpin(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    attachment_id: Annotated[str, typer.Argument()],
+) -> None:
+    """Unpin an attachment, re-exposing it to the orphan sweep."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        c.unpin_attachment(session_id, attachment_id)
+        return {"attachment_id": attachment_id, "pinned": False}
 
     _emit(_settings_from_ctx(ctx), _run)
 

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -54,6 +54,17 @@ def is_event_envelope(envelope: Mapping[str, Any]) -> bool:
     return envelope.get("type") == "event"
 
 
+def _content_disposition_filename(response: httpx.Response, fallback: str) -> str:
+    """Extract the ``filename`` from a response's Content-Disposition header,
+    falling back to ``fallback`` when it is absent or unparsable."""
+    header = response.headers.get("content-disposition", "")
+    for part in header.split(";"):
+        key, sep, value = part.strip().partition("=")
+        if sep and key.lower() == "filename":
+            return value.strip().strip('"') or fallback
+    return fallback
+
+
 def cli_token_path(settings: Settings) -> Path:
     return settings.data_dir / CLI_TOKEN_FILENAME
 
@@ -290,14 +301,57 @@ class WaypointClient:
         ).json()["session"]
         return data
 
-    def upload_attachment(self, session_id: str, path: Path) -> dict[str, Any]:
+    def upload_attachment(
+        self, session_id: str, path: Path, *, pin: bool = False
+    ) -> dict[str, Any]:
         with path.open("rb") as handle:
             spec: dict[str, Any] = self._request(
                 "POST",
                 f"/api/sessions/{session_id}/attachments",
                 files={"file": (path.name, handle)},
+                data={"pin": "true"} if pin else None,
             ).json()
         return spec
+
+    def list_attachments(self, session_id: str) -> list[dict[str, Any]]:
+        data: list[dict[str, Any]] = self._request(
+            "GET", f"/api/sessions/{session_id}/attachments"
+        ).json()
+        return data
+
+    def download_attachment(
+        self, session_id: str, attachment_id: str
+    ) -> tuple[bytes, str]:
+        """Fetch an attachment's bytes plus its original filename.
+
+        The serve endpoint authenticates by ``?token=`` query param (it must be
+        loadable from an ``<img>`` tag), not the Bearer header the other routes
+        use, so the token rides in the query string here.
+        """
+        response = self._request(
+            "GET",
+            f"/api/sessions/{session_id}/attachments/{attachment_id}",
+            params={"token": self.token()},
+        )
+        return response.content, _content_disposition_filename(response, attachment_id)
+
+    def delete_attachment(self, session_id: str, attachment_id: str) -> None:
+        self._request(
+            "DELETE", f"/api/sessions/{session_id}/attachments/{attachment_id}"
+        )
+
+    def delete_all_attachments(self, session_id: str) -> None:
+        self._request("DELETE", f"/api/sessions/{session_id}/attachments")
+
+    def pin_attachment(self, session_id: str, attachment_id: str) -> None:
+        self._request(
+            "POST", f"/api/sessions/{session_id}/attachments/{attachment_id}/pin"
+        )
+
+    def unpin_attachment(self, session_id: str, attachment_id: str) -> None:
+        self._request(
+            "DELETE", f"/api/sessions/{session_id}/attachments/{attachment_id}/pin"
+        )
 
     def send_input(
         self,

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -122,6 +122,32 @@ def test_sweep_keeps_recent_and_sent(tmp_path: Path) -> None:
     assert store.resolve("s", sent.id) is not None
 
 
+def test_sweep_keeps_pinned(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    resolved = store.resolve("s", spec.id)
+    assert resolved is not None
+    os.utime(resolved[1].parent / f"{spec.id}.json", (1000, 1000))
+    store.mark_pinned("s", [spec.id])
+
+    # Pinned survives the sweep even though it is old and unsent.
+    assert store.sweep("s", ttl_seconds=60) == 0
+    assert store.resolve("s", spec.id) is not None
+
+
+def test_unpin_re_exposes_to_sweep(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    resolved = store.resolve("s", spec.id)
+    assert resolved is not None
+    os.utime(resolved[1].parent / f"{spec.id}.json", (1000, 1000))
+    store.mark_pinned("s", [spec.id])
+    store.unmark_pinned("s", [spec.id])
+
+    assert store.sweep("s", ttl_seconds=60) == 1
+    assert store.resolve("s", spec.id) is None
+
+
 def test_sweep_missing_session_is_noop(tmp_path: Path) -> None:
     assert _store(tmp_path).sweep("never-existed", ttl_seconds=60) == 0
 

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -135,6 +135,18 @@ def test_sweep_keeps_pinned(tmp_path: Path) -> None:
     assert store.resolve("s", spec.id) is not None
 
 
+def test_pinned_ids_reports_current_pins(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    a = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    b = store.save("s", data=PNG_BYTES, filename="b.png", content_type="image/png")
+    assert store.pinned_ids("s") == set()
+    store.mark_pinned("s", [a.id])
+    assert store.pinned_ids("s") == {a.id}
+    store.unmark_pinned("s", [a.id])
+    store.mark_pinned("s", [b.id])
+    assert store.pinned_ids("s") == {b.id}
+
+
 def test_unpin_re_exposes_to_sweep(tmp_path: Path) -> None:
     store = _store(tmp_path)
     spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1737,6 +1737,44 @@ def test_sessions_attachments_list_get_delete_pin(
     assert state["pin"] == ("DELETE", "c" * 32)
 
 
+def test_sessions_attachments_get_out_directory_uses_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"blob",
+            headers={"content-disposition": 'inline; filename="shot.png"'},
+        )
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    out_dir = tmp_path / "downloads"
+    out_dir.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "attachments",
+            "get",
+            "s1",
+            "a" * 32,
+            "--out",
+            str(out_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    # A directory --out lands the blob under its original filename.
+    assert (out_dir / "shot.png").read_bytes() == b"blob"
+
+
 def test_sessions_send_attachment_id_passes_ids_to_send_input(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1614,6 +1614,129 @@ def test_sessions_upload_emits_attachment_specs(
     assert [a["id"] for a in out["attachments"]] == uploads
 
 
+def test_sessions_upload_pin_sends_form_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/sessions/s1/attachments"
+            and request.method == "POST"
+        ):
+            state["pinned"] = b'name="pin"' in request.content
+            return httpx.Response(
+                200,
+                json={
+                    "id": "att" + "0" * 29,
+                    "filename": "a.txt",
+                    "mime": "text/plain",
+                    "size": 1,
+                    "kind": "file",
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "upload",
+            "s1",
+            str(f),
+            "--pin",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["pinned"] is True
+
+
+def test_sessions_attachments_list_get_delete_pin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/sessions/s1/attachments" and request.method == "GET":
+            return httpx.Response(200, json=[{"id": "a" * 32, "filename": "shot.png"}])
+        if path.startswith("/api/sessions/s1/attachments/"):
+            tail = path[len("/api/sessions/s1/attachments/") :]
+            if tail.endswith("/pin"):
+                state["pin"] = (request.method, tail[: -len("/pin")])
+                return httpx.Response(204)
+            if request.method == "GET":
+                return httpx.Response(
+                    200,
+                    content=b"blob-bytes",
+                    headers={"content-disposition": 'inline; filename="shot.png"'},
+                )
+            if request.method == "DELETE":
+                state["deleted"] = tail
+                return httpx.Response(204)
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    cfg = str(_config(tmp_path))
+
+    listed = runner.invoke(
+        app, ["--config", cfg, "sessions", "attachments", "list", "s1"]
+    )
+    assert listed.exit_code == 0, listed.output
+    assert json.loads(listed.stdout)["attachments"][0]["filename"] == "shot.png"
+
+    out_path = tmp_path / "downloaded.png"
+    got = runner.invoke(
+        app,
+        [
+            "--config",
+            cfg,
+            "sessions",
+            "attachments",
+            "get",
+            "s1",
+            "a" * 32,
+            "--out",
+            str(out_path),
+        ],
+    )
+    assert got.exit_code == 0, got.output
+    assert out_path.read_bytes() == b"blob-bytes"
+
+    deleted = runner.invoke(
+        app, ["--config", cfg, "sessions", "attachments", "delete", "s1", "b" * 32]
+    )
+    assert deleted.exit_code == 0, deleted.output
+    assert state["deleted"] == "b" * 32
+
+    pinned = runner.invoke(
+        app, ["--config", cfg, "sessions", "attachments", "pin", "s1", "c" * 32]
+    )
+    assert pinned.exit_code == 0, pinned.output
+    assert state["pin"] == ("POST", "c" * 32)
+
+    unpinned = runner.invoke(
+        app, ["--config", cfg, "sessions", "attachments", "unpin", "s1", "c" * 32]
+    )
+    assert unpinned.exit_code == 0, unpinned.output
+    assert state["pin"] == ("DELETE", "c" * 32)
+
+
 def test_sessions_send_attachment_id_passes_ids_to_send_input(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -128,6 +128,8 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             and request.method == "POST"
         ):
             state["uploads"] = state.get("uploads", 0) + 1
+            # Multipart: the pin form field rides alongside the file part.
+            state["upload_pinned"] = b'name="pin"' in request.content
             return httpx.Response(
                 200,
                 json={
@@ -138,6 +140,35 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
                     "kind": "file",
                 },
             )
+        if (
+            request.url.path == "/api/sessions/s1/attachments"
+            and request.method == "GET"
+        ):
+            return httpx.Response(
+                200,
+                json=[{"id": "a" * 32, "filename": "shot.png", "uploaded_at": 1.0}],
+            )
+        if (
+            request.url.path == "/api/sessions/s1/attachments"
+            and request.method == "DELETE"
+        ):
+            state["deleted_all"] = True
+            return httpx.Response(204)
+        if request.url.path.startswith("/api/sessions/s1/attachments/"):
+            tail = request.url.path[len("/api/sessions/s1/attachments/") :]
+            if tail.endswith("/pin"):
+                state["pin"] = (request.method, tail[: -len("/pin")])
+                return httpx.Response(204)
+            if request.method == "GET":
+                state["download_token"] = request.url.params.get("token")
+                return httpx.Response(
+                    200,
+                    content=b"blob-bytes",
+                    headers={"content-disposition": 'inline; filename="shot.png"'},
+                )
+            if request.method == "DELETE":
+                state["deleted_one"] = tail
+                return httpx.Response(204)
         if request.url.path == "/api/sessions/s1/input":
             state["input_body"] = json.loads(request.content)
             return httpx.Response(200, json={"session": {"id": "s1"}})
@@ -412,6 +443,77 @@ def test_send_input_omits_attachments_when_none(
     with _client(_settings(tmp_path), state) as client:
         client.send_input("s1", "hi")
     assert "attachments" not in state["input_body"]
+
+
+def test_upload_attachment_pin_sends_form_field(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.upload_attachment("s1", f, pin=True)
+    assert state["upload_pinned"] is True
+
+
+def test_upload_attachment_omits_pin_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    f = tmp_path / "a.txt"
+    f.write_text("x")
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.upload_attachment("s1", f)
+    assert state["upload_pinned"] is False
+
+
+def test_list_attachments_returns_specs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        listed = client.list_attachments("s1")
+    assert listed[0]["filename"] == "shot.png"
+
+
+def test_download_attachment_uses_query_token_and_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        content, filename = client.download_attachment("s1", "a" * 32)
+    assert content == b"blob-bytes"
+    assert filename == "shot.png"
+    # The serve endpoint authenticates by query token, not the Bearer header.
+    assert state["download_token"] == VALID_TOKEN
+
+
+def test_delete_attachment_and_all(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.delete_attachment("s1", "b" * 32)
+        client.delete_all_attachments("s1")
+    assert state["deleted_one"] == "b" * 32
+    assert state["deleted_all"] is True
+
+
+def test_pin_and_unpin_attachment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.pin_attachment("s1", "c" * 32)
+        assert state["pin"] == ("POST", "c" * 32)
+        client.unpin_attachment("s1", "c" * 32)
+        assert state["pin"] == ("DELETE", "c" * 32)
 
 
 def test_create_session_omits_launch_mode_when_unset(

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -492,6 +492,21 @@ def test_download_attachment_uses_query_token_and_filename(
     assert state["download_token"] == VALID_TOKEN
 
 
+def test_download_attachment_falls_back_to_id_without_header(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"raw")  # no Content-Disposition
+
+    http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://test")
+    with WaypointClient(_settings(tmp_path), token=VALID_TOKEN, client=http) as client:
+        content, filename = client.download_attachment("s1", "d" * 32)
+    assert content == b"raw"
+    assert filename == "d" * 32
+
+
 def test_delete_attachment_and_all(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Purpose

Grounded wishlist items #2 and #3 from the PR #210 review. A bare `sessions upload` is swept after the ~24h orphan TTL unless a sent message references it, so durably surfacing a file forced a spurious message or keeping it in cwd. And the CLI only wrapped `upload` — a session couldn't list, download, or clean up what it had surfaced even though the backend endpoints exist. Relates to #210.

## Changes

### Backend

- `backend/src/waypoint/attachments.py` — add a `_pinned.json` index parallel to `_sent.json`, with `mark_pinned`/`unmark_pinned`; the sweep now keeps ids in either index. Shared `_add_to_index`/`_read_id_index` helpers back both.
- `backend/src/waypoint/api.py` — the upload endpoint takes a `pin` form field; new `POST`/`DELETE .../attachments/{id}/pin` endpoints pin/unpin an existing attachment (404 on an unknown id when pinning, idempotent unpin).
- `backend/src/waypoint/client.py` — add `list_attachments`, `download_attachment` (query-token auth, returns bytes + original filename), `delete_attachment`, `delete_all_attachments`, `pin_attachment`, `unpin_attachment`; `upload_attachment` gains `pin=`.
- `backend/src/waypoint/cli.py` — `sessions upload --pin`, and a new `sessions attachments` group: `list`, `get [--out]`, `delete`, `delete-all [--yes]`, `pin`, `unpin`.
- `backend/tests/` — cover pin/unpin sweep behavior, the new client methods (including the query-token download path), and the CLI group.

## Design

Pin is a separate index rather than a per-sidecar flag, mirroring the existing `_sent` design so it stays transparent to `entries()`/`sweep` (its stem isn't a uuid). Pin protects only against the TTL sweep — explicit `delete`/`delete-all`/session teardown still remove a pinned file, which is the correct scope. The download client method passes the token as a `?token=` query param because the serve endpoint authenticates that way (an `<img>` tag can't set an Authorization header), unlike the Bearer-header routes.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1348 passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — N/A: attachments are plugin-agnostic.
- [x] If I changed the frontend, I ran the frontend gate — N/A: no frontend change; the pin form field is additive and the existing frontend upload path is unaffected.
- [x] Not a breaking change — `--pin` and the new commands/endpoints are additive.
- [x] I have updated documentation — no `.env`/config surface changed; no docs required.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)