### PR TITLE
feat: add accounts probe/doctor/setup-transcripts CLI and endpoints

### DIFF
--- a/.agents/skills/waypoint/references/auth-config.md
+++ b/.agents/skills/waypoint/references/auth-config.md
@@ -22,5 +22,15 @@ rather than guessing.
 Claude and Codex sessions can run under named account/config-dir profiles and
 switch between them without restarting the service. List them with `waypoint
 accounts list`, pick one at launch with `--account-profile`, and switch a running
-session with `waypoint sessions set-account <session-id> <profile>`. Full
+session with `waypoint sessions set-account <session-id> <profile>`.
+
+Verify and set up a profile from the CLI:
+
+```bash
+waypoint accounts probe <backend> <profile>            # verified account (label; --show-key for the key)
+waypoint accounts doctor [--backend B] [--json]        # per-profile checklist; exits non-zero on failure
+waypoint accounts setup-transcripts <backend> <profile>  # guarded shared-transcript symlink migration
+```
+
+`waypoint doctor` also includes a short per-profile summary (no live probe). Full
 configuration and behavior: [`docs/account_profiles.md`](../../../../docs/account_profiles.md).

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -26,7 +26,10 @@ from fastapi.responses import FileResponse
 
 from waypoint.auth import TokenStore, require_token
 from waypoint.backends import BackendRegistry
-from waypoint.backends.account_profiles import redacted_profile_metadata
+from waypoint.backends.account_profiles import (
+    backend_hosts_account_profiles,
+    redacted_profile_metadata,
+)
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.backends.tmux.renderer import (
     Osc52Extractor,
@@ -40,6 +43,7 @@ from waypoint.presets import (
 )
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
+    AccountProbeResult,
     AssistantAttachRequest,
     AssistantResetRequest,
     AssistantSummary,
@@ -55,6 +59,7 @@ from waypoint.schemas import (
     LaunchTargetConnectResponse,
     LoginRequest,
     MeResponse,
+    ProfileDoctorReport,
     ScheduledMessageCreateRequest,
     ScheduleLaunchRequest,
     SessionAnswerQuestionRequest,
@@ -469,6 +474,74 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 detail=f"no resumable thread {thread_id} for {backend}",
             )
         return {"deleted": thread_id}
+
+    def _require_profile_hosting_backend(backend: str) -> None:
+        if not context.runtime.registry.has_backend(backend):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown backend: {backend}",
+            )
+        if not backend_hosts_account_profiles(context.settings, backend):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"backend {backend} does not host account profiles",
+            )
+
+    @app.get(
+        "/api/backends/{backend}/accounts/{profile}/probe",
+        response_model=AccountProbeResult,
+    )
+    async def probe_account_profile(
+        backend: str,
+        profile: str,
+        _: Annotated[str, Depends(token_dependency())],
+        launch_target_id: Annotated[str | None, Query()] = None,
+        show_key: Annotated[bool, Query()] = False,
+    ) -> AccountProbeResult:
+        _require_profile_hosting_backend(backend)
+        result = await context.runtime.probe_account_profile(
+            backend, profile, launch_target_id=launch_target_id
+        )
+        # Redact the private-class account key unless explicitly requested; the
+        # label is display-safe (phase-1 redaction rules).
+        if not show_key:
+            result = result.model_copy(update={"account_key": ""})
+        return result
+
+    @app.get(
+        "/api/backends/{backend}/accounts/doctor",
+        response_model=list[ProfileDoctorReport],
+    )
+    async def account_doctor(
+        backend: str,
+        _: Annotated[str, Depends(token_dependency())],
+        launch_target_id: Annotated[str | None, Query()] = None,
+        show_paths: Annotated[bool, Query()] = False,
+    ) -> list[ProfileDoctorReport]:
+        _require_profile_hosting_backend(backend)
+        return await context.runtime.account_doctor(
+            backend=backend,
+            launch_target_id=launch_target_id,
+            show_paths=show_paths,
+        )
+
+    @app.post("/api/backends/{backend}/accounts/{profile}/setup-transcripts")
+    async def setup_account_transcripts(
+        backend: str,
+        profile: str,
+        body: dict[str, Any],
+        _: Annotated[str, Depends(token_dependency())],
+        launch_target_id: Annotated[str | None, Query()] = None,
+    ) -> Any:
+        _require_profile_hosting_backend(backend)
+        actions = context.runtime.setup_account_transcripts(
+            backend,
+            profile,
+            launch_target_id=launch_target_id,
+            shared_dir=body.get("shared_dir"),
+            policy=body.get("policy"),
+        )
+        return {"actions": actions}
 
     @app.get("/api/sessions/{session_id}")
     async def get_session(

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -517,12 +517,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
         launch_target_id: Annotated[str | None, Query()] = None,
         show_paths: Annotated[bool, Query()] = False,
+        show_key: Annotated[bool, Query()] = False,
     ) -> list[ProfileDoctorReport]:
         _require_profile_hosting_backend(backend)
         return await context.runtime.account_doctor(
             backend=backend,
             launch_target_id=launch_target_id,
             show_paths=show_paths,
+            show_key=show_key,
         )
 
     @app.post("/api/backends/{backend}/accounts/{profile}/setup-transcripts")

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -536,7 +536,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         launch_target_id: Annotated[str | None, Query()] = None,
     ) -> Any:
         _require_profile_hosting_backend(backend)
-        actions = context.runtime.setup_account_transcripts(
+        # The migration is synchronous filesystem work (a copytree of the native
+        # store); run it off the event loop so a large store doesn't stall it.
+        actions = await asyncio.to_thread(
+            context.runtime.setup_account_transcripts,
             backend,
             profile,
             launch_target_id=launch_target_id,

--- a/backend/src/waypoint/backends/account_profiles.py
+++ b/backend/src/waypoint/backends/account_profiles.py
@@ -14,11 +14,14 @@ Public payloads expose only ``{id, label, config_dir_key}`` — never the
 ``config_dir`` path, ``expected_account_key``, or ``transcript_policy``.
 """
 
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from waypoint.backends.base import ConfigDirReadinessReporting
 from waypoint.backends.plugin_config import AccountProfileConfig
 from waypoint.backends.registry import get_registry
-from waypoint.schemas import AccountProbeResult
+from waypoint.schemas import AccountProbeResult, ProfileCheck
 
 if TYPE_CHECKING:
     from waypoint.launch_targets import SshLaunchTargetConfig
@@ -94,6 +97,157 @@ def redacted_profile_metadata(
         {"id": pid, "label": profile.label, "config_dir_key": config_dir_key}
         for pid, profile in profiles.items()
     ]
+
+
+def _redact_path(path: str, show_paths: bool) -> str:
+    return path if show_paths else "<hidden; pass --show-paths>"
+
+
+def account_profile_static_checks(
+    settings: "Settings",
+    backend: str,
+    profile_id: str,
+    profile: AccountProfileConfig,
+    *,
+    local: bool,
+    show_paths: bool = False,
+) -> list[ProfileCheck]:
+    """The server-free portion of an ``accounts doctor`` checklist for a profile.
+
+    Pure filesystem + registry lookups — no runtime, no live probe — so both the
+    ``accounts doctor`` endpoint and the root ``waypoint doctor`` (which runs
+    without the server) share it. The live ``account_matches_expected`` check is
+    appended separately by the runtime path, which owns the probe.
+
+    ``local`` is ``False`` for a remote launch target, where the config dir can't
+    be stat'd here; filesystem checks are then reported as skipped rather than
+    failed (remote diagnostics are a later phase). Config-dir paths surface in
+    details only when ``show_paths`` is set.
+    """
+    plugin = get_registry().get(backend)
+    caps = plugin.capabilities
+    config_dir = profile.config_dir
+    checks: list[ProfileCheck] = []
+
+    checks.append(
+        ProfileCheck(
+            name="supported",
+            ok=bool(caps.config_dir_env_var),
+            detail=(
+                f"hosts account profiles via {caps.config_dir_env_var}; live "
+                "switching also needs a restart-capable transport"
+                if caps.config_dir_env_var
+                else "backend has no config-dir env var"
+            ),
+        )
+    )
+
+    if not local:
+        for name in ("config_dir_exists", "ready", "transcript_setup"):
+            checks.append(
+                ProfileCheck(
+                    name=name,
+                    ok=True,
+                    detail="skipped: unsupported on a remote launch target",
+                )
+            )
+        return checks
+
+    expanded = Path(config_dir).expanduser()
+    checks.append(
+        ProfileCheck(
+            name="config_dir_exists",
+            ok=expanded.is_dir(),
+            detail=(
+                f"config dir {_redact_path(str(expanded), show_paths)} "
+                + ("exists" if expanded.is_dir() else "is missing")
+            ),
+        )
+    )
+
+    if isinstance(plugin, ConfigDirReadinessReporting):
+        readiness = plugin.config_dir_readiness(config_dir)
+        checks.append(
+            ProfileCheck(
+                name="ready",
+                ok=readiness.ready,
+                detail=readiness.reason if not readiness.ready else "ready",
+            )
+        )
+    else:
+        checks.append(
+            ProfileCheck(
+                name="ready",
+                ok=True,
+                detail="n/a: agent reports no readiness signal",
+            )
+        )
+
+    checks.append(
+        _transcript_setup_check(
+            caps.native_thread_store, profile, show_paths=show_paths
+        )
+    )
+    return checks
+
+
+def _transcript_setup_check(
+    native_thread_store: str | None,
+    profile: AccountProfileConfig,
+    *,
+    show_paths: bool,
+) -> ProfileCheck:
+    name = "transcript_setup"
+    if profile.transcript_policy != "symlink_shared":
+        return ProfileCheck(
+            name=name,
+            ok=True,
+            detail=f"n/a: transcript_policy is {profile.transcript_policy!r}",
+        )
+    shared = profile.shared_transcript_dir
+    if not shared:
+        return ProfileCheck(
+            name=name, ok=False, detail="symlink_shared requires shared_transcript_dir"
+        )
+    shared_path = Path(shared).expanduser()
+    if not shared_path.is_dir():
+        return ProfileCheck(
+            name=name,
+            ok=False,
+            detail=(
+                f"shared_transcript_dir {_redact_path(str(shared_path), show_paths)} "
+                "is missing; run 'waypoint accounts setup-transcripts'"
+            ),
+        )
+    if native_thread_store is None:
+        return ProfileCheck(
+            name=name, ok=False, detail="backend has no native transcript store"
+        )
+    store = Path(profile.config_dir).expanduser() / native_thread_store
+    if not store.is_symlink():
+        return ProfileCheck(
+            name=name,
+            ok=False,
+            detail=(
+                f"{_redact_path(str(store), show_paths)} is not a symlink; run "
+                "'waypoint accounts setup-transcripts' to set it up"
+            ),
+        )
+    if store.resolve() != shared_path.resolve():
+        return ProfileCheck(
+            name=name,
+            ok=False,
+            detail=(
+                f"{_redact_path(str(store), show_paths)} links to "
+                f"{_redact_path(os.readlink(store), show_paths)}, not "
+                f"{_redact_path(str(shared_path), show_paths)}"
+            ),
+        )
+    return ProfileCheck(
+        name=name,
+        ok=True,
+        detail=f"linked to {_redact_path(str(shared_path), show_paths)}",
+    )
 
 
 async def probe_account(

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -45,6 +45,38 @@ class ConfigDirNotReadyError(Exception):
     """
 
 
+class ConfigDirReadiness(BaseModel):
+    """A non-raising verdict on whether an account profile's config dir is set up.
+
+    ``ready`` is the same signal :class:`ConfigDirValidating` enforces at
+    launch/switch, but reported instead of raised so ``accounts doctor`` can
+    surface it alongside the other checks. ``reason`` is a terse, user-facing
+    explanation when ``ready`` is ``False`` (``None`` when ready).
+    """
+
+    ready: bool
+    reason: str | None = None
+
+
+@runtime_checkable
+class ConfigDirReadinessReporting(Protocol):
+    """An agent that can report (without raising) whether a config dir is set up.
+
+    The diagnostic sibling of :class:`ConfigDirValidating`. Every agent that owns
+    a config-dir env var can implement this so ``accounts doctor`` reports a
+    readiness verdict per profile — including codex, which deliberately does
+    *not* implement :class:`ConfigDirValidating` (its app-server transport fails
+    fast on an unset home rather than hanging, so it needs no launch/switch
+    guard) but still benefits from a doctor readiness line based on ``auth.json``
+    presence.
+    """
+
+    def config_dir_readiness(self, config_dir: str) -> ConfigDirReadiness:
+        """Report whether launching/resuming under ``config_dir`` is set up,
+        without raising."""
+        ...
+
+
 @runtime_checkable
 class ConfigDirValidating(Protocol):
     """An agent that can pre-flight an account profile's config dir.
@@ -60,7 +92,10 @@ class ConfigDirValidating(Protocol):
 
     The runtime narrows to this protocol (``isinstance``) when resolving a
     profile's config-dir env for a *local* launch or switch, and rejects up
-    front rather than launching into a hang.
+    front rather than launching into a hang. An implementer typically also
+    implements :class:`ConfigDirReadinessReporting` and defines
+    ``ensure_config_dir_ready`` in terms of it (compute the verdict once, raise
+    when not ready).
     """
 
     def ensure_config_dir_ready(self, config_dir: str) -> None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -22,6 +22,7 @@ from pydantic import BaseModel, Field
 
 from waypoint.backends.base import (
     ConfigDirNotReadyError,
+    ConfigDirReadiness,
     DefaultLaunchContract,
     config_dir_for,
 )
@@ -515,16 +516,25 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return []
         return local_claude_thread_artifacts(thread_id, config_dir)
 
-    def ensure_config_dir_ready(self, config_dir: str) -> None:
+    def config_dir_readiness(self, config_dir: str) -> ConfigDirReadiness:
         # Setting CLAUDE_CONFIG_DIR moves .claude.json into the profile dir; if
         # that copy hasn't completed onboarding the CLI relaunches into its
-        # first-run wizard, which a tmux/tty-driven turn can't dismiss (it hangs)
-        # — reject up front instead. See ConfigDirValidating.
-        if not claude_onboarding_complete(config_dir):
-            raise ConfigDirNotReadyError(
+        # first-run wizard, which a tmux/tty-driven turn can't dismiss (it hangs).
+        # See ConfigDirReadinessReporting / ConfigDirValidating.
+        if claude_onboarding_complete(config_dir):
+            return ConfigDirReadiness(ready=True)
+        return ConfigDirReadiness(
+            ready=False,
+            reason=(
                 "claude onboarding is incomplete in its config dir; open a "
                 "claude session there once to finish setup"
-            )
+            ),
+        )
+
+    def ensure_config_dir_ready(self, config_dir: str) -> None:
+        readiness = self.config_dir_readiness(config_dir)
+        if not readiness.ready:
+            raise ConfigDirNotReadyError(readiness.reason)
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -24,7 +24,11 @@ from fastapi import HTTPException, status
 from openai_codex.client import CodexClient
 from pydantic import BaseModel, Field
 
-from waypoint.backends.base import DefaultLaunchContract, config_dir_for
+from waypoint.backends.base import (
+    ConfigDirReadiness,
+    DefaultLaunchContract,
+    config_dir_for,
+)
 from waypoint.backends.capabilities import (
     BackendCapabilities,
     ModelSource,
@@ -45,6 +49,7 @@ from waypoint.backends.codex.permission_modes import (
     codex_turn_params_for,
 )
 from waypoint.backends.codex.rate_limits import (
+    codex_auth_present,
     probe_codex_status,
     probe_codex_usage_remote,
 )
@@ -486,6 +491,23 @@ class CodexPlugin(DefaultLaunchContract):
         # claude_code behaviour.
         if self.adapter is not None:
             await self.adapter.terminate_session(session.id)
+
+    def config_dir_readiness(self, config_dir: str) -> ConfigDirReadiness:
+        # Codex has no onboarding wizard: "set up" means ``codex login`` has
+        # written parseable credentials to ``<CODEX_HOME>/auth.json``. Reported
+        # for ``accounts doctor`` only — codex deliberately does not implement
+        # ConfigDirValidating (its app-server transport fails fast on an
+        # unauthenticated home rather than hanging), so this never guards a
+        # launch or switch.
+        if codex_auth_present(config_dir):
+            return ConfigDirReadiness(ready=True)
+        return ConfigDirReadiness(
+            ready=False,
+            reason=(
+                "codex auth.json is missing or unreadable in its config dir; "
+                "run 'CODEX_HOME=<dir> codex login' to set it up"
+            ),
+        )
 
     def native_thread_id(self, session: SessionRecord) -> str | None:
         thread_id = session.transport_state.get("thread_id")

--- a/backend/src/waypoint/backends/codex/rate_limits.py
+++ b/backend/src/waypoint/backends/codex/rate_limits.py
@@ -611,6 +611,16 @@ def _codex_auth_path(env: dict[str, str]) -> Path:
     return root / "auth.json"
 
 
+def codex_auth_present(config_dir: str) -> bool:
+    """Whether ``<config_dir>/auth.json`` holds parseable Codex credentials.
+
+    The readiness signal for a codex account profile: unlike claude there is no
+    onboarding wizard, so "set up" means the CLI has written credentials via
+    ``codex login``. Returns ``False`` on a missing/unreadable/unparsable file.
+    """
+    return _load_oauth_credentials({"CODEX_HOME": config_dir}) is not None
+
+
 def _resolve_usage_url(env: dict[str, str]) -> str:
     base_url = _resolve_chatgpt_base_url(env)
     normalized = _normalize_chatgpt_base_url(base_url)

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -89,7 +89,7 @@ def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
     For the populated case the sequence is data-safe against loss: (1) a conflict
     pre-flight refuses before touching anything if any top-level entry already
     exists under ``shared``; (2) contents are copied into a temp sibling of
-    ``shared`` (removed on failure) and then renamed into place, so a mid-copy
+    ``shared`` (removed afterward) and then renamed into place, so a mid-copy
     failure leaves both ``store`` and ``shared`` intact; (3) the original
     ``store`` is renamed to a timestamped backup (a complete snapshot, not an
     emptied husk); (4) ``store`` becomes the symlink. The original ``store`` is

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -18,6 +18,7 @@ to a 400 (nothing is terminated when it fires).
 import logging
 import os
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -66,6 +67,77 @@ def ensure_symlink_shared(store_dir: Path, shared_dir: Path) -> None:
         store_dir.rmdir()
     store_dir.parent.mkdir(parents=True, exist_ok=True)
     store_dir.symlink_to(shared_dir, target_is_directory=True)
+
+
+def _pin_tree_perms(root: Path) -> None:
+    """Lock a copied transcript tree to 0700 dirs / 0600 files."""
+    root.chmod(0o700)
+    for path in root.rglob("*"):
+        path.chmod(0o700 if path.is_dir() else 0o600)
+
+
+def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
+    """Make ``store_dir`` a symlink to ``shared_dir``, migrating existing content.
+
+    The action counterpart to :func:`ensure_symlink_shared`'s guard: it performs
+    the one case the guard refuses — a populated real store dir — by migrating
+    its contents into the shared dir before replacing it with the symlink. The
+    other five cases delegate to :func:`ensure_symlink_shared`. Returns a list of
+    the actions taken (for reporting); raises :class:`TranscriptUnavailableError`
+    on a same-named conflict or a symlink pointing elsewhere.
+
+    For the populated case the sequence is data-safe: (1) a conflict pre-flight
+    refuses before touching anything if any top-level entry already exists under
+    ``shared``; (2) contents are copied into a temp sibling of ``shared`` and
+    renamed into place only after the full copy succeeds, so a mid-copy failure
+    leaves both ``store`` and ``shared`` intact and a re-run stays clean; (3) the
+    original ``store`` is renamed to a timestamped backup (a complete snapshot,
+    not an emptied husk); (4) ``store`` becomes the symlink.
+    """
+    shared_dir = shared_dir.expanduser()
+    if store_dir.is_symlink() and store_dir.resolve() == shared_dir.resolve():
+        return [f"{store_dir} already links to {shared_dir}"]
+    if not store_dir.is_symlink() and store_dir.is_dir() and any(store_dir.iterdir()):
+        return _migrate_populated_store(store_dir, shared_dir)
+    ensure_symlink_shared(store_dir, shared_dir)
+    return [f"linked {store_dir} -> {shared_dir}"]
+
+
+def _migrate_populated_store(store_dir: Path, shared_dir: Path) -> list[str]:
+    shared_dir.mkdir(parents=True, exist_ok=True)
+    shared_dir.chmod(0o700)
+
+    entries = sorted(store_dir.iterdir(), key=lambda p: p.name)
+    conflicts = [e.name for e in entries if (shared_dir / e.name).exists()]
+    if conflicts:
+        raise TranscriptUnavailableError(
+            f"cannot migrate {store_dir} into {shared_dir}: these entries already "
+            f"exist in the shared dir: {', '.join(sorted(conflicts))}"
+        )
+
+    # Copy into a temp sibling first, then rename each entry into place, so a
+    # failed copy never leaves partial entries under the shared dir.
+    staging = shared_dir.parent / f".wp-migrate-{_timestamp()}"
+    if staging.exists():
+        raise TranscriptUnavailableError(f"migration staging dir {staging} exists")
+    shutil.copytree(store_dir, staging, symlinks=True)
+    _pin_tree_perms(staging)
+    for entry in sorted(staging.iterdir(), key=lambda p: p.name):
+        entry.rename(shared_dir / entry.name)
+    staging.rmdir()
+
+    backup = store_dir.parent / f"{store_dir.name}.bak-{_timestamp()}"
+    store_dir.rename(backup)
+    store_dir.symlink_to(shared_dir, target_is_directory=True)
+    return [
+        f"migrated {len(entries)} entries from {store_dir} into {shared_dir}",
+        f"backed up the original dir to {backup}",
+        f"linked {store_dir} -> {shared_dir}",
+    ]
+
+
+def _timestamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
 
 
 def copy_thread_artifacts(

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -86,13 +86,18 @@ def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
     the actions taken (for reporting); raises :class:`TranscriptUnavailableError`
     on a same-named conflict or a symlink pointing elsewhere.
 
-    For the populated case the sequence is data-safe: (1) a conflict pre-flight
-    refuses before touching anything if any top-level entry already exists under
-    ``shared``; (2) contents are copied into a temp sibling of ``shared`` and
-    renamed into place only after the full copy succeeds, so a mid-copy failure
-    leaves both ``store`` and ``shared`` intact and a re-run stays clean; (3) the
-    original ``store`` is renamed to a timestamped backup (a complete snapshot,
-    not an emptied husk); (4) ``store`` becomes the symlink.
+    For the populated case the sequence is data-safe against loss: (1) a conflict
+    pre-flight refuses before touching anything if any top-level entry already
+    exists under ``shared``; (2) contents are copied into a temp sibling of
+    ``shared`` (removed on failure) and then renamed into place, so a mid-copy
+    failure leaves both ``store`` and ``shared`` intact; (3) the original
+    ``store`` is renamed to a timestamped backup (a complete snapshot, not an
+    emptied husk); (4) ``store`` becomes the symlink. The original ``store`` is
+    never touched until every entry is safely in ``shared``, so no transcript is
+    lost. The per-entry rename in step 2 is not a single atomic commit, so a
+    process death partway through can leave some entries already under ``shared``;
+    a re-run then reports those as conflicts and the operator finishes the move by
+    hand — the original data is still intact in ``store``.
     """
     shared_dir = shared_dir.expanduser()
     if store_dir.is_symlink() and store_dir.resolve() == shared_dir.resolve():
@@ -116,15 +121,18 @@ def _migrate_populated_store(store_dir: Path, shared_dir: Path) -> list[str]:
         )
 
     # Copy into a temp sibling first, then rename each entry into place, so a
-    # failed copy never leaves partial entries under the shared dir.
+    # failed copy never leaves partial entries under the shared dir. The staging
+    # dir is removed on any failure so a re-run isn't blocked by an orphan.
     staging = shared_dir.parent / f".wp-migrate-{_timestamp()}"
     if staging.exists():
         raise TranscriptUnavailableError(f"migration staging dir {staging} exists")
-    shutil.copytree(store_dir, staging, symlinks=True)
-    _pin_tree_perms(staging)
-    for entry in sorted(staging.iterdir(), key=lambda p: p.name):
-        entry.rename(shared_dir / entry.name)
-    staging.rmdir()
+    try:
+        shutil.copytree(store_dir, staging, symlinks=True)
+        _pin_tree_perms(staging)
+        for entry in sorted(staging.iterdir(), key=lambda p: p.name):
+            entry.rename(shared_dir / entry.name)
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
 
     backup = store_dir.parent / f"{store_dir.name}.bak-{_timestamp()}"
     store_dir.rename(backup)

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -18,6 +18,11 @@ from fastapi import HTTPException
 from websockets.exceptions import WebSocketException
 
 from waypoint.api import AppContext, create_app
+from waypoint.backends.account_profiles import (
+    account_profile_static_checks,
+    backend_hosts_account_profiles,
+    resolve_account_profiles,
+)
 from waypoint.backends.registry import get_registry
 from waypoint.client import (
     WaypointClient,
@@ -3232,6 +3237,153 @@ def accounts_list(
     _emit(_settings_from_ctx(ctx), run)
 
 
+@accounts_app.command("probe")
+def accounts_probe(
+    ctx: typer.Context,
+    backend: Annotated[
+        str,
+        typer.Argument(callback=_validate_backend, autocompletion=_complete_backend),
+    ],
+    profile: Annotated[str, typer.Argument(help="Account profile id.")],
+    launch_target_id: Annotated[
+        str | None,
+        typer.Option(help="Probe the profile as resolved for this launch target."),
+    ] = None,
+    show_key: Annotated[
+        bool,
+        typer.Option(
+            "--show-key",
+            help="Include the private-class account_key (hidden by default).",
+        ),
+    ] = False,
+) -> None:
+    """Probe the account a profile authenticates as (verified label; key hidden).
+
+    The canonical way to read a profile's exact account_key for
+    ``expected_account_key`` — pass ``--show-key`` to reveal it.
+    """
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: c.probe_account(
+            backend, profile, launch_target_id=launch_target_id, show_key=show_key
+        ),
+    )
+
+
+def _profile_hosting_backends(c: WaypointClient, backend: str | None) -> list[str]:
+    return [
+        descriptor["id"]
+        for descriptor in c.list_backends()
+        if descriptor.get("account_profiles")
+        and (backend is None or descriptor["id"] == backend)
+    ]
+
+
+@accounts_app.command("doctor")
+def accounts_doctor(
+    ctx: typer.Context,
+    backend: Annotated[
+        str | None,
+        typer.Option(
+            callback=_validate_backend,
+            autocompletion=_complete_backend,
+            help="Only diagnose this backend's profiles.",
+        ),
+    ] = None,
+    launch_target_id: Annotated[
+        str | None,
+        typer.Option(help="Diagnose profiles as resolved for this launch target."),
+    ] = None,
+    json_output: Annotated[
+        bool, typer.Option("--json", help="Emit the structured report as JSON.")
+    ] = False,
+    show_paths: Annotated[
+        bool,
+        typer.Option("--show-paths", help="Include config-dir paths in details."),
+    ] = False,
+) -> None:
+    """Diagnose account profiles per backend; exits non-zero on any failing check.
+
+    Runs a checklist (config dir, readiness, transcript setup, expected-account
+    match, support) for each profile. Human table by default; ``--json`` emits a
+    machine-readable report.
+    """
+
+    def run(c: WaypointClient) -> list[dict[str, Any]]:
+        reports: list[dict[str, Any]] = []
+        for backend_id in _profile_hosting_backends(c, backend):
+            reports.extend(
+                c.account_doctor(
+                    backend_id,
+                    launch_target_id=launch_target_id,
+                    show_paths=show_paths,
+                )
+            )
+        return reports
+
+    reports = _run_client(_settings_from_ctx(ctx), run)
+    if json_output:
+        typer.echo(json.dumps(reports, indent=2))
+    else:
+        _render_doctor_reports(reports)
+    if any(not report["ok"] for report in reports):
+        raise typer.Exit(code=1)
+
+
+def _render_doctor_reports(reports: list[dict[str, Any]]) -> None:
+    if not reports:
+        typer.echo("no account profiles configured")
+        return
+    for report in reports:
+        mark = "OK" if report["ok"] else "FAIL"
+        typer.echo(
+            f"[{mark}] {report['backend']}/{report['profile']} ({report['label']})"
+        )
+        for check in report["checks"]:
+            check_mark = "ok  " if check["ok"] else "FAIL"
+            detail = f" — {check['detail']}" if check.get("detail") else ""
+            typer.echo(f"    {check_mark} {check['name']}{detail}")
+
+
+@accounts_app.command("setup-transcripts")
+def accounts_setup_transcripts(
+    ctx: typer.Context,
+    backend: Annotated[
+        str,
+        typer.Argument(callback=_validate_backend, autocompletion=_complete_backend),
+    ],
+    profile: Annotated[str, typer.Argument(help="Account profile id.")],
+    launch_target_id: Annotated[
+        str | None,
+        typer.Option(help="Reserved; remote setup-transcripts is not yet supported."),
+    ] = None,
+    shared_dir: Annotated[
+        str | None,
+        typer.Option(help="Override the profile's shared_transcript_dir."),
+    ] = None,
+    policy: Annotated[
+        str | None,
+        typer.Option(help="Override the transcript policy (only symlink_shared)."),
+    ] = None,
+) -> None:
+    """Set up a profile's shared transcript symlink (migrating existing content).
+
+    Idempotent on a correct symlink; migrates a populated native store into the
+    shared dir (refusing same-named conflicts, keeping a backup) before replacing
+    it with the symlink. Never runs implicitly during a switch.
+    """
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: c.setup_account_transcripts(
+            backend,
+            profile,
+            launch_target_id=launch_target_id,
+            shared_dir=shared_dir,
+            policy=policy,
+        ),
+    )
+
+
 @schedule_message_app.command("list")
 def schedule_message_list(
     ctx: typer.Context,
@@ -3626,7 +3778,34 @@ def run_doctor(settings: Settings | None = None) -> None:
             continue
         checks[binary] = shutil.which(binary)
     checks["config_path"] = str(settings.config_path) if settings.config_path else None
+    checks["account_profiles"] = _account_profile_doctor_summary(settings)
     print(json.dumps(checks, indent=2))
+
+
+def _account_profile_doctor_summary(settings: Settings) -> list[dict[str, Any]]:
+    """Server-free per-profile summary for the root ``doctor`` report.
+
+    Runs the shared static checklist (config dir, readiness, transcript setup,
+    support) locally — the live ``account_matches_expected`` check needs the
+    running server, so ``waypoint accounts doctor`` is the way to verify accounts.
+    """
+    summary: list[dict[str, Any]] = []
+    for backend in sorted(get_registry().backends()):
+        if not backend_hosts_account_profiles(settings, backend):
+            continue
+        for profile_id, profile in resolve_account_profiles(settings, backend).items():
+            checks = account_profile_static_checks(
+                settings, backend, profile_id, profile, local=True
+            )
+            summary.append(
+                {
+                    "backend": backend,
+                    "profile": profile_id,
+                    "ok": all(c.ok for c in checks),
+                    "checks": [c.model_dump(mode="json") for c in checks],
+                }
+            )
+    return summary
 
 
 def main() -> None:

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -3301,6 +3301,13 @@ def accounts_doctor(
         bool,
         typer.Option("--show-paths", help="Include config-dir paths in details."),
     ] = False,
+    show_key: Annotated[
+        bool,
+        typer.Option(
+            "--show-key",
+            help="Include private-class account keys in the match check detail.",
+        ),
+    ] = False,
 ) -> None:
     """Diagnose account profiles per backend; exits non-zero on any failing check.
 
@@ -3317,6 +3324,7 @@ def accounts_doctor(
                     backend_id,
                     launch_target_id=launch_target_id,
                     show_paths=show_paths,
+                    show_key=show_key,
                 )
             )
         return reports

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -260,6 +260,70 @@ class WaypointClient:
         ).json()
         return data
 
+    def probe_account(
+        self,
+        backend: str,
+        profile: str,
+        *,
+        launch_target_id: str | None = None,
+        show_key: bool = False,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if launch_target_id is not None:
+            params["launch_target_id"] = launch_target_id
+        if show_key:
+            params["show_key"] = show_key
+        data: dict[str, Any] = self._request(
+            "GET",
+            f"/api/backends/{backend}/accounts/{profile}/probe",
+            params=params or None,
+        ).json()
+        return data
+
+    def account_doctor(
+        self,
+        backend: str,
+        *,
+        launch_target_id: str | None = None,
+        show_paths: bool = False,
+    ) -> list[dict[str, Any]]:
+        params: dict[str, Any] = {}
+        if launch_target_id is not None:
+            params["launch_target_id"] = launch_target_id
+        if show_paths:
+            params["show_paths"] = show_paths
+        data: list[dict[str, Any]] = self._request(
+            "GET", f"/api/backends/{backend}/accounts/doctor", params=params or None
+        ).json()
+        return data
+
+    def setup_account_transcripts(
+        self,
+        backend: str,
+        profile: str,
+        *,
+        launch_target_id: str | None = None,
+        shared_dir: str | None = None,
+        policy: str | None = None,
+    ) -> dict[str, Any]:
+        params = (
+            {"launch_target_id": launch_target_id}
+            if launch_target_id is not None
+            else None
+        )
+        body: dict[str, Any] = {}
+        if shared_dir is not None:
+            body["shared_dir"] = shared_dir
+        if policy is not None:
+            body["policy"] = policy
+        data: dict[str, Any] = self._request(
+            "POST",
+            f"/api/backends/{backend}/accounts/{profile}/setup-transcripts",
+            params=params,
+            json=body,
+        ).json()
+        return data
+
     def list_threads(
         self, backend: str, *, launch_target_id: str | None = None
     ) -> list[dict[str, Any]]:

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -286,12 +286,15 @@ class WaypointClient:
         *,
         launch_target_id: str | None = None,
         show_paths: bool = False,
+        show_key: bool = False,
     ) -> list[dict[str, Any]]:
         params: dict[str, Any] = {}
         if launch_target_id is not None:
             params["launch_target_id"] = launch_target_id
         if show_paths:
             params["show_paths"] = show_paths
+        if show_key:
+            params["show_key"] = show_key
         data: list[dict[str, Any]] = self._request(
             "GET", f"/api/backends/{backend}/accounts/doctor", params=params or None
         ).json()

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -643,6 +643,7 @@ class SessionRuntime:
         backend: str,
         launch_target_id: str | None = None,
         show_paths: bool = False,
+        show_key: bool = False,
     ) -> list[ProfileDoctorReport]:
         """Run the per-profile ``accounts doctor`` checklist for one backend.
 
@@ -650,7 +651,8 @@ class SessionRuntime:
         from the shared server-free checklist; a live ``account_matches_expected``
         check is added when the profile declares an ``expected_account_key`` and
         the target is probeable. A profile with any failing check reports
-        ``ok=False`` so the CLI can exit non-zero.
+        ``ok=False`` so the CLI can exit non-zero. Account keys stay out of the
+        check details unless ``show_key`` is set (phase-1 redaction rules).
         """
         launch_target = self._resolve_launch_target(launch_target_id, backend)
         local = launch_target is None
@@ -668,7 +670,12 @@ class SessionRuntime:
             )
             checks.append(
                 await self._account_matches_check(
-                    backend, profile_id, profile, launch_target, probe_blocked
+                    backend,
+                    profile_id,
+                    profile,
+                    launch_target,
+                    probe_blocked,
+                    show_key=show_key,
                 )
             )
             reports.append(
@@ -689,6 +696,8 @@ class SessionRuntime:
         profile: AccountProfileConfig,
         launch_target: SshLaunchTargetConfig | None,
         probe_blocked: bool,
+        *,
+        show_key: bool,
     ) -> ProfileCheck:
         name = "account_matches_expected"
         if not profile.expected_account_key:
@@ -709,17 +718,20 @@ class SessionRuntime:
         if probe is None:
             return ProfileCheck(name=name, ok=False, detail="could not verify account")
         if probe.account_key != profile.expected_account_key:
-            return ProfileCheck(
-                name=name,
-                ok=False,
-                detail=(
-                    f"authenticates as {probe.account_key!r}, expected "
-                    f"{profile.expected_account_key!r}"
-                ),
+            detail = (
+                f"authenticates as {probe.account_key!r}, expected "
+                f"{profile.expected_account_key!r}"
+                if show_key
+                else "authenticates as a different account than expected "
+                "(pass --show-key for the keys)"
             )
-        return ProfileCheck(
-            name=name, ok=True, detail=f"matches {profile.expected_account_key!r}"
+            return ProfileCheck(name=name, ok=False, detail=detail)
+        detail = (
+            f"matches {profile.expected_account_key!r}"
+            if show_key
+            else "matches the expected account"
         )
+        return ProfileCheck(name=name, ok=True, detail=detail)
 
     def setup_account_transcripts(
         self,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -21,6 +21,7 @@ from waypoint.assistant_assets import AssistantAssetError, ensure_assistant_asse
 from waypoint.attachments import AttachmentStore, ResolvedAttachment
 from waypoint.backends import BackendRegistry, get_registry
 from waypoint.backends.account_profiles import (
+    account_profile_static_checks,
     probe_account,
     redacted_profile_metadata,
     resolve_account_profiles,
@@ -42,6 +43,7 @@ from waypoint.backends.tmux.normalize import (
 from waypoint.backends.transcripts import (
     TranscriptUnavailableError,
     ensure_thread_available,
+    setup_transcripts_symlink,
 )
 from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
@@ -50,6 +52,7 @@ from waypoint.perf import debug_timer
 from waypoint.presets import PresetManager
 from waypoint.scheduler import Scheduler
 from waypoint.schemas import (
+    AccountProbeResult,
     AssistantSummary,
     AttachmentSpec,
     BoardChannel,
@@ -71,6 +74,8 @@ from waypoint.schemas import (
     LaunchMode,
     LaunchSettingsResponse,
     LaunchSettingsUpdateRequest,
+    ProfileCheck,
+    ProfileDoctorReport,
     SessionApprovalRequest,
     SessionAttachRequest,
     SessionCommandInvocation,
@@ -581,6 +586,197 @@ class SessionRuntime:
         """
         plugin = self.registry.get(backend)
         return {**os.environ, **launch_env, **plugin.extra_env}
+
+    def _profile_launch_env(
+        self,
+        backend: str,
+        profile_id: str,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> dict[str, str]:
+        """Build the launch env a profile resolves to, outside any session.
+
+        Mirrors the switch path: the backend's default env with the profile's
+        ``config_dir`` overlaid on the config-dir env var. Raises 400 for an
+        unknown profile or a backend without a config-dir env var.
+        """
+        env = self._default_launch_env(backend, launch_target)
+        env, _ = self._apply_account_profile_env(
+            backend, env, profile_id, launch_target
+        )
+        return env
+
+    async def probe_account_profile(
+        self,
+        backend: str,
+        profile_id: str,
+        *,
+        launch_target_id: str | None = None,
+        cwd: str = ".",
+    ) -> AccountProbeResult:
+        """Probe the account an account profile authenticates as.
+
+        Resolves the profile's launch env exactly as a switch would and runs the
+        account probe against it — the canonical way to read a profile's verified
+        ``account_key``/``label`` (e.g. to fill in ``expected_account_key``).
+        Raises 400 when the account can't be verified.
+        """
+        launch_target = self._resolve_launch_target(launch_target_id, backend)
+        if launch_target is not None:
+            await self._require_live_master(launch_target)
+        env = self._profile_launch_env(backend, profile_id, launch_target)
+        result = await probe_account(
+            self, backend, env, launch_target=launch_target, cwd=cwd
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"could not verify the account for profile {profile_id!r} "
+                    f"on backend {backend}"
+                ),
+            )
+        return result
+
+    async def account_doctor(
+        self,
+        *,
+        backend: str,
+        launch_target_id: str | None = None,
+        show_paths: bool = False,
+    ) -> list[ProfileDoctorReport]:
+        """Run the per-profile ``accounts doctor`` checklist for one backend.
+
+        Static checks (config dir, readiness, transcript setup, support) come
+        from the shared server-free checklist; a live ``account_matches_expected``
+        check is added when the profile declares an ``expected_account_key`` and
+        the target is probeable. A profile with any failing check reports
+        ``ok=False`` so the CLI can exit non-zero.
+        """
+        launch_target = self._resolve_launch_target(launch_target_id, backend)
+        local = launch_target is None
+        probe_blocked = self.remote_probe_blocked(launch_target_id)
+        profiles = resolve_account_profiles(self.settings, backend, launch_target)
+        reports: list[ProfileDoctorReport] = []
+        for profile_id, profile in profiles.items():
+            checks = account_profile_static_checks(
+                self.settings,
+                backend,
+                profile_id,
+                profile,
+                local=local,
+                show_paths=show_paths,
+            )
+            checks.append(
+                await self._account_matches_check(
+                    backend, profile_id, profile, launch_target, probe_blocked
+                )
+            )
+            reports.append(
+                ProfileDoctorReport(
+                    backend=backend,
+                    profile=profile_id,
+                    label=profile.label,
+                    ok=all(c.ok for c in checks),
+                    checks=checks,
+                )
+            )
+        return reports
+
+    async def _account_matches_check(
+        self,
+        backend: str,
+        profile_id: str,
+        profile: AccountProfileConfig,
+        launch_target: SshLaunchTargetConfig | None,
+        probe_blocked: bool,
+    ) -> ProfileCheck:
+        name = "account_matches_expected"
+        if not profile.expected_account_key:
+            return ProfileCheck(
+                name=name, ok=True, detail="n/a: no expected_account_key set"
+            )
+        if probe_blocked:
+            return ProfileCheck(
+                name=name,
+                ok=True,
+                detail="skipped: launch target needs an SSH master to probe",
+            )
+        try:
+            env = self._profile_launch_env(backend, profile_id, launch_target)
+            probe = await probe_account(self, backend, env, launch_target=launch_target)
+        except HTTPException as exc:
+            return ProfileCheck(name=name, ok=False, detail=str(exc.detail))
+        if probe is None:
+            return ProfileCheck(name=name, ok=False, detail="could not verify account")
+        if probe.account_key != profile.expected_account_key:
+            return ProfileCheck(
+                name=name,
+                ok=False,
+                detail=(
+                    f"authenticates as {probe.account_key!r}, expected "
+                    f"{profile.expected_account_key!r}"
+                ),
+            )
+        return ProfileCheck(
+            name=name, ok=True, detail=f"matches {profile.expected_account_key!r}"
+        )
+
+    def setup_account_transcripts(
+        self,
+        backend: str,
+        profile_id: str,
+        *,
+        launch_target_id: str | None = None,
+        shared_dir: str | None = None,
+        policy: str | None = None,
+    ) -> list[str]:
+        """Perform the guarded transcript symlink setup for a profile (local only).
+
+        Migrates a populated native store into the shared transcript dir and
+        replaces it with a symlink, per the profile's ``symlink_shared`` policy.
+        Never runs implicitly during a switch. Raises 400 for a remote target,
+        an unsupported policy, a missing shared dir, or a migration conflict.
+        """
+        launch_target = self._resolve_launch_target(launch_target_id, backend)
+        if launch_target is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="remote setup-transcripts is not supported yet",
+            )
+        profile = self._require_account_profile(backend, profile_id, None)
+        effective_policy = policy or profile.transcript_policy
+        if effective_policy != "symlink_shared":
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"setup-transcripts only applies to the 'symlink_shared' "
+                    f"policy, not {effective_policy!r}"
+                ),
+            )
+        effective_shared = shared_dir or profile.shared_transcript_dir
+        if not effective_shared:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "symlink_shared requires a shared dir; set "
+                    "shared_transcript_dir on the profile or pass --shared-dir"
+                ),
+            )
+        native_store = self.registry.get(backend).capabilities.native_thread_store
+        if native_store is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"backend {backend} has no native transcript store",
+            )
+        store_dir = Path(profile.config_dir).expanduser() / native_store
+        try:
+            return setup_transcripts_symlink(
+                store_dir, Path(effective_shared).expanduser()
+            )
+        except TranscriptUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
 
     async def create_session(
         self,

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -335,6 +335,36 @@ class AccountProbeResult(BaseModel):
     source: Literal["oauth", "api", "cli", "unknown"] = "oauth"
 
 
+class ProfileCheck(BaseModel):
+    """One line of an ``accounts doctor`` per-profile checklist.
+
+    ``ok`` is the pass/fail verdict; ``detail`` is a terse human explanation.
+    A check may be reported ``ok=True`` with a ``detail`` of ``"n/a"`` /
+    ``"skipped"`` when it doesn't apply (e.g. a transcript check on a
+    non-``symlink_shared`` profile, or a filesystem check on a remote target).
+    """
+
+    name: str
+    ok: bool
+    detail: str | None = None
+
+
+class ProfileDoctorReport(BaseModel):
+    """The ``accounts doctor`` verdict for a single account profile.
+
+    ``ok`` is the conjunction of every check. Config-dir paths and account keys
+    appear in check details only when the caller asked for them via the
+    diagnostic flags (``show_paths`` / ``show_key``); otherwise they stay
+    redacted per the phase-1 rules.
+    """
+
+    backend: str
+    profile: str
+    label: str
+    ok: bool
+    checks: list[ProfileCheck]
+
+
 class LaunchTargetSummary(BaseModel):
     id: str
     name: str

--- a/backend/tests/test_account_doctor.py
+++ b/backend/tests/test_account_doctor.py
@@ -235,6 +235,35 @@ async def test_doctor_endpoint_reports_profiles(
 
 
 @pytest.mark.asyncio
+async def test_doctor_endpoint_redacts_account_key_by_default(
+    app_client: tuple[Any, dict[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, headers = app_client
+
+    async def wrong_probe(*args: Any, **kwargs: Any) -> AccountProbeResult:
+        return AccountProbeResult(
+            account_key="claude_code:other", account_label="Other"
+        )
+
+    monkeypatch.setattr(runtime_module, "probe_account", wrong_probe)
+
+    def _match(resp: httpx.Response) -> dict[str, Any]:
+        checks = resp.json()[0]["checks"]
+        return next(c for c in checks if c["name"] == "account_matches_expected")
+
+    redacted = await _get(app, "/api/backends/claude_code/accounts/doctor", headers)
+    detail = _match(redacted)["detail"]
+    assert _match(redacted)["ok"] is False
+    assert "claude_code:other" not in detail
+    assert "claude_code:acme" not in detail
+
+    shown = await _get(
+        app, "/api/backends/claude_code/accounts/doctor?show_key=true", headers
+    )
+    assert "claude_code:acme" in _match(shown)["detail"]
+
+
+@pytest.mark.asyncio
 async def test_doctor_endpoint_rejects_non_hosting_backend(
     app_client: tuple[Any, dict[str, str]],
 ) -> None:

--- a/backend/tests/test_account_doctor.py
+++ b/backend/tests/test_account_doctor.py
@@ -232,6 +232,8 @@ async def test_doctor_endpoint_reports_profiles(
     assert {"supported", "config_dir_exists", "ready", "transcript_setup"} <= names
     match = next(c for c in report["checks"] if c["name"] == "account_matches_expected")
     assert match["ok"] is True
+    # The matched key stays out of the detail without --show-key.
+    assert "claude_code:acme" not in (match["detail"] or "")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_account_doctor.py
+++ b/backend/tests/test_account_doctor.py
@@ -1,0 +1,438 @@
+"""Account probe / doctor / setup-transcripts: checklist, endpoints, CLI.
+
+Phase 2 of the account-switching RFC. Covers the server-free static checklist,
+the per-agent readiness verdicts, the HTTP endpoints (redaction + guards), and
+the CLI verbs (including doctor's non-zero exit).
+"""
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+import waypoint.cli as cli
+import waypoint.runtime as runtime_module
+from waypoint.api import create_app
+from waypoint.backends.account_profiles import (
+    account_profile_static_checks,
+    resolve_account_profiles,
+)
+from waypoint.backends.base import ConfigDirReadinessReporting
+from waypoint.backends.bootstrap import build_default_registry
+from waypoint.cli import app
+from waypoint.client import WaypointClient
+from waypoint.schemas import AccountProbeResult
+from waypoint.settings import Settings
+
+runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The test host may run Waypoint itself, whose WAYPOINT_* env vars would
+    # otherwise override the per-test config file (notably data_dir).
+    for var in (
+        "WAYPOINT_DATA_DIR",
+        "WAYPOINT_CONFIG_PATH",
+        "WAYPOINT_HOST",
+        "WAYPOINT_PORT",
+        "WAYPOINT_PASSWORD",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _onboarded_claude_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".claude.json").write_text(json.dumps({"hasCompletedOnboarding": True}))
+    return path
+
+
+def _settings(tmp_path: Path, profiles: dict[str, Any]) -> Settings:
+    return Settings.model_validate(
+        {
+            "data_dir": str(tmp_path / "data"),
+            "plugin_configs": {"claude_code": {"account_profiles": profiles}},
+        }
+    )
+
+
+# ── per-agent readiness verdicts ────────────────────────────────────────────
+
+
+def _readiness_reporter(backend: str) -> ConfigDirReadinessReporting:
+    plugin = build_default_registry().get(backend)
+    assert isinstance(plugin, ConfigDirReadinessReporting)
+    return plugin
+
+
+def test_claude_readiness_true_when_onboarded(tmp_path: Path) -> None:
+    cfg = _onboarded_claude_dir(tmp_path / "c")
+    verdict = _readiness_reporter("claude_code").config_dir_readiness(str(cfg))
+    assert verdict.ready is True
+    assert verdict.reason is None
+
+
+def test_claude_readiness_false_when_unonboarded(tmp_path: Path) -> None:
+    (tmp_path / "c").mkdir()
+    verdict = _readiness_reporter("claude_code").config_dir_readiness(
+        str(tmp_path / "c")
+    )
+    assert verdict.ready is False
+    assert "onboarding" in (verdict.reason or "")
+
+
+def test_codex_readiness_tracks_auth_json(tmp_path: Path) -> None:
+    plugin = _readiness_reporter("codex")
+    home = tmp_path / "codex"
+    home.mkdir()
+    assert plugin.config_dir_readiness(str(home)).ready is False
+    (home / "auth.json").write_text(json.dumps({"OPENAI_API_KEY": "sk-live"}))
+    assert plugin.config_dir_readiness(str(home)).ready is True
+
+
+# ── static checklist ────────────────────────────────────────────────────────
+
+
+def _check(checks: list[Any], name: str) -> Any:
+    return next(c for c in checks if c.name == name)
+
+
+def test_static_checks_pass_for_ready_profile(tmp_path: Path) -> None:
+    cfg = _onboarded_claude_dir(tmp_path / "work")
+    settings = _settings(tmp_path, {"work": {"label": "Work", "config_dir": str(cfg)}})
+    profile = resolve_account_profiles(settings, "claude_code")["work"]
+    checks = account_profile_static_checks(
+        settings, "claude_code", "work", profile, local=True
+    )
+    assert all(c.ok for c in checks)
+    assert _check(checks, "supported").ok
+
+
+def test_static_checks_flag_missing_dir_and_unonboarded(tmp_path: Path) -> None:
+    settings = _settings(
+        tmp_path, {"gone": {"label": "Gone", "config_dir": str(tmp_path / "nope")}}
+    )
+    profile = resolve_account_profiles(settings, "claude_code")["gone"]
+    checks = account_profile_static_checks(
+        settings, "claude_code", "gone", profile, local=True
+    )
+    assert _check(checks, "config_dir_exists").ok is False
+    assert _check(checks, "ready").ok is False
+
+
+def test_static_checks_transcript_setup_requires_symlink(tmp_path: Path) -> None:
+    cfg = _onboarded_claude_dir(tmp_path / "work")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    settings = _settings(
+        tmp_path,
+        {
+            "work": {
+                "label": "Work",
+                "config_dir": str(cfg),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(shared),
+            }
+        },
+    )
+    profile = resolve_account_profiles(settings, "claude_code")["work"]
+    checks = account_profile_static_checks(
+        settings, "claude_code", "work", profile, local=True
+    )
+    # projects/ isn't a symlink yet -> transcript_setup fails.
+    assert _check(checks, "transcript_setup").ok is False
+
+
+def test_static_checks_redact_paths_by_default(tmp_path: Path) -> None:
+    cfg = _onboarded_claude_dir(tmp_path / "work")
+    settings = _settings(tmp_path, {"work": {"label": "Work", "config_dir": str(cfg)}})
+    profile = resolve_account_profiles(settings, "claude_code")["work"]
+    checks = account_profile_static_checks(
+        settings, "claude_code", "work", profile, local=True
+    )
+    detail = _check(checks, "config_dir_exists").detail or ""
+    assert str(cfg) not in detail
+    shown = account_profile_static_checks(
+        settings, "claude_code", "work", profile, local=True, show_paths=True
+    )
+    assert str(cfg) in (_check(shown, "config_dir_exists").detail or "")
+
+
+def test_static_checks_skip_filesystem_when_remote(tmp_path: Path) -> None:
+    settings = _settings(
+        tmp_path, {"work": {"label": "Work", "config_dir": "/whatever"}}
+    )
+    profile = resolve_account_profiles(settings, "claude_code")["work"]
+    checks = account_profile_static_checks(
+        settings, "claude_code", "work", profile, local=False
+    )
+    assert _check(checks, "config_dir_exists").detail == (
+        "skipped: unsupported on a remote launch target"
+    )
+
+
+# ── HTTP endpoints ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def app_client(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> Iterator[tuple[Any, dict[str, str]]]:
+    cfg = _onboarded_claude_dir(tmp_path / "work")
+    settings = _settings(
+        tmp_path,
+        {
+            "work": {
+                "label": "Work",
+                "config_dir": str(cfg),
+                "expected_account_key": "claude_code:acme",
+            }
+        },
+    )
+    app = create_app(settings)
+    token = app.state.context.tokens.issue().token
+    yield app, {"Authorization": f"Bearer {token}"}
+
+
+async def _get(app: Any, path: str, headers: dict[str, str]) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.get(path, headers=headers)
+
+
+async def _post(
+    app: Any, path: str, headers: dict[str, str], body: dict[str, Any]
+) -> httpx.Response:
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        return await client.post(path, headers=headers, json=body)
+
+
+@pytest.mark.asyncio
+async def test_doctor_endpoint_reports_profiles(
+    app_client: tuple[Any, dict[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, headers = app_client
+
+    async def fake_probe(*args: Any, **kwargs: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="claude_code:acme", account_label="Acme")
+
+    monkeypatch.setattr(runtime_module, "probe_account", fake_probe)
+    resp = await _get(app, "/api/backends/claude_code/accounts/doctor", headers)
+    assert resp.status_code == 200
+    report = resp.json()[0]
+    assert report["profile"] == "work"
+    names = {c["name"] for c in report["checks"]}
+    assert {"supported", "config_dir_exists", "ready", "transcript_setup"} <= names
+    match = next(c for c in report["checks"] if c["name"] == "account_matches_expected")
+    assert match["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_doctor_endpoint_rejects_non_hosting_backend(
+    app_client: tuple[Any, dict[str, str]],
+) -> None:
+    app, headers = app_client
+    resp = await _get(app, "/api/backends/opencode/accounts/doctor", headers)
+    assert resp.status_code == 400
+    assert "does not host account profiles" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_probe_endpoint_redacts_key_by_default(
+    app_client: tuple[Any, dict[str, str]], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, headers = app_client
+
+    async def fake_probe(*args: Any, **kwargs: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="claude_code:acme", account_label="Acme")
+
+    monkeypatch.setattr(runtime_module, "probe_account", fake_probe)
+    redacted = await _get(app, "/api/backends/claude_code/accounts/work/probe", headers)
+    assert redacted.json()["account_key"] == ""
+    assert redacted.json()["account_label"] == "Acme"
+    shown = await _get(
+        app, "/api/backends/claude_code/accounts/work/probe?show_key=true", headers
+    )
+    assert shown.json()["account_key"] == "claude_code:acme"
+
+
+@pytest.mark.asyncio
+async def test_setup_transcripts_endpoint_migrates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _onboarded_claude_dir(tmp_path / "work")
+    (cfg / "projects" / "p").mkdir(parents=True)
+    (cfg / "projects" / "p" / "t.jsonl").write_text("thread")
+    shared = tmp_path / "shared"
+    settings = _settings(
+        tmp_path,
+        {
+            "work": {
+                "label": "Work",
+                "config_dir": str(cfg),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(shared),
+            }
+        },
+    )
+    app = create_app(settings)
+    headers = {"Authorization": f"Bearer {app.state.context.tokens.issue().token}"}
+    resp = await _post(
+        app, "/api/backends/claude_code/accounts/work/setup-transcripts", headers, {}
+    )
+    assert resp.status_code == 200
+    assert any("linked" in a for a in resp.json()["actions"])
+    assert (cfg / "projects").is_symlink()
+    assert (shared / "p" / "t.jsonl").read_text() == "thread"
+
+
+# ── CLI verbs ───────────────────────────────────────────────────────────────
+
+
+def _cli_config(tmp_path: Path) -> Path:
+    cfg = tmp_path / "waypoint.yaml"
+    cfg.write_text(f"data_dir: {tmp_path / 'data'}\n", encoding="utf-8")
+    return cfg
+
+
+def _mock_cli_client(monkeypatch: pytest.MonkeyPatch, handler: Any) -> None:
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr(cli, "WaypointClient", fake_client)
+
+
+def test_cli_doctor_exits_nonzero_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/backends":
+            return httpx.Response(
+                200,
+                json={
+                    "backends": [
+                        {"id": "claude_code", "account_profiles": [{"id": "work"}]}
+                    ]
+                },
+            )
+        if path == "/api/backends/claude_code/accounts/doctor":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "backend": "claude_code",
+                        "profile": "work",
+                        "label": "Work",
+                        "ok": False,
+                        "checks": [
+                            {"name": "ready", "ok": False, "detail": "not onboarded"}
+                        ],
+                    }
+                ],
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    _mock_cli_client(monkeypatch, handler)
+    result = runner.invoke(
+        app, ["--config", str(_cli_config(tmp_path)), "accounts", "doctor"]
+    )
+    assert result.exit_code == 1
+    assert "FAIL" in result.stdout
+
+
+def test_cli_doctor_json_ok_exits_zero(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/api/backends":
+            return httpx.Response(
+                200,
+                json={
+                    "backends": [
+                        {"id": "claude_code", "account_profiles": [{"id": "work"}]}
+                    ]
+                },
+            )
+        if path == "/api/backends/claude_code/accounts/doctor":
+            return httpx.Response(
+                200,
+                json=[
+                    {
+                        "backend": "claude_code",
+                        "profile": "work",
+                        "label": "Work",
+                        "ok": True,
+                        "checks": [{"name": "ready", "ok": True, "detail": "ready"}],
+                    }
+                ],
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {path}"})
+
+    _mock_cli_client(monkeypatch, handler)
+    result = runner.invoke(
+        app, ["--config", str(_cli_config(tmp_path)), "accounts", "doctor", "--json"]
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)[0]["ok"] is True
+
+
+def test_cli_probe_emits_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/backends/claude_code/accounts/work/probe":
+            assert request.url.params.get("show_key") == "true"
+            return httpx.Response(
+                200, json={"account_key": "claude_code:acme", "account_label": "Acme"}
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    _mock_cli_client(monkeypatch, handler)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "accounts",
+            "probe",
+            "claude_code",
+            "work",
+            "--show-key",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["account_key"] == "claude_code:acme"
+
+
+def test_cli_setup_transcripts_emits_actions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/accounts/work/setup-transcripts"):
+            return httpx.Response(200, json={"actions": ["linked X -> Y"]})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    _mock_cli_client(monkeypatch, handler)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "accounts",
+            "setup-transcripts",
+            "claude_code",
+            "work",
+        ],
+    )
+    assert result.exit_code == 0
+    assert json.loads(result.stdout)["actions"] == ["linked X -> Y"]

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -16,6 +16,7 @@ from waypoint.backends.transcripts import (
     TranscriptUnavailableError,
     ensure_symlink_shared,
     ensure_thread_available,
+    setup_transcripts_symlink,
 )
 from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
 
@@ -230,3 +231,82 @@ def test_symlink_shared_rechecks_and_rejects_when_shared_lacks_thread(
             shared_transcript_dir=str(tmp_path / "shared"),
             native_thread_store="projects",
         )
+
+
+# ── setup_transcripts_symlink (accounts setup-transcripts) ──────────────────
+
+
+def test_setup_creates_symlink_when_store_missing(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    shared = tmp_path / "shared"
+    actions = setup_transcripts_symlink(store, shared)
+    assert store.is_symlink()
+    assert store.resolve() == shared.resolve()
+    assert any("linked" in a for a in actions)
+
+
+def test_setup_is_noop_on_correct_symlink(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    shared = tmp_path / "shared"
+    setup_transcripts_symlink(store, shared)
+    actions = setup_transcripts_symlink(store, shared)
+    assert store.is_symlink()
+    assert any("already links" in a for a in actions)
+
+
+def test_setup_rejects_symlink_to_other_target(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    other = tmp_path / "other"
+    other.mkdir()
+    store.parent.mkdir(parents=True)
+    store.symlink_to(other)
+    with pytest.raises(TranscriptUnavailableError, match="not the configured"):
+        setup_transcripts_symlink(store, tmp_path / "shared")
+
+
+def test_setup_replaces_empty_real_dir(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    store.mkdir(parents=True)
+    shared = tmp_path / "shared"
+    setup_transcripts_symlink(store, shared)
+    assert store.is_symlink()
+    assert store.resolve() == shared.resolve()
+
+
+def test_setup_migrates_populated_dir_with_backup(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    (store / "proj").mkdir(parents=True)
+    (store / "proj" / "a.jsonl").write_text("thread-a")
+    (store / "top.jsonl").write_text("thread-top")
+    shared = tmp_path / "shared"
+
+    actions = setup_transcripts_symlink(store, shared)
+
+    # Store is now the symlink; contents are visible through it and in shared.
+    assert store.is_symlink()
+    assert (store / "proj" / "a.jsonl").read_text() == "thread-a"
+    assert sorted(p.name for p in shared.iterdir()) == ["proj", "top.jsonl"]
+    # Perms pinned: 0700 dirs, 0600 files.
+    assert (shared / "proj").stat().st_mode & 0o777 == 0o700
+    assert (shared / "top.jsonl").stat().st_mode & 0o777 == 0o600
+    # A complete backup of the original dir is kept.
+    backups = [p for p in store.parent.iterdir() if p.name.startswith("projects.bak-")]
+    assert len(backups) == 1
+    assert (backups[0] / "top.jsonl").read_text() == "thread-top"
+    assert any("backed up" in a for a in actions)
+
+
+def test_setup_refuses_conflict_and_does_not_mutate(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    (store / "dup").mkdir(parents=True)
+    (store / "dup" / "f.jsonl").write_text("orig")
+    shared = tmp_path / "shared"
+    (shared / "dup").mkdir(parents=True)
+
+    with pytest.raises(TranscriptUnavailableError, match="dup"):
+        setup_transcripts_symlink(store, shared)
+
+    # Nothing moved: store is still the original real dir, no symlink, no backup.
+    assert store.is_dir() and not store.is_symlink()
+    assert (store / "dup" / "f.jsonl").read_text() == "orig"
+    assert not any(p.name.startswith("projects.bak-") for p in store.parent.iterdir())

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -129,6 +129,54 @@ waypoint accounts list --backend codex
 waypoint accounts list --launch-target-id my-ssh-host
 ```
 
+### Verifying, diagnosing, and setting up a profile
+
+Three companion commands verify a profile from the CLI instead of discovering
+breakage at launch/switch time.
+
+**`probe`** resolves a profile, authenticates as its config dir, and prints the
+verified account. The label shows by default; the private-class `account_key`
+(what you put in `expected_account_key`) is hidden unless you ask for it:
+
+```bash
+waypoint accounts probe claude_code work
+waypoint accounts probe claude_code work --show-key    # reveal account_key
+```
+
+**`doctor`** runs a per-profile checklist — config dir exists, readiness
+(claude onboarding / codex `auth.json`), transcript-policy setup, expected-account
+match, and backend support — and **exits non-zero** if any check fails, so it is
+scriptable in CI. It renders a table by default and structured JSON with `--json`;
+config-dir paths stay hidden unless `--show-paths`:
+
+```bash
+waypoint accounts doctor                       # all profile-hosting backends
+waypoint accounts doctor --backend codex
+waypoint accounts doctor --json                # machine-readable report
+```
+
+`waypoint doctor` (the top-level diagnostic) also appends a short per-profile
+summary from the same checklist, minus the live account probe — run
+`accounts doctor` for the account-match verification.
+
+**`setup-transcripts`** performs the guarded conversion a `symlink_shared`
+profile needs: it makes `<config_dir>/<native-store>` a symlink to the shared
+dir, and when a populated real directory is already there it migrates the
+contents in (refusing same-named conflicts, keeping a timestamped backup of the
+original) before replacing it with the symlink. It is idempotent on a correct
+symlink and never runs implicitly during a switch:
+
+```bash
+waypoint accounts setup-transcripts claude_code work
+waypoint accounts setup-transcripts codex work --shared-dir ~/.waypoint/codex-sessions
+```
+
+Each command has an HTTP endpoint behind it
+(`GET .../accounts/{profile}/probe`, `GET .../accounts/doctor`,
+`POST .../accounts/{profile}/setup-transcripts`) so the web UI can surface the
+same diagnostics. Remote (SSH launch target) `setup-transcripts` is not yet
+supported; `doctor` reports its filesystem checks as skipped there.
+
 Launch, schedule, or preset a session under a profile with `--account-profile`:
 
 ```bash


### PR DESCRIPTION
## Purpose

Phase 1 shipped the account-profile switch mechanism and one read-only CLI command (`waypoint accounts list`); the operational tooling the phase-1 RFC specified around it — `probe`, `doctor`, `setup-transcripts` — was deferred. This completes the `accounts` command group so a profile can be **verified, diagnosed, and set up** from the CLI (and the equivalent HTTP endpoints) instead of discovering breakage only at launch/switch time. It closes two already-user-visible gaps: `symlink_shared`'s guard tells users to "run `waypoint accounts setup-transcripts`" for a command that didn't exist, and the #250 onboarding guard rejects an un-onboarded profile that a `doctor`/`setup` flow should be able to diagnose. Relates to #230.

## Changes

- `backend/src/waypoint/backends/base.py`, `claude_code/plugin.py`, `codex/plugin.py`, `codex/rate_limits.py` — split the non-raising readiness verdict into a new `ConfigDirReadinessReporting` protocol (`config_dir_readiness(config_dir) -> ConfigDirReadiness{ready, reason}`), keeping `ConfigDirValidating` as the raising launch/switch guard. claude_code implements both (the raising guard now delegates to the verdict); codex implements only the reporting side (`auth.json` presence via the new `codex_auth_present`), so `doctor` can report codex readiness without codex gaining the launch/switch hard-guard it deliberately opts out of.
- `backend/src/waypoint/backends/transcripts.py` — `setup_transcripts_symlink`, the action counterpart to the `ensure_symlink_shared` guard: it migrates a populated real store dir into the shared dir before symlinking, data-safely (conflict pre-flight refuses same-named entries with no mutation; contents are staged in a temp sibling and renamed in only after a full copy; the original dir is renamed to a timestamped backup; perms pinned to 0700/0600).
- `backend/src/waypoint/backends/account_profiles.py`, `schemas.py` — `account_profile_static_checks`, the server-free per-profile checklist (config_dir_exists, ready, transcript_setup, supported) shared by the endpoint and the root doctor, plus the `ProfileCheck` / `ProfileDoctorReport` response models. Config-dir paths stay redacted unless a diagnostic flag opts in.
- `backend/src/waypoint/runtime.py` — `probe_account_profile`, `account_doctor` (static checklist + a live `account_matches_expected` check, skipped when the target isn't probeable), and `setup_account_transcripts` (guarded, local-only).
- `backend/src/waypoint/api.py`, `client.py` — the three HTTP endpoints (`GET .../accounts/{profile}/probe`, `GET .../accounts/doctor`, `POST .../accounts/{profile}/setup-transcripts`), token-authed and guarded to profile-hosting backends, with the matching `WaypointClient` methods. Probe redacts the account key unless `?show_key`; doctor redacts paths unless `?show_paths`.
- `backend/src/waypoint/cli.py` — `accounts probe/doctor/setup-transcripts` verbs (thin clients like `accounts list`); `doctor` renders a table or `--json` and exits non-zero on any failing check. Root `waypoint doctor` gains a server-free per-profile summary from the same checklist.
- `backend/tests/test_transcripts.py`, `test_account_doctor.py` (new) — the six-case migrate state machine, readiness verdicts, the static checklist, the endpoints (ASGI), and the CLI verbs.
- `docs/account_profiles.md`, `.agents/skills/waypoint/references/auth-config.md` — document the new verbs, the root-doctor summary, and the endpoints.

## Design

The three verbs follow the same runtime-method → thin-endpoint → thin-CLI-client shape as `accounts list` / `models` / `set-account`, so the web UI gets identical behavior for free and there is one source of truth (the runtime). The probe path reuses the exact env-building the switch path uses (`_default_launch_env` + `_apply_account_profile_env`), so a profile-only probe authenticates as the same account a switch would. Root `waypoint doctor` stays server-free by design — it must work when the server is down — so it runs only the filesystem/registry checks and points at `accounts doctor` for the live account-match verification.

The readiness refactor uses two protocols rather than the RFC's single-protocol sketch: with one `runtime_checkable` protocol, codex would have to implement both methods to be detectable by `doctor`, which would newly subject it to the launch/switch guard it opts out of. Two protocols give exactly the stated intent — codex reports readiness in `doctor`, but `isinstance(codex, ConfigDirValidating)` stays False so the guard still exempts it (verified by the existing `test_config_dir_guard.py`).

Remote (SSH) `setup-transcripts` is out of scope (covered by the remote-switching RFC); it returns a clear 400 and `doctor` reports its filesystem checks as skipped on a remote target. Frontend UI that consumes these endpoints is a separate effort, as in phase 1 — no dead frontend code is added here.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit — clean (`isort`, `black`, `ruff`, `codespell`, `mypy` all pass).
- `uv run pytest` — 1614 passed, 3 warnings (pre-existing, unrelated).
- Cold-context plan review (one round) verified the readiness split keeps codex exempt, the probe path matches the switch path, root doctor needs no runtime, and the migrate ordering is data-safe before implementation.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: the doctor/probe/setup paths dispatch through the registry and the readiness protocols — no per-backend branching; claude_code/codex host profiles, opencode is rejected, tmux/claude_tty unaffected.
- [x] No frontend changes (endpoints are added for a later UI effort).
- [x] Not a breaking change.
- [x] Updated `docs/account_profiles.md` and the waypoint skill reference for the new user-facing commands.

</details>