### PR TITLE
feat: reject account profiles whose config dir isn't set up

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -36,6 +36,40 @@ def config_dir_for(
     return launch_env.get(key) if key else None
 
 
+class ConfigDirNotReadyError(Exception):
+    """A profile's config dir isn't ready to launch/resume this agent headlessly.
+
+    Raised by :meth:`ConfigDirValidating.ensure_config_dir_ready` with a terse,
+    user-facing reason; the runtime maps it to a 400 before any launch or
+    destructive switch step.
+    """
+
+
+@runtime_checkable
+class ConfigDirValidating(Protocol):
+    """An agent that can pre-flight an account profile's config dir.
+
+    Pointing an agent's ``config_dir_env_var`` (``CLAUDE_CONFIG_DIR`` /
+    ``CODEX_HOME``) at a dir the CLI treats as first-run can strand a session on
+    an interactive setup prompt it can never dismiss headlessly — the claude TUI
+    onboarding wizard (theme/login) is the motivating case: a profile aimed at a
+    config dir whose ``.claude.json`` has not completed onboarding relaunches
+    into the wizard and the tmux/tty-driven turn hangs forever. Codex's default
+    app-server transport has no such prompt (an unset home fails fast), so it
+    simply does not implement this.
+
+    The runtime narrows to this protocol (``isinstance``) when resolving a
+    profile's config-dir env for a *local* launch or switch, and rejects up
+    front rather than launching into a hang.
+    """
+
+    def ensure_config_dir_ready(self, config_dir: str) -> None:
+        """Raise :class:`ConfigDirNotReadyError` if launching or resuming under
+        ``config_dir`` would block on an interactive first-run prompt this agent
+        cannot clear headlessly; return ``None`` when the dir is ready."""
+        ...
+
+
 @runtime_checkable
 class PaneSubmitConfirming(Protocol):
     """A plugin that can read its tmux-wrapped TUI's composer to drive input

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, Any, Protocol
 from fastapi import FastAPI, HTTPException, status
 from pydantic import BaseModel, Field
 
-from waypoint.backends.base import DefaultLaunchContract, config_dir_for
+from waypoint.backends.base import (
+    ConfigDirNotReadyError,
+    DefaultLaunchContract,
+    config_dir_for,
+)
 from waypoint.backends.capabilities import (
     BackendCapabilities,
     ModelSource,
@@ -61,6 +65,7 @@ from waypoint.backends.claude_code.support import (
 from waypoint.backends.claude_code.threads import (
     UUID_RE,
     ClaudeThreadInfo,
+    claude_onboarding_complete,
     claude_projects_root,
     delete_local_claude_thread,
     find_local_claude_thread,
@@ -509,6 +514,17 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         if thread_id is None:
             return []
         return local_claude_thread_artifacts(thread_id, config_dir)
+
+    def ensure_config_dir_ready(self, config_dir: str) -> None:
+        # Setting CLAUDE_CONFIG_DIR moves .claude.json into the profile dir; if
+        # that copy hasn't completed onboarding the CLI relaunches into its
+        # first-run wizard, which a tmux/tty-driven turn can't dismiss (it hangs)
+        # — reject up front instead. See ConfigDirValidating.
+        if not claude_onboarding_complete(config_dir):
+            raise ConfigDirNotReadyError(
+                "claude onboarding is incomplete in its config dir; open a "
+                "claude session there once to finish setup"
+            )
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/claude_code/threads.py
+++ b/backend/src/waypoint/backends/claude_code/threads.py
@@ -68,6 +68,33 @@ def claude_projects_root(config_dir: str | None = None) -> Path:
     return root / "projects"
 
 
+def claude_config_file(config_dir: str) -> Path:
+    """Path to the config file the CLI uses when ``CLAUDE_CONFIG_DIR`` is set.
+
+    With ``CLAUDE_CONFIG_DIR`` exported the CLI keeps ``.claude.json`` *inside*
+    that dir (``<config_dir>/.claude.json``), not at the unset-default home
+    location ``~/.claude.json``. Account profiles always export the var, so a
+    profile's onboarding/config state lives here.
+    """
+    return Path(config_dir).expanduser() / ".claude.json"
+
+
+def claude_onboarding_complete(config_dir: str) -> bool:
+    """Whether ``<config_dir>/.claude.json`` marks first-run onboarding as done.
+
+    ``hasCompletedOnboarding`` is the flag the CLI sets once its first-run wizard
+    (theme picker, login method) is dismissed. A profile dir lacking it — missing
+    file, unreadable, or flag falsy — relaunches into that wizard, which a
+    tmux/tty-driven turn cannot dismiss and so hangs. Returns ``False`` on any
+    read/parse failure.
+    """
+    try:
+        data = json.loads(claude_config_file(config_dir).read_text())
+    except (OSError, ValueError):
+        return False
+    return bool(isinstance(data, dict) and data.get("hasCompletedOnboarding"))
+
+
 def encode_project_dir(cwd: str) -> str:
     """Encode a cwd to the project-dir name Claude stores transcripts under.
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -7,7 +7,7 @@ import secrets
 import shutil
 import subprocess
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -25,6 +25,12 @@ from waypoint.backends.account_profiles import (
     redacted_profile_metadata,
     resolve_account_profiles,
 )
+from waypoint.backends.base import (
+    ConfigDirNotReadyError,
+    ConfigDirValidating,
+    config_dir_for,
+)
+from waypoint.backends.capabilities import BackendCapabilities
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import AccountProfileConfig
 from waypoint.backends.tmux.adapter import TmuxAdapter, TmuxError
@@ -504,6 +510,45 @@ class SessionRuntime:
         env[config_dir_key] = config_dir
         return env, profile.label
 
+    def _ensure_profile_config_dir_ready(
+        self,
+        backend: str,
+        transport_caps: BackendCapabilities,
+        launch_env: Mapping[str, str],
+        account_profile_id: str | None,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> None:
+        """Reject a local profile whose config dir would strand this launch on an
+        interactive first-run prompt (e.g. claude onboarding), before the process
+        is spawned or a running session is destructively switched.
+
+        Two independent facts gate the check, kept on the axes that own them: the
+        *agent* (``registry.get(backend)`` — profiles are agent-owned) knows how
+        to judge readiness (:class:`ConfigDirValidating`); the resolved
+        *transport* knows whether an un-ready dir actually hangs — only an
+        interactive TUI in a terminal pane (``has_terminal_pane``) does, so a
+        headless transport (``claude --print``) is exempt and never rejected.
+        Remote dirs can't be stat'd here, so the check is local-only.
+        """
+        if account_profile_id is None or launch_target is not None:
+            return
+        if not transport_caps.has_terminal_pane:
+            return
+        agent = self.registry.get(backend)
+        if not isinstance(agent, ConfigDirValidating):
+            return
+        # The composed transport caps carry the agent's config-dir env var too.
+        config_dir = config_dir_for(transport_caps, launch_env)
+        if config_dir is None:
+            return
+        try:
+            agent.ensure_config_dir_ready(config_dir)
+        except ConfigDirNotReadyError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"account profile {account_profile_id!r} is not set up: {exc}",
+            ) from exc
+
     def _agent_process_env(
         self,
         backend: str,
@@ -693,6 +738,15 @@ class SessionRuntime:
             fallback = self.registry.fallback_for_managed_launch()
             if fallback is not None:
                 plugin = fallback
+        # ``plugin`` is now the resolved (agent, transport) driver — its caps
+        # carry the transport axis (e.g. ``has_terminal_pane``) the guard needs.
+        self._ensure_profile_config_dir_ready(
+            request.backend,
+            plugin.capabilities,
+            effective_env,
+            request.account_profile_id,
+            launch_target,
+        )
         session = await plugin.create_session(
             self,
             request,
@@ -1009,14 +1063,29 @@ class SessionRuntime:
         transport = getattr(request, "transport", None)
         if transport is not None:
             self._validate_supported_transport(backend, transport)
-            driver = self.registry.resolve(backend, transport)
-            # resolve() returns the transport owner; for a wrapper transport
-            # (tmux) that owner cannot enumerate threads, so the agent plugin
-            # drives the resume-via-tmux path instead.
-            if not driver.capabilities.supports_thread_import:
-                driver = agent_plugin
+            resolved = self.registry.resolve(backend, transport)
+            # The resolved transport owner carries the transport axis (e.g.
+            # has_terminal_pane) for the readiness guard; below it may be swapped
+            # for the agent plugin as the import *mechanism* (a wrapper transport
+            # can't enumerate threads), but the session still runs on ``resolved``.
+            transport_caps = resolved.capabilities
+            driver = (
+                resolved
+                if resolved.capabilities.supports_thread_import
+                else agent_plugin
+            )
         else:
             driver = agent_plugin
+            # No pinned transport: import resumes over the agent's structured
+            # (headless) path unless the caller forces the tmux wrapper.
+            if getattr(request, "launch_mode", None) == LaunchMode.TMUX_WRAPPER:
+                fallback = self.registry.fallback_for_managed_launch()
+                transport_caps = (fallback or agent_plugin).capabilities
+            else:
+                transport_caps = agent_plugin.capabilities
+        self._ensure_profile_config_dir_ready(
+            backend, transport_caps, launch_env, account_profile_id, launch_target
+        )
         session = await driver.import_thread(self, request, agent=backend)
         # Persist the profile used for listing/import so a later
         # resume/delete/history-read uses the same state root.
@@ -1781,6 +1850,12 @@ class SessionRuntime:
             session.backend, new_env, selected_profile_id, launch_target
         )
         new_profile_label = resolved_label if selected_profile_id is not None else None
+        # Reject before the destructive terminate/restore if the target profile's
+        # config dir would strand this session on an interactive first-run prompt
+        # (``caps`` is the session's composed transport capability).
+        self._ensure_profile_config_dir_ready(
+            session.backend, caps, new_env, selected_profile_id, launch_target
+        )
 
         old_launch_env = dict(session.launch_env)
         config_dir_key = caps.config_dir_env_var

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1077,8 +1077,16 @@ class SessionRuntime:
         else:
             driver = agent_plugin
             # No pinned transport: import resumes over the agent's structured
-            # (headless) path unless the caller forces the tmux wrapper.
-            if getattr(request, "launch_mode", None) == LaunchMode.TMUX_WRAPPER:
+            # (headless) path unless it falls through to the tmux wrapper — the
+            # caller forced it, or AUTO can't use the structured adapter. Mirror
+            # the plugin's own resume-wrapper predicate so the guard sees the
+            # transport the session will actually run on.
+            launch_mode = getattr(request, "launch_mode", None)
+            uses_wrapper = launch_mode == LaunchMode.TMUX_WRAPPER or (
+                launch_mode == LaunchMode.AUTO
+                and not agent_plugin.is_available_for_managed_launch(self)
+            )
+            if uses_wrapper:
                 fallback = self.registry.fallback_for_managed_launch()
                 transport_caps = (fallback or agent_plugin).capabilities
             else:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -535,11 +535,11 @@ class SessionRuntime:
         if not transport_caps.has_terminal_pane:
             return
         agent = self.registry.get(backend)
-        if not isinstance(agent, ConfigDirValidating):
-            return
-        # The composed transport caps carry the agent's config-dir env var too.
-        config_dir = config_dir_for(transport_caps, launch_env)
-        if config_dir is None:
+        # The config-dir env var is an agent-axis fact — read it off the agent,
+        # not the transport (the generic tmux wrapper is agent-agnostic and
+        # leaves it unset). ``has_terminal_pane`` above stays on the transport.
+        config_dir = config_dir_for(agent.capabilities, launch_env)
+        if config_dir is None or not isinstance(agent, ConfigDirValidating):
             return
         try:
             agent.ensure_config_dir_ready(config_dir)

--- a/backend/tests/test_config_dir_guard.py
+++ b/backend/tests/test_config_dir_guard.py
@@ -1,0 +1,163 @@
+"""Account-profile config-dir readiness guard.
+
+Pointing ``CLAUDE_CONFIG_DIR`` at a dir whose ``.claude.json`` hasn't completed
+onboarding relaunches the claude TUI into its first-run wizard, which a
+tmux/tty-driven turn can't dismiss and so hangs. The runtime rejects such a
+profile up front — but only for interactive-TUI transports (``has_terminal_pane``);
+headless ``claude --print`` runs fine there and must not be blocked.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+from waypoint.backends.base import ConfigDirNotReadyError
+from waypoint.backends.claude_code.plugin import ClaudeCodePlugin
+from waypoint.backends.claude_code.threads import claude_onboarding_complete
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.runtime import SessionRuntime
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _onboarded(dir_: Path) -> str:
+    dir_.mkdir(parents=True, exist_ok=True)
+    (dir_ / ".claude.json").write_text(json.dumps({"hasCompletedOnboarding": True}))
+    return str(dir_)
+
+
+def _unonboarded(dir_: Path) -> str:
+    dir_.mkdir(parents=True, exist_ok=True)
+    return str(dir_)
+
+
+def _runtime(tmp_path: Path) -> SessionRuntime:
+    settings = Settings(data_dir=tmp_path / "data")
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+def _caps(runtime: SessionRuntime, transport: str):
+    return runtime.registry.resolve("claude_code", transport).capabilities
+
+
+# ── threads.claude_onboarding_complete ───────────────────────────────────────
+
+
+def test_onboarding_complete_true(tmp_path: Path) -> None:
+    assert claude_onboarding_complete(_onboarded(tmp_path / "cfg")) is True
+
+
+def test_onboarding_complete_missing_file(tmp_path: Path) -> None:
+    assert claude_onboarding_complete(_unonboarded(tmp_path / "cfg")) is False
+
+
+def test_onboarding_complete_flag_absent(tmp_path: Path) -> None:
+    d = tmp_path / "cfg"
+    d.mkdir()
+    (d / ".claude.json").write_text(json.dumps({"numStartups": 3}))
+    assert claude_onboarding_complete(str(d)) is False
+
+
+def test_onboarding_complete_flag_falsy(tmp_path: Path) -> None:
+    d = tmp_path / "cfg"
+    d.mkdir()
+    (d / ".claude.json").write_text(json.dumps({"hasCompletedOnboarding": False}))
+    assert claude_onboarding_complete(str(d)) is False
+
+
+def test_onboarding_complete_malformed(tmp_path: Path) -> None:
+    d = tmp_path / "cfg"
+    d.mkdir()
+    (d / ".claude.json").write_text("{ not json")
+    assert claude_onboarding_complete(str(d)) is False
+
+
+# ── ClaudeCodePlugin.ensure_config_dir_ready ─────────────────────────────────
+
+
+def test_plugin_ensure_ready_passes(tmp_path: Path) -> None:
+    ClaudeCodePlugin().ensure_config_dir_ready(_onboarded(tmp_path / "cfg"))
+
+
+def test_plugin_ensure_ready_raises(tmp_path: Path) -> None:
+    with pytest.raises(ConfigDirNotReadyError):
+        ClaudeCodePlugin().ensure_config_dir_ready(_unonboarded(tmp_path / "cfg"))
+
+
+# ── runtime._ensure_profile_config_dir_ready (the transport gate) ────────────
+
+
+def test_guard_rejects_interactive_transport_when_unonboarded(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    cfg = _unonboarded(tmp_path / "cfg")
+    with pytest.raises(HTTPException) as exc:
+        runtime._ensure_profile_config_dir_ready(
+            "claude_code",
+            _caps(runtime, "claude_tty"),
+            {"CLAUDE_CONFIG_DIR": cfg},
+            "personal",
+            None,
+        )
+    assert exc.value.status_code == 400
+    assert "personal" in exc.value.detail
+    assert "not set up" in exc.value.detail
+
+
+def test_guard_allows_interactive_transport_when_onboarded(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    cfg = _onboarded(tmp_path / "cfg")
+    runtime._ensure_profile_config_dir_ready(
+        "claude_code",
+        _caps(runtime, "claude_tty"),
+        {"CLAUDE_CONFIG_DIR": cfg},
+        "personal",
+        None,
+    )
+
+
+def test_guard_exempts_headless_transport(tmp_path: Path) -> None:
+    # claude --print does not onboard, so a native (no terminal pane) transport
+    # must not be rejected even for an un-onboarded dir.
+    runtime = _runtime(tmp_path)
+    cfg = _unonboarded(tmp_path / "cfg")
+    caps = _caps(runtime, "claude_cli")
+    assert caps.has_terminal_pane is False
+    runtime._ensure_profile_config_dir_ready(
+        "claude_code", caps, {"CLAUDE_CONFIG_DIR": cfg}, "personal", None
+    )
+
+
+def test_guard_noop_without_profile(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    runtime._ensure_profile_config_dir_ready(
+        "claude_code", _caps(runtime, "claude_tty"), {}, None, None
+    )
+
+
+def test_guard_noop_on_remote_launch_target(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    cfg = _unonboarded(tmp_path / "cfg")
+    target = SshLaunchTargetConfig(id="s0", name="s0", ssh_destination="s0")
+    runtime._ensure_profile_config_dir_ready(
+        "claude_code",
+        _caps(runtime, "claude_tty"),
+        {"CLAUDE_CONFIG_DIR": cfg},
+        "personal",
+        target,
+    )
+
+
+def test_guard_noop_for_agent_without_validation(tmp_path: Path) -> None:
+    # codex has no onboarding hang (headless app-server fails fast); its agent
+    # plugin isn't ConfigDirValidating, so the guard is a no-op even on an
+    # interactive transport.
+    runtime = _runtime(tmp_path)
+    runtime._ensure_profile_config_dir_ready(
+        "codex",
+        _caps(runtime, "claude_tty"),
+        {"CODEX_HOME": str(tmp_path / "nope")},
+        "work",
+        None,
+    )

--- a/backend/tests/test_config_dir_guard.py
+++ b/backend/tests/test_config_dir_guard.py
@@ -105,6 +105,21 @@ def test_guard_rejects_interactive_transport_when_unonboarded(tmp_path: Path) ->
     assert "not set up" in exc.value.detail
 
 
+def test_guard_rejects_generic_tmux_transport_when_unonboarded(tmp_path: Path) -> None:
+    # The generic tmux wrapper is agent-agnostic and carries no config-dir env
+    # var, so the config dir must be resolved off the agent, not the transport;
+    # otherwise a tmux-wrapped claude launch slips the guard and hangs.
+    runtime = _runtime(tmp_path)
+    caps = _caps(runtime, "tmux")
+    assert caps.has_terminal_pane is True
+    cfg = _unonboarded(tmp_path / "cfg")
+    with pytest.raises(HTTPException) as exc:
+        runtime._ensure_profile_config_dir_ready(
+            "claude_code", caps, {"CLAUDE_CONFIG_DIR": cfg}, "personal", None
+        )
+    assert exc.value.status_code == 400
+
+
 def test_guard_allows_interactive_transport_when_onboarded(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path)
     cfg = _onboarded(tmp_path / "cfg")

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -54,6 +54,32 @@ Each profile accepts:
 | `shared_transcript_dir` | only for `symlink_shared` | The shared transcript directory the target's store is symlinked to. |
 | `expected_account_key` | no | The account the profile is asserted to authenticate as (e.g. `claude_code:<org>`, `codex:<email>`). When set, a switch is rejected unless the target actually authenticates as this key; when unset, a switch that would resolve to the *current* account is rejected as a no-op. |
 
+### A profile's `config_dir` must be a set-up config home
+
+`config_dir` becomes the agent's config-dir env var, and each agent keeps *all*
+of its per-config state under that dir. For Claude this includes the config file
+itself: with `CLAUDE_CONFIG_DIR` set, the CLI reads `<config_dir>/.claude.json`
+— **not** the unset-default home location `~/.claude.json`. So pointing a profile
+at `~/.claude` does *not* reuse your normal account: your onboarding, MCP servers,
+and permissions live in `~/.claude.json` (home), while `~/.claude/.claude.json`
+is a separate, usually un-onboarded file. Each profile dir must be a
+self-contained config home that has completed first-run setup.
+
+Set one up once, before selecting the profile:
+
+- **Claude** — run `CLAUDE_CONFIG_DIR=<config_dir> claude` interactively and finish
+  the first-run wizard (theme, login), or copy an already-onboarded
+  `~/.claude.json` into `<config_dir>/.claude.json`. Waypoint refuses to launch or
+  switch an **interactive** session (the `claude_tty` / tmux transports) onto a
+  profile whose `<config_dir>/.claude.json` hasn't completed onboarding — the TUI
+  would relaunch into the wizard and a headless-driven turn can't dismiss it, so it
+  would hang. The rejection is a 400 (`account profile '<id>' is not set up: …`).
+  The headless `claude --print` transport doesn't onboard and isn't blocked.
+- **Codex** — run `CODEX_HOME=<config_dir> codex login` to write `auth.json`. Codex
+  has no onboarding wizard: its default app-server transport fails fast on an
+  unauthenticated home (surfaced error, no hang), so profiles aren't guarded the
+  way Claude's are.
+
 ### Transcript policies
 
 When a running session switches onto a profile, its native thread must be


### PR DESCRIPTION
## Purpose

An account profile aims an agent's config-dir env var at a directory. For Claude, setting `CLAUDE_CONFIG_DIR` relocates `.claude.json` *into* that dir — so a profile pointed at a dir whose copy hasn't completed onboarding (including the common trap of aliasing a profile to `~/.claude`, whose real config lives at the home `~/.claude.json`) makes the interactive TUI relaunch into its first-run wizard. A `claude_tty`/`tmux`-driven turn can't dismiss that wizard, so the session hangs indefinitely. This adds a pre-flight guard that rejects such a profile with a clear 400 at launch and before a destructive switch, instead of launching into a hang. Relates to #230.

## Changes

- `backend/src/waypoint/backends/base.py` — new `ConfigDirNotReadyError` and a `@runtime_checkable ConfigDirValidating` protocol (`ensure_config_dir_ready(config_dir)`), mirroring the existing `PaneSubmitConfirming` capability pattern.
- `backend/src/waypoint/backends/claude_code/threads.py` — `claude_config_file()` and `claude_onboarding_complete()` helpers (read `<config_dir>/.claude.json`, require truthy `hasCompletedOnboarding`; `False` on any missing/unreadable/malformed/non-dict case).
- `backend/src/waypoint/backends/claude_code/plugin.py` — `ClaudeCodePlugin.ensure_config_dir_ready` raises when onboarding is incomplete.
- `backend/src/waypoint/runtime.py` — `_ensure_profile_config_dir_ready(...)` and its wiring at the three profile-applying sites (`create_session`, thread import, and the `_update_launch_settings_locked` switch). The config-dir env var is read from the **agent** (`registry.get(backend)`), enforcement is gated on the resolved **transport**'s `has_terminal_pane`, and remote/no-profile paths short-circuit.
- `backend/tests/test_config_dir_guard.py` (new) — onboarding-signal edge cases, the plugin method, and the runtime gate (claude_tty fires, tmux fires, claude_cli exempt, codex no-op, remote no-op, no-profile no-op).
- `docs/account_profiles.md` — a "config_dir must be a set-up config home" note explaining the `~/.claude.json` vs `<config_dir>/.claude.json` relocation and how to set up a profile dir per agent.

No frontend change: the 400 `detail` renders verbatim in the existing `.error-banner` (launch) / `.session-error-toast` (switch).

## Design

Two independent facts gate the check, kept on the axes that own them: the **agent** knows *how* to judge readiness (`ConfigDirValidating` — only claude_code implements it), and the resolved **transport** knows *whether* an un-ready dir actually hangs — only an interactive TUI in a terminal pane (`has_terminal_pane`) does. So headless `claude --print` is never rejected, and the generic tmux wrapper (agent-agnostic, no config-dir env var of its own) still resolves the dir off the agent. Codex is intentionally **not** guarded: its default headless app-server transport fails fast on an unauthenticated home (surfaced error, no hang), so its agent plugin doesn't implement the protocol and the guard is a no-op for it.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- Live e2e against the running backend on this branch (using an onboarded "Test" account for the claude runs).

## Test Result

- Pre-commit — clean (`isort`, `black`, `ruff`, `codespell`, `mypy` all pass).
- `uv run pytest` — 1592 passed, 3 warnings (pre-existing).
- Cold-context self-review (two rounds) caught and fixed two correctness gaps before this PR: the guard originally read the config-dir env var from the transport (blanked for the tmux wrapper), and the import path missed the AUTO-fallback-to-wrapper case; both are fixed with regression coverage.
- Live e2e (claude_tty on the production backend):
  - Launch → un-onboarded `personal`: **400** (`account profile 'personal' is not set up: …`), no session created (previously an unclosable onboarding hang).
  - Launch → onboarded Test account: turn completed; transcript written under the profile's `CLAUDE_CONFIG_DIR`.
  - Switch an interactive session → un-onboarded `personal`: **400**, session left untouched (no terminate).
  - Launch native `claude_cli` → un-onboarded `personal`: launched — headless correctly exempt.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the check dispatches through the registry via the `ConfigDirValidating` protocol and the transport `has_terminal_pane` capability — no per-backend branching; claude_code/codex/opencode + tmux/claude_tty all behave correctly (guard fires only for interactive claude).
- [x] No frontend changes (the backend 400 renders in the existing error surfaces).
- [x] Not a breaking change.
- [x] Updated `docs/account_profiles.md` for the new user-facing behavior.

</details>