### PR TITLE
feat: account-profile selection and display in the web UI

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1848,6 +1848,12 @@ html[data-theme="light"] .badge.transport.opencode_http {
   text-transform: lowercase;
 }
 
+.badge.account-profile {
+  color: var(--accent-cool, var(--accent));
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
 .status {
   color: var(--success);
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -65,6 +65,7 @@ import {
 } from "@/lib/store";
 import { launchableAgents, useBackendCatalog } from "@/lib/backends";
 import {
+  AccountProfile,
   AssistantSummary,
   Backend,
   BackendDescriptor,
@@ -206,6 +207,21 @@ export default function HomePage() {
       defaults[backend] = { ...env };
     }
     return defaults;
+  }, [activeLaunchTarget, backendDescriptors]);
+
+  // Account profiles keyed by backend: the global per-backend catalogue,
+  // overridden by the active launch target's merged profiles (same shape as
+  // defaultLaunchEnvByBackend above).
+  const accountProfilesByBackend = useMemo(() => {
+    const profiles: Record<Backend, AccountProfile[]> = {};
+    for (const descriptor of backendDescriptors ?? []) {
+      profiles[descriptor.id] = descriptor.account_profiles ?? [];
+    }
+    const targetProfiles = activeLaunchTarget?.account_profiles_by_backend ?? {};
+    for (const [backend, list] of Object.entries(targetProfiles)) {
+      profiles[backend] = list;
+    }
+    return profiles;
   }, [activeLaunchTarget, backendDescriptors]);
 
   const resetAuthState = useCallback((message: string) => {
@@ -570,6 +586,7 @@ export default function HomePage() {
     launchEnv: Record<string, string> = {},
     permissionMode: string | null = null,
     presetId: string | null = null,
+    accountProfileId: string | null = null,
   ) {
     setCwdError(null);
     try {
@@ -586,6 +603,7 @@ export default function HomePage() {
         model,
         effort,
         permission_mode: permissionMode,
+        account_profile_id: accountProfileId,
         // Provenance only — the fields above are already resolved.
         preset_id: presetId,
       });
@@ -632,6 +650,7 @@ export default function HomePage() {
               launchEnv,
               permissionMode,
               presetId,
+              accountProfileId,
             ),
         });
         return;
@@ -1060,6 +1079,7 @@ export default function HomePage() {
           defaultBackend={effectiveDefaultBackend}
           defaultCwd={effectiveDefaultCwd}
           defaultLaunchEnvByBackend={defaultLaunchEnvByBackend}
+          accountProfilesByBackend={accountProfilesByBackend}
           targetLabel={activeLaunchTarget?.name ?? null}
           launchTargetId={activeLaunchTargetId || null}
           recentCwds={recentCwds}

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -25,6 +25,7 @@ import { WorkingDirectoryField } from "@/components/WorkingDirectoryField";
 import type { BackendCatalog } from "@/lib/backends";
 import { permissionModesFor } from "@/lib/backends";
 import {
+  AccountProfile,
   Backend,
   BackendModelListResponse,
   SessionPresetSpec,
@@ -36,6 +37,9 @@ interface UseLaunchFormParams {
   defaultCwd: string;
   launchTargetId: string | null;
   defaultLaunchEnvByBackend: Record<Backend, Record<string, string>>;
+  // Account/config profiles keyed by backend — target-merged when a launch
+  // target is active, else the global per-backend catalogue.
+  accountProfilesByBackend: Record<Backend, AccountProfile[]>;
   catalog: BackendCatalog;
 }
 
@@ -58,6 +62,9 @@ export interface LaunchForm {
   setTransport: Dispatch<SetStateAction<SessionTransport>>;
   permissionMode: string;
   setPermissionMode: (value: string) => void;
+  accountProfileId: string;
+  setAccountProfileId: (value: string) => void;
+  accountProfiles: AccountProfile[];
   customArgsText: string;
   setCustomArgsText: (value: string) => void;
   configOverridesText: string;
@@ -85,6 +92,7 @@ export function useLaunchForm({
   defaultCwd,
   launchTargetId,
   defaultLaunchEnvByBackend,
+  accountProfilesByBackend,
   catalog,
 }: UseLaunchFormParams): LaunchForm {
   const [backend, setBackend] = useState<Backend>(defaultBackend);
@@ -94,6 +102,7 @@ export function useLaunchForm({
   const [effort, setEffort] = useState("");
   const [transport, setTransport] = useTransportForAgent(backend, catalog);
   const [permissionMode, setPermissionMode] = useState<string>("default");
+  const [accountProfileId, setAccountProfileId] = useState("");
   const [customArgsText, setCustomArgsText] = useState("");
   const [configOverridesText, setConfigOverridesText] = useState("");
   const [launchEnvText, setLaunchEnvText] = useState(() =>
@@ -104,6 +113,11 @@ export function useLaunchForm({
   const permissionOptions = useMemo(
     () => permissionModesFor(backend, catalog),
     [backend, catalog],
+  );
+
+  const accountProfiles = useMemo(
+    () => accountProfilesByBackend[backend] ?? [],
+    [accountProfilesByBackend, backend],
   );
 
   const capabilities = catalog.byId(backend)?.capabilities;
@@ -119,6 +133,7 @@ export function useLaunchForm({
     setModel("");
     setEffort("");
     setModelInfo(null);
+    setAccountProfileId("");
     setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[nextBackend]));
   }, [defaultLaunchEnvByBackend]);
 
@@ -127,6 +142,7 @@ export function useLaunchForm({
     setModel("");
     setEffort("");
     setModelInfo(null);
+    setAccountProfileId("");
     setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[defaultBackend]));
   }, [defaultBackend, defaultLaunchEnvByBackend]);
 
@@ -146,6 +162,7 @@ export function useLaunchForm({
     setEffort("");
     setModel("");
     setModelInfo(null);
+    setAccountProfileId("");
     setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[backend]));
   }, [backend, launchTargetId, defaultLaunchEnvByBackend]);
 
@@ -176,6 +193,7 @@ export function useLaunchForm({
       const applyScoped = () => {
         setModel(spec.model ?? "");
         setEffort(spec.effort ?? "");
+        setAccountProfileId(spec.account_profile_id ?? "");
         setLaunchEnvText(formatLaunchEnv(spec.launch_env ?? {}));
         if (spec.transport) setTransport(spec.transport);
       };
@@ -256,6 +274,9 @@ export function useLaunchForm({
     setTransport,
     permissionMode,
     setPermissionMode,
+    accountProfileId,
+    setAccountProfileId,
+    accountProfiles,
     customArgsText,
     setCustomArgsText,
     configOverridesText,
@@ -345,6 +366,22 @@ export function LaunchFormFields({
                 {form.permissionOptions.map((option) => (
                   <option key={option.id} value={option.id}>
                     {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          ) : null}
+          {form.accountProfiles.length > 0 ? (
+            <label className="field">
+              <span>Account</span>
+              <select
+                value={form.accountProfileId}
+                onChange={(event) => form.setAccountProfileId(event.target.value)}
+              >
+                <option value="">Default</option>
+                {form.accountProfiles.map((profile) => (
+                  <option key={profile.id} value={profile.id}>
+                    {profile.label}
                   </option>
                 ))}
               </select>

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -239,6 +239,18 @@ export function useLaunchForm({
     }
   }, [effort, effortOptions, modelInfo]);
 
+  // Drop a selected profile the current backend/target doesn't offer (e.g. a
+  // preset carrying a profile valid elsewhere) so the launch never submits an
+  // id the server would reject; falls back to the "Default" option.
+  useEffect(() => {
+    if (
+      accountProfileId &&
+      !accountProfiles.some((profile) => profile.id === accountProfileId)
+    ) {
+      setAccountProfileId("");
+    }
+  }, [accountProfileId, accountProfiles]);
+
   const handleModelsLoaded = useCallback((response: BackendModelListResponse) => {
     setModelInfo(response);
   }, []);

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -18,6 +18,7 @@ import { ResumeThreadPanel } from "@/components/ResumeThreadPanel";
 import type { BackendCatalog } from "@/lib/backends";
 import { humaniseBackend } from "@/lib/backends";
 import {
+  AccountProfile,
   Backend,
   ScheduleCreateRequest,
   SessionPreset,
@@ -48,6 +49,7 @@ interface LaunchPanelProps {
   defaultBackend: Backend;
   defaultCwd: string;
   defaultLaunchEnvByBackend: Record<Backend, Record<string, string>>;
+  accountProfilesByBackend: Record<Backend, AccountProfile[]>;
   targetLabel: string | null;
   launchTargetId: string | null;
   recentCwds: string[];
@@ -67,6 +69,7 @@ interface LaunchPanelProps {
     launchEnv: Record<string, string>,
     permissionMode: string | null,
     presetId: string | null,
+    accountProfileId: string | null,
   ) => Promise<void>;
   onAttach: (
     target: string,
@@ -108,6 +111,7 @@ export function LaunchPanel({
   defaultBackend,
   defaultCwd,
   defaultLaunchEnvByBackend,
+  accountProfilesByBackend,
   targetLabel,
   launchTargetId,
   recentCwds,
@@ -135,6 +139,7 @@ export function LaunchPanel({
     defaultBackend,
     defaultCwd,
     defaultLaunchEnvByBackend,
+    accountProfilesByBackend,
     launchTargetId,
     catalog,
   });
@@ -201,6 +206,7 @@ export function LaunchPanel({
         launchEnv,
         form.permissionMode || null,
         selectedPresetId,
+        form.accountProfileId || null,
       );
       form.setTitle("");
     } finally {
@@ -242,6 +248,7 @@ export function LaunchPanel({
       // Record which preset seeded this schedule (provenance only; the fields
       // above are the resolved values the server persists).
       preset_id: selectedPresetId,
+      account_profile_id: form.accountProfileId || null,
     };
     if (scheduleTiming === "delay") {
       const minutes = Number.parseFloat(delayMinutes);

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -20,6 +20,7 @@ function SpecSummary({ spec }: { spec: SessionPresetSummary["spec"] }) {
   if (spec.model) chips.push(spec.model);
   if (spec.effort) chips.push(spec.effort);
   if (spec.permission_mode) chips.push(spec.permission_mode);
+  if (spec.account_profile_id) chips.push(spec.account_profile_id);
   const envCount = spec.launch_env_keys?.length ?? 0;
   if (envCount) chips.push(`${envCount} env`);
   const argsCount = spec.args?.length ?? 0;
@@ -62,6 +63,7 @@ function formSpec(
     model: form.model.trim() || null,
     effort: form.effortSupported ? form.effort.trim() || null : null,
     permission_mode: form.permissionMode || null,
+    account_profile_id: form.accountProfileId || null,
     args,
     config_overrides: configOverrides,
     launch_env: launchEnv,

--- a/frontend/src/components/ScheduledSessionsPanel.tsx
+++ b/frontend/src/components/ScheduledSessionsPanel.tsx
@@ -173,6 +173,14 @@ function ScheduleRow({
             {schedule.effort}
           </span>
         ) : null}
+        {schedule.account_profile_label ? (
+          <span
+            className="badge account-profile"
+            title={`Account: ${schedule.account_profile_label}`}
+          >
+            {schedule.account_profile_label}
+          </span>
+        ) : null}
         <span className="msg-row-right">
           <span className="msg-row-when">
             {relative ? <span className="msg-countdown">{relative}</span> : null}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -4113,6 +4113,14 @@ function SessionHeader({
             {session.effort}
           </span>
         ) : null}
+        {session.account_profile_label ? (
+          <span
+            className="badge account-profile"
+            title={`Account: ${session.account_profile_label}`}
+          >
+            {session.account_profile_label}
+          </span>
+        ) : null}
         {!assistant ? (
           <span className="session-header-meta">
             {sourceLabel}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -218,6 +218,11 @@ export function SessionList({
             {session.launch_target_id ? (
               <span className="badge neutral">{session.launch_target_id}</span>
             ) : null}
+            {session.account_profile_label ? (
+              <span className="badge account-profile">
+                {session.account_profile_label}
+              </span>
+            ) : null}
             <span className={`status ${session.status}`}>
               {session.status.replace("_", " ")}
             </span>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,10 +17,12 @@ import {
   InboxItem,
   InboxQuestionAnswer,
   InboxStatus,
+  LaunchSettingsUpdate,
   MeResponse,
   MessageSchedule,
   ScheduleCreateRequest,
   ScheduledSession,
+  SessionLaunchSettings,
   SessionCompletionsResponse,
   SessionCommandInvocation,
   SessionAttachment,
@@ -478,6 +480,41 @@ export async function setSessionPermissionMode(
     body: JSON.stringify({ mode }),
   });
   await ensureOk(response, "failed to update permission mode");
+  const body = await response.json();
+  return body.session as SessionRecord;
+}
+
+export async function fetchLaunchSettings(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionLaunchSettings> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/launch-settings`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  await ensureOk(response, "failed to load launch settings");
+  return (await response.json()) as SessionLaunchSettings;
+}
+
+export async function updateLaunchSettings(
+  host: string,
+  token: string,
+  sessionId: string,
+  update: LaunchSettingsUpdate,
+): Promise<SessionRecord> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/launch-settings`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(update),
+    },
+  );
+  await ensureOk(response, "failed to update launch settings");
   const body = await response.json();
   return body.session as SessionRecord;
 }

--- a/frontend/src/lib/backends.ts
+++ b/frontend/src/lib/backends.ts
@@ -24,6 +24,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { fetchBackends } from "@/lib/api";
 import type {
+  AccountProfile,
   AgentCapabilities,
   Backend,
   BackendCapabilities,
@@ -51,6 +52,9 @@ export interface BackendCatalog {
   // Pulled from `byId(id)?.label`, with a humane fallback so a backend
   // that disappears mid-session still renders something sensible.
   labelFor: (id: Backend) => string;
+  // Global (non-target-merged) account profiles a backend hosts; empty when it
+  // hosts none. A launch target's merged profiles override this at the panel.
+  accountProfilesFor: (id: Backend) => AccountProfile[];
 }
 
 const FALLBACK_LABELS: Record<string, string> = {
@@ -132,6 +136,7 @@ export function buildCatalog(descriptors: BackendDescriptor[]): BackendCatalog {
     all: () => [...descriptors],
     ids: () => descriptors.map((d) => d.id),
     labelFor: (id) => byIdMap.get(id)?.label ?? FALLBACK_LABELS[id] ?? id,
+    accountProfilesFor: (id) => byIdMap.get(id)?.account_profiles ?? [],
   };
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -100,6 +100,10 @@ export interface SessionRecord {
   rate_limit_usage?: SessionRateLimitUsage | null;
   args: string[];
   config_overrides: string[];
+  // The account/config profile the session launched under (and resumes under
+  // across a switch); null when the backend hosts no profiles.
+  account_profile_id?: string | null;
+  account_profile_label?: string | null;
 }
 
 export type AttachmentKind = "image" | "file";
@@ -133,6 +137,15 @@ export interface BackendPermissionMode {
   label: string;
   description?: string | null;
   requires_session_restart?: boolean;
+}
+
+// Redacted account/config-profile metadata. Never carries the config-dir path,
+// expected account key, or transcript policy — display id/label plus the
+// config-dir env key the profile maps to.
+export interface AccountProfile {
+  id: string;
+  label: string;
+  config_dir_key: string;
 }
 
 export interface BackendSlashCommand {
@@ -264,6 +277,9 @@ export interface BackendDescriptor {
   label: string;
   badges: Record<string, string>;
   default_launch_env?: Record<string, string>;
+  // Redacted account/config profiles this agent hosts (claude_code, codex);
+  // empty for backends that don't. Target-merged variants live on `/api/me`.
+  account_profiles?: AccountProfile[];
   // The flat union, kept for back-compat; prefer composing `agent_capabilities`
   // with `transport_capabilities` via `capsFor()` for an (agent, transport) pair.
   capabilities: BackendCapabilities;
@@ -325,6 +341,7 @@ export interface SessionPresetSpec {
   model?: string | null;
   effort?: string | null;
   tags?: Record<string, string>;
+  account_profile_id?: string | null;
 }
 
 // Redacted spec used on list / bootstrap surfaces: env values are omitted,
@@ -341,6 +358,7 @@ export interface SessionPresetSpecSummary {
   model?: string | null;
   effort?: string | null;
   tags?: Record<string, string>;
+  account_profile_id?: string | null;
 }
 
 export interface SessionPresetSummary {
@@ -370,6 +388,34 @@ export interface SessionPresetWriteRequest {
   is_default?: boolean;
 }
 
+// GET /api/sessions/{id}/launch-settings — a session's restart-applied launch
+// settings (env redacted to keys). Drives the running-session profile switch.
+export interface SessionLaunchSettings {
+  backend: Backend;
+  transport: SessionTransport;
+  launch_target_id?: string | null;
+  account_profile_id?: string | null;
+  account_profile_label?: string | null;
+  account_profiles: AccountProfile[];
+  args: string[];
+  config_overrides: string[];
+  launch_env_keys: string[];
+  supports_custom_args: boolean;
+  supports_config_overrides: boolean;
+  supports_account_profile_with_restart: boolean;
+}
+
+// PATCH body for the same endpoint; omitted fields are left unchanged. `restart`
+// must be true to switch a running session (phase 1).
+export interface LaunchSettingsUpdate {
+  account_profile_id?: string | null;
+  args?: string[];
+  config_overrides?: string[];
+  env_set?: Record<string, string>;
+  env_unset?: string[];
+  restart: boolean;
+}
+
 export interface EventsPage {
   events: EventRecord[];
   has_more: boolean;
@@ -388,6 +434,9 @@ export interface LaunchTargetSummary {
   auth?: "key" | "password";
   connected?: boolean;
   default_launch_env_by_backend?: Record<Backend, Record<string, string>>;
+  // Target-merged account profiles keyed by agent backend id; only backends
+  // that host profiles appear.
+  account_profiles_by_backend?: Record<Backend, AccountProfile[]>;
 }
 
 export type ScheduleStatus = "pending" | "launched" | "cancelled" | "failed";
@@ -411,6 +460,8 @@ export interface ScheduledSession {
   status: ScheduleStatus;
   session_id?: string | null;
   failure_reason?: string | null;
+  account_profile_id?: string | null;
+  account_profile_label?: string | null;
 }
 
 export interface ScheduleCreateRequest {
@@ -434,6 +485,7 @@ export interface ScheduleCreateRequest {
   // Provenance only — the frontend submits already-resolved fields; sending the
   // selected preset id lets the server stamp it onto the scheduled record.
   preset_id?: string | null;
+  account_profile_id?: string | null;
 }
 
 export interface BackendModelOption {


### PR DESCRIPTION
## Purpose

Phase 6 of per-session account/config-profile switching (Relates to #230) — bring profiles to the web UI: choose an account profile when launching or scheduling a session, carry it in presets, and see which profile a session runs under. Frontend for the backend shipped in #231–#241. The running-session *in-place* switch (the GUI mirror of `sessions set-account`) is a tracked follow-up.

## Changes

### Frontend

- `src/lib/types.ts` — `AccountProfile {id,label,config_dir_key}`; `account_profiles` on `BackendDescriptor`, `account_profiles_by_backend` on `LaunchTargetSummary`, `account_profile_id`/`account_profile_label` on `SessionRecord`/`ScheduledSession`, `account_profile_id` on the preset spec + schedule request; a `SessionLaunchSettings` GET shape and `LaunchSettingsUpdate` PATCH body.
- `src/lib/api.ts` — `fetchLaunchSettings` (GET) and `updateLaunchSettings` (PATCH) clients.
- `src/lib/backends.ts` — `accountProfilesFor(backend)` catalog accessor.
- `src/components/LaunchFormFields.tsx` + `LaunchPanel.tsx` + `src/app/page.tsx` — an **Account** selector in the launch/schedule form, shown only for backends that host profiles; the choice flows into the create-session and schedule payloads and hydrates from presets. Profiles are the global per-backend catalogue, overridden by the active launch target's merged profiles (same derivation as `defaultLaunchEnvByBackend`).
- `src/components/PresetBar.tsx` — presets capture and summarize the account profile.
- `src/components/SessionDetail.tsx`, `SessionList.tsx`, `ScheduledSessionsPanel.tsx`, `src/app/globals.css` — an account-profile badge on the session header, list cards, and scheduled rows, styled as a flat `.badge.account-profile` in the cool accent hue (both themes).

## Design

The selector reuses the existing flat `.field` select; the badge reuses the `.badge` base with a token that resolves in both themes — no new layout, so it follows the flat-instruments design language without bespoke CSS. Everything is gated on a backend actually hosting profiles, so backends without them (opencode, tmux) render exactly as before. The account choice is additive on every request; omitting it preserves current behavior.

## Test Plan

- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Test Result

- `tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npm run build` — succeeds (all 10 routes generated).
- Live visual validation deferred: the selector/badge only render when the backend advertises `account_profiles`, which the default dev backend does not; validated instead by type/lint/build and by reusing existing field/badge styles. The running-session in-place switch UI (which needs a live terminate+restore to exercise) is a separate follow-up.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] Frontend checks run: `npx tsc --noEmit`, `npm run lint`, `npm run build` — all clean.
- [x] No automated frontend test harness exists in this repo; validated via type-check, lint, and a production build.
- [x] No backend changes — consumes the account-profile fields already on `/api/backends`, `/api/me`, sessions, presets, and schedules.
- [x] Additive and backward-compatible — profile UI only appears for backends that host profiles; all requests omit the field when unset.
- [x] Both themes handled — the new badge derives its color from a token defined in light and dark.

</details>