### PR TITLE
feat: session tags and selective reap

### DIFF
--- a/.agents/skills/waypoint-crew/references/org-chart.md
+++ b/.agents/skills/waypoint-crew/references/org-chart.md
@@ -65,11 +65,15 @@ Manage the cost by **size, not churn**:
   adopting a crew it did not spawn is sanctioned (as in workqueue's
   resume-after-lead-death).
 - **Ephemeral overflow workers are the exception to all of the above.** A burst
-  beyond standing headcount can spawn transient workers for one batch; reap those
-  **by their tracked session ids** (or a distinct `subagent:overflow-*` title) as
-  the batch finishes — never with the blanket `reap --spawned-by <lead>` sweep,
-  which would also reap the standing crew. Track the standing sids so they are
-  excluded. The blanket sweep is reserved for wind-down.
+  beyond standing headcount can spawn transient workers for one batch. Tag them at
+  launch (`sessions start ... --tag overflow`) and reap the batch with
+  `sessions reap --tag overflow` — this spares the standing crew without tracking
+  sids. Equivalently, tag standing roles (`--tag role=backend`) and spare them from
+  a `--spawned-by <lead>` sweep with `reap --spawned-by <lead> --exclude <sid> ...`.
+  Never use the blanket `reap --spawned-by <lead>` sweep for overflow, which would
+  also reap the standing crew. The blanket sweep is reserved for wind-down.
+  Tags survive for the life of a session but not across a relaunch/fork — re-tag a
+  respawned role with `sessions tag <sid> --set role=...`.
 - **Under a hierarchy, wind-down is tier-ordered.** Members are `--spawned-by`
   their *team lead*, not the main lead, so a main-lead `reap --spawned-by <lead>`
   sweep would orphan the members while reaping the team leads. Wind down

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -58,6 +58,7 @@ from waypoint.schemas import (
     SessionPlanApprovalRequest,
     SessionRecord,
     SessionStatus,
+    SessionTagsUpdateRequest,
     SessionTitleRequest,
 )
 from waypoint.settings import Settings, load_settings
@@ -77,6 +78,22 @@ from waypoint.workspace_preview import (
 )
 
 log = logging.getLogger("waypoint.api")
+
+
+def session_matches_tag_filters(tags: dict[str, str], filters: list[str]) -> bool:
+    """Whether ``tags`` satisfies every filter (AND semantics).
+
+    A ``key=value`` filter matches on exact value; a bare ``key`` filter matches
+    on key presence regardless of value.
+    """
+    for spec in filters:
+        key, sep, value = spec.partition("=")
+        if sep:
+            if tags.get(key) != value:
+                return False
+        elif key not in tags:
+            return False
+    return True
 
 
 def _backend_descriptors(registry: BackendRegistry) -> list[dict[str, Any]]:
@@ -281,11 +298,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def list_sessions(
         _: Annotated[str, Depends(token_dependency())],
         spawned_by: Annotated[str | None, Query()] = None,
+        tag: Annotated[list[str] | None, Query()] = None,
     ) -> Any:
         all_sessions = context.runtime.list_sessions()
         if spawned_by is not None:
             all_sessions = [
                 s for s in all_sessions if s.spawner_session_id == spawned_by
+            ]
+        if tag:
+            all_sessions = [
+                s for s in all_sessions if session_matches_tag_filters(s.tags, tag)
             ]
         sessions = [session.model_dump(mode="json") for session in all_sessions]
         return {"sessions": sessions}
@@ -1025,6 +1047,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         session = await context.runtime.set_title(session_id, body.title)
+        return {"session": session.model_dump(mode="json")}
+
+    @app.patch("/api/sessions/{session_id}/tags")
+    async def session_set_tags(
+        session_id: str,
+        body: SessionTagsUpdateRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        session = await context.runtime.set_tags(session_id, body.set, body.unset)
         return {"session": session.model_dump(mode="json")}
 
     @app.post("/api/sessions/{session_id}/mode")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -524,6 +524,18 @@ def _parse_meta(items: list[str] | None) -> dict[str, str]:
     return metadata
 
 
+def _parse_tags(items: list[str] | None) -> dict[str, str]:
+    """Parse ``--tag`` values into a dict. ``key=value`` sets a value; a bare
+    ``key`` stores an empty value (matched by presence)."""
+    tags: dict[str, str] = {}
+    for item in items or []:
+        key, _, value = item.partition("=")
+        if not key:
+            raise typer.BadParameter(f"--tag expects a key, got: {item}")
+        tags[key] = value
+    return tags
+
+
 def parse_wait_until(raw: str | None) -> frozenset[str]:
     """Parse a comma-separated ``--until`` list into a set of valid statuses.
 
@@ -796,6 +808,14 @@ def sessions_list(
             help="Return only sessions spawned by $WAYPOINT_SESSION_ID.",
         ),
     ] = False,
+    tag: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--tag",
+            help="Keep only sessions matching key=value (exact) or a bare key "
+            "(present). Repeatable; all must match.",
+        ),
+    ] = None,
 ) -> None:
     """List all sessions."""
     if mine:
@@ -807,7 +827,7 @@ def sessions_list(
             )
     _emit(
         _settings_from_ctx(ctx),
-        lambda c: {"sessions": c.list_sessions(spawned_by=spawned_by)},
+        lambda c: {"sessions": c.list_sessions(spawned_by=spawned_by, tags=tag)},
     )
 
 
@@ -817,6 +837,37 @@ def sessions_show(
 ) -> None:
     """Show one session."""
     _emit(_settings_from_ctx(ctx), lambda c: {"session": c.get_session(session_id)})
+
+
+@sessions_app.command("tag")
+def sessions_tag(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    set_: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--set",
+            help="Set a tag as key=value (or a bare key). Repeatable.",
+        ),
+    ] = None,
+    unset: Annotated[
+        list[str] | None,
+        typer.Option("--unset", help="Remove a tag key. Repeatable."),
+    ] = None,
+) -> None:
+    """Add or remove tags on an existing session."""
+    if not set_ and not unset:
+        raise typer.BadParameter("provide --set and/or --unset.")
+    set_tags = _parse_tags(set_)
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        return {
+            "session": c.set_session_tags(
+                session_id, set_tags=set_tags, unset=list(unset or [])
+            )
+        }
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @sessions_app.command("events")
@@ -1132,6 +1183,14 @@ def sessions_start(
             help="Base ref for the new worktree branch (default: current HEAD, else main).",
         ),
     ] = None,
+    tag: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--tag",
+            help="Tag the session as key=value (or a bare key). Repeatable. "
+            "Filter later with `sessions list --tag` / `reap --tag`.",
+        ),
+    ] = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Launch a new session on the running server."""
@@ -1140,6 +1199,7 @@ def sessions_start(
     if worktree is not None:
         worktree_path = _create_worktree(worktree, worktree_base, cwd)
         effective_cwd = worktree_path
+    tags = _parse_tags(tag)
 
     def _run(c: WaypointClient) -> dict[str, Any]:
         if permission_mode is not None:
@@ -1160,6 +1220,7 @@ def sessions_start(
                 spawner_session_id=spawner_session_id,
                 worktree_path=worktree_path,
                 args=list(args or []),
+                tags=tags,
             )
         }
 
@@ -1480,6 +1541,22 @@ def sessions_reap(
             "leftover branches otherwise collide with a respawn's --worktree.",
         ),
     ] = False,
+    tag: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--tag",
+            help="Reap only sessions matching key=value (exact) or a bare key "
+            "(present). Repeatable; all must match.",
+        ),
+    ] = None,
+    exclude: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--exclude",
+            help="Session id(s) to spare from the reap. Repeatable. Use to keep "
+            "the standing crew while tearing down overflow.",
+        ),
+    ] = None,
 ) -> None:
     """Terminate and delete sessions in bulk."""
     if mine:
@@ -1490,24 +1567,30 @@ def sessions_reap(
                 param_hint="--mine",
             )
 
-    if spawned_by is None and not all_sessions:
+    if spawned_by is None and not all_sessions and not tag:
         raise typer.BadParameter(
-            "pass --spawned-by <id>, --mine, or --all to select a scope",
-            param_hint="--spawned-by/--mine/--all",
+            "pass --spawned-by <id>, --mine, --all, or --tag to select a scope",
+            param_hint="--spawned-by/--mine/--all/--tag",
         )
 
+    excluded = set(exclude or [])
+
     def _run(client: WaypointClient) -> dict[str, Any]:
-        sessions = client.list_sessions(spawned_by=spawned_by)
+        sessions = client.list_sessions(spawned_by=spawned_by, tags=tag)
         reaped: list[str] = []
         failed: list[str] = []
+        skipped: list[str] = []
         for session in sessions:
             sid = session["id"]
+            if sid in excluded:
+                skipped.append(sid)
+                continue
             try:
                 client.delete(sid, prune_branches=prune_branches)
                 reaped.append(sid)
             except Exception:
                 failed.append(sid)
-        return {"reaped": reaped, "failed": failed}
+        return {"reaped": reaped, "failed": failed, "skipped": skipped}
 
     _emit(_settings_from_ctx(ctx), _run)
 

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -166,13 +166,30 @@ class WaypointClient:
 
     # ── sessions ────────────────────────────────────────────────────────
 
-    def list_sessions(self, spawned_by: str | None = None) -> list[dict[str, Any]]:
-        params: dict[str, str] = {}
+    def list_sessions(
+        self, spawned_by: str | None = None, tags: list[str] | None = None
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {}
         if spawned_by is not None:
             params["spawned_by"] = spawned_by
+        if tags:
+            params["tag"] = list(tags)
         data: list[dict[str, Any]] = self._request(
             "GET", "/api/sessions", params=params if params else None
         ).json()["sessions"]
+        return data
+
+    def set_session_tags(
+        self,
+        session_id: str,
+        *,
+        set_tags: dict[str, str] | None = None,
+        unset: list[str] | None = None,
+    ) -> dict[str, Any]:
+        body = {"set": set_tags or {}, "unset": unset or []}
+        data: dict[str, Any] = self._request(
+            "PATCH", f"/api/sessions/{session_id}/tags", json=body
+        ).json()["session"]
         return data
 
     def get_session(self, session_id: str) -> dict[str, Any]:
@@ -269,6 +286,7 @@ class WaypointClient:
         spawner_session_id: str | None = None,
         worktree_path: str | None = None,
         args: list[str] | None = None,
+        tags: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "backend": backend,
@@ -281,6 +299,7 @@ class WaypointClient:
             "spawner_session_id": spawner_session_id,
             "worktree_path": worktree_path,
             "args": args or [],
+            "tags": tags or {},
         }
         # Omit launch_mode when unset: it is a non-optional-with-default enum
         # field, so an explicit null is a 422 (mirrors create_schedule).

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -522,6 +522,10 @@ class SessionRuntime:
             session = self.storage.update_session(
                 session.id, worktree_path=request.worktree_path
             )
+        # Stamp tags generically after the plugin builds the record, so every
+        # backend picks them up without a per-plugin launch-site edit.
+        if request.tags:
+            session = self.storage.update_session(session.id, tags=request.tags)
         self._warm_command_completions(session)
         self._start_context_usage_source(session)
         return session
@@ -1672,6 +1676,19 @@ class SessionRuntime:
         if session.title == title:
             return session
         updated = self.storage.update_session(session_id, title=title)
+        await self._broadcast_session_list()
+        return updated
+
+    async def set_tags(
+        self, session_id: str, set_tags: dict[str, str], unset: list[str]
+    ) -> SessionRecord:
+        session = self.get_session(session_id)
+        new_tags = {**session.tags, **set_tags}
+        for key in unset:
+            new_tags.pop(key, None)
+        if new_tags == session.tags:
+            return session
+        updated = self.storage.update_session(session_id, tags=new_tags)
         await self._broadcast_session_list()
         return updated
 

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -219,6 +219,11 @@ class SessionRecord(BaseModel):
     config_overrides: list[str] = Field(default_factory=list)
     context_usage: SessionContextUsage | None = None
     rate_limit_usage: SessionRateLimitUsage | None = None
+    # Free-form user/agent labels for grouping and selective teardown, e.g.
+    # ``{"role": "backend-lead"}`` or ``{"overflow": ""}`` (a bare tag stores an
+    # empty value). Set at launch or via ``sessions tag``; filtered by
+    # ``sessions list --tag`` / ``sessions reap --tag``.
+    tags: dict[str, str] = Field(default_factory=dict)
 
 
 class EventRecord(BaseModel):
@@ -393,6 +398,13 @@ class SessionCreateRequest(BaseModel):
     permission_mode: str | None = None
     model: str | None = None
     effort: str | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class SessionTagsUpdateRequest(BaseModel):
+    # Merge ``set`` into the session's tags and drop each key in ``unset``.
+    set: dict[str, str] = Field(default_factory=dict)
+    unset: list[str] = Field(default_factory=list)
 
 
 class SessionAttachRequest(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -261,6 +261,7 @@ class Storage:
         self._ensure_column("sessions", "spawner_session_id", "TEXT")
         self._ensure_column("sessions", "worktree_path", "TEXT")
         self._ensure_column("sessions", "resolved_model", "TEXT")
+        self._ensure_column("sessions", "tags", "TEXT NOT NULL DEFAULT '{}'")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -291,8 +292,8 @@ class Storage:
                 last_event_at, raw_log_path, structured_log_path, transport_state,
                 pinned_at, spawner_session_id, worktree_path, permission_mode, model,
                 resolved_model, effort, args, config_overrides, context_usage,
-                rate_limit_usage
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                rate_limit_usage, tags
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -331,6 +332,7 @@ class Storage:
                     if session.rate_limit_usage is not None
                     else None
                 ),
+                json.dumps(session.tags),
             ),
         )
         self.connection.commit()
@@ -1368,6 +1370,12 @@ class Storage:
         payload["config_overrides"] = (
             parsed_overrides if isinstance(parsed_overrides, list) else []
         )
+        raw_tags = payload.get("tags") or "{}"
+        try:
+            parsed_tags = json.loads(raw_tags)
+        except json.JSONDecodeError:
+            parsed_tags = {}
+        payload["tags"] = parsed_tags if isinstance(parsed_tags, dict) else {}
         raw_context_usage = payload.get("context_usage")
         if raw_context_usage:
             try:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -480,6 +480,162 @@ def test_sessions_reap_requires_scope(tmp_path: Path) -> None:
     assert "--all" in result.output or "scope" in result.output
 
 
+def test_sessions_launch_tag_sends_tags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "POST":
+            state["create"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "new"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp",
+            "--tag",
+            "role=backend-lead",
+            "--tag",
+            "overflow",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["create"]["tags"] == {"role": "backend-lead", "overflow": ""}
+
+
+def test_sessions_tag_command_sends_set_and_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/tags" and request.method == "PATCH":
+            state["body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "s1", "tags": {}}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "tag",
+            "s1",
+            "--set",
+            "role=qa",
+            "--unset",
+            "old",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["body"] == {"set": {"role": "qa"}, "unset": ["old"]}
+
+
+def test_sessions_tag_command_requires_change(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "tag", "s1"],
+    )
+    assert result.exit_code != 0
+
+
+def test_sessions_list_tag_passes_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = list(request.url.params.multi_items())
+            return httpx.Response(200, json={"sessions": []})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "list",
+            "--tag",
+            "role=qa",
+            "--tag",
+            "overflow",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["params"] == [("tag", "role=qa"), ("tag", "overflow")]
+
+
+def test_sessions_reap_tag_and_exclude(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    deleted: list[str] = []
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = list(request.url.params.multi_items())
+            return httpx.Response(
+                200, json={"sessions": [{"id": "keep"}, {"id": "drop"}]}
+            )
+        if request.url.path.startswith("/api/sessions/") and request.method == "DELETE":
+            sid = request.url.path.rsplit("/", 1)[-1]
+            deleted.append(sid)
+            return httpx.Response(200, json={"deleted": sid})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "reap",
+            "--tag",
+            "overflow",
+            "--exclude",
+            "keep",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    summary = json.loads(result.stdout)
+    assert summary["reaped"] == ["drop"]
+    assert summary["skipped"] == ["keep"]
+    assert deleted == ["drop"]
+    assert ("tag", "overflow") in state["params"]
+
+
 def test_sessions_import_reads_json_file_and_emits_session(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -36,7 +36,11 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
         if request.headers.get("Authorization") != f"Bearer {VALID_TOKEN}":
             return httpx.Response(401, json={"detail": "invalid token"})
         if request.url.path == "/api/sessions" and request.method == "GET":
+            state["list_params"] = list(request.url.params.multi_items())
             return httpx.Response(200, json={"sessions": [{"id": "s1"}]})
+        if request.url.path == "/api/sessions/s1/tags" and request.method == "PATCH":
+            state["tags_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "s1", "tags": {}}})
         if request.url.path == "/api/backends" and request.method == "GET":
             return httpx.Response(
                 200, json={"backends": [{"id": "claude_code"}, {"id": "codex"}]}
@@ -529,6 +533,40 @@ def test_pin_and_unpin_attachment(
         assert state["pin"] == ("POST", "c" * 32)
         client.unpin_attachment("s1", "c" * 32)
         assert state["pin"] == ("DELETE", "c" * 32)
+
+
+def test_create_session_includes_tags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.create_session(backend="codex", cwd="/tmp", tags={"role": "qa"})
+    assert state["session_create"]["tags"] == {"role": "qa"}
+
+
+def test_list_sessions_passes_tag_params(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.list_sessions(spawned_by="lead", tags=["role=qa", "overflow"])
+    assert state["list_params"] == [
+        ("spawned_by", "lead"),
+        ("tag", "role=qa"),
+        ("tag", "overflow"),
+    ]
+
+
+def test_set_session_tags_sends_set_and_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.set_session_tags("s1", set_tags={"team": "1"}, unset=["role"])
+    assert state["tags_body"] == {"set": {"team": "1"}, "unset": ["role"]}
 
 
 def test_create_session_omits_launch_mode_when_unset(

--- a/backend/tests/test_session_tags.py
+++ b/backend/tests/test_session_tags.py
@@ -1,0 +1,109 @@
+"""Session tags: the tag-filter matcher plus the list-filter and set-tags
+routes over the real FastAPI app via an in-process ASGI transport."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from waypoint.api import create_app, session_matches_tag_filters
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+from waypoint.settings import Settings
+
+
+def test_matcher_key_value_and_bare_key() -> None:
+    tags = {"role": "backend-lead", "overflow": ""}
+    assert session_matches_tag_filters(tags, ["role=backend-lead"]) is True
+    assert session_matches_tag_filters(tags, ["role=frontend"]) is False
+    # A bare key matches on presence regardless of value.
+    assert session_matches_tag_filters(tags, ["overflow"]) is True
+    assert session_matches_tag_filters(tags, ["missing"]) is False
+    # Multiple filters are AND.
+    assert session_matches_tag_filters(tags, ["role=backend-lead", "overflow"]) is True
+    assert session_matches_tag_filters(tags, ["role=backend-lead", "missing"]) is False
+    assert session_matches_tag_filters({}, []) is True
+
+
+def _make_session(context: Any, tmp_path: Path, sid: str, tags: dict[str, str]) -> None:
+    now = datetime.now(UTC)
+    context.storage.create_session(
+        SessionRecord(
+            id=sid,
+            backend="codex",
+            source=SessionSource.MANAGED,
+            title=sid,
+            cwd=str(tmp_path),
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(tmp_path / "raw.log"),
+            structured_log_path=str(tmp_path / "events.jsonl"),
+            tags=tags,
+        )
+    )
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    app = create_app(Settings(data_dir=tmp_path / "data"))
+    context = app.state.context
+    _make_session(context, tmp_path, "lead", {"role": "backend-lead"})
+    _make_session(context, tmp_path, "overflow-1", {"overflow": ""})
+    _make_session(context, tmp_path, "plain", {})
+    token = context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def test_list_filters_by_tag(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    headers = {"Authorization": f"Bearer {token}"}
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/sessions", params={"tag": "role=backend-lead"}, headers=headers
+        )
+        assert resp.status_code == 200
+        ids = {s["id"] for s in resp.json()["sessions"]}
+        assert ids == {"lead"}
+
+        resp = await client.get(
+            "/api/sessions", params={"tag": "overflow"}, headers=headers
+        )
+        assert {s["id"] for s in resp.json()["sessions"]} == {"overflow-1"}
+
+
+async def test_set_tags_merges_and_unsets(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    headers = {"Authorization": f"Bearer {token}"}
+    async with _client(app) as client:
+        resp = await client.patch(
+            "/api/sessions/lead/tags",
+            json={"set": {"team": "1"}, "unset": []},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["session"]["tags"] == {"role": "backend-lead", "team": "1"}
+
+        resp = await client.patch(
+            "/api/sessions/lead/tags",
+            json={"set": {}, "unset": ["role"]},
+            headers=headers,
+        )
+        assert resp.json()["session"]["tags"] == {"team": "1"}
+
+
+async def test_set_tags_unknown_session_is_404(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.patch(
+            "/api/sessions/nope/tags",
+            json={"set": {"a": "b"}, "unset": []},
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 404

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -109,6 +109,56 @@ def test_storage_round_trip(tmp_path) -> None:
     assert len(events) == 1
 
 
+def test_storage_round_trips_tags(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    storage.create_session(
+        SessionRecord(
+            id="tagged",
+            backend="codex",
+            source=SessionSource.MANAGED,
+            title="t",
+            cwd="/tmp",
+            status=SessionStatus.RUNNING,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/tmp/raw.log",
+            structured_log_path="/tmp/events.jsonl",
+            tags={"role": "backend-lead", "overflow": ""},
+        )
+    )
+    loaded = storage.get_session("tagged")
+    assert loaded is not None
+    # The JSON column decodes back to a dict, not the raw string.
+    assert loaded.tags == {"role": "backend-lead", "overflow": ""}
+    updated = storage.update_session("tagged", tags={"role": "qa"})
+    assert updated.tags == {"role": "qa"}
+    reloaded = storage.get_session("tagged")
+    assert reloaded is not None
+    assert reloaded.tags == {"role": "qa"}
+
+
+def test_storage_defaults_tags_for_legacy_rows(tmp_path) -> None:
+    """A row written before the tags column loads with empty tags, not a crash."""
+    import sqlite3
+
+    db = tmp_path / "waypoint.db"
+    storage = Storage(db)
+    _make_session(storage, "legacy", "legacy")
+    storage.close()
+    # Simulate a pre-migration row by nulling the column, then re-open (which
+    # re-runs _ensure_column) and confirm the decode tolerates it.
+    raw = sqlite3.connect(db)
+    raw.execute("UPDATE sessions SET tags = '' WHERE id = 'legacy'")
+    raw.commit()
+    raw.close()
+    reopened = Storage(db)
+    loaded = reopened.get_session("legacy")
+    assert loaded is not None
+    assert loaded.tags == {}
+
+
 def test_storage_round_trips_pinned_at(tmp_path) -> None:
     storage = Storage(tmp_path / "waypoint.db")
     now = datetime.now(UTC)


### PR DESCRIPTION
## Purpose

Grounded wishlist item #4 from the PR #210 review. Role identity, standing-vs-overflow, and team membership were all title-string conventions, and `reap --spawned-by <lead>` couldn't spare the standing crew without sid-tracking gymnastics. First-class tags plus tag-scoped `list`/`reap` and `reap --exclude` make selective, role-aware crew teardown robust. Relates to #210.

## Changes

### Backend

- `backend/src/waypoint/schemas.py` — add `tags: dict[str, str]` to `SessionRecord` and `SessionCreateRequest`; new `SessionTagsUpdateRequest` (`set`/`unset`).
- `backend/src/waypoint/storage.py` — additive `tags` JSON column (migrated via `_ensure_column`), written in `create_session`, and decoded back to a dict in `_session_from_row` (a raw JSON string would otherwise fail validation).
- `backend/src/waypoint/runtime.py` — stamp `request.tags` in the generic `create_session` path so every backend picks them up without a per-plugin edit; add `set_tags` (merge/unset + broadcast).
- `backend/src/waypoint/api.py` — `GET /api/sessions` gains a repeatable `tag` filter (`session_matches_tag_filters`: `key=value` exact, bare `key` present, AND across filters); new `PATCH /api/sessions/{id}/tags`.
- `backend/src/waypoint/client.py` — `create_session(tags=)`, `list_sessions(tags=)`, `set_session_tags`.
- `backend/src/waypoint/cli.py` — `sessions start --tag`, `sessions tag <id> --set/--unset`, `sessions list --tag`, and `sessions reap --tag` / `--exclude` (reap reports a `skipped` list).
- `backend/tests/` — storage round-trip + legacy-row default, the matcher, the list-filter and set-tags routes (ASGI), and the client/CLI surfaces.

### Docs

- `.agents/skills/waypoint-crew/references/org-chart.md` — overflow/wind-down guidance uses `--tag`/`--exclude`; notes tags don't survive relaunch/fork.

## Design

Tags are stamped in `runtime.create_session` (the one generic wrapper around each plugin's launch) rather than threaded through all five backend launch sites — the value is passed uniformly, so it stays plugin-agnostic and can't half-wire. Tags are set at launch or via `sessions tag`; they persist for the session's life but are not carried across a relaunch/fork (documented; re-tag with `sessions tag`). A bare `--tag key` stores an empty value and matches on presence, covering both `--tag role=backend-lead` and `--tag overflow`.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1352 passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — tags are stamped generically in the runtime create path; no per-backend branch, so claude_code/codex/opencode/tmux all pick them up uniformly.
- [x] If I changed the frontend, I ran the frontend gate — N/A: no frontend change; `tags` is additive on the session payload.
- [x] Not a breaking change — tags default to empty and all new surfaces are additive.
- [x] I have updated documentation — crew org-chart guidance updated; no `.env`/config surface changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)