### PR TITLE
fix: scope claude_code per-session ops to the profile config dir

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -145,6 +145,7 @@ def _auto_approve_for_mode(
     mode: str,
     tool_name: object,
     tool_input: dict[str, Any] | None = None,
+    config_dir: str | None = None,
 ) -> dict[str, str] | None:
     if mode in CLAUDE_AUTO_APPROVE_MODES:
         return {
@@ -162,7 +163,7 @@ def _auto_approve_for_mode(
         and tool_input is not None
     ):
         path = str(tool_input.get("file_path") or "")
-        if _is_plan_file_path(path):
+        if _is_plan_file_path(path, config_dir):
             return {
                 "permissionDecision": "allow",
                 "permissionDecisionReason": (
@@ -220,9 +221,21 @@ def _apply_edit(content: str, edit: dict[str, Any]) -> str:
     return content.replace(old, new, count)
 
 
-def _is_plan_file_path(path: str) -> bool:
+def _is_plan_file_path(path: str, config_dir: str | None = None) -> bool:
+    """Whether ``path`` is Claude's plan file (``<config-dir>/plans/…``).
+
+    Claude writes plans under ``$CLAUDE_CONFIG_DIR/plans``; a profile-scoped
+    session relocates that, so match the session's config dir (default
+    ~/.claude) rather than a hardcoded ``/.claude/plans/`` substring, or plan
+    mode misfires (the plan Write isn't auto-approved and its content isn't
+    captured for the ExitPlanMode card).
+    """
     if not path:
         return False
+    # A profile relocates the config dir, so anchor to its plans/ dir; with no
+    # profile keep the home-agnostic default-config-dir match.
+    if config_dir:
+        return f"{Path(config_dir).expanduser() / 'plans'}/" in path
     return "/.claude/plans/" in path
 
 
@@ -920,7 +933,10 @@ class ClaudeCliAdapter:
                 auto = None
             else:
                 auto = _auto_approve_for_mode(
-                    state.permission_mode, tool_name, tool_input_dict
+                    state.permission_mode,
+                    tool_name,
+                    tool_input_dict,
+                    state.launch_env.get("CLAUDE_CONFIG_DIR"),
                 )
             if auto is not None:
                 # Stash the plan-file path so ExitPlanMode can echo it back
@@ -931,7 +947,9 @@ class ClaudeCliAdapter:
                     and tool_input_dict is not None
                 ):
                     path = str(tool_input_dict.get("file_path") or "")
-                    if _is_plan_file_path(path):
+                    if _is_plan_file_path(
+                        path, state.launch_env.get("CLAUDE_CONFIG_DIR")
+                    ):
                         state.last_plan_path = path
                         if tool_name == "Write":
                             content = tool_input_dict.get("content")

--- a/backend/src/waypoint/backends/claude_code/commands.py
+++ b/backend/src/waypoint/backends/claude_code/commands.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -171,33 +172,47 @@ print(json.dumps([*custom_commands(), *user_skills(), *plugin_skills()]))
 """
 
 
+def _user_config_root(config_dir: str | None) -> Path:
+    """The session's account config dir (a profile's CLAUDE_CONFIG_DIR), else ~/.claude.
+
+    User commands/skills live under it, so completion for a profile-scoped
+    session must scan the profile's dir, not the default account's.
+    """
+    return Path(config_dir).expanduser() if config_dir else Path.home() / ".claude"
+
+
 async def list_claude_command_completions(
     *,
     cwd: str,
     claude_bin: str,
     prefix: str,
     launch_target: SshLaunchTargetConfig | None = None,
+    config_dir: str | None = None,
 ) -> list[CommandCompletion]:
     records = (
         await _list_remote_records(launch_target, cwd, claude_bin)
         if launch_target is not None
-        else await _list_local_records(cwd, claude_bin)
+        else await _list_local_records(cwd, claude_bin, config_dir)
     )
     return _records_to_completions(records, prefix)
 
 
-async def _list_local_records(cwd: str, claude_bin: str) -> list[dict[str, Any]]:
+async def _list_local_records(
+    cwd: str, claude_bin: str, config_dir: str | None = None
+) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
-    records.extend(_local_custom_commands(cwd))
-    records.extend(_local_user_skills(cwd))
-    records.extend(await _local_plugin_skills(claude_bin))
+    records.extend(_local_custom_commands(cwd, config_dir))
+    records.extend(_local_user_skills(cwd, config_dir))
+    records.extend(await _local_plugin_skills(claude_bin, config_dir))
     return records
 
 
-def _local_custom_commands(cwd: str) -> list[dict[str, Any]]:
+def _local_custom_commands(
+    cwd: str, config_dir: str | None = None
+) -> list[dict[str, Any]]:
     roots = [
         Path(cwd).expanduser() / ".claude" / "commands",
-        Path.home() / ".claude" / "commands",
+        _user_config_root(config_dir) / "commands",
     ]
     records: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -222,13 +237,13 @@ def _local_custom_commands(cwd: str) -> list[dict[str, Any]]:
     return records
 
 
-def _local_user_skills(cwd: str) -> list[dict[str, Any]]:
-    # Workspace `<cwd>/.claude/skills/` wins over `~/.claude/skills/` on
+def _local_user_skills(cwd: str, config_dir: str | None = None) -> list[dict[str, Any]]:
+    # Workspace `<cwd>/.claude/skills/` wins over the account `skills/` on
     # name collision, matching how the Claude CLI itself resolves
     # overlapping skill names.
     roots = [
         Path(cwd).expanduser() / ".claude" / "skills",
-        Path.home() / ".claude" / "skills",
+        _user_config_root(config_dir) / "skills",
     ]
     records: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -253,13 +268,20 @@ def _local_user_skills(cwd: str) -> list[dict[str, Any]]:
     return records
 
 
-async def _local_plugin_skills(claude_bin: str) -> list[dict[str, Any]]:
+async def _local_plugin_skills(
+    claude_bin: str, config_dir: str | None = None
+) -> list[dict[str, Any]]:
+    # `claude plugin list` reports the plugins enabled for a config dir, so run
+    # it under the session's CLAUDE_CONFIG_DIR (a profile's) rather than the
+    # backend's default account.
+    env = {**os.environ, "CLAUDE_CONFIG_DIR": config_dir} if config_dir else None
     try:
         proc = await asyncio.create_subprocess_exec(
             claude_bin,
             "plugin",
             "list",
             "--json",
+            env=env,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel, Field
 
-from waypoint.backends.base import DefaultLaunchContract
+from waypoint.backends.base import DefaultLaunchContract, config_dir_for
 from waypoint.backends.capabilities import (
     BackendCapabilities,
     ModelSource,
@@ -790,6 +790,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 claude_bin=claude_bin,
                 prefix=prefix,
                 launch_target=launch_target,
+                config_dir=config_dir_for(self.capabilities, session.launch_env),
             )
         except Exception:
             return completions

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -45,6 +45,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import HTTPException, status
 
+from waypoint.backends.claude_code.threads import claude_projects_root
 from waypoint.launch_targets import (
     SshLaunchTargetConfig,
     _resolve_local_binary,
@@ -146,9 +147,21 @@ async def _broadcast_remove(
     )
 
 
-def _delete_fork_file_local(fork_thread_id: str) -> None:
-    """Delete ``<fork_thread_id>.jsonl`` from ``~/.claude/projects/``."""
-    projects = Path.home() / ".claude" / "projects"
+def _session_config_dir(session: SessionRecord) -> str | None:
+    """The session's CLAUDE_CONFIG_DIR override, if any.
+
+    Side-questions drive the claude_code CLI, whose config-dir env var is
+    ``CLAUDE_CONFIG_DIR``; a profile-scoped session carries its dir in
+    ``launch_env``. The one-shot fork query and fork-file cleanup must act on
+    that dir, not the default ~/.claude, or they resume/clean up the wrong
+    account's projects tree.
+    """
+    return session.launch_env.get("CLAUDE_CONFIG_DIR")
+
+
+def _delete_fork_file_local(fork_thread_id: str, config_dir: str | None = None) -> None:
+    """Delete ``<fork_thread_id>.jsonl`` from the profile's ``projects/`` dir."""
+    projects = claude_projects_root(config_dir)
     if not projects.is_dir():
         return
     for p in projects.glob(f"*/{fork_thread_id}.jsonl"):
@@ -163,10 +176,11 @@ async def _delete_fork_file(
     fork_thread_id: str,
     launch_target_id: str | None,
     runtime: "SessionRuntime",
+    config_dir: str | None = None,
 ) -> None:
     """Delete the forked thread file locally or via SSH."""
     if launch_target_id is None:
-        await asyncio.to_thread(_delete_fork_file_local, fork_thread_id)
+        await asyncio.to_thread(_delete_fork_file_local, fork_thread_id, config_dir)
         return
     launch_target = runtime._find_launch_target(launch_target_id)
     if launch_target is None:
@@ -199,8 +213,14 @@ async def _run_one_shot_local(
     thread_id: str,
     fork_id: str,
     cwd: str,
+    env: dict[str, str] | None = None,
 ) -> str:
-    """Run a one-shot fork-query locally and return the answer text."""
+    """Run a one-shot fork-query locally and return the answer text.
+
+    ``env`` is the session's process env (``os.environ`` + its ``launch_env``);
+    it carries ``CLAUDE_CONFIG_DIR`` so a profile-scoped session resumes its
+    thread under the right config dir. ``None`` inherits the parent env.
+    """
     binary = shutil.which("claude")
     if binary is None:
         raise RuntimeError("claude binary not found on PATH")
@@ -222,6 +242,7 @@ async def _run_one_shot_local(
     proc = await asyncio.create_subprocess_exec(
         *args,
         cwd=str(cwd_path),
+        env=env,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
@@ -387,10 +408,15 @@ async def _run_side_question_bg(
             ]
             _write_side_questions(runtime, session_id, qs)
 
+        config_dir = _session_config_dir(session)
         try:
             if launch_target is None:
                 answer = await _run_one_shot_local(
-                    question, thread_id, fork_id, session.cwd
+                    question,
+                    thread_id,
+                    fork_id,
+                    session.cwd,
+                    env=runtime.account_lookup_env(session.backend, session.launch_env),
                 )
             else:
                 claude_bin = plugin.remote_executable(launch_target) or "claude"
@@ -409,7 +435,7 @@ async def _run_side_question_bg(
                 extra={"session_id": session_id, "sqid": sqid},
             )
             # The one-shot may have created <E>.jsonl before failing; clean it up.
-            await _delete_fork_file(fork_id, launch_target_id, runtime)
+            await _delete_fork_file(fork_id, launch_target_id, runtime, config_dir)
             await _mark_error(runtime, session_id, sqid, str(exc))
             return
 
@@ -440,7 +466,9 @@ async def _run_side_question_bg(
                     _write_side_questions(runtime, session_id, qs)
 
         if fork_file_to_cleanup is not None:
-            await _delete_fork_file(fork_file_to_cleanup, launch_target_id, runtime)
+            await _delete_fork_file(
+                fork_file_to_cleanup, launch_target_id, runtime, config_dir
+            )
             return
 
         if updated is not None:
@@ -630,7 +658,12 @@ async def fork_aside(
             runtime.storage.delete_session(new_session_id)
         restored = await _restore_claimed_aside(runtime, session.id, sq)
         if not restored and fork_thread_id:
-            await _delete_fork_file(fork_thread_id, session.launch_target_id, runtime)
+            await _delete_fork_file(
+                fork_thread_id,
+                session.launch_target_id,
+                runtime,
+                _session_config_dir(session),
+            )
         if isinstance(exc, HTTPException):
             raise
         raise HTTPException(
@@ -709,7 +742,12 @@ async def dismiss_aside(
         _write_side_questions(runtime, session.id, qs)
 
     if fork_thread_id:
-        await _delete_fork_file(fork_thread_id, session.launch_target_id, runtime)
+        await _delete_fork_file(
+            fork_thread_id,
+            session.launch_target_id,
+            runtime,
+            _session_config_dir(session),
+        )
     await _broadcast_remove(runtime, session.id, side_question_id)
 
 
@@ -746,7 +784,10 @@ async def recover_pending_side_questions(
             for sq in questions:
                 if sq.fork_thread_id:
                     await _delete_fork_file(
-                        sq.fork_thread_id, session.launch_target_id, runtime
+                        sq.fork_thread_id,
+                        session.launch_target_id,
+                        runtime,
+                        _session_config_dir(session),
                     )
             async with _lock_for(session.id):
                 fresh = runtime.storage.get_session(session.id)
@@ -819,7 +860,10 @@ async def recover_pending_side_questions(
                 # Async I/O and task scheduling outside the lock.
                 if stale_fork_id:
                     await _delete_fork_file(
-                        stale_fork_id, session.launch_target_id, runtime
+                        stale_fork_id,
+                        session.launch_target_id,
+                        runtime,
+                        _session_config_dir(session),
                     )
                 if to_broadcast is not None:
                     await _broadcast_upsert(runtime, session.id, to_broadcast)
@@ -856,4 +900,9 @@ async def delete_session_side_questions(
             runtime.storage.update_session(session.id, transport_state=state)
 
     for fork_thread_id in fork_ids:
-        await _delete_fork_file(fork_thread_id, session.launch_target_id, runtime)
+        await _delete_fork_file(
+            fork_thread_id,
+            session.launch_target_id,
+            runtime,
+            _session_config_dir(session),
+        )

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -431,6 +431,7 @@ class ClaudeTtyPlugin:
                 claude_bin=claude_bin,
                 prefix=prefix,
                 launch_target=launch_target,
+                config_dir=self._config_dir(session),
             )
         except Exception:
             return completions

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -8,6 +8,7 @@ import pytest
 from waypoint.backends.claude_code.adapter import (
     ClaudeCliAdapter,
     ClaudeSessionState,
+    _is_plan_file_path,
     _read_stream_line,
     claude_cli_mode_for,
 )
@@ -17,6 +18,20 @@ from waypoint.backends.claude_code.models import (
 )
 from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
 from waypoint.schemas import EventKind, SessionStatus
+
+
+def test_is_plan_file_path_honors_config_dir() -> None:
+    # Default config dir: home-agnostic /.claude/plans/ match (unchanged).
+    assert _is_plan_file_path("/Users/me/.claude/plans/p.md")
+    # A profile relocates plans/; without its config_dir the profile path is
+    # not recognized, with it is — and the default dir no longer matches.
+    assert not _is_plan_file_path("/home/me/.claude-work/plans/p.md")
+    assert _is_plan_file_path(
+        "/home/me/.claude-work/plans/p.md", "/home/me/.claude-work"
+    )
+    assert not _is_plan_file_path(
+        "/home/me/.claude/plans/p.md", "/home/me/.claude-work"
+    )
 
 
 class FakeStream:

--- a/backend/tests/test_claude_commands.py
+++ b/backend/tests/test_claude_commands.py
@@ -54,6 +54,35 @@ async def test_list_claude_command_completions_reads_user_commands(
 
 
 @pytest.mark.asyncio
+async def test_list_claude_command_completions_scopes_to_config_dir(
+    tmp_path, monkeypatch
+) -> None:
+    # A profile-scoped session's user commands live under its CLAUDE_CONFIG_DIR,
+    # not the default ~/.claude; completion must scan the profile dir.
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))  # empty default account
+    profile = tmp_path / "profile"
+    command_dir = profile / "commands" / "team"
+    command_dir.mkdir(parents=True)
+    (command_dir / "ship.md").write_text(
+        "---\ndescription: Ship it\n---\nbody\n", encoding="utf-8"
+    )
+
+    default = await list_claude_command_completions(
+        cwd=str(tmp_path / "repo"),
+        claude_bin=str(tmp_path / "missing-claude"),
+        prefix="/team",
+    )
+    scoped = await list_claude_command_completions(
+        cwd=str(tmp_path / "repo"),
+        claude_bin=str(tmp_path / "missing-claude"),
+        prefix="/team",
+        config_dir=str(profile),
+    )
+    assert [item.name for item in default] == []
+    assert [item.name for item in scoped] == ["team/ship"]
+
+
+@pytest.mark.asyncio
 async def test_list_claude_command_completions_reads_plugin_skills(
     tmp_path, monkeypatch
 ) -> None:

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -1392,10 +1392,12 @@ def test_delete_fork_file_local_honors_config_dir(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_run_one_shot_local_passes_env() -> None:
+async def test_run_one_shot_local_passes_env(monkeypatch: Any) -> None:
     # The one-shot must run under the session's env so CLAUDE_CONFIG_DIR (a
     # profile's) reaches the resumed claude; else it resumes the wrong account's
-    # thread and the side-question errors.
+    # thread and the side-question errors. Stub which() so the test doesn't
+    # depend on claude being installed (it isn't in CI).
+    monkeypatch.setattr(sq_module.shutil, "which", lambda _name: "/usr/bin/claude")
     captured: dict[str, Any] = {}
 
     async def fake_exec(*args: Any, **kwargs: Any) -> Any:

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -7,6 +7,7 @@ and verify the side-effects on storage and the broadcast hub.
 """
 
 import json
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -71,6 +72,11 @@ class _FakeRuntime:
         if not launch_target_id:
             return None
         return self._launch_targets.get(launch_target_id)
+
+    def account_lookup_env(
+        self, backend: str, launch_env: dict[str, str]
+    ) -> dict[str, str]:
+        return {**os.environ, **launch_env}
 
     async def _record_user_event(
         self,
@@ -1359,3 +1365,61 @@ async def test_delete_session_side_questions_cleans_aside_absent_from_snapshot(
     fresh = runtime.storage.get_session(session.id)
     assert fresh is not None
     assert _read_side_questions(fresh) == []
+
+
+# ---------------------------------------------------------------------------
+# Account-profile config-dir scoping
+# ---------------------------------------------------------------------------
+
+
+def test_session_config_dir_reads_launch_env(runtime: Any) -> None:
+    session = _make_session(runtime.storage)
+    session = session.model_copy(update={"launch_env": {"CLAUDE_CONFIG_DIR": "/prof"}})
+    assert sq_module._session_config_dir(session) == "/prof"
+    plain = _make_session(runtime.storage, session_id="sess-2")
+    assert sq_module._session_config_dir(plain) is None
+
+
+def test_delete_fork_file_local_honors_config_dir(tmp_path: Path) -> None:
+    profile = tmp_path / "profile"
+    proj = profile / "projects" / "-tmp-project"
+    proj.mkdir(parents=True)
+    fork = "11111111-1111-1111-1111-111111111111"
+    target = proj / f"{fork}.jsonl"
+    target.write_text("{}")
+    sq_module._delete_fork_file_local(fork, str(profile))
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_one_shot_local_passes_env() -> None:
+    # The one-shot must run under the session's env so CLAUDE_CONFIG_DIR (a
+    # profile's) reaches the resumed claude; else it resumes the wrong account's
+    # thread and the side-question errors.
+    captured: dict[str, Any] = {}
+
+    async def fake_exec(*args: Any, **kwargs: Any) -> Any:
+        captured["env"] = kwargs.get("env")
+
+        class _FakeProc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                return (
+                    json.dumps(
+                        {"is_error": False, "result": "ok", "subtype": "success"}
+                    ).encode(),
+                    b"",
+                )
+
+            def kill(self) -> None:
+                pass
+
+        return _FakeProc()
+
+    with patch("asyncio.create_subprocess_exec", fake_exec):
+        out = await sq_module._run_one_shot_local(
+            "q", "t", "f", "/cwd", env={"CLAUDE_CONFIG_DIR": "/prof", "PATH": "/x"}
+        )
+    assert out == "ok"
+    assert captured["env"]["CLAUDE_CONFIG_DIR"] == "/prof"


### PR DESCRIPTION
## Purpose

Second half of the follow-up audit (companion to #247, which fixed codex). Closes the remaining three instances of the #241/#246 bug class in **claude_code** — per-session ops reading the default `~/.claude` instead of the session's profile `CLAUDE_CONFIG_DIR`.

## Changes (claude_code)

- **Side-questions** (`side_question.py`) — `_run_one_shot_local` now spawns `claude --resume` with the session's process env (`account_lookup_env`, carrying `CLAUDE_CONFIG_DIR`), and `_delete_fork_file_local` resolves the projects tree via `claude_projects_root(config_dir)`. A new `_session_config_dir(session)` reads the CLAUDE_CONFIG_DIR override; all `_delete_fork_file` sites pass it. Previously `/btw` on a profile session ran under `~/.claude`, couldn't find the thread, and **always errored**.
- **Plan mode** (`adapter.py`) — `_is_plan_file_path` takes a `config_dir` and anchors to `<config_dir>/plans/` (keeping the home-agnostic `/.claude/plans/` match when there's no profile). Previously a profile's relocated plans dir wasn't recognized → the plan Write wasn't auto-approved and its content wasn't captured for the ExitPlanMode card.
- **Slash-command/skill completion** (`commands.py`) — `list_claude_command_completions` takes a `config_dir`; user commands/skills scan `<config_dir>/{commands,skills}` and `claude plugin list` runs with the profile's `CLAUDE_CONFIG_DIR`. Previously a profile session's composer offered the default account's commands (hints only; dispatch was unaffected).

Both completion call sites (`claude_code`/`claude_tty` plugins) pass the session's config dir via the shared `config_dir_for` resolver added in #247.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit — clean.
- `uv run pytest` — 1577 passed, 3 warnings (pre-existing).
- New tests: `_is_plan_file_path` honors config_dir (and keeps the default match); `_local_custom_commands`/completion scans the profile dir; `_session_config_dir`, `_delete_fork_file_local`, and `_run_one_shot_local` (passes env with `CLAUDE_CONFIG_DIR`) for side-questions.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: changes stay within claude_code/claude_tty; the config dir comes from the agent's own env var.
- [x] No frontend changes.
- [x] Not a breaking change — every added `config_dir` defaults to None (prior default-root behavior); only profile-scoped sessions change.

</details>