### PR TITLE
feat: recursive spawn-tree and idle filtering for sessions

### DIFF
--- a/.agents/skills/waypoint-crew/references/org-chart.md
+++ b/.agents/skills/waypoint-crew/references/org-chart.md
@@ -60,10 +60,13 @@ Manage the cost by **size, not churn**:
 - **Reap at wind-down**, or when a role is genuinely never needed again. There is
   no idle-session GC, so the backstop for an abandoned crew is that the next actor
   to touch it (a successor lead, the user, or a maintenance sweep) reaps it if it
-  is stale. This is a deliberate exception to `waypoint-subagents`' reap-when-done
-  posture — crew roles are long-lived like the lead — and a successor lead
-  adopting a crew it did not spawn is sanctioned (as in workqueue's
-  resume-after-lead-death).
+  is stale. Find stale sessions with `sessions list --idle-for <dur>` (e.g.
+  `--idle-for 2h`), and reconstruct a crew you did not spawn with
+  `sessions tree <lead-sid>` or `sessions list --spawned-by <lead-sid> --recursive`
+  (which walks the whole spawn subtree, not just direct children). This is a
+  deliberate exception to `waypoint-subagents`' reap-when-done posture — crew roles
+  are long-lived like the lead — and a successor lead adopting a crew it did not
+  spawn is sanctioned (as in workqueue's resume-after-lead-death).
 - **Ephemeral overflow workers are the exception to all of the above.** A burst
   beyond standing headcount can spawn transient workers for one batch. Tag them at
   launch (`sessions start ... --tag overflow`) and reap the batch with

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -96,6 +96,27 @@ def session_matches_tag_filters(tags: dict[str, str], filters: list[str]) -> boo
     return True
 
 
+def _descendant_ids(sessions: list[SessionRecord], root_id: str) -> set[str]:
+    """Ids of every transitive descendant of ``root_id`` (excluding the root).
+
+    Walks the ``spawner_session_id`` parent pointers breadth-first with a
+    visited set so a cycle or an orphaned subtree can't loop forever.
+    """
+    children: dict[str, list[str]] = {}
+    for session in sessions:
+        if session.spawner_session_id is not None:
+            children.setdefault(session.spawner_session_id, []).append(session.id)
+    found: set[str] = set()
+    queue = list(children.get(root_id, []))
+    while queue:
+        current = queue.pop()
+        if current in found or current == root_id:
+            continue
+        found.add(current)
+        queue.extend(children.get(current, []))
+    return found
+
+
 def _backend_descriptors(registry: BackendRegistry) -> list[dict[str, Any]]:
     """Serialise every registered backend for the frontend catalogue.
 
@@ -299,12 +320,17 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
         spawned_by: Annotated[str | None, Query()] = None,
         tag: Annotated[list[str] | None, Query()] = None,
+        recursive: Annotated[bool, Query()] = False,
     ) -> Any:
         all_sessions = context.runtime.list_sessions()
         if spawned_by is not None:
-            all_sessions = [
-                s for s in all_sessions if s.spawner_session_id == spawned_by
-            ]
+            if recursive:
+                wanted = _descendant_ids(all_sessions, spawned_by)
+                all_sessions = [s for s in all_sessions if s.id in wanted]
+            else:
+                all_sessions = [
+                    s for s in all_sessions if s.spawner_session_id == spawned_by
+                ]
         if tag:
             all_sessions = [
                 s for s in all_sessions if session_matches_tag_filters(s.tags, tag)

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -99,8 +99,8 @@ def session_matches_tag_filters(tags: dict[str, str], filters: list[str]) -> boo
 def _descendant_ids(sessions: list[SessionRecord], root_id: str) -> set[str]:
     """Ids of every transitive descendant of ``root_id`` (excluding the root).
 
-    Walks the ``spawner_session_id`` parent pointers breadth-first with a
-    visited set so a cycle or an orphaned subtree can't loop forever.
+    Walks the ``spawner_session_id`` parent pointers with a visited set so a
+    cycle or an orphaned subtree can't loop forever.
     """
     children: dict[str, list[str]] = {}
     for session in sessions:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -536,6 +536,91 @@ def _parse_tags(items: list[str] | None) -> dict[str, str]:
     return tags
 
 
+_DURATION_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+
+
+def _parse_duration(value: str) -> float:
+    """Parse a duration like ``90s``/``5m``/``2h``/``1d`` (a bare number is
+    seconds) into seconds."""
+    text = value.strip().lower()
+    if not text:
+        raise typer.BadParameter("duration is empty")
+    unit = _DURATION_UNITS.get(text[-1])
+    number = text[:-1] if unit is not None else text
+    try:
+        seconds = float(number) * (unit if unit is not None else 1)
+    except ValueError as exc:
+        raise typer.BadParameter(f"invalid duration: {value}") from exc
+    if seconds < 0:
+        raise typer.BadParameter(f"duration must be non-negative: {value}")
+    return seconds
+
+
+def _last_activity(session: dict[str, Any]) -> datetime | None:
+    """A session's last-activity timestamp, parsed from ``last_event_at``."""
+    raw = session.get("last_event_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
+def _filter_idle(
+    sessions: list[dict[str, Any]], idle_seconds: float
+) -> list[dict[str, Any]]:
+    """Keep sessions whose last activity is at least ``idle_seconds`` ago.
+    Sessions with no parsable timestamp are treated as active (dropped)."""
+    cutoff = datetime.now(UTC) - timedelta(seconds=idle_seconds)
+    kept: list[dict[str, Any]] = []
+    for session in sessions:
+        last = _last_activity(session)
+        if last is not None and last <= cutoff:
+            kept.append(session)
+    return kept
+
+
+def _build_session_tree(
+    sessions: list[dict[str, Any]], root_id: str
+) -> dict[str, Any] | None:
+    """Nested spawn tree rooted at ``root_id``, or ``None`` if it isn't present.
+
+    Cycle-safe via a visited set so a self-referential or looped
+    ``spawner_session_id`` can't recurse forever.
+    """
+    by_id = {s["id"]: s for s in sessions}
+    if root_id not in by_id:
+        return None
+    children_map: dict[str, list[dict[str, Any]]] = {}
+    for session in sessions:
+        parent = session.get("spawner_session_id")
+        if parent is not None:
+            children_map.setdefault(parent, []).append(session)
+
+    def node(session: dict[str, Any], seen: set[str]) -> dict[str, Any]:
+        sid = session["id"]
+        entry: dict[str, Any] = {
+            "id": sid,
+            "title": session.get("title"),
+            "status": session.get("status"),
+            "last_event_at": session.get("last_event_at"),
+        }
+        # Forward-compatible: surface tags when the server reports them.
+        if "tags" in session:
+            entry["tags"] = session["tags"]
+        children: list[dict[str, Any]] = []
+        for child in children_map.get(sid, []):
+            if child["id"] in seen:
+                continue
+            seen.add(child["id"])
+            children.append(node(child, seen))
+        entry["children"] = children
+        return entry
+
+    return node(by_id[root_id], {root_id})
+
+
 def parse_wait_until(raw: str | None) -> frozenset[str]:
     """Parse a comma-separated ``--until`` list into a set of valid statuses.
 
@@ -816,6 +901,23 @@ def sessions_list(
             "(present). Repeatable; all must match.",
         ),
     ] = None,
+    recursive: Annotated[
+        bool,
+        typer.Option(
+            "--recursive",
+            "-r",
+            help="With --spawned-by/--mine, include the whole spawn subtree "
+            "(transitive descendants), not just direct children.",
+        ),
+    ] = False,
+    idle_for: Annotated[
+        str | None,
+        typer.Option(
+            "--idle-for",
+            help="Keep only sessions idle at least this long (e.g. 30m, 2h, 1d), "
+            "measured from last activity.",
+        ),
+    ] = None,
 ) -> None:
     """List all sessions."""
     if mine:
@@ -825,10 +927,22 @@ def sessions_list(
                 "$WAYPOINT_SESSION_ID is not set; cannot use --mine",
                 param_hint="--mine",
             )
-    _emit(
-        _settings_from_ctx(ctx),
-        lambda c: {"sessions": c.list_sessions(spawned_by=spawned_by, tags=tag)},
-    )
+    if recursive and spawned_by is None:
+        raise typer.BadParameter(
+            "--recursive requires --spawned-by or --mine",
+            param_hint="--recursive",
+        )
+    idle_seconds = _parse_duration(idle_for) if idle_for is not None else None
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        sessions = c.list_sessions(
+            spawned_by=spawned_by, tags=tag, recursive=recursive
+        )
+        if idle_seconds is not None:
+            sessions = _filter_idle(sessions, idle_seconds)
+        return {"sessions": sessions}
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @sessions_app.command("show")
@@ -866,6 +980,22 @@ def sessions_tag(
                 session_id, set_tags=set_tags, unset=list(unset or [])
             )
         }
+
+    _emit(_settings_from_ctx(ctx), _run)
+
+
+@sessions_app.command("tree")
+def sessions_tree(
+    ctx: typer.Context, session_id: Annotated[str, typer.Argument()]
+) -> None:
+    """Show the spawn subtree rooted at a session (reconstructed from the server)."""
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        tree = _build_session_tree(c.list_sessions(), session_id)
+        if tree is None:
+            typer.echo(f"error: no session with id '{session_id}'", err=True)
+            raise typer.Exit(code=1)
+        return {"tree": tree}
 
     _emit(_settings_from_ctx(ctx), _run)
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -557,14 +557,18 @@ def _parse_duration(value: str) -> float:
 
 
 def _last_activity(session: dict[str, Any]) -> datetime | None:
-    """A session's last-activity timestamp, parsed from ``last_event_at``."""
+    """A session's last-activity timestamp, parsed from ``last_event_at``.
+
+    Coerces a naive timestamp (e.g. a tz-less value from imported thread
+    history) to UTC so it can be compared against an aware ``now``."""
     raw = session.get("last_event_at")
     if not isinstance(raw, str):
         return None
     try:
-        return datetime.fromisoformat(raw)
+        parsed = datetime.fromisoformat(raw)
     except ValueError:
         return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
 def _filter_idle(
@@ -935,9 +939,7 @@ def sessions_list(
     idle_seconds = _parse_duration(idle_for) if idle_for is not None else None
 
     def _run(c: WaypointClient) -> dict[str, Any]:
-        sessions = c.list_sessions(
-            spawned_by=spawned_by, tags=tag, recursive=recursive
-        )
+        sessions = c.list_sessions(spawned_by=spawned_by, tags=tag, recursive=recursive)
         if idle_seconds is not None:
             sessions = _filter_idle(sessions, idle_seconds)
         return {"sessions": sessions}

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -167,13 +167,18 @@ class WaypointClient:
     # ── sessions ────────────────────────────────────────────────────────
 
     def list_sessions(
-        self, spawned_by: str | None = None, tags: list[str] | None = None
+        self,
+        spawned_by: str | None = None,
+        tags: list[str] | None = None,
+        recursive: bool = False,
     ) -> list[dict[str, Any]]:
         params: dict[str, Any] = {}
         if spawned_by is not None:
             params["spawned_by"] = spawned_by
         if tags:
             params["tag"] = list(tags)
+        if recursive:
+            params["recursive"] = "true"
         data: list[dict[str, Any]] = self._request(
             "GET", "/api/sessions", params=params if params else None
         ).json()["sessions"]

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -406,6 +406,138 @@ def test_sessions_list_mine_errors_when_env_unset(
     assert "WAYPOINT_SESSION_ID" in result.output
 
 
+def test_sessions_list_recursive_passes_param(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            state["params"] = dict(request.url.params)
+            return httpx.Response(200, json={"sessions": []})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "list",
+            "--spawned-by",
+            "p1",
+            "--recursive",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["params"] == {"spawned_by": "p1", "recursive": "true"}
+
+
+def test_sessions_list_recursive_requires_scope(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "list", "--recursive"],
+    )
+    assert result.exit_code != 0
+    assert "recursive" in result.output.lower()
+
+
+def test_sessions_list_idle_for_filters_client_side(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from datetime import UTC, datetime, timedelta
+
+    now = datetime.now(UTC)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "sessions": [
+                        {"id": "fresh", "last_event_at": now.isoformat()},
+                        {
+                            "id": "stale",
+                            "last_event_at": (now - timedelta(hours=2)).isoformat(),
+                        },
+                    ]
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "list", "--idle-for", "1h"],
+    )
+    assert result.exit_code == 0, result.output
+    ids = [s["id"] for s in json.loads(result.stdout)["sessions"]]
+    assert ids == ["stale"]
+
+
+def test_sessions_tree_renders_nested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "sessions": [
+                        {"id": "root", "title": "R", "status": "idle"},
+                        {"id": "a", "spawner_session_id": "root"},
+                        {"id": "b", "spawner_session_id": "a"},
+                    ]
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "tree", "root"],
+    )
+    assert result.exit_code == 0, result.output
+    tree = json.loads(result.stdout)["tree"]
+    assert tree["id"] == "root"
+    assert tree["children"][0]["id"] == "a"
+    assert tree["children"][0]["children"][0]["id"] == "b"
+
+
+def test_sessions_tree_unknown_id_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "GET":
+            return httpx.Response(200, json={"sessions": []})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "sessions", "tree", "ghost"],
+    )
+    assert result.exit_code != 0
+    assert "ghost" in result.output
+
+
 def test_sessions_reap_deletes_matched_sessions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, cast
 
@@ -450,8 +451,6 @@ def test_sessions_list_recursive_requires_scope(tmp_path: Path) -> None:
 def test_sessions_list_idle_for_filters_client_side(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from datetime import UTC, datetime, timedelta
-
     now = datetime.now(UTC)
 
     def handler(request: httpx.Request) -> httpx.Response:

--- a/backend/tests/test_spawn_tree.py
+++ b/backend/tests/test_spawn_tree.py
@@ -72,6 +72,15 @@ def test_filter_idle_keeps_only_stale() -> None:
     assert [s["id"] for s in kept] == ["stale"]
 
 
+def test_filter_idle_handles_naive_timestamp() -> None:
+    # A tz-less last_event_at (e.g. from imported thread history) must not crash
+    # the aware-vs-naive comparison; it is coerced to UTC.
+    stale_naive = (datetime.now(UTC) - timedelta(hours=2)).replace(tzinfo=None)
+    session = {"id": "imported", "last_event_at": stale_naive.isoformat()}
+    kept = _filter_idle([session], idle_seconds=3600)
+    assert [s["id"] for s in kept] == ["imported"]
+
+
 def test_build_session_tree_nests_children() -> None:
     now = datetime.now(UTC).isoformat()
     sessions = [

--- a/backend/tests/test_spawn_tree.py
+++ b/backend/tests/test_spawn_tree.py
@@ -1,0 +1,129 @@
+"""Recursive spawn-tree and idle helpers: the API descendant walk and route,
+plus the CLI-side duration parser, idle filter, and tree builder."""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import typer
+
+from waypoint.api import _descendant_ids, create_app
+from waypoint.cli import _build_session_tree, _filter_idle, _parse_duration
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+from waypoint.settings import Settings
+
+
+def _record(sid: str, parent: str | None) -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=sid,
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title=sid,
+        cwd="/tmp",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/events.jsonl",
+        spawner_session_id=parent,
+    )
+
+
+def test_descendant_ids_collects_transitively() -> None:
+    sessions = [
+        _record("root", None),
+        _record("a", "root"),
+        _record("b", "a"),
+        _record("c", "root"),
+        _record("unrelated", None),
+    ]
+    assert _descendant_ids(sessions, "root") == {"a", "b", "c"}
+    assert _descendant_ids(sessions, "a") == {"b"}
+    assert _descendant_ids(sessions, "leaf-missing") == set()
+
+
+def test_descendant_ids_survives_a_cycle() -> None:
+    # x -> y -> x is a pathological loop; the walk must terminate.
+    sessions = [_record("x", "y"), _record("y", "x")]
+    assert _descendant_ids(sessions, "x") == {"y"}
+
+
+def test_parse_duration_units() -> None:
+    assert _parse_duration("90s") == 90
+    assert _parse_duration("5m") == 300
+    assert _parse_duration("2h") == 7200
+    assert _parse_duration("1d") == 86400
+    assert _parse_duration("45") == 45  # bare number = seconds
+    for bad in ("", "abc", "-5m", "5x"):
+        with pytest.raises(typer.BadParameter):
+            _parse_duration(bad)
+
+
+def test_filter_idle_keeps_only_stale() -> None:
+    now = datetime.now(UTC)
+    fresh = {"id": "fresh", "last_event_at": now.isoformat()}
+    stale = {"id": "stale", "last_event_at": (now - timedelta(hours=2)).isoformat()}
+    no_ts = {"id": "no_ts"}
+    kept = _filter_idle([fresh, stale, no_ts], idle_seconds=3600)
+    assert [s["id"] for s in kept] == ["stale"]
+
+
+def test_build_session_tree_nests_children() -> None:
+    now = datetime.now(UTC).isoformat()
+    sessions = [
+        {"id": "root", "title": "R", "status": "idle", "last_event_at": now},
+        {"id": "a", "spawner_session_id": "root", "last_event_at": now},
+        {"id": "b", "spawner_session_id": "a", "last_event_at": now},
+        {"id": "c", "spawner_session_id": "root", "last_event_at": now},
+    ]
+    tree = _build_session_tree(sessions, "root")
+    assert tree is not None
+    assert tree["id"] == "root"
+    kids = {child["id"]: child for child in tree["children"]}
+    assert set(kids) == {"a", "c"}
+    assert [g["id"] for g in kids["a"]["children"]] == ["b"]
+    assert _build_session_tree(sessions, "nope") is None
+
+
+def test_build_session_tree_survives_a_cycle() -> None:
+    sessions = [
+        {"id": "x", "spawner_session_id": "y"},
+        {"id": "y", "spawner_session_id": "x"},
+    ]
+    tree = _build_session_tree(sessions, "x")
+    assert tree is not None
+    # y is reached once; the loop back to x is cut by the visited set.
+    assert [child["id"] for child in tree["children"]] == ["y"]
+    assert tree["children"][0]["children"] == []
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    app = create_app(Settings(data_dir=tmp_path / "data"))
+    context = app.state.context
+    for sid, parent in [("root", None), ("a", "root"), ("b", "a"), ("c", "root")]:
+        context.storage.create_session(_record(sid, parent))
+    token = context.tokens.issue().token
+    return app, token
+
+
+async def test_list_recursive_includes_whole_subtree(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    headers = {"Authorization": f"Bearer {token}"}
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        flat = await client.get(
+            "/api/sessions", params={"spawned_by": "root"}, headers=headers
+        )
+        assert {s["id"] for s in flat.json()["sessions"]} == {"a", "c"}
+
+        deep = await client.get(
+            "/api/sessions",
+            params={"spawned_by": "root", "recursive": "true"},
+            headers=headers,
+        )
+        assert {s["id"] for s in deep.json()["sessions"]} == {"a", "b", "c"}


### PR DESCRIPTION
## Purpose

Grounded wishlist items #5 and #6 from the PR #210 review. `--spawned-by` was one level only, so reconstructing a crew hierarchy was hand-rolled bookkeeping, and there was no way to query "which crew sessions are stale," leaving the wind-down/abandoned-crew story unenforceable. Relates to #210.

## Changes

### Backend

- `backend/src/waypoint/api.py` — `GET /api/sessions` gains `recursive`; with `spawned_by` it returns the whole spawn subtree via a cycle-guarded BFS (`_descendant_ids`), computed in the API layer where the one-level filter already lives (no SQL change).
- `backend/src/waypoint/client.py` — `list_sessions(recursive=)`.
- `backend/src/waypoint/cli.py` — `sessions list --recursive` (requires a `--spawned-by`/`--mine` scope) and `--idle-for <dur>` (client-side filter on last activity); new `sessions tree <id>` rendering the nested spawn hierarchy; `_parse_duration`, `_filter_idle`, and `_build_session_tree` helpers.
- `backend/tests/` — the descendant walk + recursive route (ASGI), duration parsing, idle filtering, tree building (incl. cycle safety), and the CLI surfaces.

### Docs

- `.agents/skills/waypoint-crew/references/org-chart.md` — wind-down guidance uses `list --idle-for` for staleness and `tree` / `list --spawned-by --recursive` for reconstructing an adopted crew.

## Design

Idle filtering reuses the existing `last_event_at` (already bumped on every event and indexed) as the activity signal rather than adding a new column; it's applied client-side so it composes with the server-side `--recursive`/`--spawned-by` without new query surface. `sessions tree` reads the full session list and builds the hierarchy client-side, cycle-guarded via a visited set, and surfaces `tags` when the server reports them so it stays forward-compatible.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1350 passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — N/A: the spawn-tree walk is plugin-agnostic (reads `spawner_session_id`).
- [x] If I changed the frontend, I ran the frontend gate — N/A: no frontend change.
- [x] Not a breaking change — `--recursive`, `--idle-for`, and `sessions tree` are additive.
- [x] I have updated documentation — crew wind-down guidance updated; no `.env`/config surface changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)