### PR TITLE
feat: add batch deletion to the inbox (select + delete-resolved)

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -39,6 +39,8 @@ from waypoint.schemas import (
     AssistantSummary,
     BoardEntryUpdateRequest,
     BoardPostRequest,
+    InboxBatchDeleteRequest,
+    InboxBatchDeleteResponse,
     InboxBlockSubmitRequest,
     InboxPostRequest,
     InboxStatus,
@@ -1100,6 +1102,28 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         # Seeds the cross-session badge before the first WS event arrives.
         return {"unresolved_count": context.runtime.unresolved_inbox_count()}
+
+    # Literal paths registered before ``/api/inbox/{item_id}`` so the id matcher
+    # never shadows them (both are POST; the id route is GET, so there is no
+    # method overlap either).
+    @app.post("/api/inbox/batch-delete")
+    async def inbox_batch_delete(
+        body: InboxBatchDeleteRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        deleted = await context.runtime.delete_inbox_items(body.item_ids)
+        return InboxBatchDeleteResponse(
+            deleted_ids=deleted, count=len(deleted)
+        ).model_dump(mode="json")
+
+    @app.post("/api/inbox/delete-resolved")
+    async def inbox_delete_resolved(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        deleted = await context.runtime.delete_resolved_inbox_items()
+        return InboxBatchDeleteResponse(
+            deleted_ids=deleted, count=len(deleted)
+        ).model_dump(mode="json")
 
     @app.get("/api/inbox/{item_id}")
     async def inbox_get(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1718,6 +1718,18 @@ class SessionRuntime:
             await self._publish_inbox_deleted(item_id)
         return deleted
 
+    async def delete_inbox_items(self, item_ids: list[str]) -> list[str]:
+        deleted = self.storage.delete_inbox_items(item_ids)
+        for item_id in deleted:
+            await self._publish_inbox_deleted(item_id)
+        return deleted
+
+    async def delete_resolved_inbox_items(self) -> list[str]:
+        deleted = self.storage.delete_resolved_inbox_items()
+        for item_id in deleted:
+            await self._publish_inbox_deleted(item_id)
+        return deleted
+
     def unresolved_inbox_count(self) -> int:
         return self.storage.unresolved_inbox_count()
 

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -800,3 +800,13 @@ class InboxListResponse(BaseModel):
 
 class InboxUnresolvedCountResponse(BaseModel):
     unresolved_count: int
+
+
+class InboxBatchDeleteRequest(BaseModel):
+    item_ids: list[str] = Field(default_factory=list)
+
+
+class InboxBatchDeleteResponse(BaseModel):
+    # The ids that actually existed and were removed (unknown ids are ignored).
+    deleted_ids: list[str] = Field(default_factory=list)
+    count: int

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -971,8 +971,8 @@ class Storage:
     def delete_inbox_items(self, item_ids: list[str]) -> list[str]:
         # Batch delete by id. Returns the subset that actually existed (so the
         # runtime fans a ``deleted`` broadcast only for real removals). Chunked
-        # under SQLite's ~999 bound-variable limit; whole thing is one lock hold
-        # but committed per chunk (SELECT-then-DELETE each chunk is atomic).
+        # under SQLite's ~999 bound-variable limit; the whole batch is one lock
+        # hold with a single trailing commit (all-or-nothing across chunks).
         unique_ids = list(dict.fromkeys(item_ids))
         deleted: list[str] = []
         for start in range(0, len(unique_ids), 500):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -968,6 +968,52 @@ class Storage:
         return (cursor.rowcount or 0) > 0
 
     @_synchronized
+    def delete_inbox_items(self, item_ids: list[str]) -> list[str]:
+        # Batch delete by id. Returns the subset that actually existed (so the
+        # runtime fans a ``deleted`` broadcast only for real removals). Chunked
+        # under SQLite's ~999 bound-variable limit; whole thing is one lock hold
+        # but committed per chunk (SELECT-then-DELETE each chunk is atomic).
+        unique_ids = list(dict.fromkeys(item_ids))
+        deleted: list[str] = []
+        for start in range(0, len(unique_ids), 500):
+            chunk = unique_ids[start : start + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            present = [
+                row["id"]
+                for row in self.connection.execute(
+                    f"SELECT id FROM inbox_items WHERE id IN ({placeholders})", chunk
+                ).fetchall()
+            ]
+            if not present:
+                continue
+            self.connection.execute(
+                f"DELETE FROM inbox_items WHERE id IN ({placeholders})", chunk
+            )
+            deleted.extend(present)
+        if deleted:
+            self.connection.commit()
+        return deleted
+
+    @_synchronized
+    def delete_resolved_inbox_items(self) -> list[str]:
+        # Empty-the-resolved-folder: removes every resolved item regardless of
+        # pagination. SELECT ids first so the runtime can broadcast each removal.
+        resolved = [
+            row["id"]
+            for row in self.connection.execute(
+                "SELECT id FROM inbox_items WHERE status = ?",
+                (InboxStatus.RESOLVED,),
+            ).fetchall()
+        ]
+        if not resolved:
+            return []
+        self.connection.execute(
+            "DELETE FROM inbox_items WHERE status = ?", (InboxStatus.RESOLVED,)
+        )
+        self.connection.commit()
+        return resolved
+
+    @_synchronized
     def unresolved_inbox_count(self) -> int:
         return int(
             self.connection.execute(

--- a/backend/tests/test_inbox_api.py
+++ b/backend/tests/test_inbox_api.py
@@ -287,6 +287,85 @@ async def test_delete_removes_item(tmp_path: Path) -> None:
     assert again.status_code == 404
 
 
+async def _post_item(
+    client: httpx.AsyncClient, token: str, subject: str
+) -> dict[str, Any]:
+    resp = await client.post(
+        "/api/inbox",
+        json={"subject": subject, "blocks": [_question_block()]},
+        headers=_auth(token),
+    )
+    return resp.json()["item"]
+
+
+async def _resolve(client: httpx.AsyncClient, token: str, item: dict[str, Any]) -> None:
+    block_id = item["blocks"][0]["id"]
+    await client.post(
+        f"/api/inbox/{item['id']}/blocks/{block_id}",
+        json={"answer": {"selected": ["yes"]}},
+        headers=_auth(token),
+    )
+
+
+async def test_batch_delete_removes_known_ids(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        a = await _post_item(client, token, "a")
+        b = await _post_item(client, token, "b")
+        c = await _post_item(client, token, "c")
+
+        resp = await client.post(
+            "/api/inbox/batch-delete",
+            json={"item_ids": [a["id"], c["id"], "ghost"]},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body["deleted_ids"]) == {a["id"], c["id"]}
+        assert body["count"] == 2
+
+        assert (
+            await client.get(f"/api/inbox/{a['id']}", headers=_auth(token))
+        ).status_code == 404
+        assert (
+            await client.get(f"/api/inbox/{b['id']}", headers=_auth(token))
+        ).status_code == 200
+
+
+async def test_batch_delete_empty_list(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        await _post_item(client, token, "a")
+        resp = await client.post(
+            "/api/inbox/batch-delete", json={"item_ids": []}, headers=_auth(token)
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"deleted_ids": [], "count": 0}
+        count = await client.get("/api/inbox/unresolved-count", headers=_auth(token))
+    assert count.json()["unresolved_count"] == 1
+
+
+async def test_delete_resolved_leaves_open(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        open_item = await _post_item(client, token, "open")
+        res_a = await _post_item(client, token, "res-a")
+        res_b = await _post_item(client, token, "res-b")
+        await _resolve(client, token, res_a)
+        await _resolve(client, token, res_b)
+
+        resp = await client.post("/api/inbox/delete-resolved", headers=_auth(token))
+        assert resp.status_code == 200
+        assert set(resp.json()["deleted_ids"]) == {res_a["id"], res_b["id"]}
+
+        assert (
+            await client.get(f"/api/inbox/{open_item['id']}", headers=_auth(token))
+        ).status_code == 200
+        # Idempotent once the resolved folder is empty.
+        again = await client.post("/api/inbox/delete-resolved", headers=_auth(token))
+    assert again.json() == {"deleted_ids": [], "count": 0}
+
+
 # ── WebSocket stream (drives ``inbox wait``) ──────────────────────────
 
 

--- a/backend/tests/test_inbox_storage.py
+++ b/backend/tests/test_inbox_storage.py
@@ -307,6 +307,44 @@ def test_delete_removes_row(tmp_path) -> None:
     assert storage.delete_inbox_item(item.id) is False
 
 
+def test_delete_items_removes_only_known_ids(tmp_path) -> None:
+    storage = _storage(tmp_path)
+    a = storage.create_inbox_item("s1", None, "a", [_question()])
+    b = storage.create_inbox_item("s1", None, "b", [_question()])
+    c = storage.create_inbox_item("s1", None, "c", [_question()])
+
+    deleted = storage.delete_inbox_items([a.id, c.id, "nope", a.id])
+    assert set(deleted) == {a.id, c.id}
+    assert storage.get_inbox_item(a.id) is None
+    assert storage.get_inbox_item(c.id) is None
+    assert storage.get_inbox_item(b.id) is not None
+
+
+def test_delete_items_empty_list_is_noop(tmp_path) -> None:
+    storage = _storage(tmp_path)
+    storage.create_inbox_item("s1", None, "a", [_question()])
+    assert storage.delete_inbox_items([]) == []
+    assert storage.unresolved_inbox_count() == 1
+
+
+def test_delete_resolved_leaves_open_items(tmp_path) -> None:
+    storage = _storage(tmp_path)
+    open_item = storage.create_inbox_item("s1", None, "open", [_question()])
+    resolved_a = storage.create_inbox_item("s1", None, "res-a", [_question()])
+    resolved_b = storage.create_inbox_item("s1", None, "res-b", [_question()])
+    for item in (resolved_a, resolved_b):
+        storage.submit_inbox_block(
+            item.id, item.blocks[0].id, answer={"selected": ["yes"]}
+        )
+
+    deleted = storage.delete_resolved_inbox_items()
+    assert set(deleted) == {resolved_a.id, resolved_b.id}
+    assert storage.get_inbox_item(open_item.id) is not None
+    assert storage.get_inbox_item(resolved_a.id) is None
+    # Idempotent once the resolved folder is empty.
+    assert storage.delete_resolved_inbox_items() == []
+
+
 def test_unresolved_count_tracks_open_items(tmp_path) -> None:
     storage = _storage(tmp_path)
     storage.create_inbox_item("s1", None, "a", [_question()])

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14282,6 +14282,11 @@ html[data-theme="light"] .wp-hl {
   color: var(--bg-base);
 }
 
+.inbox-check:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
 /* A selected row reads like the active row but in the accent, independent of
    which item is open in the pane. */
 .inbox-row.selected {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13986,7 +13986,9 @@ html[data-theme="light"] .wp-hl {
   color: var(--accent);
 }
 
-.inbox-action.danger:hover:not(:disabled) {
+/* Own class, not the shared ``.danger`` button style (which carries padding,
+   a border, and a boxed hover fill) — this is a bare mono action. */
+.inbox-action-danger:hover:not(:disabled) {
   color: var(--danger);
 }
 
@@ -14099,6 +14101,12 @@ html[data-theme="light"] .wp-hl {
   .inbox-row-wrap:hover .inbox-row-delete {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  /* The revealed delete button occupies the row's top-right corner, where the
+     unread dot sits — hide the dot on hover so the two don't collide. */
+  .inbox-row-wrap:hover .inbox-row-unread {
+    opacity: 0;
   }
 }
 
@@ -14353,11 +14361,11 @@ html[data-theme="light"] .wp-hl {
   color: var(--text);
 }
 
-.inbox-bulk-btn.danger {
+.inbox-bulk-btn-danger {
   color: var(--danger);
 }
 
-.inbox-bulk-btn.danger:hover:not(:disabled) {
+.inbox-bulk-btn-danger:hover:not(:disabled) {
   color: color-mix(in srgb, var(--danger) 78%, var(--text-strong));
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14070,10 +14070,11 @@ html[data-theme="light"] .wp-hl {
    focused, so it's reachable without the gesture. */
 .inbox-row-delete {
   position: absolute;
-  top: 50%;
+  /* Top-aligned to the timestamp slot it replaces on hover, so it stays clear
+     of the unread dot pinned at the bottom of the meta rail. */
+  top: 8px;
   right: 12px;
   z-index: 2;
-  transform: translateY(-50%);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -14103,9 +14104,9 @@ html[data-theme="light"] .wp-hl {
     pointer-events: auto;
   }
 
-  /* The revealed delete button occupies the row's top-right corner, where the
-     unread dot sits — hide the dot on hover so the two don't collide. */
-  .inbox-row-wrap:hover .inbox-row-unread {
+  /* The delete button takes the timestamp's top slot on hover; the timestamp
+     (ordinary metadata) gives way. The unread dot below it stays put. */
+  .inbox-row-wrap:hover .inbox-row-time {
     opacity: 0;
   }
 }
@@ -14183,12 +14184,26 @@ html[data-theme="light"] .wp-hl {
   letter-spacing: 0.03em;
 }
 
+/* Right rail: full row height, timestamp pinned top, unread dot pinned bottom
+   (space-between), so the hover delete button owns the top slot without ever
+   covering the status dot. */
+.inbox-row-meta {
+  flex: none;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 6px;
+}
+
 .inbox-row-time {
   flex: none;
   color: var(--muted-soft);
   font-family: var(--font-mono);
   font-size: 0.68rem;
   font-variant-numeric: tabular-nums;
+  transition: opacity 0.12s ease;
 }
 
 .inbox-row-subject {
@@ -14229,7 +14244,6 @@ html[data-theme="light"] .wp-hl {
   flex: none;
   width: 7px;
   height: 7px;
-  margin-top: 6px;
   border-radius: var(--radius-pill);
   background: var(--accent);
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13901,6 +13901,7 @@ html[data-theme="light"] .wp-hl {
 
 /* ── List pane ── */
 .inbox-list-pane {
+  position: relative;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -13946,6 +13947,52 @@ html[data-theme="light"] .wp-hl {
 .inbox-tab.active {
   color: var(--accent);
   border-bottom-color: currentColor;
+}
+
+/* Toolbar control row: filter tabs on the left, batch actions on the right. */
+.inbox-controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.inbox-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+/* Bare mono actions matching the doc-header control line. */
+.inbox-action {
+  border: none;
+  background: none;
+  padding: 3px 0;
+  color: var(--muted-soft);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.14s ease;
+}
+
+.inbox-action:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.inbox-action.active {
+  color: var(--accent);
+}
+
+.inbox-action.danger:hover:not(:disabled) {
+  color: var(--danger);
+}
+
+.inbox-action:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .inbox-list {
@@ -14204,6 +14251,119 @@ html[data-theme="light"] .wp-hl {
 .inbox-load-more:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+/* ── Batch selection ── */
+/* Flat checkbox occupying the lamp column while selecting; checked/mixed fill
+   with the accent, matching the row-select highlight. */
+.inbox-check {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 17px;
+  height: 17px;
+  padding: 0;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--bg-base);
+  cursor: pointer;
+}
+
+.inbox-row .inbox-check {
+  margin-top: 1px;
+}
+
+.inbox-check.checked,
+.inbox-check.mixed {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: var(--bg-base);
+}
+
+/* A selected row reads like the active row but in the accent, independent of
+   which item is open in the pane. */
+.inbox-row.selected {
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card));
+}
+
+.inbox-row.selected:hover {
+  background: color-mix(in srgb, var(--accent) 16%, var(--bg-card));
+}
+
+/* The swipe/hover single-delete affordance is meaningless while selecting. */
+.inbox-row-wrap.selecting .inbox-row-delete {
+  display: none;
+}
+
+/* Contextual bulk-action bar: floating chrome, so it takes the glass recipe.
+   Pinned to the bottom of the list pane, floating over the scrolling rows. */
+.inbox-bulk-bar {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: max(12px, env(safe-area-inset-bottom));
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--glass-line);
+  border-radius: var(--radius-glass);
+  background: var(--glass-bg-thick);
+  box-shadow:
+    inset 0 1px 0 var(--glass-hi),
+    var(--shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+.inbox-bulk-count {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-variant-numeric: tabular-nums;
+}
+
+.inbox-bulk-spacer {
+  flex: 1;
+}
+
+.inbox-bulk-btn {
+  border: none;
+  background: none;
+  padding: 3px 4px;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.14s ease;
+}
+
+.inbox-bulk-btn:hover:not(:disabled) {
+  color: var(--text);
+}
+
+.inbox-bulk-btn.danger {
+  color: var(--danger);
+}
+
+.inbox-bulk-btn.danger:hover:not(:disabled) {
+  color: color-mix(in srgb, var(--danger) 78%, var(--text-strong));
+}
+
+.inbox-bulk-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Reserve room so the floating bar never sits on top of the last row. */
+.inbox-list-pane:has(.inbox-bulk-bar) .inbox-list {
+  padding-bottom: 64px;
 }
 
 /* ── Skeleton (loading) ── */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14105,8 +14105,9 @@ html[data-theme="light"] .wp-hl {
   }
 
   /* The delete button takes the timestamp's top slot on hover; the timestamp
-     (ordinary metadata) gives way. The unread dot below it stays put. */
-  .inbox-row-wrap:hover .inbox-row-time {
+     (ordinary metadata) gives way. The unread dot below it stays put. Not in
+     select mode — the delete button is hidden there, so nothing replaces it. */
+  .inbox-row-wrap:not(.selecting):hover .inbox-row-time {
     opacity: 0;
   }
 }

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -515,7 +515,7 @@ function InboxPageInner() {
                   {!selectMode && (status === "resolved" || status === "all") ? (
                     <button
                       type="button"
-                      className="inbox-action danger"
+                      className="inbox-action inbox-action-danger"
                       disabled={busy}
                       onClick={handleDeleteResolved}
                     >
@@ -586,7 +586,7 @@ function InboxPageInner() {
                 <span className="inbox-bulk-spacer" />
                 <button
                   type="button"
-                  className="inbox-bulk-btn danger"
+                  className="inbox-bulk-btn inbox-bulk-btn-danger"
                   disabled={busy || selectedIds.size === 0}
                   onClick={handleBatchDelete}
                 >

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -10,8 +10,10 @@ import { InboxRow } from "@/components/InboxRow";
 import { SearchInput } from "@/components/SearchInput";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import {
+  batchDeleteInboxItems,
   connectSessionsSocket,
   deleteInboxItem,
+  deleteResolvedInboxItems,
   fetchInboxList,
   isAuthError,
 } from "@/lib/api";
@@ -127,6 +129,41 @@ function EnvelopeGlyph() {
   );
 }
 
+function BulkCheckGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function DashGlyph() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M6 12h12" />
+    </svg>
+  );
+}
+
 export default function InboxPage() {
   return (
     <Suspense fallback={null}>
@@ -150,6 +187,9 @@ function InboxPageInner() {
   const [debouncedQ, setDebouncedQ] = useState("");
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [mobileView, setMobileView] = useState<"list" | "item">("list");
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState(false);
   const didInit = useRef(false);
   const filterRef = useRef({ status, q: debouncedQ });
 
@@ -312,6 +352,104 @@ function InboxPageInner() {
     [host, token, selectedId, handleDeleted, handleAuthFailure],
   );
 
+  // Leaving the current filter/search invalidates any in-flight selection.
+  useEffect(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, [status, debouncedQ]);
+
+  // Keep the selection to ids still present (WS deletions, load-more churn).
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      if (prev.size === 0) return prev;
+      const present = new Set(items.map((it) => it.id));
+      const next = new Set<string>();
+      for (const id of prev) if (present.has(id)) next.add(id);
+      return next.size === prev.size ? prev : next;
+    });
+  }, [items]);
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const exitSelect = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  }, []);
+
+  const allSelected = items.length > 0 && selectedIds.size === items.length;
+  const someSelected = selectedIds.size > 0 && !allSelected;
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedIds((prev) =>
+      prev.size === items.length ? new Set() : new Set(items.map((it) => it.id)),
+    );
+  }, [items]);
+
+  const handleBatchDelete = useCallback(async () => {
+    const ids = [...selectedIds];
+    if (ids.length === 0 || busy) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        `Delete ${ids.length} selected inbox item${ids.length > 1 ? "s" : ""}? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const deleted = await batchDeleteInboxItems(host, token, ids);
+      const gone = new Set(deleted);
+      setItems((prev) => prev.filter((it) => !gone.has(it.id)));
+      if (selectedId && gone.has(selectedId)) handleDeleted();
+      exitSelect();
+    } catch (err) {
+      if (isAuthError(err)) handleAuthFailure();
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    selectedIds,
+    busy,
+    host,
+    token,
+    selectedId,
+    handleDeleted,
+    exitSelect,
+    handleAuthFailure,
+  ]);
+
+  const handleDeleteResolved = useCallback(async () => {
+    if (busy) return;
+    if (
+      typeof window !== "undefined" &&
+      !window.confirm(
+        "Delete all resolved inbox items? This cannot be undone.",
+      )
+    ) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const deleted = await deleteResolvedInboxItems(host, token);
+      const gone = new Set(deleted);
+      setItems((prev) => prev.filter((it) => !gone.has(it.id)));
+      if (selectedId && gone.has(selectedId)) handleDeleted();
+      exitSelect();
+    } catch (err) {
+      if (isAuthError(err)) handleAuthFailure();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, host, token, selectedId, handleDeleted, exitSelect, handleAuthFailure]);
+
   return (
     <div className="page-shell inbox-shell">
       <header className="app-bar">
@@ -350,18 +488,39 @@ function InboxPageInner() {
                 placeholder="Search inbox…"
                 showStatusExample={false}
               />
-              <div className="inbox-tabs" role="group" aria-label="Filter inbox">
-                {STATUS_FILTERS.map((filter) => (
+              <div className="inbox-controls">
+                <div className="inbox-tabs" role="group" aria-label="Filter inbox">
+                  {STATUS_FILTERS.map((filter) => (
+                    <button
+                      key={filter.id}
+                      type="button"
+                      aria-pressed={status === filter.id}
+                      className={`inbox-tab${status === filter.id ? " active" : ""}`}
+                      onClick={() => setStatus(filter.id)}
+                    >
+                      {filter.label}
+                    </button>
+                  ))}
+                </div>
+                <div className="inbox-actions">
                   <button
-                    key={filter.id}
                     type="button"
-                    aria-pressed={status === filter.id}
-                    className={`inbox-tab${status === filter.id ? " active" : ""}`}
-                    onClick={() => setStatus(filter.id)}
+                    className={`inbox-action${selectMode ? " active" : ""}`}
+                    aria-pressed={selectMode}
+                    disabled={!selectMode && items.length === 0}
+                    onClick={() => (selectMode ? exitSelect() : setSelectMode(true))}
                   >
-                    {filter.label}
+                    {selectMode ? "Done" : "Select"}
                   </button>
-                ))}
+                  <button
+                    type="button"
+                    className="inbox-action danger"
+                    disabled={busy}
+                    onClick={handleDeleteResolved}
+                  >
+                    Delete resolved
+                  </button>
+                </div>
               </div>
             </div>
             <div className="inbox-list" role="list">
@@ -388,6 +547,9 @@ function InboxPageInner() {
                   timeLabel={relativeTime(item.updated_at)}
                   onSelect={select}
                   onDelete={handleRowDelete}
+                  selectMode={selectMode}
+                  selected={selectedIds.has(item.id)}
+                  onToggleSelect={toggleSelect}
                 />
               ))}
               {hasMore ? (
@@ -401,6 +563,41 @@ function InboxPageInner() {
                 </button>
               ) : null}
             </div>
+            {selectMode && selectedIds.size > 0 ? (
+              <div className="inbox-bulk-bar" role="toolbar" aria-label="Bulk actions">
+                <button
+                  type="button"
+                  className={`inbox-check inbox-check-all${
+                    allSelected ? " checked" : someSelected ? " mixed" : ""
+                  }`}
+                  role="checkbox"
+                  aria-checked={allSelected ? true : someSelected ? "mixed" : false}
+                  aria-label="Select all loaded items"
+                  onClick={toggleSelectAll}
+                >
+                  {allSelected ? <BulkCheckGlyph /> : someSelected ? <DashGlyph /> : null}
+                </button>
+                <span className="inbox-bulk-count">
+                  {selectedIds.size} selected
+                </span>
+                <span className="inbox-bulk-spacer" />
+                <button
+                  type="button"
+                  className="inbox-bulk-btn danger"
+                  disabled={busy}
+                  onClick={handleBatchDelete}
+                >
+                  Delete
+                </button>
+                <button
+                  type="button"
+                  className="inbox-bulk-btn"
+                  onClick={exitSelect}
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : null}
           </div>
 
           <div

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -431,7 +431,7 @@ function InboxPageInner() {
     if (
       typeof window !== "undefined" &&
       !window.confirm(
-        "Delete all resolved inbox items? This cannot be undone.",
+        "Delete every resolved inbox item, including any hidden by the current search? This cannot be undone.",
       )
     ) {
       return;
@@ -512,14 +512,16 @@ function InboxPageInner() {
                   >
                     {selectMode ? "Done" : "Select"}
                   </button>
-                  <button
-                    type="button"
-                    className="inbox-action danger"
-                    disabled={busy}
-                    onClick={handleDeleteResolved}
-                  >
-                    Delete resolved
-                  </button>
+                  {!selectMode && (status === "resolved" || status === "all") ? (
+                    <button
+                      type="button"
+                      className="inbox-action danger"
+                      disabled={busy}
+                      onClick={handleDeleteResolved}
+                    >
+                      Delete resolved
+                    </button>
+                  ) : null}
                 </div>
               </div>
             </div>
@@ -563,7 +565,7 @@ function InboxPageInner() {
                 </button>
               ) : null}
             </div>
-            {selectMode && selectedIds.size > 0 ? (
+            {selectMode ? (
               <div className="inbox-bulk-bar" role="toolbar" aria-label="Bulk actions">
                 <button
                   type="button"
@@ -573,6 +575,7 @@ function InboxPageInner() {
                   role="checkbox"
                   aria-checked={allSelected ? true : someSelected ? "mixed" : false}
                   aria-label="Select all loaded items"
+                  disabled={items.length === 0}
                   onClick={toggleSelectAll}
                 >
                   {allSelected ? <BulkCheckGlyph /> : someSelected ? <DashGlyph /> : null}
@@ -584,7 +587,7 @@ function InboxPageInner() {
                 <button
                   type="button"
                   className="inbox-bulk-btn danger"
-                  disabled={busy}
+                  disabled={busy || selectedIds.size === 0}
                   onClick={handleBatchDelete}
                 >
                   Delete

--- a/frontend/src/components/InboxRow.tsx
+++ b/frontend/src/components/InboxRow.tsx
@@ -157,7 +157,6 @@ export function InboxRow({
         <span className="inbox-row-main">
           <span className="inbox-row-line">
             <span className="inbox-row-from">{item.from_label ?? "unknown"}</span>
-            <span className="inbox-row-time">{timeLabel}</span>
           </span>
           <span className="inbox-row-subject">{item.subject}</span>
           {chips.length > 0 ? (
@@ -173,9 +172,14 @@ export function InboxRow({
             </span>
           ) : null}
         </span>
-        {item.read_at ? null : (
-          <span className="inbox-row-unread" aria-label="unread" />
-        )}
+        {/* Right rail: timestamp pinned top (yields to the hover delete button),
+            unread dot pinned bottom so it stays clear and always visible. */}
+        <span className="inbox-row-meta">
+          <span className="inbox-row-time">{timeLabel}</span>
+          {item.read_at ? null : (
+            <span className="inbox-row-unread" aria-label="unread" />
+          )}
+        </span>
       </button>
       <button
         type="button"

--- a/frontend/src/components/InboxRow.tsx
+++ b/frontend/src/components/InboxRow.tsx
@@ -25,6 +25,9 @@ export function InboxRow({
   timeLabel,
   onSelect,
   onDelete,
+  selectMode = false,
+  selected = false,
+  onToggleSelect,
 }: {
   item: InboxItem;
   active: boolean;
@@ -32,6 +35,9 @@ export function InboxRow({
   timeLabel: string;
   onSelect: (id: string) => void;
   onDelete: (id: string) => void;
+  selectMode?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
 }) {
   const [dx, setDx] = useState(0);
   const [swiping, setSwiping] = useState(false);
@@ -58,6 +64,8 @@ export function InboxRow({
   }
 
   function onPointerDown(event: PointerEvent<HTMLButtonElement>) {
+    // No swipe-to-delete while selecting; the row is a selection toggle.
+    if (selectMode) return;
     if (event.pointerType === "mouse" && event.button !== 0) return;
     start.current = { x: event.clientX, y: event.clientY };
     axis.current = "none";
@@ -95,6 +103,11 @@ export function InboxRow({
   }
 
   function onClick() {
+    // In select mode a tap toggles selection instead of opening the item.
+    if (selectMode) {
+      onToggleSelect?.(item.id);
+      return;
+    }
     // Suppress the click that follows a drag so a swipe never also selects.
     if (draggedRef.current) {
       draggedRef.current = false;
@@ -105,7 +118,9 @@ export function InboxRow({
 
   return (
     <div
-      className={`inbox-row-wrap${swiping ? " swiping" : ""}`}
+      className={`inbox-row-wrap${swiping ? " swiping" : ""}${
+        selectMode ? " selecting" : ""
+      }`}
       role="listitem"
     >
       <span className="inbox-row-delete-bg" aria-hidden="true">
@@ -116,18 +131,29 @@ export function InboxRow({
         type="button"
         className={`inbox-row${active ? " active" : ""}${
           item.read_at ? "" : " unread"
-        }${swiping ? " swiping" : ""}`}
+        }${swiping ? " swiping" : ""}${selected ? " selected" : ""}`}
         style={dx ? { transform: `translateX(${dx}px)` } : undefined}
+        role={selectMode ? "checkbox" : undefined}
+        aria-checked={selectMode ? selected : undefined}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}
         onPointerUp={onPointerFinish}
         onPointerCancel={onPointerFinish}
         onClick={onClick}
       >
-        <span
-          className={`inbox-lamp inbox-status-${item.status}`}
-          aria-label={item.status}
-        />
+        {selectMode ? (
+          <span
+            className={`inbox-check${selected ? " checked" : ""}`}
+            aria-hidden="true"
+          >
+            {selected ? <CheckIcon /> : null}
+          </span>
+        ) : (
+          <span
+            className={`inbox-lamp inbox-status-${item.status}`}
+            aria-label={item.status}
+          />
+        )}
         <span className="inbox-row-main">
           <span className="inbox-row-line">
             <span className="inbox-row-from">{item.from_label ?? "unknown"}</span>
@@ -160,6 +186,24 @@ export function InboxRow({
         <TrashIcon />
       </button>
     </div>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
   );
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1437,6 +1437,42 @@ export async function deleteInboxItem(
   await ensureOk(response, "failed to delete inbox item");
 }
 
+// Batch delete a set of items; returns the ids that actually existed and were
+// removed (the server ignores unknown ids). Live clients also receive one
+// inbox_update {deleted} frame per removed id.
+export async function batchDeleteInboxItems(
+  host: string,
+  token: string,
+  ids: string[],
+): Promise<string[]> {
+  const response = await fetch(`${host}/api/inbox/batch-delete`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ item_ids: ids }),
+  });
+  await ensureOk(response, "failed to delete inbox items");
+  const payload = (await response.json()) as { deleted_ids?: string[] };
+  return payload.deleted_ids ?? [];
+}
+
+// Empty the resolved folder: removes every resolved item server-side,
+// regardless of what the client has loaded. Returns the removed ids.
+export async function deleteResolvedInboxItems(
+  host: string,
+  token: string,
+): Promise<string[]> {
+  const response = await fetch(`${host}/api/inbox/delete-resolved`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to delete resolved inbox items");
+  const payload = (await response.json()) as { deleted_ids?: string[] };
+  return payload.deleted_ids ?? [];
+}
+
 export function connectInboxSocket(
   host: string,
   token: string,


### PR DESCRIPTION
## Purpose

The inbox (added in #218) could only delete one item at a time. Clearing a triaged mailbox meant deleting rows one by one. This adds the two batch operations every email client has: **select-and-delete** a set of items, and **delete-all-resolved** to empty the resolved folder in one action.

## Changes

### Backend

- `backend/src/waypoint/schemas.py` — `InboxBatchDeleteRequest` (`item_ids`) and a shared `InboxBatchDeleteResponse` (`deleted_ids`, `count`).
- `backend/src/waypoint/storage.py` — `delete_inbox_items(ids)` (SELECT-then-DELETE the present subset, chunked under SQLite's bound-variable limit, returns the ids actually removed) and `delete_resolved_inbox_items()` (removes every `resolved` row regardless of pagination). Both under the storage lock like the existing single delete.
- `backend/src/waypoint/runtime.py` — async wrappers that fan one `inbox_update {deleted}` frame per removed id, so every live client's list and the cross-session unresolved badge stay correct.
- `backend/src/waypoint/api.py` — `POST /api/inbox/batch-delete` and `POST /api/inbox/delete-resolved`, registered as literal paths before `/api/inbox/{item_id}` (POST vs. the id route's GET — no shadowing either way).
- `backend/tests/{test_inbox_storage.py,test_inbox_api.py}` — cover the present-subset delete, unknown-id and empty-list handling, delete-resolved leaving open items, and idempotency.

### Frontend

- `frontend/src/lib/api.ts` — `batchDeleteInboxItems` and `deleteResolvedInboxItems` client helpers; both return the server's `deleted_ids`.
- `frontend/src/app/inbox/page.tsx` — an email-style selection mode: a toolbar **Select** toggle, a floating glass **bulk-action bar** with select-all/indeterminate, count, Delete and Cancel, and a toolbar **Delete resolved** action. Optimistic removal keys off the returned ids; the existing `inbox_update` WS reconciliation dedupes double removals. Selection resets on filter/search change and prunes to ids still present.
- `frontend/src/components/InboxRow.tsx` — a flat, focusable checkbox occupying the lamp column while selecting; a tap toggles selection (instead of opening), and swipe/hover single-delete is suppressed in select mode.
- `frontend/src/app/globals.css` — token-scoped styles for the toolbar actions, checkbox, selected-row highlight, and the bulk bar (flat in-flow surfaces; the floating bar uses the glass recipe; both themes derive from tokens).

## Design

Two distinct mechanisms because their scope differs. Select-and-delete acts on a client-chosen set of loaded rows, so it sends explicit ids. Delete-all-resolved must reach resolved items past the pagination cursor, so it deletes by status server-side rather than from a client id list — mirroring the `delete_all_attachments` empty-folder pattern. Deleting resolved items never changes the unresolved badge (it counts open only); each fan-out frame simply carries the unchanged count. The bulk-action bar is the one new piece of floating chrome, so it takes the glass recipe; everything in-flow (rows, checkboxes, toolbar) stays flat per the repo's design language.

CLI/`client.py` parity for the batch operations is intentionally out of scope here (this is a frontend feature); it can follow if wanted.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- Live e2e against a running stack: post open + resolved items, then `batch-delete` a subset (with an unknown id mixed in) and `delete-resolved`; confirm the right rows go, open items survive, unknown ids are ignored, and a second `delete-resolved` is a no-op.

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1458 passed.
- `npm run lint` — clean; `npm run build` — compiled successfully.
- e2e — batch-delete removed the two targeted ids (unknown id ignored), left the untouched item at 200; delete-resolved removed all resolved items and left open items at 200; second delete-resolved returned `{count: 0}`; `/inbox` served 200 and the unresolved count stayed consistent.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; `waypointctl` untouched).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — N/A: the inbox is plugin-agnostic and adds no per-backend branching.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (all colors derive from `:root` tokens).
- [x] Not a breaking change — additive endpoints and UI.
- [x] Documentation/config — no `.env`/`waypoint.example.yaml` surface changed.

</details>