### PR TITLE
feat: add account/config-profile switching to the CLI

### DIFF
--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -154,6 +154,10 @@ presets_app = typer.Typer(
     help="Manage reusable session-launch presets on a running Waypoint server.",
     no_args_is_help=True,
 )
+accounts_app = typer.Typer(
+    help="Inspect configured account/config-profile switching options.",
+    no_args_is_help=True,
+)
 app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
@@ -164,6 +168,7 @@ app.add_typer(schedule_app, name="schedule")
 schedule_app.add_typer(schedule_message_app, name="message")
 app.add_typer(maintenance_app, name="maintenance")
 app.add_typer(presets_app, name="presets")
+app.add_typer(accounts_app, name="accounts")
 
 
 def _version_callback(value: bool) -> None:
@@ -1664,6 +1669,14 @@ def sessions_start(
             ),
         ),
     ] = None,
+    account_profile: Annotated[
+        str | None,
+        typer.Option(
+            "--account-profile",
+            help="Launch under this account/config profile (agent backends that "
+            "host profiles only; see `accounts list`).",
+        ),
+    ] = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Launch a new session on the running server."""
@@ -1710,6 +1723,7 @@ def sessions_start(
                 args=list(args or []),
                 tags=tags,
                 launch_env=launch_env_map,
+                account_profile_id=account_profile,
                 preset_id=preset,
                 use_default_preset=use_default,
             )
@@ -1956,6 +1970,43 @@ def sessions_set_permission_mode(
     _emit(_settings_from_ctx(ctx), _run)
 
 
+@sessions_app.command("launch-settings")
+def sessions_launch_settings(
+    ctx: typer.Context, session_id: Annotated[str, typer.Argument()]
+) -> None:
+    """Show a session's restart-applied launch settings (redacted env)."""
+    _emit(_settings_from_ctx(ctx), lambda c: c.get_launch_settings(session_id))
+
+
+@sessions_app.command("set-account")
+def sessions_set_account(
+    ctx: typer.Context,
+    session_id: Annotated[str, typer.Argument()],
+    account_profile_id: Annotated[str, typer.Argument()],
+    restart: Annotated[
+        bool,
+        typer.Option(
+            "--restart/--no-restart",
+            help="Restart the session to apply the switch (required in phase 1).",
+        ),
+    ] = True,
+) -> None:
+    """Switch a session's account/config profile via restart-and-resume.
+
+    Only structured transports whose agent maps a config-dir env var accept the
+    switch; others are rejected. The session terminates and resumes its thread
+    under the new profile's config dir.
+    """
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: {
+            "session": c.update_launch_settings(
+                session_id, account_profile_id=account_profile_id, restart=restart
+            )
+        },
+    )
+
+
 @sessions_app.command("interrupt")
 def sessions_interrupt(
     ctx: typer.Context, session_id: Annotated[str, typer.Argument()]
@@ -2180,6 +2231,14 @@ def sessions_import(
             ),
         ),
     ] = None,
+    account_profile: Annotated[
+        str | None,
+        typer.Option(
+            "--account-profile",
+            help="Import (list + resume) under this account/config profile "
+            "(see `accounts list`).",
+        ),
+    ] = None,
 ) -> None:
     """Import a backend-native thread into Waypoint.
 
@@ -2193,6 +2252,8 @@ def sessions_import(
         body["import_history"] = import_history
     if launch_env is not None:
         body["launch_env"] = _parse_launch_env(launch_env)
+    if account_profile is not None:
+        body["account_profile_id"] = account_profile
     if not body.get("thread_id"):
         raise typer.BadParameter("pass --thread-id or a --json body with thread_id")
     _emit(
@@ -2823,6 +2884,14 @@ def schedule_create(
         str | None,
         typer.Option(help="ISO 8601 datetime at which to launch the session."),
     ] = None,
+    account_profile: Annotated[
+        str | None,
+        typer.Option(
+            "--account-profile",
+            help="Launch under this account/config profile (agent backends that "
+            "host profiles only; see `accounts list`).",
+        ),
+    ] = None,
     args: Annotated[list[str] | None, typer.Argument()] = None,
 ) -> None:
     """Schedule a session launch on the running server."""
@@ -2857,6 +2926,7 @@ def schedule_create(
                 delay_seconds=delay_seconds,
                 scheduled_at=scheduled_at,
                 launch_env=launch_env_map,
+                account_profile_id=account_profile,
                 preset_id=preset,
                 use_default_preset=use_default,
             )
@@ -2891,6 +2961,7 @@ def _preset_spec_payload(
     model: str | None,
     effort: str | None,
     permission_mode: str | None,
+    account_profile_id: str | None,
     args: list[str] | None,
     config_override: list[str] | None,
     launch_env: list[str] | None,
@@ -2910,6 +2981,7 @@ def _preset_spec_payload(
         ("model", model),
         ("effort", effort),
         ("permission_mode", permission_mode),
+        ("account_profile_id", account_profile_id),
     ):
         if value is not None:
             spec[key] = value
@@ -2941,6 +3013,13 @@ _PresetConfigOverrideOption = Annotated[
 _PresetTagOption = Annotated[
     list[str] | None,
     typer.Option("--tag", help="Tag as key=value (or a bare key). Repeatable."),
+]
+_PresetAccountProfileOption = Annotated[
+    str | None,
+    typer.Option(
+        "--account-profile",
+        help="Account/config profile to launch under (see `accounts list`).",
+    ),
 ]
 
 
@@ -2983,6 +3062,7 @@ def presets_create(
     model: Annotated[str | None, typer.Option()] = None,
     effort: Annotated[str | None, typer.Option()] = None,
     permission_mode: Annotated[str | None, typer.Option()] = None,
+    account_profile: _PresetAccountProfileOption = None,
     launch_env: _PresetLaunchEnvOption = None,
     config_override: _PresetConfigOverrideOption = None,
     tag: _PresetTagOption = None,
@@ -2997,6 +3077,7 @@ def presets_create(
         model=model,
         effort=effort,
         permission_mode=permission_mode,
+        account_profile_id=account_profile,
         args=args,
         config_override=config_override,
         launch_env=launch_env,
@@ -3024,6 +3105,7 @@ def presets_update(
     model: Annotated[str | None, typer.Option()] = None,
     effort: Annotated[str | None, typer.Option()] = None,
     permission_mode: Annotated[str | None, typer.Option()] = None,
+    account_profile: _PresetAccountProfileOption = None,
     launch_env: _PresetLaunchEnvOption = None,
     config_override: _PresetConfigOverrideOption = None,
     tag: _PresetTagOption = None,
@@ -3038,6 +3120,7 @@ def presets_update(
         model=model,
         effort=effort,
         permission_mode=permission_mode,
+        account_profile_id=account_profile,
         args=args,
         config_override=config_override,
         launch_env=launch_env,
@@ -3092,6 +3175,61 @@ def presets_default(
 def presets_clear_default(ctx: typer.Context) -> None:
     """Clear the default preset (leaves all presets in place)."""
     _emit(_settings_from_ctx(ctx), lambda c: c.clear_default_session_preset())
+
+
+@accounts_app.command("list")
+def accounts_list(
+    ctx: typer.Context,
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            callback=_validate_backend,
+            autocompletion=_complete_backend,
+            help="Only list profiles for this backend.",
+        ),
+    ] = None,
+    launch_target_id: Annotated[
+        str | None,
+        typer.Option(
+            help="Resolve target-merged profiles for a launch target (e.g. a "
+            "remote host) rather than the local defaults."
+        ),
+    ] = None,
+) -> None:
+    """List configured account/config profiles (redacted; ids, labels, config-dir keys).
+
+    Only agent backends that host profiles (claude_code, codex) appear. With a
+    launch target the profiles are target-merged; without one they are the local
+    defaults from the backend catalogue.
+    """
+
+    def run(c: WaypointClient) -> Any:
+        if launch_target_id is not None:
+            profiles_by_backend: dict[str, list[dict[str, Any]]] = {}
+            for target in c.get_me().get("launch_targets", []):
+                if target.get("id") == launch_target_id:
+                    profiles_by_backend = target.get("account_profiles_by_backend", {})
+                    break
+            else:
+                raise WaypointError(f"unknown launch target: {launch_target_id}")
+            accounts = [
+                {"backend": backend_id, "profiles": profiles}
+                for backend_id, profiles in profiles_by_backend.items()
+                if backend is None or backend_id == backend
+            ]
+        else:
+            accounts = [
+                {
+                    "backend": descriptor["id"],
+                    "profiles": descriptor["account_profiles"],
+                }
+                for descriptor in c.list_backends()
+                if descriptor.get("account_profiles")
+                and (backend is None or descriptor["id"] == backend)
+            ]
+        return {"accounts": accounts}
+
+    _emit(_settings_from_ctx(ctx), run)
 
 
 @schedule_message_app.command("list")

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -239,6 +239,10 @@ class WaypointClient:
         ]
         return data
 
+    def get_me(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("GET", "/api/me").json()
+        return data
+
     def list_models(
         self,
         backend: str,
@@ -304,6 +308,7 @@ class WaypointClient:
         config_overrides: list[str] | None = None,
         tags: dict[str, str] | None = None,
         launch_env: dict[str, str] | None = None,
+        account_profile_id: str | None = None,
         preset_id: str | None = None,
         use_default_preset: bool = False,
     ) -> dict[str, Any]:
@@ -323,6 +328,7 @@ class WaypointClient:
             ("worktree_path", worktree_path),
             ("launch_mode", launch_mode),
             ("transport", transport),
+            ("account_profile_id", account_profile_id),
             ("preset_id", preset_id),
         ):
             if value is not None:
@@ -451,6 +457,41 @@ class WaypointClient:
             "POST",
             f"/api/sessions/{session_id}/mode",
             json={"mode": mode},
+        ).json()["session"]
+        return data
+
+    def get_launch_settings(self, session_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "GET", f"/api/sessions/{session_id}/launch-settings"
+        ).json()
+        return data
+
+    def update_launch_settings(
+        self,
+        session_id: str,
+        *,
+        account_profile_id: str | None = None,
+        args: list[str] | None = None,
+        config_overrides: list[str] | None = None,
+        env_set: dict[str, str] | None = None,
+        env_unset: list[str] | None = None,
+        restart: bool = False,
+    ) -> dict[str, Any]:
+        # Omitted args/config_overrides are left unchanged server-side; only send
+        # the fields the caller set so the PATCH is a true partial update.
+        body: dict[str, Any] = {"restart": restart}
+        if account_profile_id is not None:
+            body["account_profile_id"] = account_profile_id
+        if args is not None:
+            body["args"] = args
+        if config_overrides is not None:
+            body["config_overrides"] = config_overrides
+        if env_set:
+            body["env_set"] = env_set
+        if env_unset:
+            body["env_unset"] = env_unset
+        data: dict[str, Any] = self._request(
+            "PATCH", f"/api/sessions/{session_id}/launch-settings", json=body
         ).json()["session"]
         return data
 
@@ -698,6 +739,7 @@ class WaypointClient:
         delay_seconds: int | None = None,
         scheduled_at: str | None = None,
         launch_env: dict[str, str] | None = None,
+        account_profile_id: str | None = None,
         preset_id: str | None = None,
         use_default_preset: bool = False,
     ) -> dict[str, Any]:
@@ -719,6 +761,7 @@ class WaypointClient:
             "delay_seconds": delay_seconds,
             "scheduled_at": scheduled_at,
             "launch_env": launch_env,
+            "account_profile_id": account_profile_id,
             "preset_id": preset_id,
         }
         body.update(

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -3007,3 +3007,440 @@ def test_schedule_message_clear_history_with_session_id(
     )
     assert result.exit_code == 0
     assert state["params"]["session_id"] == "s1"
+
+
+# ── account-profile launch surfaces ───────────────────────────────────────────
+
+
+def test_sessions_start_account_profile_sends_request_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "POST":
+            body = json.loads(request.content)
+            state["create_body"] = body
+            return httpx.Response(200, json={"session": {"id": "new", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp/repo",
+            "--account-profile",
+            "work",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["create_body"]
+    assert isinstance(body, dict)
+    assert body["account_profile_id"] == "work"
+
+
+def test_sessions_start_omits_account_profile_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions" and request.method == "POST":
+            body = json.loads(request.content)
+            state["create_body"] = body
+            return httpx.Response(200, json={"session": {"id": "new", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "start",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp/repo",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["create_body"]
+    assert isinstance(body, dict)
+    # Omitted, not sent as null, so the preset/server default still applies.
+    assert "account_profile_id" not in body
+
+
+def test_schedule_create_account_profile_sends_request_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/schedules" and request.method == "POST":
+            body = json.loads(request.content)
+            state["schedule_body"] = body
+            return httpx.Response(200, json={"schedule": {"id": "sc1", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "schedule",
+            "create",
+            "--backend",
+            "codex",
+            "--cwd",
+            "/tmp/repo",
+            "--delay-seconds",
+            "60",
+            "--account-profile",
+            "work",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["schedule_body"]
+    assert isinstance(body, dict)
+    assert body["account_profile_id"] == "work"
+
+
+def test_presets_create_account_profile_in_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/session-presets" and request.method == "POST":
+            body = json.loads(request.content)
+            state["preset_body"] = body
+            return httpx.Response(200, json={"preset": {"id": "p1", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "presets",
+            "create",
+            "--name",
+            "work-preset",
+            "--backend",
+            "codex",
+            "--account-profile",
+            "work",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["preset_body"]
+    assert isinstance(body, dict)
+    assert body["spec"]["account_profile_id"] == "work"
+
+
+def test_sessions_import_account_profile_in_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/codex/sessions/import":
+            body = json.loads(request.content)
+            state["import_body"] = body
+            return httpx.Response(200, json={"session": {"id": "new", **body}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "import",
+            "codex",
+            "--thread-id",
+            "11111111-1111-1111-1111-111111111111",
+            "--account-profile",
+            "work",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["import_body"]
+    assert isinstance(body, dict)
+    assert body["account_profile_id"] == "work"
+
+
+def test_sessions_set_account_patches_launch_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/sessions/s1/launch-settings"
+            and request.method == "PATCH"
+        ):
+            body = json.loads(request.content)
+            state["patch_body"] = body
+            return httpx.Response(
+                200,
+                json={"session": {"id": "s1", "account_profile_id": "work"}},
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "set-account",
+            "s1",
+            "work",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert state["patch_body"] == {"restart": True, "account_profile_id": "work"}
+    assert json.loads(result.stdout)["session"]["account_profile_id"] == "work"
+
+
+def test_sessions_set_account_no_restart_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/launch-settings":
+            state["patch_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"session": {"id": "s1"}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "set-account",
+            "s1",
+            "work",
+            "--no-restart",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = state["patch_body"]
+    assert isinstance(body, dict)
+    assert body["restart"] is False
+
+
+def test_sessions_launch_settings_emits_get(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if (
+            request.url.path == "/api/sessions/s1/launch-settings"
+            and request.method == "GET"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "backend": "codex",
+                    "transport": "codex_app_server",
+                    "account_profile_id": "work",
+                    "launch_env_keys": ["CODEX_HOME"],
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "launch-settings",
+            "s1",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["account_profile_id"] == "work"
+    assert payload["launch_env_keys"] == ["CODEX_HOME"]
+
+
+def test_accounts_list_from_backends(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends":
+            return httpx.Response(
+                200,
+                json={
+                    "backends": [
+                        {
+                            "id": "codex",
+                            "account_profiles": [
+                                {
+                                    "id": "work",
+                                    "label": "Work",
+                                    "config_dir_key": "CODEX_HOME",
+                                }
+                            ],
+                        },
+                        {"id": "opencode", "account_profiles": []},
+                    ]
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "accounts", "list"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    # Backends without profiles are dropped.
+    assert payload == {
+        "accounts": [
+            {
+                "backend": "codex",
+                "profiles": [
+                    {"id": "work", "label": "Work", "config_dir_key": "CODEX_HOME"}
+                ],
+            }
+        ]
+    }
+
+
+def test_accounts_list_filter_backend(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends":
+            return httpx.Response(
+                200,
+                json={
+                    "backends": [
+                        {
+                            "id": "codex",
+                            "account_profiles": [
+                                {
+                                    "id": "work",
+                                    "label": "W",
+                                    "config_dir_key": "CODEX_HOME",
+                                }
+                            ],
+                        },
+                        {
+                            "id": "claude_code",
+                            "account_profiles": [
+                                {
+                                    "id": "personal",
+                                    "label": "P",
+                                    "config_dir_key": "CLAUDE_CONFIG_DIR",
+                                }
+                            ],
+                        },
+                    ]
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        ["--config", str(_config(tmp_path)), "accounts", "list", "--backend", "codex"],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert [a["backend"] for a in payload["accounts"]] == ["codex"]
+
+
+def test_accounts_list_launch_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/me":
+            return httpx.Response(
+                200,
+                json={
+                    "launch_targets": [
+                        {
+                            "id": "ssh-box",
+                            "account_profiles_by_backend": {
+                                "codex": [
+                                    {
+                                        "id": "work",
+                                        "label": "Work",
+                                        "config_dir_key": "CODEX_HOME",
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "accounts",
+            "list",
+            "--launch-target-id",
+            "ssh-box",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["accounts"] == [
+        {
+            "backend": "codex",
+            "profiles": [
+                {"id": "work", "label": "Work", "config_dir_key": "CODEX_HOME"}
+            ],
+        }
+    ]
+
+
+def test_accounts_list_unknown_launch_target_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/me":
+            return httpx.Response(200, json={"launch_targets": []})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", _fake_client_factory(handler))
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "accounts",
+            "list",
+            "--launch-target-id",
+            "nope",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "unknown launch target" in result.output

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -41,6 +41,18 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
         if request.url.path == "/api/sessions/s1/tags" and request.method == "PATCH":
             state["tags_body"] = json.loads(request.content)
             return httpx.Response(200, json={"session": {"id": "s1", "tags": {}}})
+        if request.url.path == "/api/sessions/s1/launch-settings":
+            if request.method == "GET":
+                return httpx.Response(
+                    200,
+                    json={"backend": "codex", "account_profile_id": "work"},
+                )
+            if request.method == "PATCH":
+                state["launch_settings_body"] = json.loads(request.content)
+                return httpx.Response(
+                    200,
+                    json={"session": {"id": "s1", "account_profile_id": "work"}},
+                )
         if request.url.path == "/api/backends" and request.method == "GET":
             return httpx.Response(
                 200, json={"backends": [{"id": "claude_code"}, {"id": "codex"}]}
@@ -421,6 +433,43 @@ def test_create_session_posts_payload(
         session = client.create_session(backend="codex", cwd="/tmp", model="gpt-5")
     assert session["backend"] == "codex"
     assert session["model"] == "gpt-5"
+
+
+def test_create_session_includes_account_profile_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.create_session(backend="codex", account_profile_id="work")
+    assert state["session_create"]["account_profile_id"] == "work"
+
+
+def test_get_launch_settings_returns_payload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        settings = client.get_launch_settings("s1")
+    assert settings == {"backend": "codex", "account_profile_id": "work"}
+
+
+def test_update_launch_settings_sends_only_set_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        session = client.update_launch_settings(
+            "s1", account_profile_id="work", restart=True
+        )
+    # Unset args/config_overrides/env are omitted so the PATCH is a true partial.
+    assert state["launch_settings_body"] == {
+        "restart": True,
+        "account_profile_id": "work",
+    }
+    assert session["account_profile_id"] == "work"
 
 
 def test_send_input_uploads_attachments_and_sends_ids(


### PR DESCRIPTION
## Purpose

Phase 5 of per-session account/config-profile switching (Relates to #230) — surface the phase-4 backend (live launch-settings switch, #237) through the HTTP CLI so profiles are usable without the frontend. Every launch surface can pin a profile at creation, a running session can be switched in place, and the configured profiles are discoverable.

## Changes

### Backend

- `backend/src/waypoint/client.py` — `get_launch_settings`/`update_launch_settings` (GET/PATCH `/api/sessions/{id}/launch-settings`; the PATCH sends only the fields the caller set so it stays a true partial update), `get_me` (GET `/api/me` for target-merged profiles), and an `account_profile_id` argument threaded into `create_session` and `create_schedule` (omitted when unset so a preset/server default still applies).
- `backend/src/waypoint/cli.py` — new `accounts list [--backend] [--launch-target-id]` (redacted profiles from the backend catalogue, or target-merged from `/api/me`); `sessions launch-settings SID` (GET projection) and `sessions set-account SID PROFILE [--restart/--no-restart]` (the in-place switch); and an `--account-profile` option on `sessions start`, `schedule create`, `presets create`/`update` (into the preset spec), and `sessions import`.

## Design

The CLI is a thin transport over the already-merged endpoints — no new server behavior. `set-account` defaults `--restart` to true because phase-1 switching requires a restart; the gate/verification all live server-side. `accounts list` reads the redacted `{id, label, config_dir_key}` metadata only (never paths, keys, or transcript policy), and drops backends that host no profiles. Output stays JSON-only via the existing `_emit` path, consistent with the other read commands.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1566 passed, 3 warnings (pre-existing).
- New CLI tests (`backend/tests/test_cli.py`): `--account-profile` reaches the request body on start/schedule/import and the preset spec on presets create; it is omitted (not null) when unset; `set-account` PATCHes `{restart, account_profile_id}` and honors `--no-restart`; `launch-settings` emits the GET projection; `accounts list` projects from the catalogue, filters by backend, resolves a launch target, and errors on an unknown target.
- New client tests (`backend/tests/test_client.py`): `create_session` carries `account_profile_id`; `get_launch_settings` returns the payload; `update_launch_settings` sends only the set fields.
- Live stack e2e — not run in this PR; the CLI drives endpoints already e2e-verified for codex in #237. A claude/claude_tty switch e2e is tracked as a follow-up.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`backend/tests/test_cli.py`, `backend/tests/test_client.py`).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the CLI/client are backend-agnostic; profile hosting is decided server-side, so no per-backend branch was added.
- [x] No frontend changes in this phase (the launch-panel/composer profile UI is a later phase).
- [x] Not a breaking change — additive client methods, CLI commands, and optional flags; existing invocations are unchanged.
- [x] No user-facing config default changed.

</details>