### PR TITLE
feat: switch a running session's account profile from the composer

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -27,6 +27,7 @@ import {
   fetchBackendModels,
   fetchEvents,
   fetchSession,
+  fetchLaunchSettings,
   forkSession,
   isAuthError,
   postAction,
@@ -38,6 +39,7 @@ import {
   setSessionPermissionMode,
   setSessionPinned,
   setSessionTitle,
+  updateLaunchSettings,
 } from "@/lib/api";
 import {
   agentTransports,
@@ -114,6 +116,7 @@ import { readTodoEntries, summarizeTodos } from "@/lib/todos";
 import { effortLabel, formatResolvedModelLabel } from "@/lib/modelDisplay";
 import { useSwitcher } from "@/components/SwitcherProvider";
 import {
+  AccountProfile,
   Backend,
   BackendDescriptor,
   BackendModelOption,
@@ -121,6 +124,7 @@ import {
   EventRecord,
   SessionCommandInvocation,
   SessionEnvelope,
+  SessionLaunchSettings,
   SessionRecord,
   SessionTransport,
   SideQuestion,
@@ -416,6 +420,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [defaultEffort, setDefaultEffort] = useState<string | null>(null);
   const [modelBusy, setModelBusy] = useState(false);
   const [effortBusy, setEffortBusy] = useState(false);
+  const [accountBusy, setAccountBusy] = useState(false);
+  // Restart-applied launch settings, fetched lazily for backends that host
+  // account profiles — the only source of the target-merged profile list and
+  // the supports_account_profile_with_restart gate (both absent from the
+  // session record and the serialized capabilities).
+  const [accountSettings, setAccountSettings] =
+    useState<SessionLaunchSettings | null>(null);
   const [rateLimitRefreshBusy, setRateLimitRefreshBusy] = useState(false);
   const [approvalPageIndex, setApprovalPageIndex] = useState(0);
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
@@ -639,6 +650,83 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       }
     },
     [host, token, session, handleAuthFailure, confirmTurnInterrupt],
+  );
+
+  // Fetch launch settings once the session's backend is known to host account
+  // profiles, to populate the switch control's option list and gate. Static
+  // per session, so keyed on id/backend only (not the poll-churned session ref).
+  const sessionHostsProfiles = Boolean(
+    sessionBackend && catalog.accountProfilesFor(sessionBackend).length > 0,
+  );
+  useEffect(() => {
+    if (!sessionId || !sessionHostsProfiles) {
+      setAccountSettings(null);
+      return;
+    }
+    let cancelled = false;
+    fetchLaunchSettings(host, token, sessionId)
+      .then((settings) => {
+        if (!cancelled) setAccountSettings(settings);
+      })
+      .catch((settingsError) => {
+        if (cancelled) return;
+        if (isAuthError(settingsError)) {
+          handleAuthFailure();
+          return;
+        }
+        // Non-fatal: without settings the switch control just stays hidden.
+        setAccountSettings(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [host, token, sessionId, sessionHostsProfiles, handleAuthFailure]);
+
+  const handleAccountProfileChange = useCallback(
+    async (nextProfileId: string) => {
+      // Phase 1 offers switching between named profiles only; clearing back to
+      // the default config dir isn't a meaningful switch (it would resolve to
+      // the same account and be rejected), so an empty pick is a no-op.
+      if (!session || !nextProfileId) {
+        return;
+      }
+      if (nextProfileId === (session.account_profile_id ?? "")) {
+        return;
+      }
+      const label =
+        accountSettings?.account_profiles.find((p) => p.id === nextProfileId)
+          ?.label ?? nextProfileId;
+      if (
+        !window.confirm(
+          `Switch this session to the "${label}" account? It restarts and ` +
+            "resumes the current thread under the new config dir.",
+        )
+      ) {
+        return;
+      }
+      setAccountBusy(true);
+      setError("");
+      try {
+        const updated = await updateLaunchSettings(host, token, session.id, {
+          account_profile_id: nextProfileId,
+          restart: true,
+        });
+        setSession(updated);
+      } catch (switchError) {
+        if (isAuthError(switchError)) {
+          handleAuthFailure();
+          return;
+        }
+        setError(
+          switchError instanceof Error
+            ? switchError.message
+            : "failed to switch account",
+        );
+      } finally {
+        setAccountBusy(false);
+      }
+    },
+    [host, token, session, accountSettings, handleAuthFailure],
   );
 
   const flushPendingEvents = useCallback(() => {
@@ -2283,6 +2371,13 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           }}
           onDelete={removeFromList}
           onInterrupt={interruptSession}
+          accountProfiles={accountSettings?.account_profiles ?? []}
+          accountProfileId={session?.account_profile_id ?? null}
+          supportsAccountSwitch={
+            accountSettings?.supports_account_profile_with_restart ?? false
+          }
+          accountBusy={accountBusy}
+          onAccountChange={handleAccountProfileChange}
           onModeChange={handlePermissionModeChange}
           onModelChange={handleModelChange}
           onEffortChange={handleEffortChange}
@@ -2353,6 +2448,13 @@ interface ReplyComposerProps {
   currentModel: string | null;
   currentEffort: string | null;
   effortBusy: boolean;
+  // Account/config profiles the running session can switch between (target-
+  // merged), the current selection, whether the (agent, transport) supports a
+  // restart-applied switch, and the in-flight flag.
+  accountProfiles: AccountProfile[];
+  accountProfileId: string | null;
+  supportsAccountSwitch: boolean;
+  accountBusy: boolean;
   permissionMode: string | null;
   transport: SessionTransport | null;
   catalog: BackendCatalog;
@@ -2361,6 +2463,7 @@ interface ReplyComposerProps {
   // UX so the user knows the session will restart, vs. Codex which
   // applies inline.
   effortRequiresConfirm: boolean;
+  onAccountChange: (profileId: string) => void | Promise<void>;
   onDelete: () => void | Promise<void>;
   onInterrupt: () => void | Promise<void>;
   onModeChange: (mode: string) => void | Promise<void>;
@@ -2408,6 +2511,10 @@ const ReplyComposer = memo(function ReplyComposer({
   currentModel,
   currentEffort,
   effortBusy,
+  accountProfiles,
+  accountProfileId,
+  supportsAccountSwitch,
+  accountBusy,
   permissionMode,
   transport,
   catalog,
@@ -2415,6 +2522,7 @@ const ReplyComposer = memo(function ReplyComposer({
   hasToolRuns,
   toolRunsExpanded,
   onToggleToolRuns,
+  onAccountChange,
   onDelete,
   onInterrupt,
   onModeChange,
@@ -2751,11 +2859,13 @@ const ReplyComposer = memo(function ReplyComposer({
     await onEffortChange(value);
   };
 
+  const hasAccountPicker = supportsAccountSwitch && accountProfiles.length > 0;
   const assistantOps = assistant ? assistantControls : null;
   const tuneVisible =
     modeOptions.length > 0 ||
     hasModelPicker ||
     hasEffortPicker ||
+    hasAccountPicker ||
     assistantOps !== null;
   // Backend the assistant controls target — the picked one, or the current.
   const assistantTargetBackend = pendingBackend ?? session?.backend ?? null;
@@ -2848,6 +2958,12 @@ const ReplyComposer = memo(function ReplyComposer({
     }
     if (hasEffortPicker) {
       parts.push(currentEffort ? effortLabel(currentEffort) : "Default");
+    }
+    if (hasAccountPicker) {
+      const matched = accountProfiles.find(
+        (profile) => profile.id === (accountProfileId ?? ""),
+      );
+      parts.push(matched?.label ?? "Default");
     }
     return parts.join(" · ") || "Settings";
   })();
@@ -2996,6 +3112,27 @@ const ReplyComposer = memo(function ReplyComposer({
                       {modeOptions.map((option) => (
                         <option key={option.id} value={option.id}>
                           {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                ) : null}
+                {hasAccountPicker ? (
+                  <label className="composer-tune-field">
+                    <span>Account</span>
+                    <select
+                      value={accountProfileId ?? ""}
+                      onChange={(event) =>
+                        void onAccountChange(event.target.value)
+                      }
+                      disabled={accountBusy || disabled}
+                    >
+                      {accountProfileId ? null : (
+                        <option value="">Default</option>
+                      )}
+                      {accountProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.id}>
+                          {profile.label}
                         </option>
                       ))}
                     </select>

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3135,6 +3135,10 @@ const ReplyComposer = memo(function ReplyComposer({
                           {profile.label}
                         </option>
                       ))}
+                      {accountProfileId &&
+                      !accountProfiles.some((p) => p.id === accountProfileId) ? (
+                        <option value={accountProfileId}>{accountProfileId}</option>
+                      ) : null}
                     </select>
                   </label>
                 ) : null}


### PR DESCRIPTION
## Purpose

Phase 6b of per-session account/config-profile switching (Relates to #230) — the running-session in-place switch, the GUI mirror of `sessions set-account`. Completes the web UI started in #242 (which added launch/schedule/preset selection + display). Backed by the switch shipped in #237/#239/#241.

## Changes

### Frontend

- `src/components/SessionDetail.tsx` — an **Account** selector in the running-session settings ("tune") popover, shown only when the session's backend hosts profiles and the (agent, transport) supports a restart-applied switch. The option list and support gate come from a lazily-fetched `GET /api/sessions/{id}/launch-settings` (keyed on session id/backend), since neither the session record nor the serialized capabilities carry the target-merged profiles or the `supports_account_profile_with_restart` flag. Picking a different profile confirms (the switch restarts the session), then calls `PATCH …/launch-settings` with `restart: true` and adopts the returned session. The current profile also joins the popover trigger's summary line.

## Design

The handler mirrors the existing `handlePermissionModeChange` (busy flag, auth-failure handling, `setSession` on the returned record) so the running-session control set stays uniform. The switch always restarts (unlike an inline model/permission change), so it always confirms rather than only when a turn is mid-flight, and phase 1 offers switching between named profiles only — clearing back to the default config dir isn't a meaningful switch (it resolves to the same account and the server rejects it), so an empty pick is a no-op. The control is fully gated: backends without profiles, or transports that can't switch (tmux), never render it.

## Test Plan

- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

## Test Result

- `tsc --noEmit`, `npm run lint`, `npm run build` — all clean.
- Live UI validation deferred: the control only renders against a backend that advertises account profiles, which the default dev backend does not configure, so a browser check there can't exercise it. The underlying switch (terminate → resume the same thread under the new config dir, including claude_tty) is end-to-end verified at the API level in #241; this change is a thin, gated UI over that path, mirroring the permission-mode changer.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] Frontend checks run: `npx tsc --noEmit`, `npm run lint`, `npm run build` — all clean.
- [x] No automated frontend test harness exists in this repo; validated via type-check, lint, and a production build.
- [x] No backend changes — consumes the launch-settings GET/PATCH endpoints from #237.
- [x] Additive and gated — the control only appears for profile-hosting backends on switch-capable transports; every other session renders unchanged.
- [x] Reuses existing glass `.composer-tune-field` styling; no new CSS.

</details>