### PR TITLE
fix: add launch environment variables

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -126,7 +126,9 @@ def _descendant_ids(sessions: list[SessionRecord], root_id: str) -> set[str]:
     return found
 
 
-def _backend_descriptors(registry: BackendRegistry) -> list[dict[str, Any]]:
+def _backend_descriptors(
+    registry: BackendRegistry, settings: Settings
+) -> list[dict[str, Any]]:
     """Serialise every registered backend for the frontend catalogue.
 
     The frontend consumes this from ``GET /api/backends`` (and from the
@@ -151,6 +153,7 @@ def _backend_descriptors(registry: BackendRegistry) -> list[dict[str, Any]]:
                 ),
                 "label": plugin.label,
                 "badges": dict(caps.badges),
+                "default_launch_env": dict(settings.plugin_config(plugin.id).env),
                 # The flat ``capabilities`` object stays byte-identical for
                 # existing consumers; the split sub-objects are emitted
                 # alongside it so the frontend can migrate to the (agent,
@@ -220,7 +223,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             default_backend=context.settings.default_backend,
             default_cwd=context.settings.default_cwd,
             launch_targets=context.runtime.launch_target_summaries(),
-            backends=_backend_descriptors(context.runtime.registry),
+            backends=_backend_descriptors(context.runtime.registry, context.settings),
             assistant=context.runtime.assistant_summary(),
         )
 
@@ -312,7 +315,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def list_backends(
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        return {"backends": _backend_descriptors(context.runtime.registry)}
+        return {
+            "backends": _backend_descriptors(context.runtime.registry, context.settings)
+        }
 
     # Plugin-registered routes (e.g. the Claude PreToolUse hook) come
     # in here so api.py stays backend-agnostic.

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -245,7 +245,18 @@ EmitEvent = Callable[
 InitCallback = Callable[[str, dict[str, Any]], None]
 SessionUpdateCallback = Callable[[str, dict[str, Any], bool], Awaitable[Any]]
 LaunchFactory = Callable[
-    [str, str, str, bool, str, str | None, str | None, list[str], str | None],
+    [
+        str,
+        str,
+        str,
+        bool,
+        str,
+        str | None,
+        str | None,
+        list[str],
+        str | None,
+        dict[str, str],
+    ],
     "ClaudeLaunchSpec",
 ]
 
@@ -342,6 +353,8 @@ class ClaudeSessionState:
     # Carried across set_effort respawns so user-supplied args survive
     # mid-session effort changes.
     custom_args: list[str] = field(default_factory=list)
+    # Effective user-editable launch environment, carried across respawns.
+    launch_env: dict[str, str] = field(default_factory=dict)
     # Captures the launch_factory used to spawn this session so set_effort
     # can respawn through the same factory (local vs. remote SSH) without
     # re-resolving target config.
@@ -388,6 +401,7 @@ class ClaudeCliAdapter:
         effort: str | None = None,
         custom_args: list[str] | None = None,
         fork_from_claude_session_id: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> str:
         state = await self._spawn(
             session_id,
@@ -400,6 +414,7 @@ class ClaudeCliAdapter:
             effort=effort,
             custom_args=custom_args or [],
             fork_from_claude_session_id=fork_from_claude_session_id,
+            launch_env=launch_env or {},
         )
         return state.claude_session_id
 
@@ -413,6 +428,7 @@ class ClaudeCliAdapter:
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> None:
         await self._spawn(
             session_id,
@@ -424,6 +440,7 @@ class ClaudeCliAdapter:
             model=model,
             effort=effort,
             custom_args=custom_args or [],
+            launch_env=launch_env or {},
         )
 
     async def set_permission_mode(self, session_id: str, mode: str) -> None:
@@ -523,6 +540,7 @@ class ClaudeCliAdapter:
         model = previous.model
         custom_args = previous.custom_args
         launch_factory = previous.launch_factory
+        launch_env = dict(previous.launch_env)
         await self.terminate_session(session_id)
         await self._spawn(
             session_id,
@@ -534,6 +552,7 @@ class ClaudeCliAdapter:
             model=model,
             effort=effort or None,
             custom_args=custom_args,
+            launch_env=launch_env,
         )
 
     def session_effort(self, session_id: str) -> str | None:
@@ -1211,12 +1230,14 @@ class ClaudeCliAdapter:
         effort: str | None = None,
         custom_args: list[str] | None = None,
         fork_from_claude_session_id: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> ClaudeSessionState:
         resolved_mode = (
             permission_mode if permission_mode in CLAUDE_PERMISSION_MODES else "default"
         )
         cli_mode = claude_cli_mode_for(resolved_mode)
         effective_custom_args = custom_args or []
+        effective_launch_env = launch_env or {}
         launch_factory = launch_factory_override or self._launch_factory
         if launch_factory is None:
             spec = self._build_local_launch_spec(
@@ -1229,6 +1250,7 @@ class ClaudeCliAdapter:
                 effort,
                 effective_custom_args,
                 fork_from_claude_session_id,
+                effective_launch_env,
             )
         else:
             spec = launch_factory(
@@ -1241,6 +1263,7 @@ class ClaudeCliAdapter:
                 effort,
                 effective_custom_args,
                 fork_from_claude_session_id,
+                effective_launch_env,
             )
         process = await asyncio.create_subprocess_exec(
             *spec.args,
@@ -1264,6 +1287,7 @@ class ClaudeCliAdapter:
             effort=effort or None,
             custom_args=list(effective_custom_args),
             launch_factory=launch_factory,
+            launch_env=dict(effective_launch_env),
         )
         state.stdout_task = asyncio.create_task(self._read_stdout(state))
         state.stderr_task = asyncio.create_task(self._read_stderr(state))
@@ -1308,6 +1332,7 @@ class ClaudeCliAdapter:
         effort: str | None = None,
         custom_args: list[str] | None = None,
         fork_from_claude_session_id: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> ClaudeLaunchSpec:
         binary = self._binary or shutil.which("claude")
         if binary is None:
@@ -1350,6 +1375,7 @@ class ClaudeCliAdapter:
             args.extend(custom_args)
         env = {
             **os.environ,
+            **(launch_env or {}),
             # Enable the dynamic-workflow feature so the Workflow tool is
             # available and routes its approval through `can_use_tool`.
             "CLAUDE_CODE_WORKFLOWS": "1",

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -844,6 +844,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         adapter = self._require_adapter()
 
         async def _bring_up(new_session: SessionRecord, fork_thread_id: str) -> None:
+            process_env = runtime._agent_process_env(
+                self.id, session.launch_env, session_id=new_session.id
+            )
             await adapter.restore_session(
                 new_session.id,
                 session.cwd,
@@ -852,6 +855,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 permission_mode=session.permission_mode,
                 model=session.model,
                 effort=session.effort,
+                launch_env=process_env,
             )
 
         return await _sq.fork_aside(
@@ -996,6 +1000,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
 
         new_claude_session_id = self.generate_session_id()
         try:
+            process_env = runtime._agent_process_env(
+                self.id, session.launch_env, session_id=new_session_id
+            )
             await self.adapter.start_session(
                 new_session_id,
                 session.cwd,
@@ -1008,6 +1015,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                     runtime, session.launch_target_id, session.args
                 ),
                 fork_from_claude_session_id=thread_id,
+                launch_env=process_env,
             )
         except Exception as exc:  # noqa: BLE001
             log.exception(
@@ -1045,6 +1053,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             effort=session.effort,
             args=session.args,
             config_overrides=session.config_overrides,
+            launch_env=session.launch_env,
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
@@ -1097,6 +1106,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             )
             return
         try:
+            process_env = runtime._agent_process_env(
+                self.id, session.launch_env, session_id=session.id
+            )
             await self.adapter.restore_session(
                 session.id,
                 session.cwd,
@@ -1108,6 +1120,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 custom_args=self._effective_args(
                     runtime, session.launch_target_id, session.args
                 ),
+                launch_env=process_env,
             )
         except Exception as exc:  # noqa: BLE001
             log.exception(
@@ -1381,9 +1394,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             model=resolved_model,
             effort=resolved_effort,
             args=request.args,
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
         try:
+            process_env = runtime._agent_process_env(
+                self.id, session.launch_env, session_id=session.id
+            )
             await self.adapter.start_session(
                 session_id,
                 request.cwd,
@@ -1395,6 +1412,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 custom_args=self._effective_args(
                     runtime, session.launch_target_id, session.args
                 ),
+                launch_env=process_env,
             )
         except (ClaudeCliError, FileNotFoundError, OSError) as exc:
             runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
@@ -1485,6 +1503,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 cwd=cwd,
                 launch_target_id=request.launch_target_id,
                 title=info.title,
+                launch_env=request.launch_env,
             )
         # Direct (structured-SDK) path requires the adapter.
         if self.adapter is None:
@@ -1516,9 +1535,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             structured_log_path=str(structured_log),
             transport_state={"thread_id": info.id},
             permission_mode="default",
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
         try:
+            process_env = runtime._agent_process_env(
+                self.id, session.launch_env, session_id=session.id
+            )
             await self.adapter.restore_session(
                 session.id,
                 cwd,
@@ -1527,6 +1550,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 permission_mode=session.permission_mode,
                 model=session.model,
                 effort=session.effort,
+                launch_env=process_env,
             )
         except (ClaudeCliError, FileNotFoundError, OSError) as exc:
             log.exception(

--- a/backend/src/waypoint/backends/claude_code/remote.py
+++ b/backend/src/waypoint/backends/claude_code/remote.py
@@ -51,6 +51,7 @@ def build_remote_claude_launch_factory(
         effort: str | None = None,
         custom_args: list[str] | None = None,
         fork_from_claude_session_id: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> ClaudeLaunchSpec:
         cwd = cwd or target.default_cwd
         claude_bin = (
@@ -95,6 +96,7 @@ def build_remote_claude_launch_factory(
             target=target,
             cwd=cwd,
             claude_args=claude_args,
+            launch_env=launch_env,
         )
         args = [
             _resolve_local_binary(target.ssh_bin),
@@ -137,6 +139,7 @@ def _build_remote_claude_command(
     target: SshLaunchTargetConfig,
     cwd: str,
     claude_args: list[str],
+    launch_env: dict[str, str] | None = None,
 ) -> str:
     launch_line = [
         f"cd {quote_remote_path(cwd)}",
@@ -146,6 +149,7 @@ def _build_remote_claude_command(
     ]
     combined_env = {
         **target.remote_env,
+        **(launch_env or {}),
         # Enable the dynamic-workflow feature so the Workflow tool is available
         # and routes its approval through `can_use_tool`.
         "CLAUDE_CODE_WORKFLOWS": "1",

--- a/backend/src/waypoint/backends/claude_code/schemas.py
+++ b/backend/src/waypoint/backends/claude_code/schemas.py
@@ -10,8 +10,9 @@ so callers don't need to import these types directly.
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from waypoint.launch_env import LaunchEnv
 from waypoint.schemas import LaunchMode, SessionTransportId
 
 
@@ -43,6 +44,7 @@ class ClaudeThreadImportRequest(BaseModel):
     # thread under the tty-tail driver while still persisting
     # ``backend=claude_code``.
     transport: SessionTransportId | None = None
+    launch_env: LaunchEnv = Field(default_factory=dict)
     # When true (default), the prior conversation is replayed into the new
     # session's transcript at import time; when false the transcript starts
     # empty and only the underlying agent resumes its own context.

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -612,6 +612,7 @@ async def fork_aside(
             effort=session.effort,
             args=session.args,
             config_overrides=session.config_overrides,
+            launch_env=session.launch_env,
         )
         runtime.storage.create_session(new_session)
         created = True

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -509,6 +509,7 @@ class ClaudeTtyPlugin:
                 request.cwd,
                 allocate_tty=True,
                 session_id=session_id,
+                launch_env=request.launch_env,
             )
         except HTTPException:
             raise
@@ -558,6 +559,7 @@ class ClaudeTtyPlugin:
             model=resolved_model,
             effort=resolved_effort,
             args=request.args,
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
         await runtime._record_system_event(
@@ -629,6 +631,7 @@ class ClaudeTtyPlugin:
                 session.cwd,
                 allocate_tty=True,
                 session_id=session.id,
+                launch_env=session.launch_env,
             )
         except HTTPException as exc:
             await runtime._record_system_event(
@@ -730,6 +733,7 @@ class ClaudeTtyPlugin:
                 session.cwd,
                 allocate_tty=True,
                 session_id=new_session_id,
+                launch_env=session.launch_env,
             )
         except HTTPException:
             raise
@@ -778,6 +782,7 @@ class ClaudeTtyPlugin:
             model=session.model,
             effort=session.effort,
             args=session.args,
+            launch_env=session.launch_env,
         )
         runtime.storage.create_session(new_session)
         await runtime._record_system_event(
@@ -914,6 +919,7 @@ class ClaudeTtyPlugin:
             session.cwd,
             allocate_tty=True,
             session_id=session.id,
+            launch_env=session.launch_env,
         )
         raw_log = Path(session.raw_log_path)
         with suppress(OSError):
@@ -1043,6 +1049,7 @@ class ClaudeTtyPlugin:
             new_session.cwd,
             allocate_tty=True,
             session_id=new_session.id,
+            launch_env=parent.launch_env,
         )
         raw_log = Path(new_session.raw_log_path)
         raw_log.parent.mkdir(parents=True, exist_ok=True)
@@ -1268,6 +1275,7 @@ class ClaudeTtyPlugin:
                 cwd,
                 allocate_tty=True,
                 session_id=session_id,
+                launch_env=request.launch_env,
             )
         except HTTPException:
             raise
@@ -1306,6 +1314,7 @@ class ClaudeTtyPlugin:
                 "thread_id": request.thread_id,
                 "launch_args": launch_args,
             },
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
 

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -59,6 +59,7 @@ def _apply_codex_args(
     base: ClientFactory | None,
     cli_args: tuple[str, ...],
     config_overrides: tuple[str, ...],
+    launch_env: dict[str, str] | None = None,
 ) -> ClientFactory | None:
     """Wrap *base* so it injects *cli_args* / *config_overrides* into local launches.
 
@@ -72,7 +73,7 @@ def _apply_codex_args(
     ourselves so the raw flags reach codex; otherwise we use the simpler
     ``config_overrides`` slot.
     """
-    if not cli_args and not config_overrides:
+    if not cli_args and not config_overrides and not launch_env:
         return base
     if base is not None:
         # Remote factory — args were baked in at construction; return as-is.
@@ -89,6 +90,7 @@ def _apply_codex_args(
                 config=CodexConfig(
                     launch_args_override=tuple(argv),
                     cwd=cwd,
+                    env=launch_env,
                     client_name="waypoint",
                     client_title="Waypoint",
                 ),
@@ -100,6 +102,7 @@ def _apply_codex_args(
                 client_name="waypoint",
                 client_title="Waypoint",
                 config_overrides=config_overrides,
+                env=launch_env,
             ),
             approval_handler=approval_handler,
         )
@@ -166,11 +169,13 @@ class CodexAppServerAdapter:
         effort: str | None = None,
         custom_args: list[str] | None = None,
         config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> str:
         effective_factory = _apply_codex_args(
             client_factory_override,
             tuple(custom_args or []),
             tuple(config_overrides or []),
+            launch_env or {},
         )
         state = await self._spawn_session(
             session_id,
@@ -203,11 +208,13 @@ class CodexAppServerAdapter:
         effort: str | None = None,
         custom_args: list[str] | None = None,
         config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> None:
         effective_factory = _apply_codex_args(
             client_factory_override,
             tuple(custom_args or []),
             tuple(config_overrides or []),
+            launch_env or {},
         )
         state = await self._spawn_session(
             session_id,
@@ -230,11 +237,13 @@ class CodexAppServerAdapter:
         effort: str | None = None,
         custom_args: list[str] | None = None,
         config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> str:
         effective_factory = _apply_codex_args(
             client_factory_override,
             tuple(custom_args or []),
             tuple(config_overrides or []),
+            launch_env or {},
         )
         state = await self._spawn_session(
             session_id,

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -834,6 +834,9 @@ class CodexPlugin(DefaultLaunchContract):
         effective_config_overrides = self._effective_config_overrides(
             runtime, session.launch_target_id, session.config_overrides
         )
+        process_env = runtime._agent_process_env(
+            self.id, session.launch_env, session_id=new_session_id
+        )
 
         try:
             new_thread_id = await self._require_adapter().fork_session(
@@ -845,11 +848,13 @@ class CodexPlugin(DefaultLaunchContract):
                     session.launch_target_id,
                     custom_args=effective_cli_args,
                     custom_config_overrides=effective_config_overrides,
+                    launch_env=process_env,
                 ),
                 model=session.model,
                 effort=session.effort,
                 custom_args=effective_cli_args,
                 config_overrides=effective_config_overrides,
+                launch_env=process_env,
             )
         except Exception as exc:  # noqa: BLE001
             log.exception(
@@ -893,6 +898,7 @@ class CodexPlugin(DefaultLaunchContract):
             effort=session.effort,
             args=session.args,
             config_overrides=session.config_overrides,
+            launch_env=session.launch_env,
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
@@ -939,6 +945,9 @@ class CodexPlugin(DefaultLaunchContract):
         effective_config_overrides = self._effective_config_overrides(
             runtime, session.launch_target_id, session.config_overrides
         )
+        process_env = runtime._agent_process_env(
+            self.id, session.launch_env, session_id=session.id
+        )
         try:
             await self._require_adapter().restore_session(
                 session.id,
@@ -949,11 +958,13 @@ class CodexPlugin(DefaultLaunchContract):
                     session.launch_target_id,
                     custom_args=effective_cli_args,
                     custom_config_overrides=effective_config_overrides,
+                    launch_env=process_env,
                 ),
                 model=session.model,
                 effort=session.effort,
                 custom_args=effective_cli_args,
                 config_overrides=effective_config_overrides,
+                launch_env=process_env,
             )
         except Exception as exc:  # noqa: BLE001
             log.exception(
@@ -1253,6 +1264,7 @@ class CodexPlugin(DefaultLaunchContract):
         launch_target_id: str | None,
         custom_args: list[str] | None = None,
         custom_config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> ClientFactory | None:
         launch_target = runtime._find_launch_target(launch_target_id)
         if launch_target is None:
@@ -1261,6 +1273,7 @@ class CodexPlugin(DefaultLaunchContract):
             launch_target,
             cli_args=tuple(custom_args or ()),
             config_overrides=tuple(custom_config_overrides or ()),
+            launch_env=launch_env,
         )
 
     def client_cwd(
@@ -1423,6 +1436,7 @@ class CodexPlugin(DefaultLaunchContract):
             effort=resolved_effort,
             args=list(request.args),
             config_overrides=list(request.config_overrides),
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
         effective_cli_args = self._effective_args(
@@ -1430,6 +1444,9 @@ class CodexPlugin(DefaultLaunchContract):
         )
         effective_config_overrides = self._effective_config_overrides(
             runtime, session.launch_target_id, request.config_overrides
+        )
+        process_env = runtime._agent_process_env(
+            self.id, session.launch_env, session_id=session.id
         )
         try:
             thread_id = await self._require_adapter().start_session(
@@ -1440,11 +1457,13 @@ class CodexPlugin(DefaultLaunchContract):
                     session.launch_target_id,
                     custom_args=effective_cli_args,
                     custom_config_overrides=effective_config_overrides,
+                    launch_env=process_env,
                 ),
                 model=resolved_model,
                 effort=resolved_effort,
                 custom_args=effective_cli_args,
                 config_overrides=effective_config_overrides,
+                launch_env=process_env,
             )
         except Exception:
             runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
@@ -1521,6 +1540,7 @@ class CodexPlugin(DefaultLaunchContract):
                 cwd=_thread_cwd(thread),
                 launch_target_id=request.launch_target_id,
                 title=_thread_title(thread),
+                launch_env=request.launch_env,
             )
         session_id = runtime._generate_session_id(self.id)
         session_dir = runtime._session_dir(session_id)
@@ -1547,6 +1567,7 @@ class CodexPlugin(DefaultLaunchContract):
             structured_log_path=str(structured_log),
             transport_state={"thread_id": thread.id},
             permission_mode="default",
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
         # Imported sessions start with no per-session args/config_overrides;
@@ -1555,6 +1576,9 @@ class CodexPlugin(DefaultLaunchContract):
         effective_cli_args = self._effective_args(runtime, session.launch_target_id, [])
         effective_config_overrides = self._effective_config_overrides(
             runtime, session.launch_target_id, []
+        )
+        process_env = runtime._agent_process_env(
+            self.id, session.launch_env, session_id=session.id
         )
         try:
             await self._require_adapter().restore_session(
@@ -1566,9 +1590,11 @@ class CodexPlugin(DefaultLaunchContract):
                     session.launch_target_id,
                     custom_args=effective_cli_args,
                     custom_config_overrides=effective_config_overrides,
+                    launch_env=process_env,
                 ),
                 custom_args=effective_cli_args,
                 config_overrides=effective_config_overrides,
+                launch_env=process_env,
             )
         except Exception as exc:  # noqa: BLE001
             log.exception(

--- a/backend/src/waypoint/backends/codex/remote.py
+++ b/backend/src/waypoint/backends/codex/remote.py
@@ -21,6 +21,7 @@ def build_codex_launch_args(
     cwd: str,
     cli_args: tuple[str, ...] = (),
     config_overrides: tuple[str, ...] = (),
+    launch_env: dict[str, str] | None = None,
 ) -> tuple[str, ...]:
     """Build the remote argv for ``codex app-server``.
 
@@ -44,21 +45,23 @@ def build_codex_launch_args(
     for override in config_overrides:
         codex_args.extend(["--config", override])
     codex_args.extend(["app-server", "--listen", "stdio://"])
-    return target.build_remote_exec_args(codex_args, cwd)
+    return target.build_remote_exec_args(codex_args, cwd, extra_env=launch_env)
 
 
 def build_remote_codex_client_factory(
     target: SshLaunchTargetConfig,
     cli_args: tuple[str, ...] = (),
     config_overrides: tuple[str, ...] = (),
+    launch_env: dict[str, str] | None = None,
 ) -> ClientFactory:
     def factory(cwd: str, approval_handler: ApprovalCallback) -> CodexClient:
         launch_cwd = cwd or target.default_cwd
         return CodexClient(
             config=CodexConfig(
                 launch_args_override=build_codex_launch_args(
-                    target, launch_cwd, cli_args, config_overrides
+                    target, launch_cwd, cli_args, config_overrides, launch_env
                 ),
+                env=launch_env,
                 client_name="waypoint",
                 client_title="Waypoint",
             ),

--- a/backend/src/waypoint/backends/codex/schemas.py
+++ b/backend/src/waypoint/backends/codex/schemas.py
@@ -10,8 +10,9 @@ so callers don't need to import these types directly.
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
+from waypoint.launch_env import LaunchEnv
 from waypoint.schemas import LaunchMode, SessionTransportId
 
 
@@ -41,6 +42,7 @@ class CodexThreadImportRequest(BaseModel):
     # ``launch_mode`` and must be one the agent declares (the runtime
     # rejects mismatches with 400).
     transport: SessionTransportId | None = None
+    launch_env: LaunchEnv = Field(default_factory=dict)
     # When true (default), the prior conversation is replayed into the new
     # session's transcript at import time; when false the transcript starts
     # empty and only the underlying agent resumes its own context.

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -121,6 +121,7 @@ class OpenCodeAdapter:
         on_server_died: ServerDiedCallback | None = None,
         workdir: str | None = None,
         extra_args: tuple[str, ...] = (),
+        launch_env: dict[str, str] | None = None,
     ) -> None:
         self._emit_event = emit_event
         self._on_session_update = on_session_update
@@ -132,6 +133,7 @@ class OpenCodeAdapter:
         self._on_server_died_callback = on_server_died
         self._workdir = workdir
         self._extra_args = extra_args
+        self._launch_env = dict(launch_env or {})
         self._sessions: dict[str, OpenCodeSessionState] = {}
         self._remote_sessions: dict[str, str] = {}
         self._part_sessions: dict[str, str] = {}
@@ -179,6 +181,7 @@ class OpenCodeAdapter:
             stderr=asyncio.subprocess.PIPE,
             start_new_session=True,
             cwd=cwd,
+            env={**os.environ, **self._launch_env},
         )
 
         bound_port = await self._read_local_listening_port()
@@ -231,7 +234,11 @@ class OpenCodeAdapter:
             self._launch_target.remote_bin_for("opencode", "opencode") or "opencode"
         )
         args = build_remote_serve_args(
-            self._launch_target, binary, self._workdir, self._extra_args
+            self._launch_target,
+            binary,
+            self._workdir,
+            self._extra_args,
+            self._launch_env,
         )
         log.info(
             "starting remote opencode server on %s", self._launch_target.ssh_destination

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, HTTPException, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from waypoint.backends.base import DefaultLaunchContract
 from waypoint.backends.capabilities import (
@@ -22,6 +22,7 @@ from waypoint.backends.opencode.normalize import historical_events_from_messages
 from waypoint.backends.opencode.pane import composer_ready, composer_submitted
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.git_meta import GitMeta
+from waypoint.launch_env import LaunchEnv
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
     CommandCompletion,
@@ -85,6 +86,9 @@ OPENCODE_REASONING_EFFORTS = (
     "extra high",
     "max",
 )
+
+OpenCodeLaunchEnvKey = tuple[tuple[str, str], ...]
+OpenCodeAdapterKey = tuple[str | None, str, tuple[str, ...], OpenCodeLaunchEnvKey]
 OPENCODE_REASONING_EFFORT_LEVELS = dict(
     (level.lower(), i) for i, level in enumerate(OPENCODE_REASONING_EFFORTS)
 )
@@ -111,6 +115,15 @@ def _ruleset_for_mode(mode: str | None) -> list[dict[str, str]] | None:
     return [{"permission": "*", "pattern": "*", "action": mode}]
 
 
+def _agent_process_env(
+    runtime: "SessionRuntime", backend: str, launch_env: dict[str, str]
+) -> dict[str, str]:
+    merger = getattr(runtime, "_agent_process_env", None)
+    if callable(merger):
+        return merger(backend, launch_env)
+    return dict(launch_env)
+
+
 class OpenCodePluginConfig(PluginConfig):
     pass
 
@@ -124,6 +137,7 @@ class OpenCodeThreadImportRequest(BaseModel):
     # transport (e.g. the tmux wrapper) is rejected with 400 since there is no
     # resume-via-tmux path for OpenCode. ``None`` keeps the native behavior.
     transport: SessionTransportId | None = None
+    launch_env: LaunchEnv = Field(default_factory=dict)
     # When true (default), the prior conversation is replayed into the new
     # session's transcript at import time; when false the transcript starts
     # empty and only the underlying agent resumes its own context.
@@ -180,24 +194,18 @@ class OpenCodePlugin(DefaultLaunchContract):
     )
 
     def __init__(self) -> None:
-        # Adapter key is (launch_target_id, normalized_cwd, extra_args).
-        # Sessions with distinct custom_cli_args get their own server process.
-        self._adapters: dict[
-            tuple[str | None, str, tuple[str, ...]], OpenCodeAdapter
-        ] = {}
+        # Adapter key is (launch_target_id, normalized_cwd, extra_args, env).
+        # Sessions with distinct custom_cli_args or env get their own server process.
+        self._adapters: dict[OpenCodeAdapterKey, OpenCodeAdapter] = {}
         # Per-adapter health (cooldown after death + circuit breaker after
         # repeated launch failures). Keyed identically to ``_adapters`` so
         # one entry survives adapter object replacement.
-        self._health: dict[tuple[str | None, str, tuple[str, ...]], AdapterHealth] = {}
+        self._health: dict[OpenCodeAdapterKey, AdapterHealth] = {}
         # Reconnect tasks keyed on adapter key so a single launch_target
         # never has more than one reconnect loop running concurrently.
-        self._reconnect_tasks: dict[
-            tuple[str | None, str, tuple[str, ...]], asyncio.Task[None]
-        ] = {}
+        self._reconnect_tasks: dict[OpenCodeAdapterKey, asyncio.Task[None]] = {}
         # Sessions tracked by the reconnect loop per adapter key.
-        self._reconnect_targets: dict[
-            tuple[str | None, str, tuple[str, ...]], set[str]
-        ] = {}
+        self._reconnect_targets: dict[OpenCodeAdapterKey, set[str]] = {}
         self._lock = asyncio.Lock()
         self._pending_tasks: set[asyncio.Task[Any]] = set()
         self._shutting_down = False
@@ -250,11 +258,13 @@ class OpenCodePlugin(DefaultLaunchContract):
         launch_target_id: str | None,
         cwd: str | None,
         custom_args: tuple[str, ...] = (),
-    ) -> tuple[str | None, str, tuple[str, ...]]:
+        launch_env: dict[str, str] | None = None,
+    ) -> OpenCodeAdapterKey:
         return (
             launch_target_id,
             self._adapter_cwd(runtime, launch_target_id, cwd),
             custom_args,
+            tuple(sorted((launch_env or {}).items())),
         )
 
     def _find_adapter_for_launch_target(
@@ -280,9 +290,10 @@ class OpenCodePlugin(DefaultLaunchContract):
         launch_target_id: str | None = None,
         cwd: str | None = None,
         custom_args: tuple[str, ...] = (),
+        launch_env: dict[str, str] | None = None,
     ) -> OpenCodeAdapter:
         adapter = self._adapters.get(
-            self._adapter_key(runtime, launch_target_id, cwd, custom_args)
+            self._adapter_key(runtime, launch_target_id, cwd, custom_args, launch_env)
         )
         if adapter is None:
             raise HTTPException(
@@ -316,6 +327,9 @@ class OpenCodePlugin(DefaultLaunchContract):
                             self._effective_args(
                                 runtime, session.launch_target_id, session.args
                             )
+                        ),
+                        launch_env=_agent_process_env(
+                            runtime, self.id, session.launch_env
                         ),
                     )
                     target_mode = adapter.get_pre_plan_mode(session.id) or "default"
@@ -353,9 +367,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                     )
                 )
 
-    def _health_for(
-        self, key: tuple[str | None, str, tuple[str, ...]]
-    ) -> AdapterHealth:
+    def _health_for(self, key: OpenCodeAdapterKey) -> AdapterHealth:
         if key not in self._health:
             self._health[key] = AdapterHealth()
         return self._health[key]
@@ -366,11 +378,14 @@ class OpenCodePlugin(DefaultLaunchContract):
         launch_target_id: str | None,
         cwd: str | None,
         custom_args: tuple[str, ...] = (),
+        launch_env: dict[str, str] | None = None,
         *,
         user_initiated: bool = False,
     ) -> OpenCodeAdapter:
         async with self._lock:
-            key = self._adapter_key(runtime, launch_target_id, cwd, custom_args)
+            key = self._adapter_key(
+                runtime, launch_target_id, cwd, custom_args, launch_env
+            )
             if key in self._adapters:
                 return self._adapters[key]
 
@@ -416,6 +431,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                 on_server_died=_on_server_died,
                 workdir=key[1],
                 extra_args=custom_args,
+                launch_env=dict(key[3]),
             )
             self._adapters[key] = adapter
             return adapter
@@ -423,7 +439,7 @@ class OpenCodePlugin(DefaultLaunchContract):
     def _handle_server_died(
         self,
         runtime: "SessionRuntime",
-        key: tuple[str | None, str, tuple[str, ...]],
+        key: OpenCodeAdapterKey,
         active_session_ids: list[str],
     ) -> None:
         # Synchronous bridge from the adapter's `_on_server_died` into the
@@ -439,7 +455,7 @@ class OpenCodePlugin(DefaultLaunchContract):
     def _ensure_reconnect_task(
         self,
         runtime: "SessionRuntime",
-        key: tuple[str | None, str, tuple[str, ...]],
+        key: OpenCodeAdapterKey,
     ) -> None:
         existing = self._reconnect_tasks.get(key)
         if existing is not None and not existing.done():
@@ -456,7 +472,7 @@ class OpenCodePlugin(DefaultLaunchContract):
     async def _reconnect_loop(
         self,
         runtime: "SessionRuntime",
-        key: tuple[str | None, str, tuple[str, ...]],
+        key: OpenCodeAdapterKey,
     ) -> None:
         # Capped exponential backoff that loops forever until either every
         # tracked session is gone (user deleted them) or the plugin is
@@ -479,7 +495,12 @@ class OpenCodePlugin(DefaultLaunchContract):
                 # really touching SSH. The gate exists to fail-fast
                 # passive HTTP callers, not the loop.
                 adapter = await self._get_or_create_adapter(
-                    runtime, key[0], key[1] or None, key[2], user_initiated=True
+                    runtime,
+                    key[0],
+                    key[1] or None,
+                    key[2],
+                    dict(key[3]),
+                    user_initiated=True,
                 )
                 await adapter.start()
                 health = self._health_for(key)
@@ -511,7 +532,7 @@ class OpenCodePlugin(DefaultLaunchContract):
     async def _restore_after_reconnect(
         self,
         runtime: "SessionRuntime",
-        key: tuple[str | None, str, tuple[str, ...]],
+        key: OpenCodeAdapterKey,
     ) -> None:
         targets = list(self._reconnect_targets.get(key, set()))
         for session_id in targets:
@@ -609,6 +630,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         # Drop this session from any in-flight reconnect-loop target set so
         # an explicit terminate can't be silently undone by a later loop
@@ -638,6 +660,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         health = self._health.get(key)
         if health is not None:
@@ -666,6 +689,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                         runtime, session.launch_target_id, session.args
                     )
                 ),
+                _agent_process_env(runtime, self.id, session.launch_env),
             )
         )
         if adapter is not None:
@@ -724,6 +748,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
 
         if mode == "plan":
@@ -779,6 +804,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         success = await adapter.set_model(session.id, model)
         if not success:
@@ -800,6 +826,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         success = await adapter.set_effort(session.id, effort)
         if not success:
@@ -901,6 +928,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                         runtime, session.launch_target_id, session.args
                     )
                 ),
+                _agent_process_env(runtime, self.id, session.launch_env),
             )
             commands = await adapter.list_commands(session.id)
         except Exception:
@@ -1099,6 +1127,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
 
         if command == "compact":
@@ -1192,6 +1221,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         request_id = tool_use_id or adapter.current_question_id(session.id)
         if not request_id:
@@ -1253,6 +1283,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             tuple(
                 self._effective_args(runtime, session.launch_target_id, session.args)
             ),
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         try:
             adapter = await self._get_or_create_adapter(
@@ -1264,6 +1295,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                         runtime, session.launch_target_id, session.args
                     )
                 ),
+                launch_env=_agent_process_env(runtime, self.id, session.launch_env),
             )
         except Exception as exc:
             self._health_for(key).record_failure()
@@ -1330,6 +1362,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             session.launch_target_id,
             session.cwd,
             effective_args,
+            _agent_process_env(runtime, self.id, session.launch_env),
         )
         try:
             adapter = await self._get_or_create_adapter(
@@ -1337,6 +1370,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                 session.launch_target_id,
                 session.cwd,
                 custom_args=effective_args,
+                launch_env=_agent_process_env(runtime, self.id, session.launch_env),
             )
         except Exception as exc:
             self._health_for(key).record_failure()
@@ -1405,6 +1439,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             effort=session.effort,
             args=session.args,
             config_overrides=session.config_overrides,
+            launch_env=session.launch_env,
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)
@@ -1526,16 +1561,19 @@ class OpenCodePlugin(DefaultLaunchContract):
                     detail="session already imported",
                 )
 
+        request_launch_env = getattr(request, "launch_env", {})
+        process_env = _agent_process_env(runtime, self.id, request_launch_env)
         # Fetch the session first so the adapter we cache and the
         # SessionRecord we persist agree on cwd. The session already exists
         # on the OpenCode server with whatever directory it was created in;
         # keying the adapter by `requested_cwd` here would orphan it from
         # later `_require_adapter(..., session.cwd)` lookups.
-        fetch_adapter = self._find_adapter_for_launch_target(launch_target_id)
-        if fetch_adapter is None:
-            fetch_adapter = await self._get_or_create_adapter(
-                runtime, launch_target_id, requested_cwd
-            )
+        fetch_adapter = await self._get_or_create_adapter(
+            runtime,
+            launch_target_id,
+            requested_cwd,
+            launch_env=process_env,
+        )
         sess = await fetch_adapter.get_session(opencode_session_id)
         if not sess:
             raise HTTPException(
@@ -1548,7 +1586,9 @@ class OpenCodePlugin(DefaultLaunchContract):
             if isinstance(raw_directory, str) and raw_directory
             else (requested_cwd or ".")
         )
-        adapter = await self._get_or_create_adapter(runtime, launch_target_id, cwd)
+        adapter = await self._get_or_create_adapter(
+            runtime, launch_target_id, cwd, launch_env=process_env
+        )
         session_id = runtime._generate_session_id(self.id)
         session_dir = runtime._session_dir(session_id)
         raw_log = session_dir / "raw.log"
@@ -1573,6 +1613,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             structured_log_path=str(structured_log),
             transport_state={"opencode_session_id": opencode_session_id},
             permission_mode="ask",
+            launch_env=request_launch_env,
         )
         runtime.storage.create_session(session)
         try:
@@ -1633,6 +1674,7 @@ class OpenCodePlugin(DefaultLaunchContract):
         resolved_effort: str | None,
     ) -> SessionRecord:
         launch_target_id = launch_target.id if launch_target else None
+        process_env = _agent_process_env(runtime, self.id, request.launch_env)
         try:
             adapter = await self._get_or_create_adapter(
                 runtime,
@@ -1645,6 +1687,7 @@ class OpenCodePlugin(DefaultLaunchContract):
                         request.args,
                     )
                 ),
+                launch_env=process_env,
             )
         except Exception as exc:
             raise HTTPException(
@@ -1676,6 +1719,7 @@ class OpenCodePlugin(DefaultLaunchContract):
             model=resolved_model,
             effort=resolved_effort,
             args=request.args,
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
 

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -118,10 +118,7 @@ def _ruleset_for_mode(mode: str | None) -> list[dict[str, str]] | None:
 def _agent_process_env(
     runtime: "SessionRuntime", backend: str, launch_env: dict[str, str]
 ) -> dict[str, str]:
-    merger = getattr(runtime, "_agent_process_env", None)
-    if callable(merger):
-        return merger(backend, launch_env)
-    return dict(launch_env)
+    return runtime._agent_process_env(backend, launch_env)
 
 
 class OpenCodePluginConfig(PluginConfig):
@@ -1561,19 +1558,21 @@ class OpenCodePlugin(DefaultLaunchContract):
                     detail="session already imported",
                 )
 
-        request_launch_env = getattr(request, "launch_env", {})
+        request_launch_env = request.launch_env
         process_env = _agent_process_env(runtime, self.id, request_launch_env)
-        # Fetch the session first so the adapter we cache and the
-        # SessionRecord we persist agree on cwd. The session already exists
-        # on the OpenCode server with whatever directory it was created in;
-        # keying the adapter by `requested_cwd` here would orphan it from
-        # later `_require_adapter(..., session.cwd)` lookups.
-        fetch_adapter = await self._get_or_create_adapter(
-            runtime,
-            launch_target_id,
-            requested_cwd,
-            launch_env=process_env,
-        )
+        # Fetch through any live adapter for this target first. The OpenCode
+        # session already exists on that server with whatever directory it was
+        # created in; after fetching metadata we cache the driving adapter
+        # under the actual session cwd so later _require_adapter(...,
+        # session.cwd) lookups find it.
+        fetch_adapter = self._find_adapter_for_launch_target(launch_target_id)
+        if fetch_adapter is None:
+            fetch_adapter = await self._get_or_create_adapter(
+                runtime,
+                launch_target_id,
+                requested_cwd,
+                launch_env=process_env,
+            )
         sess = await fetch_adapter.get_session(opencode_session_id)
         if not sess:
             raise HTTPException(

--- a/backend/src/waypoint/backends/opencode/remote.py
+++ b/backend/src/waypoint/backends/opencode/remote.py
@@ -15,10 +15,13 @@ def build_remote_serve_args(
     opencode_bin: str,
     cwd: str | None = None,
     extra_args: tuple[str, ...] = (),
+    launch_env: dict[str, str] | None = None,
 ) -> tuple[str, ...]:
     # Pass cwd as $1 so the script's clean (rcfile-free) subshell can cd
     # itself — outer-shell cd is fragile when user rcfiles wrap `cd`
     # (oh-my-bash plugins do). Extra CLI args follow as $2…$# and the
     # script `shift`s the cwd off so $@ ends up holding only those flags.
     cmd = ["bash", "-c", REMOTE_SERVE_SCRIPT, opencode_bin, cwd or "", *extra_args]
-    return with_ssh_keepalive(target.build_remote_exec_args(cmd, None))
+    return with_ssh_keepalive(
+        target.build_remote_exec_args(cmd, None, extra_env=launch_env)
+    )

--- a/backend/src/waypoint/backends/plugin_config.py
+++ b/backend/src/waypoint/backends/plugin_config.py
@@ -18,6 +18,8 @@ errors surface at startup rather than first runtime access.
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from waypoint.launch_env import LaunchEnv
+
 
 class PluginConfig(BaseModel):
     """Base class for per-plugin global config blocks.
@@ -38,6 +40,9 @@ class PluginConfig(BaseModel):
     local_bin: str | None = None
     # Additional CLI arguments to pass to the agent binary when launched locally.
     cli_args: list[str] = Field(default_factory=list)
+    # Environment variables added to local agent launches. Per-launch values
+    # from the UI/API override these defaults.
+    env: LaunchEnv = Field(default_factory=dict)
 
 
 class PluginLaunchTargetConfig(BaseModel):
@@ -57,3 +62,6 @@ class PluginLaunchTargetConfig(BaseModel):
     remote_bin: str | None = None
     # Additional CLI arguments to pass to the agent binary on this specific target.
     cli_args: list[str] = Field(default_factory=list)
+    # Environment variables added to agent launches on this SSH target. These
+    # override global plugin env defaults; per-launch values override both.
+    env: LaunchEnv = Field(default_factory=dict)

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -50,6 +50,17 @@ def _unsupported(action: str) -> Never:
     )
 
 
+def _default_launch_env(
+    runtime: "SessionRuntime",
+    backend: str,
+    launch_target: SshLaunchTargetConfig | None,
+) -> dict[str, str]:
+    resolver = getattr(runtime, "_default_launch_env", None)
+    if callable(resolver):
+        return resolver(backend, launch_target)
+    return {}
+
+
 class TmuxPluginConfig(PluginConfig):
     """Tmux fallback plugin configuration block.
 
@@ -436,6 +447,7 @@ class TmuxPlugin:
                 session.cwd,
                 allocate_tty=True,
                 session_id=session.id,
+                launch_env=session.launch_env,
             )
         except HTTPException as exc:
             await runtime._record_system_event(
@@ -782,6 +794,7 @@ class TmuxPlugin:
             request.cwd,
             allocate_tty=True,
             session_id=session_id,
+            launch_env=request.launch_env,
         )
         try:
             target = await runtime.tmux.start_managed_session(
@@ -827,6 +840,7 @@ class TmuxPlugin:
             permission_mode=persisted_permission_mode,
             model=resolved_model,
             effort=persisted_effort,
+            launch_env=request.launch_env,
         )
         runtime.storage.create_session(session)
         await runtime._record_system_event(
@@ -850,6 +864,7 @@ class TmuxPlugin:
         cwd: str,
         launch_target_id: str | None,
         title: str,
+        launch_env: dict[str, str] | None = None,
     ) -> SessionRecord:
         """Create a tmux-wrapped session that resumes an existing thread.
 
@@ -862,6 +877,11 @@ class TmuxPlugin:
         """
         inner = self._agent_launch(runtime, backend)
         launch_target = runtime._find_launch_target(launch_target_id)
+        effective_launch_env = (
+            dict(launch_env)
+            if launch_env is not None
+            else _default_launch_env(runtime, backend, launch_target)
+        )
         if not await inner.conversation_exists(thread_id, cwd, launch_target):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -880,6 +900,7 @@ class TmuxPlugin:
                 cwd,
                 allocate_tty=True,
                 session_id=session_id,
+                launch_env=effective_launch_env,
             )
         except HTTPException:
             raise
@@ -930,6 +951,7 @@ class TmuxPlugin:
             raw_log_path=str(raw_log),
             structured_log_path=str(structured_log),
             transport_state=transport_state,
+            launch_env=effective_launch_env,
         )
         runtime.storage.create_session(session)
         await runtime._record_system_event(

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -55,10 +55,7 @@ def _default_launch_env(
     backend: str,
     launch_target: SshLaunchTargetConfig | None,
 ) -> dict[str, str]:
-    resolver = getattr(runtime, "_default_launch_env", None)
-    if callable(resolver):
-        return resolver(backend, launch_target)
-    return {}
+    return runtime._default_launch_env(backend, launch_target)
 
 
 class TmuxPluginConfig(PluginConfig):

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -25,6 +25,7 @@ from waypoint.client import (
     session_status_from_envelope,
     write_cli_token,
 )
+from waypoint.launch_env import validate_launch_env
 from waypoint.schemas import (
     LaunchMode,
     SessionAttachRequest,
@@ -390,6 +391,16 @@ def session_start(
         ),
     ] = None,
     title: Annotated[str | None, typer.Option()] = None,
+    launch_env: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--launch-env",
+            help=(
+                "Environment variable for the agent process as KEY=VALUE. "
+                "Repeatable; values may contain '='."
+            ),
+        ),
+    ] = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Start a session in-process and print it as JSON."""
@@ -402,6 +413,9 @@ def session_start(
             launch_mode=launch_mode,
             transport=transport,
             title=title,
+            launch_env=(
+                _parse_launch_env(launch_env) if launch_env is not None else None
+            ),
             args=args or [],
         )
     )
@@ -434,6 +448,7 @@ async def _session_start(
     launch_mode: LaunchMode | None,
     transport: str | None,
     title: str | None,
+    launch_env: dict[str, str] | None,
     args: list[str],
 ) -> None:
     context = AppContext(settings)
@@ -446,6 +461,8 @@ async def _session_start(
             "title": title,
             "args": list(args),
         }
+        if launch_env is not None:
+            request_fields["launch_env"] = launch_env
         # Omit launch_mode when unset so the request model's AUTO default applies.
         if launch_mode is not None:
             request_fields["launch_mode"] = launch_mode.value
@@ -533,6 +550,19 @@ def _parse_meta(items: list[str] | None) -> dict[str, str]:
             raise typer.BadParameter(f"--meta expects key=value, got: {item}")
         metadata[key] = value
     return metadata
+
+
+def _parse_launch_env(items: list[str] | None) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for item in items or []:
+        key, sep, value = item.partition("=")
+        if not sep:
+            raise typer.BadParameter(f"--launch-env expects KEY=VALUE, got: {item}")
+        env[key] = value
+    try:
+        return validate_launch_env(env)
+    except (TypeError, ValueError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
 
 
 def _parse_tags(items: list[str] | None) -> dict[str, str]:
@@ -1535,6 +1565,16 @@ def sessions_start(
             "Filter later with `sessions list --tag` / `reap --tag`.",
         ),
     ] = None,
+    launch_env: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--launch-env",
+            help=(
+                "Environment variable for the agent process as KEY=VALUE. "
+                "Repeatable; values may contain '='."
+            ),
+        ),
+    ] = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Launch a new session on the running server."""
@@ -1544,6 +1584,7 @@ def sessions_start(
         worktree_path = _create_worktree(worktree, worktree_base, cwd)
         effective_cwd = worktree_path
     tags = _parse_tags(tag)
+    launch_env_map = _parse_launch_env(launch_env) if launch_env is not None else None
 
     def _run(c: WaypointClient) -> dict[str, Any]:
         if permission_mode is not None:
@@ -1565,6 +1606,7 @@ def sessions_start(
                 worktree_path=worktree_path,
                 args=list(args or []),
                 tags=tags,
+                launch_env=launch_env_map,
             )
         }
 
@@ -2023,6 +2065,16 @@ def sessions_import(
             ),
         ),
     ] = None,
+    launch_env: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--launch-env",
+            help=(
+                "Environment variable for the agent process as KEY=VALUE. "
+                "Repeatable; values may contain '='."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Import a backend-native thread into Waypoint.
 
@@ -2034,6 +2086,8 @@ def sessions_import(
         body["thread_id"] = thread_id
     if import_history is not None:
         body["import_history"] = import_history
+    if launch_env is not None:
+        body["launch_env"] = _parse_launch_env(launch_env)
     if not body.get("thread_id"):
         raise typer.BadParameter("pass --thread-id or a --json body with thread_id")
     _emit(
@@ -2626,6 +2680,16 @@ def schedule_create(
         str | None,
         typer.Option("--prompt", help="Initial prompt sent to the session on launch."),
     ] = None,
+    launch_env: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--launch-env",
+            help=(
+                "Environment variable for the agent process as KEY=VALUE. "
+                "Repeatable; values may contain '='."
+            ),
+        ),
+    ] = None,
     delay_seconds: Annotated[
         int | None,
         typer.Option(help="Launch this many seconds from now."),
@@ -2637,6 +2701,7 @@ def schedule_create(
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Schedule a session launch on the running server."""
+    launch_env_map = _parse_launch_env(launch_env) if launch_env is not None else None
     _emit(
         _settings_from_ctx(ctx),
         lambda c: {
@@ -2654,6 +2719,7 @@ def schedule_create(
                 args=list(args or []),
                 delay_seconds=delay_seconds,
                 scheduled_at=scheduled_at,
+                launch_env=launch_env_map,
             )
         },
     )

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -302,6 +302,7 @@ class WaypointClient:
         worktree_path: str | None = None,
         args: list[str] | None = None,
         tags: dict[str, str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {
             "backend": backend,
@@ -324,6 +325,8 @@ class WaypointClient:
         # today's launch_mode-derived behavior.
         if transport is not None:
             body["transport"] = transport
+        if launch_env is not None:
+            body["launch_env"] = launch_env
         data: dict[str, Any] = self._request("POST", "/api/sessions", json=body).json()[
             "session"
         ]
@@ -683,6 +686,7 @@ class WaypointClient:
         args: list[str] | None = None,
         delay_seconds: int | None = None,
         scheduled_at: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"backend": backend, "cwd": cwd, "args": args or []}
         # Omit unset optionals so the server's model defaults apply. Sending an
@@ -700,6 +704,7 @@ class WaypointClient:
             "initial_prompt": initial_prompt,
             "delay_seconds": delay_seconds,
             "scheduled_at": scheduled_at,
+            "launch_env": launch_env,
         }
         body.update(
             {key: value for key, value in optional.items() if value is not None}

--- a/backend/src/waypoint/launch_env.py
+++ b/backend/src/waypoint/launch_env.py
@@ -1,0 +1,23 @@
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
+
+
+def validate_launch_env(value: Any) -> dict[str, str]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise TypeError("launch env must be a mapping of variable names to values")
+    env: dict[str, str] = {}
+    for raw_key, raw_value in value.items():
+        if not isinstance(raw_key, str) or not raw_key:
+            raise ValueError("launch env variable names must be non-empty strings")
+        if "=" in raw_key or "\x00" in raw_key:
+            raise ValueError(f"invalid launch env variable name: {raw_key!r}")
+        if raw_value is None:
+            raise ValueError(f"launch env variable {raw_key!r} cannot be null")
+        env[raw_key] = str(raw_value)
+    return env
+
+
+LaunchEnv = Annotated[dict[str, str], BeforeValidator(validate_launch_env)]

--- a/backend/src/waypoint/launch_env.py
+++ b/backend/src/waypoint/launch_env.py
@@ -16,7 +16,10 @@ def validate_launch_env(value: Any) -> dict[str, str]:
             raise ValueError(f"invalid launch env variable name: {raw_key!r}")
         if raw_value is None:
             raise ValueError(f"launch env variable {raw_key!r} cannot be null")
-        env[raw_key] = str(raw_value)
+        coerced = str(raw_value)
+        if "\x00" in coerced:
+            raise ValueError(f"launch env variable {raw_key!r} cannot contain NUL")
+        env[raw_key] = coerced
     return env
 
 

--- a/backend/src/waypoint/launch_targets.py
+++ b/backend/src/waypoint/launch_targets.py
@@ -214,10 +214,10 @@ class SshLaunchTargetConfig(BaseModel):
         thread enumerator) need stdin as a real pipe.
         """
         ssh_bin = _resolve_local_binary(self.ssh_bin)
-        # Plugin contributions (e.g. claude's ``CLAUDE_CODE_NO_FLICKER=1``)
-        # form the base; user-supplied ``remote_env`` overrides on key
-        # collision so explicit yaml config still wins.
-        merged_env = {**(extra_env or {}), **self.remote_env}
+        # Target-wide remote_env is the base. Call-site extra_env can include
+        # runtime-required values (e.g. WAYPOINT_SESSION_ID), so it must win
+        # on collisions.
+        merged_env = {**self.remote_env, **(extra_env or {})}
         remote_parts: list[str] = []
         if cwd:
             remote_parts.extend([f"cd {quote_remote_path(cwd)}", "&&"])

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
-from typing import Any, TextIO
+from typing import Any, TextIO, cast
 
 from fastapi import HTTPException, status
 
@@ -399,6 +399,40 @@ class SessionRuntime:
                 ),
             )
 
+    def _default_launch_env(
+        self,
+        backend: str,
+        launch_target: SshLaunchTargetConfig | None = None,
+    ) -> dict[str, str]:
+        env = dict(self.settings.plugin_config(backend).env)
+        if launch_target is not None:
+            env.update(launch_target.plugin_config(backend).env)
+        return env
+
+    def _effective_launch_env_for_request(
+        self,
+        request: Any,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> dict[str, str]:
+        if "launch_env" in request.model_fields_set:
+            return dict(request.launch_env)
+        return self._default_launch_env(request.backend, launch_target)
+
+    def _agent_process_env(
+        self,
+        backend: str,
+        launch_env: dict[str, str],
+        *,
+        session_id: str | None = None,
+    ) -> dict[str, str]:
+        plugin = self.registry.get(backend)
+        env = {**launch_env, **plugin.extra_env}
+        if session_id:
+            # Runtime-owned keys win even if a user-supplied launch env tried
+            # to shadow them.
+            env["WAYPOINT_SESSION_ID"] = session_id
+        return env
+
     async def create_session(self, request: SessionCreateRequest) -> SessionRecord:
         if request.source_mode != SessionSource.MANAGED:
             raise HTTPException(
@@ -417,7 +451,14 @@ class SessionRuntime:
             local_cwd = request.cwd or launch_target.default_cwd
         else:
             local_cwd = require_existing_local_dir(request.cwd)
-        request = request.model_copy(update={"cwd": local_cwd})
+        request = request.model_copy(
+            update={
+                "cwd": local_cwd,
+                "launch_env": self._effective_launch_env_for_request(
+                    request, launch_target
+                ),
+            }
+        )
         title = (
             request.title
             or f"{request.backend} {Path(request.cwd).name or request.backend}"
@@ -823,6 +864,14 @@ class SessionRuntime:
                 detail=f"thread import is not supported for {backend}",
             )
         request = schema.model_validate(body)
+        launch_target_id = getattr(request, "launch_target_id", None)
+        launch_target = self._resolve_launch_target(launch_target_id, backend)
+        launch_env = (
+            dict(cast(Any, request).launch_env)
+            if "launch_env" in request.model_fields_set
+            else self._default_launch_env(backend, launch_target)
+        )
+        request = request.model_copy(update={"launch_env": launch_env})
         transport = getattr(request, "transport", None)
         if transport is not None:
             self._validate_supported_transport(backend, transport)
@@ -2012,6 +2061,10 @@ class SessionRuntime:
                     "default_cwd": target.default_cwd,
                     "auth": target.ssh_auth,
                     "connected": self.ssh_master.is_connected_cached(target),
+                    "default_launch_env_by_backend": {
+                        backend: self._default_launch_env(backend, target)
+                        for backend in target.supported_plugins()
+                    },
                 }
             )
         return summaries
@@ -2328,13 +2381,12 @@ class SessionRuntime:
         *,
         allocate_tty: bool = False,
         session_id: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> list[str]:
         plugin = self.registry.get(backend)
-        extra_env = dict(plugin.extra_env)
-        if session_id:
-            # So the wrapped agent (and any waypoint CLI it runs) knows its own
-            # session and can inherit this session's posture into children.
-            extra_env["WAYPOINT_SESSION_ID"] = session_id
+        extra_env = self._agent_process_env(
+            backend, dict(launch_env or {}), session_id=session_id
+        )
         if launch_target is None:
             executable = (
                 self.settings.plugin_config(backend).local_bin

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -109,6 +109,9 @@ class Scheduler:
             title=request.title,
             args=list(request.args),
             config_overrides=list(request.config_overrides),
+            launch_env=self._runtime._effective_launch_env_for_request(
+                request, launch_target
+            ),
             initial_prompt=request.initial_prompt,
             permission_mode=permission_mode,
             model=request.model or None,
@@ -330,6 +333,7 @@ class Scheduler:
                     title=schedule.title,
                     args=schedule.args,
                     config_overrides=schedule.config_overrides,
+                    launch_env=schedule.launch_env,
                     source_mode=SessionSource.MANAGED,
                     permission_mode=schedule.permission_mode,
                     model=schedule.model,

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -5,6 +5,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, StringConstraints
 
+from waypoint.launch_env import LaunchEnv
+
 
 def _validate_backend_id(value: Any) -> str:
     if isinstance(value, StrEnum):
@@ -217,6 +219,10 @@ class SessionRecord(BaseModel):
     # Codex uses this for ``--config K=V`` entries; other backends ignore
     # the field. Empty list = none.
     config_overrides: list[str] = Field(default_factory=list)
+    # Environment variables applied when the agent process was launched.
+    # Excluded from public dumps because values commonly contain secrets; the
+    # runtime still uses the field internally for restore/relaunch.
+    launch_env: LaunchEnv = Field(default_factory=dict, exclude=True)
     context_usage: SessionContextUsage | None = None
     rate_limit_usage: SessionRateLimitUsage | None = None
     # Free-form user/agent labels for grouping and selective teardown, e.g.
@@ -303,6 +309,10 @@ class LaunchTargetSummary(BaseModel):
     auth: Literal["key", "password"] = "key"
     # Live ControlMaster state; only meaningful when ``auth == "password"``.
     connected: bool = False
+    # Effective launch-env defaults keyed by backend id for this target.
+    default_launch_env_by_backend: dict[BackendId, LaunchEnv] = Field(
+        default_factory=dict
+    )
 
 
 class LaunchTargetConnectRequest(BaseModel):
@@ -389,6 +399,8 @@ class SessionCreateRequest(BaseModel):
     title: str | None = None
     args: list[str] = Field(default_factory=list)
     config_overrides: list[str] = Field(default_factory=list)
+    # Private in responses; schedule rows are public over the same list API.
+    launch_env: LaunchEnv = Field(default_factory=dict, exclude=True)
     source_mode: SessionSource = SessionSource.MANAGED
     # Set by the CLI from ``WAYPOINT_SESSION_ID`` when an agent inside a session
     # spawns this one. When ``permission_mode`` is unset and the spawner shares
@@ -509,6 +521,7 @@ class ScheduledSessionRecord(BaseModel):
     title: str | None = None
     args: list[str] = Field(default_factory=list)
     config_overrides: list[str] = Field(default_factory=list)
+    launch_env: LaunchEnv = Field(default_factory=dict, exclude=True)
     initial_prompt: str | None = None
     permission_mode: str | None = None
     model: str | None = None
@@ -532,6 +545,7 @@ class ScheduleCreateRequest(BaseModel):
     title: str | None = None
     args: list[str] = Field(default_factory=list)
     config_overrides: list[str] = Field(default_factory=list)
+    launch_env: LaunchEnv = Field(default_factory=dict)
     initial_prompt: str | None = None
     permission_mode: str | None = None
     model: str | None = None

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -208,6 +208,7 @@ class Storage:
                 effort TEXT,
                 args TEXT NOT NULL DEFAULT '[]',
                 config_overrides TEXT NOT NULL DEFAULT '[]',
+                launch_env TEXT NOT NULL DEFAULT '{}',
                 context_usage TEXT,
                 rate_limit_usage TEXT
             );
@@ -245,6 +246,7 @@ class Storage:
                 title TEXT,
                 args TEXT NOT NULL DEFAULT '[]',
                 config_overrides TEXT NOT NULL DEFAULT '[]',
+                launch_env TEXT NOT NULL DEFAULT '{}',
                 initial_prompt TEXT,
                 permission_mode TEXT,
                 scheduled_at TEXT NOT NULL,
@@ -331,6 +333,7 @@ class Storage:
         self._ensure_column(
             "sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
+        self._ensure_column("sessions", "launch_env", "TEXT NOT NULL DEFAULT '{}'")
         self._ensure_column("sessions", "launch_mode", "TEXT NOT NULL DEFAULT 'auto'")
         self._ensure_column("sessions", "context_usage", "TEXT")
         self._ensure_column("sessions", "rate_limit_usage", "TEXT")
@@ -340,6 +343,9 @@ class Storage:
         self._ensure_column("sessions", "tags", "TEXT NOT NULL DEFAULT '{}'")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
+        )
+        self._ensure_column(
+            "scheduled_sessions", "launch_env", "TEXT NOT NULL DEFAULT '{}'"
         )
         # Additive migration for the inbox table on databases that predate it.
         # (No-ops on a fresh DB where the CREATE TABLE above already made the
@@ -377,9 +383,9 @@ class Storage:
                 launch_mode, repo_name, branch, status, created_at, updated_at,
                 last_event_at, raw_log_path, structured_log_path, transport_state,
                 pinned_at, spawner_session_id, worktree_path, permission_mode, model,
-                resolved_model, effort, args, config_overrides, context_usage,
+                resolved_model, effort, args, config_overrides, launch_env, context_usage,
                 rate_limit_usage, tags
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -408,6 +414,7 @@ class Storage:
                 session.effort,
                 json.dumps(list(session.args)),
                 json.dumps(list(session.config_overrides)),
+                json.dumps(session.launch_env),
                 (
                     json.dumps(session.context_usage.model_dump(mode="json"))
                     if session.context_usage is not None
@@ -1351,9 +1358,9 @@ class Storage:
             """
             INSERT INTO scheduled_sessions (
                 id, backend, cwd, launch_target_id, launch_mode, transport, title, args,
-                config_overrides, initial_prompt, permission_mode, model, effort, scheduled_at,
+                config_overrides, launch_env, initial_prompt, permission_mode, model, effort, scheduled_at,
                 created_at, status, session_id, failure_reason
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 schedule.id,
@@ -1365,6 +1372,7 @@ class Storage:
                 schedule.title,
                 json.dumps(list(schedule.args)),
                 json.dumps(list(schedule.config_overrides)),
+                json.dumps(schedule.launch_env),
                 schedule.initial_prompt,
                 schedule.permission_mode,
                 schedule.model,
@@ -1720,6 +1728,14 @@ class Storage:
         payload["config_overrides"] = (
             parsed_overrides if isinstance(parsed_overrides, list) else []
         )
+        raw_launch_env = payload.get("launch_env") or "{}"
+        try:
+            parsed_launch_env = json.loads(raw_launch_env)
+        except json.JSONDecodeError:
+            parsed_launch_env = {}
+        payload["launch_env"] = (
+            parsed_launch_env if isinstance(parsed_launch_env, dict) else {}
+        )
         raw_tags = payload.get("tags") or "{}"
         try:
             parsed_tags = json.loads(raw_tags)
@@ -1771,6 +1787,14 @@ class Storage:
             parsed_overrides = []
         payload["config_overrides"] = (
             parsed_overrides if isinstance(parsed_overrides, list) else []
+        )
+        raw_launch_env = payload.get("launch_env") or "{}"
+        try:
+            parsed_launch_env = json.loads(raw_launch_env)
+        except json.JSONDecodeError:
+            parsed_launch_env = {}
+        payload["launch_env"] = (
+            parsed_launch_env if isinstance(parsed_launch_env, dict) else {}
         )
         return ScheduledSessionRecord.model_validate(payload)
 

--- a/backend/tests/golden/backends_payload.json
+++ b/backend/tests/golden/backends_payload.json
@@ -13,6 +13,7 @@
       "glyph": "C",
       "color": "#a78bfa"
     },
+    "default_launch_env": {},
     "capabilities": {
       "is_structured": true,
       "supports_resume": false,
@@ -288,6 +289,7 @@
       "glyph": "C",
       "color": "#a78bfa"
     },
+    "default_launch_env": {},
     "capabilities": {
       "is_structured": true,
       "supports_resume": true,
@@ -564,6 +566,7 @@
       "glyph": "X",
       "color": "#34d399"
     },
+    "default_launch_env": {},
     "capabilities": {
       "is_structured": true,
       "supports_resume": false,
@@ -746,6 +749,7 @@
       "glyph": "O",
       "color": "#cbd5e1"
     },
+    "default_launch_env": {},
     "capabilities": {
       "is_structured": true,
       "supports_resume": false,
@@ -939,6 +943,7 @@
       "glyph": "T",
       "color": "#94a3b8"
     },
+    "default_launch_env": {},
     "capabilities": {
       "is_structured": false,
       "supports_resume": true,

--- a/backend/tests/test_backend_capabilities_split.py
+++ b/backend/tests/test_backend_capabilities_split.py
@@ -18,6 +18,7 @@ from waypoint.backends.capabilities import (
     BackendCapabilities,
     TransportCapabilities,
 )
+from waypoint.settings import Settings
 
 _GOLDEN = Path(__file__).parent / "golden" / "backends_payload.json"
 
@@ -96,7 +97,7 @@ def test_backends_payload_matches_golden() -> None:
     fixture deliberately if the contract intentionally changes.
     """
     registry = build_default_registry()
-    live = _backend_descriptors(registry)
+    live = _backend_descriptors(registry, Settings())
     expected = json.loads(_GOLDEN.read_text())
     assert live == expected
 
@@ -106,7 +107,7 @@ def test_backends_payload_carries_split_subobjects() -> None:
     disturbing the flat ``capabilities`` block (kept byte-identical for
     existing consumers) — and the sub-objects are exactly the projections."""
     registry = build_default_registry()
-    descriptors = _backend_descriptors(registry)
+    descriptors = _backend_descriptors(registry, Settings())
     for plugin, entry in zip(registry.all(), descriptors, strict=True):
         caps = plugin.capabilities
         assert entry["capabilities"] == caps.model_dump(mode="json")

--- a/backend/tests/test_claude_remote.py
+++ b/backend/tests/test_claude_remote.py
@@ -30,6 +30,7 @@ def test_remote_claude_launch_factory_uses_stdio_permission_protocol(
         None,
         [],
         None,
+        {},
     )
 
     assert launch.cwd is None
@@ -90,6 +91,7 @@ def test_remote_claude_launch_factory_appends_model_flag(monkeypatch) -> None:
         None,
         [],
         None,
+        {},
     )
     assert "--model opus" in launch.args[-1]
 

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1561,8 +1561,7 @@ def test_sessions_start_rejects_malformed_launch_env(tmp_path: Path) -> None:
             "NOT_KEY_VALUE",
         ],
     )
-    assert result.exit_code != 0
-    assert "--launch-env expects KEY=VALUE" in result.output
+    assert result.exit_code == 2
 
 
 def test_sessions_start_worktree_git_failure_exits_one(

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -104,6 +104,9 @@ def test_help_json_is_structured() -> None:
     backend = next(o for o in start["options"] if "--backend" in o["flags"])
     assert backend["required"] is True
     assert backend["type"] == "text"
+    assert any("--launch-env" in o["flags"] for o in start["options"])
+    schedule_create = by_path["schedule create"]
+    assert any("--launch-env" in o["flags"] for o in schedule_create["options"])
 
 
 def _walk_leaf_paths(group: click.Group, prefix: str) -> list[str]:
@@ -804,6 +807,56 @@ def test_sessions_import_reads_json_file_and_emits_session(
     assert state["import_body"] == {"thread_id": "thread-1", "cwd": "/tmp/repo"}
 
 
+def test_sessions_import_launch_env_overrides_json_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload_path = tmp_path / "thread.json"
+    payload_path.write_text(
+        json.dumps(
+            {
+                "thread_id": "thread-1",
+                "launch_env": {"FROM_JSON": "old"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/claude_code/sessions/import":
+            state["import_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "imported-env"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "import",
+            "claude_code",
+            "--json",
+            str(payload_path),
+            "--launch-env",
+            "FROM_FLAG=new",
+            "--launch-env",
+            "HAS_EQUALS=a=b",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {"session": {"id": "imported-env"}}
+    assert state["import_body"] == {
+        "thread_id": "thread-1",
+        "launch_env": {"FROM_FLAG": "new", "HAS_EQUALS": "a=b"},
+    }
+
+
 def test_sessions_import_reads_stdin_when_dash(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1105,9 +1158,12 @@ def test_schedule_create_rejects_unknown_backend(tmp_path: Path) -> None:
 def test_schedule_create_emits_schedule(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    state: dict[str, object] = {}
+
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/api/schedules" and request.method == "POST":
             payload = json.loads(request.content)
+            state["payload"] = payload
             return httpx.Response(200, json={"schedule": {"id": "sc1", **payload}})
         return httpx.Response(404, json={"detail": "unexpected"})
 
@@ -1129,6 +1185,10 @@ def test_schedule_create_emits_schedule(
             "/tmp",
             "--prompt",
             "hello",
+            "--launch-env",
+            "FOO=bar",
+            "--launch-env",
+            "HAS_EQUALS=a=b",
             "--delay-seconds",
             "60",
         ],
@@ -1138,6 +1198,9 @@ def test_schedule_create_emits_schedule(
     assert out["schedule"]["id"] == "sc1"
     assert out["schedule"]["initial_prompt"] == "hello"
     assert out["schedule"]["delay_seconds"] == 60
+    payload = state["payload"]
+    assert isinstance(payload, dict)
+    assert payload["launch_env"] == {"FOO": "bar", "HAS_EQUALS": "a=b"}
 
 
 def test_parse_wait_until_defaults_and_validates() -> None:
@@ -1440,6 +1503,66 @@ def test_sessions_start_worktree_creates_worktree_and_sets_cwd(
     assert isinstance(body, dict)
     assert body["worktree_path"] == worktree_dir
     assert body["cwd"] == worktree_dir
+
+
+def test_sessions_start_launch_env_sends_request_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "POST":
+            body = json.loads(request.content)
+            state["create_body"] = body
+            return httpx.Response(200, json={"session": {"id": "new", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp/repo",
+            "--launch-env",
+            "FOO=bar",
+            "--launch-env",
+            "HAS_EQUALS=a=b",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["create_body"]
+    assert isinstance(body, dict)
+    assert body["launch_env"] == {"FOO": "bar", "HAS_EQUALS": "a=b"}
+
+
+def test_sessions_start_rejects_malformed_launch_env(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp/repo",
+            "--launch-env",
+            "NOT_KEY_VALUE",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--launch-env expects KEY=VALUE" in result.output
 
 
 def test_sessions_start_worktree_git_failure_exits_one(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from waypoint import settings as settings_module
 from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
+from waypoint.launch_env import validate_launch_env
 from waypoint.settings import DEFAULT_CONFIG_PATH, load_settings
 
 
@@ -178,6 +179,11 @@ def test_load_settings_parses_launch_env_defaults(
         "OPENAI_API_KEY": "remote-secret",
         "FEATURE_FLAG": "enabled",
     }
+
+
+def test_launch_env_rejects_nul_in_values() -> None:
+    with pytest.raises(ValueError, match="cannot contain NUL"):
+        validate_launch_env({"TOKEN": "abc\x00def"})
 
 
 def test_assistant_defaults_to_none_when_block_absent(

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -145,6 +145,41 @@ def test_load_settings_parses_plugin_configs(
     assert [model.id for model in claude_config.models] == ["opus"]
 
 
+def test_load_settings_parses_launch_env_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_file = tmp_path / "waypoint.yaml"
+    config_file.write_text(
+        "\n".join(
+            [
+                "plugin_configs:",
+                "  codex:",
+                "    env:",
+                "      OPENAI_API_KEY: local-secret",
+                "ssh_targets:",
+                "  - id: devbox",
+                "    name: Devbox",
+                "    ssh_destination: dev@example.com",
+                "    plugin_configs:",
+                "      codex:",
+                "        env:",
+                "          OPENAI_API_KEY: remote-secret",
+                "          FEATURE_FLAG: enabled",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(settings_module, "DEFAULT_CONFIG_PATH", config_file)
+    monkeypatch.delenv("WAYPOINT_CONFIG_PATH", raising=False)
+    settings = load_settings()
+    assert settings.plugin_config("codex").env == {"OPENAI_API_KEY": "local-secret"}
+    target = settings.ssh_targets[0]
+    assert target.plugin_config("codex").env == {
+        "OPENAI_API_KEY": "remote-secret",
+        "FEATURE_FLAG": "enabled",
+    }
+
+
 def test_assistant_defaults_to_none_when_block_absent(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_import_history_opencode.py
+++ b/backend/tests/test_import_history_opencode.py
@@ -307,6 +307,15 @@ async def test_import_thread_seeds_history_before_the_imported_note() -> None:
             path.mkdir(parents=True, exist_ok=True)
             return path
 
+        def _agent_process_env(
+            self,
+            backend: str,
+            launch_env: dict[str, str],
+            *,
+            session_id: str | None = None,
+        ) -> dict[str, str]:
+            return dict(launch_env)
+
         async def _record_system_event(self, *args: Any, **kwargs: Any) -> None:
             calls.append("note")
 
@@ -329,6 +338,7 @@ async def test_import_thread_seeds_history_before_the_imported_note() -> None:
             "launch_target_id": None,
             "cwd": "/repo",
             "import_history": True,
+            "launch_env": {},
         },
     )()
 
@@ -397,6 +407,15 @@ async def test_import_thread_skips_history_when_disabled() -> None:
             path.mkdir(parents=True, exist_ok=True)
             return path
 
+        def _agent_process_env(
+            self,
+            backend: str,
+            launch_env: dict[str, str],
+            *,
+            session_id: str | None = None,
+        ) -> dict[str, str]:
+            return dict(launch_env)
+
         async def _record_system_event(self, *args: Any, **kwargs: Any) -> None:
             return None
 
@@ -416,6 +435,7 @@ async def test_import_thread_skips_history_when_disabled() -> None:
             "launch_target_id": None,
             "cwd": "/repo",
             "import_history": False,
+            "launch_env": {},
         },
     )()
 

--- a/backend/tests/test_import_history_opencode.py
+++ b/backend/tests/test_import_history_opencode.py
@@ -272,7 +272,7 @@ async def test_import_thread_seeds_history_before_the_imported_note() -> None:
     ):
         return fake_adapter
 
-    plugin._get_or_create_adapter = fake_get_or_create_adapter  # type: ignore[method-assign]
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
 
     class FakeStorage:
         def __init__(self) -> None:
@@ -365,7 +365,7 @@ async def test_import_thread_skips_history_when_disabled() -> None:
     ):
         return fake_adapter
 
-    plugin._get_or_create_adapter = fake_get_or_create_adapter  # type: ignore[method-assign]
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
 
     class FakeStorage:
         def __init__(self) -> None:

--- a/backend/tests/test_launch_targets.py
+++ b/backend/tests/test_launch_targets.py
@@ -237,9 +237,9 @@ def test_build_remote_exec_args_allocates_tty_when_requested(monkeypatch) -> Non
 
 
 def test_build_remote_exec_args_merges_extra_env_with_target_env(monkeypatch) -> None:
-    """Plugin-contributed env (e.g. claude's CLAUDE_CODE_NO_FLICKER) merges
-    with the target's user-configured ``remote_env``; on key collision the
-    target wins so explicit yaml config still overrides plugin defaults."""
+    """Call-site env merges with the target's configured ``remote_env``; on key
+    collision the call-site value wins so runtime-required vars cannot be
+    shadowed by yaml config."""
     monkeypatch.setattr(
         "waypoint.launch_targets.shutil.which", lambda _: "/usr/bin/ssh"
     )
@@ -257,8 +257,8 @@ def test_build_remote_exec_args_merges_extra_env_with_target_env(monkeypatch) ->
     )
 
     remote_command = args[-1]
-    assert "FOO=from-target" in remote_command
-    assert "FOO=from-plugin" not in remote_command
+    assert "FOO=from-plugin" in remote_command
+    assert "FOO=from-target" not in remote_command
     assert "TARGET_ONLY=1" in remote_command
     assert "PLUGIN_ONLY=1" in remote_command
 

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -53,6 +53,15 @@ def _session(**overrides: Any) -> SessionRecord:
     )
 
 
+def _passthrough_agent_process_env(
+    backend: str,
+    launch_env: dict[str, str],
+    *,
+    session_id: str | None = None,
+) -> dict[str, str]:
+    return dict(launch_env)
+
+
 def test_serialize_question_answers_preserves_choices_and_notes() -> None:
     plugin = OpenCodePlugin()
 
@@ -164,6 +173,7 @@ async def test_create_plan_session_persists_plan_agent_state(tmp_path) -> None:
         storage=storage,
         settings=SimpleNamespace(plugin_config=lambda _id: OpenCodePluginConfig()),
         _find_launch_target=lambda _id: None,
+        _agent_process_env=_passthrough_agent_process_env,
         get_session=lambda session_id: storage.sessions[session_id],
     )
     request = SessionCreateRequest(
@@ -219,6 +229,7 @@ async def test_list_command_completions_reads_opencode_commands(tmp_path) -> Non
     runtime: Any = SimpleNamespace(
         settings=Settings(data_dir=tmp_path / "data"),
         _find_launch_target=lambda _id: None,
+        _agent_process_env=_passthrough_agent_process_env,
     )
 
     completions = await plugin.list_command_completions(
@@ -285,6 +296,15 @@ async def test_maybe_handle_input_routes_manual_opencode_command(tmp_path) -> No
 
         def _find_launch_target(self, launch_target_id: str | None) -> None:
             return None
+
+        def _agent_process_env(
+            self,
+            backend: str,
+            launch_env: dict[str, str],
+            *,
+            session_id: str | None = None,
+        ) -> dict[str, str]:
+            return dict(launch_env)
 
         def cached_command_completion(
             self, session_id: str, *, trigger: str, name: str
@@ -506,6 +526,7 @@ async def test_transport_routes_calls_by_session_launch_target() -> None:
         Any,
         SimpleNamespace(
             _find_launch_target=lambda _id: None,
+            _agent_process_env=_passthrough_agent_process_env,
             settings=SimpleNamespace(
                 plugin_config=lambda _id: SimpleNamespace(cli_args=[])
             ),
@@ -1037,6 +1058,7 @@ async def test_fork_plan_session_persists_pre_plan_mode(tmp_path) -> None:
         storage=storage,
         settings=SimpleNamespace(plugin_config=lambda _id: OpenCodePluginConfig()),
         _find_launch_target=lambda _id: None,
+        _agent_process_env=_passthrough_agent_process_env,
         _record_system_event=record_system_event,
         get_session=lambda session_id: storage.sessions[session_id],
     )
@@ -1128,6 +1150,15 @@ async def test_import_thread_preserves_launch_target_id() -> None:
             path.mkdir(parents=True, exist_ok=True)
             return path
 
+        def _agent_process_env(
+            self,
+            backend: str,
+            launch_env: dict[str, str],
+            *,
+            session_id: str | None = None,
+        ) -> dict[str, str]:
+            return dict(launch_env)
+
         async def _record_system_event(self, *args, **kwargs) -> None:
             return None
 
@@ -1152,6 +1183,7 @@ async def test_import_thread_preserves_launch_target_id() -> None:
             "launch_target_id": "ssh-1",
             "cwd": "/repo",
             "import_history": False,
+            "launch_env": {},
         },
     )()
 
@@ -1234,6 +1266,15 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
             path.mkdir(parents=True, exist_ok=True)
             return path
 
+        def _agent_process_env(
+            self,
+            backend: str,
+            launch_env: dict[str, str],
+            *,
+            session_id: str | None = None,
+        ) -> dict[str, str]:
+            return dict(launch_env)
+
         async def _record_system_event(self, *args, **kwargs) -> None:
             return None
 
@@ -1258,6 +1299,7 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
             "launch_target_id": "ssh-1",
             "cwd": "/repo/requested",
             "import_history": False,
+            "launch_env": {},
         },
     )()
 
@@ -1269,6 +1311,115 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
     # The final adapter lookup must be keyed by /repo/actual so future
     # _require_adapter calls (which key by session.cwd) hit a live adapter.
     assert "/repo/actual" in cwds_seen
+
+
+@pytest.mark.asyncio
+async def test_import_thread_fetches_through_existing_target_adapter() -> None:
+    plugin = OpenCodePlugin()
+
+    class FetchAdapter:
+        async def get_session(self, session_id: str) -> dict[str, object] | None:
+            return {
+                "id": session_id,
+                "title": "Imported",
+                "directory": "/repo/actual",
+            }
+
+    class DriveAdapter:
+        async def restore_session(
+            self,
+            session_id: str,
+            cwd: str,
+            opencode_session_id: str,
+            model: str | None = None,
+            agent: str | None = None,
+            effort: str | None = None,
+        ) -> None:
+            return None
+
+    plugin._adapters = cast(Any, {("ssh-1", "/already-live", (), ()): FetchAdapter()})
+    adapter_calls: list[tuple[str | None, dict[str, str] | None]] = []
+    drive_adapter = DriveAdapter()
+
+    async def fake_get_or_create_adapter(
+        runtime,
+        launch_target_id,
+        cwd,
+        custom_args=(),
+        launch_env=None,
+        *,
+        user_initiated=False,
+    ):
+        adapter_calls.append((cwd, launch_env))
+        return drive_adapter
+
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
+
+    class FakeStorage:
+        def __init__(self) -> None:
+            self.sessions: list[SessionRecord] = []
+
+        def list_sessions(self) -> list[SessionRecord]:
+            return list(self.sessions)
+
+        def create_session(self, session: SessionRecord) -> None:
+            self.sessions.append(session)
+
+        def update_session(self, session_id: str, **kwargs) -> SessionRecord:
+            session = self.sessions[-1]
+            for key, value in kwargs.items():
+                setattr(session, key, value)
+            return session
+
+    class FakeRuntime:
+        def __init__(self) -> None:
+            self.storage = FakeStorage()
+
+        def _agent_process_env(
+            self,
+            backend: str,
+            launch_env: dict[str, str],
+            *,
+            session_id: str | None = None,
+        ) -> dict[str, str]:
+            return {**launch_env, "RUNTIME": "1"}
+
+        def _generate_session_id(self, backend_id: str) -> str:
+            return f"{backend_id}-1"
+
+        def _session_dir(self, session_id: str):
+            from pathlib import Path
+
+            path = Path("/tmp") / session_id
+            path.mkdir(parents=True, exist_ok=True)
+            return path
+
+        async def _record_system_event(self, *args, **kwargs) -> None:
+            return None
+
+        async def seed_thread_history(self, session_id, reader, *, enabled) -> int:
+            return 0
+
+        def get_session(self, session_id: str) -> SessionRecord:
+            return self.storage.sessions[-1]
+
+    runtime: Any = FakeRuntime()
+    request = type(
+        "Req",
+        (),
+        {
+            "thread_id": "ses_1",
+            "launch_target_id": "ssh-1",
+            "cwd": "/repo/requested",
+            "import_history": False,
+            "launch_env": {"USER": "1"},
+        },
+    )()
+
+    result = await plugin.import_thread(runtime, request)
+
+    assert result.cwd == "/repo/actual"
+    assert adapter_calls == [("/repo/actual", {"USER": "1", "RUNTIME": "1"})]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -497,8 +497,8 @@ async def test_transport_routes_calls_by_session_launch_target() -> None:
     plugin._adapters = cast(
         Any,
         {
-            (None, "/tmp", ()): default_adapter,
-            ("ssh-1", "/tmp", ()): remote_adapter,
+            (None, "/tmp", (), ()): default_adapter,
+            ("ssh-1", "/tmp", (), ()): remote_adapter,
         },
     )
 
@@ -571,8 +571,8 @@ async def test_delete_thread_routes_to_launch_target_adapter() -> None:
     plugin._adapters = cast(
         Any,
         {
-            (None, "/tmp", ()): local,
-            ("ssh-1", "/tmp", ()): remote,
+            (None, "/tmp", (), ()): local,
+            ("ssh-1", "/tmp", (), ()): remote,
         },
     )
 
@@ -590,8 +590,8 @@ async def test_delete_thread_tries_every_adapter_until_one_deletes() -> None:
     plugin._adapters = cast(
         Any,
         {
-            (None, "/a", ()): first,
-            (None, "/b", ()): second,
+            (None, "/a", (), ()): first,
+            (None, "/b", (), ()): second,
         },
     )
 
@@ -608,8 +608,8 @@ async def test_delete_thread_short_circuits_after_first_success() -> None:
     plugin._adapters = cast(
         Any,
         {
-            (None, "/a", ()): first,
-            (None, "/b", ()): second,
+            (None, "/a", (), ()): first,
+            (None, "/b", (), ()): second,
         },
     )
 
@@ -622,7 +622,7 @@ async def test_delete_thread_short_circuits_after_first_success() -> None:
 async def test_delete_thread_returns_false_when_no_adapter_has_it() -> None:
     plugin = OpenCodePlugin()
     only = _DeleteAdapter(set())
-    plugin._adapters = cast(Any, {(None, "/tmp", ()): only})
+    plugin._adapters = cast(Any, {(None, "/tmp", (), ()): only})
 
     assert await plugin.delete_thread(cast(Any, None), "missing", None) is False
     assert only.calls == ["missing"]
@@ -644,6 +644,7 @@ async def test_get_or_create_adapter_keys_by_cwd(
             on_server_died=None,
             workdir=None,
             extra_args=(),
+            launch_env=None,
         ) -> None:
             self.workdir = workdir
 
@@ -690,6 +691,7 @@ async def test_get_or_create_adapter_normalizes_equivalent_cwds(
             on_server_died=None,
             workdir=None,
             extra_args=(),
+            launch_env=None,
         ) -> None:
             self.workdir = workdir
 
@@ -748,8 +750,8 @@ async def test_list_models_uses_target_adapter_independent_of_cwd() -> None:
     plugin._adapters = cast(
         Any,
         {
-            ("ssh-1", "/repo-a"): stale_adapter,
-            ("ssh-1", "/repo-b"): healthy_adapter,
+            ("ssh-1", "/repo-a", (), ()): stale_adapter,
+            ("ssh-1", "/repo-b", (), ()): healthy_adapter,
         },
     )
 
@@ -784,7 +786,7 @@ async def test_list_threads_ignores_cwd_and_dedupes_by_launch_target() -> None:
     plugin._adapters = cast(
         Any,
         {
-            ("ssh-1", "/repo-a"): FakeAdapter(
+            ("ssh-1", "/repo-a", (), ()): FakeAdapter(
                 [
                     {
                         "id": "ses_1",
@@ -794,7 +796,7 @@ async def test_list_threads_ignores_cwd_and_dedupes_by_launch_target() -> None:
                     }
                 ]
             ),
-            ("ssh-1", "/repo-b"): FakeAdapter(
+            ("ssh-1", "/repo-b", (), ()): FakeAdapter(
                 [
                     {
                         "id": "ses_1",
@@ -869,7 +871,7 @@ async def test_list_threads_sorts_by_updated_at_after_merging_adapters() -> None
     plugin._adapters = cast(
         Any,
         {
-            ("ssh-1", "/repo-a"): FakeAdapter(
+            ("ssh-1", "/repo-a", (), ()): FakeAdapter(
                 [
                     {
                         "id": "ses_a",
@@ -879,7 +881,7 @@ async def test_list_threads_sorts_by_updated_at_after_merging_adapters() -> None
                     }
                 ]
             ),
-            ("ssh-1", "/repo-b"): FakeAdapter(
+            ("ssh-1", "/repo-b", (), ()): FakeAdapter(
                 [
                     {
                         "id": "ses_b",
@@ -941,7 +943,7 @@ async def test_reconnect_restore_rehydrates_pre_plan_mode(tmp_path) -> None:
             return True
 
     fake_adapter = FakeAdapter()
-    key = (None, "/repo", ())
+    key = (None, "/repo", (), ())
     plugin._adapters = cast(Any, {key: fake_adapter})
     plugin._reconnect_targets[key] = {"sess"}
 
@@ -1082,13 +1084,19 @@ async def test_import_thread_preserves_launch_target_id() -> None:
     fake_adapter = FakeAdapter()
 
     async def fake_get_or_create_adapter(
-        runtime, launch_target_id, cwd, custom_args=(), *, user_initiated=False
+        runtime,
+        launch_target_id,
+        cwd,
+        custom_args=(),
+        launch_env=None,
+        *,
+        user_initiated=False,
     ):
         assert launch_target_id == "ssh-1"
         assert cwd == "/repo"
         return fake_adapter
 
-    plugin._get_or_create_adapter = fake_get_or_create_adapter  # type: ignore[method-assign]
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
 
     class FakeStorage:
         def __init__(self) -> None:
@@ -1183,12 +1191,18 @@ async def test_import_thread_keys_adapter_by_session_directory() -> None:
     cwds_seen: list[str | None] = []
 
     async def fake_get_or_create_adapter(
-        runtime, launch_target_id, cwd, custom_args=(), *, user_initiated=False
+        runtime,
+        launch_target_id,
+        cwd,
+        custom_args=(),
+        launch_env=None,
+        *,
+        user_initiated=False,
     ):
         cwds_seen.append(cwd)
         return fake_adapter
 
-    plugin._get_or_create_adapter = fake_get_or_create_adapter  # type: ignore[method-assign]
+    cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
 
     class FakeStorage:
         def __init__(self) -> None:

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -145,6 +145,7 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> None:
         self.restore_calls.append(
             (
@@ -172,6 +173,7 @@ class FakeClaudeAdapter(FakeStructuredAdapter):
         model: str | None = None,
         effort: str | None = None,
         custom_args: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> str:
         self.start_calls.append(
             (
@@ -258,6 +260,7 @@ class FakeCodexRuntimeAdapter(FakeStructuredAdapter):
         effort: str | None = None,
         custom_args: list[str] | None = None,
         config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> None:
         self.restore_calls.append(
             (session_id, cwd, thread_id, client_factory_override, model, effort)
@@ -342,6 +345,37 @@ def test_command_for_backend_injects_session_id(tmp_path) -> None:
     assert "WAYPOINT_SESSION_ID=codex-1234" in command
     cli_idx = command.index("codex")
     assert command[cli_idx:] == ["codex", "resume", "abc"]
+
+
+def test_command_for_backend_merges_launch_env_without_overriding_runtime_keys(
+    tmp_path,
+) -> None:
+    runtime, _, _ = make_runtime(tmp_path)
+    command = runtime._command_for_backend(
+        "claude_code",
+        ["--session-id", "abc"],
+        session_id="claude-1234",
+        launch_env={
+            "ANTHROPIC_AUTH_TOKEN": "secret",
+            "CLAUDE_CODE_NO_FLICKER": "user",
+            "WAYPOINT_SESSION_ID": "user",
+        },
+    )
+    assert command[0] == "env"
+    assert "ANTHROPIC_AUTH_TOKEN=secret" in command
+    assert "CLAUDE_CODE_NO_FLICKER=1" in command
+    assert "CLAUDE_CODE_NO_FLICKER=user" not in command
+    assert "WAYPOINT_SESSION_ID=claude-1234" in command
+    assert "WAYPOINT_SESSION_ID=user" not in command
+
+
+def test_session_record_excludes_launch_env_from_public_dump(tmp_path) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    session = make_session(settings, id="secret-env", launch_env={"TOKEN": "secret"})
+    storage.create_session(session)
+    stored = runtime.get_session("secret-env")
+    assert stored.launch_env == {"TOKEN": "secret"}
+    assert "launch_env" not in stored.model_dump(mode="json")
 
 
 def test_effective_permission_mode_inherits_same_backend(tmp_path) -> None:
@@ -612,6 +646,7 @@ def make_session(settings: Settings, **overrides) -> SessionRecord:
         raw_log_path=str(session_dir / "raw.log"),
         structured_log_path=str(session_dir / "events.jsonl"),
         permission_mode=overrides.get("permission_mode"),
+        launch_env=overrides.get("launch_env", {}),
     )
 
 
@@ -1304,10 +1339,19 @@ async def test_reattach_terminates_before_restoring_codex(tmp_path) -> None:
             effort: str | None = None,
             custom_args: list[str] | None = None,
             config_overrides: list[str] | None = None,
+            launch_env: dict[str, str] | None = None,
         ) -> None:
             self._log.append(f"restore:{session_id}")
             await super().restore_session(
-                session_id, cwd, thread_id, client_factory_override, model, effort
+                session_id,
+                cwd,
+                thread_id,
+                client_factory_override,
+                model,
+                effort,
+                custom_args,
+                config_overrides,
+                launch_env,
             )
 
     timeline: list[str] = []
@@ -3046,7 +3090,7 @@ async def test_import_claude_thread_terminal_supersedes_launch_mode(
     resume_calls: list[str] = []
 
     async def _fake_resume(
-        _runtime, *, backend, thread_id, cwd, launch_target_id, title
+        _runtime, *, backend, thread_id, cwd, launch_target_id, title, launch_env=None
     ):
         resume_calls.append(backend)
         session = make_session(
@@ -3354,6 +3398,7 @@ async def test_runtime_fork_codex_session_uses_codex_plugin(tmp_path) -> None:
             effort: str | None = None,
             custom_args: list[str] | None = None,
             config_overrides: list[str] | None = None,
+            launch_env: dict[str, str] | None = None,
         ) -> str:
             assert session_id.startswith("codex-")
             assert (cwd, thread_id) == ("/tmp/project", "thread-1")
@@ -3386,6 +3431,7 @@ async def test_fork_codex_plan_session_persists_pre_plan_mode(tmp_path) -> None:
             effort: str | None = None,
             custom_args: list[str] | None = None,
             config_overrides: list[str] | None = None,
+            launch_env: dict[str, str] | None = None,
         ) -> str:
             assert (session_id, cwd, thread_id) == (
                 "forked",

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -66,6 +66,23 @@ async def test_create_schedule_with_delay_persists_pending(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_schedule_persists_launch_env_privately(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex",
+            cwd="/tmp/project",
+            delay_seconds=60,
+            launch_env={"OPENAI_API_KEY": "secret"},
+        )
+    )
+    stored = runtime.storage.get_schedule(schedule.id)
+    assert stored is not None
+    assert stored.launch_env == {"OPENAI_API_KEY": "secret"}
+    assert "launch_env" not in stored.model_dump(mode="json")
+
+
+@pytest.mark.asyncio
 async def test_create_schedule_requires_time_input(tmp_path) -> None:
     runtime = make_runtime(tmp_path)
     with pytest.raises(HTTPException) as exc:
@@ -255,6 +272,35 @@ async def test_fire_passes_permission_mode_to_create_session(
     await runtime.scheduler._fire_due_schedules()
 
     assert captured == ["acceptEdits"]
+
+
+@pytest.mark.asyncio
+async def test_fire_passes_launch_env_to_create_session(tmp_path, monkeypatch) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex",
+            cwd="/tmp/project",
+            delay_seconds=0,
+            launch_env={"OPENAI_API_KEY": "secret"},
+        )
+    )
+    runtime.storage.update_schedule(
+        schedule.id, scheduled_at=datetime.now(UTC) - timedelta(seconds=1)
+    )
+    created_session = make_session(runtime.settings, "codex-env")
+    runtime.storage.create_session(created_session)
+    captured: list[dict[str, str]] = []
+
+    async def fake_create_session(request) -> SessionRecord:
+        captured.append(request.launch_env)
+        return created_session
+
+    monkeypatch.setattr(runtime, "create_session", fake_create_session)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    assert captured == [{"OPENAI_API_KEY": "secret"}]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -200,6 +200,9 @@ class _FakeRuntime:
     def _find_launch_target(self, _lt_id: str | None) -> None:
         return None
 
+    def _default_launch_env(self, backend: str, launch_target: Any) -> dict[str, str]:
+        return {}
+
     def _command_for_backend(
         self,
         backend: str,

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -209,6 +209,7 @@ class _FakeRuntime:
         *,
         allocate_tty: bool = False,
         session_id: str | None = None,
+        launch_env: dict[str, str] | None = None,
     ) -> list[str]:
         self.command_calls.append(
             {
@@ -216,6 +217,7 @@ class _FakeRuntime:
                 "args": args,
                 "allocate_tty": allocate_tty,
                 "session_id": session_id,
+                "launch_env": launch_env,
             }
         )
         return [backend, *args]

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -34,6 +34,12 @@ cors_origins: []
 # against the plugin's `config_schema` (see `backends/<id>/plugin.py`).
 # Keys here must match a registered plugin; unknown ids fail
 # validation. Omit a block to use the schema's defaults.
+#
+# `env` values reach the agent process directly for the structured local
+# transports (claude_code, codex, and opencode adapters). For the tmux /
+# claude_tty and SSH-remote transports they are rendered into the launch
+# command line, so on a shared host another user can read them via `ps`.
+# Prefer host/SSH environment over `env` for secrets on those transports.
 plugin_configs:
   codex:
     # default_model_id: gpt-5

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -39,6 +39,8 @@ plugin_configs:
     # default_model_id: gpt-5
     # default_effort: high
     # local_bin: /opt/codex/bin/codex   # path on the local host; falls back to `codex`
+    # env:                              # editable defaults surfaced in the launch panel
+    #   OPENAI_API_KEY: sk-your-key
     # cli_args:                              # raw flags for `codex …` before `app-server`
     #   - "--verbose"
     # config_overrides:                      # codex-only; each entry → `codex --config K=V`
@@ -47,6 +49,8 @@ plugin_configs:
     # default_model_id: opus
     # default_effort: high
     # local_bin: /opt/claude/bin/claude
+    # env:
+    #   ANTHROPIC_AUTH_TOKEN: sk-ant-your-key
     # cli_args:
     #   - "--dangerously-skip-permissions"
     # models:
@@ -57,6 +61,8 @@ plugin_configs:
     # default_model_id: anthropic/claude-sonnet-4-6
     # default_effort: high
     # local_bin: /opt/codex/bin/opencode
+    # env:
+    #   OPENAI_API_KEY: sk-your-key
     # cli_args:
     #   - "--max-iterations=50"
 
@@ -98,16 +104,22 @@ ssh_targets:
     plugin_configs:
       codex:
         # remote_bin: /opt/codex/bin/codex     # path on the remote host
+        # env:                                  # editable defaults for this target/backend
+        #   OPENAI_API_KEY: sk-your-key
         # cli_args:                            # raw flags before `app-server`
         #   - "--verbose"
         config_overrides:                      # codex --config K=V
           - model_reasoning_effort="high"
       claude_code:
         # remote_bin: /opt/claude/bin/claude
+        # env:
+        #   ANTHROPIC_AUTH_TOKEN: sk-ant-your-key
         # cli_args:
         #   - "--dangerously-skip-permissions"
       opencode:
         # remote_bin: /opt/codex/bin/opencode
+        # env:
+        #   OPENAI_API_KEY: sk-your-key
         # cli_args:
         #   - "--max-iterations=50"
     default_cwd: "~"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { AssistantMark } from "@/components/AssistantMark";
 import { BackendSwitcher } from "@/components/BackendSwitcher";
@@ -187,6 +187,17 @@ export default function HomePage() {
     ? (activeLaunchTarget?.default_backend ?? defaultBackend)
     : launchableBackends[0] ?? supportedBackends[0];
   const effectiveDefaultCwd = activeLaunchTarget?.default_cwd ?? defaultCwd;
+  const defaultLaunchEnvByBackend = useMemo(() => {
+    const defaults: Record<Backend, Record<string, string>> = {};
+    for (const descriptor of backendDescriptors ?? []) {
+      defaults[descriptor.id] = { ...(descriptor.default_launch_env ?? {}) };
+    }
+    const targetDefaults = activeLaunchTarget?.default_launch_env_by_backend ?? {};
+    for (const [backend, env] of Object.entries(targetDefaults)) {
+      defaults[backend] = { ...env };
+    }
+    return defaults;
+  }, [activeLaunchTarget, backendDescriptors]);
 
   const resetAuthState = useCallback((message: string) => {
     clearToken();
@@ -545,6 +556,7 @@ export default function HomePage() {
     transport: SessionTransport | null = null,
     args: string[] = [],
     configOverrides: string[] = [],
+    launchEnv: Record<string, string> = {},
     permissionMode: string | null = null,
   ) {
     setCwdError(null);
@@ -558,6 +570,7 @@ export default function HomePage() {
         source_mode: "managed",
         args,
         config_overrides: configOverrides,
+        launch_env: launchEnv,
         model,
         effort,
         permission_mode: permissionMode,
@@ -602,6 +615,7 @@ export default function HomePage() {
               transport,
               args,
               configOverrides,
+              launchEnv,
               permissionMode,
             ),
         });
@@ -651,6 +665,7 @@ export default function HomePage() {
     cwd: string,
     transport: SessionTransport | null,
     importHistory: boolean,
+    launchEnv: Record<string, string>,
   ) {
     try {
       const payload = {
@@ -661,6 +676,7 @@ export default function HomePage() {
         // pin the chosen transport and leave the launch mode on "auto".
         launch_mode: "auto",
         transport: transport || null,
+        launch_env: launchEnv,
         // Replay the thread's prior conversation into the new session's
         // transcript; false starts empty and only resumes the agent's context.
         import_history: importHistory,
@@ -991,6 +1007,7 @@ export default function HomePage() {
           token={token}
           defaultBackend={effectiveDefaultBackend}
           defaultCwd={effectiveDefaultCwd}
+          defaultLaunchEnvByBackend={defaultLaunchEnvByBackend}
           targetLabel={activeLaunchTarget?.name ?? null}
           launchTargetId={activeLaunchTargetId || null}
           recentCwds={recentCwds}

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -14,7 +14,11 @@ import {
   useTransportForAgent,
 } from "@/components/AgentTransportPicker";
 import { EffortPicker } from "@/components/EffortPicker";
-import { LaunchOptionsDetails } from "@/components/LaunchOptions";
+import {
+  formatLaunchEnv,
+  LaunchOptionsDetails,
+  parseLaunchEnv,
+} from "@/components/LaunchOptions";
 import { ModelPicker } from "@/components/ModelPicker";
 import { WorkingDirectoryField } from "@/components/WorkingDirectoryField";
 import type { BackendCatalog } from "@/lib/backends";
@@ -29,6 +33,7 @@ interface UseLaunchFormParams {
   defaultBackend: Backend;
   defaultCwd: string;
   launchTargetId: string | null;
+  defaultLaunchEnvByBackend: Record<Backend, Record<string, string>>;
   catalog: BackendCatalog;
 }
 
@@ -55,6 +60,8 @@ export interface LaunchForm {
   setCustomArgsText: (value: string) => void;
   configOverridesText: string;
   setConfigOverridesText: (value: string) => void;
+  launchEnvText: string;
+  setLaunchEnvText: (value: string) => void;
   modelInfo: BackendModelListResponse | null;
   permissionOptions: ReturnType<typeof permissionModesFor>;
   supportsCustomArgs: boolean;
@@ -63,13 +70,18 @@ export interface LaunchForm {
   effortOptions: string[];
   changeBackend: (backend: Backend) => void;
   handleModelsLoaded: (response: BackendModelListResponse) => void;
-  collectArgs: () => { args: string[]; configOverrides: string[] };
+  collectArgs: () => {
+    args: string[];
+    configOverrides: string[];
+    launchEnv: Record<string, string>;
+  };
 }
 
 export function useLaunchForm({
   defaultBackend,
   defaultCwd,
   launchTargetId,
+  defaultLaunchEnvByBackend,
   catalog,
 }: UseLaunchFormParams): LaunchForm {
   const [backend, setBackend] = useState<Backend>(defaultBackend);
@@ -81,6 +93,9 @@ export function useLaunchForm({
   const [permissionMode, setPermissionMode] = useState<string>("default");
   const [customArgsText, setCustomArgsText] = useState("");
   const [configOverridesText, setConfigOverridesText] = useState("");
+  const [launchEnvText, setLaunchEnvText] = useState(() =>
+    formatLaunchEnv(defaultLaunchEnvByBackend[defaultBackend]),
+  );
   const [modelInfo, setModelInfo] = useState<BackendModelListResponse | null>(null);
 
   const permissionOptions = useMemo(
@@ -101,14 +116,16 @@ export function useLaunchForm({
     setModel("");
     setEffort("");
     setModelInfo(null);
-  }, []);
+    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[nextBackend]));
+  }, [defaultLaunchEnvByBackend]);
 
   useEffect(() => {
     setBackend(defaultBackend);
     setModel("");
     setEffort("");
     setModelInfo(null);
-  }, [defaultBackend]);
+    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[defaultBackend]));
+  }, [defaultBackend, defaultLaunchEnvByBackend]);
 
   useEffect(() => {
     setCwd(defaultCwd);
@@ -126,7 +143,8 @@ export function useLaunchForm({
     setEffort("");
     setModel("");
     setModelInfo(null);
-  }, [backend, launchTargetId]);
+    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[backend]));
+  }, [backend, launchTargetId, defaultLaunchEnvByBackend]);
 
   const effortOptions = useMemo(() => {
     if (!modelInfo) return [];
@@ -168,8 +186,15 @@ export function useLaunchForm({
     const configOverrides = supportsConfigOverrides
       ? configOverridesText.split("\n").map((value) => value.trim()).filter(Boolean)
       : [];
-    return { args, configOverrides };
-  }, [supportsCustomArgs, supportsConfigOverrides, customArgsText, configOverridesText]);
+    const launchEnv = parseLaunchEnv(launchEnvText);
+    return { args, configOverrides, launchEnv };
+  }, [
+    supportsCustomArgs,
+    supportsConfigOverrides,
+    customArgsText,
+    configOverridesText,
+    launchEnvText,
+  ]);
 
   return {
     backend,
@@ -189,6 +214,8 @@ export function useLaunchForm({
     setCustomArgsText,
     configOverridesText,
     setConfigOverridesText,
+    launchEnvText,
+    setLaunchEnvText,
     modelInfo,
     permissionOptions,
     supportsCustomArgs,
@@ -307,6 +334,8 @@ export function LaunchFormFields({
         onCustomArgsChange={form.setCustomArgsText}
         configOverridesText={form.configOverridesText}
         onConfigOverridesChange={form.setConfigOverridesText}
+        launchEnvText={form.launchEnvText}
+        onLaunchEnvChange={form.setLaunchEnvText}
         formBusy={busy}
       />
     </>

--- a/frontend/src/components/LaunchOptions.tsx
+++ b/frontend/src/components/LaunchOptions.tsx
@@ -32,6 +32,8 @@ interface LaunchOptionsDetailsProps {
   mode: "new" | "resume";
   supportsCustomArgs?: boolean;
   supportsConfigOverrides?: boolean;
+  launchEnvText?: string;
+  onLaunchEnvChange?: (value: string) => void;
   customArgsText?: string;
   onCustomArgsChange?: (value: string) => void;
   configOverridesText?: string;
@@ -43,6 +45,8 @@ export function LaunchOptionsDetails({
   mode,
   supportsCustomArgs,
   supportsConfigOverrides,
+  launchEnvText,
+  onLaunchEnvChange,
   customArgsText,
   onCustomArgsChange,
   configOverridesText,
@@ -50,12 +54,13 @@ export function LaunchOptionsDetails({
   formBusy,
 }: LaunchOptionsDetailsProps) {
   const [open, setOpen] = useState(false);
+  const showLaunchEnv = launchEnvText !== undefined && Boolean(onLaunchEnvChange);
   const showCustomArgs = mode === "new" && Boolean(supportsCustomArgs);
   const showConfigOverrides = mode === "new" && Boolean(supportsConfigOverrides);
-  const showWarning = showCustomArgs || showConfigOverrides;
+  const showWarning = showLaunchEnv || showCustomArgs || showConfigOverrides;
 
   // Nothing to configure — don't render an empty Advanced toggle.
-  if (!showCustomArgs && !showConfigOverrides) {
+  if (!showLaunchEnv && !showCustomArgs && !showConfigOverrides) {
     return null;
   }
 
@@ -73,6 +78,22 @@ export function LaunchOptionsDetails({
       </button>
       <div className="advanced-body">
         <div className="advanced-body-inner">
+          {showLaunchEnv ? (
+            <label className="field advanced-args-field">
+              <span>Environment variables</span>
+              <textarea
+                rows={3}
+                value={launchEnvText ?? ""}
+                onChange={(e) => onLaunchEnvChange?.(e.target.value)}
+                placeholder={"One per line, e.g.\nOPENAI_API_KEY=sk-..."}
+                disabled={formBusy}
+                spellCheck={false}
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+              />
+            </label>
+          ) : null}
           {showCustomArgs ? (
             <label className="field advanced-args-field">
               <span>Custom CLI args</span>
@@ -114,4 +135,28 @@ export function LaunchOptionsDetails({
       </div>
     </div>
   );
+}
+
+export function formatLaunchEnv(env: Record<string, string> | undefined): string {
+  return Object.entries(env ?? {})
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+}
+
+export function parseLaunchEnv(text: string): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) {
+      env[line] = "";
+      continue;
+    }
+    const key = line.slice(0, eq).trim();
+    if (!key) continue;
+    env[key] = line.slice(eq + 1);
+  }
+  return env;
 }

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -40,6 +40,7 @@ interface LaunchPanelProps {
   token: string;
   defaultBackend: Backend;
   defaultCwd: string;
+  defaultLaunchEnvByBackend: Record<Backend, Record<string, string>>;
   targetLabel: string | null;
   launchTargetId: string | null;
   recentCwds: string[];
@@ -56,6 +57,7 @@ interface LaunchPanelProps {
     transport: SessionTransport | null,
     args: string[],
     configOverrides: string[],
+    launchEnv: Record<string, string>,
     permissionMode: string | null,
   ) => Promise<void>;
   onAttach: (
@@ -69,6 +71,7 @@ interface LaunchPanelProps {
     cwd: string,
     transport: SessionTransport | null,
     importHistory: boolean,
+    launchEnv: Record<string, string>,
   ) => Promise<void>;
   onDeleteThread?: (
     backend: Backend,
@@ -87,6 +90,7 @@ export function LaunchPanel({
   token,
   defaultBackend,
   defaultCwd,
+  defaultLaunchEnvByBackend,
   targetLabel,
   launchTargetId,
   recentCwds,
@@ -104,7 +108,13 @@ export function LaunchPanel({
   onClearCwdError,
 }: LaunchPanelProps) {
   const [mode, setMode] = useState<PanelMode>("new");
-  const form = useLaunchForm({ defaultBackend, defaultCwd, launchTargetId, catalog });
+  const form = useLaunchForm({
+    defaultBackend,
+    defaultCwd,
+    defaultLaunchEnvByBackend,
+    launchTargetId,
+    catalog,
+  });
   const [tmuxTarget, setTmuxTarget] = useState("");
   const [prompt, setPrompt] = useState("");
   const [scheduleTiming, setScheduleTiming] = useState<ScheduleTiming>("delay");
@@ -117,7 +127,7 @@ export function LaunchPanel({
     event.preventDefault();
     setFormBusy(true);
     try {
-      const { args, configOverrides } = form.collectArgs();
+      const { args, configOverrides, launchEnv } = form.collectArgs();
       await onCreate(
         form.backend,
         form.cwd,
@@ -127,6 +137,7 @@ export function LaunchPanel({
         form.transport || null,
         args,
         configOverrides,
+        launchEnv,
         form.permissionMode || null,
       );
       form.setTitle("");
@@ -150,7 +161,7 @@ export function LaunchPanel({
   async function submitSchedule(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setScheduleError("");
-    const { args, configOverrides } = form.collectArgs();
+    const { args, configOverrides, launchEnv } = form.collectArgs();
     const payload: ScheduleCreateRequest = {
       backend: form.backend,
       cwd: form.cwd,
@@ -165,6 +176,7 @@ export function LaunchPanel({
       effort: form.effortSupported ? form.effort.trim() || null : null,
       args,
       config_overrides: configOverrides,
+      launch_env: launchEnv,
     };
     if (scheduleTiming === "delay") {
       const minutes = Number.parseFloat(delayMinutes);
@@ -318,6 +330,7 @@ export function LaunchPanel({
           onImportThread={onImportThread}
           onDeleteThread={onDeleteThread}
           catalog={catalog}
+          defaultLaunchEnvByBackend={defaultLaunchEnvByBackend}
         />
       ) : null}
 

--- a/frontend/src/components/ResumeThreadPanel.tsx
+++ b/frontend/src/components/ResumeThreadPanel.tsx
@@ -6,6 +6,11 @@ import {
   TransportPicker,
   useTransportForAgent,
 } from "@/components/AgentTransportPicker";
+import {
+  formatLaunchEnv,
+  LaunchOptionsDetails,
+  parseLaunchEnv,
+} from "@/components/LaunchOptions";
 import type { BackendCatalog } from "@/lib/backends";
 import { defaultTransportFor, humaniseBackend } from "@/lib/backends";
 import { matchesQuery, parseQuery } from "@/lib/search";
@@ -40,6 +45,7 @@ interface ResumeThreadPanelProps {
     cwd: string,
     transport: SessionTransport | null,
     importHistory: boolean,
+    launchEnv: Record<string, string>,
   ) => Promise<void>;
   onDeleteThread?: (
     backend: Backend,
@@ -47,6 +53,7 @@ interface ResumeThreadPanelProps {
     launchTargetId?: string,
   ) => Promise<void>;
   catalog: BackendCatalog;
+  defaultLaunchEnvByBackend: Record<Backend, Record<string, string>>;
 }
 
 // "all" merges every agent's threads into one list; a concrete backend narrows
@@ -80,6 +87,7 @@ export function ResumeThreadPanel({
   onImportThread,
   onDeleteThread,
   catalog,
+  defaultLaunchEnvByBackend,
 }: ResumeThreadPanelProps) {
   const multiAgent = supportedBackends.length >= 2;
 
@@ -129,10 +137,17 @@ export function ResumeThreadPanel({
         ? preferredBackend
         : (supportedBackends[0] ?? preferredBackend)
       : filter;
+  const [launchEnvText, setLaunchEnvText] = useState(() =>
+    formatLaunchEnv(defaultLaunchEnvByBackend[transportAgent]),
+  );
   const [transport, setTransport, transports] = useTransportForAgent(
     transportAgent,
     catalog,
   );
+
+  useEffect(() => {
+    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[transportAgent]));
+  }, [defaultLaunchEnvByBackend, transportAgent]);
 
   const isExpanded = expanded || query.trim().length > 0;
 
@@ -191,6 +206,10 @@ export function ResumeThreadPanel({
       filter === thread.backend
         ? transport || null
         : defaultTransportFor(thread.backend, catalog);
+    const launchEnv =
+      filter === thread.backend
+        ? parseLaunchEnv(launchEnvText)
+        : { ...(defaultLaunchEnvByBackend[thread.backend] ?? {}) };
     setImportingId(thread.id);
     try {
       await onImportThread(
@@ -199,6 +218,7 @@ export function ResumeThreadPanel({
         thread.cwd,
         chosen,
         importHistory,
+        launchEnv,
       );
     } finally {
       setImportingId(null);
@@ -259,6 +279,15 @@ export function ResumeThreadPanel({
             })}
           </select>
         </label>
+      ) : null}
+
+      {filter !== "all" ? (
+        <LaunchOptionsDetails
+          mode="resume"
+          launchEnvText={launchEnvText}
+          onLaunchEnvChange={setLaunchEnvText}
+          formBusy={importingId !== null || deletingId !== null}
+        />
       ) : null}
 
       {filter !== "all" ? (

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -263,6 +263,7 @@ export interface BackendDescriptor {
   default_transport: SessionTransport;
   label: string;
   badges: Record<string, string>;
+  default_launch_env?: Record<string, string>;
   // The flat union, kept for back-compat; prefer composing `agent_capabilities`
   // with `transport_capabilities` via `capsFor()` for an (agent, transport) pair.
   capabilities: BackendCapabilities;
@@ -323,6 +324,7 @@ export interface LaunchTargetSummary {
   default_cwd?: string | null;
   auth?: "key" | "password";
   connected?: boolean;
+  default_launch_env_by_backend?: Record<Backend, Record<string, string>>;
 }
 
 export type ScheduleStatus = "pending" | "launched" | "cancelled" | "failed";
@@ -359,6 +361,7 @@ export interface ScheduleCreateRequest {
   title?: string | null;
   args?: string[];
   config_overrides?: string[];
+  launch_env?: Record<string, string>;
   initial_prompt?: string | null;
   permission_mode?: string | null;
   model?: string | null;


### PR DESCRIPTION
## Purpose

Launching coding-agent sessions sometimes needs per-process environment, especially for API keys, provider toggles, and backend-specific feature flags. Before this change, those variables had to come from the surrounding Waypoint process or target-level SSH env, and users could not see or edit the effective defaults from the launch UI. This adds an explicit launch-env surface for new, resumed/imported, and scheduled sessions, with defaults sourced from `waypoint.yaml`.

## Changes

### Backend

- `backend/src/waypoint/launch_env.py` — shared validator for launch environment maps; keys must be non-empty strings without `=` or NUL, and values are coerced to strings.
- `backend/src/waypoint/backends/plugin_config.py` — global `plugin_configs.<backend>.env` and per-SSH-target `plugin_configs.<backend>.env` defaults.
- `backend/src/waypoint/runtime.py`, `scheduler.py`, `storage.py`, and `schemas.py` — launch env defaults are resolved for create/import/schedule requests, persisted for relaunch/restore, and excluded from public session/schedule dumps.
- `backend/src/waypoint/cli.py` and `client.py` — `waypoint session start`, `waypoint sessions start`, `waypoint sessions import`, and `waypoint schedule create` accept repeatable `--launch-env KEY=VALUE` flags.
- Backend plugins and transports — Claude Code, Claude tty-tail, Codex, OpenCode, and tmux launches pass env into their local/remote process factories; OpenCode adapter keys include env so sessions with different env do not share one server process.
- `backend/src/waypoint/api.py` and launch-target summaries — authenticated backend/target descriptors expose the default env maps needed by the launch panels.
- Tests cover config parsing, persistence privacy, scheduler firing, remote env precedence, OpenCode env-keyed adapters, restore/import/fork paths, and CLI request payloads.

### Frontend

- `frontend/src/components/LaunchOptions.tsx` — advanced settings now include an environment-variable textarea using `KEY=value` lines.
- `LaunchFormFields`, `LaunchPanel`, `ResumeThreadPanel`, and `page.tsx` — new, schedule, and resume/import flows initialize from backend/target defaults and send the edited `launch_env` payload.
- `frontend/src/lib/types.ts` — frontend API types include backend and launch-target env defaults plus schedule create payload env.

### Docs

- `backend/waypoint.example.yaml` shows global and SSH-target `env:` examples for Claude Code, Codex, and OpenCode.

## Design

Defaults are backend-specific, and SSH target defaults override global plugin defaults. A launch panel receives the effective default for the selected backend/target and sends the edited result explicitly; deleting a default in the UI sends an empty or reduced map rather than silently reapplying config defaults. Runtime-owned env still wins at process launch (`WAYPOINT_SESSION_ID` and plugin-required env), so user config cannot shadow control variables. Persisted session and schedule env is kept private via Pydantic field exclusion, while authenticated launch metadata exposes defaults so the UI can edit them before launch.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Live stack e2e through `waypointctl` and `uv run waypoint`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1466 passed, 3 warnings.
- `npm run lint` — clean.
- `npm run build` — not completed locally: this shell has Node `v18.19.1`, while Next.js requires Node `>=20.9.0`.
- Live stack e2e — `waypointctl status` reported backend/frontend healthy; `uv run waypoint schedule create --launch-env ...` created `sched-0ff023ab`; the SQLite row persisted `{"WAYPOINT_E2E_CLI": "1", "WAYPOINT_E2E_CLI_EQUALS": "a=b"}`; the e2e schedule row was cancelled and removed.
- Browser UI e2e — not run locally because this environment has no browser binary or Playwright/Puppeteer/Selenium install.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`; live `waypointctl`/`waypoint` schedule e2e).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends — Claude Code, Claude tty-tail, Codex, OpenCode, and tmux were updated and covered by tests.
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity — lint passed; build is blocked locally by Node `v18.19.1` vs. Next.js `>=20.9.0`.
- [x] Not a breaking change — additive config/API/UI/CLI surface.
- [x] Documentation/config — `backend/waypoint.example.yaml` documents the new `env:` defaults.

</details>
