### PR TITLE
fix: resume the same thread across an account switch on pane transports

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -536,6 +536,7 @@ class AgentLaunchContract(Protocol):
         thread_id: str,
         cwd: str,
         launch_target: "SshLaunchTargetConfig | None",
+        config_dir: str | None = None,
     ) -> bool:
         """Whether the agent has persisted ``thread_id`` to disk yet.
 
@@ -543,7 +544,12 @@ class AgentLaunchContract(Protocol):
         input; resuming a never-written thread makes the CLI exit with "no
         conversation found", so callers gate resume on this. Checks the
         local filesystem, or the remote one over SSH when ``launch_target``
-        is set.
+        is set. ``config_dir`` overrides the agent's state root (the value of
+        its ``config_dir_env_var`` in the session's launch env, e.g.
+        ``CLAUDE_CONFIG_DIR``/``CODEX_HOME``); ``None`` uses the default. A
+        pane-wrapping transport that resumes under a switched account profile
+        must pass it, or the check reads the default root and the thread is
+        never found — forking a new conversation instead of resuming.
         """
         ...
 
@@ -596,6 +602,7 @@ class DefaultLaunchContract:
         thread_id: str,
         cwd: str,
         launch_target: "SshLaunchTargetConfig | None",
+        config_dir: str | None = None,
     ) -> bool:
         return False
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -1296,7 +1296,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # otherwise the shell expands the default ``$HOME/.claude``. ``$HOME``
         # / ``$CLAUDE_CONFIG_DIR`` stay outside the quoted needle so the remote
         # shell expands them; quoting the whole path would look for a literal.
-        root = f"{shlex.quote(config_dir)}" if config_dir else "$HOME/.claude"
+        root = shlex.quote(config_dir) if config_dir else "$HOME/.claude"
         stdout = await launch_target.ssh_capture(
             f"ls {root}/projects/*/{shlex.quote(needle)} 2>/dev/null | head -n 1",
         )

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -61,6 +61,7 @@ from waypoint.backends.claude_code.support import (
 from waypoint.backends.claude_code.threads import (
     UUID_RE,
     ClaudeThreadInfo,
+    claude_projects_root,
     delete_local_claude_thread,
     find_local_claude_thread,
     list_local_claude_threads,
@@ -1276,25 +1277,28 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         thread_id: str,
         cwd: str,
         launch_target: SshLaunchTargetConfig | None,
+        config_dir: str | None = None,
     ) -> bool:
-        # ~/.claude/projects/<dashed-absolute-cwd>/<uuid>.jsonl — but the
+        # <config-dir>/projects/<dashed-absolute-cwd>/<uuid>.jsonl — but the
         # dashed key uses claude's view of the absolute cwd, which may not
         # match what we have on hand (SSH sessions carry the raw ``~/foo``
         # form; ``cd`` symlinks resolve on the remote). UUIDs are globally
         # unique under projects/, so glob across all project dirs and pick
-        # the file by name.
+        # the file by name. ``config_dir`` (the session's CLAUDE_CONFIG_DIR,
+        # e.g. a switched account profile's) overrides the default ~/.claude.
         needle = f"{thread_id}.jsonl"
         if launch_target is None:
-            projects = Path.home() / ".claude" / "projects"
+            projects = claude_projects_root(config_dir)
             if not projects.is_dir():
                 return False
             return any(projects.glob(f"*/{needle}"))
-        # ``$HOME`` must be left *outside* the quoted needle so the remote
-        # shell expands it; shlex-quoting the whole path would single-quote
-        # the dollar and look for a literal ``$HOME`` directory.
+        # A remote CLAUDE_CONFIG_DIR (unusual, but honor it) roots the search;
+        # otherwise the shell expands the default ``$HOME/.claude``. ``$HOME``
+        # / ``$CLAUDE_CONFIG_DIR`` stay outside the quoted needle so the remote
+        # shell expands them; quoting the whole path would look for a literal.
+        root = f"{shlex.quote(config_dir)}" if config_dir else "$HOME/.claude"
         stdout = await launch_target.ssh_capture(
-            f"ls $HOME/.claude/projects/*/{shlex.quote(needle)} "
-            "2>/dev/null | head -n 1",
+            f"ls {root}/projects/*/{shlex.quote(needle)} 2>/dev/null | head -n 1",
         )
         return bool(stdout.strip())
 

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -441,19 +441,34 @@ class ClaudeTtyPlugin:
                 seen.add(key)
         return completions
 
+    def _config_dir(self, session: SessionRecord) -> str | None:
+        """The session's CLAUDE_CONFIG_DIR override, if any.
+
+        A session launched under (or switched to) an account profile carries
+        its config dir in ``launch_env``; the resume-existence check must look
+        there, not the default ~/.claude, or it never finds the thread and
+        relaunches into a fresh conversation.
+        """
+        key = self._claude.capabilities.config_dir_env_var
+        return session.launch_env.get(key) if key else None
+
     async def _conversation_exists(
         self,
         thread_id: str,
         cwd: str,
         launch_target: SshLaunchTargetConfig | None,
+        config_dir: str | None = None,
     ) -> bool:
         """Whether Claude has persisted ``thread_id`` to disk.
 
-        claude_tty stores transcripts in the same ``~/.claude/projects``
-        tree claude_code uses, so the existence check defers to the composed
-        claude_code agent's launch contract.
+        claude_tty stores transcripts in the same ``projects`` tree
+        claude_code uses, so the existence check defers to the composed
+        claude_code agent's launch contract. ``config_dir`` scopes it to the
+        session's (possibly profile-switched) CLAUDE_CONFIG_DIR.
         """
-        return await self._claude.conversation_exists(thread_id, cwd, launch_target)
+        return await self._claude.conversation_exists(
+            thread_id, cwd, launch_target, config_dir
+        )
 
     # ── Session lifecycle ────────────────────────────────────────────────────
 
@@ -625,7 +640,7 @@ class ClaudeTtyPlugin:
 
         effective_thread_id: str | None = None
         if thread_id and await self._conversation_exists(
-            thread_id, session.cwd, launch_target
+            thread_id, session.cwd, launch_target, self._config_dir(session)
         ):
             effective_thread_id = thread_id
 
@@ -924,7 +939,9 @@ class ClaudeTtyPlugin:
         # with `--resume` makes the CLI exit with "no conversation found" and kills
         # the pane. Reuse the same thread id via `--session-id` in that case so the
         # relaunch starts the (still-empty) conversation cleanly with the new flags.
-        resumed = await self._conversation_exists(thread_id, session.cwd, launch_target)
+        resumed = await self._conversation_exists(
+            thread_id, session.cwd, launch_target, self._config_dir(session)
+        )
         identity = ["--resume", thread_id] if resumed else ["--session-id", thread_id]
         launch_args = [*identity, *flag_pairs, *base_args]
         command = runtime._command_for_backend(

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import shlex
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from datetime import UTC, datetime
@@ -412,12 +413,17 @@ class CodexPlugin(DefaultLaunchContract):
         thread_id: str,
         cwd: str,
         launch_target: SshLaunchTargetConfig | None,
+        config_dir: str | None = None,
     ) -> bool:
-        # $CODEX_HOME/sessions/YYYY/MM/DD/rollout-*-<uuid>.jsonl
+        # <codex-home>/sessions/YYYY/MM/DD/rollout-*-<uuid>.jsonl.
+        # ``config_dir`` (the session's CODEX_HOME, e.g. a switched account
+        # profile's) overrides the default ~/.codex.
         _ = cwd
         needle = f"-{thread_id}.jsonl"
         if launch_target is None:
-            home = Path(os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
+            home = Path(
+                config_dir or os.environ.get("CODEX_HOME") or "~/.codex"
+            ).expanduser()
             sessions_dir = home / "sessions"
             if not sessions_dir.is_dir():
                 return False
@@ -425,9 +431,11 @@ class CodexPlugin(DefaultLaunchContract):
                 entry.name.endswith(needle)
                 for entry in sessions_dir.glob("*/*/*/rollout-*.jsonl")
             )
+        root = (
+            shlex.quote(config_dir) if config_dir else '"${CODEX_HOME:-$HOME/.codex}"'
+        )
         stdout = await launch_target.ssh_capture(
-            f'ls "${{CODEX_HOME:-$HOME/.codex}}/sessions/"*/*/*/rollout-*{needle} '
-            "2>/dev/null | head -n 1",
+            f"ls {root}/sessions/*/*/*/rollout-*{needle} 2>/dev/null | head -n 1",
         )
         return bool(stdout.strip())
 

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -442,9 +442,16 @@ class TmuxPlugin:
         # ``codex resume <uuid>``: no rollout file means no thread to
         # resume. Fall back to verbatim launch args in that case.
         launch_target = runtime._find_launch_target(session.launch_target_id)
+        # Scope the resume check to the session's config dir (a switched account
+        # profile's CLAUDE_CONFIG_DIR/CODEX_HOME), else it reads the default root,
+        # never finds the thread, and relaunches into a fresh conversation.
+        config_dir_key = runtime.registry.get(
+            session.backend
+        ).capabilities.config_dir_env_var
+        config_dir = session.launch_env.get(config_dir_key) if config_dir_key else None
         effective_thread_id: str | None = None
         if thread_id and await inner.conversation_exists(
-            thread_id, session.cwd, launch_target
+            thread_id, session.cwd, launch_target, config_dir
         ):
             effective_thread_id = thread_id
         launch_args = (
@@ -895,7 +902,13 @@ class TmuxPlugin:
             if launch_env is not None
             else _default_launch_env(runtime, backend, launch_target)
         )
-        if not await inner.conversation_exists(thread_id, cwd, launch_target):
+        config_dir_key = runtime.registry.get(backend).capabilities.config_dir_env_var
+        config_dir = (
+            effective_launch_env.get(config_dir_key) if config_dir_key else None
+        )
+        if not await inner.conversation_exists(
+            thread_id, cwd, launch_target, config_dir
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(

--- a/backend/tests/test_claude_launch_contract.py
+++ b/backend/tests/test_claude_launch_contract.py
@@ -126,6 +126,31 @@ async def test_conversation_exists_local(
 
 
 @pytest.mark.asyncio
+async def test_conversation_exists_honors_config_dir(
+    plugin: ClaudeCodePlugin, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: a thread living under a switched account profile's
+    # CLAUDE_CONFIG_DIR must be found via the ``config_dir`` override, not the
+    # default ~/.claude — else a pane-wrapping transport resuming after a switch
+    # never finds it and forks a new conversation. HOME points at an *empty*
+    # default tree so a hit can only come from the override.
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    profile_dir = tmp_path / "profile"
+    cwd = "/Users/me/proj"
+    project_dir = profile_dir / "projects" / cwd.replace("/", "-")
+    project_dir.mkdir(parents=True)
+    uuid_str = "00000000-0000-0000-0000-000000000042"
+    (project_dir / f"{uuid_str}.jsonl").write_text("")
+    # Default root (no override) can't see it.
+    assert await plugin.conversation_exists(uuid_str, cwd, None) is False
+    # Scoped to the profile's config dir, it does.
+    assert (
+        await plugin.conversation_exists(uuid_str, cwd, None, str(profile_dir)) is True
+    )
+
+
+@pytest.mark.asyncio
 async def test_conversation_exists_local_no_projects_dir(
     plugin: ClaudeCodePlugin, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -14,6 +14,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -47,6 +48,12 @@ class _FakeAgentPlugin:
     def __init__(self, *, pregenerates: bool, exists: bool = False) -> None:
         self._pregenerates = pregenerates
         self.exists = exists
+        # The reconnect path reads the agent's config-dir env key (via the
+        # registry plugin's capabilities) to scope the resume-existence check
+        # to a switched profile's config dir.
+        self.capabilities = SimpleNamespace(
+            config_dir_env_var="CLAUDE_CONFIG_DIR" if pregenerates else "CODEX_HOME"
+        )
 
     def launch_flags(
         self,
@@ -94,7 +101,11 @@ class _FakeAgentPlugin:
         return ["resume", thread_id, *scrubbed]
 
     async def conversation_exists(
-        self, thread_id: str, cwd: str, launch_target: Any
+        self,
+        thread_id: str,
+        cwd: str,
+        launch_target: Any,
+        config_dir: str | None = None,
     ) -> bool:
         return self.exists
 


### PR DESCRIPTION
## Purpose

Fix a correctness defect in per-session account/config-profile switching (Relates to #230), found while confirming the claude_tty switch end-to-end. The switch is meant to *restart and resume* the same thread under the new config dir; for the pane-wrapping transports (claude_tty and the generic tmux wrapper) it silently *forked a new thread* instead, orphaning the copied transcript. Follow-up to #237 (the switch) and #239 (pane relaunch).

## Changes

### Backend

- `backend/src/waypoint/backends/base.py` — `AgentLaunchContract.conversation_exists` (and the `DefaultLaunchContract` default) gain an optional `config_dir: str | None = None` overriding the agent's state root.
- `backend/src/waypoint/backends/claude_code/plugin.py` — `conversation_exists` resolves the projects root via `claude_projects_root(config_dir)` instead of a hardcoded `~/.claude/projects` (local and SSH branches).
- `backend/src/waypoint/backends/codex/plugin.py` — same, honoring `config_dir` as the `CODEX_HOME` override.
- `backend/src/waypoint/backends/claude_tty/plugin.py` — a `_config_dir(session)` helper reads the session's `CLAUDE_CONFIG_DIR` from `launch_env`; the restore and fork resume-existence checks pass it through.
- `backend/src/waypoint/backends/tmux/plugin.py` — the two reconnect/import resume-existence checks pass the wrapped agent's config-dir override (from `launch_env`, via the agent plugin's `config_dir_env_var`).

## Design

`conversation_exists` gates `--resume <id>` (a never-persisted thread makes the CLI exit with "no conversation found"). claude_cli/codex *native* restore resumes the persisted thread id unconditionally, so it was unaffected — which is why that e2e passed. The pane transports relaunch a fresh CLI and must re-check the thread on disk; checking the default root after a switch never found the thread (it now lives under the target profile's config dir), so they fell back to `--session-id <new>`. Passing the session's config-dir override scopes the check correctly. `config_dir=None` preserves the default-root behavior for every non-switched session.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1568 passed, 3 warnings (pre-existing).
- New `test_conversation_exists_honors_config_dir` (`backend/tests/test_claude_launch_contract.py`): a thread under a profile's config dir is invisible to the default-root lookup and found via the `config_dir` override; `test_tmux_plugin.py`'s agent double updated to carry `capabilities.config_dir_env_var` and the new param.
- Live e2e (ephemeral backend, isolated config-dir clones, main stack untouched): a **claude_tty account switch now keeps the same thread id** across launch → switch → post-switch turn (`d47dd730…` throughout), and the post-switch turn **appends to the resumed transcript** under the target config dir (`secondary/<same-id>.jsonl` grew from 1 → 2 replies) instead of forking a new `<new-id>.jsonl`. Before this fix the same run forked a new thread and left the copy orphaned.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (`test_claude_launch_contract.py`, `test_tmux_plugin.py`).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the fix stays backend-agnostic — the config-dir key comes from each agent's `config_dir_env_var` capability, no per-backend branch.
- [x] No frontend changes.
- [x] Not a breaking change — `config_dir` defaults to None (prior default-root behavior); only the pane-transport resume-after-switch path changes.
- [x] No user-facing config default changed.

</details>