### PR TITLE
fix: scope claude_tty plan-file detection to the profile config dir

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -73,7 +73,10 @@ class TranscriptNormalizer:
     ``process_record``.  Usage deduplication state is accumulated across calls.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, config_dir: str | None = None) -> None:
+        # The session's CLAUDE_CONFIG_DIR (an account profile's), so plan-file
+        # detection anchors to the profile's plans/ dir rather than the default.
+        self._config_dir = config_dir
         self._seen_message_ids: set[str] = set()
         self._task_tracker: TaskListTracker = TaskListTracker()
         self._pending_task_creates: dict[str, dict[str, Any]] = {}
@@ -330,7 +333,7 @@ class TranscriptNormalizer:
         transcript, never read off disk — which would fail for remote sessions.
         """
         path = str(tool_input.get("file_path") or "")
-        if not _is_plan_file_path(path):
+        if not _is_plan_file_path(path, self._config_dir):
             return
         self.last_plan_path = path
         if tool_name == "Write":

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -83,7 +83,7 @@ class TranscriptTailer:
         self._path = transcript_path(cwd, session_uuid, config_dir)
         self._runtime = runtime
         self._plugin = plugin
-        self._normalizer = TranscriptNormalizer()
+        self._normalizer = TranscriptNormalizer(config_dir)
         self._pane_check_elapsed = 0.0
         self._dialog_check_elapsed = 0.0
         self._offset = (

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -1051,6 +1051,28 @@ def test_plan_file_write_captures_body_and_still_surfaces_tool_call() -> None:
     assert len(tool_calls) == 1 and tool_calls[0].metadata["tool_name"] == "Write"
 
 
+def test_plan_file_capture_honors_profile_config_dir() -> None:
+    # A profile-scoped session writes its plan under the profile's config dir;
+    # the normalizer must recognize it there, not only under the default ~/.claude.
+    path = "/home/u/.claude-work/plans/make-a-plan.md"
+    plan = "# Plan"
+    record = _assistant_record(
+        "msg1",
+        [_tool_use_block("w1", "Write", {"file_path": path, "content": plan})],
+        stop_reason="tool_use",
+    )
+    # Default normalizer (no config dir) does not recognize the profile path.
+    assert TranscriptNormalizer().process_record(record) is not None
+    default_norm = TranscriptNormalizer()
+    default_norm.process_record(record)
+    assert default_norm.last_plan_path is None
+    # Scoped to the profile config dir, it captures the plan.
+    scoped = TranscriptNormalizer("/home/u/.claude-work")
+    scoped.process_record(record)
+    assert scoped.last_plan_path == path
+    assert scoped.last_plan_content == plan
+
+
 def test_non_plan_file_write_does_not_capture_plan() -> None:
     norm = TranscriptNormalizer()
     norm.process_record(


### PR DESCRIPTION
## Purpose

Final instance of the config-dir bug class (#241/#246/#247/#248), surfaced by #248's review: the claude_tty transcript normalizer's plan-file detection ignored the session's profile config dir. Closes the plan-mode part of the class for the tty transport.

## Changes

- `claude_tty/normalize.py` — `TranscriptNormalizer(config_dir=None)` stores the session's `CLAUDE_CONFIG_DIR` and passes it to `_is_plan_file_path`, so a profile-scoped session's relocated `plans/` dir is recognized and the plan body is captured for the approval card.
- `claude_tty/tailer.py` — construct the normalizer with the tailer's `config_dir` (already resolved per #246).

`pane_dialog.py`'s `~/.claude/plans/` regex is intentionally unchanged: it's a display-only echo fallback for the approval card's `planFilePath`; the canonical path and body come from this normalizer capture.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit — clean.
- `uv run pytest` — 1578 passed, 3 warnings (pre-existing).
- New `test_plan_file_capture_honors_profile_config_dir`: the default normalizer doesn't capture a profile-path plan; scoped to the profile config dir it captures path + body.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] No frontend changes.
- [x] Not a breaking change — `config_dir` defaults to None (prior behavior); only profile-scoped tty sessions change.

</details>