### PR TITLE
docs: document account/config-profile switching

### DIFF
--- a/.agents/skills/waypoint/references/auth-config.md
+++ b/.agents/skills/waypoint/references/auth-config.md
@@ -16,3 +16,11 @@ Environment overrides may affect data dir, host, port, and password.
 
 If the server is unreachable, inspect the stack with the `waypointctl` skill
 rather than guessing.
+
+## Account / config profiles
+
+Claude and Codex sessions can run under named account/config-dir profiles and
+switch between them without restarting the service. List them with `waypoint
+accounts list`, pick one at launch with `--account-profile`, and switch a running
+session with `waypoint sessions set-account <session-id> <profile>`. Full
+configuration and behavior: [`docs/account_profiles.md`](../../../../docs/account_profiles.md).

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -51,6 +51,15 @@ plugin_configs:
     #   - "--verbose"
     # config_overrides:                      # codex-only; each entry → `codex --config K=V`
     #   - 'model_reasoning_effort="high"'
+    # account_profiles:                      # named CODEX_HOME profiles; see docs/account_profiles.md
+    #   personal:
+    #     label: Personal
+    #     config_dir: ~/.codex
+    #   work:
+    #     label: Work
+    #     config_dir: ~/.codex-work
+    #     transcript_policy: copy_thread_on_switch  # require_existing | symlink_shared | copy_thread_on_switch
+    #     expected_account_key: codex:work@example.com   # gate the switch to this account (optional)
   claude_code:
     # default_model_id: opus
     # default_effort: high
@@ -63,6 +72,15 @@ plugin_configs:
     #   - id: opus
     #     label: Opus 4.7
     #     is_default: true
+    # account_profiles:                      # named CLAUDE_CONFIG_DIR profiles; see docs/account_profiles.md
+    #   personal:
+    #     label: Personal
+    #     config_dir: ~/.claude
+    #   work:
+    #     label: Work
+    #     config_dir: ~/.claude-work
+    #     transcript_policy: copy_thread_on_switch  # require_existing | symlink_shared | copy_thread_on_switch
+    #     expected_account_key: claude_code:acme-corp   # gate the switch to this account (optional)
   opencode:
     # default_model_id: anthropic/claude-sonnet-4-6
     # default_effort: high

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -1,0 +1,136 @@
+# Account / config-profile switching
+
+A single machine often has more than one account for the same coding agent — a
+personal Claude login and a work one, two Codex accounts on different plans.
+Waypoint models each as a named **account profile**: a label bound to a
+config-dir environment variable (`CLAUDE_CONFIG_DIR` for Claude, `CODEX_HOME`
+for Codex) plus a policy for how a running session's transcript follows it.
+
+You can pick a profile when launching, scheduling, or presetting a session, and
+switch a *running* session between profiles without restarting the Waypoint
+service — the session terminates and resumes the same thread under the new
+config dir (restart-and-resume).
+
+Only the agent backends that own a config-dir env var host profiles today:
+**`claude_code` and `codex`**. `opencode` and the transport wrappers do not, and
+the config parser rejects an `account_profiles` block on any other backend.
+
+## Configuring profiles
+
+Profiles live under `plugin_configs.<agent>.account_profiles` in `waypoint.yaml`,
+keyed by a profile id:
+
+```yaml
+plugin_configs:
+  claude_code:
+    account_profiles:
+      personal:
+        label: Personal
+        config_dir: ~/.claude
+        transcript_policy: require_existing
+      work:
+        label: Work
+        config_dir: ~/.claude-work
+        transcript_policy: copy_thread_on_switch
+        expected_account_key: claude_code:acme-corp
+  codex:
+    account_profiles:
+      personal:
+        label: Personal
+        config_dir: ~/.codex
+      work:
+        label: Work
+        config_dir: ~/.codex-work
+        expected_account_key: codex:work@example.com
+```
+
+Each profile accepts:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `label` | yes | Human-facing name shown in the CLI, picker, and badges. |
+| `config_dir` | yes | Value for the agent's config-dir env var. `~` is kept verbatim and expanded only when used. |
+| `transcript_policy` | no (default `require_existing`) | How the target profile gets to see the session's native thread on a switch. See below. |
+| `shared_transcript_dir` | only for `symlink_shared` | The shared transcript directory the target's store is symlinked to. |
+| `expected_account_key` | no | The account the profile is asserted to authenticate as (e.g. `claude_code:<org>`, `codex:<email>`). When set, a switch is rejected unless the target actually authenticates as this key; when unset, a switch that would resolve to the *current* account is rejected as a no-op. |
+
+### Transcript policies
+
+When a running session switches onto a profile, its native thread must be
+visible under the target config dir or the resumed agent can't continue it. The
+policy decides how:
+
+- **`require_existing`** (default) — verify the target config dir already has the
+  thread; never touch files. Use when profiles share a config dir, or you manage
+  the transcript trees yourself.
+- **`symlink_shared`** — point the target's native transcript store at a shared
+  directory (requires `shared_transcript_dir`), so every profile sees the same
+  threads.
+- **`copy_thread_on_switch`** — copy just the current thread's artifacts into the
+  target config dir on the switch. Use for fully independent config dirs.
+
+## Using profiles from the CLI
+
+List the configured profiles (redacted — ids, labels, and the config-dir env key
+only), optionally scoped to a backend or launch target:
+
+```bash
+waypoint accounts list
+waypoint accounts list --backend codex
+waypoint accounts list --launch-target-id my-ssh-host
+```
+
+Launch, schedule, or preset a session under a profile with `--account-profile`:
+
+```bash
+waypoint sessions start --backend claude_code --cwd ~/proj --account-profile work
+waypoint schedule create --backend codex --cwd ~/proj --delay-seconds 300 \
+  --account-profile work
+waypoint presets create --name work-claude --backend claude_code --account-profile work
+waypoint sessions import codex --thread-id <uuid> --account-profile work
+```
+
+Inspect a session's restart-applied launch settings (env is redacted to keys):
+
+```bash
+waypoint sessions launch-settings <session-id>
+```
+
+Switch a running session onto a different profile. This restarts the session
+and resumes its thread under the new config dir, so it is confirmed by default:
+
+```bash
+waypoint sessions set-account <session-id> work
+waypoint sessions set-account <session-id> work --no-restart   # rejected in phase 1
+```
+
+## Using profiles in the web UI
+
+- The launch and schedule forms show an **Account** selector for backends that
+  host profiles; the choice is carried into the session and into any preset you
+  save from the form.
+- A session's profile appears as a badge on its header, its list card, and any
+  scheduled-session row.
+- The running-session settings ("tune") popover has an **Account** selector that
+  performs the in-place switch — the GUI mirror of `sessions set-account`.
+
+## How the switch works, and its limits
+
+The switch is **restart-and-resume**: Waypoint verifies the target account,
+flushes any running turn, makes the thread available under the target config dir
+per the transcript policy, terminates the session, persists the new profile, and
+restores it — resuming the *same* thread under the new `CLAUDE_CONFIG_DIR` /
+`CODEX_HOME`.
+
+- It applies only to **structured transports** whose agent owns a config-dir env
+  var: Claude's native (`claude_cli`) and emulated (`claude_tty`) transports and
+  Codex's app-server transport. The generic `tmux` wrapper has no config-dir env
+  var and is refused.
+- A switch that wouldn't change the account is rejected, so set
+  `expected_account_key` when two profiles intentionally point at the same
+  underlying account (e.g. a copied config dir).
+- Remote (SSH) `copy_thread_on_switch` and tmux-wrapped switching are not yet
+  supported.
+
+See issue [#230](https://github.com/kaiitunnz/waypoint/issues/230) for the
+original design.

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -146,6 +146,7 @@ Properties of the CLI/protocol itself, the same whichever transport drives it.
 | `supports_config_overrides` | `bool` | Exposes a separate `config_overrides` input wrapped per-agent (Codex's `--config K=V`). |
 | `supports_slash_compact` | `bool` | Frontend hint that `/compact` is meaningful for this agent. |
 | `cli_binary` | `str \| None` | Default CLI for local launches and tmux fallback; `None` opts out. Override via `plugin_configs.<id>.local_bin` (local) or `ssh_targets[*].plugin_configs.<id>.remote_bin` (per SSH target). |
+| `config_dir_env_var` | `str \| None` | The env var that scopes the agent's config/account state (`CLAUDE_CONFIG_DIR`, `CODEX_HOME`). Non-`None` lets the agent host named account profiles and support restart-and-resume account switching — see [`account_profiles.md`](account_profiles.md). |
 | `target_aliases` | `tuple[str, ...]` | Substrings used to infer this agent from a tmux pane name. |
 | `badges` | `dict[str, str]` | UI palette: `{"glyph": "X", "color": "#34d399"}`. |
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -403,6 +403,8 @@ export interface SessionLaunchSettings {
   supports_custom_args: boolean;
   supports_config_overrides: boolean;
   supports_account_profile_with_restart: boolean;
+  // Whether applying a change requires restarting the session (true in phase 1).
+  requires_restart: boolean;
 }
 
 // PATCH body for the same endpoint; omitted fields are left unchanged. `restart`


### PR DESCRIPTION
## Purpose

The account/config-profile switching feature (#230, shipped across #231–#243) had no tracked documentation — the auth-config reference is a stub, the plugin doc doesn't mention profiles, and the only example config is gitignored. This adds a user-facing guide and completes a lagging frontend type. Addresses the two gaps flagged in review; the tracking issue (#230) is being closed separately.

## Changes

- `docs/account_profiles.md` (new) — how to configure `account_profiles` (the block, its fields, and the three transcript policies), how to use it from the CLI and the web UI, and the restart-and-resume behavior with its `claude_code`/`codex` + structured-transport scope. Includes a worked YAML example.
- `docs/coding_agent_plugins.md` — document the `config_dir_env_var` agent capability and link the feature doc from it.
- `.agents/skills/waypoint/references/auth-config.md` — a short profiles pointer for the CLI-driving skill.
- `frontend/src/lib/types.ts` — add `requires_restart` to `SessionLaunchSettings`, mirroring the backend `LaunchSettingsResponse`.

## Test Plan

- `cd frontend && npx tsc --noEmit && npm run lint && npm run build`
- `uvx codespell docs/account_profiles.md docs/coding_agent_plugins.md .agents/…/auth-config.md`
- Fact-check the doc against the code (config schema, policies, CLI names, behavior/scope).

## Test Result

- Frontend `tsc --noEmit`, `lint`, `build` — clean.
- codespell — clean.
- Doc fact-checked field-by-field against `plugin_config.py`, `transcripts.py`, `cli.py`, `runtime.py`, and the plugin capabilities: no inaccuracies (field names/defaults, the three policies, every CLI command/flag, the restart-and-resume order, the `supports_account_profile_with_restart` scope, and the `CLAUDE_CONFIG_DIR`/`CODEX_HOME` env vars all match).

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] Frontend checks (`tsc`/`lint`/`build`) and `codespell` on the docs run clean.
- [x] Documentation-only plus a one-field type addition; no runtime behavior change.
- [x] Doc verified accurate against the implementation.
- [x] Scope stated honestly: claude_code + codex only; opencode and tmux-wrapped/remote switching excluded.

</details>