### PR TITLE
fix: tail the profile's config dir for claude_tty sessions

### DIFF
--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -538,6 +538,11 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             session_uuid=thread_id,
             cwd=session.cwd,
             runtime=runtime,
+            config_dir=(
+                session.launch_env.get(self.capabilities.config_dir_env_var)
+                if self.capabilities.config_dir_env_var
+                else None
+            ),
         )
 
     def register_routes(self, app: FastAPI, context: Any) -> None:

--- a/backend/src/waypoint/backends/claude_code/usage_source.py
+++ b/backend/src/waypoint/backends/claude_code/usage_source.py
@@ -31,9 +31,10 @@ class TranscriptContextUsageSource(ContextUsageSource):
         session_uuid: str,
         cwd: str,
         runtime: "SessionRuntime",
+        config_dir: str | None = None,
     ) -> None:
         self._session_id = session_id
-        self._path = transcript_path(cwd, session_uuid)
+        self._path = transcript_path(cwd, session_uuid, config_dir)
         self._runtime = runtime
         self._offset = 0
         self._context_usage_signature: tuple[int, int | None] | None = None

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -441,16 +441,21 @@ class ClaudeTtyPlugin:
                 seen.add(key)
         return completions
 
+    def _config_dir_from_env(self, launch_env: dict[str, str]) -> str | None:
+        """The CLAUDE_CONFIG_DIR override carried in a launch env, if any."""
+        key = self._claude.capabilities.config_dir_env_var
+        return launch_env.get(key) if key else None
+
     def _config_dir(self, session: SessionRecord) -> str | None:
         """The session's CLAUDE_CONFIG_DIR override, if any.
 
         A session launched under (or switched to) an account profile carries
-        its config dir in ``launch_env``; the resume-existence check must look
-        there, not the default ~/.claude, or it never finds the thread and
-        relaunches into a fresh conversation.
+        its config dir in ``launch_env``; the resume-existence check and the
+        transcript tailer must look there, not the default ~/.claude, or they
+        read the wrong path — resuming into a fresh conversation, or tailing a
+        file the CLI never writes so the session hangs in ``running``.
         """
-        key = self._claude.capabilities.config_dir_env_var
-        return session.launch_env.get(key) if key else None
+        return self._config_dir_from_env(session.launch_env)
 
     async def _conversation_exists(
         self,
@@ -480,6 +485,7 @@ class ClaudeTtyPlugin:
         cwd: str,
         *,
         start_at_end: bool = False,
+        config_dir: str | None = None,
     ) -> None:
         if session_id in self._tailer_tasks:
             return
@@ -490,6 +496,7 @@ class ClaudeTtyPlugin:
             runtime=runtime,
             plugin=self,
             start_at_end=start_at_end,
+            config_dir=config_dir,
         )
         self._tailer_tasks[session_id] = asyncio.create_task(tailer.run())
 
@@ -595,7 +602,13 @@ class ClaudeTtyPlugin:
             f"Claude TUI session started (thread {thread_id})",
             status=SessionStatus.IDLE,
         )
-        self._start_tailer(runtime, session.id, thread_id, request.cwd)
+        self._start_tailer(
+            runtime,
+            session.id,
+            thread_id,
+            request.cwd,
+            config_dir=self._config_dir_from_env(request.launch_env),
+        )
         self._spawn_rate_limit_watcher(runtime, session)
         return runtime.get_session(session.id)
 
@@ -616,6 +629,7 @@ class ClaudeTtyPlugin:
                     thread_id,
                     session.cwd,
                     start_at_end=True,
+                    config_dir=self._config_dir(session),
                 )
             else:
                 log.warning(
@@ -717,6 +731,7 @@ class ClaudeTtyPlugin:
             new_thread_id,
             session.cwd,
             start_at_end=effective_thread_id is not None,
+            config_dir=self._config_dir(session),
         )
         self._spawn_rate_limit_watcher(runtime, session)
 
@@ -820,7 +835,13 @@ class ClaudeTtyPlugin:
             f"Claude TUI forked from {session.title or session.id} (thread {new_thread_id})",
             status=SessionStatus.IDLE,
         )
-        self._start_tailer(runtime, new_session_id, new_thread_id, session.cwd)
+        self._start_tailer(
+            runtime,
+            new_session_id,
+            new_thread_id,
+            session.cwd,
+            config_dir=self._config_dir(new_session),
+        )
         self._spawn_rate_limit_watcher(runtime, new_session)
         return runtime.get_session(new_session_id)
 
@@ -1008,7 +1029,12 @@ class ClaudeTtyPlugin:
         # in the event DB) so tail from the end; a fresh --session-id thread
         # starts an empty file, so read from byte 0.
         self._start_tailer(
-            runtime, session.id, thread_id, session.cwd, start_at_end=resumed
+            runtime,
+            session.id,
+            thread_id,
+            session.cwd,
+            start_at_end=resumed,
+            config_dir=self._config_dir(session),
         )
         return True
 
@@ -1117,7 +1143,12 @@ class ClaudeTtyPlugin:
             # DB by fork_aside, so tail from the end and only pick up turns added
             # from here.
             self._start_tailer(
-                runtime, new_session.id, thread_id, new_session.cwd, start_at_end=True
+                runtime,
+                new_session.id,
+                thread_id,
+                new_session.cwd,
+                start_at_end=True,
+                config_dir=self._config_dir(new_session),
             )
             self._spawn_rate_limit_watcher(runtime, new_session)
         except Exception:
@@ -1369,7 +1400,12 @@ class ClaudeTtyPlugin:
         # seed above has already replayed them, from the on-disk transcript
         # directly rather than the live tail).
         self._start_tailer(
-            runtime, session.id, request.thread_id, cwd, start_at_end=True
+            runtime,
+            session.id,
+            request.thread_id,
+            cwd,
+            start_at_end=True,
+            config_dir=self._config_dir(session),
         )
         self._spawn_rate_limit_watcher(runtime, session)
         return runtime.get_session(session.id)

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -40,15 +40,23 @@ _DIALOG_POLL_INTERVAL = 1.0  # seconds between live-pane dialog captures
 _DIALOG_STABLE_TICKS = 2  # consecutive identical captures before surfacing
 
 
-def transcript_path(cwd: str, session_uuid: str) -> Path:
+def transcript_path(cwd: str, session_uuid: str, config_dir: str | None = None) -> Path:
     """Return the Claude TUI's JSONL transcript path for the given session.
 
     Resolves the store root and the encoded project-dir name through the same
     helpers thread discovery uses, so the tailed path matches where the CLI
     actually writes — including for cwds with non-slash special characters
-    (hidden dirs, worktrees) and a non-default ``$CLAUDE_CONFIG_DIR``.
+    (hidden dirs, worktrees). ``config_dir`` is the session's
+    ``CLAUDE_CONFIG_DIR`` (e.g. an account profile's); pass it or the path
+    resolves under the default ``~/.claude`` and the tailer reads the wrong
+    file for a profile-scoped session — the session then never leaves
+    ``running`` because no transcript records reach the normalizer.
     """
-    return claude_projects_root() / encode_project_dir(cwd) / f"{session_uuid}.jsonl"
+    return (
+        claude_projects_root(config_dir)
+        / encode_project_dir(cwd)
+        / f"{session_uuid}.jsonl"
+    )
 
 
 class TranscriptTailer:
@@ -69,9 +77,10 @@ class TranscriptTailer:
         plugin: "ClaudeTtyPlugin",
         *,
         start_at_end: bool = False,
+        config_dir: str | None = None,
     ) -> None:
         self._session_id = session_id
-        self._path = transcript_path(cwd, session_uuid)
+        self._path = transcript_path(cwd, session_uuid, config_dir)
         self._runtime = runtime
         self._plugin = plugin
         self._normalizer = TranscriptNormalizer()

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -583,6 +583,7 @@ async def _run_exited_reconnect(resumes: bool) -> bool:
         cwd: str,
         *,
         start_at_end: bool = False,
+        config_dir: str | None = None,
     ) -> None:
         captured["start_at_end"] = start_at_end
 

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -98,9 +98,11 @@ def _stub_lifecycle(plugin: ClaudeTtyPlugin) -> dict[str, object]:
         cwd: str,
         *,
         start_at_end: bool = False,
+        config_dir: str | None = None,
     ) -> None:
         captured["tailer_thread_id"] = thread_id
         captured["start_at_end"] = start_at_end
+        captured["tailer_config_dir"] = config_dir
 
     plugin._start_tailer = _fake_start_tailer  # type: ignore[method-assign]
     plugin._spawn_rate_limit_watcher = MagicMock()  # type: ignore[method-assign]

--- a/backend/tests/test_claude_tty_tailer.py
+++ b/backend/tests/test_claude_tty_tailer.py
@@ -6,8 +6,21 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from waypoint.backends.claude_tty.tailer import TranscriptTailer
+from waypoint.backends.claude_tty.tailer import TranscriptTailer, transcript_path
 from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+
+def test_transcript_path_honors_config_dir() -> None:
+    # Regression: a profile-scoped claude_tty session writes its transcript
+    # under its CLAUDE_CONFIG_DIR; the tailer must resolve the same path, or it
+    # reads the default ~/.claude, sees no records, and the session hangs in
+    # "running" while the pane shows real output.
+    uuid = "00000000-0000-0000-0000-000000000001"
+    default = transcript_path("/repo/app", uuid)
+    scoped = transcript_path("/repo/app", uuid, "/home/me/.claude-work")
+    assert scoped != default
+    assert str(scoped).startswith("/home/me/.claude-work/projects/")
+    assert scoped.name == f"{uuid}.jsonl"
 
 
 def _make_session(session_id: str = "sess-1") -> SessionRecord:


### PR DESCRIPTION
## Purpose

A claude_tty session launched under an account profile hangs in `running` forever even though its agent produces output in the tmux pane. Found while testing a `~/.claude-test` profile (#230). Companion to #241 (which fixed the same class of bug in `conversation_exists`).

## Root cause

`transcript_path()` (`claude_tty/tailer.py`) resolved the transcript via `claude_projects_root()` with no config dir, so it read the default `~/.claude` regardless of the session's `CLAUDE_CONFIG_DIR`. A profile-scoped session's CLI writes its transcript under the profile's config dir (`~/.claude-test/projects/…`), but the tailer watched `~/.claude/projects/…` — a file the CLI never writes. No records reached the normalizer, so no status/events were emitted and the session never left `running`; the pane showed real output because that comes from tmux, not the tailer. The tmux-wrapped context-usage source (`claude_code/usage_source.py`) shared the same bug.

## Changes

### Backend

- `claude_tty/tailer.py` — `transcript_path(cwd, session_uuid, config_dir=None)` resolves via `claude_projects_root(config_dir)`; `TranscriptTailer` takes and forwards `config_dir`.
- `claude_tty/plugin.py` — `_start_tailer` takes `config_dir`; all seven call sites pass the session's config dir (a new `_config_dir_from_env` sibling to the existing `_config_dir(session)` covers the create path, which has only the request's launch env).
- `claude_code/usage_source.py` + `claude_code/plugin.py` — `TranscriptContextUsageSource` takes `config_dir`; `create_context_usage_source` passes the session's `CLAUDE_CONFIG_DIR`.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1569 passed, 3 warnings (pre-existing).
- New `test_transcript_path_honors_config_dir` asserts the path resolves under the profile's config dir, not the default `~/.claude`; the two claude_tty test fakes updated for the new kwarg.
- Diagnosed against a live stuck session: the transcript existed and was complete under `~/.claude-test/projects/…` while the session's tailer read `~/.claude/projects/…` (absent), leaving it stuck in `running`.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the fix stays within the claude_tty/claude_code plugins; the config dir comes from the agent's own `config_dir_env_var`, no cross-backend branch.
- [x] No frontend changes.
- [x] Not a breaking change — `config_dir` defaults to None (prior default-root behavior); only profile-scoped sessions change.

</details>