### PR TITLE
fix: probe rate limits with the session's account env

### DIFF
--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -366,7 +366,17 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return
 
         async def _probe() -> SessionRateLimitUsage | None:
-            return await probe_claude_usage_shared()
+            # Probe the account the session actually runs as: its launch_env
+            # carries the profile's CLAUDE_CONFIG_DIR, which selects the
+            # credentials/account (and the shared probe's cache key). Looked up
+            # per probe so it tracks a live settings change.
+            session = runtime.storage.get_session(session_id)
+            env = (
+                runtime.account_lookup_env(self.id, session.launch_env)
+                if session is not None
+                else None
+            )
+            return await probe_claude_usage_shared(env=env)
 
         await self.adapter.register_rate_limit_probe(
             session_id, _probe, refresh_interval_seconds=300.0
@@ -429,6 +439,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         launch_target: SshLaunchTargetConfig | None,
         *,
         cwd: str | None = None,
+        launch_env: dict[str, str] | None = None,
         force: bool = False,
     ) -> SessionRateLimitUsage | None:
         """Fetch the account's current rate-limit snapshot without a session.
@@ -444,7 +455,12 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         """
         _ = cwd
         if launch_target is None:
-            return await probe_claude_usage_shared(force=force)
+            env = (
+                runtime.account_lookup_env(self.id, launch_env)
+                if launch_env is not None
+                else None
+            )
+            return await probe_claude_usage_shared(env=env, force=force)
         return await probe_claude_usage_remote_shared(launch_target, force=force)
 
     def rate_limit_account(

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -286,10 +286,11 @@ class ClaudeTtyPlugin:
         launch_target: SshLaunchTargetConfig | None,
         *,
         cwd: str | None = None,
+        launch_env: dict[str, str] | None = None,
         force: bool = False,
     ) -> SessionRateLimitUsage | None:
         return await self._claude.probe_account_rate_limit(
-            runtime, launch_target, cwd=cwd, force=force
+            runtime, launch_target, cwd=cwd, launch_env=launch_env, force=force
         )
 
     def validate_permission_mode(self, mode: str | None) -> str | None:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -250,7 +250,16 @@ class CodexPlugin(DefaultLaunchContract):
         )
 
         async def _probe() -> SessionRateLimitUsage | None:
-            return await probe_codex_status(cwd=cwd, binary=binary)
+            # Probe the account the session runs as: its launch_env carries the
+            # profile's CODEX_HOME, which selects the auth.json/config.toml the
+            # probe reads. Looked up per probe so it tracks a live change.
+            session = runtime.storage.get_session(session_id)
+            env = (
+                runtime.account_lookup_env(self.id, session.launch_env)
+                if session is not None
+                else None
+            )
+            return await probe_codex_status(cwd=cwd, binary=binary, env=env)
 
         await self.adapter.register_rate_limit_probe(
             session_id, _probe, refresh_interval_seconds=300.0
@@ -308,6 +317,7 @@ class CodexPlugin(DefaultLaunchContract):
         launch_target: SshLaunchTargetConfig | None,
         *,
         cwd: str,
+        launch_env: dict[str, str] | None = None,
         force: bool = False,
     ) -> SessionRateLimitUsage | None:
         """Fetch the account's current rate-limit snapshot without a session.
@@ -326,7 +336,12 @@ class CodexPlugin(DefaultLaunchContract):
                 or self.capabilities.cli_binary
                 or "codex"
             )
-            return await probe_codex_status(cwd=cwd, binary=binary)
+            env = (
+                runtime.account_lookup_env(self.id, launch_env)
+                if launch_env is not None
+                else None
+            )
+            return await probe_codex_status(cwd=cwd, binary=binary, env=env)
         binary = self.remote_executable(launch_target) or "codex"
         return await probe_codex_usage_remote(launch_target, binary=binary)
 

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -342,8 +342,16 @@ class TmuxPlugin:
         # The account-level probe is uniform across agents; ``cwd`` is
         # always supplied (codex's ``/status`` PTY fallback needs it, the
         # others ignore it) so no per-backend call shape is needed here.
+        # ``launch_env`` carries the session's profile config-dir so the probe
+        # reads the account this wrapped session actually runs as.
         try:
-            snapshot = await probe(runtime, launch_target, cwd=session.cwd, force=force)
+            snapshot = await probe(
+                runtime,
+                launch_target,
+                cwd=session.cwd,
+                launch_env=session.launch_env,
+                force=force,
+            )
         except Exception:  # noqa: BLE001
             log.exception(
                 "tmux rate-limit probe failed",

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -508,6 +508,24 @@ class SessionRuntime:
             env["WAYPOINT_SESSION_ID"] = session_id
         return env
 
+    def account_lookup_env(
+        self, backend: str, launch_env: dict[str, str]
+    ) -> dict[str, str]:
+        """Env for account-scoped *lookups* (rate-limit/thread/model probes).
+
+        The account a probe authenticates as is selected by the config-dir env
+        var (``CLAUDE_CONFIG_DIR``/``CODEX_HOME``), which a profile bakes into
+        ``launch_env``. Mirror the env the session process actually sees —
+        ``os.environ`` overlaid with the session's ``launch_env`` and the
+        backend's ``extra_env`` — so a lookup resolves the same account the
+        session runs as. Unlike ``_agent_process_env`` this never adds
+        runtime-only keys (e.g. ``WAYPOINT_SESSION_ID``); it's a read helper,
+        not a launch helper. Dispatches through the registry — no per-backend
+        branching.
+        """
+        plugin = self.registry.get(backend)
+        return {**os.environ, **launch_env, **plugin.extra_env}
+
     async def create_session(
         self,
         request: SessionCreateRequest,

--- a/backend/tests/test_account_probe_env.py
+++ b/backend/tests/test_account_probe_env.py
@@ -1,0 +1,114 @@
+"""Account-scoped probe env: probes read the account the session runs as.
+
+Phase 3a. Rate-limit probes previously ran with the process env, so a session
+under a non-default CLAUDE_CONFIG_DIR/CODEX_HOME (e.g. a switched account
+profile) bucketed under the wrong account. ``account_lookup_env`` mirrors the
+session's env and is threaded into the probes.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from waypoint.runtime import SessionRuntime
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _runtime(tmp_path: Path) -> SessionRuntime:
+    settings = Settings(data_dir=tmp_path / "data")
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+# ── account_lookup_env ──────────────────────────────────────────────────────
+
+
+def test_account_lookup_env_overlays_launch_env_over_process_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PATH", "/usr/bin")
+    runtime = _runtime(tmp_path)
+    env = runtime.account_lookup_env("codex", {"CODEX_HOME": "/x", "FOO": "bar"})
+    # Session launch_env wins, process env (PATH) is present for the subprocess.
+    assert env["CODEX_HOME"] == "/x"
+    assert env["FOO"] == "bar"
+    assert env["PATH"] == "/usr/bin"
+
+
+def test_account_lookup_env_includes_extra_env_not_runtime_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Isolate the env: WAYPOINT_SESSION_ID is set when the test itself runs
+    # inside a Waypoint session (it's inherited from os.environ, not injected).
+    monkeypatch.delenv("WAYPOINT_SESSION_ID", raising=False)
+    runtime = _runtime(tmp_path)
+    env = runtime.account_lookup_env("claude_code", {})
+    # Backend extra_env is included (matches the launched process)...
+    assert env.get("CLAUDE_CODE_NO_FLICKER") == "1"
+    # ...but the helper never *injects* a session id (unlike _agent_process_env).
+    assert "WAYPOINT_SESSION_ID" not in env
+
+
+# ── probe_account_rate_limit threads the config-dir env ─────────────────────
+
+
+async def test_claude_probe_uses_session_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin: Any = runtime.registry.get("claude_code")
+    captured: dict[str, Any] = {}
+
+    async def fake_shared(*, env: Any = None, force: bool = False) -> None:
+        captured["env"] = env
+        return None
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.probe_claude_usage_shared", fake_shared
+    )
+    await plugin.probe_account_rate_limit(
+        runtime, None, cwd="/x", launch_env={"CLAUDE_CONFIG_DIR": "/team"}
+    )
+    assert captured["env"]["CLAUDE_CONFIG_DIR"] == "/team"
+
+
+async def test_claude_probe_without_launch_env_uses_process_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin: Any = runtime.registry.get("claude_code")
+    captured: dict[str, Any] = {}
+
+    async def fake_shared(*, env: Any = None, force: bool = False) -> None:
+        captured["env"] = env
+        return None
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.probe_claude_usage_shared", fake_shared
+    )
+    await plugin.probe_account_rate_limit(runtime, None, cwd="/x")
+    # No launch_env -> env stays None so the probe falls back to os.environ.
+    assert captured["env"] is None
+
+
+async def test_codex_probe_uses_session_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin: Any = runtime.registry.get("codex")
+    captured: dict[str, Any] = {}
+
+    async def fake_status(
+        *, cwd: str, binary: str, env: Any = None, timeout_seconds: float = 8.0
+    ) -> None:
+        captured["env"] = env
+        return None
+
+    monkeypatch.setattr(
+        "waypoint.backends.codex.plugin.probe_codex_status", fake_status
+    )
+    await plugin.probe_account_rate_limit(
+        runtime, None, cwd="/x", launch_env={"CODEX_HOME": "/work"}
+    )
+    assert captured["env"]["CODEX_HOME"] == "/work"

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -743,6 +743,7 @@ class _InnerPluginStub:
     def __init__(self) -> None:
         self.calls = 0
         self.forces: list[bool] = []
+        self.launch_envs: list[dict[str, str] | None] = []
 
     async def probe_account_rate_limit(
         self,
@@ -750,10 +751,12 @@ class _InnerPluginStub:
         _launch_target: Any,
         *,
         cwd: str | None = None,
+        launch_env: dict[str, str] | None = None,
         force: bool = False,
     ) -> Any:
         self.calls += 1
         self.forces.append(force)
+        self.launch_envs.append(launch_env)
         from waypoint.schemas import SessionRateLimitUsage
 
         return SessionRateLimitUsage(


### PR DESCRIPTION
## Purpose

Phase 3a of per-session account/config-profile switching (Relates to #230). Fixes a real bug and lays the shared account-env contract the switch phase builds on. Rate-limit probes ran with the **process** env, so a session launched under a non-default `CLAUDE_CONFIG_DIR`/`CODEX_HOME` — e.g. an account profile (#231/#234) — authenticated as, and was bucketed in the usage dashboard under, the **wrong** account. This threads the session's account env into the probes.

## Changes

### Backend

- `backend/src/waypoint/runtime.py` — `SessionRuntime.account_lookup_env(backend, launch_env)`: the env for account-scoped *lookups*, mirroring what the session process sees (`os.environ` overlaid with the session `launch_env` and the backend's `extra_env`) but **without** runtime-only keys like `WAYPOINT_SESSION_ID`. Dispatches through the registry — no per-backend branching.
- `backend/src/waypoint/backends/claude_code/plugin.py`, `backends/codex/plugin.py` — the per-session rate-limit probe closures now look up the session's `launch_env` (from storage, at probe time so it tracks a live change) and pass `env=account_lookup_env(...)` to `probe_claude_usage_shared` / `probe_codex_status`. Both probe functions already accepted an `env` arg. `probe_account_rate_limit` (the tmux-fallback entry) gains a `launch_env` param on both agents.
- `backend/src/waypoint/backends/claude_tty/plugin.py` — forwards `launch_env` through its `probe_account_rate_limit` delegation to the wrapped claude agent.
- `backend/src/waypoint/backends/tmux/plugin.py` — the rate-limit delegation passes `launch_env=session.launch_env` to the wrapped backend's probe.

## Design

The account a probe authenticates as is selected by the config-dir env var, which a profile bakes into `launch_env` at launch (Phase 2). Claude's shared probe additionally caches keyed on `CLAUDE_CONFIG_DIR`, so an envless probe both read the wrong credentials and cached under the wrong key. `account_lookup_env` is a read helper distinct from the launch helper `_agent_process_env` — same account-relevant env, but it never injects `WAYPOINT_SESSION_ID`. The structured per-session probes are fixed inside their existing closures (a storage lookup keyed on the captured `session_id`), so no launch-site call chains had to be widened; only the tmux-fallback probe grew a parameter. Everything dispatches through the plugin registry, so adding a backend needs no change here.

Scope: this is the "account env as a shared contract" slice. `agent_process_env_for_session` (a launch/restore helper) lands with the live-switch phase that consumes it, and discovery-with-profile (models/threads listed under a profile) is a separate follow-up because claude's local thread discovery reads `CLAUDE_CONFIG_DIR` from `os.environ` with no parameter seam yet.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1528 passed, 3 warnings (pre-existing).
- New `backend/tests/test_account_probe_env.py`: `account_lookup_env` overlays `launch_env` over `os.environ` and includes `extra_env` but never injects a session id; the claude and codex `probe_account_rate_limit` pass the session's config-dir env to the underlying probe, and fall back to the process env (`env=None`) when no `launch_env` is given. Updated `test_tmux_plugin.py`'s `FakeInner` to the new `launch_env` signature.
- Live stack e2e — not run: backend-only, exercised by unit tests; a live `waypointctl` backend restart would risk interrupting the Waypoint session this runs inside.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`backend/tests/test_account_probe_env.py`; `test_tmux_plugin.py` mock).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id (rate-limit probe registration, tmux delegation): `account_lookup_env` and the probe threading are generic via the registry with no per-backend branch; verified claude_code, codex, claude_tty, tmux paths and the full suite pass.
- [x] No frontend changes in this phase.
- [x] Not a breaking change — additive `launch_env` params default to `None` (process-env fallback = prior behavior); non-profile sessions probe exactly as before.
- [x] No user-facing config change.

</details>