### PR TITLE
feat: add native transcript availability for profile switching

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -425,6 +425,21 @@ class BackendPlugin(Protocol):
         """
         ...
 
+    def native_thread_artifacts(
+        self, session: SessionRecord, config_dir: str | None = None
+    ) -> list[Path]:
+        """On-disk artifact file(s) needed to resume this session's native
+        thread, resolved under ``config_dir`` (the backend's config/state root,
+        e.g. a target account profile's ``CLAUDE_CONFIG_DIR``/``CODEX_HOME``).
+
+        ``config_dir=None`` resolves under the process default. Returns ``[]``
+        when the thread isn't present under that root — the signal that a
+        target profile can't yet see it — or when the backend has no resumable
+        native store. Used by account-profile switching to verify/copy the
+        transcript before restore.
+        """
+        ...
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -64,6 +64,7 @@ from waypoint.backends.claude_code.threads import (
     delete_local_claude_thread,
     find_local_claude_thread,
     list_local_claude_threads,
+    local_claude_thread_artifacts,
 )
 from waypoint.backends.claude_code.threads_remote import RemoteClaudeThreadEnumerator
 from waypoint.backends.claude_code.version import detect_claude_cli_version
@@ -499,6 +500,14 @@ class ClaudeCodePlugin(DefaultLaunchContract):
     def native_thread_id(self, session: SessionRecord) -> str | None:
         thread_id = session.transport_state.get("thread_id")
         return thread_id if isinstance(thread_id, str) else None
+
+    def native_thread_artifacts(
+        self, session: SessionRecord, config_dir: str | None = None
+    ) -> list[Path]:
+        thread_id = self.native_thread_id(session)
+        if thread_id is None:
+            return []
+        return local_claude_thread_artifacts(thread_id, config_dir)
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/claude_code/threads.py
+++ b/backend/src/waypoint/backends/claude_code/threads.py
@@ -56,14 +56,15 @@ class ClaudeThreadInfo:
     updated_at: datetime
 
 
-def claude_projects_root() -> Path:
+def claude_projects_root(config_dir: str | None = None) -> Path:
     """Directory under which Claude stores per-project session transcripts.
 
-    Mirrors the precedence the CLI uses: ``$CLAUDE_CONFIG_DIR`` overrides
-    the default ``~/.claude``.
+    Mirrors the precedence the CLI uses: an explicit ``config_dir`` (e.g. a
+    target account profile's) wins, else ``$CLAUDE_CONFIG_DIR`` overrides the
+    default ``~/.claude``.
     """
-    base = os.environ.get("CLAUDE_CONFIG_DIR")
-    root = Path(base) if base else Path.home() / ".claude"
+    base = config_dir or os.environ.get("CLAUDE_CONFIG_DIR")
+    root = Path(base).expanduser() if base else Path.home() / ".claude"
     return root / "projects"
 
 
@@ -96,6 +97,28 @@ def list_local_claude_threads() -> list[ClaudeThreadInfo]:
                 results.append(info)
     results.sort(key=lambda info: info.updated_at, reverse=True)
     return results
+
+
+def local_claude_thread_artifacts(
+    thread_id: str, config_dir: str | None = None
+) -> list[Path]:
+    """The on-disk transcript file(s) for ``thread_id`` under ``config_dir``.
+
+    Scans every encoded-cwd project dir (the encoding is lossy, so the exact
+    dir isn't derivable) for ``<thread_id>.jsonl``. Returns the matching paths
+    (normally one), or ``[]`` when the thread isn't present under this config
+    dir — the signal a target profile can't yet see it. UUID-guarded.
+    """
+    if not UUID_RE.match(thread_id):
+        return []
+    root = claude_projects_root(config_dir)
+    if not root.is_dir():
+        return []
+    return [
+        project_dir / f"{thread_id}.jsonl"
+        for project_dir in root.iterdir()
+        if project_dir.is_dir() and (project_dir / f"{thread_id}.jsonl").is_file()
+    ]
 
 
 def find_local_claude_thread(thread_id: str) -> ClaudeThreadInfo | None:

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -215,6 +215,13 @@ class ClaudeTtyPlugin:
     def native_thread_id(self, session: SessionRecord) -> str | None:
         return self._tmux.native_thread_id(session)
 
+    def native_thread_artifacts(
+        self, session: SessionRecord, config_dir: str | None = None
+    ) -> list[Path]:
+        # The native transcript is Claude's (projects JSONL); the agent owns
+        # the config-dir/thread-store path logic, so delegate to it.
+        return self._claude.native_thread_artifacts(session, config_dir)
+
     def pane_ready_for_input(self, pane_text: str) -> bool:
         return pane_dialog.composer_ready(pane_text)
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -479,6 +479,18 @@ class CodexPlugin(DefaultLaunchContract):
         thread_id = session.transport_state.get("thread_id")
         return thread_id if isinstance(thread_id, str) else None
 
+    def native_thread_artifacts(
+        self, session: SessionRecord, config_dir: str | None = None
+    ) -> list[Path]:
+        # Imported lazily to avoid the plugin ↔ usage_source ↔ adapter cycle.
+        from waypoint.backends.codex.usage_source import find_codex_rollout
+
+        thread_id = self.native_thread_id(session)
+        if thread_id is None:
+            return []
+        rollout = find_codex_rollout(thread_id, config_dir)
+        return [rollout] if rollout is not None else []
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/codex/usage_source.py
+++ b/backend/src/waypoint/backends/codex/usage_source.py
@@ -26,13 +26,23 @@ log = logging.getLogger("waypoint.backends.codex")
 _POLL_INTERVAL = 1.0
 
 
-def _find_rollout_path(thread_id: str) -> Path | None:
-    codex_home = Path(os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
-    sessions_dir = codex_home / "sessions"
+def find_codex_rollout(thread_id: str, codex_home: str | None = None) -> Path | None:
+    """The rollout JSONL for ``thread_id`` under ``codex_home``.
+
+    An explicit ``codex_home`` (e.g. a target account profile's) wins, else
+    ``$CODEX_HOME`` / ``~/.codex``. Returns ``None`` when absent — the signal a
+    target profile can't yet see the thread.
+    """
+    home = Path(codex_home or os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
+    sessions_dir = home / "sessions"
     if not sessions_dir.is_dir():
         return None
     suffix = f"-{thread_id}.jsonl"
     return next(sessions_dir.glob(f"*/*/*/rollout-*{suffix}"), None)
+
+
+def _find_rollout_path(thread_id: str) -> Path | None:
+    return find_codex_rollout(thread_id)
 
 
 def _parse_token_count_record(record: dict[str, Any]) -> SessionContextUsage | None:

--- a/backend/src/waypoint/backends/codex/usage_source.py
+++ b/backend/src/waypoint/backends/codex/usage_source.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -26,6 +27,11 @@ log = logging.getLogger("waypoint.backends.codex")
 _POLL_INTERVAL = 1.0
 
 
+_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-" r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
 def find_codex_rollout(thread_id: str, codex_home: str | None = None) -> Path | None:
     """The rollout JSONL for ``thread_id`` under ``codex_home``.
 
@@ -33,6 +39,9 @@ def find_codex_rollout(thread_id: str, codex_home: str | None = None) -> Path | 
     ``$CODEX_HOME`` / ``~/.codex``. Returns ``None`` when absent — the signal a
     target profile can't yet see the thread.
     """
+    # Codex thread ids are UUIDs; guard before it reaches a glob pattern.
+    if not _UUID_RE.match(thread_id):
+        return None
     home = Path(codex_home or os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
     sessions_dir = home / "sessions"
     if not sessions_dir.is_dir():

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -671,6 +671,12 @@ class OpenCodePlugin(DefaultLaunchContract):
         session_id = session.transport_state.get("opencode_session_id")
         return session_id if isinstance(session_id, str) else None
 
+    def native_thread_artifacts(
+        self, session: SessionRecord, config_dir: str | None = None
+    ) -> list[Path]:
+        # No config-dir env var / account-profile support in phase 1.
+        return []
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -186,6 +186,14 @@ class TmuxPlugin:
         thread_id = session.transport_state.get("thread_id")
         return thread_id if isinstance(thread_id, str) else None
 
+    def native_thread_artifacts(
+        self, session: SessionRecord, config_dir: str | None = None
+    ) -> list[Path]:
+        # The wrapper has no native store of its own; the resumable transcript
+        # belongs to the wrapped agent, which owns the artifact lookup and is
+        # dispatched via ``session.backend``. Nothing to contribute here.
+        return []
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -79,11 +79,17 @@ def copy_thread_artifacts(
     for artifact in artifacts:
         rel = artifact.relative_to(src_root)
         dest = dst_root / rel
+        # Lock only the dirs this copy creates to 0700; leave pre-existing ones
+        # (including the config root) untouched. The transcript is copied with
+        # its metadata (shutil.copy2) then pinned to 0600 as a backstop.
+        new_dirs = [
+            dst_root / parent
+            for parent in reversed(rel.parents)
+            if (dst_root / parent) != dst_root and not (dst_root / parent).exists()
+        ]
         dest.parent.mkdir(parents=True, exist_ok=True)
-        # Keep created dirs owner-only; the transcript itself is copied with its
-        # metadata (shutil.copy2) and then pinned to 0600 as a backstop.
-        for parent in reversed(dest.relative_to(dst_root).parents):
-            (dst_root / parent).chmod(0o700)
+        for created in new_dirs:
+            created.chmod(0o700)
         shutil.copy2(artifact, dest)
         dest.chmod(0o600)
 

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -1,0 +1,144 @@
+"""Native transcript availability for account-profile switching.
+
+Before a config-dir profile switch can resume, the target profile's state root
+must be able to see the session's native thread transcript. This applies the
+profile's ``transcript_policy`` locally:
+
+- ``require_existing`` — verify the target already has it; never mutate files.
+- ``symlink_shared`` — point the target's native store dir at a shared dir.
+- ``copy_thread_on_switch`` — copy only the current thread's artifact set.
+
+The runtime drives the locate → check → apply → re-check sequence via
+:func:`ensure_thread_available`; per-backend path logic stays in each plugin's
+``native_thread_artifacts``. Local launch targets only — remote (over SSH) is a
+later phase. Raises :class:`TranscriptUnavailableError`, which the runtime maps
+to a 400 (nothing is terminated when it fires).
+"""
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from waypoint.backends.plugin_config import TranscriptPolicy
+from waypoint.schemas import SessionRecord
+
+if TYPE_CHECKING:
+    from waypoint.backends.base import BackendPlugin
+
+log = logging.getLogger("waypoint.backends.transcripts")
+
+
+class TranscriptUnavailableError(Exception):
+    """The target profile cannot see the native thread and policy can't fix it."""
+
+
+def ensure_symlink_shared(store_dir: Path, shared_dir: Path) -> None:
+    """Ensure ``store_dir`` is a symlink to ``shared_dir`` (guarded).
+
+    Idempotent and non-destructive: a real, populated store dir is refused
+    rather than silently converted (migrate it with ``accounts
+    setup-transcripts`` first). Cases: missing → create; already the right
+    symlink → no-op; a symlink elsewhere → error; an empty real dir → replace;
+    a non-empty real dir → error.
+    """
+    shared_dir.mkdir(parents=True, exist_ok=True)
+    shared_dir.chmod(0o700)
+    if store_dir.is_symlink():
+        if store_dir.resolve() == shared_dir.resolve():
+            return
+        raise TranscriptUnavailableError(
+            f"{store_dir} is a symlink to {os.readlink(store_dir)!r}, "
+            f"not the configured shared_transcript_dir {shared_dir}"
+        )
+    if store_dir.exists():
+        if not store_dir.is_dir():
+            raise TranscriptUnavailableError(
+                f"{store_dir} exists and is not a directory"
+            )
+        if any(store_dir.iterdir()):
+            raise TranscriptUnavailableError(
+                f"{store_dir} is a non-empty directory; run "
+                "'waypoint accounts setup-transcripts' to migrate it into the "
+                "shared dir before switching"
+            )
+        store_dir.rmdir()
+    store_dir.parent.mkdir(parents=True, exist_ok=True)
+    store_dir.symlink_to(shared_dir, target_is_directory=True)
+
+
+def copy_thread_artifacts(
+    artifacts: list[Path], src_root: Path, dst_root: Path
+) -> None:
+    """Copy each artifact from under ``src_root`` to the same relative path
+    under ``dst_root``, preserving restrictive permissions.
+
+    Only the passed artifact set is copied — never whole history directories.
+    """
+    for artifact in artifacts:
+        rel = artifact.relative_to(src_root)
+        dest = dst_root / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        # Keep created dirs owner-only; the transcript itself is copied with its
+        # metadata (shutil.copy2) and then pinned to 0600 as a backstop.
+        for parent in reversed(dest.relative_to(dst_root).parents):
+            (dst_root / parent).chmod(0o700)
+        shutil.copy2(artifact, dest)
+        dest.chmod(0o600)
+
+
+def ensure_thread_available(
+    plugin: "BackendPlugin",
+    session: SessionRecord,
+    *,
+    current_config_dir: str,
+    target_config_dir: str,
+    policy: TranscriptPolicy,
+    shared_transcript_dir: str | None,
+    native_thread_store: str | None,
+) -> None:
+    """Make the session's native thread visible under ``target_config_dir``.
+
+    No-op when it's already visible. Otherwise applies ``policy`` and re-checks;
+    raises :class:`TranscriptUnavailableError` (before any process is touched)
+    when the thread still isn't available.
+    """
+    target = str(Path(target_config_dir).expanduser())
+    if plugin.native_thread_artifacts(session, target):
+        return
+
+    if policy == "require_existing":
+        raise TranscriptUnavailableError(
+            "the target account profile cannot see the native thread transcript "
+            "and transcript_policy is 'require_existing'"
+        )
+    if policy == "symlink_shared":
+        if not shared_transcript_dir:
+            raise TranscriptUnavailableError(
+                "transcript_policy 'symlink_shared' requires shared_transcript_dir"
+            )
+        if not native_thread_store:
+            raise TranscriptUnavailableError(
+                "backend has no native transcript store for symlink_shared"
+            )
+        ensure_symlink_shared(
+            Path(target) / native_thread_store,
+            Path(shared_transcript_dir).expanduser(),
+        )
+    elif policy == "copy_thread_on_switch":
+        current = str(Path(current_config_dir).expanduser())
+        artifacts = plugin.native_thread_artifacts(session, current)
+        if not artifacts:
+            raise TranscriptUnavailableError(
+                "source native thread artifact not found to copy"
+            )
+        copy_thread_artifacts(artifacts, Path(current), Path(target))
+    else:  # pragma: no cover - exhaustive over TranscriptPolicy
+        raise TranscriptUnavailableError(f"unknown transcript policy {policy!r}")
+
+    if not plugin.native_thread_artifacts(session, target):
+        raise TranscriptUnavailableError(
+            "native thread still unavailable in the target profile after "
+            f"applying transcript_policy {policy!r}"
+        )

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -49,6 +49,11 @@ class _StubPlugin:
     def native_thread_id(self, session: Any) -> str | None:
         return None
 
+    def native_thread_artifacts(
+        self, session: Any, config_dir: str | None = None
+    ) -> list[Any]:
+        return []
+
     def on_session_deleted(self, runtime: Any, session: Any) -> None:
         return None
 

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -114,6 +114,30 @@ def test_copy_thread_on_switch_copies_codex_rollout(tmp_path: Path) -> None:
     assert _plugin("codex").native_thread_artifacts(_session("codex"), str(target))
 
 
+def test_copy_thread_on_switch_leaves_preexisting_dirs_untouched(
+    tmp_path: Path,
+) -> None:
+    current = tmp_path / "current"
+    target = tmp_path / "target"
+    _write_codex_rollout(current)
+    # A pre-existing target config root with a non-0700 mode must not be
+    # re-chmod'd by the copy — only newly-created dirs are locked down.
+    target.mkdir()
+    target.chmod(0o755)
+    ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(current),
+        target_config_dir=str(target),
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+    )
+    assert oct(target.stat().st_mode)[-3:] == "755"
+    # ...but a dir this copy created is owner-only.
+    assert oct((target / "sessions").stat().st_mode)[-3:] == "700"
+
+
 def test_copy_thread_on_switch_rejects_when_source_missing(tmp_path: Path) -> None:
     with pytest.raises(TranscriptUnavailableError, match="not found to copy"):
         ensure_thread_available(

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -1,0 +1,208 @@
+"""Native transcript availability policies (Phase 3b).
+
+Exercises the per-backend artifact locator and the local require_existing /
+symlink_shared / copy_thread_on_switch policies against real claude_code/codex
+plugins with temporary config dirs.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from waypoint.backends.base import BackendPlugin
+from waypoint.backends.bootstrap import build_default_registry
+from waypoint.backends.transcripts import (
+    TranscriptUnavailableError,
+    ensure_symlink_shared,
+    ensure_thread_available,
+)
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+TID = "11111111-1111-1111-1111-111111111111"
+
+
+def _plugin(backend: str) -> BackendPlugin:
+    return build_default_registry().get(backend)
+
+
+def _session(backend: str) -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id="s1",
+        backend=backend,
+        source=SessionSource.MANAGED,
+        title="t",
+        cwd="/repo/app",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/r",
+        structured_log_path="/e",
+        transport_state={"thread_id": TID},
+    )
+
+
+def _write_claude_thread(config_dir: Path, project: str = "-repo-app") -> Path:
+    proj = config_dir / "projects" / project
+    proj.mkdir(parents=True)
+    path = proj / f"{TID}.jsonl"
+    path.write_text("{}")
+    return path
+
+
+def _write_codex_rollout(config_dir: Path) -> Path:
+    day = config_dir / "sessions" / "2026" / "07" / "08"
+    day.mkdir(parents=True)
+    path = day / f"rollout-2026-07-08T00-00-00-{TID}.jsonl"
+    path.write_text("{}")
+    return path
+
+
+# ── require_existing ────────────────────────────────────────────────────────
+
+
+def test_require_existing_noop_when_present(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    _write_claude_thread(target)
+    # Already visible under the target -> returns without touching anything.
+    ensure_thread_available(
+        _plugin("claude_code"),
+        _session("claude_code"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(target),
+        policy="require_existing",
+        shared_transcript_dir=None,
+        native_thread_store="projects",
+    )
+
+
+def test_require_existing_rejects_when_absent(tmp_path: Path) -> None:
+    with pytest.raises(TranscriptUnavailableError, match="require_existing"):
+        ensure_thread_available(
+            _plugin("claude_code"),
+            _session("claude_code"),
+            current_config_dir=str(tmp_path / "current"),
+            target_config_dir=str(tmp_path / "target"),
+            policy="require_existing",
+            shared_transcript_dir=None,
+            native_thread_store="projects",
+        )
+
+
+# ── copy_thread_on_switch ───────────────────────────────────────────────────
+
+
+def test_copy_thread_on_switch_copies_codex_rollout(tmp_path: Path) -> None:
+    current = tmp_path / "current"
+    target = tmp_path / "target"
+    src = _write_codex_rollout(current)
+    ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(current),
+        target_config_dir=str(target),
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+    )
+    dest = target / src.relative_to(current)
+    assert dest.is_file()
+    # Copied only the one artifact, with restrictive perms.
+    assert oct(dest.stat().st_mode)[-3:] == "600"
+    assert _plugin("codex").native_thread_artifacts(_session("codex"), str(target))
+
+
+def test_copy_thread_on_switch_rejects_when_source_missing(tmp_path: Path) -> None:
+    with pytest.raises(TranscriptUnavailableError, match="not found to copy"):
+        ensure_thread_available(
+            _plugin("codex"),
+            _session("codex"),
+            current_config_dir=str(tmp_path / "current"),
+            target_config_dir=str(tmp_path / "target"),
+            policy="copy_thread_on_switch",
+            shared_transcript_dir=None,
+            native_thread_store="sessions",
+        )
+
+
+# ── symlink_shared (guarded conversion) ─────────────────────────────────────
+
+
+def test_symlink_shared_creates_symlink_when_missing(tmp_path: Path) -> None:
+    store = tmp_path / "target" / "projects"
+    shared = tmp_path / "shared"
+    ensure_symlink_shared(store, shared)
+    assert store.is_symlink()
+    assert store.resolve() == shared.resolve()
+
+
+def test_symlink_shared_idempotent_on_correct_symlink(tmp_path: Path) -> None:
+    store = tmp_path / "target" / "projects"
+    shared = tmp_path / "shared"
+    ensure_symlink_shared(store, shared)
+    ensure_symlink_shared(store, shared)  # no error on second run
+    assert store.resolve() == shared.resolve()
+
+
+def test_symlink_shared_rejects_wrong_symlink(tmp_path: Path) -> None:
+    store = tmp_path / "target" / "projects"
+    store.parent.mkdir(parents=True)
+    store.symlink_to(tmp_path / "elsewhere", target_is_directory=True)
+    with pytest.raises(TranscriptUnavailableError, match="not the configured"):
+        ensure_symlink_shared(store, tmp_path / "shared")
+
+
+def test_symlink_shared_replaces_empty_real_dir(tmp_path: Path) -> None:
+    store = tmp_path / "target" / "projects"
+    store.mkdir(parents=True)
+    ensure_symlink_shared(store, tmp_path / "shared")
+    assert store.is_symlink()
+
+
+def test_symlink_shared_refuses_nonempty_real_dir(tmp_path: Path) -> None:
+    store = tmp_path / "target" / "projects"
+    store.mkdir(parents=True)
+    (store / "keep.jsonl").write_text("{}")
+    with pytest.raises(TranscriptUnavailableError, match="non-empty"):
+        ensure_symlink_shared(store, tmp_path / "shared")
+
+
+def test_symlink_shared_end_to_end_makes_thread_visible(tmp_path: Path) -> None:
+    # Shared dir already holds the thread (the current profile also points here);
+    # symlinking the target's projects dir at it makes the thread visible.
+    shared = tmp_path / "shared"
+    (shared / "-repo-app").mkdir(parents=True)
+    (shared / "-repo-app" / f"{TID}.jsonl").write_text("{}")
+    target = tmp_path / "target"
+    ensure_thread_available(
+        _plugin("claude_code"),
+        _session("claude_code"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(target),
+        policy="symlink_shared",
+        shared_transcript_dir=str(shared),
+        native_thread_store="projects",
+    )
+    assert (target / "projects").is_symlink()
+    assert _plugin("claude_code").native_thread_artifacts(
+        _session("claude_code"), str(target)
+    )
+
+
+def test_symlink_shared_rechecks_and_rejects_when_shared_lacks_thread(
+    tmp_path: Path,
+) -> None:
+    # Shared dir is empty, so after symlinking the thread still isn't visible;
+    # the re-check turns that into a clear failure rather than a false success.
+    with pytest.raises(TranscriptUnavailableError, match="still unavailable"):
+        ensure_thread_available(
+            _plugin("claude_code"),
+            _session("claude_code"),
+            current_config_dir=str(tmp_path / "current"),
+            target_config_dir=str(tmp_path / "target"),
+            policy="symlink_shared",
+            shared_transcript_dir=str(tmp_path / "shared"),
+            native_thread_store="projects",
+        )


### PR DESCRIPTION
## Purpose

Phase 3b of per-session account/config-profile switching (Relates to #230). A config-dir profile switch can only resume if the target profile's state root can see the session's native thread transcript. This adds the **primitives** that make it visible — the artifact locator and the three transcript policies applied locally. The switch that drives them (and remote/SSH copy) land in later phases; this PR is foundational and fully unit-tested in isolation.

## Changes

### Backend

- `backend/src/waypoint/backends/base.py` — new `BackendPlugin.native_thread_artifacts(session, config_dir=None) -> list[Path]`: the on-disk artifact file(s) needed to resume the session's native thread, resolved under an arbitrary config root. Returns `[]` when the thread isn't present under that root (the signal a target profile can't yet see it) or the backend has no resumable store.
- `backend/src/waypoint/backends/claude_code/threads.py` — `claude_projects_root(config_dir=None)` now accepts an explicit config dir; new `local_claude_thread_artifacts(thread_id, config_dir=None)` reuses the existing scan-all-project-dirs resolution (the encoding is lossy).
- `backend/src/waypoint/backends/codex/usage_source.py` — `_find_rollout_path` generalized into public `find_codex_rollout(thread_id, codex_home=None)`.
- `backend/src/waypoint/backends/{claude_code,codex}/plugin.py` — implement `native_thread_artifacts` (claude: `projects/*/<tid>.jsonl`; codex: `sessions/*/*/*/rollout-*-<tid>.jsonl`). `claude_tty` delegates to the wrapped claude agent; `tmux`/`opencode` return `[]` (a transport isn't the artifact target — dispatch is by `session.backend`; opencode has no config-dir store).
- `backend/src/waypoint/backends/transcripts.py` (new) — `ensure_thread_available(...)` runs the locate → check-target → apply-policy → re-check sequence and raises `TranscriptUnavailableError` (before anything is terminated) when the thread still isn't available. `require_existing` verifies without mutating; `ensure_symlink_shared` does the guarded, non-destructive store-dir conversion (missing → create, correct symlink → no-op, wrong symlink → error, empty real dir → replace, non-empty real dir → error); `copy_thread_artifacts` copies only the passed artifact set to the same relative path under the target, with `0600`/`0700` perms.

## Design

Per-backend path logic stays in each plugin's `native_thread_artifacts`; the policy engine calls it polymorphically twice (under the current root to copy *from*, under the target root to verify), so there's no per-backend branching in `transcripts.py`. The module raises a domain error rather than an `HTTPException` so it stays framework-free; the switch phase's runtime helper will translate it to a 400. `symlink_shared` is deliberately non-destructive — a populated real store dir is refused with a pointer to `accounts setup-transcripts` (the migration command lands with the CLI phase) rather than silently converted. The final re-check turns a policy that didn't actually expose the thread (e.g. `symlink_shared` when the shared dir is empty) into a clear failure instead of a false success.

Scope: local launch targets only. Remote `copy_thread_on_switch` over SSH, and the `update_launch_settings` runtime helper / live API that call `ensure_thread_available` before terminating a session, are later phases.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1539 passed, 3 warnings (pre-existing).
- New `backend/tests/test_transcripts.py` (11 cases) exercises the real claude_code/codex plugins with temp config dirs: the locator finds/misses the artifact per config root; `require_existing` is a no-op when present and rejects when absent; `copy_thread_on_switch` copies the codex rollout (with `0600` perms) and makes it visible, and rejects a missing source; `symlink_shared` covers all five guard cases plus an end-to-end make-visible and the re-check-rejects-when-shared-is-empty path. Updated `test_backend_registry.py`'s `_StubPlugin` for the new protocol method.
- Live stack e2e — not run: backend-only primitives with no runtime caller yet (the switch phase wires them in), fully covered by the filesystem unit tests; a live `waypointctl` restart would risk interrupting the Waypoint session this runs inside.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`backend/tests/test_transcripts.py`; `test_backend_registry.py` stub).
- [x] I added a `BackendPlugin` protocol method and implemented it for all backends (claude_code, codex, claude_tty, tmux, opencode); verified the registry/protocol conformance test and full suite pass. No per-backend branching in the policy engine.
- [x] No frontend changes in this phase.
- [x] Not a breaking change — new method + new module; no existing behavior altered (generalized helpers keep their prior default via `config_dir=None`).
- [x] No user-facing config change.

</details>