### PR TITLE
fix: support session path copying

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9161,6 +9161,7 @@ html[data-theme="light"] .preset-modal-overlay {
   top: 0;
   right: 0;
   z-index: 2;
+  pointer-events: none;
   border-top: 15px solid var(--accent);
   border-left: 15px solid transparent;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9091,11 +9091,18 @@ html[data-theme="light"] .preset-modal-overlay {
 .session-card > :not(.session-card-hit-target) {
   position: relative;
   z-index: 1;
+  pointer-events: none;
 }
 
 .session-card-selectable {
   user-select: text;
   cursor: text;
+}
+
+.session-card .session-card-selectable,
+.session-card button,
+.session-card input {
+  pointer-events: auto;
 }
 
 .session-card h3 {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1296,6 +1296,13 @@ html[data-theme="light"] .clipboard-prompt__arrow {
   overflow-wrap: anywhere;
 }
 
+.session-header-cwd-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
 .session-header-cwd {
   margin: 0;
   font-family: var(--font-mono);
@@ -1308,6 +1315,10 @@ html[data-theme="light"] .clipboard-prompt__arrow {
   gap: 0;
   overflow-wrap: anywhere;
   min-width: 0;
+}
+
+.session-header-cwd-row .session-header-cwd {
+  flex: 0 1 auto;
 }
 
 .session-header-cwd .cwd-segment {
@@ -1327,6 +1338,43 @@ html[data-theme="light"] .clipboard-prompt__arrow {
 .session-header-target {
   color: var(--accent-cool);
   margin-left: 4px;
+}
+
+.session-cwd-copy {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted-soft);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  line-height: 1;
+  cursor: pointer;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease,
+    border-color 140ms ease;
+}
+
+.session-cwd-copy:hover,
+.session-cwd-copy:focus-visible {
+  border-color: var(--line);
+  background: color-mix(in srgb, var(--accent-cool) 10%, transparent);
+  color: var(--text);
+}
+
+.session-cwd-copy:focus-visible {
+  outline: none;
+}
+
+.session-cwd-copy.copied {
+  color: var(--success);
 }
 
 .session-header-tags {
@@ -9012,11 +9060,42 @@ html[data-theme="light"] .preset-modal-overlay {
   width: 100%;
   position: relative;
   overflow: hidden;
+  isolation: isolate;
   transition: border-color 140ms ease;
 }
 
 .session-card:hover {
   border-color: var(--line-strong);
+}
+
+.session-card-hit-target {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  border-radius: inherit;
+}
+
+.session-card-hit-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.session-card-hit-target:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.session-card > :not(.session-card-hit-target) {
+  position: relative;
+  z-index: 1;
+}
+
+.session-card-selectable {
+  user-select: text;
+  cursor: text;
 }
 
 .session-card h3 {
@@ -9074,6 +9153,7 @@ html[data-theme="light"] .preset-modal-overlay {
   position: absolute;
   top: 0;
   right: 0;
+  z-index: 2;
   border-top: 15px solid var(--accent);
   border-left: 15px solid transparent;
 }
@@ -9136,6 +9216,15 @@ html[data-theme="light"] .preset-modal-overlay {
 
 .session-card-title-row .session-card-title {
   flex-grow: 1;
+}
+
+.session-card-title-row,
+.session-card-path,
+.session-card-meta,
+.session-card-actions {
+  justify-self: start;
+  width: fit-content;
+  max-width: 100%;
 }
 
 .inline-title-input {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -204,6 +204,24 @@ function SessionIdCopy({ id }: { id: string }) {
   );
 }
 
+function SessionCwdCopy({ cwd }: { cwd: string }) {
+  const { copied, markCopied } = useCopied();
+  return (
+    <button
+      type="button"
+      className={`session-cwd-copy${copied ? " copied" : ""}`}
+      title={copied ? "Copied" : `Copy working directory: ${cwd}`}
+      aria-label={copied ? "Working directory copied" : `Copy working directory ${cwd}`}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (copyTextSync(cwd)) markCopied();
+      }}
+    >
+      <span aria-hidden>{copied ? "✓" : "⎘"}</span>
+    </button>
+  );
+}
+
 // WebKit (desktop Safari + every iOS browser, since the App Store
 // requires WebKit) gates ``navigator.clipboard.readText()`` behind a
 // system "Paste" banner that the user must click to authorize. Other
@@ -4061,17 +4079,20 @@ function SessionHeader({
       {/* cwd / transport / source frame a task session; for the persistent
           assistant they're noise — keep just which backend + model answers. */}
       {!assistant ? (
-        <p className="session-header-cwd" title={session.cwd}>
-          {cwdSegments.map((segment, index) => (
-            <span key={index}>
-              {index > 0 ? <span className="cwd-sep" aria-hidden>/</span> : null}
-              <span className={index === cwdSegments.length - 1 ? "cwd-leaf" : "cwd-segment"}>
-                {segment}
+        <div className="session-header-cwd-row">
+          <p className="session-header-cwd" title={session.cwd}>
+            {cwdSegments.map((segment, index) => (
+              <span key={index}>
+                {index > 0 ? <span className="cwd-sep" aria-hidden>/</span> : null}
+                <span className={index === cwdSegments.length - 1 ? "cwd-leaf" : "cwd-segment"}>
+                  {segment}
+                </span>
               </span>
-            </span>
-          ))}
-          {target ? <span className="session-header-target"> · {target}</span> : null}
-        </p>
+            ))}
+            {target ? <span className="session-header-target"> · {target}</span> : null}
+          </p>
+          <SessionCwdCopy cwd={session.cwd} />
+        </div>
       ) : null}
       <div className="session-header-tags">
         <span className={`badge ${headerAgent}`}>
@@ -4273,4 +4294,3 @@ function stripAnsi(text: string): string {
     .replace(/\u001B\[[0-?]*[ -/]*[@-~]/g, "")
     .replace(/\u001B[@-_]/g, "");
 }
-

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -197,7 +197,14 @@ export function SessionList({
     const showTransport =
       agentDefault !== null && session.transport !== agentDefault;
     return (
-      <Link className="panel session-card" href={`/session/${session.id}`} key={session.id}>
+      <article className="panel session-card" key={session.id}>
+        <Link
+          className="session-card-hit-target"
+          href={`/session/${session.id}`}
+          aria-label={`Open session ${session.title}`}
+        >
+          <span aria-hidden className="session-card-hit-label" />
+        </Link>
         <div className="session-row">
           <div className="session-card-badges">
             <span className={`badge ${agent}`}>
@@ -239,7 +246,7 @@ export function SessionList({
             />
           ) : (
             <>
-              <h3 className="session-card-title">{session.title}</h3>
+              <h3 className="session-card-title session-card-selectable">{session.title}</h3>
               {onSetTitle ? (
                 <button
                   className="link-button edit-title-btn"
@@ -254,11 +261,11 @@ export function SessionList({
             </>
           )}
         </div>
-        <p className="muted session-card-path">
+        <p className="muted session-card-path session-card-selectable">
           {session.cwd}
         </p>
         <div className="session-card-meta">
-          <p className="meta">
+          <p className="meta session-card-selectable">
             {session.repo_name ?? "No repo"}
             {session.branch ? ` · ${session.branch}` : null}
             {session.source === "managed" ? " · managed" : " · attached"}
@@ -294,7 +301,7 @@ export function SessionList({
             </button>
           ) : null}
         </div>
-      </Link>
+      </article>
     );
   }
 


### PR DESCRIPTION
## Purpose

Session working directories are operational values that users often need to paste into shells or hand to agents. The session header renders the cwd as styled path segments, so manual selection can paste as broken wrapped text. Home-page session cards had the opposite problem: the full-card link made title and cwd text hard to select at all. This adds an exact-copy affordance in the session header and restores normal browser text selection on session cards without dropping quick background navigation.

## Changes

### Frontend

- `frontend/src/components/SessionDetail.tsx` — add a quiet cwd copy button beside the segmented header cwd display; it copies the raw `session.cwd` via the existing Safari-safe clipboard path and shows the same transient copied state used by session-id copying.
- `frontend/src/components/SessionList.tsx` — replace the full-card link wrapper with a card container that keeps a real Next `Link` as the background hit target while title/cwd/meta content remains selectable foreground text.
- `frontend/src/app/globals.css` — add token-derived styles for the cwd copy affordance, stretched card background link, focus outline, and selectable card text rows.

## Design

The session header keeps the existing segmented visual path because it scans well, but copying no longer depends on selecting that visual representation. The copy button copies only `session.cwd`, not the optional launch target suffix.

Cards use a stretched-link pattern rather than `router.push` on a `div`: the background still has a real `href` for native link behavior, while visible text and action buttons are outside the anchor layer. Foreground title/cwd/meta rows size to content, so unused card chrome and gaps remain background-link hit targets. No copy buttons were added to cards; text copying there is intentionally implicit through normal selection.

## Test Plan

- `cd frontend && npm run lint`
- `cd frontend && npm_config_cache=/tmp/waypoint-npm-cache npx -y node@20.11.1 /usr/share/nodejs/npm/bin/npm-cli.js run build`

## Test Result

- `npm run lint` — clean.
- `npm run build` under the shell default Node failed before compilation because the shell has Node `v18.19.1`, while Next.js 16 requires Node `>=20.9.0`.
- `npm run build` under a temporary Node `20.11.1` binary — clean; Next compiled, TypeScript passed, and static pages generated successfully.
- Browser e2e — not run: this repo does not declare a frontend e2e suite.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] Backend pre-commit not run; backend code was not touched.
- [x] Automated UI tests not added; this repo does not currently have a frontend test harness for this interaction.
- [x] I have verified the relevant suites pass locally: `cd frontend && npm run lint`, plus `npm run build` under Node 20.
- [x] I did not touch the coding-agent plugin/transport contract or code that dispatches by plugin id.
- [x] Frontend lint/build passed; new styles derive from tokens and do not add hardcoded per-theme surfaces.
- [x] Not a breaking change.
- [x] No documentation or config examples required.

</details>
