### PR TITLE
fix: relaunch the pane when switching launch settings on claude_tty

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1881,11 +1881,17 @@ class SessionRuntime:
 
         # Terminate → persist new settings → restore. terminate/restore cycle the
         # rate-limit watcher; restore rebuilds env from the persisted record, so
-        # the account is fixed by the (already-verified) launch_env.
+        # the account is fixed by the (already-verified) launch_env. Mark the
+        # record EXITED before restore: the process is gone, and a pane-wrapping
+        # transport (claude_tty) only relaunches on an EXITED reattach — without
+        # this it would take the boot-time branch, keep the dead pane, and reject
+        # the next input with "can't find pane". Native transports (claude_cli,
+        # codex) relaunch unconditionally, so this is a no-op for them.
         await plugin.terminate_session(self, session)
         await self._cancel_context_usage_source(session.id)
         self.storage.update_session(
             session.id,
+            status=SessionStatus.EXITED,
             args=new_args,
             config_overrides=new_config_overrides,
             launch_env=new_env,

--- a/backend/tests/test_launch_settings.py
+++ b/backend/tests/test_launch_settings.py
@@ -234,6 +234,37 @@ async def test_update_rejects_noop_account_switch(
     assert "same account" in str(getattr(exc.value, "detail", ""))
 
 
+async def test_switch_marks_exited_before_restore(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: a pane-wrapping transport (claude_tty) only relaunches on an
+    # EXITED reattach, so the switch must persist EXITED before restore — else
+    # restore keeps the dead pane and the next input fails "can't find pane".
+    # An env-only edit reaches terminate→persist→restore without the
+    # account-probe branch.
+    runtime = _runtime(tmp_path)
+    _session(runtime, status=SessionStatus.IDLE)
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+    seen: dict[str, Any] = {}
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_self_rt: Any, session: SessionRecord) -> None:
+        # Capture the status the transport is asked to restore from, then
+        # simulate a healthy relaunch so the post-restore gate passes.
+        seen["restore_status"] = session.status
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+
+    await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(env_set={"FOO": "bar"}, restart=True)
+    )
+    assert seen["restore_status"] == SessionStatus.EXITED
+
+
 async def test_update_rejects_config_overrides_when_unsupported(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Purpose

Fix a claude_tty-specific bug in the account/launch-settings switch (Relates to #230), surfaced by a live claude_tty switch e2e. The switch is transport-agnostic and was verified for codex (#237) and now claude native, but claude_tty was left with a dead tmux pane after a switch.

## Changes

### Backend

- `backend/src/waypoint/runtime.py` — in `update_launch_settings`, persist `status=EXITED` before `restore_session` in the terminate → persist → restore cycle. `terminate_session` tears down the process but does not change the record's status; a pane-wrapping transport (claude_tty) only relaunches its tmux pane on an EXITED reattach, otherwise `restore_session` assumes the pane is still alive and just restarts the tailer. Without this the switch left a dead pane and the next input failed with `can't find pane: %NNN`. Native transports (claude_cli, codex) relaunch unconditionally from the persisted record, so this is a no-op for them.

## Design

`restore_session` is intentionally status-branched for claude_tty: on a boot-time restore the tmux server usually outlives the waypoint process, so the pane is still there and only the tailer needs re-arming; only an EXITED reattach relaunches. The switch always kills the pane, so it must present the honest post-terminate state (EXITED) for restore to relaunch. Marking EXITED here reflects reality and keeps the post-restore failure gate correct — a successful relaunch transitions the record back to a live status, and a genuine restore failure stays EXITED/ERROR and is surfaced.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1567 passed, 3 warnings (pre-existing).
- New regression `backend/tests/test_launch_settings.py::test_switch_marks_exited_before_restore`: mocks terminate/restore and asserts `restore_session` observes `EXITED` for an env-only switch (the path that reaches terminate → persist → restore without the account-probe branch).
- Live e2e (ephemeral backend on a spare port, isolated config-dir clones, never the main stack): **claude native (claude_cli) full switch PASS** — launch under one profile, materialize the transcript, switch to a copy-on-switch profile, resume the same thread under the new `CLAUDE_CONFIG_DIR`, and a post-switch turn grows the copied transcript; **no-op-account reject PASS** (400). For **claude_tty**, this fix removes the `can't find pane` failure — the pane now relaunches under the new profile and the thread resumes and is copied into the target config dir. A post-switch turn does not reliably complete in the *resumed* headless TUI within the harness (the pre-switch turn does), so the second-turn completion on tty was verified only up to pane relaunch + thread resume; that residual is a headless-TUI-on-resume harness limitation, not a switch defect.

> Note: the generic `tmux` transport shares the identical `status != EXITED` restore branching, so this same change also fixes the dead-pane case there; claude_tty is just where the e2e surfaced it.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`backend/tests/test_launch_settings.py`).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the fix is in the generic switch path and stays backend-agnostic (no per-backend branch); it simply presents the correct post-terminate status so each transport's own `restore_session` does the right thing.
- [x] No frontend changes.
- [x] Not a breaking change — corrects the restart-and-resume state for pane-wrapping transports; native transports are unaffected.
- [x] No user-facing config default changed.

</details>
