### PR TITLE
feat: add board ready dep-satisfaction query

### DIFF
--- a/.agents/skills/waypoint-crew/references/coordination.md
+++ b/.agents/skills/waypoint-crew/references/coordination.md
@@ -53,8 +53,11 @@ turns that coupling into an explicit, enforced order:
   treat it as last-wins).
 - **The gate.** There is no server-side enforcement — it is lead discipline. Each
   lead turn: read all `status:<n>` cells in the channel and assign a `todo` task
-  only when every id in its `task:<n>` `deps=` is `done`. That gate is what lets a
-  flat crew execute a coupled dependency graph correctly.
+  only when every id in its `task:<n>` `deps=` is `done`. `waypoint board ready
+  <channel>` computes this for you — a read-only view that returns the `todo` tasks
+  whose deps are all `done` — but it enforces nothing; the assignment discipline is
+  still the lead's. That gate is what lets a flat crew execute a coupled dependency
+  graph correctly.
 - **Scope: `deps=` is intra-`job:`-channel.** Because `<n>` is channel-local, a
   `deps=` id can only reference tasks **in the same `job:` channel**. Two
   consequences, and they are the crux of coupled work:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -625,6 +625,56 @@ def _build_session_tree(
     return node(by_id[root_id], {root_id})
 
 
+def compute_ready_tasks(cells: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Read-only view over the workqueue/crew ``task:``/``status:`` convention:
+    the tasks that are pending and whose every dep is done.
+
+    Follows the documented layout — ``deps=`` on the immutable ``task:<n>`` cell,
+    ``state=`` on the mutable ``status:<n>`` cell — but tolerates both keys living
+    on either cell (a one-cell layout after a metadata patch). A task is *ready*
+    when its own state is ``todo``/unset and every id in its ``deps`` has state
+    ``done``; a missing dep cell counts as not-done. Channels that don't follow
+    the convention yield an empty list rather than an error.
+    """
+    meta_by_key = {
+        cell["key"]: (cell.get("metadata") or {})
+        for cell in cells
+        if cell.get("key") is not None
+    }
+    text_by_key = {
+        cell["key"]: cell.get("text", "")
+        for cell in cells
+        if cell.get("key") is not None
+    }
+
+    def meta_for(n: str) -> dict[str, Any]:
+        # Merge task/status metadata so a key on either cell is seen.
+        return {
+            **meta_by_key.get(f"task:{n}", {}),
+            **meta_by_key.get(f"status:{n}", {}),
+        }
+
+    def state_of(n: str) -> str:
+        return str(meta_for(n).get("state", "") or "")
+
+    task_numbers = sorted(
+        (key.split(":", 1)[1] for key in meta_by_key if key.startswith("task:")),
+        key=lambda n: (0, int(n)) if n.isdigit() else (1, 0),
+    )
+    ready: list[dict[str, Any]] = []
+    for n in task_numbers:
+        own_state = state_of(n)
+        if own_state not in ("", "todo"):
+            continue
+        deps_raw = str(meta_for(n).get("deps", "") or "")
+        deps = [d.strip() for d in deps_raw.split(",") if d.strip()]
+        if all(state_of(dep) == "done" for dep in deps):
+            ready.append(
+                {"task": n, "text": text_by_key.get(f"task:{n}", ""), "deps": deps}
+            )
+    return ready
+
+
 def parse_wait_until(raw: str | None) -> frozenset[str]:
     """Parse a comma-separated ``--until`` list into a set of valid statuses.
 
@@ -1984,6 +2034,22 @@ def board_read(
             typer.echo(f"{ts}  {author}: {post.get('text', '')}")
     else:
         typer.echo("(no posts)")
+
+
+@board_app.command("ready")
+def board_ready(
+    ctx: typer.Context,
+    channel: Annotated[str, typer.Argument()],
+) -> None:
+    """List tasks in a channel whose deps are all done (read-only helper).
+
+    Reads the ``task:``/``status:`` cell convention and reports the tasks that
+    are pending with every dependency satisfied. This is a convenience view; it
+    enforces nothing and stays out of the way of the skill-side task logic.
+    """
+    entries = _run_client(_settings_from_ctx(ctx), lambda c: c.read_board(channel))
+    ready = compute_ready_tasks(entries)
+    typer.echo(json.dumps({"channel": channel, "ready": ready}, indent=2))
 
 
 @board_app.command("log")

--- a/backend/tests/test_board_ready.py
+++ b/backend/tests/test_board_ready.py
@@ -1,0 +1,146 @@
+"""`board ready`: the dep-satisfaction view over the task:/status: convention,
+plus the CLI command."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from waypoint.cli import app, compute_ready_tasks
+from waypoint.settings import Settings
+
+runner = CliRunner()
+
+
+def _cell(key: str, text: str = "", **meta: str) -> dict[str, Any]:
+    return {"key": key, "text": text, "metadata": dict(meta)}
+
+
+def test_ready_when_all_deps_done() -> None:
+    cells = [
+        _cell("task:1", "scaffold"),
+        _cell("status:1", state="done"),
+        _cell("task:2", "build", deps="1"),
+        _cell("status:2", state="todo"),
+    ]
+    ready = compute_ready_tasks(cells)
+    assert [r["task"] for r in ready] == ["2"]
+    assert ready[0]["deps"] == ["1"]
+
+
+def test_not_ready_with_a_pending_dep() -> None:
+    cells = [
+        _cell("task:1"),
+        _cell("status:1", state="doing"),
+        _cell("task:2", deps="1"),
+        _cell("status:2", state="todo"),
+    ]
+    assert compute_ready_tasks(cells) == []
+
+
+def test_missing_dep_status_counts_as_not_done() -> None:
+    # task:2 depends on 1, but there is no status:1 cell at all.
+    cells = [_cell("task:2", deps="1"), _cell("status:2", state="todo")]
+    assert compute_ready_tasks(cells) == []
+
+
+def test_started_task_is_not_ready() -> None:
+    # A task already doing/done is not "ready to start" even with deps clear.
+    cells = [
+        _cell("task:1", deps=""),
+        _cell("status:1", state="doing"),
+    ]
+    assert compute_ready_tasks(cells) == []
+
+
+def test_no_deps_and_todo_is_ready() -> None:
+    cells = [_cell("task:1"), _cell("status:1", state="todo")]
+    assert [r["task"] for r in compute_ready_tasks(cells)] == ["1"]
+
+
+def test_multiple_comma_deps() -> None:
+    cells = [
+        _cell("task:1"),
+        _cell("status:1", state="done"),
+        _cell("task:2"),
+        _cell("status:2", state="done"),
+        _cell("task:3", deps="1, 2"),
+        _cell("status:3", state="todo"),
+    ]
+    assert [r["task"] for r in compute_ready_tasks(cells)] == ["3"]
+
+
+def test_one_cell_layout_is_tolerated() -> None:
+    # deps and state both on the task cell (a post-metadata-patch one-cell shape).
+    cells = [
+        _cell("task:1", state="done"),
+        _cell("task:2", deps="1", state="todo"),
+    ]
+    assert [r["task"] for r in compute_ready_tasks(cells)] == ["2"]
+
+
+def test_non_conforming_channel_yields_empty() -> None:
+    cells = [_cell("note:x", "hello"), _cell("phase", "build")]
+    assert compute_ready_tasks(cells) == []
+
+
+def _config(tmp_path: Path) -> Path:
+    settings = Settings(data_dir=tmp_path / "data")
+    path = tmp_path / "waypoint.yaml"
+    path.write_text(f"data_dir: {settings.data_dir}\n", encoding="utf-8")
+    return path
+
+
+def test_board_ready_command_emits_ready(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", "t")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/board/job:x" and request.method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "channel": "job:x",
+                    "entries": [
+                        {"id": 1, "key": "task:1", "text": "a", "metadata": {}},
+                        {
+                            "id": 2,
+                            "key": "status:1",
+                            "text": "",
+                            "metadata": {"state": "done"},
+                        },
+                        {
+                            "id": 3,
+                            "key": "task:2",
+                            "text": "b",
+                            "metadata": {"deps": "1"},
+                        },
+                        {
+                            "id": 4,
+                            "key": "status:2",
+                            "text": "",
+                            "metadata": {"state": "todo"},
+                        },
+                    ],
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    from waypoint.client import WaypointClient
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app, ["--config", str(_config(tmp_path)), "board", "ready", "job:x"]
+    )
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.stdout)
+    assert out["channel"] == "job:x"
+    assert [r["task"] for r in out["ready"]] == ["2"]

--- a/backend/tests/test_board_ready.py
+++ b/backend/tests/test_board_ready.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from waypoint.cli import app, compute_ready_tasks
+from waypoint.client import WaypointClient
 from waypoint.settings import Settings
 
 runner = CliRunner()
@@ -87,6 +88,20 @@ def test_non_conforming_channel_yields_empty() -> None:
     assert compute_ready_tasks(cells) == []
 
 
+def test_mixed_numeric_and_named_task_keys_do_not_crash() -> None:
+    # A non-numeric task key must not blow up the numeric sort, and a status
+    # cell with no matching task cell is ignored.
+    cells = [
+        _cell("task:2"),
+        _cell("status:2", state="todo"),
+        _cell("task:foo"),
+        _cell("status:foo", state="todo"),
+        _cell("status:99", state="done"),  # orphan status, no task:99
+    ]
+    ready = {r["task"] for r in compute_ready_tasks(cells)}
+    assert ready == {"2", "foo"}
+
+
 def _config(tmp_path: Path) -> Path:
     settings = Settings(data_dir=tmp_path / "data")
     path = tmp_path / "waypoint.yaml"
@@ -129,8 +144,6 @@ def test_board_ready_command_emits_ready(
                 },
             )
         return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
-
-    from waypoint.client import WaypointClient
 
     def fake_client(settings: Settings, **_: object) -> WaypointClient:
         http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")


### PR DESCRIPTION
## Purpose

Grounded wishlist item #8 from the PR #210 review. The `deps=` gate was pure lead discipline — read every `status:*` cell and check each dep is `done` by hand — a class of lead bugs. A read-only query returning the ready tasks removes them, capped deliberately as a helper so the task logic stays skill-side rather than duplicating a workqueue engine in the backend. Relates to #210.

## Changes

### Backend

- `backend/src/waypoint/cli.py` — new `board ready <channel>` command and a `compute_ready_tasks` helper over the existing `read_board` (no API/storage/schema change). Follows the `task:`/`status:` convention: a task is ready when its own state is `todo`/unset and every id in its `deps` has state `done`.
- `backend/tests/test_board_ready.py` — cover all-deps-done, a pending dep, missing dep status, already-started tasks, multi-dep, the one-cell layout, a non-conforming channel, and the CLI command.

### Docs

- `.agents/skills/waypoint-crew/references/coordination.md` — point the dep gate at `board ready` while keeping assignment discipline lead-side.

## Design

Pure read-only view — it enforces nothing and reuses `read_board`, so there's no backend surface to maintain and the skill's task semantics stay in skill-land. It merges `task:<n>` and `status:<n>` metadata so a dep key on either cell is seen, which tolerates both the documented two-cell layout and the one-cell layout that a metadata patch enables. Missing status cells count as not-done and a channel that doesn't follow the convention yields an empty list rather than erroring.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1347 passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — N/A: read-only board view, plugin-agnostic.
- [x] If I changed the frontend, I ran the frontend gate — N/A: no frontend change.
- [x] Not a breaking change — a new read-only command.
- [x] I have updated documentation — crew coordination guidance updated; no `.env`/config surface changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)