### PR TITLE
fix: resolve codex per-session ops against the profile CODEX_HOME

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
@@ -15,6 +16,24 @@ if TYPE_CHECKING:
     from waypoint.backends.context_usage_source import ContextUsageSource
     from waypoint.launch_targets import SshLaunchTargetConfig
     from waypoint.runtime import SessionRuntime
+
+
+def config_dir_for(
+    capabilities: BackendCapabilities, launch_env: Mapping[str, str]
+) -> str | None:
+    """The session's override for the agent's config-dir env var, if any.
+
+    The single resolver for "which config/account dir does this session use":
+    an account profile sets the agent's ``config_dir_env_var``
+    (``CLAUDE_CONFIG_DIR`` / ``CODEX_HOME``) in ``launch_env``. Every
+    per-session operation that touches on-disk agent state (transcript tailing,
+    thread lookup/resume, rollout discovery, side-questions, plan-file
+    detection) MUST resolve the dir through this — reading the process env or a
+    hardcoded default instead makes the op operate on the wrong account's dir
+    for a profile-scoped session (the failure mode behind PRs #241/#246).
+    """
+    key = capabilities.config_dir_env_var
+    return launch_env.get(key) if key else None
 
 
 @runtime_checkable

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
+from waypoint.backends.base import config_dir_for
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.claude_code import side_question as _sq
 from waypoint.backends.claude_code.commands import list_claude_command_completions
@@ -443,8 +444,7 @@ class ClaudeTtyPlugin:
 
     def _config_dir_from_env(self, launch_env: dict[str, str]) -> str | None:
         """The CLAUDE_CONFIG_DIR override carried in a launch env, if any."""
-        key = self._claude.capabilities.config_dir_env_var
-        return launch_env.get(key) if key else None
+        return config_dir_for(self._claude.capabilities, launch_env)
 
     def _config_dir(self, session: SessionRecord) -> str | None:
         """The session's CLAUDE_CONFIG_DIR override, if any.

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -24,7 +24,7 @@ from fastapi import HTTPException, status
 from openai_codex.client import CodexClient
 from pydantic import BaseModel, Field
 
-from waypoint.backends.base import DefaultLaunchContract
+from waypoint.backends.base import DefaultLaunchContract, config_dir_for
 from waypoint.backends.capabilities import (
     BackendCapabilities,
     ModelSource,
@@ -370,7 +370,11 @@ class CodexPlugin(DefaultLaunchContract):
             return None
         from waypoint.backends.codex.usage_source import CodexRolloutUsageSource
 
-        return CodexRolloutUsageSource(session.id, runtime)
+        return CodexRolloutUsageSource(
+            session.id,
+            runtime,
+            codex_home=config_dir_for(self.capabilities, session.launch_env),
+        )
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None
@@ -1107,13 +1111,24 @@ class CodexPlugin(DefaultLaunchContract):
         # opens an SSH connection per tick, so back off there.
         POLL_INTERVAL = 2.0 if launch_target is None else 10.0
         elapsed = 0.0
+        # Scope the local search to the session's profile CODEX_HOME; the CLI
+        # writes the rollout there, so reading the default ~/.codex would never
+        # find it (thread id never captured → the session can't resume).
+        watched = runtime.storage.get_session(session_id)
+        config_dir = (
+            config_dir_for(self.capabilities, watched.launch_env)
+            if watched is not None
+            else None
+        )
         try:
             while elapsed < DEADLINE:
                 # Probe before sleeping so we don't waste POLL_INTERVAL
                 # in the case where the user has already typed and the
                 # rollout file exists when this watcher starts.
                 if launch_target is None:
-                    uuid_found = self._find_codex_thread_id_local(cwd, since)
+                    uuid_found = self._find_codex_thread_id_local(
+                        cwd, since, config_dir
+                    )
                 else:
                     uuid_found = await self._find_codex_thread_id_remote(
                         cwd, since, launch_target
@@ -1139,8 +1154,12 @@ class CodexPlugin(DefaultLaunchContract):
         finally:
             runtime._thread_id_watchers.pop(session_id, None)
 
-    def _find_codex_thread_id_local(self, cwd: str, since: datetime) -> str | None:
-        codex_home = Path(os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
+    def _find_codex_thread_id_local(
+        self, cwd: str, since: datetime, config_dir: str | None = None
+    ) -> str | None:
+        codex_home = Path(
+            config_dir or os.environ.get("CODEX_HOME") or "~/.codex"
+        ).expanduser()
         sessions_dir = codex_home / "sessions"
         if not sessions_dir.is_dir():
             return None

--- a/backend/src/waypoint/backends/codex/usage_source.py
+++ b/backend/src/waypoint/backends/codex/usage_source.py
@@ -50,10 +50,6 @@ def find_codex_rollout(thread_id: str, codex_home: str | None = None) -> Path | 
     return next(sessions_dir.glob(f"*/*/*/rollout-*{suffix}"), None)
 
 
-def _find_rollout_path(thread_id: str) -> Path | None:
-    return find_codex_rollout(thread_id)
-
-
 def _parse_token_count_record(record: dict[str, Any]) -> SessionContextUsage | None:
     """Extract a SessionContextUsage from a rollout ``token_count`` event_msg.
 
@@ -99,9 +95,17 @@ def _parse_token_count_record(record: dict[str, Any]) -> SessionContextUsage | N
 class CodexRolloutUsageSource(ContextUsageSource):
     """Tails a Codex rollout JSONL and publishes context usage for tmux sessions."""
 
-    def __init__(self, session_id: str, runtime: "SessionRuntime") -> None:
+    def __init__(
+        self,
+        session_id: str,
+        runtime: "SessionRuntime",
+        codex_home: str | None = None,
+    ) -> None:
         self._session_id = session_id
         self._runtime = runtime
+        # The session's CODEX_HOME (an account profile's), so the rollout is
+        # found under the profile dir rather than the default ~/.codex.
+        self._codex_home = codex_home
         self._offset = 0
         self._context_usage_signature: tuple[int, int | None] | None = None
 
@@ -159,7 +163,9 @@ class CodexRolloutUsageSource(ContextUsageSource):
 
             path: Path | None = None
             while path is None:
-                path = await asyncio.to_thread(_find_rollout_path, thread_id)
+                path = await asyncio.to_thread(
+                    find_codex_rollout, thread_id, self._codex_home
+                )
                 if path is None:
                     await asyncio.sleep(_POLL_INTERVAL)
 

--- a/backend/tests/test_codex_plugin.py
+++ b/backend/tests/test_codex_plugin.py
@@ -9,12 +9,33 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from waypoint.backends.base import config_dir_for
 from waypoint.backends.codex.plugin import CodexPlugin
 from waypoint.backends.codex.usage_source import (
     CodexRolloutUsageSource,
     _parse_token_count_record,
+    find_codex_rollout,
 )
 from waypoint.launch_targets import SshLaunchTargetConfig
+
+
+def test_config_dir_for_resolves_from_launch_env(plugin: CodexPlugin) -> None:
+    # The chokepoint every per-session on-disk op resolves the profile dir through.
+    assert config_dir_for(plugin.capabilities, {"CODEX_HOME": "/x"}) == "/x"
+    assert config_dir_for(plugin.capabilities, {}) is None
+
+
+def test_find_codex_rollout_honors_codex_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "default"))
+    profile = tmp_path / "profile"
+    sessions_dir = profile / "sessions" / "2026" / "05" / "16"
+    sessions_dir.mkdir(parents=True)
+    uuid = "55555555-5555-5555-5555-555555555555"
+    (sessions_dir / f"rollout-2026-05-16T12-00-00-{uuid}.jsonl").write_text("{}\n")
+    assert find_codex_rollout(uuid) is None
+    assert find_codex_rollout(uuid, str(profile)) is not None
 
 
 @pytest.fixture
@@ -135,6 +156,38 @@ def test_find_codex_thread_id_local_filters_by_cwd_and_since(
     assert found == newer_uuid
 
 
+def test_find_codex_thread_id_local_honors_config_dir(
+    plugin: CodexPlugin, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The rollout lives under a profile's CODEX_HOME; passing config_dir must
+    # find it even when the process env points elsewhere (else the thread id is
+    # never captured and the session can't resume).
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "default"))
+    profile = tmp_path / "profile"
+    sessions_dir = profile / "sessions" / "2026" / "05" / "16"
+    sessions_dir.mkdir(parents=True)
+    uuid = "44444444-4444-4444-4444-444444444444"
+    roll = sessions_dir / f"rollout-2026-05-16T12-00-00-{uuid}.jsonl"
+    roll.write_text(json.dumps({"cwd": "/repo"}) + "\n")
+    ts = datetime(2026, 5, 16, 12, 0, 0, tzinfo=UTC).timestamp()
+    os.utime(roll, (ts, ts))
+
+    assert (
+        plugin._find_codex_thread_id_local(
+            "/repo", datetime(2026, 5, 16, 11, 59, 59, tzinfo=UTC)
+        )
+        is None
+    )
+    assert (
+        plugin._find_codex_thread_id_local(
+            "/repo",
+            datetime(2026, 5, 16, 11, 59, 59, tzinfo=UTC),
+            str(profile),
+        )
+        == uuid
+    )
+
+
 @pytest.mark.asyncio
 async def test_find_codex_thread_id_remote_filters_by_cwd(
     plugin: CodexPlugin, monkeypatch: pytest.MonkeyPatch
@@ -172,6 +225,7 @@ async def test_capture_thread_id_pulls_uuid_from_filename(
 
     class _Session:
         transport_state: dict[str, object] = {}
+        launch_env: dict[str, str] = {}
 
     class _Storage:
         def get_session(self, _sid: str) -> _Session:


### PR DESCRIPTION
## Purpose

Follow-up audit (requested) of the account-profile feature found more instances of the #241/#246 bug class — per-session code reading the default config dir instead of the session's profile config dir. This adds a single chokepoint resolver and fixes the two **codex** instances. A companion PR fixes the three claude_code instances.

## The chokepoint

`backends/base.py` gains `config_dir_for(capabilities, launch_env)` — the one resolver for "which config/account dir does this session use" (`launch_env.get(capabilities.config_dir_env_var)`). Every per-session on-disk op resolves the dir through it, so the recurring defect has one seam instead of ad-hoc `os.environ`/default reads. `claude_tty._config_dir_from_env` now delegates to it.

## Changes (codex)

- `codex/plugin.py` `capture_thread_id` / `_find_codex_thread_id_local` — scope the rollout search to the session's `CODEX_HOME` (resolved once from the watched session's `launch_env`). Previously read the default `~/.codex`, so a profile-scoped codex-over-tmux session never captured `transport_state.thread_id` → **could not resume/reattach**.
- `codex/usage_source.py` `CodexRolloutUsageSource(+codex_home)` and `codex/plugin.py` `create_context_usage_source` — pass the session's `CODEX_HOME` so `find_codex_rollout` looks under the profile dir. Previously read the default home (the unported #246 fix), so the **context-usage pill never populated** for a profile session. Removed the now-dead `_find_rollout_path` shim.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit (isort, black, ruff, codespell, mypy) — clean.
- `uv run pytest` — 1572 passed, 3 warnings (pre-existing).
- New tests: `config_dir_for` resolves/absent; `find_codex_rollout` and `_find_codex_thread_id_local` honor an explicit config dir over the process env.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the resolver reads each agent's own `config_dir_env_var` capability; no cross-backend branch.
- [x] No frontend changes.
- [x] Not a breaking change — `config_dir` defaults to None (prior default-root behavior); only profile-scoped codex-over-tmux sessions change.

</details>