### PR TITLE
docs: thread the inbox into the coding-agent skills

### DIFF
--- a/.agents/skills/waypoint-comms/SKILL.md
+++ b/.agents/skills/waypoint-comms/SKILL.md
@@ -24,6 +24,10 @@ two mechanisms, and picking the right one matters:
 Rule of thumb: one specific session must act now → direct send. Otherwise (no
 single recipient, not urgent, should persist, or the target is busy) → board.
 
+Both reach only **other sessions**. To ask the **human** something and
+optionally block on their answer, use the inbox (the `waypoint` skill's
+`references/inbox.md`), not a send or board post.
+
 ## Preflight
 
 Confirm the CLI is reachable before relying on it:

--- a/.agents/skills/waypoint-crew/SKILL.md
+++ b/.agents/skills/waypoint-crew/SKILL.md
@@ -107,8 +107,10 @@ than producing nothing (see `references/lifecycle.md`).
   so reach for them only for a product too large for a single lead to sequence —
   not as a starting structure (`references/org-chart.md`).
 - **Checkpoint, don't drift.** At PRD, architecture, and pre-ship, post the
-  artifact and gate on the user's approval — the lead must not silently redefine
-  the product's scope. Between checkpoints, run autonomously.
+  artifact and gate on the user's approval through the inbox (`inbox post` an
+  approval item, block on `inbox wait`; `references/lifecycle.md`) — the lead
+  must not silently redefine the product's scope. Between checkpoints, run
+  autonomously.
 - **Be inquisitive about environmental choices.** Settle each role's model and an
   auto-approving permission mode before spawning — a guessed mode stalls the
   session on its first approval and a wrong model id dies on turn 1. Pass ids verbatim from `waypoint

--- a/.agents/skills/waypoint-crew/references/lifecycle.md
+++ b/.agents/skills/waypoint-crew/references/lifecycle.md
@@ -7,6 +7,13 @@ the next phase start, and whether it carries a **human checkpoint**. The lead
 runs the phases in order but loops back freely — QA findings and new backlog
 items re-enter earlier phases.
 
+A **human checkpoint** is the one place the lead pauses for the *user* (the
+board and direct sends only reach other sessions). Surface it through the inbox:
+post the artifact as an approval item, wait until it resolves, and read the
+decision back into the phase's `approved=` cell — the CLI mechanics are in the
+`waypoint` skill's `references/inbox.md`. Between checkpoints the crew runs
+autonomously.
+
 Small products compress this: several phases can be a single lead turn. Do not
 run a heavyweight seven-phase process on a thin slice.
 

--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -31,8 +31,8 @@ trusting any flag list reproduced in this skill.
   `references/scheduling.md`.
 - Respond to approval requests or answer a session's question: see
   `references/sessions-approvals.md`.
-- Reach the **human** with a durable checkpoint — post a message the user
-  triages in the inbox UI (a question or an approval) and optionally block until
+- Reach the **human** — post a message the user triages in the inbox UI (ask a
+  question, request an approval, or surface an FYI) and optionally block until
   they answer: see `references/inbox.md`.
 - Handle destructive operations such as reset or termination: see
   `references/destructive-ops.md`.

--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -31,6 +31,9 @@ trusting any flag list reproduced in this skill.
   `references/scheduling.md`.
 - Respond to approval requests or answer a session's question: see
   `references/sessions-approvals.md`.
+- Reach the **human** with a durable checkpoint — post a message the user
+  triages in the inbox UI (a question or an approval) and optionally block until
+  they answer: see `references/inbox.md`.
 - Handle destructive operations such as reset or termination: see
   `references/destructive-ops.md`.
 - Diagnose CLI auth/config issues: see `references/auth-config.md`.

--- a/.agents/skills/waypoint/references/inbox.md
+++ b/.agents/skills/waypoint/references/inbox.md
@@ -1,11 +1,12 @@
-# Inbox — durable human checkpoints
+# Inbox — reach the human
 
-The inbox is the one channel that reaches the **human**, not another session:
-post a message the user triages in the inbox UI, and optionally block until they
-answer. Use it to gate on a human decision — a crew/workqueue lead pausing at a
-phase boundary, or any session that needs the user to choose before it proceeds.
-Answers live on the item and are read back over the API; they are never injected
-into an agent's input. Run `waypoint help` for exact flags.
+The inbox is the one channel that reaches the **user**, not another session:
+post a message they triage in the inbox UI, and optionally block until they
+answer. Reach for it whenever a session needs a decision, a sign-off, or input
+from the user before it can proceed — a risky action to confirm, a choice
+between options, or just an FYI to surface. Answers live on the item and are
+read back over the API; they are never injected into an agent's input. Run
+`waypoint help` for exact flags.
 
 ## Post an item
 
@@ -14,15 +15,15 @@ ordered list of typed **blocks**:
 
 ```json
 {
-  "subject": "Approve the PRD?",
+  "subject": "Drop the legacy users table?",
   "from_session_id": "<your session id>",
   "blocks": [
-    { "type": "markdown", "text": "## Scope\n- ..." },
-    { "type": "question", "question": "Which stack?",
-      "options": [{ "label": "Next.js" }, { "label": "SvelteKit" }],
+    { "type": "markdown", "text": "The migration is ready. Details:\n- ..." },
+    { "type": "question", "question": "Which rollout?",
+      "options": [{ "label": "all at once" }, { "label": "canary first" }],
       "multi": false, "required": true },
-    { "type": "approval", "prompt": "Approve and build?",
-      "options": ["approve", "request changes"], "required": true },
+    { "type": "approval", "prompt": "Run it against production?",
+      "options": ["approve", "hold"], "required": true },
     { "type": "attachment", "ref": { "session_id": "<sid>", "attachment_id": "<id>" } }
   ]
 }
@@ -48,14 +49,14 @@ on the first change. It prefers the live stream and falls back to polling.
 
 `waypoint inbox get <item-id>` returns the item with each block's `answer`
 (`{"selected": [...]}` for a question, `{"decision": "..."}` for an approval) and
-any `reply`. The lead reads the decision here and acts on it (e.g. records a
-crew's `approved=` cell). `waypoint inbox list` (status filter, search,
-load-more) enumerates items; `answer`, `read`, and `delete` are the remaining
-scripting verbs — the UI is the primary answer path.
+any `reply`; the requesting session reads the decision here and acts on it.
+`waypoint inbox list` (status filter, search, load-more) enumerates items;
+`answer`, `read`, and `delete` are the remaining scripting verbs — the UI is the
+primary answer path.
 
 ## The pattern
 
 Post → wait → get: `id=$(… inbox post --json body.json | jq -r .item.id)`, then
 `waypoint inbox wait "$id" --until resolved`, then `waypoint inbox get "$id"` to
-branch on the answer. Reserve it for genuine human gates — between them, run
-autonomously.
+branch on the answer. Reserve it for decisions that genuinely need the user —
+don't interrupt them for what the session can settle itself.

--- a/.agents/skills/waypoint/references/inbox.md
+++ b/.agents/skills/waypoint/references/inbox.md
@@ -1,0 +1,61 @@
+# Inbox — durable human checkpoints
+
+The inbox is the one channel that reaches the **human**, not another session:
+post a message the user triages in the inbox UI, and optionally block until they
+answer. Use it to gate on a human decision — a crew/workqueue lead pausing at a
+phase boundary, or any session that needs the user to choose before it proceeds.
+Answers live on the item and are read back over the API; they are never injected
+into an agent's input. Run `waypoint help` for exact flags.
+
+## Post an item
+
+`waypoint inbox post --json <file|->` — the body is JSON because an item is an
+ordered list of typed **blocks**:
+
+```json
+{
+  "subject": "Approve the PRD?",
+  "from_session_id": "<your session id>",
+  "blocks": [
+    { "type": "markdown", "text": "## Scope\n- ..." },
+    { "type": "question", "question": "Which stack?",
+      "options": [{ "label": "Next.js" }, { "label": "SvelteKit" }],
+      "multi": false, "required": true },
+    { "type": "approval", "prompt": "Approve and build?",
+      "options": ["approve", "request changes"], "required": true },
+    { "type": "attachment", "ref": { "session_id": "<sid>", "attachment_id": "<id>" } }
+  ]
+}
+```
+
+An item **resolves** once every required question/approval block is answered; an
+item with no required blocks is a pure FYI that resolves when the user reads it.
+Post prints the created item (its `id` and per-block `id`s).
+
+## Block until the user decides
+
+`waypoint inbox wait <item-id> [--until resolved|update] [--timeout 30m]` blocks
+and prints `{"outcome", "item"}`. Exit codes let a shell chain branch:
+
+- `0` — `resolved` (all required blocks answered) or `update` (first change past `--since`)
+- `124` — `timeout`
+- `3` — `gone` (the item was deleted)
+
+`--until resolved` is the default (wait for the decision); `--until update` wakes
+on the first change. It prefers the live stream and falls back to polling.
+
+## Read the answer back
+
+`waypoint inbox get <item-id>` returns the item with each block's `answer`
+(`{"selected": [...]}` for a question, `{"decision": "..."}` for an approval) and
+any `reply`. The lead reads the decision here and acts on it (e.g. records a
+crew's `approved=` cell). `waypoint inbox list` (status filter, search,
+load-more) enumerates items; `answer`, `read`, and `delete` are the remaining
+scripting verbs — the UI is the primary answer path.
+
+## The pattern
+
+Post → wait → get: `id=$(… inbox post --json body.json | jq -r .item.id)`, then
+`waypoint inbox wait "$id" --until resolved`, then `waypoint inbox get "$id"` to
+branch on the answer. Reserve it for genuine human gates — between them, run
+autonomously.


### PR DESCRIPTION
## Summary

The inbox (durable agent→human checkpoints) shipped in #218, but none of the distributed coding-agent skills referenced it. This threads it into the three skills that genuinely need it — kept minimal, deferring exact flags to `waypoint help`. Docs elsewhere already defer to the `waypoint` skill (`personal_assistant.md`) or are orthogonal, so no other surface changed.

## Changes

- **`waypoint`** — new `references/inbox.md` (the post→wait→get pattern, the JSON block body, `inbox wait` exit codes, read-back) plus one Common Routing bullet pointing to it. It's the CLI skill, and agent→human checkpoints is a capability class not covered by any existing bullet.
- **`waypoint-crew`** — the PRD / architecture / pre-ship human checkpoints already say "post the artifact and gate on the user's approval," but never named the mechanism (none existed when written). `references/lifecycle.md` now surfaces the checkpoint through the inbox and records the decision in `approved=` (mechanics deferred to the `waypoint` reference); the "Checkpoint, don't drift" guardrail gets a matching pointer.
- **`waypoint-comms`** — one line disambiguating that comms reaches other *sessions*; to reach the *human*, use the inbox.

`waypoint-workqueue` runs unattended by design (no human checkpoint), so it was intentionally left untouched.

## Test Plan

Docs-only; no code paths change. Verified the CLI claims in `references/inbox.md` against the live `waypoint inbox` help (post body/blocks, `wait` exit codes 0/124/3, `list --status/--q/--limit/--cursor`, `answer`/`read`/`delete`) and the resolution semantics against `_recompute_inbox_status`. A fresh-context review pass converged (accuracy, placement, no duplication).