### PR TITLE
feat: add account/config-dir profiles (config, capabilities, metadata)

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -26,6 +26,7 @@ from fastapi.responses import FileResponse
 
 from waypoint.auth import TokenStore, require_token
 from waypoint.backends import BackendRegistry
+from waypoint.backends.account_profiles import redacted_profile_metadata
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.backends.tmux.renderer import (
     Osc52Extractor,
@@ -162,6 +163,11 @@ def _backend_descriptors(
                 "label": plugin.label,
                 "badges": dict(caps.badges),
                 "default_launch_env": dict(settings.plugin_config(plugin.id).env),
+                # Redacted global account-profile metadata ({id, label,
+                # config_dir_key} only). Non-empty for agent backends that host
+                # profiles (claude_code, codex); empty otherwise. Target-merged
+                # profiles live on GET /api/me per launch target.
+                "account_profiles": redacted_profile_metadata(settings, plugin.id),
                 # The flat ``capabilities`` object stays byte-identical for
                 # existing consumers; the split sub-objects are emitted
                 # alongside it so the frontend can migrate to the (agent,

--- a/backend/src/waypoint/backends/account_profiles.py
+++ b/backend/src/waypoint/backends/account_profiles.py
@@ -1,0 +1,94 @@
+"""Resolution and redaction of account/config-dir profiles.
+
+Profiles are **agent-owned**: only backends whose config subclass carries an
+``account_profiles`` field (``claude_code``, ``codex``) host them — transports
+(``claude_tty``, ``tmux``) and backends without a config-dir env var
+(``opencode``) never do, so profiles surface under agent ids only and consumers
+map transport → agent.
+
+Global profiles come from ``Settings.plugin_config(backend)``. A launch target
+may override an existing profile field-by-field by id (only the fields it sets
+win; unset fields fall back to the global) and may introduce target-only ids.
+
+Public payloads expose only ``{id, label, config_dir_key}`` — never the
+``config_dir`` path, ``expected_account_key``, or ``transcript_policy``.
+"""
+
+from typing import TYPE_CHECKING
+
+from waypoint.backends.plugin_config import AccountProfileConfig
+from waypoint.backends.registry import get_registry
+
+if TYPE_CHECKING:
+    from waypoint.launch_targets import SshLaunchTargetConfig
+    from waypoint.settings import Settings
+
+
+def backend_hosts_account_profiles(settings: "Settings", backend: str) -> bool:
+    """Whether ``backend``'s config model carries an ``account_profiles`` field.
+
+    True only for the agent backends that own a config-dir env var
+    (``claude_code``, ``codex``); the base config model omits the field so every
+    other backend rejects an ``account_profiles`` block at parse time.
+    """
+    return "account_profiles" in type(settings.plugin_config(backend)).model_fields
+
+
+def _profiles_of(config: object) -> dict[str, AccountProfileConfig]:
+    # ``account_profiles`` lives only on the agent config subclasses; the
+    # getattr default covers configs that don't host it.
+    return dict(getattr(config, "account_profiles", {}))
+
+
+def _merge_profile(
+    base: AccountProfileConfig, override: AccountProfileConfig
+) -> AccountProfileConfig:
+    """Overlay only the fields the target explicitly set onto the global base.
+
+    Using ``model_fields_set`` (not the resolved values) so a target that omits
+    ``transcript_policy`` inherits the global one rather than clobbering it with
+    the field default. Re-validates so a merge can't produce an invalid state.
+    """
+    data = base.model_dump()
+    data.update(
+        {field: getattr(override, field) for field in override.model_fields_set}
+    )
+    return AccountProfileConfig.model_validate(data)
+
+
+def resolve_account_profiles(
+    settings: "Settings",
+    backend: str,
+    launch_target: "SshLaunchTargetConfig | None" = None,
+) -> dict[str, AccountProfileConfig]:
+    """Global profiles for ``backend``, with target overrides merged in by id."""
+    if not backend_hosts_account_profiles(settings, backend):
+        return {}
+    profiles = _profiles_of(settings.plugin_config(backend))
+    if launch_target is not None:
+        for pid, override in _profiles_of(launch_target.plugin_config(backend)).items():
+            base = profiles.get(pid)
+            profiles[pid] = (
+                _merge_profile(base, override) if base is not None else override
+            )
+    return profiles
+
+
+def redacted_profile_metadata(
+    settings: "Settings",
+    backend: str,
+    launch_target: "SshLaunchTargetConfig | None" = None,
+) -> list[dict[str, str]]:
+    """Public ``{id, label, config_dir_key}`` metadata for a backend's profiles.
+
+    Returns an empty list for backends that don't host profiles. Never leaks the
+    config-dir path, expected account key, or transcript policy.
+    """
+    config_dir_key = get_registry().get(backend).capabilities.config_dir_env_var
+    if config_dir_key is None:
+        return []
+    profiles = resolve_account_profiles(settings, backend, launch_target)
+    return [
+        {"id": pid, "label": profile.label, "config_dir_key": config_dir_key}
+        for pid, profile in profiles.items()
+    ]

--- a/backend/src/waypoint/backends/account_profiles.py
+++ b/backend/src/waypoint/backends/account_profiles.py
@@ -14,7 +14,7 @@ Public payloads expose only ``{id, label, config_dir_key}`` — never the
 ``config_dir`` path, ``expected_account_key``, or ``transcript_policy``.
 """
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from waypoint.backends.plugin_config import AccountProfileConfig
 from waypoint.backends.registry import get_registry
@@ -34,7 +34,7 @@ def backend_hosts_account_profiles(settings: "Settings", backend: str) -> bool:
     return "account_profiles" in type(settings.plugin_config(backend)).model_fields
 
 
-def _profiles_of(config: object) -> dict[str, AccountProfileConfig]:
+def _profiles_of(config: Any) -> dict[str, AccountProfileConfig]:
     # ``account_profiles`` lives only on the agent config subclasses; the
     # getattr default covers configs that don't host it.
     return dict(getattr(config, "account_profiles", {}))

--- a/backend/src/waypoint/backends/capabilities.py
+++ b/backend/src/waypoint/backends/capabilities.py
@@ -56,6 +56,14 @@ class AgentCapabilities(_FrozenModel):
     cli_binary: str | None = None
     target_aliases: tuple[str, ...] = ()
     badges: dict[str, str] = Field(default_factory=dict)
+    # The env var this agent's CLI reads for its config/state root
+    # (``CLAUDE_CONFIG_DIR`` / ``CODEX_HOME``). ``None`` means the agent has no
+    # config-dir concept and cannot participate in account-profile switching.
+    config_dir_env_var: str | None = None
+    # Human label for where this agent keeps its resumable native thread under
+    # the config-dir root (e.g. ``projects`` for Claude, ``sessions`` for
+    # Codex). ``None`` when the agent exposes no resumable native store.
+    native_thread_store: str | None = None
 
 
 class TransportCapabilities(_FrozenModel):
@@ -78,6 +86,11 @@ class TransportCapabilities(_FrozenModel):
     supports_set_effort_with_restart: bool = False
     supports_set_permission_mode_inline: bool = False
     settings_change_interrupts_turn: bool = False
+    # The transport can apply restart-scoped launch-settings edits (env, args,
+    # config overrides, account profile) by terminating and restoring the
+    # session, not just the inline model/effort/permission knobs. Requires
+    # ``supports_reattach_after_exit``.
+    supports_launch_settings_with_restart: bool = False
     # The transport drives the agent in a live terminal pane (a pty). The
     # runtime tails its raw log to scrape session state, and the frontend can
     # mirror the pane over the terminal websocket. True for the generic tmux
@@ -142,6 +155,10 @@ class BackendCapabilities(_FrozenModel):
     # so every swap kills the pane and respawns ``--resume``. The frontend
     # reads this to warn before changing settings on a running session.
     settings_change_interrupts_turn: bool = False
+    # The transport can apply restart-scoped launch-settings edits (env, args,
+    # config overrides, account profile) via terminate+restore. Requires
+    # supports_reattach_after_exit. Drives the live launch-settings API.
+    supports_launch_settings_with_restart: bool = False
     # The transport drives the agent in a live terminal pane (a pty): the
     # runtime tails its raw log to scrape state and the frontend can mirror the
     # pane over the terminal websocket. True for the generic tmux wrapper only.
@@ -189,6 +206,12 @@ class BackendCapabilities(_FrozenModel):
     # passed through as raw flags. Only codex sets this today.
     supports_config_overrides: bool = False
     cli_binary: str | None = None
+    # The env var this agent's CLI reads for its config/state root
+    # (CLAUDE_CONFIG_DIR / CODEX_HOME); None when it has no config-dir concept.
+    config_dir_env_var: str | None = None
+    # Label for where this agent keeps its resumable native thread under the
+    # config-dir root (projects for Claude, sessions for Codex); None if absent.
+    native_thread_store: str | None = None
     # Substrings (case-insensitive) used to infer a backend from a tmux
     # target name when the user attaches to an existing pane without
     # specifying which CLI is running there.
@@ -200,6 +223,19 @@ class BackendCapabilities(_FrozenModel):
     # one registered plugin should set this to ``True``; today only
     # the tmux fallback does.
     is_fallback_for_managed_launch: bool = False
+
+    @property
+    def supports_account_profile_with_restart(self) -> bool:
+        """Account-profile switching is the product of the two axes.
+
+        Derived, not declared: the composed ``(agent, transport)`` session
+        supports it iff the agent owns a config-dir env var and the transport
+        can apply restart-scoped launch-settings edits. Kept a property (not a
+        field) so it stays off the flat/axis partition.
+        """
+        return (
+            bool(self.config_dir_env_var) and self.supports_launch_settings_with_restart
+        )
 
     def agent_capabilities(self) -> AgentCapabilities:
         """Project the agent-axis subset (CLI/protocol traits)."""
@@ -222,6 +258,8 @@ class BackendCapabilities(_FrozenModel):
             cli_binary=self.cli_binary,
             target_aliases=self.target_aliases,
             badges=self.badges,
+            config_dir_env_var=self.config_dir_env_var,
+            native_thread_store=self.native_thread_store,
         )
 
     def transport_capabilities(self) -> TransportCapabilities:
@@ -236,6 +274,7 @@ class BackendCapabilities(_FrozenModel):
             supports_set_effort_with_restart=self.supports_set_effort_with_restart,
             supports_set_permission_mode_inline=self.supports_set_permission_mode_inline,
             settings_change_interrupts_turn=self.settings_change_interrupts_turn,
+            supports_launch_settings_with_restart=self.supports_launch_settings_with_restart,
             live_terminal=self.live_terminal,
             has_terminal_pane=self.has_terminal_pane,
             terminal_interactive=self.terminal_interactive,

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -73,7 +73,11 @@ from waypoint.backends.claude_tty.pane_dialog import (
     shows_blocking_dialog,
 )
 from waypoint.backends.completions import static_slash_completions
-from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
+from waypoint.backends.plugin_config import (
+    AccountProfileConfig,
+    PluginConfig,
+    PluginLaunchTargetConfig,
+)
 from waypoint.backends.tmux.plugin import TmuxPlugin
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -198,6 +202,10 @@ class ClaudeCodePluginConfig(PluginConfig):
     # the `can_use_tool` control protocol, which has no network timeout.
     # Retained so existing configs that still set it keep loading.
     hook_timeout_seconds: int = Field(default=3600, ge=1)
+    # Named account/config-dir profiles (mapped to CLAUDE_CONFIG_DIR). Only
+    # backends that own a config-dir env var carry this field; the base config
+    # model rejects it for other backends via extra="forbid".
+    account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
 
 
 class ClaudeCodeLaunchTargetConfig(PluginLaunchTargetConfig):
@@ -205,6 +213,9 @@ class ClaudeCodeLaunchTargetConfig(PluginLaunchTargetConfig):
 
     # Deprecated no-op; see ``ClaudeCodePluginConfig.hook_timeout_seconds``.
     hook_timeout_seconds: int | None = Field(default=None, ge=1)
+    # Target-level profiles merge field-by-field over the global set by id and
+    # may introduce target-only ids (see runtime._resolved_account_profiles).
+    account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
 
 
 class ClaudeCodePlugin(DefaultLaunchContract):
@@ -254,6 +265,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         badges={"glyph": "C", "color": "#a78bfa"},
         cli_binary="claude",
         target_aliases=("claude",),
+        config_dir_env_var="CLAUDE_CONFIG_DIR",
+        native_thread_store="projects",
+        supports_launch_settings_with_restart=True,
     )
 
     def __init__(self) -> None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -214,7 +214,7 @@ class ClaudeCodeLaunchTargetConfig(PluginLaunchTargetConfig):
     # Deprecated no-op; see ``ClaudeCodePluginConfig.hook_timeout_seconds``.
     hook_timeout_seconds: int | None = Field(default=None, ge=1)
     # Target-level profiles merge field-by-field over the global set by id and
-    # may introduce target-only ids (see runtime._resolved_account_profiles).
+    # may introduce target-only ids (see account_profiles.resolve_account_profiles).
     account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
 
 

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -147,6 +147,7 @@ class ClaudeTtyPlugin:
         supports_set_effort_with_restart=True,
         supports_set_permission_mode_inline=True,
         settings_change_interrupts_turn=True,
+        supports_launch_settings_with_restart=True,
         supports_custom_cli_args=True,
         supports_thread_discovery=True,
         supports_thread_import=True,
@@ -154,6 +155,10 @@ class ClaudeTtyPlugin:
         model_source=ModelSource.STATIC,
         permission_modes=ClaudeCodePlugin.capabilities.permission_modes,
         slash_commands=ClaudeCodePlugin.capabilities.slash_commands,
+        # Agent-axis fields sourced from the wrapped claude_code agent so the
+        # two backends can't drift on the config-dir/thread-store contract.
+        config_dir_env_var=ClaudeCodePlugin.capabilities.config_dir_env_var,
+        native_thread_store=ClaudeCodePlugin.capabilities.native_thread_store,
         badges={"glyph": "C", "color": "#a78bfa"},
         has_terminal_pane=True,
         terminal_interactive=False,

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -53,7 +53,11 @@ from waypoint.backends.codex.schemas import (
     CodexThreadSummary,
 )
 from waypoint.backends.completions import static_slash_completions
-from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
+from waypoint.backends.plugin_config import (
+    AccountProfileConfig,
+    PluginConfig,
+    PluginLaunchTargetConfig,
+)
 from waypoint.backends.tmux.plugin import TmuxPlugin
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
@@ -116,6 +120,10 @@ class CodexPluginConfig(PluginConfig):
     """
 
     config_overrides: list[str] = Field(default_factory=list)
+    # Named account/config-dir profiles (mapped to CODEX_HOME). Only backends
+    # that own a config-dir env var carry this field; the base config model
+    # rejects it for other backends via extra="forbid".
+    account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
 
 
 class CodexLaunchTargetConfig(PluginLaunchTargetConfig):
@@ -127,6 +135,9 @@ class CodexLaunchTargetConfig(PluginLaunchTargetConfig):
     """
 
     config_overrides: list[str] = Field(default_factory=list)
+    # Target-level profiles merge field-by-field over the global set by id and
+    # may introduce target-only ids (see runtime._resolved_account_profiles).
+    account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
 
 
 class CodexPlugin(DefaultLaunchContract):
@@ -176,6 +187,9 @@ class CodexPlugin(DefaultLaunchContract):
         badges={"glyph": "X", "color": "#34d399"},
         cli_binary="codex",
         target_aliases=("codex",),
+        config_dir_env_var="CODEX_HOME",
+        native_thread_store="sessions",
+        supports_launch_settings_with_restart=True,
     )
 
     def __init__(self) -> None:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -136,7 +136,7 @@ class CodexLaunchTargetConfig(PluginLaunchTargetConfig):
 
     config_overrides: list[str] = Field(default_factory=list)
     # Target-level profiles merge field-by-field over the global set by id and
-    # may introduce target-only ids (see runtime._resolved_account_profiles).
+    # may introduce target-only ids (see account_profiles.resolve_account_profiles).
     account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
 
 

--- a/backend/src/waypoint/backends/plugin_config.py
+++ b/backend/src/waypoint/backends/plugin_config.py
@@ -16,9 +16,47 @@ the registry-aware validators on ``Settings`` and
 errors surface at startup rather than first runtime access.
 """
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from waypoint.launch_env import LaunchEnv
+
+TranscriptPolicy = Literal[
+    "require_existing", "symlink_shared", "copy_thread_on_switch"
+]
+
+
+class AccountProfileConfig(BaseModel):
+    """A named account/config-dir profile for a coding-agent backend.
+
+    Resolves to the backend's config-dir env var (``CLAUDE_CONFIG_DIR`` /
+    ``CODEX_HOME``) plus the transcript-availability policy used when a running
+    session is switched onto this profile. Only backends that own a config-dir
+    env var accept these (``claude_code``/``codex``); the base config models
+    stay ``extra="forbid"`` so other backends reject an ``account_profiles``
+    block at parse time. Path fields keep ``~`` verbatim and are expanded only
+    where consumed, so parsing stays filesystem-free.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: str
+    config_dir: str
+    transcript_policy: TranscriptPolicy = "require_existing"
+    shared_transcript_dir: str | None = None
+    expected_account_key: str | None = None
+
+    @model_validator(mode="after")
+    def _require_shared_dir_for_symlink(self) -> "AccountProfileConfig":
+        if (
+            self.transcript_policy == "symlink_shared"
+            and not self.shared_transcript_dir
+        ):
+            raise ValueError(
+                "transcript_policy 'symlink_shared' requires 'shared_transcript_dir'"
+            )
+        return self
 
 
 class PluginConfig(BaseModel):

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -20,6 +20,7 @@ from fastapi import HTTPException, status
 from waypoint.assistant_assets import AssistantAssetError, ensure_assistant_assets
 from waypoint.attachments import AttachmentStore, ResolvedAttachment
 from waypoint.backends import BackendRegistry, get_registry
+from waypoint.backends.account_profiles import redacted_profile_metadata
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
 from waypoint.backends.tmux.normalize import (
@@ -2078,6 +2079,17 @@ class SessionRuntime:
                     "default_launch_env_by_backend": {
                         backend: self._default_launch_env(backend, target)
                         for backend in target.supported_plugins()
+                    },
+                    # Only agent backends that host profiles produce a non-empty
+                    # list, so transports/opencode are omitted (agent-ids only).
+                    "account_profiles_by_backend": {
+                        backend: profiles
+                        for backend in target.supported_plugins()
+                        if (
+                            profiles := redacted_profile_metadata(
+                                self.settings, backend, target
+                            )
+                        )
                     },
                 }
             )

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -304,6 +304,18 @@ class LoginResponse(BaseModel):
     expires_at: datetime
 
 
+class AccountProfileMeta(BaseModel):
+    """Public, redacted account-profile metadata.
+
+    Display id/label plus the config-dir env var key the profile maps to. Never
+    carries the config-dir path, expected account key, or transcript policy.
+    """
+
+    id: str
+    label: str
+    config_dir_key: str
+
+
 class LaunchTargetSummary(BaseModel):
     id: str
     name: str
@@ -316,6 +328,12 @@ class LaunchTargetSummary(BaseModel):
     connected: bool = False
     # Effective launch-env defaults keyed by backend id for this target.
     default_launch_env_by_backend: dict[BackendId, LaunchEnv] = Field(
+        default_factory=dict
+    )
+    # Target-merged redacted account-profile metadata keyed by agent backend id.
+    # Only backends that host profiles (claude_code, codex) appear; each entry is
+    # {id, label, config_dir_key} — no paths, keys, or transcript policy.
+    account_profiles_by_backend: dict[BackendId, list[AccountProfileMeta]] = Field(
         default_factory=dict
     )
 

--- a/backend/tests/golden/backends_payload.json
+++ b/backend/tests/golden/backends_payload.json
@@ -14,6 +14,7 @@
       "color": "#a78bfa"
     },
     "default_launch_env": {},
+    "account_profiles": [],
     "capabilities": {
       "is_structured": true,
       "supports_resume": false,
@@ -24,6 +25,7 @@
       "supports_set_effort_with_restart": true,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": true,
       "live_terminal": false,
       "has_terminal_pane": false,
       "terminal_interactive": false,
@@ -137,6 +139,8 @@
       "supports_custom_cli_args": true,
       "supports_config_overrides": false,
       "cli_binary": "claude",
+      "config_dir_env_var": "CLAUDE_CONFIG_DIR",
+      "native_thread_store": "projects",
       "target_aliases": [
         "claude"
       ],
@@ -257,7 +261,9 @@
       "badges": {
         "glyph": "C",
         "color": "#a78bfa"
-      }
+      },
+      "config_dir_env_var": "CLAUDE_CONFIG_DIR",
+      "native_thread_store": "projects"
     },
     "transport_capabilities": {
       "is_structured": true,
@@ -269,6 +275,7 @@
       "supports_set_effort_with_restart": true,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": true,
       "live_terminal": false,
       "has_terminal_pane": false,
       "terminal_interactive": false,
@@ -290,6 +297,7 @@
       "color": "#a78bfa"
     },
     "default_launch_env": {},
+    "account_profiles": [],
     "capabilities": {
       "is_structured": true,
       "supports_resume": true,
@@ -300,6 +308,7 @@
       "supports_set_effort_with_restart": true,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": true,
+      "supports_launch_settings_with_restart": true,
       "live_terminal": false,
       "has_terminal_pane": true,
       "terminal_interactive": false,
@@ -413,6 +422,8 @@
       "supports_custom_cli_args": true,
       "supports_config_overrides": false,
       "cli_binary": "claude",
+      "config_dir_env_var": "CLAUDE_CONFIG_DIR",
+      "native_thread_store": "projects",
       "target_aliases": [
         "claude_tty"
       ],
@@ -533,7 +544,9 @@
       "badges": {
         "glyph": "C",
         "color": "#a78bfa"
-      }
+      },
+      "config_dir_env_var": "CLAUDE_CONFIG_DIR",
+      "native_thread_store": "projects"
     },
     "transport_capabilities": {
       "is_structured": true,
@@ -545,6 +558,7 @@
       "supports_set_effort_with_restart": true,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": true,
+      "supports_launch_settings_with_restart": true,
       "live_terminal": false,
       "has_terminal_pane": true,
       "terminal_interactive": false,
@@ -567,6 +581,7 @@
       "color": "#34d399"
     },
     "default_launch_env": {},
+    "account_profiles": [],
     "capabilities": {
       "is_structured": true,
       "supports_resume": false,
@@ -577,6 +592,7 @@
       "supports_set_effort_with_restart": false,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": true,
       "live_terminal": false,
       "has_terminal_pane": false,
       "terminal_interactive": false,
@@ -643,6 +659,8 @@
       "supports_custom_cli_args": true,
       "supports_config_overrides": true,
       "cli_binary": "codex",
+      "config_dir_env_var": "CODEX_HOME",
+      "native_thread_store": "sessions",
       "target_aliases": [
         "codex"
       ],
@@ -716,7 +734,9 @@
       "badges": {
         "glyph": "X",
         "color": "#34d399"
-      }
+      },
+      "config_dir_env_var": "CODEX_HOME",
+      "native_thread_store": "sessions"
     },
     "transport_capabilities": {
       "is_structured": true,
@@ -728,6 +748,7 @@
       "supports_set_effort_with_restart": false,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": true,
       "live_terminal": false,
       "has_terminal_pane": false,
       "terminal_interactive": false,
@@ -750,6 +771,7 @@
       "color": "#cbd5e1"
     },
     "default_launch_env": {},
+    "account_profiles": [],
     "capabilities": {
       "is_structured": true,
       "supports_resume": false,
@@ -760,6 +782,7 @@
       "supports_set_effort_with_restart": false,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": false,
       "live_terminal": false,
       "has_terminal_pane": false,
       "terminal_interactive": false,
@@ -832,6 +855,8 @@
       "supports_custom_cli_args": true,
       "supports_config_overrides": false,
       "cli_binary": "opencode",
+      "config_dir_env_var": null,
+      "native_thread_store": null,
       "target_aliases": [
         "opencode"
       ],
@@ -911,7 +936,9 @@
       "badges": {
         "glyph": "O",
         "color": "#cbd5e1"
-      }
+      },
+      "config_dir_env_var": null,
+      "native_thread_store": null
     },
     "transport_capabilities": {
       "is_structured": true,
@@ -923,6 +950,7 @@
       "supports_set_effort_with_restart": false,
       "supports_set_permission_mode_inline": true,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": false,
       "live_terminal": false,
       "has_terminal_pane": false,
       "terminal_interactive": false,
@@ -944,6 +972,7 @@
       "color": "#94a3b8"
     },
     "default_launch_env": {},
+    "account_profiles": [],
     "capabilities": {
       "is_structured": false,
       "supports_resume": true,
@@ -954,6 +983,7 @@
       "supports_set_effort_with_restart": false,
       "supports_set_permission_mode_inline": false,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": false,
       "live_terminal": true,
       "has_terminal_pane": true,
       "terminal_interactive": true,
@@ -978,6 +1008,8 @@
       "supports_custom_cli_args": false,
       "supports_config_overrides": false,
       "cli_binary": null,
+      "config_dir_env_var": null,
+      "native_thread_store": null,
       "target_aliases": [],
       "is_fallback_for_managed_launch": true
     },
@@ -1005,7 +1037,9 @@
       "badges": {
         "glyph": "T",
         "color": "#94a3b8"
-      }
+      },
+      "config_dir_env_var": null,
+      "native_thread_store": null
     },
     "transport_capabilities": {
       "is_structured": false,
@@ -1017,6 +1051,7 @@
       "supports_set_effort_with_restart": false,
       "supports_set_permission_mode_inline": false,
       "settings_change_interrupts_turn": false,
+      "supports_launch_settings_with_restart": false,
       "live_terminal": true,
       "has_terminal_pane": true,
       "terminal_interactive": true,

--- a/backend/tests/test_account_profiles.py
+++ b/backend/tests/test_account_profiles.py
@@ -1,0 +1,323 @@
+"""Account/config-dir profiles: config parsing, merge, redaction, capabilities.
+
+Phase 1 of the account-switching RFC. Profiles are agent-owned config
+(claude_code / codex), merged field-by-field per launch target, and surfaced as
+redacted ``{id, label, config_dir_key}`` metadata on the read APIs — never the
+config-dir path, expected account key, or transcript policy.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from waypoint.api import _backend_descriptors, create_app
+from waypoint.backends.account_profiles import (
+    backend_hosts_account_profiles,
+    redacted_profile_metadata,
+    resolve_account_profiles,
+)
+from waypoint.backends.bootstrap import build_default_registry
+from waypoint.settings import Settings
+
+
+def _settings(**overrides: object) -> Settings:
+    return Settings.model_validate(overrides)
+
+
+def _codex_profiles() -> dict[str, object]:
+    return {
+        "personal": {"label": "Personal", "config_dir": "~/.codex-personal"},
+        "work": {
+            "label": "Work",
+            "config_dir": "~/.codex-work",
+            "transcript_policy": "copy_thread_on_switch",
+            "expected_account_key": "user@company.com",
+        },
+    }
+
+
+def _target(**plugin_configs: object) -> dict[str, object]:
+    return {
+        "id": "devbox",
+        "name": "devbox",
+        "ssh_destination": "user@devbox",
+        "plugin_configs": plugin_configs,
+    }
+
+
+# ── Parsing ───────────────────────────────────────────────────────────────
+
+
+def test_global_profiles_parse_for_agent_backends() -> None:
+    s = _settings(plugin_configs={"codex": {"account_profiles": _codex_profiles()}})
+    profiles = resolve_account_profiles(s, "codex")
+    assert sorted(profiles) == ["personal", "work"]
+    assert profiles["work"].transcript_policy == "copy_thread_on_switch"
+
+
+def test_symlink_shared_requires_shared_transcript_dir() -> None:
+    with pytest.raises(ValidationError, match="symlink_shared"):
+        _settings(
+            plugin_configs={
+                "claude_code": {
+                    "account_profiles": {
+                        "team": {
+                            "label": "Team",
+                            "config_dir": "~/.claude-team",
+                            "transcript_policy": "symlink_shared",
+                        }
+                    }
+                }
+            }
+        )
+
+
+def test_symlink_shared_accepts_when_shared_dir_present() -> None:
+    s = _settings(
+        plugin_configs={
+            "claude_code": {
+                "account_profiles": {
+                    "team": {
+                        "label": "Team",
+                        "config_dir": "~/.claude-team",
+                        "transcript_policy": "symlink_shared",
+                        "shared_transcript_dir": "~/.waypoint/agent-state/claude-projects",
+                    }
+                }
+            }
+        }
+    )
+    assert resolve_account_profiles(s, "claude_code")["team"].transcript_policy == (
+        "symlink_shared"
+    )
+
+
+@pytest.mark.parametrize("backend", ["opencode", "claude_tty", "tmux"])
+def test_account_profiles_rejected_for_non_agent_backends_global(backend: str) -> None:
+    with pytest.raises(ValidationError):
+        _settings(
+            plugin_configs={
+                backend: {
+                    "account_profiles": {"x": {"label": "X", "config_dir": "~/x"}}
+                }
+            }
+        )
+
+
+def test_account_profiles_rejected_for_opencode_target_level() -> None:
+    with pytest.raises(ValidationError):
+        _settings(
+            ssh_targets=[
+                _target(
+                    opencode={
+                        "account_profiles": {"x": {"label": "X", "config_dir": "~/x"}}
+                    }
+                )
+            ]
+        )
+
+
+# ── Merge ─────────────────────────────────────────────────────────────────
+
+
+def test_target_override_wins_field_by_field_and_inherits_unset() -> None:
+    s = _settings(
+        plugin_configs={"codex": {"account_profiles": _codex_profiles()}},
+        ssh_targets=[
+            _target(
+                codex={
+                    "account_profiles": {
+                        "work": {
+                            "label": "Work on devbox",
+                            "config_dir": "~/.codex-work-devbox",
+                        }
+                    }
+                }
+            )
+        ],
+    )
+    merged = resolve_account_profiles(s, "codex", s.ssh_targets[0])
+    work = merged["work"]
+    # Explicitly-set target fields win...
+    assert work.label == "Work on devbox"
+    assert work.config_dir == "~/.codex-work-devbox"
+    # ...unset fields fall back to the global (not the field default).
+    assert work.transcript_policy == "copy_thread_on_switch"
+    assert work.expected_account_key == "user@company.com"
+
+
+def test_target_only_profile_id_is_added() -> None:
+    s = _settings(
+        plugin_configs={"codex": {"account_profiles": _codex_profiles()}},
+        ssh_targets=[
+            _target(
+                codex={
+                    "account_profiles": {
+                        "lab": {"label": "Lab", "config_dir": "~/.codex-lab"}
+                    }
+                }
+            )
+        ],
+    )
+    merged = resolve_account_profiles(s, "codex", s.ssh_targets[0])
+    assert sorted(merged) == ["lab", "personal", "work"]
+    assert merged["lab"].label == "Lab"
+
+
+def test_merge_does_not_mutate_global_profiles() -> None:
+    s = _settings(
+        plugin_configs={"codex": {"account_profiles": _codex_profiles()}},
+        ssh_targets=[
+            _target(
+                codex={
+                    "account_profiles": {
+                        "work": {"label": "Work on devbox", "config_dir": "~/w"}
+                    }
+                }
+            )
+        ],
+    )
+    resolve_account_profiles(s, "codex", s.ssh_targets[0])
+    assert resolve_account_profiles(s, "codex")["work"].label == "Work"
+
+
+def test_hosts_only_agent_backends() -> None:
+    s = _settings()
+    assert backend_hosts_account_profiles(s, "codex")
+    assert backend_hosts_account_profiles(s, "claude_code")
+    assert not backend_hosts_account_profiles(s, "opencode")
+    assert not backend_hosts_account_profiles(s, "claude_tty")
+
+
+# ── Redaction ───────────────────────────────────────────────────────────────
+
+
+def test_redacted_metadata_exposes_only_id_label_key() -> None:
+    s = _settings(plugin_configs={"codex": {"account_profiles": _codex_profiles()}})
+    meta = redacted_profile_metadata(s, "codex")
+    assert {m["id"] for m in meta} == {"personal", "work"}
+    for entry in meta:
+        assert set(entry) == {"id", "label", "config_dir_key"}
+        assert entry["config_dir_key"] == "CODEX_HOME"
+    # Nothing sensitive leaks into the public payload.
+    blob = repr(meta)
+    assert "~/.codex" not in blob
+    assert "company.com" not in blob
+    assert "copy_thread_on_switch" not in blob
+
+
+def test_backends_payload_carries_redacted_global_profiles() -> None:
+    s = _settings(plugin_configs={"codex": {"account_profiles": _codex_profiles()}})
+    desc = {d["id"]: d for d in _backend_descriptors(build_default_registry(), s)}
+    assert {m["id"] for m in desc["codex"]["account_profiles"]} == {"personal", "work"}
+    # Agent ids only: transports/opencode host nothing.
+    assert desc["claude_tty"]["account_profiles"] == []
+    assert desc["opencode"]["account_profiles"] == []
+    # No target merge on the global catalogue; paths never appear.
+    assert "~/.codex" not in repr(desc["codex"]["account_profiles"])
+
+
+# ── Capability descriptor ────────────────────────────────────────────────────
+
+
+def test_capability_config_dir_fields() -> None:
+    caps = {p.id: p.capabilities for p in build_default_registry().all()}
+    assert caps["claude_code"].config_dir_env_var == "CLAUDE_CONFIG_DIR"
+    assert caps["claude_code"].native_thread_store == "projects"
+    assert caps["codex"].config_dir_env_var == "CODEX_HOME"
+    assert caps["codex"].native_thread_store == "sessions"
+    # Transport inherits the agent's config-dir contract, can't drift.
+    assert caps["claude_tty"].config_dir_env_var == "CLAUDE_CONFIG_DIR"
+    assert caps["opencode"].config_dir_env_var is None
+    assert caps["tmux"].config_dir_env_var is None
+
+
+def test_supports_account_profile_with_restart_is_derived() -> None:
+    caps = {p.id: p.capabilities for p in build_default_registry().all()}
+    # Derived from (config-dir var present) AND (restart-applied settings).
+    assert caps["claude_code"].supports_account_profile_with_restart is True
+    assert caps["claude_tty"].supports_account_profile_with_restart is True
+    assert caps["codex"].supports_account_profile_with_restart is True
+    assert caps["opencode"].supports_account_profile_with_restart is False
+    assert caps["tmux"].supports_account_profile_with_restart is False
+
+
+# ── Route-level (in-process ASGI) ────────────────────────────────────────────
+
+
+def _app_and_token(tmp_path: Path, **settings_kw: Any) -> tuple[Any, str]:
+    settings = Settings(data_dir=tmp_path / "data", **settings_kw)
+    app = create_app(settings)
+    token = app.state.context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+async def test_api_backends_exposes_redacted_global_profiles(tmp_path: Path) -> None:
+    app, token = _app_and_token(
+        tmp_path,
+        plugin_configs={"codex": {"account_profiles": _codex_profiles()}},
+    )
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/backends", headers={"Authorization": f"Bearer {token}"}
+        )
+    assert resp.status_code == 200
+    backends = {b["id"]: b for b in resp.json()["backends"]}
+    assert {m["id"] for m in backends["codex"]["account_profiles"]} == {
+        "personal",
+        "work",
+    }
+    assert backends["codex"]["capabilities"]["config_dir_env_var"] == "CODEX_HOME"
+    # No config-dir path, expected key, or transcript policy on the wire.
+    assert "~/.codex" not in resp.text
+    assert "company.com" not in resp.text
+    assert "copy_thread_on_switch" not in resp.text
+
+
+async def test_api_me_exposes_target_merged_profiles(tmp_path: Path) -> None:
+    app, token = _app_and_token(
+        tmp_path,
+        password="pw",
+        plugin_configs={"codex": {"account_profiles": _codex_profiles()}},
+        ssh_targets=[
+            {
+                "id": "devbox",
+                "name": "devbox",
+                "ssh_destination": "user@devbox",
+                "plugin_configs": {
+                    "codex": {
+                        "account_profiles": {
+                            "work": {
+                                "label": "Work on devbox",
+                                "config_dir": "~/.codex-work-devbox",
+                            },
+                            "lab": {"label": "Lab", "config_dir": "~/.codex-lab"},
+                        }
+                    }
+                },
+            }
+        ],
+    )
+    async with _client(app) as client:
+        resp = await client.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    target = {t["id"]: t for t in resp.json()["launch_targets"]}["devbox"]
+    codex_profiles = {
+        m["id"]: m for m in target["account_profiles_by_backend"]["codex"]
+    }
+    assert set(codex_profiles) == {"personal", "work", "lab"}
+    # Target override wins on label; target-only id present.
+    assert codex_profiles["work"]["label"] == "Work on devbox"
+    assert codex_profiles["lab"]["label"] == "Lab"
+    # Transports/opencode host nothing, so they're absent from the map.
+    assert "opencode" not in target["account_profiles_by_backend"]
+    assert "~/.codex" not in resp.text


### PR DESCRIPTION
## Purpose

First phase of per-session account/config-profile switching (Relates to #230). The goal of the whole feature is to switch one running session between named account/config-dir profiles (`CLAUDE_CONFIG_DIR` / `CODEX_HOME`) via restart-and-resume. This PR lands only the inert **foundation** the rest builds on: named profiles in config, the capability descriptor fields that say which backends can switch, and redacted profile metadata on the read APIs. There is no launch or switching behavior change yet — this is additive and fully back-compatible.

## Changes

### Backend

- `backend/src/waypoint/backends/plugin_config.py` — new `AccountProfileConfig` model (`label`, `config_dir`, `transcript_policy`, `shared_transcript_dir`, `expected_account_key`; validates that `symlink_shared` carries a `shared_transcript_dir`). Kept off the base config models so `extra="forbid"` rejects an `account_profiles` block for backends that don't own a config-dir env var.
- `backend/src/waypoint/backends/claude_code/plugin.py`, `backends/codex/plugin.py` — `account_profiles` on the claude_code/codex global and launch-target config subclasses only, and the agent capability fields (`config_dir_env_var`, `native_thread_store`, `supports_launch_settings_with_restart`).
- `backend/src/waypoint/backends/claude_tty/plugin.py` — sources the agent-axis config-dir fields from the wrapped `claude_code` agent (as it already does for effort/permission/slash), so the transport can't drift from the agent.
- `backend/src/waypoint/backends/capabilities.py` — `config_dir_env_var`/`native_thread_store` on `AgentCapabilities`, `supports_launch_settings_with_restart` on `TransportCapabilities`, wired through the flat aggregate, the split projections, and `from_split`; `supports_account_profile_with_restart` is a derived `@property` (config-dir var present AND restart-applied settings), not a stored field, so the disjoint/total partition holds.
- `backend/src/waypoint/backends/account_profiles.py` — new module: the global+target profile resolver (target overrides merge field-by-field by id using `model_fields_set`, so an unset field inherits the global rather than clobbering it with the default; target-only ids are added), a host check, and the redaction helper that emits only `{id, label, config_dir_key}`.
- `backend/src/waypoint/api.py`, `runtime.py`, `schemas.py` — redacted global profiles per backend on `GET /api/backends`, and target-merged `account_profiles_by_backend` (new `AccountProfileMeta`) on each `LaunchTargetSummary` for `GET /api/me`. Profiles surface under agent ids only.
- `backend/tests/test_account_profiles.py`, `tests/golden/backends_payload.json` — parse/merge/reject/redaction/capability coverage plus in-process ASGI route tests for both endpoints; golden regenerated for the additive descriptor fields.

## Design

Profiles are **agent-owned**: only backends whose config subclass carries `account_profiles` host them, which makes the base `extra="forbid"` do the rejection for opencode/tmux/claude_tty on both the global and per-target axes with no extra validator. The capability fields are assigned to the axis that owns them — the config-dir/thread-store belong to the agent, restart-applied settings belong to the transport — and `supports_account_profile_with_restart` is derived from the composed pair rather than declared, so a transport (claude_tty) and its agent can't drift. The resolver and redaction live in a single module both the API function and the runtime summary builder call, dispatching through the plugin registry with no per-backend branching. Public payloads carry only `{id, label, config_dir_key}`; the config-dir path, expected account key, and transcript policy never leave the backend.

Note on macOS (documented in the RFC, relevant here): Claude keeps credentials in a single global Keychain entry, so a `CLAUDE_CONFIG_DIR` switch there changes settings/history but not the account — Claude account switching is Linux/Windows only. This PR only exposes capability/metadata and does not gate by platform yet; that gating lands with the runtime switch (a later phase).

## Test Plan

- `cd backend && uv run pre-commit run --all-files` (via the commit hook on the changed files)
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1511 passed, 3 warnings (pre-existing).
- API e2e — covered in-process: `tests/test_account_profiles.py` drives `GET /api/backends` and `GET /api/me` over an ASGI transport, asserting redacted `{id,label,config_dir_key}` output, target-merge, and that no config-dir path / expected key / transcript policy appears on the wire.
- Live stack e2e — not run: this phase is backend-only and inert (no frontend change and no runtime switch), the wire contract is fully exercised by the in-process route tests, and a live `waypointctl` backend restart would redeploy the branch but risk interrupting the Waypoint session this work runs inside. It will matter at the frontend/runtime-switch phases.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`backend/tests/test_account_profiles.py`; golden regenerated).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched the capability descriptor and config schema, which dispatch by plugin id: verified claude_code, codex, claude_tty, opencode, and tmux still build the registry and pass the capability split/golden tests; no per-backend branch was added.
- [x] No frontend changes in this phase.
- [x] Not a breaking change — additive config/capability/read-API surface; existing configs with no `account_profiles` parse and serve unchanged.
- [x] No user-facing config default changed; `.env.example` / `waypoint.example.yaml` need no changes (documenting the `account_profiles` block follows with the launch/UI phases).

</details>