### PR TITLE
feat: add session creation presets

### DIFF
--- a/.agents/skills/waypoint-crew/SKILL.md
+++ b/.agents/skills/waypoint-crew/SKILL.md
@@ -114,6 +114,10 @@ than producing nothing (see `references/lifecycle.md`).
 - **Be inquisitive about environmental choices.** Settle each role's model and an
   auto-approving permission mode before spawning — a guessed mode stalls the
   session on its first approval and a wrong model id dies on turn 1. Pass ids verbatim from `waypoint
-  models` / `waypoint backends`, and ask the user when unsure.
+  models` / `waypoint backends`, and ask the user when unsure. A role session can
+  be **seeded from a preset** (`waypoint presets list`, then `sessions start
+  --preset <id>`) that pins its backend/model/permission profile — but inspect the
+  preset (`waypoint presets show <id>`) rather than trusting the name, and ask the
+  user when its permission posture is ambiguous for unattended work.
 - **Check the shipped product, not just green tests.** Before a phase or the
   product is called done, exercise the real running app, not only unit tests.

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -64,6 +64,13 @@ posture — but widening is a deliberate act, not a default. Guidance:
   `default` and discovering the stall later. Leaving it on `default` is only the
   right default when you will be **interactively servicing** the child's approvals
   yourself.
+- **A preset can carry a `permission_mode`, but do not assume it auto-approves.**
+  When you spawn with `--preset`, inspect it (`waypoint presets show <id>`) rather
+  than trusting the name — a preset whose posture is `default`, or that carries no
+  mode at all, leaves an unattended child stalling on its first approval just as a
+  bare spawn would. If the preset's permission posture is ambiguous for
+  unattended work, pass an explicit auto-approving `--permission-mode` (it
+  overrides the preset) or ask the user before spawning.
 
 ## Fix a posture without respawning
 

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -36,6 +36,24 @@ waypoint sessions start \
   `--permission-mode` only to override this. See `references/permissions.md`.
 - Capture the returned session id. Keep it for the rest of the turn.
 
+### Spawn from a preset
+
+If the user has a **preset** for this worker role, spawn from it instead of
+re-specifying backend/model/permission each time — the preset supplies those
+defaults and any explicit flag still overrides them. Run `waypoint presets list`
+first to see what exists (and the default); still keep the `subagent:` title and
+`--spawner-session-id` so the child is recognizable and owner-scoped:
+
+```bash
+waypoint sessions start --preset worker-codex-high \
+  --cwd "$repo" --worktree "wq/$job-t$n" --worktree-base "wq/$job" \
+  --title "subagent:wq-$job-$n" --spawner-session-id "$lead"
+```
+
+`--backend` becomes optional when the preset supplies it. Don't assume a preset
+auto-approves: see `references/permissions.md` before relying on it for an
+unattended child.
+
 Then send the task as the first input:
 
 ```bash

--- a/.agents/skills/waypoint-workqueue/references/backends.md
+++ b/.agents/skills/waypoint-workqueue/references/backends.md
@@ -37,6 +37,15 @@ it is the right fit for the job, **ask the user** (use the ask-question tool if
 your harness has one) rather than guessing. The user is the fallback — never pick
 a backend or model blindly.
 
+A **preset** can pin a whole worker profile — backend, model, transport, effort,
+and permission mode — so a crew's workers spawn from one named default instead of
+re-deriving each field per task (`waypoint presets list`, then `sessions start
+--preset <id>`; see `waypoint-subagents`'s `references/spawn-and-poll.md`). A
+preset is a convenience layer, not a substitute for the discovery above: still
+run `waypoint backends` / `waypoint models` when creating or overriding one so the
+ids it pins are real, and confirm its permission posture before trusting it for
+unattended workers.
+
 ## The harnesses
 
 - **`claude_code`** — wraps the Claude Code CLI (Claude models). Structured;

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -16,6 +16,14 @@ git -C "$repo" switch -c "wq/$job" "$base"
 Assign — for each free worker and each `todo` task, give it a worktree and send
 it off. Pre-spawn checklist, all settled **before** the `sessions start`:
 
+- **Preset (preferred).** Run `waypoint presets list` first. If the user has a
+  worker preset for this crew (or a suitable default), spawn with `--preset <id>`
+  and let it supply backend/model/effort/permission — you still pass the
+  per-worker `--cwd` / `--worktree` / `--title` / `--spawner-session-id`, and any
+  explicit flag overrides the preset. Confirm the preset's model and permission
+  posture (`waypoint presets show <id>`) satisfy the two checks below; don't
+  assume a preset auto-approves. With no fitting preset, set the fields
+  explicitly as follows.
 - **Model.** Run `waypoint models <backend>` and pass an id **verbatim** — never
   guess from memory (a wrong id spawns fine and only dies on turn 1). Unsure
   which tier fits? Ask the user. `sessions start` warns if the id isn't in the

--- a/.agents/skills/waypoint/references/scheduling.md
+++ b/.agents/skills/waypoint/references/scheduling.md
@@ -40,10 +40,11 @@ cancelled | failed`; once launched it carries the new `session_id`, and a
 
 `schedule create` also honors `--preset <id-or-name>` (and `--no-preset` to skip
 the default) exactly like `sessions start` — the preset supplies the launch
-defaults, and `--backend` / `--cwd` become optional when it does; see the Presets
-subsection in `references/sessions-launch.md`. A preset carries only launch
-defaults, **not** the schedule's initial `--prompt` or its `--scheduled-at` /
-`--delay-seconds` timing — set those on `schedule create` itself.
+defaults, and `--backend` becomes optional when it does (`--cwd` is never a
+preset field, so keep passing it); see the Presets subsection in
+`references/sessions-launch.md`. A preset carries only launch defaults, **not**
+the schedule's initial `--prompt` or its `--scheduled-at` / `--delay-seconds`
+timing — set those on `schedule create` itself.
 
 ## Scheduled messages
 

--- a/.agents/skills/waypoint/references/scheduling.md
+++ b/.agents/skills/waypoint/references/scheduling.md
@@ -38,6 +38,13 @@ manual `sessions start` has no flag for. A record moves `pending → launched |
 cancelled | failed`; once launched it carries the new `session_id`, and a
 `failure_reason` on failure.
 
+`schedule create` also honors `--preset <id-or-name>` (and `--no-preset` to skip
+the default) exactly like `sessions start` — the preset supplies the launch
+defaults, and `--backend` / `--cwd` become optional when it does; see the Presets
+subsection in `references/sessions-launch.md`. A preset carries only launch
+defaults, **not** the schedule's initial `--prompt` or its `--scheduled-at` /
+`--delay-seconds` timing — set those on `schedule create` itself.
+
 ## Scheduled messages
 
 ```bash

--- a/.agents/skills/waypoint/references/sessions-launch.md
+++ b/.agents/skills/waypoint/references/sessions-launch.md
@@ -34,11 +34,13 @@ the assistant workspace is the user's target project.
 ## Presets
 
 A **preset** is a reusable, server-side bundle of launch defaults — backend,
-transport, model, effort, permission mode, cwd, launch target, launch_mode,
-title, args, config_overrides, launch_env, and tags. It is resolved at
-launch/schedule time; any explicit flag you pass **always overrides** the
-preset's value. Prefer a user-provided or default preset for repeated worker
-roles instead of re-deriving model/permission/transport from scratch each time.
+transport, model, effort, permission mode, launch target, launch_mode, args,
+config_overrides, launch_env, and tags. It deliberately excludes `cwd` and
+`title`: those are per-launch specifics, not reusable defaults, so you always
+supply them at launch. A preset is resolved at launch/schedule time; any
+explicit flag you pass **always overrides** the preset's value. Prefer a
+user-provided or default preset for repeated worker roles instead of re-deriving
+model/permission/transport from scratch each time.
 
 ```bash
 waypoint presets list                          # all presets (env values redacted) + the default id
@@ -46,7 +48,7 @@ waypoint presets show <id-or-name>             # one preset; env values redacted
 waypoint presets show <id-or-name> --show-secrets   # reveal launch_env values
 waypoint presets create --name worker-codex-high \
   --backend codex --model <model> --effort high \
-  --permission-mode <auto-approving-mode> --cwd <path> \
+  --permission-mode <auto-approving-mode> \
   --launch-env KEY=VAL --config-override X --tag role=worker [--default] [ARGS...]
 waypoint presets update <id-or-name> [same launch options]   # PATCH: only passed fields change
 waypoint presets delete <id-or-name>           # existing sessions/schedules are unaffected
@@ -61,14 +63,15 @@ or schedules already launched from it.
 Launch from a preset with `--preset`:
 
 ```bash
-waypoint sessions start --preset worker-codex-high              # backend/cwd come from the preset
-waypoint sessions start --preset worker-codex-high --cwd <path> # explicit flag overrides the preset
-waypoint sessions start --no-preset --backend <id> --cwd <path> # ignore the default preset
+waypoint sessions start --preset worker-codex-high --cwd <path>  # backend etc. from preset; cwd always explicit
+waypoint sessions start --preset worker-codex-high --cwd <path> --model <id>  # explicit flag overrides the preset
+waypoint sessions start --no-preset --backend <id> --cwd <path>  # ignore the default preset
 ```
 
-With `--preset`, `--backend` / `--cwd` become optional when the preset (or the
-default) supplies them. When `--preset` is omitted and a default preset exists,
-it is applied automatically — pass `--no-preset` to opt out. Run `waypoint
-presets list` before choosing settings from scratch, and still consult `waypoint
-backends` / `waypoint models` when overriding or creating a preset so the ids you
-pin are real.
+With `--preset`, `--backend` becomes optional when the preset (or the default)
+supplies it. `--cwd` is never a preset field, so it stays required at launch —
+an omitted cwd fails with a clear 400. When `--preset` is omitted and a default
+preset exists, it is applied automatically — pass `--no-preset` to opt out. Run
+`waypoint presets list` before choosing settings from scratch, and still consult
+`waypoint backends` / `waypoint models` when overriding or creating a preset so
+the ids you pin are real.

--- a/.agents/skills/waypoint/references/sessions-launch.md
+++ b/.agents/skills/waypoint/references/sessions-launch.md
@@ -30,3 +30,45 @@ surface.
 Choose `cwd` deliberately. For repository work, use the repo root. For host
 inspection or scratch work, use an explicit safe directory rather than assuming
 the assistant workspace is the user's target project.
+
+## Presets
+
+A **preset** is a reusable, server-side bundle of launch defaults — backend,
+transport, model, effort, permission mode, cwd, launch target, launch_mode,
+title, args, config_overrides, launch_env, and tags. It is resolved at
+launch/schedule time; any explicit flag you pass **always overrides** the
+preset's value. Prefer a user-provided or default preset for repeated worker
+roles instead of re-deriving model/permission/transport from scratch each time.
+
+```bash
+waypoint presets list                          # all presets (env values redacted) + the default id
+waypoint presets show <id-or-name>             # one preset; env values redacted
+waypoint presets show <id-or-name> --show-secrets   # reveal launch_env values
+waypoint presets create --name worker-codex-high \
+  --backend codex --model <model> --effort high \
+  --permission-mode <auto-approving-mode> --cwd <path> \
+  --launch-env KEY=VAL --config-override X --tag role=worker [--default] [ARGS...]
+waypoint presets update <id-or-name> [same launch options]   # PATCH: only passed fields change
+waypoint presets delete <id-or-name>           # existing sessions/schedules are unaffected
+waypoint presets default [<id-or-name>]        # set the default, or print it with no arg
+waypoint presets clear-default
+```
+
+`update` has PATCH semantics — omitted fields (including `--tag`) are preserved,
+so pass only what you want to change. Deleting a preset does not touch sessions
+or schedules already launched from it.
+
+Launch from a preset with `--preset`:
+
+```bash
+waypoint sessions start --preset worker-codex-high              # backend/cwd come from the preset
+waypoint sessions start --preset worker-codex-high --cwd <path> # explicit flag overrides the preset
+waypoint sessions start --no-preset --backend <id> --cwd <path> # ignore the default preset
+```
+
+With `--preset`, `--backend` / `--cwd` become optional when the preset (or the
+default) supplies them. When `--preset` is omitted and a default preset exists,
+it is applied automatically — pass `--no-preset` to opt out. Run `waypoint
+presets list` before choosing settings from scratch, and still consult `waypoint
+backends` / `waypoint models` when overriding or creating a preset so the ids you
+pin are real.

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -32,6 +32,11 @@ from waypoint.backends.tmux.renderer import (
     SyncFrameTracker,
     make_renderer,
 )
+from waypoint.presets import (
+    redact_preset,
+    resolve_schedule_create_request,
+    resolve_session_create_request,
+)
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     AssistantAttachRequest,
@@ -48,19 +53,22 @@ from waypoint.schemas import (
     LaunchTargetConnectResponse,
     LoginRequest,
     MeResponse,
-    ScheduleCreateRequest,
     ScheduledMessageCreateRequest,
+    ScheduleLaunchRequest,
     SessionAnswerQuestionRequest,
     SessionApprovalRequest,
     SessionAttachRequest,
     SessionCompletionsResponse,
-    SessionCreateRequest,
     SessionEffortRequest,
     SessionEnvelope,
     SessionInputRequest,
+    SessionLaunchRequest,
     SessionModelRequest,
     SessionPermissionModeRequest,
     SessionPlanApprovalRequest,
+    SessionPresetCreateRequest,
+    SessionPresetListResponse,
+    SessionPresetUpdateRequest,
     SessionRecord,
     SessionStatus,
     SessionTagsUpdateRequest,
@@ -168,6 +176,11 @@ def _backend_descriptors(
     return payload
 
 
+def _default_preset_id(context: "AppContext") -> str | None:
+    default = context.runtime.presets.default()
+    return default.id if default is not None else None
+
+
 class AppContext:
     def __init__(self, settings: Settings | None = None) -> None:
         self.settings = settings or load_settings()
@@ -225,6 +238,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             launch_targets=context.runtime.launch_target_summaries(),
             backends=_backend_descriptors(context.runtime.registry, context.settings),
             assistant=context.runtime.assistant_summary(),
+            session_presets=[
+                redact_preset(preset) for preset in context.runtime.presets.list()
+            ],
+            default_preset_id=_default_preset_id(context),
         )
 
     @app.post(
@@ -381,10 +398,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @app.post("/api/sessions")
     async def create_session(
-        request: SessionCreateRequest,
+        request: SessionLaunchRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        session = await context.runtime.create_session(request)
+        resolved, preset = resolve_session_create_request(context.storage, request)
+        session = await context.runtime.create_session(
+            resolved,
+            preset_id=preset.id if preset else None,
+            preset_name=preset.name if preset else None,
+        )
         return {"session": session.model_dump(mode="json")}
 
     @app.post("/api/backends/{backend}/sessions/import")
@@ -1304,10 +1326,15 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
     @app.post("/api/schedules")
     async def create_schedule(
-        request: ScheduleCreateRequest,
+        request: ScheduleLaunchRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        schedule = context.runtime.scheduler.create_schedule(request)
+        resolved, preset = resolve_schedule_create_request(context.storage, request)
+        schedule = context.runtime.scheduler.create_schedule(
+            resolved,
+            preset_id=preset.id if preset else None,
+            preset_name=preset.name if preset else None,
+        )
         return {"schedule": schedule.model_dump(mode="json")}
 
     @app.delete("/api/schedules/{schedule_id}")
@@ -1324,6 +1351,78 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         removed = context.runtime.scheduler.clear_history()
         return {"removed": removed}
+
+    # ── Session presets ──────────────────────────────────────────────────
+    @app.get("/api/session-presets", response_model=SessionPresetListResponse)
+    async def list_session_presets(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> SessionPresetListResponse:
+        presets = context.runtime.presets.list()
+        return SessionPresetListResponse(
+            presets=[redact_preset(preset) for preset in presets],
+            default_preset_id=next(
+                (preset.id for preset in presets if preset.is_default), None
+            ),
+        )
+
+    @app.post("/api/session-presets")
+    async def create_session_preset(
+        request: SessionPresetCreateRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        preset = context.runtime.presets.create(request)
+        return {"preset": redact_preset(preset).model_dump(mode="json")}
+
+    # Registered before ``/{preset_id}`` so "default" is not captured as an id.
+    @app.delete("/api/session-presets/default")
+    async def clear_default_session_preset(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        context.runtime.presets.set_default(None)
+        return {"default_preset_id": None}
+
+    @app.get("/api/session-presets/{preset_id}")
+    async def get_session_preset(
+        preset_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        include_secret_values: bool = Query(default=False),
+    ) -> Any:
+        preset = context.runtime.presets.require_ref(preset_id)
+        if include_secret_values:
+            return {"preset": preset.model_dump(mode="json")}
+        return {"preset": redact_preset(preset).model_dump(mode="json")}
+
+    @app.patch("/api/session-presets/{preset_id}")
+    async def update_session_preset(
+        preset_id: str,
+        request: SessionPresetUpdateRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        preset = context.runtime.presets.update(preset_id, request)
+        return {"preset": redact_preset(preset).model_dump(mode="json")}
+
+    @app.delete("/api/session-presets/{preset_id}")
+    async def delete_session_preset(
+        preset_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        deleted = context.runtime.presets.delete(preset_id)
+        if not deleted:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown preset: {preset_id!r}",
+            )
+        return {"deleted": True}
+
+    @app.post("/api/session-presets/{preset_id}/default")
+    async def set_default_session_preset(
+        preset_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        preset = context.runtime.presets.set_default(preset_id)
+        return {
+            "preset": redact_preset(preset).model_dump(mode="json") if preset else None
+        }
 
     @app.get("/api/message-schedules")
     async def list_message_schedules(

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -14,6 +14,7 @@ from typing import Annotated, Any, NamedTuple, Protocol, cast
 import click
 import typer
 import uvicorn
+from fastapi import HTTPException
 from websockets.exceptions import WebSocketException
 
 from waypoint.api import AppContext, create_app
@@ -26,10 +27,11 @@ from waypoint.client import (
     write_cli_token,
 )
 from waypoint.launch_env import validate_launch_env
+from waypoint.presets import resolve_session_create_request
 from waypoint.schemas import (
     LaunchMode,
     SessionAttachRequest,
-    SessionCreateRequest,
+    SessionLaunchRequest,
     SessionStatus,
 )
 from waypoint.settings import Settings, load_settings
@@ -148,6 +150,10 @@ maintenance_app = typer.Typer(
     help="Maintenance commands for the Waypoint server data.",
     no_args_is_help=True,
 )
+presets_app = typer.Typer(
+    help="Manage reusable session-launch presets on a running Waypoint server.",
+    no_args_is_help=True,
+)
 app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
@@ -157,6 +163,7 @@ app.add_typer(inbox_app, name="inbox")
 app.add_typer(schedule_app, name="schedule")
 schedule_app.add_typer(schedule_message_app, name="message")
 app.add_typer(maintenance_app, name="maintenance")
+app.add_typer(presets_app, name="presets")
 
 
 def _version_callback(value: bool) -> None:
@@ -370,8 +377,26 @@ def help_(
 @session_app.command("start")
 def session_start(
     ctx: typer.Context,
-    backend: BackendOption,
-    cwd: Annotated[str, typer.Option(help="Working directory for the session.")],
+    backend: Annotated[
+        str | None,
+        typer.Option(callback=_validate_backend, autocompletion=_complete_backend),
+    ] = None,
+    cwd: Annotated[
+        str | None, typer.Option(help="Working directory for the session.")
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset", help="Apply a session preset (by id or name) before launch."
+        ),
+    ] = None,
+    no_preset: Annotated[
+        bool,
+        typer.Option(
+            "--no-preset",
+            help="Do not apply the default preset when --preset is unset.",
+        ),
+    ] = False,
     launch_target_id: Annotated[str | None, typer.Option()] = None,
     launch_mode: Annotated[
         LaunchMode | None,
@@ -409,6 +434,8 @@ def session_start(
             _settings_from_ctx(ctx),
             backend=backend,
             cwd=cwd,
+            preset=preset,
+            no_preset=no_preset,
             launch_target_id=launch_target_id,
             launch_mode=launch_mode,
             transport=transport,
@@ -442,8 +469,10 @@ def session_attach(
 async def _session_start(
     settings: Settings,
     *,
-    backend: str,
-    cwd: str,
+    backend: str | None,
+    cwd: str | None,
+    preset: str | None,
+    no_preset: bool,
     launch_target_id: str | None,
     launch_mode: LaunchMode | None,
     transport: str | None,
@@ -455,12 +484,15 @@ async def _session_start(
     context.settings.ensure_dirs()
     try:
         request_fields: dict[str, Any] = {
-            "backend": backend,
-            "cwd": cwd,
             "launch_target_id": launch_target_id,
             "title": title,
             "args": list(args),
         }
+        # Only send backend/cwd when supplied; a preset may fill them in.
+        if backend is not None:
+            request_fields["backend"] = backend
+        if cwd is not None:
+            request_fields["cwd"] = cwd
         if launch_env is not None:
             request_fields["launch_env"] = launch_env
         # Omit launch_mode when unset so the request model's AUTO default applies.
@@ -470,8 +502,20 @@ async def _session_start(
         # today's launch_mode-derived behavior.
         if transport is not None:
             request_fields["transport"] = transport
+        if preset is not None:
+            request_fields["preset_id"] = preset
+        elif not no_preset:
+            request_fields["use_default_preset"] = True
+        try:
+            resolved, matched = resolve_session_create_request(
+                context.storage, SessionLaunchRequest(**request_fields)
+            )
+        except HTTPException as exc:
+            raise typer.BadParameter(str(exc.detail)) from exc
         session = await context.runtime.create_session(
-            SessionCreateRequest(**request_fields)
+            resolved,
+            preset_id=matched.id if matched else None,
+            preset_name=matched.name if matched else None,
         )
         typer.echo(json.dumps({"session": session.model_dump(mode="json")}, indent=2))
     finally:
@@ -1508,11 +1552,56 @@ def _validate_launch_permission_mode(
         )
 
 
+def _preset_spec_for_warnings(
+    client: WaypointClient, preset_ref: str | None, use_default: bool
+) -> dict[str, Any]:
+    """Fetch the applicable preset's redacted spec, for computing the effective
+    launch values the model/permission warnings run against.
+
+    Best-effort only: any discovery failure yields ``{}`` so warnings degrade to
+    the explicit-flag behavior instead of erroring."""
+    try:
+        if preset_ref is not None:
+            preset = client.get_session_preset(preset_ref)
+        elif use_default:
+            listing = client.list_session_presets()
+            default_id = listing.get("default_preset_id")
+            if not default_id:
+                return {}
+            preset = client.get_session_preset(default_id)
+        else:
+            return {}
+    except WaypointError:
+        return {}
+    spec = preset.get("spec")
+    return spec if isinstance(spec, dict) else {}
+
+
 @sessions_app.command("start")
 def sessions_start(
     ctx: typer.Context,
-    backend: BackendOption,
-    cwd: Annotated[str, typer.Option(help="Working directory for the session.")],
+    backend: Annotated[
+        str | None,
+        typer.Option(callback=_validate_backend, autocompletion=_complete_backend),
+    ] = None,
+    cwd: Annotated[
+        str | None, typer.Option(help="Working directory for the session.")
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help="Apply a session preset (by id or name) before launch. Explicit "
+            "flags override preset values.",
+        ),
+    ] = None,
+    no_preset: Annotated[
+        bool,
+        typer.Option(
+            "--no-preset",
+            help="Do not apply the default preset when --preset is unset.",
+        ),
+    ] = False,
     launch_target_id: Annotated[str | None, typer.Option()] = None,
     launch_mode: Annotated[
         LaunchMode | None,
@@ -1578,19 +1667,33 @@ def sessions_start(
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Launch a new session on the running server."""
+    use_default = preset is None and not no_preset
     effective_cwd = cwd
     worktree_path: str | None = None
     if worktree is not None:
+        if cwd is None:
+            raise typer.BadParameter(
+                "--cwd is required with --worktree", param_hint="--cwd"
+            )
         worktree_path = _create_worktree(worktree, worktree_base, cwd)
         effective_cwd = worktree_path
     tags = _parse_tags(tag)
     launch_env_map = _parse_launch_env(launch_env) if launch_env is not None else None
 
     def _run(c: WaypointClient) -> dict[str, Any]:
-        if permission_mode is not None:
-            _validate_launch_permission_mode(c, backend, permission_mode)
-        if model is not None:
-            _warn_unknown_model(c, backend, model, launch_target_id)
+        # Compute the effective backend/model/permission after the preset would
+        # apply (explicit flag wins) so the warnings still fire for stale preset
+        # values even when the user passes only --preset.
+        spec = _preset_spec_for_warnings(c, preset, use_default)
+        eff_backend = backend or spec.get("backend")
+        eff_model = model or spec.get("model")
+        eff_permission = permission_mode or spec.get("permission_mode")
+        eff_target = launch_target_id or spec.get("launch_target_id")
+        if eff_backend:
+            if eff_permission is not None:
+                _validate_launch_permission_mode(c, eff_backend, eff_permission)
+            if eff_model is not None:
+                _warn_unknown_model(c, eff_backend, eff_model, eff_target)
         return {
             "session": c.create_session(
                 backend=backend,
@@ -1607,6 +1710,8 @@ def sessions_start(
                 args=list(args or []),
                 tags=tags,
                 launch_env=launch_env_map,
+                preset_id=preset,
+                use_default_preset=use_default,
             )
         }
 
@@ -2658,8 +2763,28 @@ def schedule_list(ctx: typer.Context) -> None:
 @schedule_app.command("create")
 def schedule_create(
     ctx: typer.Context,
-    backend: BackendOption,
-    cwd: Annotated[str, typer.Option(help="Working directory for the session.")],
+    backend: Annotated[
+        str | None,
+        typer.Option(callback=_validate_backend, autocompletion=_complete_backend),
+    ] = None,
+    cwd: Annotated[
+        str | None, typer.Option(help="Working directory for the session.")
+    ] = None,
+    preset: Annotated[
+        str | None,
+        typer.Option(
+            "--preset",
+            help="Apply a session preset (by id or name) before scheduling. "
+            "Explicit flags override preset values.",
+        ),
+    ] = None,
+    no_preset: Annotated[
+        bool,
+        typer.Option(
+            "--no-preset",
+            help="Do not apply the default preset when --preset is unset.",
+        ),
+    ] = False,
     launch_target_id: Annotated[str | None, typer.Option()] = None,
     launch_mode: Annotated[str | None, typer.Option()] = None,
     transport: Annotated[
@@ -2701,10 +2826,22 @@ def schedule_create(
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Schedule a session launch on the running server."""
+    use_default = preset is None and not no_preset
     launch_env_map = _parse_launch_env(launch_env) if launch_env is not None else None
-    _emit(
-        _settings_from_ctx(ctx),
-        lambda c: {
+
+    def _run(c: WaypointClient) -> dict[str, Any]:
+        # Preserve the launch warnings on the values the preset would resolve to.
+        spec = _preset_spec_for_warnings(c, preset, use_default)
+        eff_backend = backend or spec.get("backend")
+        eff_model = model or spec.get("model")
+        eff_permission = permission_mode or spec.get("permission_mode")
+        eff_target = launch_target_id or spec.get("launch_target_id")
+        if eff_backend:
+            if eff_permission is not None:
+                _validate_launch_permission_mode(c, eff_backend, eff_permission)
+            if eff_model is not None:
+                _warn_unknown_model(c, eff_backend, eff_model, eff_target)
+        return {
             "schedule": c.create_schedule(
                 backend=backend,
                 cwd=cwd,
@@ -2720,9 +2857,12 @@ def schedule_create(
                 delay_seconds=delay_seconds,
                 scheduled_at=scheduled_at,
                 launch_env=launch_env_map,
+                preset_id=preset,
+                use_default_preset=use_default,
             )
-        },
-    )
+        }
+
+    _emit(_settings_from_ctx(ctx), _run)
 
 
 @schedule_app.command("delete")
@@ -2740,6 +2880,227 @@ def schedule_delete(
 def schedule_clear_history(ctx: typer.Context) -> None:
     """Remove completed/cancelled schedule records."""
     _emit(_settings_from_ctx(ctx), lambda c: c.clear_schedule_history())
+
+
+def _preset_spec_payload(
+    *,
+    backend: str | None,
+    cwd: str | None,
+    launch_target_id: str | None,
+    launch_mode: str | None,
+    transport: str | None,
+    title: str | None,
+    model: str | None,
+    effort: str | None,
+    permission_mode: str | None,
+    args: list[str] | None,
+    config_override: list[str] | None,
+    launch_env: list[str] | None,
+    tag: list[str] | None,
+) -> dict[str, Any]:
+    """Build a preset spec body from launch options, including only the fields the
+    caller supplied so update PATCH-merges instead of clobbering omitted fields."""
+    spec: dict[str, Any] = {}
+    for key, value in (
+        ("backend", backend),
+        ("cwd", cwd),
+        ("launch_target_id", launch_target_id),
+        ("launch_mode", launch_mode),
+        ("transport", transport),
+        ("title", title),
+        ("model", model),
+        ("effort", effort),
+        ("permission_mode", permission_mode),
+    ):
+        if value is not None:
+            spec[key] = value
+    if args is not None:
+        spec["args"] = list(args)
+    if config_override is not None:
+        spec["config_overrides"] = list(config_override)
+    if launch_env is not None:
+        spec["launch_env"] = _parse_launch_env(launch_env)
+    if tag is not None:
+        spec["tags"] = _parse_tags(tag)
+    return spec
+
+
+_PresetBackendOption = Annotated[
+    str | None, typer.Option(help="Backend id for the preset.")
+]
+_PresetLaunchEnvOption = Annotated[
+    list[str] | None,
+    typer.Option(
+        "--launch-env",
+        help="Environment variable as KEY=VALUE. Repeatable; values may contain '='.",
+    ),
+]
+_PresetConfigOverrideOption = Annotated[
+    list[str] | None,
+    typer.Option("--config-override", help="Backend config override. Repeatable."),
+]
+_PresetTagOption = Annotated[
+    list[str] | None,
+    typer.Option("--tag", help="Tag as key=value (or a bare key). Repeatable."),
+]
+
+
+@presets_app.command("list")
+def presets_list(ctx: typer.Context) -> None:
+    """List session presets (env values redacted)."""
+    _emit(_settings_from_ctx(ctx), lambda c: c.list_session_presets())
+
+
+@presets_app.command("show")
+def presets_show(
+    ctx: typer.Context,
+    ref: Annotated[str, typer.Argument(help="Preset id or name.")],
+    show_secrets: Annotated[
+        bool,
+        typer.Option("--show-secrets", help="Include launch_env values in output."),
+    ] = False,
+) -> None:
+    """Show a single preset. Env values are redacted unless --show-secrets."""
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "preset": c.get_session_preset(ref, include_secret_values=show_secrets)
+        },
+    )
+
+
+@presets_app.command("create")
+def presets_create(
+    ctx: typer.Context,
+    name: Annotated[str, typer.Option(help="Unique preset name.")],
+    description: Annotated[str | None, typer.Option()] = None,
+    default: Annotated[
+        bool, typer.Option("--default", help="Mark this preset as the default.")
+    ] = False,
+    backend: _PresetBackendOption = None,
+    cwd: Annotated[str | None, typer.Option()] = None,
+    launch_target_id: Annotated[str | None, typer.Option()] = None,
+    launch_mode: Annotated[str | None, typer.Option()] = None,
+    transport: Annotated[str | None, typer.Option()] = None,
+    title: Annotated[str | None, typer.Option()] = None,
+    model: Annotated[str | None, typer.Option()] = None,
+    effort: Annotated[str | None, typer.Option()] = None,
+    permission_mode: Annotated[str | None, typer.Option()] = None,
+    launch_env: _PresetLaunchEnvOption = None,
+    config_override: _PresetConfigOverrideOption = None,
+    tag: _PresetTagOption = None,
+    args: Annotated[list[str] | None, typer.Argument()] = None,
+) -> None:
+    """Create a session preset from launch options."""
+    spec = _preset_spec_payload(
+        backend=backend,
+        cwd=cwd,
+        launch_target_id=launch_target_id,
+        launch_mode=launch_mode,
+        transport=transport,
+        title=title,
+        model=model,
+        effort=effort,
+        permission_mode=permission_mode,
+        args=args,
+        config_override=config_override,
+        launch_env=launch_env,
+        tag=tag,
+    )
+    body: dict[str, Any] = {"name": name, "spec": spec, "is_default": default}
+    if description is not None:
+        body["description"] = description
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {"preset": c.create_session_preset(body)},
+    )
+
+
+@presets_app.command("update")
+def presets_update(
+    ctx: typer.Context,
+    ref: Annotated[str, typer.Argument(help="Preset id or name.")],
+    name: Annotated[str | None, typer.Option()] = None,
+    description: Annotated[str | None, typer.Option()] = None,
+    backend: _PresetBackendOption = None,
+    cwd: Annotated[str | None, typer.Option()] = None,
+    launch_target_id: Annotated[str | None, typer.Option()] = None,
+    launch_mode: Annotated[str | None, typer.Option()] = None,
+    transport: Annotated[str | None, typer.Option()] = None,
+    title: Annotated[str | None, typer.Option()] = None,
+    model: Annotated[str | None, typer.Option()] = None,
+    effort: Annotated[str | None, typer.Option()] = None,
+    permission_mode: Annotated[str | None, typer.Option()] = None,
+    launch_env: _PresetLaunchEnvOption = None,
+    config_override: _PresetConfigOverrideOption = None,
+    tag: _PresetTagOption = None,
+    args: Annotated[list[str] | None, typer.Argument()] = None,
+) -> None:
+    """Update a preset. Only the fields you pass change; the rest are preserved."""
+    spec = _preset_spec_payload(
+        backend=backend,
+        cwd=cwd,
+        launch_target_id=launch_target_id,
+        launch_mode=launch_mode,
+        transport=transport,
+        title=title,
+        model=model,
+        effort=effort,
+        permission_mode=permission_mode,
+        args=args,
+        config_override=config_override,
+        launch_env=launch_env,
+        tag=tag,
+    )
+    body: dict[str, Any] = {}
+    if name is not None:
+        body["name"] = name
+    if description is not None:
+        body["description"] = description
+    if spec:
+        body["spec"] = spec
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {"preset": c.update_session_preset(ref, body)},
+    )
+
+
+@presets_app.command("delete")
+def presets_delete(
+    ctx: typer.Context,
+    ref: Annotated[str, typer.Argument(help="Preset id or name.")],
+) -> None:
+    """Delete a preset. Sessions/schedules created from it are unaffected."""
+    _emit(_settings_from_ctx(ctx), lambda c: c.delete_session_preset(ref))
+
+
+@presets_app.command("default")
+def presets_default(
+    ctx: typer.Context,
+    ref: Annotated[
+        str | None,
+        typer.Argument(help="Preset id or name. Omit to show the current default."),
+    ] = None,
+) -> None:
+    """Set the default preset, or show the current default when no id is given."""
+    if ref is None:
+        _emit(
+            _settings_from_ctx(ctx),
+            lambda c: {
+                "default_preset_id": c.list_session_presets().get("default_preset_id")
+            },
+        )
+    else:
+        _emit(
+            _settings_from_ctx(ctx),
+            lambda c: {"preset": c.set_default_session_preset(ref)},
+        )
+
+
+@presets_app.command("clear-default")
+def presets_clear_default(ctx: typer.Context) -> None:
+    """Clear the default preset (leaves all presets in place)."""
+    _emit(_settings_from_ctx(ctx), lambda c: c.clear_default_session_preset())
 
 
 @schedule_message_app.command("list")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -2885,11 +2885,9 @@ def schedule_clear_history(ctx: typer.Context) -> None:
 def _preset_spec_payload(
     *,
     backend: str | None,
-    cwd: str | None,
     launch_target_id: str | None,
     launch_mode: str | None,
     transport: str | None,
-    title: str | None,
     model: str | None,
     effort: str | None,
     permission_mode: str | None,
@@ -2899,15 +2897,16 @@ def _preset_spec_payload(
     tag: list[str] | None,
 ) -> dict[str, Any]:
     """Build a preset spec body from launch options, including only the fields the
-    caller supplied so update PATCH-merges instead of clobbering omitted fields."""
+    caller supplied so update PATCH-merges instead of clobbering omitted fields.
+
+    Presets deliberately omit cwd/title (per-launch specifics), so those are not
+    accepted here — they stay on ``sessions start`` / ``schedule create``."""
     spec: dict[str, Any] = {}
     for key, value in (
         ("backend", backend),
-        ("cwd", cwd),
         ("launch_target_id", launch_target_id),
         ("launch_mode", launch_mode),
         ("transport", transport),
-        ("title", title),
         ("model", model),
         ("effort", effort),
         ("permission_mode", permission_mode),
@@ -2978,11 +2977,9 @@ def presets_create(
         bool, typer.Option("--default", help="Mark this preset as the default.")
     ] = False,
     backend: _PresetBackendOption = None,
-    cwd: Annotated[str | None, typer.Option()] = None,
     launch_target_id: Annotated[str | None, typer.Option()] = None,
     launch_mode: Annotated[str | None, typer.Option()] = None,
     transport: Annotated[str | None, typer.Option()] = None,
-    title: Annotated[str | None, typer.Option()] = None,
     model: Annotated[str | None, typer.Option()] = None,
     effort: Annotated[str | None, typer.Option()] = None,
     permission_mode: Annotated[str | None, typer.Option()] = None,
@@ -2991,14 +2988,12 @@ def presets_create(
     tag: _PresetTagOption = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
-    """Create a session preset from launch options."""
+    """Create a session preset from launch options (cwd/title are per-launch)."""
     spec = _preset_spec_payload(
         backend=backend,
-        cwd=cwd,
         launch_target_id=launch_target_id,
         launch_mode=launch_mode,
         transport=transport,
-        title=title,
         model=model,
         effort=effort,
         permission_mode=permission_mode,
@@ -3023,11 +3018,9 @@ def presets_update(
     name: Annotated[str | None, typer.Option()] = None,
     description: Annotated[str | None, typer.Option()] = None,
     backend: _PresetBackendOption = None,
-    cwd: Annotated[str | None, typer.Option()] = None,
     launch_target_id: Annotated[str | None, typer.Option()] = None,
     launch_mode: Annotated[str | None, typer.Option()] = None,
     transport: Annotated[str | None, typer.Option()] = None,
-    title: Annotated[str | None, typer.Option()] = None,
     model: Annotated[str | None, typer.Option()] = None,
     effort: Annotated[str | None, typer.Option()] = None,
     permission_mode: Annotated[str | None, typer.Option()] = None,
@@ -3039,11 +3032,9 @@ def presets_update(
     """Update a preset. Only the fields you pass change; the rest are preserved."""
     spec = _preset_spec_payload(
         backend=backend,
-        cwd=cwd,
         launch_target_id=launch_target_id,
         launch_mode=launch_mode,
         transport=transport,
-        title=title,
         model=model,
         effort=effort,
         permission_mode=permission_mode,

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -289,8 +289,8 @@ class WaypointClient:
     def create_session(
         self,
         *,
-        backend: str,
-        cwd: str,
+        backend: str | None = None,
+        cwd: str | None = None,
         launch_target_id: str | None = None,
         launch_mode: str | None = None,
         transport: str | None = None,
@@ -301,32 +301,42 @@ class WaypointClient:
         spawner_session_id: str | None = None,
         worktree_path: str | None = None,
         args: list[str] | None = None,
+        config_overrides: list[str] | None = None,
         tags: dict[str, str] | None = None,
         launch_env: dict[str, str] | None = None,
+        preset_id: str | None = None,
+        use_default_preset: bool = False,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {
-            "backend": backend,
-            "cwd": cwd,
-            "launch_target_id": launch_target_id,
-            "title": title,
-            "model": model,
-            "effort": effort,
-            "permission_mode": permission_mode,
-            "spawner_session_id": spawner_session_id,
-            "worktree_path": worktree_path,
-            "args": args or [],
-            "tags": tags or {},
-        }
-        # Omit launch_mode when unset: it is a non-optional-with-default enum
-        # field, so an explicit null is a 422 (mirrors create_schedule).
-        if launch_mode is not None:
-            body["launch_mode"] = launch_mode
-        # Omit transport when unset so the request model's None default keeps
-        # today's launch_mode-derived behavior.
-        if transport is not None:
-            body["transport"] = transport
+        # Unset/empty fields are omitted, not sent as null: an omitted field is
+        # left to the preset (or the server default), while a present value is
+        # treated as an explicit override. Sending null would defeat preset merge.
+        body: dict[str, Any] = {}
+        for key, value in (
+            ("backend", backend),
+            ("cwd", cwd),
+            ("launch_target_id", launch_target_id),
+            ("title", title),
+            ("model", model),
+            ("effort", effort),
+            ("permission_mode", permission_mode),
+            ("spawner_session_id", spawner_session_id),
+            ("worktree_path", worktree_path),
+            ("launch_mode", launch_mode),
+            ("transport", transport),
+            ("preset_id", preset_id),
+        ):
+            if value is not None:
+                body[key] = value
+        if args:
+            body["args"] = args
+        if config_overrides:
+            body["config_overrides"] = config_overrides
+        if tags:
+            body["tags"] = tags
         if launch_env is not None:
             body["launch_env"] = launch_env
+        if use_default_preset:
+            body["use_default_preset"] = True
         data: dict[str, Any] = self._request("POST", "/api/sessions", json=body).json()[
             "session"
         ]
@@ -673,8 +683,8 @@ class WaypointClient:
     def create_schedule(
         self,
         *,
-        backend: str,
-        cwd: str,
+        backend: str | None = None,
+        cwd: str | None = None,
         launch_target_id: str | None = None,
         launch_mode: str | None = None,
         transport: str | None = None,
@@ -684,16 +694,20 @@ class WaypointClient:
         permission_mode: str | None = None,
         initial_prompt: str | None = None,
         args: list[str] | None = None,
+        config_overrides: list[str] | None = None,
         delay_seconds: int | None = None,
         scheduled_at: str | None = None,
         launch_env: dict[str, str] | None = None,
+        preset_id: str | None = None,
+        use_default_preset: bool = False,
     ) -> dict[str, Any]:
-        body: dict[str, Any] = {"backend": backend, "cwd": cwd, "args": args or []}
-        # Omit unset optionals so the server's model defaults apply. Sending an
-        # explicit null for a non-optional-with-default field like launch_mode
-        # is a 422 (it is validated against the enum, default or not). transport
-        # is optional-with-None, so omit it to keep the launch_mode behavior.
+        # Omit unset/empty optionals so a preset (or the server's model defaults)
+        # applies; a present value is an explicit override. Sending an explicit
+        # null for a non-optional-with-default field like launch_mode is a 422.
+        body: dict[str, Any] = {}
         optional = {
+            "backend": backend,
+            "cwd": cwd,
             "launch_target_id": launch_target_id,
             "launch_mode": launch_mode,
             "transport": transport,
@@ -705,10 +719,17 @@ class WaypointClient:
             "delay_seconds": delay_seconds,
             "scheduled_at": scheduled_at,
             "launch_env": launch_env,
+            "preset_id": preset_id,
         }
         body.update(
             {key: value for key, value in optional.items() if value is not None}
         )
+        if args:
+            body["args"] = args
+        if config_overrides:
+            body["config_overrides"] = config_overrides
+        if use_default_preset:
+            body["use_default_preset"] = True
         data: dict[str, Any] = self._request(
             "POST", "/api/schedules", json=body
         ).json()["schedule"]
@@ -723,6 +744,53 @@ class WaypointClient:
     def clear_schedule_history(self) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
             "POST", "/api/schedules/clear-history"
+        ).json()
+        return data
+
+    # ── session presets ──────────────────────────────────────────────────
+
+    def list_session_presets(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("GET", "/api/session-presets").json()
+        return data
+
+    def get_session_preset(
+        self, preset_id: str, *, include_secret_values: bool = False
+    ) -> dict[str, Any]:
+        params = {"include_secret_values": "true"} if include_secret_values else None
+        data: dict[str, Any] = self._request(
+            "GET", f"/api/session-presets/{preset_id}", params=params
+        ).json()["preset"]
+        return data
+
+    def create_session_preset(self, body: dict[str, Any]) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", "/api/session-presets", json=body
+        ).json()["preset"]
+        return data
+
+    def update_session_preset(
+        self, preset_id: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "PATCH", f"/api/session-presets/{preset_id}", json=body
+        ).json()["preset"]
+        return data
+
+    def delete_session_preset(self, preset_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "DELETE", f"/api/session-presets/{preset_id}"
+        ).json()
+        return data
+
+    def set_default_session_preset(self, preset_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", f"/api/session-presets/{preset_id}/default"
+        ).json()["preset"]
+        return data
+
+    def clear_default_session_preset(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "DELETE", "/api/session-presets/default"
         ).json()
         return data
 

--- a/backend/src/waypoint/presets.py
+++ b/backend/src/waypoint/presets.py
@@ -44,11 +44,9 @@ from waypoint.storage import Storage
 # default launch env.
 _SCALAR_FIELDS = (
     "backend",
-    "cwd",
     "launch_target_id",
     "launch_mode",
     "transport",
-    "title",
     "permission_mode",
     "model",
     "effort",
@@ -65,11 +63,9 @@ def redact_preset(record: SessionPresetRecord) -> SessionPresetSummary:
     spec = record.spec
     summary_spec = SessionPresetSpecSummary(
         backend=spec.backend,
-        cwd=spec.cwd,
         launch_target_id=spec.launch_target_id,
         launch_mode=spec.launch_mode,
         transport=spec.transport,
-        title=spec.title,
         args=list(spec.args),
         config_overrides=list(spec.config_overrides),
         launch_env_keys=sorted(spec.launch_env.keys()),

--- a/backend/src/waypoint/presets.py
+++ b/backend/src/waypoint/presets.py
@@ -1,0 +1,286 @@
+"""Session presets: reusable launch defaults resolved at request boundaries.
+
+Presets are Waypoint-level launch defaults, not backend-native templates. They
+are resolved into the existing launch-request shape before the runtime's own
+validation, so backend plugins, transports, the runtime, and the scheduler's
+``_fire`` path stay entirely preset-agnostic.
+
+Two concerns live here:
+
+* :class:`PresetManager` — CRUD orchestration over storage, id generation, and
+  the single-default invariant.
+* :func:`resolve_session_create_request` / :func:`resolve_schedule_create_request`
+  — the boundary merge: overlay a preset under the explicit request fields and
+  re-validate into a strict request.
+"""
+
+import secrets
+import sqlite3
+from datetime import UTC, datetime
+
+from fastapi import HTTPException, status
+from pydantic import ValidationError
+
+from waypoint.schemas import (
+    ScheduleCreateRequest,
+    ScheduleLaunchRequest,
+    SessionCreateRequest,
+    SessionLaunchRequest,
+    SessionPresetCreateRequest,
+    SessionPresetRecord,
+    SessionPresetSpec,
+    SessionPresetSpecSummary,
+    SessionPresetSummary,
+    SessionPresetUpdateRequest,
+)
+from waypoint.storage import Storage
+
+# Spec fields grouped by merge rule. A field is overlaid from the preset only
+# when the request omitted it (not in ``model_fields_set``) and the preset value
+# is *meaningful*: non-``None`` for scalars, non-empty for lists/maps. Gating on
+# emptiness (not mere presence) is load-bearing: a persisted preset always
+# deserializes with empty containers present, and blindly overlaying an empty
+# ``launch_env`` would mark it as explicitly set and suppress the backend's
+# default launch env.
+_SCALAR_FIELDS = (
+    "backend",
+    "cwd",
+    "launch_target_id",
+    "launch_mode",
+    "transport",
+    "title",
+    "permission_mode",
+    "model",
+    "effort",
+)
+_LIST_FIELDS = ("args", "config_overrides")
+_MAP_FIELDS = ("launch_env", "tags")
+
+# Request-only control fields that must never flow into the resolved launch.
+_CONTROL_FIELDS = ("preset_id", "use_default_preset")
+
+
+def redact_preset(record: SessionPresetRecord) -> SessionPresetSummary:
+    """Public, secret-free view of a preset: env values dropped, keys kept."""
+    spec = record.spec
+    summary_spec = SessionPresetSpecSummary(
+        backend=spec.backend,
+        cwd=spec.cwd,
+        launch_target_id=spec.launch_target_id,
+        launch_mode=spec.launch_mode,
+        transport=spec.transport,
+        title=spec.title,
+        args=list(spec.args),
+        config_overrides=list(spec.config_overrides),
+        launch_env_keys=sorted(spec.launch_env.keys()),
+        permission_mode=spec.permission_mode,
+        model=spec.model,
+        effort=spec.effort,
+        tags=dict(spec.tags),
+    )
+    return SessionPresetSummary(
+        id=record.id,
+        name=record.name,
+        description=record.description,
+        spec=summary_spec,
+        is_default=record.is_default,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+class PresetManager:
+    """CRUD orchestration for session presets, owning the default invariant."""
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+
+    @staticmethod
+    def _new_id() -> str:
+        return f"preset-{secrets.token_hex(4)}"
+
+    def resolve_ref(self, ref: str) -> SessionPresetRecord | None:
+        """Look a preset up by id, falling back to its (unique) name."""
+        return self._storage.get_session_preset(
+            ref
+        ) or self._storage.get_session_preset_by_name(ref)
+
+    def require_ref(self, ref: str) -> SessionPresetRecord:
+        record = self.resolve_ref(ref)
+        if record is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown preset: {ref!r}",
+            )
+        return record
+
+    def list(self) -> list[SessionPresetRecord]:
+        return self._storage.list_session_presets()
+
+    def default(self) -> SessionPresetRecord | None:
+        return self._storage.get_default_session_preset()
+
+    def create(self, request: SessionPresetCreateRequest) -> SessionPresetRecord:
+        now = datetime.now(UTC)
+        record = SessionPresetRecord(
+            id=self._new_id(),
+            name=request.name,
+            description=request.description,
+            spec=request.spec,
+            is_default=False,
+            created_at=now,
+            updated_at=now,
+        )
+        try:
+            self._storage.create_session_preset(record)
+        except sqlite3.IntegrityError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"a preset named {request.name!r} already exists",
+            ) from exc
+        if request.is_default:
+            self._storage.set_default_session_preset(record.id)
+            record = self.require_ref(record.id)
+        return record
+
+    def update(
+        self, ref: str, request: SessionPresetUpdateRequest
+    ) -> SessionPresetRecord:
+        existing = self.require_ref(ref)
+        fields: dict[str, object] = {}
+        given = request.model_fields_set
+        if "name" in given and request.name is not None:
+            fields["name"] = request.name
+        if "description" in given:
+            fields["description"] = request.description
+        if "spec" in given and request.spec is not None:
+            fields["spec"] = _merge_spec(existing.spec, request.spec)
+        if fields:
+            try:
+                existing = self._storage.update_session_preset(existing.id, **fields)
+            except sqlite3.IntegrityError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=f"a preset named {request.name!r} already exists",
+                ) from exc
+        if "is_default" in given and request.is_default is not None:
+            if request.is_default:
+                self._storage.set_default_session_preset(existing.id)
+            elif existing.is_default:
+                self._storage.set_default_session_preset(None)
+            existing = self.require_ref(existing.id)
+        return existing
+
+    def delete(self, ref: str) -> bool:
+        record = self.resolve_ref(ref)
+        if record is None:
+            return False
+        # Removing the row also clears the default when it was the default; the
+        # partial unique index simply has no ``is_default = 1`` row afterwards.
+        return self._storage.delete_session_preset(record.id)
+
+    def set_default(self, ref: str | None) -> SessionPresetRecord | None:
+        if ref is None:
+            self._storage.set_default_session_preset(None)
+            return None
+        record = self.require_ref(ref)
+        self._storage.set_default_session_preset(record.id)
+        return self.require_ref(record.id)
+
+
+def _merge_spec(
+    existing: SessionPresetSpec, incoming: SessionPresetSpec
+) -> SessionPresetSpec:
+    """Overlay only the fields the client explicitly sent, preserving the rest."""
+    data = existing.model_dump()
+    for name in incoming.model_fields_set:
+        data[name] = getattr(incoming, name)
+    return SessionPresetSpec.model_validate(data)
+
+
+def _select_preset(
+    storage: Storage, preset_id: str | None, use_default: bool
+) -> SessionPresetRecord | None:
+    if preset_id is not None:
+        record = storage.get_session_preset(
+            preset_id
+        ) or storage.get_session_preset_by_name(preset_id)
+        if record is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown preset: {preset_id!r}",
+            )
+        return record
+    if use_default:
+        return storage.get_default_session_preset()
+    return None
+
+
+def _merge(request: object, preset: SessionPresetRecord | None) -> dict[str, object]:
+    req_fields = type(request).model_fields  # type: ignore[attr-defined]
+    explicit = request.model_fields_set  # type: ignore[attr-defined]
+    merged: dict[str, object] = {
+        name: getattr(request, name)
+        for name in req_fields
+        if name in explicit and name not in _CONTROL_FIELDS
+    }
+    if preset is None:
+        return merged
+    spec = preset.spec
+    for name in _SCALAR_FIELDS:
+        if name in req_fields and name not in explicit:
+            value = getattr(spec, name)
+            if value is not None:
+                merged[name] = value
+    for name in _LIST_FIELDS:
+        if name in req_fields and name not in explicit:
+            value = getattr(spec, name)
+            if value:
+                merged[name] = list(value)
+    for name in _MAP_FIELDS:
+        if name in req_fields and name not in explicit:
+            value = getattr(spec, name)
+            if value:
+                merged[name] = dict(value)
+    return merged
+
+
+def _validation_detail(exc: ValidationError, preset: SessionPresetRecord | None) -> str:
+    prefix = (
+        f"invalid launch after applying preset {preset.name!r}: "
+        if preset is not None
+        else "invalid launch: "
+    )
+    return prefix + "; ".join(
+        f"{'.'.join(str(p) for p in err['loc'])}: {err['msg']}" for err in exc.errors()
+    )
+
+
+def resolve_session_create_request(
+    storage: Storage, request: SessionLaunchRequest
+) -> tuple[SessionCreateRequest, SessionPresetRecord | None]:
+    preset = _select_preset(storage, request.preset_id, request.use_default_preset)
+    merged = _merge(request, preset)
+    try:
+        resolved = SessionCreateRequest.model_validate(merged)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_validation_detail(exc, preset),
+        ) from exc
+    return resolved, preset
+
+
+def resolve_schedule_create_request(
+    storage: Storage, request: ScheduleLaunchRequest
+) -> tuple[ScheduleCreateRequest, SessionPresetRecord | None]:
+    preset = _select_preset(storage, request.preset_id, request.use_default_preset)
+    merged = _merge(request, preset)
+    try:
+        resolved = ScheduleCreateRequest.model_validate(merged)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=_validation_detail(exc, preset),
+        ) from exc
+    return resolved, preset

--- a/backend/src/waypoint/presets.py
+++ b/backend/src/waypoint/presets.py
@@ -99,6 +99,16 @@ class PresetManager:
     def _new_id() -> str:
         return f"preset-{secrets.token_hex(4)}"
 
+    @staticmethod
+    def _reject_reserved_name(name: str | None) -> None:
+        # "default" is a route segment on /api/session-presets/{id}; a preset by
+        # that name would be unreachable by name for GET/PATCH/DELETE.
+        if name is not None and name.strip().lower() == "default":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="'default' is a reserved preset name",
+            )
+
     def resolve_ref(self, ref: str) -> SessionPresetRecord | None:
         """Look a preset up by id, falling back to its (unique) name."""
         return self._storage.get_session_preset(
@@ -121,6 +131,7 @@ class PresetManager:
         return self._storage.get_default_session_preset()
 
     def create(self, request: SessionPresetCreateRequest) -> SessionPresetRecord:
+        self._reject_reserved_name(request.name)
         now = datetime.now(UTC)
         record = SessionPresetRecord(
             id=self._new_id(),
@@ -150,6 +161,7 @@ class PresetManager:
         fields: dict[str, object] = {}
         given = request.model_fields_set
         if "name" in given and request.name is not None:
+            self._reject_reserved_name(request.name)
             fields["name"] = request.name
         if "description" in given:
             fields["description"] = request.description

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -31,6 +31,7 @@ from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.perf import debug_timer
+from waypoint.presets import PresetManager
 from waypoint.scheduler import Scheduler
 from waypoint.schemas import (
     AssistantSummary,
@@ -278,6 +279,7 @@ class SessionRuntime:
         }
         for plugin in self.registry.all():
             plugin.setup(self)
+        self.presets = PresetManager(storage)
         self.scheduler = Scheduler(self)
 
     def transport_for(self, session: SessionRecord) -> TransportAdapter:
@@ -433,7 +435,13 @@ class SessionRuntime:
             env["WAYPOINT_SESSION_ID"] = session_id
         return env
 
-    async def create_session(self, request: SessionCreateRequest) -> SessionRecord:
+    async def create_session(
+        self,
+        request: SessionCreateRequest,
+        *,
+        preset_id: str | None = None,
+        preset_name: str | None = None,
+    ) -> SessionRecord:
         if request.source_mode != SessionSource.MANAGED:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -599,6 +607,12 @@ class SessionRuntime:
         # backend picks them up without a per-plugin launch-site edit.
         if request.tags:
             session = self.storage.update_session(session.id, tags=request.tags)
+        # Preset provenance is opaque display metadata — stamped the same generic
+        # way as tags so the runtime never inspects the preset spec.
+        if preset_id is not None or preset_name is not None:
+            session = self.storage.update_session(
+                session.id, preset_id=preset_id, preset_name=preset_name
+            )
         self._warm_command_completions(session)
         self._start_context_usage_source(session)
         return session

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -81,7 +81,13 @@ class Scheduler:
     def list_schedules(self) -> list[ScheduledSessionRecord]:
         return self._runtime.storage.list_schedules()
 
-    def create_schedule(self, request: ScheduleCreateRequest) -> ScheduledSessionRecord:
+    def create_schedule(
+        self,
+        request: ScheduleCreateRequest,
+        *,
+        preset_id: str | None = None,
+        preset_name: str | None = None,
+    ) -> ScheduledSessionRecord:
         scheduled_at = self._resolve_scheduled_at(request)
         permission_mode = self._resolve_permission_mode(request)
         # Validate launch target and transport up-front so the user gets
@@ -119,6 +125,8 @@ class Scheduler:
             scheduled_at=scheduled_at,
             created_at=now,
             status=ScheduleStatus.PENDING,
+            preset_id=preset_id,
+            preset_name=preset_name,
         )
         self._runtime.storage.create_schedule(record)
         self._wakeup.set()
@@ -338,7 +346,9 @@ class Scheduler:
                     permission_mode=schedule.permission_mode,
                     model=schedule.model,
                     effort=schedule.effort,
-                )
+                ),
+                preset_id=schedule.preset_id,
+                preset_name=schedule.preset_name,
             )
             self._runtime.storage.update_schedule(
                 schedule.id,

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -376,12 +376,15 @@ class SessionPresetSpec(BaseModel):
     # ``backend``/``transport`` are plain strings (not registry-validated ids) so
     # a preset stays listable/editable/deletable after a plugin is removed or
     # renamed; the resolver validates them only when applying the preset.
+    #
+    # Deliberately excludes ``cwd`` and ``title``: those are per-launch specifics
+    # (which repo, what to call this run), not reusable launch defaults, so the
+    # launch surfaces always supply them explicitly. ``extra="ignore"`` (Pydantic
+    # default) means presets persisted with older cwd/title keys drop them on load.
     backend: str | None = None
-    cwd: str | None = None
     launch_target_id: str | None = None
     launch_mode: LaunchMode | None = None
     transport: str | None = None
-    title: str | None = None
     args: list[str] = Field(default_factory=list)
     config_overrides: list[str] = Field(default_factory=list)
     launch_env: LaunchEnv = Field(default_factory=dict)
@@ -406,11 +409,9 @@ class SessionPresetSpecSummary(BaseModel):
     # the keys are exposed, so preset secrets never ride in list / bootstrap
     # payloads. Full values come from GET .../{id}?include_secret_values=true.
     backend: str | None = None
-    cwd: str | None = None
     launch_target_id: str | None = None
     launch_mode: LaunchMode | None = None
     transport: str | None = None
-    title: str | None = None
     args: list[str] = Field(default_factory=list)
     config_overrides: list[str] = Field(default_factory=list)
     launch_env_keys: list[str] = Field(default_factory=list)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -515,10 +515,11 @@ class SessionCreateRequest(BaseModel):
 
 
 class SessionLaunchRequest(SessionCreateRequest):
-    # Boundary input for POST /api/sessions and the in-process CLI launch: when a
-    # preset (or the default) supplies them, ``backend``/``cwd`` may be omitted.
-    # The preset resolver merges preset + explicit request fields and re-validates
-    # the result into a strict ``SessionCreateRequest`` before the runtime sees it.
+    # Boundary input for POST /api/sessions and the in-process CLI launch:
+    # ``backend`` may be omitted when a preset (or the default) supplies it.
+    # ``cwd`` is never a preset field, so it stays effectively required — an
+    # omitted cwd fails re-validation with a clean 400. Both are optional here
+    # only so the resolver can merge and re-validate rather than 422 up-front.
     # Widening the parent's required fields to optional is an intentional Pydantic
     # subclass override; mypy flags it as an LSP violation, which does not apply
     # here (this type is only ever an input, never used where the parent is).

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -230,6 +230,11 @@ class SessionRecord(BaseModel):
     # empty value). Set at launch or via ``sessions tag``; filtered by
     # ``sessions list --tag`` / ``sessions reap --tag``.
     tags: dict[str, str] = Field(default_factory=dict)
+    # Provenance for launches created from a session preset. Audit/display hints
+    # only — the resolved launch settings are snapshotted onto the record, so
+    # later preset edits/deletes do not affect an existing session.
+    preset_id: str | None = None
+    preset_name: str | None = None
 
 
 class EventRecord(BaseModel):
@@ -362,6 +367,91 @@ class AssistantAttachRequest(BaseModel):
     launch_target_id: str | None = None
 
 
+PresetName = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]
+
+
+class SessionPresetSpec(BaseModel):
+    # Reusable launch defaults. All fields are optional so partial presets can
+    # exist; a resolved launch must still satisfy the non-null request rules.
+    # ``backend``/``transport`` are plain strings (not registry-validated ids) so
+    # a preset stays listable/editable/deletable after a plugin is removed or
+    # renamed; the resolver validates them only when applying the preset.
+    backend: str | None = None
+    cwd: str | None = None
+    launch_target_id: str | None = None
+    launch_mode: LaunchMode | None = None
+    transport: str | None = None
+    title: str | None = None
+    args: list[str] = Field(default_factory=list)
+    config_overrides: list[str] = Field(default_factory=list)
+    launch_env: LaunchEnv = Field(default_factory=dict)
+    permission_mode: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class SessionPresetRecord(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    spec: SessionPresetSpec
+    is_default: bool = False
+    created_at: datetime
+    updated_at: datetime
+
+
+class SessionPresetSpecSummary(BaseModel):
+    # Redacted spec for read surfaces: ``launch_env`` values are omitted and only
+    # the keys are exposed, so preset secrets never ride in list / bootstrap
+    # payloads. Full values come from GET .../{id}?include_secret_values=true.
+    backend: str | None = None
+    cwd: str | None = None
+    launch_target_id: str | None = None
+    launch_mode: LaunchMode | None = None
+    transport: str | None = None
+    title: str | None = None
+    args: list[str] = Field(default_factory=list)
+    config_overrides: list[str] = Field(default_factory=list)
+    launch_env_keys: list[str] = Field(default_factory=list)
+    permission_mode: str | None = None
+    model: str | None = None
+    effort: str | None = None
+    tags: dict[str, str] = Field(default_factory=dict)
+
+
+class SessionPresetSummary(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    spec: SessionPresetSpecSummary
+    is_default: bool = False
+    created_at: datetime
+    updated_at: datetime
+
+
+class SessionPresetCreateRequest(BaseModel):
+    name: PresetName
+    description: str | None = None
+    spec: SessionPresetSpec = Field(default_factory=SessionPresetSpec)
+    is_default: bool = False
+
+
+class SessionPresetUpdateRequest(BaseModel):
+    # PATCH semantics: only fields present in the body change. A provided ``spec``
+    # is merged field-by-field using its ``model_fields_set``, so fields the
+    # client omits (e.g. ``tags``) are preserved on the stored preset.
+    name: PresetName | None = None
+    description: str | None = None
+    spec: SessionPresetSpec | None = None
+    is_default: bool | None = None
+
+
+class SessionPresetListResponse(BaseModel):
+    presets: list[SessionPresetSummary] = Field(default_factory=list)
+    default_preset_id: str | None = None
+
+
 class MeResponse(BaseModel):
     authenticated: bool = True
     default_backend: BackendId = "codex"
@@ -374,6 +464,10 @@ class MeResponse(BaseModel):
     # The personal-assistant singleton, when enabled. The frontend uses
     # this to locate and render the dedicated assistant page.
     assistant: AssistantSummary | None = None
+    # Redacted session presets + the default preset id, so the launch panel can
+    # populate its selector without a second round-trip. Env values are omitted.
+    session_presets: list[SessionPresetSummary] = Field(default_factory=list)
+    default_preset_id: str | None = None
 
 
 class EventsPageResponse(BaseModel):
@@ -411,6 +505,24 @@ class SessionCreateRequest(BaseModel):
     model: str | None = None
     effort: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
+    # Apply a session preset before validation: ``preset_id`` names a specific
+    # preset; ``use_default_preset`` applies the deployment default. Explicit
+    # request fields always win over preset values. Resolution happens at the
+    # request boundary (API / in-process CLI); the runtime stays preset-agnostic.
+    preset_id: str | None = None
+    use_default_preset: bool = False
+
+
+class SessionLaunchRequest(SessionCreateRequest):
+    # Boundary input for POST /api/sessions and the in-process CLI launch: when a
+    # preset (or the default) supplies them, ``backend``/``cwd`` may be omitted.
+    # The preset resolver merges preset + explicit request fields and re-validates
+    # the result into a strict ``SessionCreateRequest`` before the runtime sees it.
+    # Widening the parent's required fields to optional is an intentional Pydantic
+    # subclass override; mypy flags it as an LSP violation, which does not apply
+    # here (this type is only ever an input, never used where the parent is).
+    backend: BackendId | None = None  # type: ignore[assignment]
+    cwd: str | None = None  # type: ignore[assignment]
 
 
 class SessionTagsUpdateRequest(BaseModel):
@@ -531,6 +643,9 @@ class ScheduledSessionRecord(BaseModel):
     status: ScheduleStatus = ScheduleStatus.PENDING
     session_id: str | None = None
     failure_reason: str | None = None
+    # Preset provenance snapshotted at schedule-creation time (see SessionRecord).
+    preset_id: str | None = None
+    preset_name: str | None = None
 
 
 class ScheduleCreateRequest(BaseModel):
@@ -552,6 +667,17 @@ class ScheduleCreateRequest(BaseModel):
     effort: str | None = None
     delay_seconds: int | None = None
     scheduled_at: datetime | None = None
+    # See SessionCreateRequest — apply a preset before validation. Explicit
+    # request fields win; schedule timing/prompt fields are never taken from a
+    # preset.
+    preset_id: str | None = None
+    use_default_preset: bool = False
+
+
+class ScheduleLaunchRequest(ScheduleCreateRequest):
+    # Boundary input for POST /api/schedules — see SessionLaunchRequest.
+    backend: BackendId | None = None  # type: ignore[assignment]
+    cwd: str | None = None  # type: ignore[assignment]
 
 
 class SessionEnvelope(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -33,6 +33,7 @@ from waypoint.schemas import (
     ScheduleStatus,
     SessionCommandInvocation,
     SessionInputItem,
+    SessionPresetRecord,
     SessionRecord,
     SessionStatus,
 )
@@ -314,6 +315,26 @@ class Storage:
                 updated_at TEXT NOT NULL,
                 blocks TEXT NOT NULL DEFAULT '[]'
             );
+
+            -- Reusable launch defaults applied at session/schedule request
+            -- boundaries. ``spec`` is the JSON-serialized SessionPresetSpec.
+            CREATE TABLE IF NOT EXISTS session_presets (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                description TEXT,
+                spec TEXT NOT NULL DEFAULT '{}',
+                is_default INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            -- At most one default preset per deployment; names are unique
+            -- case-insensitively.
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_session_presets_default
+                ON session_presets(is_default)
+                WHERE is_default = 1;
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_session_presets_name_nocase
+                ON session_presets(LOWER(name));
             """)
         # Register any channels that predate the board_channels table.
         self.connection.execute(
@@ -341,12 +362,16 @@ class Storage:
         self._ensure_column("sessions", "worktree_path", "TEXT")
         self._ensure_column("sessions", "resolved_model", "TEXT")
         self._ensure_column("sessions", "tags", "TEXT NOT NULL DEFAULT '{}'")
+        self._ensure_column("sessions", "preset_id", "TEXT")
+        self._ensure_column("sessions", "preset_name", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
         self._ensure_column(
             "scheduled_sessions", "launch_env", "TEXT NOT NULL DEFAULT '{}'"
         )
+        self._ensure_column("scheduled_sessions", "preset_id", "TEXT")
+        self._ensure_column("scheduled_sessions", "preset_name", "TEXT")
         # Additive migration for the inbox table on databases that predate it.
         # (No-ops on a fresh DB where the CREATE TABLE above already made the
         # complete table; only load-bearing for columns added in a later release.)
@@ -384,8 +409,8 @@ class Storage:
                 last_event_at, raw_log_path, structured_log_path, transport_state,
                 pinned_at, spawner_session_id, worktree_path, permission_mode, model,
                 resolved_model, effort, args, config_overrides, launch_env, context_usage,
-                rate_limit_usage, tags
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                rate_limit_usage, tags, preset_id, preset_name
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -426,6 +451,8 @@ class Storage:
                     else None
                 ),
                 json.dumps(session.tags),
+                session.preset_id,
+                session.preset_name,
             ),
         )
         self.connection.commit()
@@ -1359,8 +1386,8 @@ class Storage:
             INSERT INTO scheduled_sessions (
                 id, backend, cwd, launch_target_id, launch_mode, transport, title, args,
                 config_overrides, launch_env, initial_prompt, permission_mode, model, effort, scheduled_at,
-                created_at, status, session_id, failure_reason
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, status, session_id, failure_reason, preset_id, preset_name
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 schedule.id,
@@ -1382,6 +1409,8 @@ class Storage:
                 schedule.status,
                 schedule.session_id,
                 schedule.failure_reason,
+                schedule.preset_id,
+                schedule.preset_name,
             ),
         )
         self.connection.commit()
@@ -1450,6 +1479,129 @@ class Storage:
         )
         self.connection.commit()
         return cursor.rowcount or 0
+
+    # ── Session presets ──────────────────────────────────────────────────
+    @_synchronized
+    def create_session_preset(self, preset: SessionPresetRecord) -> SessionPresetRecord:
+        self.connection.execute(
+            """
+            INSERT INTO session_presets (
+                id, name, description, spec, is_default, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                preset.id,
+                preset.name,
+                preset.description,
+                json.dumps(preset.spec.model_dump(mode="json")),
+                1 if preset.is_default else 0,
+                preset.created_at.isoformat(),
+                preset.updated_at.isoformat(),
+            ),
+        )
+        self.connection.commit()
+        return preset
+
+    @_synchronized
+    def list_session_presets(self) -> list[SessionPresetRecord]:
+        rows = self.connection.execute(
+            "SELECT * FROM session_presets ORDER BY LOWER(name) ASC"
+        ).fetchall()
+        return [self._preset_from_row(row) for row in rows]
+
+    @_synchronized
+    def get_session_preset(self, preset_id: str) -> SessionPresetRecord | None:
+        row = self.connection.execute(
+            "SELECT * FROM session_presets WHERE id = ?", (preset_id,)
+        ).fetchone()
+        return self._preset_from_row(row) if row is not None else None
+
+    @_synchronized
+    def get_session_preset_by_name(self, name: str) -> SessionPresetRecord | None:
+        row = self.connection.execute(
+            "SELECT * FROM session_presets WHERE LOWER(name) = LOWER(?)", (name,)
+        ).fetchone()
+        return self._preset_from_row(row) if row is not None else None
+
+    @_synchronized
+    def get_default_session_preset(self) -> SessionPresetRecord | None:
+        row = self.connection.execute(
+            "SELECT * FROM session_presets WHERE is_default = 1"
+        ).fetchone()
+        return self._preset_from_row(row) if row is not None else None
+
+    @_synchronized
+    def update_session_preset(
+        self, preset_id: str, **fields: Any
+    ) -> SessionPresetRecord:
+        # ``is_default`` is intentionally not updatable here — the default
+        # invariant is managed exclusively by ``set_default_session_preset`` so
+        # the partial unique index is never violated by a raw column write.
+        fields.pop("is_default", None)
+        fields.setdefault("updated_at", datetime.now(UTC))
+        assignments = ", ".join(f"{name} = ?" for name in fields)
+        values = [self._serialize_field(value) for value in fields.values()]
+        values.append(preset_id)
+        if _SUPPORTS_RETURNING:
+            row = self.connection.execute(
+                f"UPDATE session_presets SET {assignments} WHERE id = ? RETURNING *",
+                values,
+            ).fetchone()
+            self.connection.commit()
+            if row is None:
+                raise KeyError(preset_id)
+            return self._preset_from_row(row)
+        if self.get_session_preset(preset_id) is None:
+            raise KeyError(preset_id)
+        self.connection.execute(
+            f"UPDATE session_presets SET {assignments} WHERE id = ?", values
+        )
+        self.connection.commit()
+        updated = self.get_session_preset(preset_id)
+        assert updated is not None
+        return updated
+
+    @_synchronized
+    def delete_session_preset(self, preset_id: str) -> bool:
+        cursor = self.connection.execute(
+            "DELETE FROM session_presets WHERE id = ?", (preset_id,)
+        )
+        self.connection.commit()
+        return (cursor.rowcount or 0) > 0
+
+    @_synchronized
+    def set_default_session_preset(self, preset_id: str | None) -> None:
+        # Clear the current default and (optionally) set a new one in one
+        # transaction so the ``is_default = 1`` partial unique index always holds.
+        ts = datetime.now(UTC).isoformat()
+        self.connection.execute(
+            "UPDATE session_presets SET is_default = 0, updated_at = ? "
+            "WHERE is_default = 1",
+            (ts,),
+        )
+        if preset_id is not None:
+            cursor = self.connection.execute(
+                "UPDATE session_presets SET is_default = 1, updated_at = ? "
+                "WHERE id = ?",
+                (ts, preset_id),
+            )
+            if (cursor.rowcount or 0) == 0:
+                self.connection.rollback()
+                raise KeyError(preset_id)
+        self.connection.commit()
+
+    def _preset_from_row(self, row: sqlite3.Row) -> SessionPresetRecord:
+        payload = dict(row)
+        for field_name in ("created_at", "updated_at"):
+            payload[field_name] = datetime.fromisoformat(payload[field_name])
+        payload["is_default"] = bool(payload.get("is_default", 0))
+        raw_spec = payload.get("spec") or "{}"
+        try:
+            parsed_spec = json.loads(raw_spec)
+        except json.JSONDecodeError:
+            parsed_spec = {}
+        payload["spec"] = parsed_spec if isinstance(parsed_spec, dict) else {}
+        return SessionPresetRecord.model_validate(payload)
 
     @_synchronized
     def create_scheduled_message(

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -102,9 +102,12 @@ def test_help_json_is_structured() -> None:
     by_path = {entry["command"]: entry for entry in commands}
     start = by_path["sessions start"]
     backend = next(o for o in start["options"] if "--backend" in o["flags"])
-    assert backend["required"] is True
+    # --backend is optional: a --preset (or the default preset) may supply it,
+    # with required-field validation happening after preset resolution.
+    assert backend["required"] is False
     assert backend["type"] == "text"
     assert any("--launch-env" in o["flags"] for o in start["options"])
+    assert any("--preset" in o["flags"] for o in start["options"])
     schedule_create = by_path["schedule create"]
     assert any("--launch-env" in o["flags"] for o in schedule_create["options"])
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -155,7 +155,7 @@ async def test_fire_due_schedules_creates_session_and_sends_prompt(
     runtime.storage.create_session(created_session)
     inputs: list[tuple[str, str]] = []
 
-    async def fake_create_session(request) -> SessionRecord:
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
         return created_session
 
     async def fake_handle_input(session_id: str, request) -> SessionRecord:
@@ -184,7 +184,7 @@ async def test_fire_due_schedules_records_failure(tmp_path, monkeypatch) -> None
         schedule.id, scheduled_at=datetime.now(UTC) - timedelta(seconds=1)
     )
 
-    async def fake_create_session(_request) -> SessionRecord:
+    async def fake_create_session(_request, **_kwargs) -> SessionRecord:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(runtime, "create_session", fake_create_session)
@@ -263,7 +263,7 @@ async def test_fire_passes_permission_mode_to_create_session(
     runtime.storage.create_session(created_session)
     captured: list[str | None] = []
 
-    async def fake_create_session(request) -> SessionRecord:
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
         captured.append(request.permission_mode)
         return created_session
 
@@ -292,7 +292,7 @@ async def test_fire_passes_launch_env_to_create_session(tmp_path, monkeypatch) -
     runtime.storage.create_session(created_session)
     captured: list[dict[str, str]] = []
 
-    async def fake_create_session(request) -> SessionRecord:
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
         captured.append(request.launch_env)
         return created_session
 
@@ -321,7 +321,7 @@ async def test_fire_passes_launch_mode_to_create_session(tmp_path, monkeypatch) 
     runtime.storage.create_session(created_session)
     captured: list[LaunchMode] = []
 
-    async def fake_create_session(request) -> SessionRecord:
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
         captured.append(request.launch_mode)
         return created_session
 
@@ -399,7 +399,7 @@ async def test_fire_passes_transport_to_create_session(tmp_path, monkeypatch) ->
     runtime.storage.create_session(created_session)
     captured: list[str | None] = []
 
-    async def fake_create_session(request) -> SessionRecord:
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
         captured.append(request.transport)
         return created_session
 

--- a/backend/tests/test_session_presets.py
+++ b/backend/tests/test_session_presets.py
@@ -117,6 +117,13 @@ def test_manager_create_and_default(tmp_path: Path) -> None:
     assert exc.value.status_code == 409
 
 
+def test_manager_rejects_reserved_default_name(tmp_path: Path) -> None:
+    manager = PresetManager(_storage(tmp_path))
+    with pytest.raises(HTTPException) as exc:
+        manager.create(SessionPresetCreateRequest(name="Default"))
+    assert exc.value.status_code == 400
+
+
 def test_manager_update_preserves_omitted_spec_fields(tmp_path: Path) -> None:
     manager = PresetManager(_storage(tmp_path))
     manager.create(

--- a/backend/tests/test_session_presets.py
+++ b/backend/tests/test_session_presets.py
@@ -1,0 +1,498 @@
+"""Tests for session presets: storage CRUD, resolver merge, API, and CLI."""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import HTTPException
+from typer.testing import CliRunner
+
+from waypoint.api import create_app
+from waypoint.cli import app as cli_app
+from waypoint.client import WaypointClient
+from waypoint.presets import (
+    PresetManager,
+    redact_preset,
+    resolve_schedule_create_request,
+    resolve_session_create_request,
+)
+from waypoint.schemas import (
+    ScheduleLaunchRequest,
+    SessionLaunchRequest,
+    SessionPresetCreateRequest,
+    SessionPresetRecord,
+    SessionPresetSpec,
+    SessionPresetUpdateRequest,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+runner = CliRunner()
+
+
+def _storage(tmp_path: Path) -> Storage:
+    return Storage(tmp_path / "waypoint.db")
+
+
+def _record(name: str, **spec_kwargs: Any) -> SessionPresetRecord:
+    now = datetime.now(UTC)
+    return SessionPresetRecord(
+        id=f"preset-{name}",
+        name=name,
+        spec=SessionPresetSpec(**spec_kwargs),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+# ── Storage ──────────────────────────────────────────────────────────────────
+
+
+def test_storage_round_trip(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    record = _record("Worker", backend="codex", model="gpt-5", launch_env={"A": "1"})
+    storage.create_session_preset(record)
+    fetched = storage.get_session_preset(record.id)
+    assert fetched is not None
+    assert fetched.name == "Worker"
+    assert fetched.spec.backend == "codex"
+    assert fetched.spec.launch_env == {"A": "1"}
+    assert storage.get_session_preset_by_name("worker") is not None  # case-insensitive
+    assert [p.name for p in storage.list_session_presets()] == ["Worker"]
+
+
+def test_storage_default_invariant(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    storage.create_session_preset(_record("A", backend="codex"))
+    storage.create_session_preset(_record("B", backend="codex"))
+    storage.set_default_session_preset("preset-A")
+    assert storage.get_default_session_preset().id == "preset-A"  # type: ignore[union-attr]
+    # Switching the default clears the previous one (partial unique index holds).
+    storage.set_default_session_preset("preset-B")
+    default = storage.get_default_session_preset()
+    assert default is not None and default.id == "preset-B"
+    assert storage.get_session_preset("preset-A").is_default is False  # type: ignore[union-attr]
+    # Clearing removes the default entirely.
+    storage.set_default_session_preset(None)
+    assert storage.get_default_session_preset() is None
+
+
+def test_storage_name_uniqueness_is_case_insensitive(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    storage.create_session_preset(_record("Worker", backend="codex"))
+    import sqlite3
+
+    with pytest.raises(sqlite3.IntegrityError):
+        storage.create_session_preset(_record("worker", backend="claude_code"))
+
+
+def test_storage_delete_default_clears_default(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    storage.create_session_preset(_record("A", backend="codex"))
+    storage.set_default_session_preset("preset-A")
+    assert storage.delete_session_preset("preset-A") is True
+    assert storage.get_default_session_preset() is None
+
+
+# ── PresetManager ────────────────────────────────────────────────────────────
+
+
+def test_manager_create_and_default(tmp_path: Path) -> None:
+    manager = PresetManager(_storage(tmp_path))
+    created = manager.create(
+        SessionPresetCreateRequest(
+            name="Worker",
+            spec=SessionPresetSpec(backend="codex"),
+            is_default=True,
+        )
+    )
+    assert created.is_default is True
+    assert manager.default() is not None
+    # Duplicate name is a 409.
+    with pytest.raises(HTTPException) as exc:
+        manager.create(SessionPresetCreateRequest(name="worker"))
+    assert exc.value.status_code == 409
+
+
+def test_manager_update_preserves_omitted_spec_fields(tmp_path: Path) -> None:
+    manager = PresetManager(_storage(tmp_path))
+    manager.create(
+        SessionPresetCreateRequest(
+            name="Worker",
+            spec=SessionPresetSpec(
+                backend="codex", model="gpt-5", tags={"role": "worker"}
+            ),
+        )
+    )
+    # Update only the model; tags and backend must survive (PATCH merge).
+    updated = manager.update(
+        "Worker",
+        SessionPresetUpdateRequest(spec=SessionPresetSpec(model="gpt-5-mini")),
+    )
+    assert updated.spec.model == "gpt-5-mini"
+    assert updated.spec.backend == "codex"
+    assert updated.spec.tags == {"role": "worker"}
+
+
+# ── Resolver ─────────────────────────────────────────────────────────────────
+
+
+def _seed(storage: Storage, **spec_kwargs: Any) -> SessionPresetRecord:
+    return PresetManager(storage).create(
+        SessionPresetCreateRequest(name="P", spec=SessionPresetSpec(**spec_kwargs))
+    )
+
+
+def test_resolve_scalar_override(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex", model="gpt-5")
+    request = SessionLaunchRequest(preset_id=preset.id, cwd="/x", model="gpt-5-mini")
+    resolved, matched = resolve_session_create_request(storage, request)
+    assert matched is not None
+    assert resolved.backend == "codex"  # from preset
+    assert resolved.model == "gpt-5-mini"  # explicit wins
+
+
+def test_resolve_list_replaces_not_appends(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex", args=["--a", "--b"])
+    request = SessionLaunchRequest(preset_id=preset.id, cwd="/x", args=["--c"])
+    resolved, _ = resolve_session_create_request(storage, request)
+    assert resolved.args == ["--c"]
+
+
+def test_resolve_preset_fills_omitted_list(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex", args=["--a"])
+    resolved, _ = resolve_session_create_request(
+        storage, SessionLaunchRequest(preset_id=preset.id, cwd="/x")
+    )
+    assert resolved.args == ["--a"]
+
+
+def test_resolve_empty_preset_env_preserves_backend_defaults(tmp_path: Path) -> None:
+    # A persisted preset always has launch_env={} present; the resolver must NOT
+    # mark it as explicitly set, or the runtime would skip the backend default env.
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex")
+    resolved, _ = resolve_session_create_request(
+        storage, SessionLaunchRequest(preset_id=preset.id, cwd="/x")
+    )
+    assert "launch_env" not in resolved.model_fields_set
+
+
+def test_resolve_nonempty_preset_env_is_applied(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex", launch_env={"A": "1"})
+    resolved, _ = resolve_session_create_request(
+        storage, SessionLaunchRequest(preset_id=preset.id, cwd="/x")
+    )
+    assert "launch_env" in resolved.model_fields_set
+    assert resolved.launch_env == {"A": "1"}
+
+
+def test_resolve_explicit_empty_env_wins(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex", launch_env={"A": "1"})
+    request = SessionLaunchRequest(preset_id=preset.id, cwd="/x", launch_env={})
+    resolved, _ = resolve_session_create_request(storage, request)
+    assert "launch_env" in resolved.model_fields_set
+    assert resolved.launch_env == {}
+
+
+def test_resolve_unknown_backend_preset_is_400_but_listable(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="nope-backend")
+    with pytest.raises(HTTPException) as exc:
+        resolve_session_create_request(
+            storage, SessionLaunchRequest(preset_id=preset.id, cwd="/x")
+        )
+    assert exc.value.status_code == 400
+    # Still listable despite the stale backend.
+    assert storage.get_session_preset(preset.id) is not None
+
+
+def test_resolve_missing_backend_is_400(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    with pytest.raises(HTTPException) as exc:
+        resolve_session_create_request(storage, SessionLaunchRequest(cwd="/x"))
+    assert exc.value.status_code == 400
+
+
+def test_resolve_default_only_with_flag(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    manager = PresetManager(storage)
+    manager.create(
+        SessionPresetCreateRequest(
+            name="D", spec=SessionPresetSpec(backend="codex"), is_default=True
+        )
+    )
+    # No flag → no preset applied → missing backend → 400.
+    with pytest.raises(HTTPException):
+        resolve_session_create_request(storage, SessionLaunchRequest(cwd="/x"))
+    # With the flag the default is applied.
+    resolved, matched = resolve_session_create_request(
+        storage, SessionLaunchRequest(cwd="/x", use_default_preset=True)
+    )
+    assert matched is not None and resolved.backend == "codex"
+
+
+def test_resolve_schedule_snapshots_and_ignores_tags(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    preset = _seed(storage, backend="codex", model="gpt-5", tags={"role": "x"})
+    resolved, matched = resolve_schedule_create_request(
+        storage, ScheduleLaunchRequest(preset_id=preset.id, cwd="/x", delay_seconds=60)
+    )
+    assert matched is not None
+    assert resolved.backend == "codex"
+    assert resolved.model == "gpt-5"
+    assert resolved.delay_seconds == 60
+    assert not hasattr(resolved, "tags")  # schedule has no tags field
+
+
+# ── Redaction ────────────────────────────────────────────────────────────────
+
+
+def test_redact_drops_env_values_keeps_keys(tmp_path: Path) -> None:
+    record = _record("W", backend="codex", launch_env={"SECRET": "v", "B": "w"})
+    summary = redact_preset(record)
+    assert summary.spec.launch_env_keys == ["B", "SECRET"]
+    assert not hasattr(summary.spec, "launch_env")
+
+
+# ── API ──────────────────────────────────────────────────────────────────────
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    token = app.state.context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_api_requires_auth(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/session-presets")
+    assert resp.status_code == 401
+
+
+async def test_api_crud_and_redaction(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        create = await client.post(
+            "/api/session-presets",
+            headers=_auth(token),
+            json={
+                "name": "Worker",
+                "spec": {"backend": "codex", "launch_env": {"SECRET": "v"}},
+            },
+        )
+        assert create.status_code == 200
+        preset_id = create.json()["preset"]["id"]
+        # List is redacted.
+        listing = await client.get("/api/session-presets", headers=_auth(token))
+        spec = listing.json()["presets"][0]["spec"]
+        assert spec["launch_env_keys"] == ["SECRET"]
+        assert "launch_env" not in spec
+        # Plain GET is redacted; include_secret_values reveals values.
+        redacted = await client.get(
+            f"/api/session-presets/{preset_id}", headers=_auth(token)
+        )
+        assert "launch_env" not in redacted.json()["preset"]["spec"]
+        full = await client.get(
+            f"/api/session-presets/{preset_id}?include_secret_values=true",
+            headers=_auth(token),
+        )
+        assert full.json()["preset"]["spec"]["launch_env"] == {"SECRET": "v"}
+        # Duplicate name is a 409.
+        dup = await client.post(
+            "/api/session-presets", headers=_auth(token), json={"name": "worker"}
+        )
+        assert dup.status_code == 409
+        # Delete.
+        deleted = await client.delete(
+            f"/api/session-presets/{preset_id}", headers=_auth(token)
+        )
+        assert deleted.status_code == 200
+        missing = await client.get(
+            f"/api/session-presets/{preset_id}", headers=_auth(token)
+        )
+        assert missing.status_code == 404
+
+
+async def test_api_default_lifecycle_and_me(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        a = (
+            await client.post(
+                "/api/session-presets",
+                headers=_auth(token),
+                json={"name": "A", "spec": {"backend": "codex"}},
+            )
+        ).json()["preset"]["id"]
+        await client.post(f"/api/session-presets/{a}/default", headers=_auth(token))
+        me = await client.get("/api/me", headers=_auth(token))
+        body = me.json()
+        assert body["default_preset_id"] == a
+        assert len(body["session_presets"]) == 1
+        # Clearing the default.
+        await client.delete("/api/session-presets/default", headers=_auth(token))
+        me2 = await client.get("/api/me", headers=_auth(token))
+        assert me2.json()["default_preset_id"] is None
+
+
+async def test_api_schedule_snapshots_preset(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        preset = (
+            await client.post(
+                "/api/session-presets",
+                headers=_auth(token),
+                json={"name": "S", "spec": {"backend": "codex", "model": "gpt-5"}},
+            )
+        ).json()["preset"]
+        sched = await client.post(
+            "/api/schedules",
+            headers=_auth(token),
+            json={"preset_id": preset["id"], "cwd": "/tmp", "delay_seconds": 60},
+        )
+        assert sched.status_code == 200
+        record = sched.json()["schedule"]
+        assert record["backend"] == "codex"
+        assert record["model"] == "gpt-5"
+        assert record["preset_id"] == preset["id"]
+        assert record["preset_name"] == "S"
+        # Deleting the preset leaves the snapshotted schedule intact.
+        await client.delete(
+            f"/api/session-presets/{preset['id']}", headers=_auth(token)
+        )
+        schedules = await client.get("/api/schedules", headers=_auth(token))
+        assert schedules.json()["schedules"][0]["backend"] == "codex"
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def _cli_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "waypoint.yaml"
+    cfg.write_text(
+        f"default_backend: codex\ndata_dir: {tmp_path / 'data'}\n", encoding="utf-8"
+    )
+    return cfg
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in (
+        "WAYPOINT_DATA_DIR",
+        "WAYPOINT_CONFIG_PATH",
+        "WAYPOINT_HOST",
+        "WAYPOINT_PORT",
+        "WAYPOINT_PASSWORD",
+        "WAYPOINT_TOKEN",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _mock_cli(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+
+
+def test_cli_presets_list(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/session-presets"
+        return httpx.Response(
+            200, json={"presets": [{"id": "preset-1"}], "default_preset_id": "preset-1"}
+        )
+
+    _mock_cli(monkeypatch, handler)
+    result = runner.invoke(
+        cli_app, ["--config", str(_cli_config(tmp_path)), "presets", "list"]
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["default_preset_id"] == "preset-1"
+
+
+def test_cli_presets_create_sends_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"preset": {"id": "preset-1"}})
+
+    _mock_cli(monkeypatch, handler)
+    result = runner.invoke(
+        cli_app,
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "presets",
+            "create",
+            "--name",
+            "Worker",
+            "--backend",
+            "codex",
+            "--model",
+            "gpt-5",
+            "--launch-env",
+            "A=1",
+        ],
+    )
+    assert result.exit_code == 0
+    body = captured["body"]
+    assert body["name"] == "Worker"
+    assert body["spec"]["backend"] == "codex"
+    assert body["spec"]["launch_env"] == {"A": "1"}
+
+
+def test_cli_sessions_start_sends_preset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/session-presets/worker":
+            return httpx.Response(200, json={"preset": {"spec": {"backend": "codex"}}})
+        if path == "/api/sessions":
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "codex-1"}})
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    _mock_cli(monkeypatch, handler)
+    result = runner.invoke(
+        cli_app,
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "sessions",
+            "start",
+            "--preset",
+            "worker",
+            "--cwd",
+            "/tmp",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert captured["body"]["preset_id"] == "worker"
+    assert captured["body"]["cwd"] == "/tmp"

--- a/backend/tests/test_session_presets.py
+++ b/backend/tests/test_session_presets.py
@@ -361,7 +361,10 @@ async def test_api_default_lifecycle_and_me(tmp_path: Path) -> None:
             await client.post(
                 "/api/session-presets",
                 headers=_auth(token),
-                json={"name": "A", "spec": {"backend": "codex"}},
+                json={
+                    "name": "A",
+                    "spec": {"backend": "codex", "launch_env": {"K": "v"}},
+                },
             )
         ).json()["preset"]["id"]
         await client.post(f"/api/session-presets/{a}/default", headers=_auth(token))
@@ -369,6 +372,10 @@ async def test_api_default_lifecycle_and_me(tmp_path: Path) -> None:
         body = me.json()
         assert body["default_preset_id"] == a
         assert len(body["session_presets"]) == 1
+        # /api/me must redact env values, exposing only keys (same as list).
+        me_spec = body["session_presets"][0]["spec"]
+        assert "launch_env" not in me_spec
+        assert me_spec["launch_env_keys"] == ["K"]
         # Clearing the default.
         await client.delete("/api/session-presets/default", headers=_auth(token))
         me2 = await client.get("/api/me", headers=_auth(token))

--- a/backend/tests/test_session_presets.py
+++ b/backend/tests/test_session_presets.py
@@ -117,6 +117,19 @@ def test_manager_create_and_default(tmp_path: Path) -> None:
     assert exc.value.status_code == 409
 
 
+def test_preset_spec_excludes_cwd_and_title() -> None:
+    # cwd/title are per-launch specifics, not preset fields; a spec built from a
+    # payload carrying them (e.g. an older persisted preset) silently drops them.
+    spec = SessionPresetSpec.model_validate(
+        {"backend": "codex", "cwd": "/x", "title": "t", "model": "m"}
+    )
+    assert not hasattr(spec, "cwd")
+    assert not hasattr(spec, "title")
+    assert spec.model == "m"
+    assert "cwd" not in spec.model_dump()
+    assert "title" not in spec.model_dump()
+
+
 def test_manager_rejects_reserved_default_name(tmp_path: Path) -> None:
     manager = PresetManager(_storage(tmp_path))
     with pytest.raises(HTTPException) as exc:

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8643,38 +8643,154 @@ html[data-theme="light"] .term-compose-send {
 }
 
 /* ─── Session presets ─── */
-/* In-flow bar above the shared launch form: flat token surface, no glass — it
-   belongs to the launch card's in-flow content, not the floating chrome. */
+/* In-flow bar above the shared launch form: a flat token instrument, not glass.
+   It reuses the app's badge/mono + action-chip vocabulary so it reads as part
+   of the launch card rather than a bolted-on control. */
 .preset-bar {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 10px;
-  padding: 12px;
+  position: relative;
+  display: grid;
+  gap: 8px;
+  padding: 11px 13px;
   background: var(--bg-card-soft);
   border: 1px solid var(--line);
   border-radius: var(--radius);
 }
 
-.preset-bar-select {
-  flex: 1 1 220px;
-  min-width: 180px;
+/* The default preset carries the same dog-ear fold as a pinned card — default
+   is a pin. The corner beneath the fold is squared so it reads as intentional. */
+.preset-bar.is-default {
+  border-color: color-mix(in srgb, var(--accent) 40%, var(--line));
+  border-top-right-radius: 0;
+}
+
+.preset-bar.is-default::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  border-top: 13px solid var(--accent);
+  border-left: 13px solid transparent;
+}
+
+.preset-bar-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+/* Mono micro-label, same register as a badge caption. */
+.preset-bar-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  flex: none;
+}
+
+.preset-bar-picker {
+  flex: 1 1 200px;
+  min-width: 160px;
+}
+
+/* Matches the ``.field select`` instrument (custom chevron, same metrics) so
+   the preset picker lines up with the form controls below it. */
+.preset-select {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+  padding: 9px 34px 9px 12px;
+  appearance: none;
+  -webkit-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M2.5 4.5l3.5 3.5 3.5-3.5' fill='none' stroke='%23a09380' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 11px center;
+  background-size: 12px 12px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+html[data-theme="light"] .preset-select {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M2.5 4.5l3.5 3.5 3.5-3.5' fill='none' stroke='%236e6356' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+}
+
+.preset-select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
 .preset-bar-actions {
   display: flex;
-  gap: 8px;
+  gap: 2px;
   flex-wrap: wrap;
+  margin-left: auto;
+}
+
+/* The default action-chip lights gold when the selection IS the default —
+   the pinned state, matching the dog-ear fold. */
+.preset-bar-actions .action-chip.pin-link.active {
+  color: var(--accent);
+}
+
+/* Spec summary: the backend rides an owner-hue badge, everything else is a
+   muted mono chip separated by a small dot — the badge/status register. */
+.preset-bar-detail {
+  min-height: 1.1rem;
+  animation: preset-detail-in 200ms ease;
+}
+
+.preset-summary {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.preset-summary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+}
+
+.preset-summary-dot {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--muted-soft, var(--muted));
+  opacity: 0.7;
+}
+
+.preset-bar-hint {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--muted);
 }
 
 .preset-bar-error {
-  flex-basis: 100%;
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 0.8rem;
 }
 
-/* The save dialog is floating chrome, so it takes the app's modal recipe
-   (flat opaque card over a blurred scrim), matching ScheduleMessageModal. */
+@keyframes preset-detail-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* The save sheet is floating chrome: the app's modal recipe (flat opaque card
+   over a blurred scrim), mirroring ScheduleMessageModal for consistency. */
 .preset-modal-overlay {
   position: fixed;
   inset: 0;
@@ -8685,6 +8801,7 @@ html[data-theme="light"] .term-compose-send {
   align-items: center;
   justify-content: center;
   padding: 24px;
+  animation: preset-modal-fade 160ms ease;
 }
 
 html[data-theme="light"] .preset-modal-overlay {
@@ -8699,6 +8816,73 @@ html[data-theme="light"] .preset-modal-overlay {
   width: 100%;
   max-width: 460px;
   box-shadow: var(--shadow);
+  animation: preset-modal-pop 200ms cubic-bezier(0.2, 0.9, 0.3, 1.1);
+}
+
+@keyframes preset-modal-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes preset-modal-pop {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .preset-bar-detail,
+  .preset-modal-overlay,
+  .preset-modal {
+    animation: none;
+  }
+}
+
+.preset-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.preset-modal-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--font-display);
+  font-weight: 600;
+}
+
+/* The ƒ glyph is the preset mark — the same family as the ⁂ board glyph. */
+.preset-modal-glyph {
+  font-family: var(--font-mono);
+  font-style: italic;
+  color: var(--accent);
+  font-size: 1.05rem;
+}
+
+.preset-modal-close {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 1.3rem;
+  line-height: 1;
+  padding: 2px 6px;
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.preset-modal-close:hover {
+  color: var(--text);
 }
 
 .preset-modal form {
@@ -8706,10 +8890,25 @@ html[data-theme="light"] .preset-modal-overlay {
   gap: 14px;
 }
 
-.preset-modal h3 {
-  margin: 0;
-  font-family: var(--font-display);
-  font-weight: 600;
+/* The captures preview: what this preset will pin, in the same summary
+   vocabulary as the bar, so save and select read identically. */
+.preset-modal-captures {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  padding: 10px 12px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+
+.preset-modal-captures-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
 }
 
 .preset-modal-check {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8642,6 +8642,95 @@ html[data-theme="light"] .term-compose-send {
   font-size: 0.82rem;
 }
 
+/* ─── Session presets ─── */
+/* In-flow bar above the shared launch form: flat token surface, no glass — it
+   belongs to the launch card's in-flow content, not the floating chrome. */
+.preset-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+  padding: 12px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.preset-bar-select {
+  flex: 1 1 220px;
+  min-width: 180px;
+}
+
+.preset-bar-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.preset-bar-error {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.82rem;
+}
+
+/* The save dialog is floating chrome, so it takes the app's modal recipe
+   (flat opaque card over a blurred scrim), matching ScheduleMessageModal. */
+.preset-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 6, 10, 0.55);
+  backdrop-filter: blur(3px);
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+html[data-theme="light"] .preset-modal-overlay {
+  background: rgba(30, 26, 18, 0.28);
+}
+
+.preset-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  padding: 20px;
+  width: 100%;
+  max-width: 460px;
+  box-shadow: var(--shadow);
+}
+
+.preset-modal form {
+  display: grid;
+  gap: 14px;
+}
+
+.preset-modal h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+}
+
+.preset-modal-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.preset-modal-check input {
+  width: auto;
+}
+
+.preset-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
 /* ─── Form field hints ─── */
 /* Secondary one-line help beneath a ``.field`` control (e.g. the selected
    Interface's description, the Reasoning-effort hint). Rides ``--muted`` so it

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8724,31 +8724,59 @@ html[data-theme="light"] .preset-select {
 
 /* Bottom-of-panel capture actions: they snapshot the whole configured form, so
    they sit just above Launch with a mono caption stating what they act on. */
+/* Preset save actions: a quiet labelled toolbar of bare mono chips (the
+   session-card action vocabulary), not boxed buttons — so the gold Launch
+   stays the single primary CTA below them instead of one of four peers. */
 .preset-save {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 8px 12px;
+  gap: 6px 10px;
+}
+
+.preset-save-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+  flex: none;
 }
 
 .preset-save-actions {
   display: flex;
-  gap: 8px;
+  gap: 2px;
   flex-wrap: wrap;
   margin-left: auto;
 }
 
-/* The default button reads as a settled state, not an action, once it's on. */
-.preset-save-actions .secondary.preset-default-on {
-  color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+.preset-act {
+  background: transparent;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color 140ms ease, background 140ms ease;
 }
 
-/* Brief confirmation after an in-place Update. */
-.preset-save-actions .secondary.preset-flash {
+.preset-act:hover:not(:disabled) {
+  color: var(--text);
+  background: color-mix(in srgb, currentColor 12%, transparent);
+}
+
+.preset-act:disabled {
+  cursor: default;
+}
+
+/* ✓ Default (settled) and the brief post-Update flash both light gold. */
+.preset-act.preset-default-on,
+.preset-act.preset-default-on:disabled,
+.preset-act.preset-flash {
   color: var(--accent);
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
-  transition: color 140ms ease, border-color 140ms ease;
 }
 
 .preset-save-error {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8731,14 +8731,6 @@ html[data-theme="light"] .preset-select {
   gap: 8px 12px;
 }
 
-.preset-save-label {
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  text-transform: uppercase;
-  letter-spacing: 0.16em;
-  color: var(--muted);
-}
-
 .preset-save-actions {
   display: flex;
   gap: 8px;
@@ -8752,19 +8744,21 @@ html[data-theme="light"] .preset-select {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
 }
 
+/* Brief confirmation after an in-place Update. */
+.preset-save-actions .secondary.preset-flash {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+  transition: color 140ms ease, border-color 140ms ease;
+}
+
 .preset-save-error {
   flex-basis: 100%;
   margin: 0;
   font-size: 0.8rem;
 }
 
-/* Spec summary: the backend rides an owner-hue badge, everything else is a
-   muted mono chip separated by a small dot — the badge/status register. */
-.preset-bar-detail {
-  min-height: 1.1rem;
-  animation: preset-detail-in 200ms ease;
-}
-
+/* Spec summary (save-sheet captures readout): the backend rides an owner-hue
+   badge, everything else is a muted mono chip separated by a small dot. */
 .preset-summary {
   display: inline-flex;
   align-items: center;
@@ -8790,26 +8784,9 @@ html[data-theme="light"] .preset-select {
   opacity: 0.7;
 }
 
-.preset-bar-hint {
-  margin: 0;
-  font-size: 0.78rem;
-  color: var(--muted);
-}
-
 .preset-bar-error {
   margin: 0;
   font-size: 0.8rem;
-}
-
-@keyframes preset-detail-in {
-  from {
-    opacity: 0;
-    transform: translateY(-2px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
 }
 
 /* The save sheet is floating chrome: the app's modal recipe (flat opaque card
@@ -8863,7 +8840,6 @@ html[data-theme="light"] .preset-modal-overlay {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .preset-bar-detail,
   .preset-modal-overlay,
   .preset-modal {
     animation: none;
@@ -8964,9 +8940,18 @@ html[data-theme="light"] .preset-modal-overlay {
 /* Secondary one-line help beneath a ``.field`` control (e.g. the selected
    Interface's description, the Reasoning-effort hint). Rides ``--muted`` so it
    adapts across themes without an override. */
-.field-hint {
+/* A descriptive hint under a field control is prose, not a label, so it must
+   undo the uppercase mono `.field span` applies to every span in a field. The
+   `.field span.field-hint` specificity (0,2,1) beats `.field span` (0,2,0) so
+   the hint reads as sentence-case body text and wraps cleanly. */
+.field-hint,
+.field span.field-hint {
   font-size: 0.78rem;
-  line-height: 1.4;
+  line-height: 1.45;
+  text-transform: none;
+  letter-spacing: normal;
+  font-family: inherit;
+  color: var(--muted);
 }
 
 .terminal pre {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8722,17 +8722,40 @@ html[data-theme="light"] .preset-select {
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
 }
 
-.preset-bar-actions {
+/* Bottom-of-panel capture actions: they snapshot the whole configured form, so
+   they sit just above Launch with a mono caption stating what they act on. */
+.preset-save {
   display: flex;
-  gap: 2px;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.preset-save-label {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+.preset-save-actions {
+  display: flex;
+  gap: 8px;
   flex-wrap: wrap;
   margin-left: auto;
 }
 
-/* The default action-chip lights gold when the selection IS the default —
-   the pinned state, matching the dog-ear fold. */
-.preset-bar-actions .action-chip.pin-link.active {
+/* The default button reads as a settled state, not an action, once it's on. */
+.preset-save-actions .secondary.preset-default-on {
   color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
+}
+
+.preset-save-error {
+  flex-basis: 100%;
+  margin: 0;
+  font-size: 0.8rem;
 }
 
 /* Spec summary: the backend rides an owner-hue badge, everything else is a
@@ -8890,22 +8913,22 @@ html[data-theme="light"] .preset-modal-overlay {
   gap: 14px;
 }
 
-/* The captures preview: what this preset will pin, in the same summary
-   vocabulary as the bar, so save and select read identically. */
+/* The captures readout: what this preset will pin. Borderless with a faint warm
+   inset so it reads as a derived receipt, not another input box competing with
+   the fields above it. A leading hairline separates it from the description. */
 .preset-modal-captures {
   display: flex;
   align-items: baseline;
   flex-wrap: wrap;
-  gap: 8px 10px;
-  padding: 10px 12px;
-  background: var(--bg-card-soft);
-  border: 1px solid var(--line);
+  gap: 6px 10px;
+  padding: 11px 12px;
+  background: color-mix(in srgb, var(--accent) 5%, var(--bg-card-soft));
   border-radius: var(--radius-sm);
 }
 
 .preset-modal-captures-label {
   font-family: var(--font-mono);
-  font-size: 0.62rem;
+  font-size: 0.6rem;
   text-transform: uppercase;
   letter-spacing: 0.16em;
   color: var(--muted);
@@ -8914,13 +8937,20 @@ html[data-theme="light"] .preset-modal-overlay {
 .preset-modal-check {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
+  gap: 9px;
   font-size: 0.85rem;
   color: var(--muted);
+  cursor: pointer;
 }
 
+/* Theme the native checkbox to the accent so it stops reading as a stray
+   OS-blue against the warm dark palette. */
 .preset-modal-check input {
-  width: auto;
+  width: 16px;
+  height: 16px;
+  flex: none;
+  accent-color: var(--accent);
+  cursor: pointer;
 }
 
 .preset-modal-actions {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -569,6 +569,7 @@ export default function HomePage() {
     configOverrides: string[] = [],
     launchEnv: Record<string, string> = {},
     permissionMode: string | null = null,
+    presetId: string | null = null,
   ) {
     setCwdError(null);
     try {
@@ -585,6 +586,8 @@ export default function HomePage() {
         model,
         effort,
         permission_mode: permissionMode,
+        // Provenance only — the fields above are already resolved.
+        preset_id: presetId,
       });
       setSessions((current) => [
         session,
@@ -628,6 +631,7 @@ export default function HomePage() {
               configOverrides,
               launchEnv,
               permissionMode,
+              presetId,
             ),
         });
         return;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -26,8 +26,10 @@ import {
   connectSessionsSocket,
   createSchedule as createScheduleRequest,
   createSession,
+  createSessionPreset,
   deleteMessageSchedule as deleteMessageScheduleRequest,
   deleteSession as deleteSessionRequest,
+  deleteSessionPreset,
   deleteThread,
   disconnectLaunchTarget,
   fetchBackendThreads,
@@ -36,13 +38,16 @@ import {
   fetchMe,
   fetchMessageSchedules,
   fetchSchedules,
+  fetchSessionPreset,
   fetchSessions,
   importBackendThread,
   isAuthError,
   login,
   postAction,
+  setDefaultSessionPreset,
   setSessionPinned,
   setSessionTitle,
+  updateSessionPreset,
   SSH_MASTER_REQUIRED_DETAIL,
   CWD_NOT_FOUND_DETAIL,
 } from "@/lib/api";
@@ -69,6 +74,8 @@ import {
   ScheduleCreateRequest,
   ScheduledSession,
   SessionEnvelope,
+  SessionPresetSummary,
+  SessionPresetWriteRequest,
   SessionRecord,
   SessionTransport,
 } from "@/lib/types";
@@ -136,6 +143,8 @@ export default function HomePage() {
   const [defaultBackend, setDefaultBackend] = useState<Backend>("codex");
   const [defaultCwd, setDefaultCwd] = useState("~/");
   const [launchTargets, setLaunchTargets] = useState<LaunchTargetSummary[]>([]);
+  const [sessionPresets, setSessionPresets] = useState<SessionPresetSummary[]>([]);
+  const [defaultPresetId, setDefaultPresetId] = useState<string | null>(null);
   const [activeLaunchTargetId, setActiveLaunchTargetId] = useState("");
   // Password-auth SSH connect prompt. ``retry`` re-runs the launch that hit a
   // 409 once the ControlMaster is up; ``null`` when the prompt was opened
@@ -282,6 +291,8 @@ export default function HomePage() {
         if (me.backends && me.backends.length > 0) {
           setBackendDescriptors(me.backends);
         }
+        setSessionPresets(me.session_presets ?? []);
+        setDefaultPresetId(me.default_preset_id ?? null);
         setSchedules(scheduleItems);
         setMessageSchedules(messageItems);
         const storedTargetId = readLaunchTarget(host);
@@ -627,6 +638,40 @@ export default function HomePage() {
           : "failed to create session",
       );
     }
+  }
+
+  async function refreshPresets() {
+    try {
+      const me = await fetchMe(host, token);
+      setSessionPresets(me.session_presets ?? []);
+      setDefaultPresetId(me.default_preset_id ?? null);
+    } catch (refreshError) {
+      if (isAuthError(refreshError)) {
+        resetAuthState("Session expired. Log in again.");
+      }
+    }
+  }
+
+  async function handleSavePreset(
+    payload: SessionPresetWriteRequest,
+    presetId: string | null,
+  ) {
+    if (presetId) {
+      await updateSessionPreset(host, token, presetId, payload);
+    } else {
+      await createSessionPreset(host, token, payload);
+    }
+    await refreshPresets();
+  }
+
+  async function handleSetDefaultPreset(presetId: string) {
+    await setDefaultSessionPreset(host, token, presetId);
+    await refreshPresets();
+  }
+
+  async function handleDeletePreset(presetId: string) {
+    await deleteSessionPreset(host, token, presetId);
+    await refreshPresets();
   }
 
   async function handleAttach(
@@ -1023,6 +1068,14 @@ export default function HomePage() {
           onAuthFailure={handleAuthFailure}
           cwdError={cwdError}
           onClearCwdError={() => setCwdError(null)}
+          presets={sessionPresets}
+          defaultPresetId={defaultPresetId}
+          onFetchPresetSpec={(presetId) =>
+            fetchSessionPreset(host, token, presetId, true)
+          }
+          onSavePreset={handleSavePreset}
+          onSetDefaultPreset={handleSetDefaultPreset}
+          onDeletePreset={handleDeletePreset}
         />
       ) : null}
       {token ? (

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -26,6 +27,7 @@ import { permissionModesFor } from "@/lib/backends";
 import {
   Backend,
   BackendModelListResponse,
+  SessionPresetSpec,
   SessionTransport,
 } from "@/lib/types";
 
@@ -69,6 +71,7 @@ export interface LaunchForm {
   effortSupported: boolean;
   effortOptions: string[];
   changeBackend: (backend: Backend) => void;
+  applyPreset: (spec: SessionPresetSpec) => void;
   handleModelsLoaded: (response: BackendModelListResponse) => void;
   collectArgs: () => {
     args: string[];
@@ -145,6 +148,47 @@ export function useLaunchForm({
     setModelInfo(null);
     setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[backend]));
   }, [backend, launchTargetId, defaultLaunchEnvByBackend]);
+
+  // Applying a preset that changes the backend triggers the reset effect above,
+  // which clears model/effort/env (and useTransportForAgent resets transport).
+  // So backend-scoped fields are stashed here and re-applied once, after those
+  // resets settle, by the effect below. Same-backend applies run inline.
+  const pendingPresetRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const pending = pendingPresetRef.current;
+    if (pending) {
+      pendingPresetRef.current = null;
+      pending();
+    }
+  }, [backend]);
+
+  const applyPreset = useCallback(
+    (spec: SessionPresetSpec) => {
+      const nextBackend = (spec.backend as Backend | null | undefined) ?? backend;
+      // Fields untouched by the backend-reset can be set immediately.
+      if (spec.cwd != null) setCwd(spec.cwd);
+      if (spec.title != null) setTitle(spec.title);
+      if (spec.permission_mode) setPermissionMode(spec.permission_mode);
+      setCustomArgsText((spec.args ?? []).join("\n"));
+      setConfigOverridesText((spec.config_overrides ?? []).join("\n"));
+      // Backend-scoped fields: model/effort/env/transport are wiped by the
+      // backend-change resets, so apply them after those run.
+      const applyScoped = () => {
+        setModel(spec.model ?? "");
+        setEffort(spec.effort ?? "");
+        setLaunchEnvText(formatLaunchEnv(spec.launch_env ?? {}));
+        if (spec.transport) setTransport(spec.transport);
+      };
+      if (nextBackend !== backend) {
+        pendingPresetRef.current = applyScoped;
+        setBackend(nextBackend);
+      } else {
+        applyScoped();
+      }
+    },
+    [backend, setTransport],
+  );
 
   const effortOptions = useMemo(() => {
     if (!modelInfo) return [];
@@ -223,6 +267,7 @@ export function useLaunchForm({
     effortSupported,
     effortOptions,
     changeBackend,
+    applyPreset,
     handleModelsLoaded,
     collectArgs,
   };

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -212,12 +212,15 @@ export function useLaunchForm({
     return Array.from(union);
   }, [modelInfo, model]);
 
-  // Drop the picked level if the new model doesn't support it.
+  // Drop the picked level if the loaded model doesn't support it. Gated on
+  // modelInfo: while models are still loading (modelInfo === null) the option
+  // list is empty and we can't yet tell a valid level from an invalid one —
+  // clamping then would wipe a preset-applied effort before its model arrives.
   useEffect(() => {
-    if (effort && !effortOptions.includes(effort)) {
+    if (modelInfo && effort && !effortOptions.includes(effort)) {
       setEffort("");
     }
-  }, [effort, effortOptions]);
+  }, [effort, effortOptions, modelInfo]);
 
   const handleModelsLoaded = useCallback((response: BackendModelListResponse) => {
     setModelInfo(response);

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -166,9 +166,8 @@ export function useLaunchForm({
   const applyPreset = useCallback(
     (spec: SessionPresetSpec) => {
       const nextBackend = (spec.backend as Backend | null | undefined) ?? backend;
-      // Fields untouched by the backend-reset can be set immediately.
-      if (spec.cwd != null) setCwd(spec.cwd);
-      if (spec.title != null) setTitle(spec.title);
+      // Presets carry launch defaults only — cwd and title are per-launch and
+      // deliberately left as the user set them.
       if (spec.permission_mode) setPermissionMode(spec.permission_mode);
       setCustomArgsText((spec.args ?? []).join("\n"));
       setConfigOverridesText((spec.config_overrides ?? []).join("\n"));

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -158,8 +158,10 @@ export function LaunchPanel({
           form.applyPreset(summary.spec as unknown as SessionPresetSpec);
         }
       } catch {
-        // Surfaced by the bar's own error handling on user actions; a failed
-        // hydrate simply leaves the form as-is.
+        // The full (env-carrying) spec couldn't load. Deselect rather than leave
+        // a half-hydrated selection: an Update against it would otherwise
+        // overwrite the preset's env with the form's empty env.
+        setSelectedPresetId(null);
       }
     },
     [presets, onFetchPresetSpec, form],

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -2,6 +2,8 @@
 
 import {
   FormEvent,
+  useCallback,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -11,12 +13,17 @@ import {
   LaunchFormFields,
   useLaunchForm,
 } from "@/components/LaunchFormFields";
+import { PresetBar } from "@/components/PresetBar";
 import { ResumeThreadPanel } from "@/components/ResumeThreadPanel";
 import type { BackendCatalog } from "@/lib/backends";
 import { humaniseBackend } from "@/lib/backends";
 import {
   Backend,
   ScheduleCreateRequest,
+  SessionPreset,
+  SessionPresetSpec,
+  SessionPresetSummary,
+  SessionPresetWriteRequest,
   SessionTransport,
 } from "@/lib/types";
 
@@ -83,6 +90,15 @@ interface LaunchPanelProps {
   // The cwd the backend rejected as nonexistent on the last New launch, or null.
   cwdError?: string | null;
   onClearCwdError?: () => void;
+  presets: SessionPresetSummary[];
+  defaultPresetId: string | null;
+  onFetchPresetSpec: (presetId: string) => Promise<SessionPreset>;
+  onSavePreset: (
+    payload: SessionPresetWriteRequest,
+    presetId: string | null,
+  ) => Promise<void>;
+  onSetDefaultPreset: (presetId: string) => Promise<void>;
+  onDeletePreset: (presetId: string) => Promise<void>;
 }
 
 export function LaunchPanel({
@@ -106,6 +122,12 @@ export function LaunchPanel({
   onAuthFailure,
   cwdError,
   onClearCwdError,
+  presets,
+  defaultPresetId,
+  onFetchPresetSpec,
+  onSavePreset,
+  onSetDefaultPreset,
+  onDeletePreset,
 }: LaunchPanelProps) {
   const [mode, setMode] = useState<PanelMode>("new");
   const form = useLaunchForm({
@@ -115,6 +137,41 @@ export function LaunchPanel({
     launchTargetId,
     catalog,
   });
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+  const presetHydratedRef = useRef(false);
+
+  const applyPresetById = useCallback(
+    async (id: string | null) => {
+      setSelectedPresetId(id);
+      if (!id) return;
+      const summary = presets.find((preset) => preset.id === id);
+      if (!summary) return;
+      try {
+        // A preset with env vars needs the full (unredacted) spec before hydrating.
+        if ((summary.spec.launch_env_keys?.length ?? 0) > 0) {
+          const full = await onFetchPresetSpec(id);
+          form.applyPreset(full.spec);
+        } else {
+          // No env values to fetch; the redacted summary spec carries every
+          // other field, and applyPreset ignores launch_env_keys.
+          form.applyPreset(summary.spec as unknown as SessionPresetSpec);
+        }
+      } catch {
+        // Surfaced by the bar's own error handling on user actions; a failed
+        // hydrate simply leaves the form as-is.
+      }
+    },
+    [presets, onFetchPresetSpec, form],
+  );
+
+  // Hydrate the default preset into the shared form once on first load.
+  useEffect(() => {
+    if (presetHydratedRef.current) return;
+    presetHydratedRef.current = true;
+    if (defaultPresetId) {
+      void applyPresetById(defaultPresetId);
+    }
+  }, [defaultPresetId, applyPresetById]);
   const [tmuxTarget, setTmuxTarget] = useState("");
   const [prompt, setPrompt] = useState("");
   const [scheduleTiming, setScheduleTiming] = useState<ScheduleTiming>("delay");
@@ -177,6 +234,9 @@ export function LaunchPanel({
       args,
       config_overrides: configOverrides,
       launch_env: launchEnv,
+      // Record which preset seeded this schedule (provenance only; the fields
+      // above are the resolved values the server persists).
+      preset_id: selectedPresetId,
     };
     if (scheduleTiming === "delay") {
       const minutes = Number.parseFloat(delayMinutes);
@@ -227,6 +287,17 @@ export function LaunchPanel({
 
       {mode === "new" ? (
         <form className="launch-body" onSubmit={submitCreate}>
+          <PresetBar
+            form={form}
+            presets={presets}
+            selectedPresetId={selectedPresetId}
+            onSelectPreset={(id) => void applyPresetById(id)}
+            supportedBackends={supportedBackends}
+            launchTargetId={launchTargetId}
+            savePreset={onSavePreset}
+            setDefaultPreset={onSetDefaultPreset}
+            deletePreset={onDeletePreset}
+          />
           <LaunchFormFields
             form={form}
             host={host}
@@ -252,6 +323,17 @@ export function LaunchPanel({
 
       {mode === "schedule" ? (
         <form className="launch-body" onSubmit={submitSchedule}>
+          <PresetBar
+            form={form}
+            presets={presets}
+            selectedPresetId={selectedPresetId}
+            onSelectPreset={(id) => void applyPresetById(id)}
+            supportedBackends={supportedBackends}
+            launchTargetId={launchTargetId}
+            savePreset={onSavePreset}
+            setDefaultPreset={onSetDefaultPreset}
+            deletePreset={onDeletePreset}
+          />
           <LaunchFormFields
             form={form}
             host={host}

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -66,6 +66,7 @@ interface LaunchPanelProps {
     configOverrides: string[],
     launchEnv: Record<string, string>,
     permissionMode: string | null,
+    presetId: string | null,
   ) => Promise<void>;
   onAttach: (
     target: string,
@@ -196,6 +197,7 @@ export function LaunchPanel({
         configOverrides,
         launchEnv,
         form.permissionMode || null,
+        selectedPresetId,
       );
       form.setTitle("");
     } finally {

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -13,7 +13,7 @@ import {
   LaunchFormFields,
   useLaunchForm,
 } from "@/components/LaunchFormFields";
-import { PresetBar } from "@/components/PresetBar";
+import { PresetSaveActions, PresetSelect } from "@/components/PresetBar";
 import { ResumeThreadPanel } from "@/components/ResumeThreadPanel";
 import type { BackendCatalog } from "@/lib/backends";
 import { humaniseBackend } from "@/lib/backends";
@@ -289,15 +289,11 @@ export function LaunchPanel({
 
       {mode === "new" ? (
         <form className="launch-body" onSubmit={submitCreate}>
-          <PresetBar
-            form={form}
+          <PresetSelect
             presets={presets}
             selectedPresetId={selectedPresetId}
             onSelectPreset={(id) => void applyPresetById(id)}
             supportedBackends={supportedBackends}
-            launchTargetId={launchTargetId}
-            savePreset={onSavePreset}
-            setDefaultPreset={onSetDefaultPreset}
             deletePreset={onDeletePreset}
           />
           <LaunchFormFields
@@ -314,6 +310,14 @@ export function LaunchPanel({
             cwdError={cwdError}
             onClearCwdError={onClearCwdError}
           />
+          <PresetSaveActions
+            form={form}
+            presets={presets}
+            selectedPresetId={selectedPresetId}
+            launchTargetId={launchTargetId}
+            savePreset={onSavePreset}
+            setDefaultPreset={onSetDefaultPreset}
+          />
           <div className="launch-actions">
             <span className="grow" />
             <button className="primary" disabled={formBusy} type="submit">
@@ -325,15 +329,11 @@ export function LaunchPanel({
 
       {mode === "schedule" ? (
         <form className="launch-body" onSubmit={submitSchedule}>
-          <PresetBar
-            form={form}
+          <PresetSelect
             presets={presets}
             selectedPresetId={selectedPresetId}
             onSelectPreset={(id) => void applyPresetById(id)}
             supportedBackends={supportedBackends}
-            launchTargetId={launchTargetId}
-            savePreset={onSavePreset}
-            setDefaultPreset={onSetDefaultPreset}
             deletePreset={onDeletePreset}
           />
           <LaunchFormFields
@@ -395,6 +395,14 @@ export function LaunchPanel({
             </label>
           )}
           {scheduleError ? <p className="error">{scheduleError}</p> : null}
+          <PresetSaveActions
+            form={form}
+            presets={presets}
+            selectedPresetId={selectedPresetId}
+            launchTargetId={launchTargetId}
+            savePreset={onSavePreset}
+            setDefaultPreset={onSetDefaultPreset}
+          />
           <div className="launch-actions">
             <span className="grow" />
             <button className="primary" disabled={formBusy} type="submit">

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -165,13 +165,14 @@ export function LaunchPanel({
     [presets, onFetchPresetSpec, form],
   );
 
-  // Hydrate the default preset into the shared form once on first load.
+  // Hydrate the default preset into the shared form once on first load. Wait
+  // for the id to actually arrive (bootstrap resolves after mount) before
+  // consuming the once-guard, otherwise the first null run would disable it.
   useEffect(() => {
     if (presetHydratedRef.current) return;
+    if (!defaultPresetId) return;
     presetHydratedRef.current = true;
-    if (defaultPresetId) {
-      void applyPresetById(defaultPresetId);
-    }
+    void applyPresetById(defaultPresetId);
   }, [defaultPresetId, applyPresetById]);
   const [tmuxTarget, setTmuxTarget] = useState("");
   const [prompt, setPrompt] = useState("");

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import { FormEvent, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { LaunchForm } from "@/components/LaunchFormFields";
+import type {
+  Backend,
+  SessionPresetSpec,
+  SessionPresetSummary,
+  SessionPresetWriteRequest,
+} from "@/lib/types";
+
+interface PresetBarProps {
+  form: LaunchForm;
+  presets: SessionPresetSummary[];
+  selectedPresetId: string | null;
+  // Controlled by the panel so selection + hydration survive mode switches.
+  onSelectPreset: (id: string | null) => void;
+  supportedBackends: Backend[];
+  launchTargetId: string | null;
+  savePreset: (
+    payload: SessionPresetWriteRequest,
+    presetId: string | null,
+  ) => Promise<void>;
+  setDefaultPreset: (presetId: string) => Promise<void>;
+  deletePreset: (presetId: string) => Promise<void>;
+}
+
+// Flat, in-flow preset control that sits above the shared launch form: a
+// selector that hydrates the form from a preset, plus save / set-default /
+// delete actions. Only the save dialog floats (glass modal); the bar itself is
+// flat token chrome to match the launch card.
+export function PresetBar({
+  form,
+  presets,
+  selectedPresetId,
+  onSelectPreset,
+  supportedBackends,
+  launchTargetId,
+  savePreset,
+  setDefaultPreset,
+  deletePreset,
+}: PresetBarProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saveOpen, setSaveOpen] = useState(false);
+
+  const selected = presets.find((p) => p.id === selectedPresetId) ?? null;
+  const presetBackend = selected?.spec.backend ?? null;
+  const backendUnsupported =
+    !!presetBackend && !supportedBackends.includes(presetBackend as Backend);
+
+  function currentSpec(): SessionPresetSpec {
+    const { args, configOverrides, launchEnv } = form.collectArgs();
+    return {
+      backend: form.backend,
+      cwd: form.cwd || null,
+      launch_target_id: launchTargetId,
+      transport: form.transport || null,
+      title: form.title.trim() || null,
+      model: form.model.trim() || null,
+      effort: form.effortSupported ? form.effort.trim() || null : null,
+      permission_mode: form.permissionMode || null,
+      args,
+      config_overrides: configOverrides,
+      launch_env: launchEnv,
+    };
+  }
+
+  async function handleSetDefault(): Promise<void> {
+    setError(null);
+    if (!selectedPresetId) {
+      // Nothing selected — offer to save the current form as a default preset.
+      setSaveOpen(true);
+      return;
+    }
+    setBusy(true);
+    try {
+      await setDefaultPreset(selectedPresetId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to set default");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleDelete(): Promise<void> {
+    if (!selected) return;
+    if (
+      selected.is_default &&
+      !window.confirm(
+        `Delete the default preset "${selected.name}"? There will be no default afterwards.`,
+      )
+    ) {
+      return;
+    }
+    setError(null);
+    setBusy(true);
+    try {
+      await deletePreset(selected.id);
+      onSelectPreset(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to delete preset");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="preset-bar">
+      <label className="preset-bar-select field">
+        <span>Preset</span>
+        <select
+          value={selectedPresetId ?? ""}
+          disabled={busy}
+          onChange={(event) => onSelectPreset(event.target.value || null)}
+        >
+          <option value="">No preset</option>
+          {presets.map((preset) => (
+            <option key={preset.id} value={preset.id}>
+              {preset.name}
+              {preset.is_default ? " · Default" : ""}
+            </option>
+          ))}
+        </select>
+      </label>
+      <div className="preset-bar-actions">
+        <button
+          type="button"
+          className="secondary"
+          disabled={busy}
+          onClick={() => setSaveOpen(true)}
+        >
+          Save…
+        </button>
+        <button
+          type="button"
+          className="secondary"
+          disabled={busy}
+          onClick={() => void handleSetDefault()}
+        >
+          {selected?.is_default ? "Default ✓" : "Set default"}
+        </button>
+        <button
+          type="button"
+          className="danger"
+          disabled={busy || !selected}
+          onClick={() => void handleDelete()}
+        >
+          Delete
+        </button>
+      </div>
+      {backendUnsupported ? (
+        <p className="error preset-bar-error">
+          This preset&apos;s backend ({presetBackend}) isn&apos;t available on the
+          current launch target. Change the backend or target before launching.
+        </p>
+      ) : null}
+      {error ? <p className="error preset-bar-error">{error}</p> : null}
+      {saveOpen ? (
+        <PresetSaveModal
+          selected={selected}
+          onClose={() => setSaveOpen(false)}
+          onSave={async (payload, presetId) => {
+            setBusy(true);
+            setError(null);
+            try {
+              await savePreset(payload, presetId);
+              setSaveOpen(false);
+            } catch (err) {
+              setError(err instanceof Error ? err.message : "failed to save preset");
+            } finally {
+              setBusy(false);
+            }
+          }}
+          currentSpec={currentSpec}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+interface PresetSaveModalProps {
+  selected: SessionPresetSummary | null;
+  onClose: () => void;
+  onSave: (
+    payload: SessionPresetWriteRequest,
+    presetId: string | null,
+  ) => Promise<void>;
+  currentSpec: () => SessionPresetSpec;
+}
+
+function PresetSaveModal({
+  selected,
+  onClose,
+  onSave,
+  currentSpec,
+}: PresetSaveModalProps) {
+  const [name, setName] = useState(selected?.name ?? "");
+  const [description, setDescription] = useState(selected?.description ?? "");
+  const [asDefault, setAsDefault] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function submitNew(event: FormEvent) {
+    event.preventDefault();
+    if (!name.trim()) return;
+    void onSave(
+      {
+        name: name.trim(),
+        description: description.trim() || null,
+        spec: currentSpec(),
+        is_default: asDefault,
+      },
+      null,
+    );
+  }
+
+  function submitUpdate() {
+    if (!selected) return;
+    void onSave(
+      {
+        name: name.trim() || undefined,
+        description: description.trim() || null,
+        spec: currentSpec(),
+      },
+      selected.id,
+    );
+  }
+
+  return createPortal(
+    <div
+      className="preset-modal-overlay"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="preset-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Save preset"
+      >
+        <form onSubmit={submitNew}>
+          <h3>{selected ? "Save preset" : "New preset"}</h3>
+          <label className="field">
+            <span>Name</span>
+            <input
+              ref={inputRef}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="e.g. Claude worker"
+            />
+          </label>
+          <label className="field">
+            <span>Description</span>
+            <input
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Optional"
+            />
+          </label>
+          <label className="preset-modal-check">
+            <input
+              type="checkbox"
+              checked={asDefault}
+              onChange={(event) => setAsDefault(event.target.checked)}
+            />
+            <span>Make this the default preset</span>
+          </label>
+          <div className="preset-modal-actions">
+            <button type="button" className="secondary" onClick={onClose}>
+              Cancel
+            </button>
+            {selected ? (
+              <>
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={submitUpdate}
+                  disabled={!!selected && !name.trim()}
+                >
+                  Update &quot;{selected.name}&quot;
+                </button>
+                <button type="submit" className="primary" disabled={!name.trim()}>
+                  Save as new
+                </button>
+              </>
+            ) : (
+              <button type="submit" className="primary" disabled={!name.trim()}>
+                Create preset
+              </button>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -238,12 +238,13 @@ export function PresetSaveActions({
 
   return (
     <div className="preset-save">
+      <span className="preset-save-label">Preset</span>
       <div className="preset-save-actions">
         {selected ? (
           <>
             <button
               type="button"
-              className={`secondary${flashed ? " preset-flash" : ""}`}
+              className={`preset-act${flashed ? " preset-flash" : ""}`}
               disabled={busy}
               onClick={() => void handleUpdate()}
             >
@@ -251,7 +252,7 @@ export function PresetSaveActions({
             </button>
             <button
               type="button"
-              className="secondary"
+              className="preset-act"
               disabled={busy}
               onClick={() => {
                 setSeedDefault(false);
@@ -264,7 +265,7 @@ export function PresetSaveActions({
         ) : (
           <button
             type="button"
-            className="secondary"
+            className="preset-act"
             disabled={busy}
             onClick={() => {
               setSeedDefault(false);
@@ -276,7 +277,7 @@ export function PresetSaveActions({
         )}
         <button
           type="button"
-          className={`secondary${isDefault ? " preset-default-on" : ""}`}
+          className={`preset-act${isDefault ? " preset-default-on" : ""}`}
           disabled={busy || isDefault}
           title={isDefault ? "This preset is the default" : undefined}
           onClick={() => void handleSetDefault()}

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -14,6 +14,7 @@ import type {
 
 // A compact key=value summary of what a preset spec pins, in the badge/mono
 // vocabulary: the backend rides an owner-hue badge, the rest are muted chips.
+// Used only in the save sheet's captures readout.
 function SpecSummary({ spec }: { spec: SessionPresetSummary["spec"] }) {
   const chips: string[] = [];
   if (spec.model) chips.push(spec.model);
@@ -47,7 +48,8 @@ function selectedOf(
   return presets.find((p) => p.id === id) ?? null;
 }
 
-// Build a spec snapshot of the current launch form — the payload a save captures.
+// A spec snapshot of the current launch form — the payload a save/update
+// captures. Excludes cwd and title: those are per-launch, not preset defaults.
 function formSpec(
   form: LaunchForm,
   launchTargetId: string | null,
@@ -55,10 +57,8 @@ function formSpec(
   const { args, configOverrides, launchEnv } = form.collectArgs();
   return {
     backend: form.backend,
-    cwd: form.cwd || null,
     launch_target_id: launchTargetId,
     transport: form.transport || null,
-    title: form.title.trim() || null,
     model: form.model.trim() || null,
     effort: form.effortSupported ? form.effort.trim() || null : null,
     permission_mode: form.permissionMode || null,
@@ -76,9 +76,9 @@ interface PresetSelectProps {
   deletePreset: (presetId: string) => Promise<void>;
 }
 
-// Top-of-panel selector: pick a saved launch profile and hydrate the form. The
-// default carries the dog-ear fold (default is a pin), the spec rides an
-// owner-hue badge + mono summary, and Delete manages the current selection.
+// Top-of-panel selector: pick a saved launch profile and hydrate the form.
+// Minimal by design — just the picker, a Delete affordance for the current
+// selection, and the dog-ear fold marking the default (default is a pin).
 export function PresetSelect({
   presets,
   selectedPresetId,
@@ -149,20 +149,10 @@ export function PresetSelect({
           </button>
         ) : null}
       </div>
-      {selected ? (
-        <div className="preset-bar-detail">
-          <SpecSummary spec={selected.spec} />
-        </div>
-      ) : (
-        <p className="preset-bar-hint">
-          Reuse a launch profile, or configure the form and save it as one below.
-        </p>
-      )}
       {backendUnsupported ? (
         <p className="error preset-bar-error" role="alert">
           This preset&apos;s backend ({humaniseBackend(presetBackend as Backend)})
-          isn&apos;t available on the current launch target — change the backend or
-          target before launching.
+          isn&apos;t available here — change the backend or launch target.
         </p>
       ) : null}
       {error ? (
@@ -187,9 +177,9 @@ interface PresetSaveActionsProps {
 }
 
 // Bottom-of-panel capture actions: these snapshot the fully-configured form, so
-// they live next to Launch rather than with the selector. Save opens the sheet;
-// Set-default marks the selected preset (or, with none selected, saves the
-// current form as a new default).
+// they sit next to Launch. Update overwrites the selected preset in place; Save
+// as new opens the create sheet; Set default marks the selection (or, with none
+// selected, saves the current form as a new default).
 export function PresetSaveActions({
   form,
   presets,
@@ -202,9 +192,31 @@ export function PresetSaveActions({
   const [error, setError] = useState<string | null>(null);
   const [saveOpen, setSaveOpen] = useState(false);
   const [seedDefault, setSeedDefault] = useState(false);
+  const [flashed, setFlashed] = useState(false);
 
   const selected = selectedOf(presets, selectedPresetId);
   const isDefault = selected?.is_default ?? false;
+
+  useEffect(() => {
+    if (!flashed) return;
+    const t = window.setTimeout(() => setFlashed(false), 1600);
+    return () => window.clearTimeout(t);
+  }, [flashed]);
+
+  async function handleUpdate(): Promise<void> {
+    if (!selected) return;
+    setError(null);
+    setBusy(true);
+    try {
+      // PATCH the spec only; name/description (and tags) are preserved server-side.
+      await savePreset({ spec: formSpec(form, launchTargetId) }, selected.id);
+      setFlashed(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to update preset");
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function handleSetDefault(): Promise<void> {
     setError(null);
@@ -226,19 +238,42 @@ export function PresetSaveActions({
 
   return (
     <div className="preset-save">
-      <span className="preset-save-label">Save this configuration</span>
       <div className="preset-save-actions">
-        <button
-          type="button"
-          className="secondary"
-          disabled={busy}
-          onClick={() => {
-            setSeedDefault(false);
-            setSaveOpen(true);
-          }}
-        >
-          {selected ? "Save preset…" : "Save as preset…"}
-        </button>
+        {selected ? (
+          <>
+            <button
+              type="button"
+              className={`secondary${flashed ? " preset-flash" : ""}`}
+              disabled={busy}
+              onClick={() => void handleUpdate()}
+            >
+              {flashed ? "Updated ✓" : "Update"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy}
+              onClick={() => {
+                setSeedDefault(false);
+                setSaveOpen(true);
+              }}
+            >
+              Save as new…
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            className="secondary"
+            disabled={busy}
+            onClick={() => {
+              setSeedDefault(false);
+              setSaveOpen(true);
+            }}
+          >
+            Save as preset…
+          </button>
+        )}
         <button
           type="button"
           className={`secondary${isDefault ? " preset-default-on" : ""}`}
@@ -246,7 +281,7 @@ export function PresetSaveActions({
           title={isDefault ? "This preset is the default" : undefined}
           onClick={() => void handleSetDefault()}
         >
-          {isDefault ? "✓ Default" : "Set as default"}
+          {isDefault ? "✓ Default" : "Set default"}
         </button>
       </div>
       {error ? (
@@ -256,15 +291,14 @@ export function PresetSaveActions({
       ) : null}
       {saveOpen ? (
         <PresetSaveModal
-          selected={selected}
           seedDefault={seedDefault}
           spec={formSpec(form, launchTargetId)}
           onClose={() => setSaveOpen(false)}
-          onSave={async (payload, presetId) => {
+          onSave={async (payload) => {
             setBusy(true);
             setError(null);
             try {
-              await savePreset(payload, presetId);
+              await savePreset(payload, null);
               setSaveOpen(false);
             } catch (err) {
               setError(err instanceof Error ? err.message : "failed to save preset");
@@ -279,29 +313,24 @@ export function PresetSaveActions({
 }
 
 interface PresetSaveModalProps {
-  selected: SessionPresetSummary | null;
   seedDefault: boolean;
   spec: SessionPresetSpec;
   onClose: () => void;
-  onSave: (
-    payload: SessionPresetWriteRequest,
-    presetId: string | null,
-  ) => Promise<void>;
+  onSave: (payload: SessionPresetWriteRequest) => Promise<void>;
 }
 
-// Portaled save sheet, mirroring ScheduleMessageModal's conventions: rendered to
-// document.body, Escape to close, focus trap, focus restored on unmount, and a
-// body-scroll lock. Leads with a captures readout so the user sees exactly what
-// the preset will pin.
+// Portaled create sheet, mirroring ScheduleMessageModal's conventions: rendered
+// to document.body, Escape to close, focus trap, focus restored on unmount, and
+// a body-scroll lock. Leads with a captures readout so the user sees exactly
+// what the new preset will pin.
 function PresetSaveModal({
-  selected,
   seedDefault,
   spec,
   onClose,
   onSave,
 }: PresetSaveModalProps) {
-  const [name, setName] = useState(selected?.name ?? "");
-  const [description, setDescription] = useState(selected?.description ?? "");
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
   const [asDefault, setAsDefault] = useState(seedDefault);
   const modalRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -318,7 +347,6 @@ function PresetSaveModal({
   useEffect(() => {
     const previouslyFocused = document.activeElement as HTMLElement | null;
     inputRef.current?.focus();
-    inputRef.current?.select();
     return () => previouslyFocused?.focus();
   }, []);
 
@@ -359,24 +387,17 @@ function PresetSaveModal({
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  function submit(presetId: string | null) {
-    if (presetId === null && !name.trim()) return;
-    onSave(
-      {
-        name: name.trim() || undefined,
-        description: description.trim() || null,
-        spec,
-        ...(presetId === null ? { is_default: asDefault } : {}),
-      },
-      presetId,
-    ).catch(() => {
-      /* surfaced by the actions bar */
-    });
-  }
-
   function onSubmitForm(event: FormEvent) {
     event.preventDefault();
-    submit(null);
+    if (!name.trim()) return;
+    onSave({
+      name: name.trim(),
+      description: description.trim() || null,
+      spec,
+      is_default: asDefault,
+    }).catch(() => {
+      /* surfaced by the actions bar */
+    });
   }
 
   return createPortal(
@@ -392,14 +413,14 @@ function PresetSaveModal({
         className="preset-modal"
         role="dialog"
         aria-modal="true"
-        aria-label={selected ? "Save preset" : "New preset"}
+        aria-label="New preset"
       >
         <div className="preset-modal-header">
           <span className="preset-modal-title">
             <span className="preset-modal-glyph" aria-hidden="true">
               ƒ
             </span>
-            {selected ? "Save preset" : "New preset"}
+            New preset
           </span>
           <button
             type="button"
@@ -432,39 +453,21 @@ function PresetSaveModal({
             <span className="preset-modal-captures-label">Captures</span>
             <SpecSummary spec={summarySpec} />
           </div>
-          {!selected ? (
-            <label className="preset-modal-check">
-              <input
-                type="checkbox"
-                checked={asDefault}
-                onChange={(event) => setAsDefault(event.target.checked)}
-              />
-              <span>Make this the default preset</span>
-            </label>
-          ) : null}
+          <label className="preset-modal-check">
+            <input
+              type="checkbox"
+              checked={asDefault}
+              onChange={(event) => setAsDefault(event.target.checked)}
+            />
+            <span>Make this the default preset</span>
+          </label>
           <div className="preset-modal-actions">
             <button type="button" className="secondary" onClick={onClose}>
               Cancel
             </button>
-            {selected ? (
-              <>
-                <button
-                  type="button"
-                  className="secondary"
-                  disabled={!name.trim()}
-                  onClick={() => submit(selected.id)}
-                >
-                  Update &quot;{selected.name}&quot;
-                </button>
-                <button type="submit" className="primary" disabled={!name.trim()}>
-                  Save as new
-                </button>
-              </>
-            ) : (
-              <button type="submit" className="primary" disabled={!name.trim()}>
-                Create preset
-              </button>
-            )}
+            <button type="submit" className="primary" disabled={!name.trim()}>
+              Create preset
+            </button>
           </div>
         </form>
       </div>

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -12,29 +12,9 @@ import type {
   SessionPresetWriteRequest,
 } from "@/lib/types";
 
-interface PresetBarProps {
-  form: LaunchForm;
-  presets: SessionPresetSummary[];
-  selectedPresetId: string | null;
-  // Controlled by the panel so selection + hydration survive mode switches.
-  onSelectPreset: (id: string | null) => void;
-  supportedBackends: Backend[];
-  launchTargetId: string | null;
-  savePreset: (
-    payload: SessionPresetWriteRequest,
-    presetId: string | null,
-  ) => Promise<void>;
-  setDefaultPreset: (presetId: string) => Promise<void>;
-  deletePreset: (presetId: string) => Promise<void>;
-}
-
 // A compact key=value summary of what a preset spec pins, in the badge/mono
 // vocabulary: the backend rides an owner-hue badge, the rest are muted chips.
-function SpecSummary({
-  spec,
-}: {
-  spec: SessionPresetSummary["spec"];
-}) {
+function SpecSummary({ spec }: { spec: SessionPresetSummary["spec"] }) {
   const chips: string[] = [];
   if (spec.model) chips.push(spec.model);
   if (spec.effort) chips.push(spec.effort);
@@ -60,66 +40,60 @@ function SpecSummary({
   );
 }
 
-// Flat, in-flow preset control above the shared launch form. Reuses the app's
-// instrument vocabulary: an owner-hue backend badge + mono spec summary, the
-// session-card action-chips (with the pin control standing in for "set
-// default"), and a dog-ear fold marking the default — the same marker pinned
-// cards carry. Only the save dialog floats (portaled glass sheet).
-export function PresetBar({
-  form,
+function selectedOf(
+  presets: SessionPresetSummary[],
+  id: string | null,
+): SessionPresetSummary | null {
+  return presets.find((p) => p.id === id) ?? null;
+}
+
+// Build a spec snapshot of the current launch form — the payload a save captures.
+function formSpec(
+  form: LaunchForm,
+  launchTargetId: string | null,
+): SessionPresetSpec {
+  const { args, configOverrides, launchEnv } = form.collectArgs();
+  return {
+    backend: form.backend,
+    cwd: form.cwd || null,
+    launch_target_id: launchTargetId,
+    transport: form.transport || null,
+    title: form.title.trim() || null,
+    model: form.model.trim() || null,
+    effort: form.effortSupported ? form.effort.trim() || null : null,
+    permission_mode: form.permissionMode || null,
+    args,
+    config_overrides: configOverrides,
+    launch_env: launchEnv,
+  };
+}
+
+interface PresetSelectProps {
+  presets: SessionPresetSummary[];
+  selectedPresetId: string | null;
+  onSelectPreset: (id: string | null) => void;
+  supportedBackends: Backend[];
+  deletePreset: (presetId: string) => Promise<void>;
+}
+
+// Top-of-panel selector: pick a saved launch profile and hydrate the form. The
+// default carries the dog-ear fold (default is a pin), the spec rides an
+// owner-hue badge + mono summary, and Delete manages the current selection.
+export function PresetSelect({
   presets,
   selectedPresetId,
   onSelectPreset,
   supportedBackends,
-  launchTargetId,
-  savePreset,
-  setDefaultPreset,
   deletePreset,
-}: PresetBarProps) {
+}: PresetSelectProps) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [saveOpen, setSaveOpen] = useState(false);
 
-  const selected = presets.find((p) => p.id === selectedPresetId) ?? null;
+  const selected = selectedOf(presets, selectedPresetId);
   const isDefault = selected?.is_default ?? false;
   const presetBackend = selected?.spec.backend ?? null;
   const backendUnsupported =
     !!presetBackend && !supportedBackends.includes(presetBackend as Backend);
-
-  function currentSpec(): SessionPresetSpec {
-    const { args, configOverrides, launchEnv } = form.collectArgs();
-    return {
-      backend: form.backend,
-      cwd: form.cwd || null,
-      launch_target_id: launchTargetId,
-      transport: form.transport || null,
-      title: form.title.trim() || null,
-      model: form.model.trim() || null,
-      effort: form.effortSupported ? form.effort.trim() || null : null,
-      permission_mode: form.permissionMode || null,
-      args,
-      config_overrides: configOverrides,
-      launch_env: launchEnv,
-    };
-  }
-
-  async function handleSetDefault(): Promise<void> {
-    setError(null);
-    if (!selectedPresetId) {
-      // Nothing selected — offer to save the current form as a default preset.
-      setSaveOpen(true);
-      return;
-    }
-    if (isDefault) return;
-    setBusy(true);
-    try {
-      await setDefaultPreset(selectedPresetId);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "failed to set default");
-    } finally {
-      setBusy(false);
-    }
-  }
 
   async function handleDelete(): Promise<void> {
     if (!selected) return;
@@ -164,33 +138,16 @@ export function PresetBar({
             ))}
           </select>
         </div>
-        <div className="preset-bar-actions">
-          <button
-            type="button"
-            className="link-button action-chip"
-            disabled={busy}
-            onClick={() => setSaveOpen(true)}
-          >
-            {selected ? "Save…" : "Save preset…"}
-          </button>
-          <button
-            type="button"
-            className={`link-button action-chip pin-link${isDefault ? " active" : ""}`}
-            disabled={busy || isDefault}
-            title={isDefault ? "This is the default preset" : "Make default"}
-            onClick={() => void handleSetDefault()}
-          >
-            {isDefault ? "✓ Default" : "Set default"}
-          </button>
+        {selected ? (
           <button
             type="button"
             className="link-button action-chip danger-link"
-            disabled={busy || !selected}
+            disabled={busy}
             onClick={() => void handleDelete()}
           >
             Delete
           </button>
-        </div>
+        ) : null}
       </div>
       {selected ? (
         <div className="preset-bar-detail">
@@ -198,7 +155,7 @@ export function PresetBar({
         </div>
       ) : (
         <p className="preset-bar-hint">
-          Reuse a launch profile, or save the current form as one.
+          Reuse a launch profile, or configure the form and save it as one below.
         </p>
       )}
       {backendUnsupported ? (
@@ -213,9 +170,95 @@ export function PresetBar({
           {error}
         </p>
       ) : null}
+    </div>
+  );
+}
+
+interface PresetSaveActionsProps {
+  form: LaunchForm;
+  presets: SessionPresetSummary[];
+  selectedPresetId: string | null;
+  launchTargetId: string | null;
+  savePreset: (
+    payload: SessionPresetWriteRequest,
+    presetId: string | null,
+  ) => Promise<void>;
+  setDefaultPreset: (presetId: string) => Promise<void>;
+}
+
+// Bottom-of-panel capture actions: these snapshot the fully-configured form, so
+// they live next to Launch rather than with the selector. Save opens the sheet;
+// Set-default marks the selected preset (or, with none selected, saves the
+// current form as a new default).
+export function PresetSaveActions({
+  form,
+  presets,
+  selectedPresetId,
+  launchTargetId,
+  savePreset,
+  setDefaultPreset,
+}: PresetSaveActionsProps) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [seedDefault, setSeedDefault] = useState(false);
+
+  const selected = selectedOf(presets, selectedPresetId);
+  const isDefault = selected?.is_default ?? false;
+
+  async function handleSetDefault(): Promise<void> {
+    setError(null);
+    if (!selectedPresetId) {
+      setSeedDefault(true);
+      setSaveOpen(true);
+      return;
+    }
+    if (isDefault) return;
+    setBusy(true);
+    try {
+      await setDefaultPreset(selectedPresetId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to set default");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="preset-save">
+      <span className="preset-save-label">Save this configuration</span>
+      <div className="preset-save-actions">
+        <button
+          type="button"
+          className="secondary"
+          disabled={busy}
+          onClick={() => {
+            setSeedDefault(false);
+            setSaveOpen(true);
+          }}
+        >
+          {selected ? "Save preset…" : "Save as preset…"}
+        </button>
+        <button
+          type="button"
+          className={`secondary${isDefault ? " preset-default-on" : ""}`}
+          disabled={busy || isDefault}
+          title={isDefault ? "This preset is the default" : undefined}
+          onClick={() => void handleSetDefault()}
+        >
+          {isDefault ? "✓ Default" : "Set as default"}
+        </button>
+      </div>
+      {error ? (
+        <p className="error preset-save-error" role="alert">
+          {error}
+        </p>
+      ) : null}
       {saveOpen ? (
         <PresetSaveModal
           selected={selected}
+          seedDefault={seedDefault}
+          spec={formSpec(form, launchTargetId)}
           onClose={() => setSaveOpen(false)}
           onSave={async (payload, presetId) => {
             setBusy(true);
@@ -229,7 +272,6 @@ export function PresetBar({
               setBusy(false);
             }
           }}
-          currentSpec={currentSpec}
         />
       ) : null}
     </div>
@@ -238,31 +280,32 @@ export function PresetBar({
 
 interface PresetSaveModalProps {
   selected: SessionPresetSummary | null;
+  seedDefault: boolean;
+  spec: SessionPresetSpec;
   onClose: () => void;
   onSave: (
     payload: SessionPresetWriteRequest,
     presetId: string | null,
   ) => Promise<void>;
-  currentSpec: () => SessionPresetSpec;
 }
 
 // Portaled save sheet, mirroring ScheduleMessageModal's conventions: rendered to
 // document.body, Escape to close, focus trap, focus restored on unmount, and a
-// body-scroll lock. Leads with a captures-preview so the user sees exactly what
+// body-scroll lock. Leads with a captures readout so the user sees exactly what
 // the preset will pin.
 function PresetSaveModal({
   selected,
+  seedDefault,
+  spec,
   onClose,
   onSave,
-  currentSpec,
 }: PresetSaveModalProps) {
   const [name, setName] = useState(selected?.name ?? "");
   const [description, setDescription] = useState(selected?.description ?? "");
-  const [asDefault, setAsDefault] = useState(false);
+  const [asDefault, setAsDefault] = useState(seedDefault);
   const modalRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
-  const spec = currentSpec();
   const summarySpec: SessionPresetSummary["spec"] = {
     backend: spec.backend,
     model: spec.model,
@@ -327,7 +370,7 @@ function PresetSaveModal({
       },
       presetId,
     ).catch(() => {
-      /* surfaced by the bar */
+      /* surfaced by the actions bar */
     });
   }
 

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import type { LaunchForm } from "@/components/LaunchFormFields";
+import { humaniseBackend } from "@/lib/backends";
 import type {
   Backend,
   SessionPresetSpec,
@@ -27,10 +28,43 @@ interface PresetBarProps {
   deletePreset: (presetId: string) => Promise<void>;
 }
 
-// Flat, in-flow preset control that sits above the shared launch form: a
-// selector that hydrates the form from a preset, plus save / set-default /
-// delete actions. Only the save dialog floats (glass modal); the bar itself is
-// flat token chrome to match the launch card.
+// A compact key=value summary of what a preset spec pins, in the badge/mono
+// vocabulary: the backend rides an owner-hue badge, the rest are muted chips.
+function SpecSummary({
+  spec,
+}: {
+  spec: SessionPresetSummary["spec"];
+}) {
+  const chips: string[] = [];
+  if (spec.model) chips.push(spec.model);
+  if (spec.effort) chips.push(spec.effort);
+  if (spec.permission_mode) chips.push(spec.permission_mode);
+  const envCount = spec.launch_env_keys?.length ?? 0;
+  if (envCount) chips.push(`${envCount} env`);
+  const argsCount = spec.args?.length ?? 0;
+  if (argsCount) chips.push(`${argsCount} arg${argsCount > 1 ? "s" : ""}`);
+  return (
+    <span className="preset-summary">
+      {spec.backend ? (
+        <span className={`badge ${spec.backend}`}>
+          {humaniseBackend(spec.backend as Backend)}
+        </span>
+      ) : null}
+      {chips.map((chip, i) => (
+        <span key={`${i}-${chip}`} className="preset-summary-chip">
+          {i > 0 || spec.backend ? <span className="preset-summary-dot" /> : null}
+          {chip}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+// Flat, in-flow preset control above the shared launch form. Reuses the app's
+// instrument vocabulary: an owner-hue backend badge + mono spec summary, the
+// session-card action-chips (with the pin control standing in for "set
+// default"), and a dog-ear fold marking the default — the same marker pinned
+// cards carry. Only the save dialog floats (portaled glass sheet).
 export function PresetBar({
   form,
   presets,
@@ -47,6 +81,7 @@ export function PresetBar({
   const [saveOpen, setSaveOpen] = useState(false);
 
   const selected = presets.find((p) => p.id === selectedPresetId) ?? null;
+  const isDefault = selected?.is_default ?? false;
   const presetBackend = selected?.spec.backend ?? null;
   const backendUnsupported =
     !!presetBackend && !supportedBackends.includes(presetBackend as Backend);
@@ -75,6 +110,7 @@ export function PresetBar({
       setSaveOpen(true);
       return;
     }
+    if (isDefault) return;
     setBusy(true);
     try {
       await setDefaultPreset(selectedPresetId);
@@ -108,56 +144,75 @@ export function PresetBar({
   }
 
   return (
-    <div className="preset-bar">
-      <label className="preset-bar-select field">
-        <span>Preset</span>
-        <select
-          value={selectedPresetId ?? ""}
-          disabled={busy}
-          onChange={(event) => onSelectPreset(event.target.value || null)}
-        >
-          <option value="">No preset</option>
-          {presets.map((preset) => (
-            <option key={preset.id} value={preset.id}>
-              {preset.name}
-              {preset.is_default ? " · Default" : ""}
-            </option>
-          ))}
-        </select>
-      </label>
-      <div className="preset-bar-actions">
-        <button
-          type="button"
-          className="secondary"
-          disabled={busy}
-          onClick={() => setSaveOpen(true)}
-        >
-          Save…
-        </button>
-        <button
-          type="button"
-          className="secondary"
-          disabled={busy}
-          onClick={() => void handleSetDefault()}
-        >
-          {selected?.is_default ? "Default ✓" : "Set default"}
-        </button>
-        <button
-          type="button"
-          className="danger"
-          disabled={busy || !selected}
-          onClick={() => void handleDelete()}
-        >
-          Delete
-        </button>
+    <div className={`preset-bar${isDefault ? " is-default" : ""}`}>
+      <div className="preset-bar-row">
+        <span className="preset-bar-label">Preset</span>
+        <div className="preset-bar-picker">
+          <select
+            className="preset-select"
+            value={selectedPresetId ?? ""}
+            disabled={busy}
+            aria-label="Session preset"
+            onChange={(event) => onSelectPreset(event.target.value || null)}
+          >
+            <option value="">No preset</option>
+            {presets.map((preset) => (
+              <option key={preset.id} value={preset.id}>
+                {preset.name}
+                {preset.is_default ? "  ·  default" : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="preset-bar-actions">
+          <button
+            type="button"
+            className="link-button action-chip"
+            disabled={busy}
+            onClick={() => setSaveOpen(true)}
+          >
+            {selected ? "Save…" : "Save preset…"}
+          </button>
+          <button
+            type="button"
+            className={`link-button action-chip pin-link${isDefault ? " active" : ""}`}
+            disabled={busy || isDefault}
+            title={isDefault ? "This is the default preset" : "Make default"}
+            onClick={() => void handleSetDefault()}
+          >
+            {isDefault ? "✓ Default" : "Set default"}
+          </button>
+          <button
+            type="button"
+            className="link-button action-chip danger-link"
+            disabled={busy || !selected}
+            onClick={() => void handleDelete()}
+          >
+            Delete
+          </button>
+        </div>
       </div>
+      {selected ? (
+        <div className="preset-bar-detail">
+          <SpecSummary spec={selected.spec} />
+        </div>
+      ) : (
+        <p className="preset-bar-hint">
+          Reuse a launch profile, or save the current form as one.
+        </p>
+      )}
       {backendUnsupported ? (
-        <p className="error preset-bar-error">
-          This preset&apos;s backend ({presetBackend}) isn&apos;t available on the
-          current launch target. Change the backend or target before launching.
+        <p className="error preset-bar-error" role="alert">
+          This preset&apos;s backend ({humaniseBackend(presetBackend as Backend)})
+          isn&apos;t available on the current launch target — change the backend or
+          target before launching.
         </p>
       ) : null}
-      {error ? <p className="error preset-bar-error">{error}</p> : null}
+      {error ? (
+        <p className="error preset-bar-error" role="alert">
+          {error}
+        </p>
+      ) : null}
       {saveOpen ? (
         <PresetSaveModal
           selected={selected}
@@ -191,6 +246,10 @@ interface PresetSaveModalProps {
   currentSpec: () => SessionPresetSpec;
 }
 
+// Portaled save sheet, mirroring ScheduleMessageModal's conventions: rendered to
+// document.body, Escape to close, focus trap, focus restored on unmount, and a
+// body-scroll lock. Leads with a captures-preview so the user sees exactly what
+// the preset will pin.
 function PresetSaveModal({
   selected,
   onClose,
@@ -200,58 +259,115 @@ function PresetSaveModal({
   const [name, setName] = useState(selected?.name ?? "");
   const [description, setDescription] = useState(selected?.description ?? "");
   const [asDefault, setAsDefault] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
+  const spec = currentSpec();
+  const summarySpec: SessionPresetSummary["spec"] = {
+    backend: spec.backend,
+    model: spec.model,
+    effort: spec.effort,
+    permission_mode: spec.permission_mode,
+    launch_env_keys: Object.keys(spec.launch_env ?? {}),
+    args: spec.args,
+  };
+
   useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
     inputRef.current?.focus();
-    function onKey(event: KeyboardEvent) {
-      if (event.key === "Escape") onClose();
+    inputRef.current?.select();
+    return () => previouslyFocused?.focus();
+  }, []);
+
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  useEffect(() => {
+    function onKey(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const root = modalRef.current;
+      if (!root) return;
+      const focusable = root.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+      if (event.shiftKey && (active === first || !root.contains(active))) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
+        event.preventDefault();
+        first.focus();
+      }
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [onClose]);
 
-  function submitNew(event: FormEvent) {
-    event.preventDefault();
-    if (!name.trim()) return;
-    void onSave(
-      {
-        name: name.trim(),
-        description: description.trim() || null,
-        spec: currentSpec(),
-        is_default: asDefault,
-      },
-      null,
-    );
-  }
-
-  function submitUpdate() {
-    if (!selected) return;
-    void onSave(
+  function submit(presetId: string | null) {
+    if (presetId === null && !name.trim()) return;
+    onSave(
       {
         name: name.trim() || undefined,
         description: description.trim() || null,
-        spec: currentSpec(),
+        spec,
+        ...(presetId === null ? { is_default: asDefault } : {}),
       },
-      selected.id,
-    );
+      presetId,
+    ).catch(() => {
+      /* surfaced by the bar */
+    });
+  }
+
+  function onSubmitForm(event: FormEvent) {
+    event.preventDefault();
+    submit(null);
   }
 
   return createPortal(
     <div
       className="preset-modal-overlay"
+      role="presentation"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >
       <div
+        ref={modalRef}
         className="preset-modal"
         role="dialog"
         aria-modal="true"
-        aria-label="Save preset"
+        aria-label={selected ? "Save preset" : "New preset"}
       >
-        <form onSubmit={submitNew}>
-          <h3>{selected ? "Save preset" : "New preset"}</h3>
+        <div className="preset-modal-header">
+          <span className="preset-modal-title">
+            <span className="preset-modal-glyph" aria-hidden="true">
+              ƒ
+            </span>
+            {selected ? "Save preset" : "New preset"}
+          </span>
+          <button
+            type="button"
+            className="preset-modal-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+        <form onSubmit={onSubmitForm}>
           <label className="field">
             <span>Name</span>
             <input
@@ -269,14 +385,20 @@ function PresetSaveModal({
               placeholder="Optional"
             />
           </label>
-          <label className="preset-modal-check">
-            <input
-              type="checkbox"
-              checked={asDefault}
-              onChange={(event) => setAsDefault(event.target.checked)}
-            />
-            <span>Make this the default preset</span>
-          </label>
+          <div className="preset-modal-captures">
+            <span className="preset-modal-captures-label">Captures</span>
+            <SpecSummary spec={summarySpec} />
+          </div>
+          {!selected ? (
+            <label className="preset-modal-check">
+              <input
+                type="checkbox"
+                checked={asDefault}
+                onChange={(event) => setAsDefault(event.target.checked)}
+              />
+              <span>Make this the default preset</span>
+            </label>
+          ) : null}
           <div className="preset-modal-actions">
             <button type="button" className="secondary" onClick={onClose}>
               Cancel
@@ -286,8 +408,8 @@ function PresetSaveModal({
                 <button
                   type="button"
                   className="secondary"
-                  onClick={submitUpdate}
-                  disabled={!!selected && !name.trim()}
+                  disabled={!name.trim()}
+                  onClick={() => submit(selected.id)}
                 >
                   Update &quot;{selected.name}&quot;
                 </button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -25,6 +25,9 @@ import {
   SessionCommandInvocation,
   SessionAttachment,
   SessionEnvelope,
+  SessionPreset,
+  SessionPresetSummary,
+  SessionPresetWriteRequest,
   SessionRecord,
   UsageDashboardResponse,
 } from "@/lib/types";
@@ -620,6 +623,101 @@ export async function clearScheduleHistory(host: string, token: string): Promise
   await ensureOk(response, "failed to clear schedule history");
   const payload = (await response.json()) as { removed?: number };
   return payload.removed ?? 0;
+}
+
+// ── Session presets ──────────────────────────────────────────────────────
+
+// Fetch one preset. Pass includeSecretValues to get launch_env values back
+// (required before hydrating a form from a preset that has env vars); the
+// list/bootstrap payloads are always redacted.
+export async function fetchSessionPreset(
+  host: string,
+  token: string,
+  presetId: string,
+  includeSecretValues = false,
+): Promise<SessionPreset> {
+  const query = includeSecretValues ? "?include_secret_values=true" : "";
+  const response = await fetch(
+    `${host}/api/session-presets/${presetId}${query}`,
+    { headers: { Authorization: `Bearer ${token}` }, cache: "no-store" },
+  );
+  await ensureOk(response, "failed to fetch preset");
+  const body = await response.json();
+  return body.preset as SessionPreset;
+}
+
+export async function createSessionPreset(
+  host: string,
+  token: string,
+  payload: SessionPresetWriteRequest,
+): Promise<SessionPresetSummary> {
+  const response = await fetch(`${host}/api/session-presets`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  await ensureOk(response, "failed to create preset");
+  const body = await response.json();
+  return body.preset as SessionPresetSummary;
+}
+
+export async function updateSessionPreset(
+  host: string,
+  token: string,
+  presetId: string,
+  payload: SessionPresetWriteRequest,
+): Promise<SessionPresetSummary> {
+  const response = await fetch(`${host}/api/session-presets/${presetId}`, {
+    method: "PATCH",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+  await ensureOk(response, "failed to update preset");
+  const body = await response.json();
+  return body.preset as SessionPresetSummary;
+}
+
+export async function deleteSessionPreset(
+  host: string,
+  token: string,
+  presetId: string,
+): Promise<void> {
+  const response = await fetch(`${host}/api/session-presets/${presetId}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to delete preset");
+}
+
+export async function setDefaultSessionPreset(
+  host: string,
+  token: string,
+  presetId: string,
+): Promise<SessionPresetSummary> {
+  const response = await fetch(
+    `${host}/api/session-presets/${presetId}/default`,
+    { method: "POST", headers: { Authorization: `Bearer ${token}` } },
+  );
+  await ensureOk(response, "failed to set default preset");
+  const body = await response.json();
+  return body.preset as SessionPresetSummary;
+}
+
+export async function clearDefaultSessionPreset(
+  host: string,
+  token: string,
+): Promise<void> {
+  const response = await fetch(`${host}/api/session-presets/default`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to clear default preset");
 }
 
 export async function fetchMessageSchedules(

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -311,13 +311,13 @@ export interface MeResponse {
 
 // Full preset spec (with launch_env values); returned only from the
 // include_secret_values single-preset fetch and used to hydrate the form.
+// cwd and title are intentionally absent — they are per-launch specifics, not
+// reusable launch defaults, so the launch surfaces always supply them directly.
 export interface SessionPresetSpec {
   backend?: Backend | null;
-  cwd?: string | null;
   launch_target_id?: string | null;
   launch_mode?: LaunchMode | null;
   transport?: SessionTransport | null;
-  title?: string | null;
   args?: string[];
   config_overrides?: string[];
   launch_env?: Record<string, string>;
@@ -331,11 +331,9 @@ export interface SessionPresetSpec {
 // only the keys are exposed.
 export interface SessionPresetSpecSummary {
   backend?: Backend | null;
-  cwd?: string | null;
   launch_target_id?: string | null;
   launch_mode?: LaunchMode | null;
   transport?: SessionTransport | null;
-  title?: string | null;
   args?: string[];
   config_overrides?: string[];
   launch_env_keys?: string[];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -305,6 +305,71 @@ export interface MeResponse {
   launch_targets: LaunchTargetSummary[];
   backends?: BackendDescriptor[];
   assistant?: AssistantSummary | null;
+  session_presets?: SessionPresetSummary[];
+  default_preset_id?: string | null;
+}
+
+// Full preset spec (with launch_env values); returned only from the
+// include_secret_values single-preset fetch and used to hydrate the form.
+export interface SessionPresetSpec {
+  backend?: Backend | null;
+  cwd?: string | null;
+  launch_target_id?: string | null;
+  launch_mode?: LaunchMode | null;
+  transport?: SessionTransport | null;
+  title?: string | null;
+  args?: string[];
+  config_overrides?: string[];
+  launch_env?: Record<string, string>;
+  permission_mode?: string | null;
+  model?: string | null;
+  effort?: string | null;
+  tags?: Record<string, string>;
+}
+
+// Redacted spec used on list / bootstrap surfaces: env values are omitted,
+// only the keys are exposed.
+export interface SessionPresetSpecSummary {
+  backend?: Backend | null;
+  cwd?: string | null;
+  launch_target_id?: string | null;
+  launch_mode?: LaunchMode | null;
+  transport?: SessionTransport | null;
+  title?: string | null;
+  args?: string[];
+  config_overrides?: string[];
+  launch_env_keys?: string[];
+  permission_mode?: string | null;
+  model?: string | null;
+  effort?: string | null;
+  tags?: Record<string, string>;
+}
+
+export interface SessionPresetSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  spec: SessionPresetSpecSummary;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SessionPreset {
+  id: string;
+  name: string;
+  description?: string | null;
+  spec: SessionPresetSpec;
+  is_default: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface SessionPresetWriteRequest {
+  name?: string;
+  description?: string | null;
+  spec?: SessionPresetSpec;
+  is_default?: boolean;
 }
 
 export interface EventsPage {
@@ -368,6 +433,9 @@ export interface ScheduleCreateRequest {
   effort?: string | null;
   delay_seconds?: number | null;
   scheduled_at?: string | null;
+  // Provenance only — the frontend submits already-resolved fields; sending the
+  // selected preset id lets the server stamp it onto the scheduled record.
+  preset_id?: string | null;
 }
 
 export interface BackendModelOption {


### PR DESCRIPTION
## Purpose

Session launch options have grown well beyond a backend and cwd — a useful launch now often pins a transport, model, effort, permission mode, launch target, launch mode, `launch_env`, custom args, config overrides, and tags. Re-entering those combinations on every launch surface is repetitive in the UI and error-prone for agent skills, where a wrong model or a non-auto-approving permission mode can stall or kill a worker on turn one. This adds durable, named **session presets**: reusable launch defaults stored server-side and applied — under any explicit overrides — when creating a session or a schedule, from the frontend, the `waypoint` CLI, and agent skills.

## Changes

### Backend

- `backend/src/waypoint/schemas.py` — `SessionPresetSpec`/`SessionPresetRecord` plus create/update requests, a redacted `SessionPresetSummary` (env values dropped, keys exposed), `preset_id`/`use_default_preset` on the session and schedule create requests, `preset_id`/`preset_name` provenance on the session and schedule records, `session_presets`/`default_preset_id` on `MeResponse`, and lenient `SessionLaunchRequest`/`ScheduleLaunchRequest` boundary inputs (optional backend/cwd) so a preset can supply the required fields.
- `backend/src/waypoint/storage.py` — a `session_presets` table with a case-insensitive-unique name and a partial unique index enforcing at most one default, preset CRUD + the default invariant, and `preset_id`/`preset_name` columns on `sessions`/`scheduled_sessions` (additive `_ensure_column` migrations).
- `backend/src/waypoint/presets.py` — a `PresetManager` (CRUD, id generation, default invariant) and the boundary resolver that overlays a preset under the explicit request fields and re-validates into a strict request. Container overlays are gated on emptiness so an empty preset `launch_env` never suppresses the backend's default env.
- `backend/src/waypoint/api.py` — preset CRUD endpoints (redacted by default, full values behind `?include_secret_values=true`), preset resolution wired into `POST /api/sessions` and `POST /api/schedules`, and presets surfaced on `/api/me`.
- `backend/src/waypoint/runtime.py`, `scheduler.py` — `create_session`/`create_schedule` accept preset provenance and stamp it generically (like tags); `_fire` replays the snapshot and never re-resolves, so later preset edits/deletes never change an existing schedule. Plugin dispatch stays preset-agnostic.
- `backend/src/waypoint/cli.py`, `client.py` — a `waypoint presets` command group (list/show/create/update/delete/default/clear-default), `--preset`/`--no-preset` on `session start`, `sessions start`, and `schedule create` (with `--backend`/`--cwd` now optional when a preset supplies them), and warnings that run against the effective model/permission after the preset would apply.

### Frontend

- `frontend/src/components/PresetBar.tsx` — a flat, in-flow preset selector above the shared launch form with save / set-default / delete actions and a glass save dialog.
- `frontend/src/components/LaunchFormFields.tsx`, `LaunchPanel.tsx`, `frontend/src/app/page.tsx` — `applyPreset` hydrates the form (fetching env values on demand, since bootstrap is redacted) while guarding the backend-change resets so model/effort/env/transport survive; the default preset hydrates once on first load; presets arrive via `/api/me` and the selected preset rides along as provenance on scheduled launches.
- `frontend/src/lib/api.ts`, `types.ts`, `frontend/src/app/globals.css` — preset API client + types, and flat preset-bar / glass save-dialog styles derived from tokens for both themes.

### Docs

- `.agents/skills/waypoint*` references — thread presets through the launch, scheduling, subagent, workqueue, and crew skills: prefer a user/default preset for repeated worker roles, still inspect `backends`/`models` when overriding, and don't assume the default preset auto-approves for unattended crews.

## Design

Presets are a request-boundary feature, not backend-native templates: a preset resolves into the existing launch-request shape before the runtime's own validation, so backend plugins, transports, the runtime, and the scheduler's `_fire` path stay entirely preset-agnostic. Merge is deterministic — explicit request fields (decided by `model_fields_set`, not truthiness) always win; the preset fills in only omitted, non-empty values, which preserves the runtime's omitted-vs-explicit `launch_env` behavior. The API never applies a default implicitly; a caller opts in with `preset_id` or `use_default_preset`. `launch_env` stays write-only on read surfaces exactly as today: list/bootstrap/plain-GET responses are redacted to `launch_env_keys`, and full values come only from an explicit `?include_secret_values=true` fetch (which the frontend calls before hydrating a preset with env). Launches snapshot the resolved settings, so preset edits or deletes never mutate an existing session or schedule.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Live stack e2e through `waypointctl` and `uv run waypoint`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1492 passed, 3 warnings (pre-existing).
- `npm run lint` — clean.
- `npm run build` — clean (TypeScript check passed).
- Live stack e2e — restarted backend + frontend on this branch via `waypointctl` (both healthy), then exercised the full preset lifecycle over `uv run waypoint`: create (with a secret `launch_env` and `--default`), `list`/`show` redacted vs `show --show-secrets` (value revealed), `update` PATCH preserving omitted tags, `presets default`, `schedule create --preset` snapshotting the resolved backend/model/permission plus `preset_id`/`preset_name`, and `delete` clearing the default. The stale-preset guard fired correctly: a preset carrying a Claude permission mode was rejected at `schedule create` time against the codex vocabulary. The test schedule was cleaned up afterward.
- Browser UI e2e — not run: this environment has no browser automation. The frontend was deployed and healthy; theme parity relies on token-derived styles rather than a visual screenshot pass.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (storage/resolver/API/CLI/scheduler in `backend/tests/test_session_presets.py`, plus scheduler/CLI adjustments).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`, plus live `waypointctl`/`waypoint` preset e2e). `waypointctl` was not touched.
- [x] Preset resolution happens at the request boundary and adds no per-backend branch; the runtime, scheduler `_fire`, and plugin dispatch stay preset-agnostic, so no backend-specific behavior changed.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build`; new controls derive from tokens for both themes (visual screenshot pass not run in this environment).
- [x] Not a breaking change — additive schema/API/CLI/UI surface; existing launch flows work unchanged with no presets configured.
- [x] No new user-facing config; `.env.example` / `waypoint.example.yaml` need no changes.

</details>
