### PR TITLE
fix: add transcript response submit shortcuts

### DIFF
--- a/frontend/src/components/ApprovalCard.tsx
+++ b/frontend/src/components/ApprovalCard.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
 
+import { isModifiedEnterShortcut } from "@/lib/keyboard";
 import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 import { CopyMessageButton } from "@/components/CopyMessageButton";
@@ -67,6 +74,22 @@ export function SharedApprovalCard({
     }
   }
 
+  function handleNoteKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (!isModifiedEnterShortcut(event)) {
+      return;
+    }
+    event.preventDefault();
+    if (pendingAction) {
+      return;
+    }
+    const primaryAction =
+      actions.find((action) => action.className === "primary") ?? actions[0];
+    if (!primaryAction) {
+      return;
+    }
+    void handleAction(primaryAction);
+  }
+
   const cardClassName = `panel approval${className ? ` ${className}` : ""}`;
 
   return (
@@ -84,8 +107,10 @@ export function SharedApprovalCard({
               className="ask-question-note-input"
               value={noteText}
               onChange={(event) => setNoteText(event.target.value)}
+              onKeyDown={handleNoteKeyDown}
               placeholder={notePlaceholder}
               rows={2}
+              aria-keyshortcuts="Meta+Enter Control+Enter"
             />
             <button
               type="button"

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 
 import type { LaunchForm } from "@/components/LaunchFormFields";
 import { humaniseBackend } from "@/lib/backends";
+import { trapTabFocus } from "@/lib/keyboard";
 import type {
   Backend,
   SessionPresetSpec,
@@ -369,23 +370,7 @@ function PresetSaveModal({
         onClose();
         return;
       }
-      if (event.key !== "Tab") return;
-      const root = modalRef.current;
-      if (!root) return;
-      const focusable = root.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) return;
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-      if (event.shiftKey && (active === first || !root.contains(active))) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
-        event.preventDefault();
-        first.focus();
-      }
+      trapTabFocus(event, modalRef.current);
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);

--- a/frontend/src/components/ScheduleMessageModal.tsx
+++ b/frontend/src/components/ScheduleMessageModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { createMessageSchedule } from "@/lib/api";
+import { trapTabFocus } from "@/lib/keyboard";
 
 interface ScheduleMessageModalProps {
   host: string;
@@ -69,29 +70,7 @@ export function ScheduleMessageModal({
         onClose();
         return;
       }
-      if (event.key !== "Tab") {
-        return;
-      }
-      const root = modalRef.current;
-      if (!root) {
-        return;
-      }
-      const focusable = root.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), input:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) {
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-      if (event.shiftKey && (active === first || !root.contains(active))) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
-        event.preventDefault();
-        first.focus();
-      }
+      trapTabFocus(event, modalRef.current);
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -68,6 +68,7 @@ import {
 } from "@/lib/backends";
 import { clearToken } from "@/lib/store";
 import { type TerminalSubmitResult } from "@/lib/composer";
+import { isModifiedEnterShortcut } from "@/lib/keyboard";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import { useFileMentions } from "@/lib/use-file-mentions";
 import { useCopied } from "@/lib/use-copied";
@@ -2791,12 +2792,7 @@ const ReplyComposer = memo(function ReplyComposer({
     if (handleSuggestionKey(event)) {
       return;
     }
-    // Treat Cmd+Enter (mac) and Ctrl+Enter (windows/linux) as the send
-    // shortcut. Plain Enter inserts a newline as expected.
-    if (event.key !== "Enter" || event.shiftKey) {
-      return;
-    }
-    if (!event.metaKey && !event.ctrlKey) {
+    if (!isModifiedEnterShortcut(event)) {
       return;
     }
     event.preventDefault();

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { connectSessionsSocket, fetchSessions } from "@/lib/api";
+import { trapTabFocus } from "@/lib/keyboard";
 import { matchesQuery, parseQuery } from "@/lib/search";
 import { SessionEnvelope, SessionRecord } from "@/lib/types";
 import { SearchInput } from "@/components/SearchInput";
@@ -173,25 +174,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
     }
 
     if (e.key === "Tab") {
-      const root = modalRef.current;
-      if (!root) return;
-      const focusable = root.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) {
-        e.preventDefault();
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-      if (e.shiftKey && (active === first || !root.contains(active))) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && (active === last || !root.contains(active))) {
-        e.preventDefault();
-        first.focus();
-      }
+      trapTabFocus(e, modalRef.current, { preventWhenEmpty: true });
       return;
     }
 

--- a/frontend/src/components/SshConnectModal.tsx
+++ b/frontend/src/components/SshConnectModal.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { PasswordInput } from "@/components/PasswordInput";
+import { trapTabFocus } from "@/lib/keyboard";
 
 interface SshConnectModalProps {
   targetName: string;
@@ -42,29 +43,7 @@ export function SshConnectModal({
         onCancel();
         return;
       }
-      if (event.key !== "Tab") {
-        return;
-      }
-      const root = modalRef.current;
-      if (!root) {
-        return;
-      }
-      const focusable = root.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-      if (focusable.length === 0) {
-        return;
-      }
-      const first = focusable[0];
-      const last = focusable[focusable.length - 1];
-      const active = document.activeElement;
-      if (event.shiftKey && (active === first || !root.contains(active))) {
-        event.preventDefault();
-        last.focus();
-      } else if (!event.shiftKey && (active === last || !root.contains(active))) {
-        event.preventDefault();
-        first.focus();
-      }
+      trapTabFocus(event, modalRef.current);
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -23,6 +23,7 @@ import { CommandSuggestions } from "@/components/CommandSuggestions";
 import { FileMentions } from "@/components/FileMentions";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
 import { type TerminalSubmitResult } from "@/lib/composer";
+import { isModifiedEnterShortcut } from "@/lib/keyboard";
 import { useCommandCompletions } from "@/lib/composer-completions";
 import { useFileMentions } from "@/lib/use-file-mentions";
 
@@ -221,8 +222,7 @@ export function TerminalCompose({
         window.setTimeout(refocusTerminal, 0);
         return;
       }
-      if (event.key !== "Enter" || event.shiftKey) return;
-      if (!event.metaKey && !event.ctrlKey) return;
+      if (!isModifiedEnterShortcut(event)) return;
       event.preventDefault();
       send();
     },

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -4,6 +4,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type KeyboardEvent,
 } from "react";
 
 import {
@@ -12,6 +13,7 @@ import {
   humaniseBackend,
   type BackendCatalog,
 } from "@/lib/backends";
+import { isModifiedEnterShortcut } from "@/lib/keyboard";
 import { EventRecord, SessionTransport } from "@/lib/types";
 import {
   normalizeToolName,
@@ -940,6 +942,18 @@ function AskUserQuestionCard({
   );
   const totalNotes = Object.values(notes).filter((value) => value.trim()).length;
   const interactive = Boolean(onAnswer) && !answered;
+  const canSubmit = interactive && !submitting && (totalPicked > 0 || totalNotes > 0);
+
+  function handleNoteKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
+    if (!isModifiedEnterShortcut(event)) {
+      return;
+    }
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    void submit();
+  }
 
   return (
     <article className="panel transcript codex tool_call ask-user-question">
@@ -1010,9 +1024,11 @@ function AskUserQuestionCard({
                         [index]: e.target.value,
                       }))
                     }
+                    onKeyDown={handleNoteKeyDown}
                     placeholder="Type your own answer or add a note here…"
                     rows={2}
                     disabled={submitting}
+                    aria-keyshortcuts="Meta+Enter Control+Enter"
                   />
                   <button
                     type="button"
@@ -1062,7 +1078,7 @@ function AskUserQuestionCard({
           <button
             type="button"
             className="primary"
-            disabled={submitting || (totalPicked === 0 && totalNotes === 0)}
+            disabled={!canSubmit}
             onClick={() => void submit()}
           >
             {submitting ? "Sending…" : "Send answers"}

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { commandLabel } from "@/components/CommandSuggestions";
 import { fetchSessionCompletionsResponse } from "@/lib/api";
+import { isInlineMenuAcceptKey } from "@/lib/keyboard";
 import type {
   CommandCompletion,
   SessionCommandInvocation,
@@ -278,12 +279,7 @@ export function useCommandCompletions({
     event: KeyboardEvent<HTMLTextAreaElement>,
   ): boolean {
     if (!suggestionsOpen) return false;
-    if (
-      event.key === "Tab" ||
-      (event.key === "Enter" &&
-        !(event.metaKey || event.ctrlKey) &&
-        !event.shiftKey)
-    ) {
+    if (isInlineMenuAcceptKey(event)) {
       event.preventDefault();
       applySuggestion(activeIndex);
       return true;

--- a/frontend/src/lib/keyboard.ts
+++ b/frontend/src/lib/keyboard.ts
@@ -1,0 +1,72 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+type KeyboardEventLike = Pick<
+  globalThis.KeyboardEvent,
+  "ctrlKey" | "key" | "metaKey" | "shiftKey"
+> & {
+  isComposing?: boolean;
+  nativeEvent?: {
+    isComposing?: boolean;
+  };
+};
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function isComposingKeyEvent(event: KeyboardEventLike): boolean {
+  return event.isComposing === true || event.nativeEvent?.isComposing === true;
+}
+
+export function isModifiedEnterShortcut(
+  event: ReactKeyboardEvent<HTMLTextAreaElement>,
+): boolean {
+  if (isComposingKeyEvent(event)) {
+    return false;
+  }
+  return event.key === "Enter" && !event.shiftKey && (event.metaKey || event.ctrlKey);
+}
+
+export function isUnmodifiedEnterKey(event: KeyboardEventLike): boolean {
+  return (
+    !isComposingKeyEvent(event) &&
+    event.key === "Enter" &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey
+  );
+}
+
+export function isInlineMenuAcceptKey(event: KeyboardEventLike): boolean {
+  return event.key === "Tab" || isUnmodifiedEnterKey(event);
+}
+
+export function trapTabFocus(
+  event: globalThis.KeyboardEvent,
+  root: HTMLElement | null,
+  options: { preventWhenEmpty?: boolean; selector?: string } = {},
+): boolean {
+  if (event.key !== "Tab" || !root) {
+    return false;
+  }
+  const focusable = root.querySelectorAll<HTMLElement>(
+    options.selector ?? FOCUSABLE_SELECTOR,
+  );
+  if (focusable.length === 0) {
+    if (options.preventWhenEmpty) {
+      event.preventDefault();
+      return true;
+    }
+    return false;
+  }
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  const active = document.activeElement;
+  if (event.shiftKey && (active === first || !root.contains(active))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && (active === last || !root.contains(active))) {
+    event.preventDefault();
+    first.focus();
+  }
+  return true;
+}

--- a/frontend/src/lib/use-file-mentions.ts
+++ b/frontend/src/lib/use-file-mentions.ts
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { wordRangeAt } from "@/lib/composer-completions";
 import { fetchSessionAttachments } from "@/lib/api";
+import { isInlineMenuAcceptKey } from "@/lib/keyboard";
 import type { SessionAttachment } from "@/lib/types";
 
 interface UseFileMentionsOptions {
@@ -133,12 +134,7 @@ export function useFileMentions({
 
   function handleKey(event: KeyboardEvent<HTMLTextAreaElement>): boolean {
     if (!open) return false;
-    if (
-      event.key === "Tab" ||
-      (event.key === "Enter" &&
-        !(event.metaKey || event.ctrlKey) &&
-        !event.shiftKey)
-    ) {
+    if (isInlineMenuAcceptKey(event)) {
       event.preventDefault();
       apply(activeIndex);
       return true;


### PR DESCRIPTION
## Summary
- Add a neutral `frontend/src/lib/keyboard.ts` utility for reusable keyboard behavior
- Reuse `isModifiedEnterShortcut` for chat composer, terminal quick-compose, approval/plan notes, and AskUserQuestion custom responses
- Reuse inline-menu and Tab focus-trap helpers across completions, file mentions, and modal/switcher focus loops
- Preserve newline behavior, IME composition guards, pending/empty guards, and add aria-keyshortcuts metadata to the new response fields

## Verification
- `cd frontend && . /home/noppanat/.nvm/nvm.sh && npm run lint`
- `cd frontend && . /home/noppanat/.nvm/nvm.sh && NEXT_PUBLIC_BACKEND_PORT=8787 npm run build`

Note: `npm run build` needs unsandboxed execution here because `next.config.ts` calls `os.networkInterfaces()` and the sandbox blocks `uv_interface_addresses`.