### PR TITLE
docs: thread upload --pin and attachment management into the skills

### DIFF
--- a/.agents/skills/waypoint-crew/references/coordination.md
+++ b/.agents/skills/waypoint-crew/references/coordination.md
@@ -135,7 +135,8 @@ two, mirroring the ownership tiers:
   artifacts stay board cells as above, but a *file* the user should open (a
   generated report, design doc, or diagram) that lives outside any session's
   working directory is invisible in the UI — write it into the repo/cwd, or
-  `sessions upload` it (the `waypoint` skill's `references/artifacts.md`).
+  `sessions upload --pin` it (the `waypoint` skill's `references/artifacts.md`;
+  `--pin` keeps it past the orphan sweep).
 - **"Act now" → direct send.** To hand a specific idle role a task or wake it
   after a contract change, `waypoint sessions send` (send-vs-board trade:
   `waypoint-comms`).

--- a/.agents/skills/waypoint-crew/references/lifecycle.md
+++ b/.agents/skills/waypoint-crew/references/lifecycle.md
@@ -131,7 +131,7 @@ Two things must hold, or a phase quietly produces nothing:
   `contract:`; if a contract must change, renegotiate it
   (`references/coordination.md`) rather than letting the sides diverge. Ephemeral
   **overflow workers** cover a burst beyond standing headcount, reaped per batch by
-  tracked id (`references/org-chart.md`). Frame each task as *build and ship this
+  tag or tracked id (`references/org-chart.md`). Frame each task as *build and ship this
   feature / implement this*, and verify each with its own check before integrating.
   For a build too large for one lead to sequence, split it into per-team `job:`
   channels each run by a **team lead**, with the main lead sequencing across teams

--- a/.agents/skills/waypoint-subagents/references/cleanup.md
+++ b/.agents/skills/waypoint-subagents/references/cleanup.md
@@ -36,9 +36,9 @@ waypoint sessions delete <child-id>
   done or it has gone stale.
 - It produced output the **user should review**. Files in the child's own cwd are
   already user-readable — the user opens the child's session and browses its
-  working directory — so don't upload them; reserve `sessions upload` for an
-  artifact outside any session's cwd (the `waypoint` skill's
-  `references/artifacts.md`).
+  working directory — so don't upload them; reserve `sessions upload` (with
+  `--pin` if it must outlive the child) for an artifact outside any session's cwd
+  (the `waypoint` skill's `references/artifacts.md`).
 - It ended in `error` — deleting it would hide the failure. Leave it and surface
   it to the user.
 - It is **pinned** by the user (`pinned_at` set) — never delete a pinned session.

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -156,9 +156,10 @@ rather than reaping now — a later fix continues a parked worker in place, wher
 reaped one would have to reimport the thread.
 
 A worker's cwd files are user-readable by opening its session, so don't
-bulk-upload them; but reaping removes the worktree, so `sessions upload` (the
-`waypoint` skill's `references/artifacts.md`) anything the user must keep that
-isn't already landed on `wq/$job` or in a durable cwd.
+bulk-upload them; but reaping removes the worktree, so `sessions upload --pin`
+(the `waypoint` skill's `references/artifacts.md`) anything the user must keep
+that isn't already landed on `wq/$job` or in a durable cwd — `--pin` keeps it past
+the orphan sweep.
 
 ## Worker
 

--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -50,5 +50,6 @@ trusting any flag list reproduced in this skill.
 - When reporting status, include concrete session ids and current statuses.
 - A file outside a session's working directory is invisible in that session's
   file explorer. If the user needs to see it, either keep it in a session cwd (they
-  can open that session) or `sessions upload` it — minding the orphan TTL for
-  anything durable (`references/artifacts.md`).
+  can open that session) or `sessions upload` it — with `--pin` for anything
+  durable, since an unpinned upload is swept after the orphan TTL
+  (`references/artifacts.md`).

--- a/.agents/skills/waypoint/references/artifacts.md
+++ b/.agents/skills/waypoint/references/artifacts.md
@@ -22,13 +22,30 @@ working directory is reachable already.
    `$WAYPOINT_SESSION_ID` is your own session id, so this lands the file in your
    session's files panel, where the user opens it. Upload sends **no message**, so
    it doesn't disturb the agent in the target session.
-3. **Must persist for the long term → don't rely on a bare upload.** An eager
-   upload that no sent message references is an **orphan**: it shows in the panel
-   but is swept once older than `WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS` (default
-   **24h**). For anything durable, keep the file in a session cwd (option 1), or
-   attach it to an actual message (`sessions send --attach <file>`), which marks it
-   sent and exempt from the sweep. Uploads and cwd files alike also vanish if the
+3. **Must persist for the long term → pin it, or keep it in a cwd.** An eager
+   upload that nothing keeps is an **orphan**: it shows in the panel but is swept
+   once older than `WAYPOINT_ATTACHMENT_ORPHAN_TTL_SECONDS` (default **24h**). To
+   keep an uploaded file *without* sending a message, pass **`--pin`**:
+
+   ```bash
+   waypoint sessions upload --pin "$WAYPOINT_SESSION_ID" <file>
+   ```
+
+   Pinned uploads are exempt from the sweep (a file carried by a sent message —
+   `sessions send --attach` — is likewise kept). Keeping the file in a session cwd
+   (option 1) is durable too. Either way, uploads and cwd files vanish if the
    session is **deleted/reaped** — surface or commit before wind-down.
+
+## Managing what's surfaced
+
+```bash
+waypoint sessions attachments list <session-id>              # what's already surfaced
+waypoint sessions attachments get <session-id> <att-id>      # download one back
+waypoint sessions attachments pin <session-id> <att-id>      # keep a past upload; unpin re-exposes it
+waypoint sessions attachments delete <session-id> <att-id>   # (delete-all clears the session)
+```
+
+List first to avoid re-uploading a file already surfaced.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Follow-up to the primitives shipped in #212–#220. #219 threaded the new **inbox** into the coding-agent skills, and the merged docs already cover `board set-meta --merge`/`--unset`, `board ready`, session tags, `reap --tag`/`--exclude`, `sessions tree`/`--recursive`, and `sessions list --idle-for`. The one thread left untouched was **attachment pinning** (#213): the artifact-surfacing guidance still taught the "send a message to keep it" workaround for durability. This threads `sessions upload --pin` and the `sessions attachments` management commands through the skills.

## Changes

- **`waypoint/references/artifacts.md`** — durability now leads with `sessions upload --pin` instead of `sessions send --attach`; adds a "Managing what's surfaced" section (`attachments list`/`get`/`pin`/`delete`).
- **`waypoint/SKILL.md`** — the artifact guardrail points at `--pin` for durable uploads.
- **`waypoint-crew/references/coordination.md`** — the handoff file-deliverable bullet uses `sessions upload --pin`.
- **`waypoint-crew/references/lifecycle.md`** — overflow reap phrased as "by tag or tracked id", aligning with the tag-based sweep in org-chart.
- **`waypoint-workqueue/references/playbook.md`** and **`waypoint-subagents/references/cleanup.md`** — the keep-past-reap upload notes use `--pin`.

## Verification

- `python` frontmatter YAML parse — all SKILL.md valid
- `pre-commit run codespell` — passed
- `backend` `pytest tests/test_assistant_assets.py` — 5 passed
- `waypointctl` `pytest tests/test_skills.py` — 12 passed