### PR TITLE
feat: persist and apply account-profile selection at launch

### DIFF
--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -1068,6 +1068,8 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             args=session.args,
             config_overrides=session.config_overrides,
             launch_env=session.launch_env,
+            account_profile_id=session.account_profile_id,
+            account_profile_label=session.account_profile_label,
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)

--- a/backend/src/waypoint/backends/claude_code/schemas.py
+++ b/backend/src/waypoint/backends/claude_code/schemas.py
@@ -45,6 +45,9 @@ class ClaudeThreadImportRequest(BaseModel):
     # ``backend=claude_code``.
     transport: SessionTransportId | None = None
     launch_env: LaunchEnv = Field(default_factory=dict)
+    # Account/config-dir profile used to list/import this thread; persisted so a
+    # later resume/delete/history-read uses the same state root.
+    account_profile_id: str | None = None
     # When true (default), the prior conversation is replayed into the new
     # session's transcript at import time; when false the transcript starts
     # empty and only the underlying agent resumes its own context.

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -613,6 +613,8 @@ async def fork_aside(
             args=session.args,
             config_overrides=session.config_overrides,
             launch_env=session.launch_env,
+            account_profile_id=session.account_profile_id,
+            account_profile_label=session.account_profile_label,
         )
         runtime.storage.create_session(new_session)
         created = True

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -788,6 +788,8 @@ class ClaudeTtyPlugin:
             effort=session.effort,
             args=session.args,
             launch_env=session.launch_env,
+            account_profile_id=session.account_profile_id,
+            account_profile_label=session.account_profile_label,
         )
         runtime.storage.create_session(new_session)
         await runtime._record_system_event(

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -913,6 +913,8 @@ class CodexPlugin(DefaultLaunchContract):
             args=session.args,
             config_overrides=session.config_overrides,
             launch_env=session.launch_env,
+            account_profile_id=session.account_profile_id,
+            account_profile_label=session.account_profile_label,
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)

--- a/backend/src/waypoint/backends/codex/schemas.py
+++ b/backend/src/waypoint/backends/codex/schemas.py
@@ -43,6 +43,9 @@ class CodexThreadImportRequest(BaseModel):
     # rejects mismatches with 400).
     transport: SessionTransportId | None = None
     launch_env: LaunchEnv = Field(default_factory=dict)
+    # Account/config-dir profile used to list/import this thread; persisted so a
+    # later resume/delete/history-read uses the same state root.
+    account_profile_id: str | None = None
     # When true (default), the prior conversation is replayed into the new
     # session's transcript at import time; when false the transcript starts
     # empty and only the underlying agent resumes its own context.

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -1437,6 +1437,8 @@ class OpenCodePlugin(DefaultLaunchContract):
             args=session.args,
             config_overrides=session.config_overrides,
             launch_env=session.launch_env,
+            account_profile_id=session.account_profile_id,
+            account_profile_label=session.account_profile_label,
         )
         runtime.storage.create_session(new_session)
         runtime.storage.clone_events(session.id, new_session_id)

--- a/backend/src/waypoint/presets.py
+++ b/backend/src/waypoint/presets.py
@@ -50,6 +50,7 @@ _SCALAR_FIELDS = (
     "permission_mode",
     "model",
     "effort",
+    "account_profile_id",
 )
 _LIST_FIELDS = ("args", "config_overrides")
 _MAP_FIELDS = ("launch_env", "tags")
@@ -73,6 +74,7 @@ def redact_preset(record: SessionPresetRecord) -> SessionPresetSummary:
         model=spec.model,
         effort=spec.effort,
         tags=dict(spec.tags),
+        account_profile_id=spec.account_profile_id,
     )
     return SessionPresetSummary(
         id=record.id,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -473,10 +473,22 @@ class SessionRuntime:
             )
         config_dir = profile.config_dir
         # Expand ``~`` for local launches (the config dir is a path on this
-        # host). Remote targets keep it verbatim — remote-home expansion lands
-        # with the remote transcript/probe work.
+        # host). Remote-home expansion isn't supported yet, and env values are
+        # injected shell-quoted so a remote shell won't expand ``~`` either —
+        # rather than silently launch under a literal ``~`` dir (wrong account),
+        # reject a ``~``-relative remote config_dir until that lands. Absolute
+        # remote paths are fine.
         if launch_target is None:
             config_dir = os.path.expanduser(config_dir)
+        elif config_dir.startswith("~"):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"account profile {account_profile_id!r} uses a '~'-relative "
+                    "config_dir on a remote launch target; use an absolute path "
+                    "(remote home expansion is not yet supported)"
+                ),
+            )
         env = dict(launch_env)
         env[config_dir_key] = config_dir
         return env, profile.label

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -20,8 +20,12 @@ from fastapi import HTTPException, status
 from waypoint.assistant_assets import AssistantAssetError, ensure_assistant_assets
 from waypoint.attachments import AttachmentStore, ResolvedAttachment
 from waypoint.backends import BackendRegistry, get_registry
-from waypoint.backends.account_profiles import redacted_profile_metadata
+from waypoint.backends.account_profiles import (
+    redacted_profile_metadata,
+    resolve_account_profiles,
+)
 from waypoint.backends.completions import static_slash_completions
+from waypoint.backends.plugin_config import AccountProfileConfig
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
 from waypoint.backends.tmux.normalize import (
     TMUX_CONTENT_KINDS,
@@ -421,6 +425,62 @@ class SessionRuntime:
             return dict(request.launch_env)
         return self._default_launch_env(request.backend, launch_target)
 
+    def _require_account_profile(
+        self,
+        backend: str,
+        account_profile_id: str,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> AccountProfileConfig:
+        """Resolve a selected profile or raise 400 if the id is unknown."""
+        profiles = resolve_account_profiles(self.settings, backend, launch_target)
+        profile = profiles.get(account_profile_id)
+        if profile is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"unknown account profile {account_profile_id!r} "
+                    f"for backend {backend}"
+                ),
+            )
+        return profile
+
+    def _apply_account_profile_env(
+        self,
+        backend: str,
+        launch_env: dict[str, str],
+        account_profile_id: str | None,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> tuple[dict[str, str], str | None]:
+        """Overlay the selected account profile's config-dir env key.
+
+        Profile-owned: when a profile is selected its ``config_dir`` wins for the
+        backend's ``config_dir_env_var``, stripping any raw value the request
+        supplied for that key (profile-wins, never a 400 on disagreement).
+        Returns ``(launch_env, label)`` — the label for stamping — and is a no-op
+        returning ``(launch_env, None)`` when no profile is selected. Unknown
+        ids, or a backend without a config-dir env var, are rejected with 400.
+        """
+        if account_profile_id is None:
+            return launch_env, None
+        profile = self._require_account_profile(
+            backend, account_profile_id, launch_target
+        )
+        config_dir_key = self.registry.get(backend).capabilities.config_dir_env_var
+        if config_dir_key is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"backend {backend} does not support account profiles",
+            )
+        config_dir = profile.config_dir
+        # Expand ``~`` for local launches (the config dir is a path on this
+        # host). Remote targets keep it verbatim — remote-home expansion lands
+        # with the remote transcript/probe work.
+        if launch_target is None:
+            config_dir = os.path.expanduser(config_dir)
+        env = dict(launch_env)
+        env[config_dir_key] = config_dir
+        return env, profile.label
+
     def _agent_process_env(
         self,
         backend: str,
@@ -460,12 +520,17 @@ class SessionRuntime:
             local_cwd = request.cwd or launch_target.default_cwd
         else:
             local_cwd = require_existing_local_dir(request.cwd)
+        effective_env = self._effective_launch_env_for_request(request, launch_target)
+        effective_env, account_profile_label = self._apply_account_profile_env(
+            request.backend,
+            effective_env,
+            request.account_profile_id,
+            launch_target,
+        )
         request = request.model_copy(
             update={
                 "cwd": local_cwd,
-                "launch_env": self._effective_launch_env_for_request(
-                    request, launch_target
-                ),
+                "launch_env": effective_env,
             }
         )
         title = (
@@ -613,6 +678,15 @@ class SessionRuntime:
         if preset_id is not None or preset_name is not None:
             session = self.storage.update_session(
                 session.id, preset_id=preset_id, preset_name=preset_name
+            )
+        # Account-profile selection is opaque display/audit metadata; the
+        # profile's config-dir is already baked into launch_env above. Stamped
+        # generically like preset provenance.
+        if request.account_profile_id is not None:
+            session = self.storage.update_session(
+                session.id,
+                account_profile_id=request.account_profile_id,
+                account_profile_label=account_profile_label,
             )
         self._warm_command_completions(session)
         self._start_context_usage_source(session)
@@ -886,6 +960,10 @@ class SessionRuntime:
             if "launch_env" in request.model_fields_set
             else self._default_launch_env(backend, launch_target)
         )
+        account_profile_id = getattr(request, "account_profile_id", None)
+        launch_env, account_profile_label = self._apply_account_profile_env(
+            backend, launch_env, account_profile_id, launch_target
+        )
         request = request.model_copy(update={"launch_env": launch_env})
         transport = getattr(request, "transport", None)
         if transport is not None:
@@ -898,7 +976,16 @@ class SessionRuntime:
                 driver = agent_plugin
         else:
             driver = agent_plugin
-        return await driver.import_thread(self, request, agent=backend)
+        session = await driver.import_thread(self, request, agent=backend)
+        # Persist the profile used for listing/import so a later
+        # resume/delete/history-read uses the same state root.
+        if account_profile_id is not None:
+            session = self.storage.update_session(
+                session.id,
+                account_profile_id=account_profile_id,
+                account_profile_label=account_profile_label,
+            )
+        return session
 
     async def attach_assistant(
         self,

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -101,6 +101,14 @@ class Scheduler:
             self._runtime._validate_supported_transport(
                 request.backend, request.transport
             )
+        # Validate the account profile up-front and capture its label; the
+        # config-dir is resolved from the profile at fire time (not snapshotted),
+        # so the schedule launches under the profile as it exists when it fires.
+        account_profile_label = None
+        if request.account_profile_id is not None:
+            account_profile_label = self._runtime._require_account_profile(
+                request.backend, request.account_profile_id, launch_target
+            ).label
         cwd = request.cwd
         if launch_target is not None and not cwd:
             cwd = launch_target.default_cwd
@@ -127,6 +135,8 @@ class Scheduler:
             status=ScheduleStatus.PENDING,
             preset_id=preset_id,
             preset_name=preset_name,
+            account_profile_id=request.account_profile_id,
+            account_profile_label=account_profile_label,
         )
         self._runtime.storage.create_schedule(record)
         self._wakeup.set()
@@ -346,6 +356,7 @@ class Scheduler:
                     permission_mode=schedule.permission_mode,
                     model=schedule.model,
                     effort=schedule.effort,
+                    account_profile_id=schedule.account_profile_id,
                 ),
                 preset_id=schedule.preset_id,
                 preset_name=schedule.preset_name,

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -235,6 +235,11 @@ class SessionRecord(BaseModel):
     # later preset edits/deletes do not affect an existing session.
     preset_id: str | None = None
     preset_name: str | None = None
+    # Account/config-dir profile this session was launched under. Non-secret
+    # display/audit hints; the profile's config-dir is snapshotted into the
+    # private launch_env, so the account is bound even if config changes later.
+    account_profile_id: str | None = None
+    account_profile_label: str | None = None
 
 
 class EventRecord(BaseModel):
@@ -410,6 +415,9 @@ class SessionPresetSpec(BaseModel):
     model: str | None = None
     effort: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
+    # Preset the account/config-dir profile to launch under. Applying the preset
+    # selects this profile first, so model/thread lists are fetched profile-scoped.
+    account_profile_id: str | None = None
 
 
 class SessionPresetRecord(BaseModel):
@@ -437,6 +445,7 @@ class SessionPresetSpecSummary(BaseModel):
     model: str | None = None
     effort: str | None = None
     tags: dict[str, str] = Field(default_factory=dict)
+    account_profile_id: str | None = None
 
 
 class SessionPresetSummary(BaseModel):
@@ -530,6 +539,10 @@ class SessionCreateRequest(BaseModel):
     # request boundary (API / in-process CLI); the runtime stays preset-agnostic.
     preset_id: str | None = None
     use_default_preset: bool = False
+    # Launch under a named account/config-dir profile. Resolved at launch: the
+    # profile owns its config-dir env key (it wins over any raw launch_env value
+    # for that key). Unknown ids are rejected. Label is derived server-side.
+    account_profile_id: str | None = None
 
 
 class SessionLaunchRequest(SessionCreateRequest):
@@ -666,6 +679,10 @@ class ScheduledSessionRecord(BaseModel):
     # Preset provenance snapshotted at schedule-creation time (see SessionRecord).
     preset_id: str | None = None
     preset_name: str | None = None
+    # Account/config-dir profile snapshotted at schedule-creation time; the
+    # schedule fires under this profile (see SessionRecord).
+    account_profile_id: str | None = None
+    account_profile_label: str | None = None
 
 
 class ScheduleCreateRequest(BaseModel):
@@ -692,6 +709,8 @@ class ScheduleCreateRequest(BaseModel):
     # preset.
     preset_id: str | None = None
     use_default_preset: bool = False
+    # Launch under a named account/config-dir profile (see SessionCreateRequest).
+    account_profile_id: str | None = None
 
 
 class ScheduleLaunchRequest(ScheduleCreateRequest):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -364,6 +364,8 @@ class Storage:
         self._ensure_column("sessions", "tags", "TEXT NOT NULL DEFAULT '{}'")
         self._ensure_column("sessions", "preset_id", "TEXT")
         self._ensure_column("sessions", "preset_name", "TEXT")
+        self._ensure_column("sessions", "account_profile_id", "TEXT")
+        self._ensure_column("sessions", "account_profile_label", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -372,6 +374,8 @@ class Storage:
         )
         self._ensure_column("scheduled_sessions", "preset_id", "TEXT")
         self._ensure_column("scheduled_sessions", "preset_name", "TEXT")
+        self._ensure_column("scheduled_sessions", "account_profile_id", "TEXT")
+        self._ensure_column("scheduled_sessions", "account_profile_label", "TEXT")
         # Additive migration for the inbox table on databases that predate it.
         # (No-ops on a fresh DB where the CREATE TABLE above already made the
         # complete table; only load-bearing for columns added in a later release.)
@@ -409,8 +413,9 @@ class Storage:
                 last_event_at, raw_log_path, structured_log_path, transport_state,
                 pinned_at, spawner_session_id, worktree_path, permission_mode, model,
                 resolved_model, effort, args, config_overrides, launch_env, context_usage,
-                rate_limit_usage, tags, preset_id, preset_name
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                rate_limit_usage, tags, preset_id, preset_name,
+                account_profile_id, account_profile_label
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 session.id,
@@ -453,6 +458,8 @@ class Storage:
                 json.dumps(session.tags),
                 session.preset_id,
                 session.preset_name,
+                session.account_profile_id,
+                session.account_profile_label,
             ),
         )
         self.connection.commit()
@@ -1386,8 +1393,9 @@ class Storage:
             INSERT INTO scheduled_sessions (
                 id, backend, cwd, launch_target_id, launch_mode, transport, title, args,
                 config_overrides, launch_env, initial_prompt, permission_mode, model, effort, scheduled_at,
-                created_at, status, session_id, failure_reason, preset_id, preset_name
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                created_at, status, session_id, failure_reason, preset_id, preset_name,
+                account_profile_id, account_profile_label
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 schedule.id,
@@ -1411,6 +1419,8 @@ class Storage:
                 schedule.failure_reason,
                 schedule.preset_id,
                 schedule.preset_name,
+                schedule.account_profile_id,
+                schedule.account_profile_label,
             ),
         )
         self.connection.commit()

--- a/backend/tests/test_account_profile_selection.py
+++ b/backend/tests/test_account_profile_selection.py
@@ -1,0 +1,169 @@
+"""Account-profile selection: persistence, launch-env overlay, preset carry.
+
+Phase 2 of the account-switching RFC. A launched/scheduled/imported/forked
+session records which account profile it ran under, and the profile's config-dir
+is overlaid (profile-wins) into the private launch_env at launch time.
+"""
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from waypoint.backends.codex.schemas import CodexThreadImportRequest
+from waypoint.presets import resolve_session_create_request
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import (
+    SessionLaunchRequest,
+    SessionPresetRecord,
+    SessionPresetSpec,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _runtime(
+    tmp_path: Path, **plugin_configs: object
+) -> tuple[SessionRuntime, Storage]:
+    settings = Settings(data_dir=tmp_path / "data", plugin_configs=plugin_configs)
+    storage = Storage(settings.database_path)
+    return SessionRuntime(settings, storage), storage
+
+
+def _codex_profiles() -> dict[str, object]:
+    return {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": "~/.codex-work",
+                "transcript_policy": "copy_thread_on_switch",
+            }
+        }
+    }
+
+
+def _session(**kw: object) -> SessionRecord:
+    now = datetime.now(UTC)
+    base: dict[str, object] = dict(
+        id="s1",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        title="t",
+        cwd="/tmp",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/events.jsonl",
+    )
+    base.update(kw)
+    return SessionRecord(**base)
+
+
+# ── Persistence ──────────────────────────────────────────────────────────
+
+
+def test_session_record_round_trips_profile_selection(tmp_path: Path) -> None:
+    _, storage = _runtime(tmp_path)
+    storage.create_session(
+        _session(account_profile_id="work", account_profile_label="Work")
+    )
+    got = storage.get_session("s1")
+    assert got is not None
+    assert got.account_profile_id == "work"
+    assert got.account_profile_label == "Work"
+
+
+def test_session_record_defaults_none_when_absent(tmp_path: Path) -> None:
+    _, storage = _runtime(tmp_path)
+    storage.create_session(_session())
+    got = storage.get_session("s1")
+    assert got is not None
+    assert got.account_profile_id is None
+    assert got.account_profile_label is None
+
+
+# ── Launch-env overlay ─────────────────────────────────────────────────────
+
+
+def test_overlay_sets_config_dir_and_returns_label(tmp_path: Path) -> None:
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    env, label = runtime._apply_account_profile_env(
+        "codex", {"EXISTING": "1"}, "work", None
+    )
+    assert env["CODEX_HOME"] == os.path.expanduser("~/.codex-work")
+    assert env["EXISTING"] == "1"
+    assert label == "Work"
+
+
+def test_overlay_strips_raw_config_dir_value(tmp_path: Path) -> None:
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    # A raw launch_env value for the config-dir key is overridden by the profile
+    # (profile-wins), never honored and never a 400.
+    env, _ = runtime._apply_account_profile_env(
+        "codex", {"CODEX_HOME": "/wrong/path"}, "work", None
+    )
+    assert env["CODEX_HOME"] == os.path.expanduser("~/.codex-work")
+
+
+def test_overlay_noop_without_profile(tmp_path: Path) -> None:
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    env, label = runtime._apply_account_profile_env("codex", {"A": "1"}, None, None)
+    assert env == {"A": "1"}
+    assert label is None
+
+
+def test_overlay_rejects_unknown_profile(tmp_path: Path) -> None:
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    with pytest.raises(HTTPException) as exc:
+        runtime._apply_account_profile_env("codex", {}, "nope", None)
+    assert exc.value.status_code == 400
+
+
+# ── Preset carry ────────────────────────────────────────────────────────────
+
+
+def _preset(account_profile_id: str | None) -> SessionPresetRecord:
+    now = datetime.now(UTC)
+    return SessionPresetRecord(
+        id="p1",
+        name="p",
+        spec=SessionPresetSpec(backend="codex", account_profile_id=account_profile_id),
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_preset_supplies_profile_when_request_omits_it(tmp_path: Path) -> None:
+    _, storage = _runtime(tmp_path)
+    storage.create_session_preset(_preset("work"))
+    resolved, _ = resolve_session_create_request(
+        storage, SessionLaunchRequest(backend="codex", cwd="/tmp", preset_id="p1")
+    )
+    assert resolved.account_profile_id == "work"
+
+
+def test_explicit_request_profile_wins_over_preset(tmp_path: Path) -> None:
+    _, storage = _runtime(tmp_path)
+    storage.create_session_preset(_preset("work"))
+    resolved, _ = resolve_session_create_request(
+        storage,
+        SessionLaunchRequest(
+            backend="codex", cwd="/tmp", preset_id="p1", account_profile_id="personal"
+        ),
+    )
+    assert resolved.account_profile_id == "personal"
+
+
+# ── Import request ──────────────────────────────────────────────────────────
+
+
+def test_import_request_accepts_profile() -> None:
+    req = CodexThreadImportRequest(thread_id="t", account_profile_id="work")
+    assert req.account_profile_id == "work"

--- a/backend/tests/test_account_profile_selection.py
+++ b/backend/tests/test_account_profile_selection.py
@@ -13,9 +13,11 @@ import pytest
 from fastapi import HTTPException
 
 from waypoint.backends.codex.schemas import CodexThreadImportRequest
+from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.presets import resolve_session_create_request
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
+    ScheduleCreateRequest,
     SessionLaunchRequest,
     SessionPresetRecord,
     SessionPresetSpec,
@@ -126,6 +128,17 @@ def test_overlay_rejects_unknown_profile(tmp_path: Path) -> None:
     assert exc.value.status_code == 400
 
 
+def test_overlay_rejects_tilde_config_dir_on_remote(tmp_path: Path) -> None:
+    # ``~`` can't be expanded to the remote home yet and won't be shell-expanded
+    # in the injected env, so a remote profile with a ``~`` config_dir is
+    # rejected rather than silently launching under a literal ``~`` dir.
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    target = SshLaunchTargetConfig(id="d", name="d", ssh_destination="u@d")
+    with pytest.raises(HTTPException) as exc:
+        runtime._apply_account_profile_env("codex", {}, "work", target)
+    assert exc.value.status_code == 400
+
+
 # ── Preset carry ────────────────────────────────────────────────────────────
 
 
@@ -167,3 +180,33 @@ def test_explicit_request_profile_wins_over_preset(tmp_path: Path) -> None:
 def test_import_request_accepts_profile() -> None:
     req = CodexThreadImportRequest(thread_id="t", account_profile_id="work")
     assert req.account_profile_id == "work"
+
+
+# ── Schedule ────────────────────────────────────────────────────────────────
+
+
+async def test_schedule_persists_and_validates_profile(tmp_path: Path) -> None:
+    # create_schedule arms an asyncio fire-timer, so it needs a running loop.
+    runtime, storage = _runtime(tmp_path, codex=_codex_profiles())
+    record = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex", cwd="/tmp", delay_seconds=60, account_profile_id="work"
+        )
+    )
+    stored = storage.get_schedule(record.id)
+    assert stored is not None
+    # Selection persisted; label resolved at create time. The config-dir itself
+    # is resolved from the profile at fire time, not snapshotted here.
+    assert stored.account_profile_id == "work"
+    assert stored.account_profile_label == "Work"
+
+
+def test_schedule_rejects_unknown_profile(tmp_path: Path) -> None:
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_schedule(
+            ScheduleCreateRequest(
+                backend="codex", cwd="/tmp", delay_seconds=60, account_profile_id="nope"
+            )
+        )
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## Purpose

Second phase of per-session account/config-profile switching (Relates to #230). **Stacked on #231** (base branch `feat/account-profiles-config`); rebases onto `main` once #231 merges. Phase 1 exposed profiles as config + read-API metadata; this phase makes a launched/scheduled/imported/forked session actually **remember and run under** a selected profile. No live-switching of a running session yet (that's a later phase).

## Changes

### Backend

- `backend/src/waypoint/schemas.py` — `account_profile_id`/`account_profile_label` selection fields on `SessionRecord`, `SessionCreateRequest`, `ScheduledSessionRecord`, `ScheduleCreateRequest`, and `SessionPresetSpec`/`SessionPresetSpecSummary`. `verified_account_*` (probe results) are intentionally not added yet — they're written by the account probe in the probe phase.
- `backend/src/waypoint/backends/{codex,claude_code}/schemas.py` — `account_profile_id` on the thread-import requests, persisted so a later resume/delete/history-read uses the same state root.
- `backend/src/waypoint/storage.py` — additive `account_profile_id`/`account_profile_label` columns on `sessions` and `scheduled_sessions` (via `_ensure_column`), wired into the create inserts (reads reconstruct via `model_validate`).
- `backend/src/waypoint/runtime.py` — `_require_account_profile` (resolve-or-400) and `_apply_account_profile_env` (overlay the profile's `config_dir` into the backend's `config_dir_env_var`, profile-wins: any raw value for that key is stripped, never a 400; `~` expanded for local launches). Applied in `create_session` and `import_thread`; the selection is stamped on the record generically, like preset provenance.
- `backend/src/waypoint/presets.py` — `account_profile_id` added to the preset scalar-merge set, so applying a preset selects its profile (explicit request wins).
- `backend/src/waypoint/scheduler.py` — schedules validate the profile up front, store the selection, and resolve the config-dir from the profile at fire time (not snapshotted), so a schedule launches under the profile as it exists when it fires.
- `backend/src/waypoint/backends/{codex,claude_code,claude_tty,opencode}/plugin.py`, `claude_code/side_question.py` — fork/aside `SessionRecord` builds inherit the parent's profile selection (the config-dir is already inherited via the copied `launch_env`).

## Design

The profile's config-dir is baked into the private `launch_env` at launch time, so the running process gets the right `CLAUDE_CONFIG_DIR`/`CODEX_HOME` and the account binding survives later config edits (snapshot model, matching presets). The overlay is profile-owned — a raw `launch_env` value for the config-dir key is silently overridden by the selected profile rather than rejected, the single rule the RFC settled on for both launch and (later) live PATCH. Selection is opaque provenance stamped generically after the plugin builds the record, so no per-plugin launch-site edits and no per-backend branching. Schedules keep the existing snapshot-at-create model for `launch_env` but resolve the profile config-dir at fire time, since "launch with that profile later" means the profile as configured when it fires.

Scope note: `verified_account_*` fields, the shared `account_lookup_env`/`agent_process_env_for_session` contract, and discovery-with-profile (models/threads listed under a profile) are deferred to the probe phase, because they thread env into the same plugin `client_factory`/`run_client_operation` paths the account probes touch — cleaner to land together.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1520 passed, 3 warnings (pre-existing).
- New `backend/tests/test_account_profile_selection.py` covers: selection round-trips through storage (and defaults to None), the launch-env overlay (sets/expands the config-dir key, strips a raw value, no-op without a profile, 400 on unknown id), preset carry (preset supplies the profile; explicit request wins), and the import request accepting a profile.
- Live stack e2e — not run: backend-only phase with no frontend/runtime-switch surface, exercised by unit + in-process tests; a live `waypointctl` backend restart would risk interrupting the Waypoint session this runs inside.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`backend/tests/test_account_profile_selection.py`).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id (runtime launch/import, fork sites across backends): the overlay/stamp are generic with no per-backend branch; verified claude_code, codex, claude_tty, opencode, tmux forks and the full suite pass.
- [x] No frontend changes in this phase.
- [x] Not a breaking change — additive nullable fields/columns; sessions with no profile launch exactly as before.
- [x] No user-facing config default changed; documenting the profile launch/CLI surface follows with the CLI/UI phases.

</details>