### PR TITLE
feat: extend account-profile switching to SSH remote launch targets

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -528,6 +528,20 @@ class BackendPlugin(Protocol):
         """
         ...
 
+    def native_thread_artifact_glob(self, session: SessionRecord) -> str | None:
+        """Glob pattern, relative to a config dir, matching this session's
+        native thread artifact file(s) on disk (e.g.
+        ``projects/*/<uuid>.jsonl``).
+
+        Reuses the same needle :meth:`AgentLaunchContract.conversation_exists`
+        checks, so local and remote transcript-availability discovery
+        (:mod:`waypoint.backends.transcript_fs`) share one declared pattern
+        instead of re-deriving backend-specific path knowledge per IO backend.
+        ``None`` when the backend has no resumable native store, or the
+        session has no native thread id yet to search for.
+        """
+        ...
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -516,6 +516,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return []
         return local_claude_thread_artifacts(thread_id, config_dir)
 
+    def native_thread_artifact_glob(self, session: SessionRecord) -> str | None:
+        # Same needle as conversation_exists: <config_dir>/projects/*/<uuid>.jsonl.
+        thread_id = self.native_thread_id(session)
+        if thread_id is None or not UUID_RE.match(thread_id):
+            return None
+        return f"projects/*/{thread_id}.jsonl"
+
     def config_dir_readiness(self, config_dir: str) -> ConfigDirReadiness:
         # Setting CLAUDE_CONFIG_DIR moves .claude.json into the profile dir; if
         # that copy hasn't completed onboarding the CLI relaunches into its

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -400,7 +400,14 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return
 
         async def _probe() -> SessionRateLimitUsage | None:
-            return await probe_claude_usage_remote_shared(launch_target)
+            # Same reasoning as the local probe above: look up the session's
+            # launch_env per probe so it tracks a live profile switch, and
+            # scope the shared cache key to that profile's config dir.
+            session = runtime.storage.get_session(session_id)
+            launch_env = session.launch_env if session is not None else None
+            return await probe_claude_usage_remote_shared(
+                launch_target, launch_env=launch_env
+            )
 
         await self.adapter.register_rate_limit_probe(
             session_id, _probe, refresh_interval_seconds=300.0
@@ -434,7 +441,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         if launch_target is None:
             invalidate_shared_probe_local()
         else:
-            invalidate_shared_probe_remote(launch_target)
+            invalidate_shared_probe_remote(launch_target, session.launch_env)
         # Run the probe inline so the caller's HTTP response carries the
         # post-refresh snapshot — otherwise the response races the WS push
         # from the periodic loop and the UI sees stale data.
@@ -469,7 +476,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 else None
             )
             return await probe_claude_usage_shared(env=env, force=force)
-        return await probe_claude_usage_remote_shared(launch_target, force=force)
+        return await probe_claude_usage_remote_shared(
+            launch_target, launch_env=launch_env, force=force
+        )
 
     def rate_limit_account(
         self, snapshot: SessionRateLimitUsage

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -144,9 +144,12 @@ async def probe_claude_usage(
 async def probe_claude_usage_remote(
     launch_target: SshLaunchTargetConfig,
     *,
+    launch_env: dict[str, str] | None = None,
     timeout_seconds: float = 30.0,
 ) -> SessionRateLimitUsage | None:
-    payload = await _run_remote_probe_script(launch_target, timeout_seconds)
+    payload = await _run_remote_probe_script(
+        launch_target, timeout_seconds, launch_env=launch_env
+    )
     if payload is None:
         return None
     error = payload.get("error")
@@ -293,8 +296,11 @@ def _local_probe_cache_key(env: dict[str, str]) -> str:
     return f"local:{env.get('CLAUDE_CONFIG_DIR') or '~'}"
 
 
-def _remote_probe_cache_key(launch_target: SshLaunchTargetConfig) -> str:
-    return f"remote:{launch_target.id}"
+def _remote_probe_cache_key(
+    launch_target: SshLaunchTargetConfig, launch_env: dict[str, str] | None = None
+) -> str:
+    config_dir = (launch_env or {}).get("CLAUDE_CONFIG_DIR") or "~"
+    return f"remote:{launch_target.id}:{config_dir}"
 
 
 async def probe_claude_usage_shared(
@@ -320,15 +326,17 @@ async def probe_claude_usage_shared(
 async def probe_claude_usage_remote_shared(
     launch_target: SshLaunchTargetConfig,
     *,
+    launch_env: dict[str, str] | None = None,
     timeout_seconds: float = 30.0,
     force: bool = False,
 ) -> SessionRateLimitUsage | None:
     """Account-shared variant of :func:`probe_claude_usage_remote`, keyed by
-    launch-target id."""
+    launch-target id and the profile's ``CLAUDE_CONFIG_DIR`` so two profiles
+    on one target don't alias to the same cached snapshot."""
     return await _SHARED_PROBE_CACHE.get_or_probe(
-        _remote_probe_cache_key(launch_target),
+        _remote_probe_cache_key(launch_target, launch_env),
         lambda: probe_claude_usage_remote(
-            launch_target, timeout_seconds=timeout_seconds
+            launch_target, launch_env=launch_env, timeout_seconds=timeout_seconds
         ),
         force=force,
     )
@@ -339,8 +347,10 @@ def invalidate_shared_probe_local(env: dict[str, str] | None = None) -> None:
     _SHARED_PROBE_CACHE.invalidate(_local_probe_cache_key(resolved_env))
 
 
-def invalidate_shared_probe_remote(launch_target: SshLaunchTargetConfig) -> None:
-    _SHARED_PROBE_CACHE.invalidate(_remote_probe_cache_key(launch_target))
+def invalidate_shared_probe_remote(
+    launch_target: SshLaunchTargetConfig, launch_env: dict[str, str] | None = None
+) -> None:
+    _SHARED_PROBE_CACHE.invalidate(_remote_probe_cache_key(launch_target, launch_env))
 
 
 def _string_list(value: Any) -> list[str]:
@@ -364,9 +374,12 @@ def _remote_probe_script_bytes() -> bytes:
 
 
 async def _run_remote_probe_script(
-    launch_target: SshLaunchTargetConfig, timeout_seconds: float
+    launch_target: SshLaunchTargetConfig,
+    timeout_seconds: float,
+    *,
+    launch_env: dict[str, str] | None = None,
 ) -> dict[str, Any] | None:
-    argv = launch_target.build_remote_exec_args(["python3", "-"])
+    argv = launch_target.build_remote_exec_args(["python3", "-"], extra_env=launch_env)
     try:
         proc = await asyncio.create_subprocess_exec(
             *argv,

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -223,6 +223,9 @@ class ClaudeTtyPlugin:
         # the config-dir/thread-store path logic, so delegate to it.
         return self._claude.native_thread_artifacts(session, config_dir)
 
+    def native_thread_artifact_glob(self, session: SessionRecord) -> str | None:
+        return self._claude.native_thread_artifact_glob(session)
+
     def pane_ready_for_input(self, pane_text: str) -> bool:
         return pane_dialog.composer_ready(pane_text)
 

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -282,7 +282,13 @@ class CodexPlugin(DefaultLaunchContract):
         binary = self.remote_executable(launch_target) or "codex"
 
         async def _probe() -> SessionRateLimitUsage | None:
-            return await probe_codex_usage_remote(launch_target, binary=binary)
+            # Same reasoning as the local probe above: look up the session's
+            # launch_env per probe so it reads the profile's CODEX_HOME.
+            session = runtime.storage.get_session(session_id)
+            launch_env = session.launch_env if session is not None else None
+            return await probe_codex_usage_remote(
+                launch_target, binary=binary, launch_env=launch_env
+            )
 
         await self.adapter.register_rate_limit_probe(
             session_id, _probe, refresh_interval_seconds=300.0
@@ -349,7 +355,9 @@ class CodexPlugin(DefaultLaunchContract):
             )
             return await probe_codex_status(cwd=cwd, binary=binary, env=env)
         binary = self.remote_executable(launch_target) or "codex"
-        return await probe_codex_usage_remote(launch_target, binary=binary)
+        return await probe_codex_usage_remote(
+            launch_target, binary=binary, launch_env=launch_env
+        )
 
     def rate_limit_account(
         self, snapshot: SessionRateLimitUsage

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -525,6 +525,13 @@ class CodexPlugin(DefaultLaunchContract):
         rollout = find_codex_rollout(thread_id, config_dir)
         return [rollout] if rollout is not None else []
 
+    def native_thread_artifact_glob(self, session: SessionRecord) -> str | None:
+        # Same needle as conversation_exists: <config_dir>/sessions/*/*/*/rollout-*-<uuid>.jsonl.
+        thread_id = self.native_thread_id(session)
+        if thread_id is None or not _UUID_RE.match(thread_id):
+            return None
+        return f"sessions/*/*/*/rollout-*-{thread_id}.jsonl"
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/codex/rate_limits.py
+++ b/backend/src/waypoint/backends/codex/rate_limits.py
@@ -173,9 +173,12 @@ async def probe_codex_usage_remote(
     launch_target: SshLaunchTargetConfig,
     *,
     binary: str = "codex",
+    launch_env: dict[str, str] | None = None,
     timeout_seconds: float = 30.0,
 ) -> SessionRateLimitUsage | None:
-    payload = await _run_remote_probe_script(launch_target, binary, timeout_seconds)
+    payload = await _run_remote_probe_script(
+        launch_target, binary, timeout_seconds, launch_env=launch_env
+    )
     if payload is None:
         return None
     error = payload.get("error")
@@ -206,9 +209,12 @@ async def _run_remote_probe_script(
     launch_target: SshLaunchTargetConfig,
     binary: str,
     timeout_seconds: float,
+    *,
+    launch_env: dict[str, str] | None = None,
 ) -> dict[str, Any] | None:
     argv = launch_target.build_remote_exec_args(
-        ["env", f"{_REMOTE_PROBE_CODEX_BIN_ENV}={binary}", "python3", "-"]
+        ["env", f"{_REMOTE_PROBE_CODEX_BIN_ENV}={binary}", "python3", "-"],
+        extra_env=launch_env,
     )
     try:
         proc = await asyncio.create_subprocess_exec(

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -677,6 +677,10 @@ class OpenCodePlugin(DefaultLaunchContract):
         # No config-dir env var / account-profile support in phase 1.
         return []
 
+    def native_thread_artifact_glob(self, session: SessionRecord) -> str | None:
+        # No config-dir env var / account-profile support in phase 1.
+        return None
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -194,6 +194,13 @@ class TmuxPlugin:
         # dispatched via ``session.backend``. Nothing to contribute here.
         return []
 
+    def native_thread_artifact_glob(self, session: SessionRecord) -> str | None:
+        # Generic wrapper for any agent; it doesn't hold a reference to the
+        # wrapped agent's plugin, so it has no pattern to contribute. Moot in
+        # practice: this plugin's capabilities carry no config_dir_env_var, so
+        # account-profile switching (the only caller) never reaches this.
+        return None
+
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord
     ) -> None:

--- a/backend/src/waypoint/backends/transcript_fs.py
+++ b/backend/src/waypoint/backends/transcript_fs.py
@@ -8,6 +8,7 @@ only the :class:`TranscriptFilesystem` implementation differs, never the
 policy branching.
 """
 
+import os
 import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
@@ -63,6 +64,17 @@ class TranscriptFilesystem(Protocol):
         """Copy the file ``src`` to ``dst`` and set ``dst``'s mode."""
         ...
 
+    def expanduser(self, path: str) -> str:
+        """Expand a leading ``~`` against the home of the filesystem the path
+        lives on.
+
+        Local expands against this host; the remote implementation leaves the
+        path untouched so the remote shell/interpreter expands it against the
+        *remote* home — expanding a remote path against the backend host's home
+        would glob the wrong directory.
+        """
+        ...
+
     def glob_artifacts(
         self, session: SessionRecord, plugin: "BackendPlugin", config_dir: str
     ) -> list[str]:
@@ -113,6 +125,9 @@ class LocalTranscriptFilesystem:
     def copy_file(self, src: str, dst: str, mode: int) -> None:
         shutil.copy2(src, dst)
         Path(dst).chmod(mode)
+
+    def expanduser(self, path: str) -> str:
+        return os.path.expanduser(path)
 
     def glob_artifacts(
         self, session: SessionRecord, plugin: "BackendPlugin", config_dir: str

--- a/backend/src/waypoint/backends/transcript_fs.py
+++ b/backend/src/waypoint/backends/transcript_fs.py
@@ -1,0 +1,126 @@
+"""IO seam for native-thread transcript-availability policy.
+
+``backends/transcripts.py`` implements the ``require_existing`` /
+``symlink_shared`` / ``copy_thread_on_switch`` policy logic against this
+minimal filesystem interface, so the same policy code runs unchanged whether
+the target account profile is local or (a later phase) reached over SSH —
+only the :class:`TranscriptFilesystem` implementation differs, never the
+policy branching.
+"""
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from waypoint.schemas import SessionRecord
+
+if TYPE_CHECKING:
+    from waypoint.backends.base import BackendPlugin
+
+
+class TranscriptFilesystem(Protocol):
+    """Filesystem primitives the transcript policies need, local or remote."""
+
+    def exists(self, path: str) -> bool:
+        """Whether ``path`` exists (following symlinks)."""
+        ...
+
+    def is_dir(self, path: str) -> bool:
+        """Whether ``path`` exists and is a directory."""
+        ...
+
+    def is_symlink(self, path: str) -> bool:
+        """Whether ``path`` is a symlink (whatever it points at)."""
+        ...
+
+    def readlink(self, path: str) -> str:
+        """The raw target ``path`` (a symlink) points at, unresolved."""
+        ...
+
+    def listdir(self, path: str) -> list[str]:
+        """Entry names directly under directory ``path``."""
+        ...
+
+    def mkdir(
+        self, path: str, *, parents: bool = False, exist_ok: bool = False
+    ) -> None:
+        """Create directory ``path`` (mirrors ``Path.mkdir``)."""
+        ...
+
+    def chmod(self, path: str, mode: int) -> None:
+        """Set ``path``'s permission bits to ``mode``."""
+        ...
+
+    def rmdir(self, path: str) -> None:
+        """Remove the empty directory at ``path``."""
+        ...
+
+    def symlink(self, path: str, target: str) -> None:
+        """Create a symlink at ``path`` pointing to ``target``."""
+        ...
+
+    def copy_file(self, src: str, dst: str, mode: int) -> None:
+        """Copy the file ``src`` to ``dst`` and set ``dst``'s mode."""
+        ...
+
+    def glob_artifacts(
+        self, session: SessionRecord, plugin: "BackendPlugin", config_dir: str
+    ) -> list[str]:
+        """Discover ``session``'s native thread artifact(s) under ``config_dir``.
+
+        Runs ``plugin.native_thread_artifact_glob(session)`` against
+        ``config_dir`` and returns the full matched path(s) (not truncated to
+        a bare name) — the caller needs the path relative to ``config_dir`` to
+        build a copy destination. Returns ``[]`` when the plugin has no
+        pattern for this session (no native store, or no thread id yet) or
+        nothing under ``config_dir`` matches.
+        """
+        ...
+
+
+class LocalTranscriptFilesystem:
+    """Today's pathlib/shutil behavior, exposed through the seam."""
+
+    def exists(self, path: str) -> bool:
+        return Path(path).exists()
+
+    def is_dir(self, path: str) -> bool:
+        return Path(path).is_dir()
+
+    def is_symlink(self, path: str) -> bool:
+        return Path(path).is_symlink()
+
+    def readlink(self, path: str) -> str:
+        return str(Path(path).readlink())
+
+    def listdir(self, path: str) -> list[str]:
+        return [entry.name for entry in Path(path).iterdir()]
+
+    def mkdir(
+        self, path: str, *, parents: bool = False, exist_ok: bool = False
+    ) -> None:
+        Path(path).mkdir(parents=parents, exist_ok=exist_ok)
+
+    def chmod(self, path: str, mode: int) -> None:
+        Path(path).chmod(mode)
+
+    def rmdir(self, path: str) -> None:
+        Path(path).rmdir()
+
+    def symlink(self, path: str, target: str) -> None:
+        Path(path).symlink_to(target, target_is_directory=True)
+
+    def copy_file(self, src: str, dst: str, mode: int) -> None:
+        shutil.copy2(src, dst)
+        Path(dst).chmod(mode)
+
+    def glob_artifacts(
+        self, session: SessionRecord, plugin: "BackendPlugin", config_dir: str
+    ) -> list[str]:
+        pattern = plugin.native_thread_artifact_glob(session)
+        if pattern is None:
+            return []
+        root = Path(config_dir).expanduser()
+        if not root.is_dir():
+            return []
+        return sorted(str(match) for match in root.glob(pattern))

--- a/backend/src/waypoint/backends/transcript_fs.py
+++ b/backend/src/waypoint/backends/transcript_fs.py
@@ -66,12 +66,14 @@ class TranscriptFilesystem(Protocol):
 
     def expanduser(self, path: str) -> str:
         """Expand a leading ``~`` against the home of the filesystem the path
-        lives on.
+        lives on, returning an absolute path.
 
-        Local expands against this host; the remote implementation leaves the
-        path untouched so the remote shell/interpreter expands it against the
-        *remote* home — expanding a remote path against the backend host's home
-        would glob the wrong directory.
+        Local expands against this host; the remote implementation resolves it
+        against the *remote* home (over SSH) — expanding a remote path against
+        the backend host's home would glob the wrong directory, and returning
+        it unexpanded would leave a ``~`` base that later ``relative_to`` /
+        symlink-target comparisons can't match against the absolute paths the
+        other ops produce. An absolute path is returned unchanged.
         """
         ...
 

--- a/backend/src/waypoint/backends/transcript_fs_remote.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote.py
@@ -123,6 +123,11 @@ class RemoteTranscriptFilesystem:
     def copy_file(self, src: str, dst: str, mode: int) -> None:
         self._mutate("copy_file", src, dst, str(mode))
 
+    def expanduser(self, path: str) -> str:
+        # Leave ``~`` intact: the remote helper script expands it against the
+        # remote home per op. Expanding here would use the backend host's home.
+        return path
+
     # -- transport --------------------------------------------------------
 
     def _run(self, op: str, *args: str) -> dict[str, Any]:

--- a/backend/src/waypoint/backends/transcript_fs_remote.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote.py
@@ -124,9 +124,21 @@ class RemoteTranscriptFilesystem:
         self._mutate("copy_file", src, dst, str(mode))
 
     def expanduser(self, path: str) -> str:
-        # Leave ``~`` intact: the remote helper script expands it against the
-        # remote home per op. Expanding here would use the backend host's home.
-        return path
+        # Resolve ``~`` against the *remote* home (never the backend host's).
+        # Absolute paths skip the round-trip. The policy logic downstream
+        # (``relative_to``, symlink-target comparison) needs the same absolute
+        # form the remote glob/symlink ops produce, so this must expand rather
+        # than leave ``~`` for per-op expansion.
+        if not path.startswith("~"):
+            return path
+        result = self._run("expanduser", path)
+        expanded = result.get("path")
+        if not isinstance(expanded, str) or expanded.startswith("~"):
+            raise TranscriptUnavailableError(
+                f"could not expand remote path {path!r}: "
+                f"{result.get('error', 'unknown error')}"
+            )
+        return expanded
 
     # -- transport --------------------------------------------------------
 

--- a/backend/src/waypoint/backends/transcript_fs_remote.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote.py
@@ -1,0 +1,165 @@
+"""Remote (SSH) implementation of the TranscriptFilesystem seam.
+
+``RemoteTranscriptFilesystem`` drives the exact same
+:mod:`waypoint.backends.transcripts` policy code as the local implementation,
+substituting SSH round-trips (over the existing ControlMaster — see
+``launch_targets.SshLaunchTargetConfig``/``ssh_master.py``) for local
+``pathlib``/``shutil`` calls. One vendored, stdlib-only helper script
+(:mod:`waypoint.backends.transcript_fs_remote_script`, piped to ``python3 -``)
+implements every operation, so there is one remote command surface to reason
+about instead of a bespoke ``ssh`` invocation per op.
+
+Fail-before-destroy: read-only queries (``exists``/``is_dir``/``is_symlink``/
+``listdir``/``glob_artifacts``) degrade to a "not found" answer when the
+round-trip itself fails (timeout, dropped connection, bad output) rather than
+raising — the worst outcome is a wrong turn that itself degrades to a clean,
+non-destructive :class:`~waypoint.backends.transcripts.TranscriptUnavailableError`
+further down the policy (a stale symlink target compares unequal, a copy finds
+no source, a final re-check reports the thread still unavailable). Mutating
+ops (``mkdir``/``chmod``/``rmdir``/``symlink``/``copy_file``/``readlink``)
+instead raise immediately on any failure — remote or transport — since there
+is no safe default for "did the write happen".
+
+``shared_transcript_dir`` remote-locality is validated implicitly, not with a
+dedicated check: ``ensure_symlink_shared`` always calls ``fs.mkdir`` on it
+first, so a dangling or unreachable shared dir (wrong host, bad permissions,
+a path that only makes sense on the machine running waypoint) surfaces as a
+loud ``TranscriptUnavailableError`` from that remote ``mkdir`` before any
+symlink or copy is attempted — mirroring how the local implementation never
+special-cases this either.
+"""
+
+import importlib.resources
+import json
+import logging
+import subprocess
+from typing import Any
+
+from waypoint.backends.transcripts import TranscriptUnavailableError
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import SessionRecord
+
+log = logging.getLogger("waypoint.backends.transcript_fs_remote")
+
+SENTINEL = "__WP_FS_BEGIN__"
+DEFAULT_TIMEOUT_SECONDS = 20.0
+
+_SCRIPT_BYTES: bytes | None = None
+
+
+def _script_bytes() -> bytes:
+    global _SCRIPT_BYTES
+    if _SCRIPT_BYTES is None:
+        _SCRIPT_BYTES = (
+            importlib.resources.files("waypoint.backends")
+            .joinpath("transcript_fs_remote_script.py")
+            .read_bytes()
+        )
+    return _SCRIPT_BYTES
+
+
+class RemoteTranscriptFilesystem:
+    """Drives :mod:`transcript_fs_remote_script` over ``launch_target``."""
+
+    def __init__(
+        self,
+        launch_target: SshLaunchTargetConfig,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        self._launch_target = launch_target
+        self._timeout = timeout_seconds
+
+    # -- query ops: degrade to a safe "not found" answer on transport failure
+
+    def exists(self, path: str) -> bool:
+        return bool(self._run("exists", path).get("exists", False))
+
+    def is_dir(self, path: str) -> bool:
+        return bool(self._run("is_dir", path).get("is_dir", False))
+
+    def is_symlink(self, path: str) -> bool:
+        return bool(self._run("is_symlink", path).get("is_symlink", False))
+
+    def listdir(self, path: str) -> list[str]:
+        entries = self._run("listdir", path).get("entries", [])
+        return entries if isinstance(entries, list) else []
+
+    def glob_artifacts(
+        self, session: SessionRecord, plugin: Any, config_dir: str
+    ) -> list[str]:
+        pattern = plugin.native_thread_artifact_glob(session)
+        if pattern is None:
+            return []
+        paths = self._run("glob", config_dir, pattern).get("paths", [])
+        return paths if isinstance(paths, list) else []
+
+    # -- mutating ops: raise on any failure, transport or remote
+
+    def readlink(self, path: str) -> str:
+        result = self._run("readlink", path)
+        target = result.get("target")
+        if not isinstance(target, str):
+            raise TranscriptUnavailableError(
+                f"remote readlink failed for {path}: "
+                f"{result.get('error', 'unknown error')}"
+            )
+        return target
+
+    def mkdir(
+        self, path: str, *, parents: bool = False, exist_ok: bool = False
+    ) -> None:
+        self._mutate("mkdir", path, "1" if parents else "0", "1" if exist_ok else "0")
+
+    def chmod(self, path: str, mode: int) -> None:
+        self._mutate("chmod", path, str(mode))
+
+    def rmdir(self, path: str) -> None:
+        self._mutate("rmdir", path)
+
+    def symlink(self, path: str, target: str) -> None:
+        self._mutate("symlink", path, target)
+
+    def copy_file(self, src: str, dst: str, mode: int) -> None:
+        self._mutate("copy_file", src, dst, str(mode))
+
+    # -- transport --------------------------------------------------------
+
+    def _run(self, op: str, *args: str) -> dict[str, Any]:
+        argv = self._launch_target.build_remote_exec_args(["python3", "-", op, *args])
+        try:
+            completed = subprocess.run(
+                argv,
+                input=_script_bytes(),
+                capture_output=True,
+                timeout=self._timeout,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return {"error": f"transport failure running {op!r}: {exc}"}
+        if completed.returncode != 0:
+            stderr = completed.stderr.decode("utf-8", errors="replace").strip()
+            return {
+                "error": f"remote {op!r} exited {completed.returncode}: {stderr[:240]}"
+            }
+        stdout = completed.stdout.decode("utf-8", errors="replace")
+        index = stdout.find(SENTINEL)
+        if index == -1:
+            return {"error": f"remote {op!r} produced no sentinel-framed output"}
+        line = stdout[index + len(SENTINEL) :].strip().splitlines()[0:1]
+        if not line:
+            return {"error": f"remote {op!r} produced an empty payload"}
+        try:
+            payload = json.loads(line[0])
+        except json.JSONDecodeError:
+            return {"error": f"remote {op!r} produced non-JSON output"}
+        if not isinstance(payload, dict):
+            return {"error": f"remote {op!r} produced a malformed payload"}
+        return payload
+
+    def _mutate(self, op: str, *args: str) -> None:
+        result = self._run(op, *args)
+        if not result.get("ok"):
+            raise TranscriptUnavailableError(
+                f"remote transcript fs op {op!r} failed: "
+                f"{result.get('error', 'unknown error')}"
+            )

--- a/backend/src/waypoint/backends/transcript_fs_remote_script.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote_script.py
@@ -1,0 +1,172 @@
+"""Remote filesystem helper for RemoteTranscriptFilesystem.
+
+Designed to be piped to ``python3 -`` over SSH on a remote launch target
+(model: ``claude_code/remote_probe_script.py``). The operation and its
+arguments travel as trailing argv after the ``-`` (stdin carries only this
+script's own source), since stdin is already spent on the script body. Prints
+one sentinel-framed JSON line to stdout describing the result.
+
+Stdlib-only; targets Python 3.8+ so it runs on most pre-installed remote
+interpreters without a virtualenv.
+
+Output schema (always one line, ``SENTINEL`` immediately followed by JSON,
+``\\n``-terminated) — query ops:
+
+    {"exists": bool}
+    {"is_dir": bool}
+    {"is_symlink": bool}
+    {"target": str} | {"error": str}            # readlink
+    {"entries": [str, ...]} | {"error": str}    # listdir
+    {"paths": [str, ...]}                       # glob
+
+and mutating ops (mkdir, chmod, rmdir, symlink, copy_file):
+
+    {"ok": true} | {"error": str}
+"""
+
+# Deferred annotation evaluation lets this file carry modern-syntax type hints
+# (for mypy, which runs on the dev machine) while never evaluating them on the
+# remote Python 3.8+ interpreter that actually executes this script.
+from __future__ import annotations
+
+import glob as _glob
+import json
+import os
+import shutil
+import sys
+from collections.abc import Callable
+
+SENTINEL = "__WP_FS_BEGIN__"
+
+
+def emit(payload):
+    sys.stdout.write(SENTINEL)
+    sys.stdout.write(json.dumps(payload))
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+
+def op_exists(path):
+    emit({"exists": os.path.exists(path)})
+
+
+def op_is_dir(path):
+    emit({"is_dir": os.path.isdir(path)})
+
+
+def op_is_symlink(path):
+    emit({"is_symlink": os.path.islink(path)})
+
+
+def op_readlink(path):
+    try:
+        emit({"target": os.readlink(path)})
+    except OSError as exc:
+        emit({"error": str(exc)})
+
+
+def op_listdir(path):
+    try:
+        emit({"entries": os.listdir(path)})
+    except OSError as exc:
+        emit({"error": str(exc)})
+
+
+def op_mkdir(path, parents, exist_ok):
+    want_parents = parents == "1"
+    want_exist_ok = exist_ok == "1"
+    try:
+        if want_parents:
+            os.makedirs(path, exist_ok=want_exist_ok)
+        else:
+            os.mkdir(path)
+    except FileExistsError:
+        if want_exist_ok:
+            emit({"ok": True})
+        else:
+            emit({"error": "path exists: " + path})
+        return
+    except OSError as exc:
+        emit({"error": str(exc)})
+        return
+    emit({"ok": True})
+
+
+def op_chmod(path, mode):
+    try:
+        os.chmod(path, int(mode))
+    except OSError as exc:
+        emit({"error": str(exc)})
+        return
+    emit({"ok": True})
+
+
+def op_rmdir(path):
+    try:
+        os.rmdir(path)
+    except OSError as exc:
+        emit({"error": str(exc)})
+        return
+    emit({"ok": True})
+
+
+def op_symlink(path, target):
+    try:
+        os.symlink(target, path)
+    except OSError as exc:
+        emit({"error": str(exc)})
+        return
+    emit({"ok": True})
+
+
+def op_copy_file(src, dst, mode):
+    try:
+        shutil.copy2(src, dst)
+        os.chmod(dst, int(mode))
+    except OSError as exc:
+        emit({"error": str(exc)})
+        return
+    emit({"ok": True})
+
+
+def op_glob(config_dir, pattern):
+    root = os.path.expanduser(config_dir)
+    matches = sorted(_glob.glob(os.path.join(root, pattern)))
+    emit({"paths": matches})
+
+
+OPS: dict[str, Callable[..., None]] = {
+    "exists": op_exists,
+    "is_dir": op_is_dir,
+    "is_symlink": op_is_symlink,
+    "readlink": op_readlink,
+    "listdir": op_listdir,
+    "mkdir": op_mkdir,
+    "chmod": op_chmod,
+    "rmdir": op_rmdir,
+    "symlink": op_symlink,
+    "copy_file": op_copy_file,
+    "glob": op_glob,
+}
+
+
+def main():
+    if len(sys.argv) < 2:
+        emit({"error": "missing op"})
+        return
+    op, args = sys.argv[1], sys.argv[2:]
+    handler = OPS.get(op)
+    if handler is None:
+        emit({"error": "unknown op: " + op})
+        return
+    try:
+        handler(*args)
+    except TypeError:
+        emit({"error": "wrong number of arguments for op: " + op})
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:  # noqa: BLE001
+        emit({"error": "internal: " + repr(exc)})

--- a/backend/src/waypoint/backends/transcript_fs_remote_script.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote_script.py
@@ -143,6 +143,13 @@ def op_glob(config_dir, pattern):
     emit({"paths": matches})
 
 
+def op_expanduser(path):
+    # Resolve ``~`` against the remote home so the caller's policy logic
+    # (relative_to, symlink-target comparison) works with absolute paths that
+    # match what glob/symlink produce on this host.
+    emit({"path": os.path.expanduser(path)})
+
+
 OPS: dict[str, Callable[..., None]] = {
     "exists": op_exists,
     "is_dir": op_is_dir,
@@ -155,6 +162,7 @@ OPS: dict[str, Callable[..., None]] = {
     "symlink": op_symlink,
     "copy_file": op_copy_file,
     "glob": op_glob,
+    "expanduser": op_expanduser,
 }
 
 

--- a/backend/src/waypoint/backends/transcript_fs_remote_script.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote_script.py
@@ -46,33 +46,41 @@ def emit(payload):
     sys.stdout.flush()
 
 
+def _u(path):
+    # Expand a leading ``~`` against the remote home. Every path arg is run
+    # through this so a ``~``-relative config_dir/shared dir resolves on the
+    # remote host, not the backend host that built the command.
+    return os.path.expanduser(path)
+
+
 def op_exists(path):
-    emit({"exists": os.path.exists(path)})
+    emit({"exists": os.path.exists(_u(path))})
 
 
 def op_is_dir(path):
-    emit({"is_dir": os.path.isdir(path)})
+    emit({"is_dir": os.path.isdir(_u(path))})
 
 
 def op_is_symlink(path):
-    emit({"is_symlink": os.path.islink(path)})
+    emit({"is_symlink": os.path.islink(_u(path))})
 
 
 def op_readlink(path):
     try:
-        emit({"target": os.readlink(path)})
+        emit({"target": os.readlink(_u(path))})
     except OSError as exc:
         emit({"error": str(exc)})
 
 
 def op_listdir(path):
     try:
-        emit({"entries": os.listdir(path)})
+        emit({"entries": os.listdir(_u(path))})
     except OSError as exc:
         emit({"error": str(exc)})
 
 
 def op_mkdir(path, parents, exist_ok):
+    path = _u(path)
     want_parents = parents == "1"
     want_exist_ok = exist_ok == "1"
     try:
@@ -94,7 +102,7 @@ def op_mkdir(path, parents, exist_ok):
 
 def op_chmod(path, mode):
     try:
-        os.chmod(path, int(mode))
+        os.chmod(_u(path), int(mode))
     except OSError as exc:
         emit({"error": str(exc)})
         return
@@ -103,7 +111,7 @@ def op_chmod(path, mode):
 
 def op_rmdir(path):
     try:
-        os.rmdir(path)
+        os.rmdir(_u(path))
     except OSError as exc:
         emit({"error": str(exc)})
         return
@@ -112,7 +120,7 @@ def op_rmdir(path):
 
 def op_symlink(path, target):
     try:
-        os.symlink(target, path)
+        os.symlink(_u(target), _u(path))
     except OSError as exc:
         emit({"error": str(exc)})
         return
@@ -121,8 +129,8 @@ def op_symlink(path, target):
 
 def op_copy_file(src, dst, mode):
     try:
-        shutil.copy2(src, dst)
-        os.chmod(dst, int(mode))
+        shutil.copy2(_u(src), _u(dst))
+        os.chmod(_u(dst), int(mode))
     except OSError as exc:
         emit({"error": str(exc)})
         return

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -2,27 +2,33 @@
 
 Before a config-dir profile switch can resume, the target profile's state root
 must be able to see the session's native thread transcript. This applies the
-profile's ``transcript_policy`` locally:
+profile's ``transcript_policy``:
 
 - ``require_existing`` — verify the target already has it; never mutate files.
 - ``symlink_shared`` — point the target's native store dir at a shared dir.
 - ``copy_thread_on_switch`` — copy only the current thread's artifact set.
 
 The runtime drives the locate → check → apply → re-check sequence via
-:func:`ensure_thread_available`; per-backend path logic stays in each plugin's
-``native_thread_artifacts``. Local launch targets only — remote (over SSH) is a
-later phase. Raises :class:`TranscriptUnavailableError`, which the runtime maps
-to a 400 (nothing is terminated when it fires).
+:func:`ensure_thread_available`; per-backend path knowledge stays in each
+plugin's ``native_thread_artifact_glob``. All IO goes through the
+:class:`~waypoint.backends.transcript_fs.TranscriptFilesystem` seam
+(:mod:`waypoint.backends.transcript_fs`), defaulting to
+``LocalTranscriptFilesystem`` — a remote implementation (over SSH) plugs into
+the same policy code unchanged. Raises :class:`TranscriptUnavailableError`,
+which the runtime maps to a 400 (nothing is terminated when it fires).
 """
 
 import logging
-import os
 import shutil
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from waypoint.backends.plugin_config import TranscriptPolicy
+from waypoint.backends.transcript_fs import (
+    LocalTranscriptFilesystem,
+    TranscriptFilesystem,
+)
 from waypoint.schemas import SessionRecord
 
 if TYPE_CHECKING:
@@ -30,12 +36,19 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("waypoint.backends.transcripts")
 
+_LOCAL_FS = LocalTranscriptFilesystem()
+
 
 class TranscriptUnavailableError(Exception):
     """The target profile cannot see the native thread and policy can't fix it."""
 
 
-def ensure_symlink_shared(store_dir: Path, shared_dir: Path) -> None:
+def ensure_symlink_shared(
+    store_dir: Path,
+    shared_dir: Path,
+    *,
+    fs: TranscriptFilesystem = _LOCAL_FS,
+) -> None:
     """Ensure ``store_dir`` is a symlink to ``shared_dir`` (guarded).
 
     Idempotent and non-destructive: a real, populated store dir is refused
@@ -44,29 +57,31 @@ def ensure_symlink_shared(store_dir: Path, shared_dir: Path) -> None:
     symlink → no-op; a symlink elsewhere → error; an empty real dir → replace;
     a non-empty real dir → error.
     """
-    shared_dir.mkdir(parents=True, exist_ok=True)
-    shared_dir.chmod(0o700)
-    if store_dir.is_symlink():
-        if store_dir.resolve() == shared_dir.resolve():
+    store, shared = str(store_dir), str(shared_dir)
+    fs.mkdir(shared, parents=True, exist_ok=True)
+    fs.chmod(shared, 0o700)
+    if fs.is_symlink(store):
+        target = fs.readlink(store)
+        if target == shared:
             return
         raise TranscriptUnavailableError(
-            f"{store_dir} is a symlink to {os.readlink(store_dir)!r}, "
+            f"{store_dir} is a symlink to {target!r}, "
             f"not the configured shared_transcript_dir {shared_dir}"
         )
-    if store_dir.exists():
-        if not store_dir.is_dir():
+    if fs.exists(store):
+        if not fs.is_dir(store):
             raise TranscriptUnavailableError(
                 f"{store_dir} exists and is not a directory"
             )
-        if any(store_dir.iterdir()):
+        if fs.listdir(store):
             raise TranscriptUnavailableError(
                 f"{store_dir} is a non-empty directory; run "
                 "'waypoint accounts setup-transcripts' to migrate it into the "
                 "shared dir before switching"
             )
-        store_dir.rmdir()
-    store_dir.parent.mkdir(parents=True, exist_ok=True)
-    store_dir.symlink_to(shared_dir, target_is_directory=True)
+        fs.rmdir(store)
+    fs.mkdir(str(store_dir.parent), parents=True, exist_ok=True)
+    fs.symlink(store, shared)
 
 
 def _pin_tree_perms(root: Path) -> None:
@@ -85,6 +100,13 @@ def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
     other five cases delegate to :func:`ensure_symlink_shared`. Returns a list of
     the actions taken (for reporting); raises :class:`TranscriptUnavailableError`
     on a same-named conflict or a symlink pointing elsewhere.
+
+    This is the local-only migration CLI (``waypoint accounts
+    setup-transcripts``), not part of the account-profile switch flow that
+    goes remote — its data-safe migration (staged copy, atomic rename,
+    timestamped backup) has no remote counterpart in scope, so it stays on
+    ``pathlib``/``shutil`` directly rather than the ``TranscriptFilesystem``
+    seam.
 
     For the populated case the sequence is data-safe against loss: (1) a conflict
     pre-flight refuses before touching anything if any top-level entry already
@@ -149,29 +171,33 @@ def _timestamp() -> str:
 
 
 def copy_thread_artifacts(
-    artifacts: list[Path], src_root: Path, dst_root: Path
+    artifacts: list[str],
+    src_root: str,
+    dst_root: str,
+    *,
+    fs: TranscriptFilesystem = _LOCAL_FS,
 ) -> None:
     """Copy each artifact from under ``src_root`` to the same relative path
     under ``dst_root``, preserving restrictive permissions.
 
     Only the passed artifact set is copied — never whole history directories.
     """
+    src, dst = PurePosixPath(src_root), PurePosixPath(dst_root)
     for artifact in artifacts:
-        rel = artifact.relative_to(src_root)
-        dest = dst_root / rel
+        rel = PurePosixPath(artifact).relative_to(src)
+        dest = dst / rel
         # Lock only the dirs this copy creates to 0700; leave pre-existing ones
         # (including the config root) untouched. The transcript is copied with
-        # its metadata (shutil.copy2) then pinned to 0600 as a backstop.
+        # its metadata then pinned to 0600 as a backstop.
         new_dirs = [
-            dst_root / parent
+            dst / parent
             for parent in reversed(rel.parents)
-            if (dst_root / parent) != dst_root and not (dst_root / parent).exists()
+            if (dst / parent) != dst and not fs.exists(str(dst / parent))
         ]
-        dest.parent.mkdir(parents=True, exist_ok=True)
+        fs.mkdir(str(dest.parent), parents=True, exist_ok=True)
         for created in new_dirs:
-            created.chmod(0o700)
-        shutil.copy2(artifact, dest)
-        dest.chmod(0o600)
+            fs.chmod(str(created), 0o700)
+        fs.copy_file(artifact, str(dest), 0o600)
 
 
 def ensure_thread_available(
@@ -183,15 +209,17 @@ def ensure_thread_available(
     policy: TranscriptPolicy,
     shared_transcript_dir: str | None,
     native_thread_store: str | None,
+    fs: TranscriptFilesystem = _LOCAL_FS,
 ) -> None:
     """Make the session's native thread visible under ``target_config_dir``.
 
     No-op when it's already visible. Otherwise applies ``policy`` and re-checks;
     raises :class:`TranscriptUnavailableError` (before any process is touched)
-    when the thread still isn't available.
+    when the thread still isn't available. All filesystem access — local by
+    default via ``fs`` — goes through the ``TranscriptFilesystem`` seam.
     """
     target = str(Path(target_config_dir).expanduser())
-    if plugin.native_thread_artifacts(session, target):
+    if fs.glob_artifacts(session, plugin, target):
         return
 
     if policy == "require_existing":
@@ -211,19 +239,20 @@ def ensure_thread_available(
         ensure_symlink_shared(
             Path(target) / native_thread_store,
             Path(shared_transcript_dir).expanduser(),
+            fs=fs,
         )
     elif policy == "copy_thread_on_switch":
         current = str(Path(current_config_dir).expanduser())
-        artifacts = plugin.native_thread_artifacts(session, current)
+        artifacts = fs.glob_artifacts(session, plugin, current)
         if not artifacts:
             raise TranscriptUnavailableError(
                 "source native thread artifact not found to copy"
             )
-        copy_thread_artifacts(artifacts, Path(current), Path(target))
+        copy_thread_artifacts(artifacts, current, target, fs=fs)
     else:  # pragma: no cover - exhaustive over TranscriptPolicy
         raise TranscriptUnavailableError(f"unknown transcript policy {policy!r}")
 
-    if not plugin.native_thread_artifacts(session, target):
+    if not fs.glob_artifacts(session, plugin, target):
         raise TranscriptUnavailableError(
             "native thread still unavailable in the target profile after "
             f"applying transcript_policy {policy!r}"

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -218,7 +218,7 @@ def ensure_thread_available(
     when the thread still isn't available. All filesystem access — local by
     default via ``fs`` — goes through the ``TranscriptFilesystem`` seam.
     """
-    target = str(Path(target_config_dir).expanduser())
+    target = fs.expanduser(target_config_dir)
     if fs.glob_artifacts(session, plugin, target):
         return
 
@@ -238,11 +238,11 @@ def ensure_thread_available(
             )
         ensure_symlink_shared(
             Path(target) / native_thread_store,
-            Path(shared_transcript_dir).expanduser(),
+            Path(fs.expanduser(shared_transcript_dir)),
             fs=fs,
         )
     elif policy == "copy_thread_on_switch":
-        current = str(Path(current_config_dir).expanduser())
+        current = fs.expanduser(current_config_dir)
         artifacts = fs.glob_artifacts(session, plugin, current)
         if not artifacts:
             raise TranscriptUnavailableError(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -580,6 +580,32 @@ class SessionRuntime:
         if resolved:
             self._remote_home_cache[cache_key] = resolved
 
+    async def _warm_remote_home_for_profile(
+        self,
+        launch_target: SshLaunchTargetConfig | None,
+        backend: str,
+        profile_id: str | None,
+    ) -> None:
+        """Warm the remote-home cache for a profile's tilde prefix before the
+        synchronous ``_apply_account_profile_env`` read on the same code path.
+
+        No-op locally. Every path that applies a profile env for a remote
+        target (switch, create, import, probe) must call this first, or a
+        ``~``-relative remote ``config_dir`` hits a cold cache and 400s. Bare
+        ``~`` covers a non-``~`` / unknown / unresolvable profile, since the
+        cache read is a no-op for an absolute ``config_dir``.
+        """
+        if launch_target is None:
+            return
+        tilde_prefix = "~"
+        if profile_id is not None:
+            candidate = resolve_account_profiles(
+                self.settings, backend, launch_target
+            ).get(profile_id)
+            if candidate is not None and candidate.config_dir.startswith("~"):
+                tilde_prefix, _ = self._split_tilde_config_dir(candidate.config_dir)
+        await self._ensure_remote_home_cached(launch_target, tilde_prefix)
+
     def _ensure_profile_config_dir_ready(
         self,
         backend: str,
@@ -688,6 +714,7 @@ class SessionRuntime:
         launch_target = self._resolve_launch_target(launch_target_id, backend)
         if launch_target is not None:
             await self._require_live_master(launch_target)
+        await self._warm_remote_home_for_profile(launch_target, backend, profile_id)
         env = self._profile_launch_env(backend, profile_id, launch_target)
         result = await probe_account(
             self, backend, env, launch_target=launch_target, cwd=cwd
@@ -927,6 +954,9 @@ class SessionRuntime:
             request.launch_target_id, request.backend
         )
         await self._require_live_master(launch_target)
+        await self._warm_remote_home_for_profile(
+            launch_target, request.backend, request.account_profile_id
+        )
         # Local cwd is fed to subprocess.Popen / tmux new-session, neither of
         # which expand `~`. Resolve it before storing/launching. The remote
         # cwd is left verbatim so the remote shell can do its own expansion.
@@ -1384,6 +1414,9 @@ class SessionRuntime:
             else self._default_launch_env(backend, launch_target)
         )
         account_profile_id = getattr(request, "account_profile_id", None)
+        await self._warm_remote_home_for_profile(
+            launch_target, backend, account_profile_id
+        )
         launch_env, account_profile_label = self._apply_account_profile_env(
             backend, launch_env, account_profile_id, launch_target
         )
@@ -2157,18 +2190,9 @@ class SessionRuntime:
             # Clean 409 ``ssh-master-required`` for a dead password master
             # before any destructive step (the frontend prompts + retries).
             await self._require_live_master(launch_target)
-            # Warm the remote-home cache for the selected profile's tilde
-            # prefix before the synchronous ``_apply_account_profile_env``
-            # read below — bare ``~`` covers a non-``~`` or unresolvable
-            # profile too, since it's a harmless no-op there.
-            tilde_prefix = "~"
-            if selected_profile_id is not None:
-                candidate = resolve_account_profiles(
-                    self.settings, session.backend, launch_target
-                ).get(selected_profile_id)
-                if candidate is not None and candidate.config_dir.startswith("~"):
-                    tilde_prefix, _ = self._split_tilde_config_dir(candidate.config_dir)
-            await self._ensure_remote_home_cached(launch_target, tilde_prefix)
+            await self._warm_remote_home_for_profile(
+                launch_target, session.backend, selected_profile_id
+            )
 
         if request.args is not None and not caps.supports_custom_cli_args:
             raise HTTPException(
@@ -2302,7 +2326,12 @@ class SessionRuntime:
                         else RemoteTranscriptFilesystem(launch_target)
                     )
                     try:
-                        ensure_thread_available(
+                        # Off-thread: the remote fs does blocking SSH I/O
+                        # (~8-15 round-trips), which would freeze the event
+                        # loop for every other session; the local fs is fast
+                        # but wrapping uniformly keeps one code path.
+                        await asyncio.to_thread(
+                            ensure_thread_available,
                             plugin,
                             session,
                             current_config_dir=current_config_dir or target_config_dir,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -40,6 +40,11 @@ from waypoint.backends.tmux.normalize import (
     NormalizedChunk,
     TerminalNormalizer,
 )
+from waypoint.backends.transcript_fs import (
+    LocalTranscriptFilesystem,
+    TranscriptFilesystem,
+)
+from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
 from waypoint.backends.transcripts import (
     TranscriptUnavailableError,
     ensure_thread_available,
@@ -507,11 +512,8 @@ class SessionRuntime:
         if launch_target is None:
             config_dir = os.path.expanduser(config_dir)
         elif config_dir.startswith("~"):
-            tilde_prefix, remainder = self._split_tilde_config_dir(config_dir)
-            resolved_home = self._remote_home_cache.get(
-                (launch_target.id, tilde_prefix)
-            )
-            if not resolved_home:
+            resolved = self._expand_remote_config_dir(launch_target, config_dir)
+            if resolved is None:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=(
@@ -519,7 +521,7 @@ class SessionRuntime:
                         "absolute config_dir or ensure the target is reachable"
                     ),
                 )
-            config_dir = resolved_home.rstrip("/") + remainder
+            config_dir = resolved
         env = dict(launch_env)
         env[config_dir_key] = config_dir
         return env, profile.label
@@ -534,6 +536,26 @@ class SessionRuntime:
         """
         head, sep, tail = config_dir.partition("/")
         return head, (sep + tail if sep else "")
+
+    def _expand_remote_config_dir(
+        self, launch_target: SshLaunchTargetConfig, config_dir: str
+    ) -> str | None:
+        """Expand a ``~``-relative remote ``config_dir`` from the warm cache.
+
+        Returns ``None`` on a cache miss (target unreachable, or
+        :meth:`_ensure_remote_home_cached` never called for this tilde prefix)
+        rather than raising, so both the raising overlay
+        (``_apply_account_profile_env``) and the non-raising doctor check can
+        share the same resolution. A non-``~`` ``config_dir`` is returned
+        unchanged.
+        """
+        if not config_dir.startswith("~"):
+            return config_dir
+        tilde_prefix, remainder = self._split_tilde_config_dir(config_dir)
+        resolved_home = self._remote_home_cache.get((launch_target.id, tilde_prefix))
+        if not resolved_home:
+            return None
+        return resolved_home.rstrip("/") + remainder
 
     async def _ensure_remote_home_cached(
         self, launch_target: SshLaunchTargetConfig, tilde_prefix: str = "~"
@@ -711,6 +733,12 @@ class SessionRuntime:
                 local=local,
                 show_paths=show_paths,
             )
+            if launch_target is not None:
+                checks.append(
+                    await self._remote_config_dir_check(
+                        launch_target, profile, probe_blocked, show_paths=show_paths
+                    )
+                )
             checks.append(
                 await self._account_matches_check(
                     backend,
@@ -731,6 +759,55 @@ class SessionRuntime:
                 )
             )
         return reports
+
+    async def _remote_config_dir_check(
+        self,
+        launch_target: SshLaunchTargetConfig,
+        profile: AccountProfileConfig,
+        probe_blocked: bool,
+        *,
+        show_paths: bool,
+    ) -> ProfileCheck:
+        """Best-effort remote existence check for a profile's config dir.
+
+        ``account_profile_static_checks`` skips its filesystem checks entirely
+        for a remote target (it has no launch target to reach over SSH); this
+        fills the do-not-regress gap by confirming the config dir actually
+        resolves and exists on the target, catching a typo'd/never-created
+        remote config dir before it surfaces as a launch-time 400 or (worse) a
+        silent onboarding hang. The interactive-onboarding readiness verdict
+        (``ConfigDirReadinessReporting``) reads local files and has no remote
+        implementation yet — a documented follow-up, not covered here.
+        """
+        name = "remote_config_dir_exists"
+        if probe_blocked:
+            return ProfileCheck(
+                name=name,
+                ok=True,
+                detail="skipped: launch target needs an SSH master to probe",
+            )
+        config_dir = profile.config_dir
+        if config_dir.startswith("~"):
+            tilde_prefix, _ = self._split_tilde_config_dir(config_dir)
+            await self._ensure_remote_home_cached(launch_target, tilde_prefix)
+        resolved = self._expand_remote_config_dir(launch_target, config_dir)
+        if resolved is None:
+            return ProfileCheck(
+                name=name,
+                ok=False,
+                detail=(
+                    "could not resolve remote home for '~' expansion; "
+                    "target may be unreachable"
+                ),
+            )
+        exists = RemoteTranscriptFilesystem(launch_target).exists(resolved)
+        shown = resolved if show_paths else "<hidden; pass --show-paths>"
+        return ProfileCheck(
+            name=name,
+            ok=exists,
+            detail=f"remote config dir {shown} "
+            + ("exists" if exists else "is missing"),
+        )
 
     async def _account_matches_check(
         self,
@@ -2076,6 +2153,23 @@ class SessionRuntime:
                 detail=f"{session.backend} does not support account-profile switching",
             )
 
+        if launch_target is not None:
+            # Clean 409 ``ssh-master-required`` for a dead password master
+            # before any destructive step (the frontend prompts + retries).
+            await self._require_live_master(launch_target)
+            # Warm the remote-home cache for the selected profile's tilde
+            # prefix before the synchronous ``_apply_account_profile_env``
+            # read below — bare ``~`` covers a non-``~`` or unresolvable
+            # profile too, since it's a harmless no-op there.
+            tilde_prefix = "~"
+            if selected_profile_id is not None:
+                candidate = resolve_account_profiles(
+                    self.settings, session.backend, launch_target
+                ).get(selected_profile_id)
+                if candidate is not None and candidate.config_dir.startswith("~"):
+                    tilde_prefix, _ = self._split_tilde_config_dir(candidate.config_dir)
+            await self._ensure_remote_home_cached(launch_target, tilde_prefix)
+
         if request.args is not None and not caps.supports_custom_cli_args:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -2181,11 +2275,17 @@ class SessionRuntime:
                 session = self.storage.update_session(
                     session.id, status=SessionStatus.INTERRUPTED
                 )
-            if launch_target is None and config_dir_key:
-                current_config_dir = old_launch_env.get(
-                    config_dir_key
-                ) or os.environ.get(config_dir_key)
-                target_config_dir = new_env.get(config_dir_key)
+            if config_dir_key:
+                # ``config_dir_for`` reads only launch_env — no ``os.environ``
+                # fallback for remote (the backend host's env is meaningless on
+                # the remote target); local keeps the existing host-env fallback
+                # for a session that never had an explicit override.
+                current_config_dir = config_dir_for(caps, old_launch_env)
+                if launch_target is None:
+                    current_config_dir = current_config_dir or os.environ.get(
+                        config_dir_key
+                    )
+                target_config_dir = config_dir_for(caps, new_env)
                 if (
                     profile.transcript_policy == "copy_thread_on_switch"
                     and not current_config_dir
@@ -2196,6 +2296,11 @@ class SessionRuntime:
                         detail="cannot determine the current config dir to copy the thread from",
                     )
                 if target_config_dir:
+                    fs: TranscriptFilesystem = (
+                        LocalTranscriptFilesystem()
+                        if launch_target is None
+                        else RemoteTranscriptFilesystem(launch_target)
+                    )
                     try:
                         ensure_thread_available(
                             plugin,
@@ -2205,6 +2310,7 @@ class SessionRuntime:
                             policy=profile.transcript_policy,
                             shared_transcript_dir=profile.shared_transcript_dir,
                             native_thread_store=caps.native_thread_store,
+                            fs=fs,
                         )
                     except TranscriptUnavailableError as exc:
                         await self._broadcast_session_list()

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -276,6 +276,10 @@ class SessionRuntime:
         # switch is a terminate→restore sequence that must not interleave with
         # another switch/reattach/terminate on the same session).
         self._session_locks: dict[str, asyncio.Lock] = {}
+        # Resolved remote ``$HOME`` (or ``~user``) per (target id, tilde prefix),
+        # so ``_apply_account_profile_env`` can expand a ``~``-relative remote
+        # config_dir without an SSH round-trip on its own (synchronous) path.
+        self._remote_home_cache: dict[tuple[str, str], str] = {}
         self._completion_cache: dict[CompletionCacheKey, list[CommandCompletion]] = {}
         self._completion_cache_updated_at: dict[CompletionCacheKey, float] = {}
         self._completion_refresh_tasks: dict[
@@ -495,25 +499,64 @@ class SessionRuntime:
             )
         config_dir = profile.config_dir
         # Expand ``~`` for local launches (the config dir is a path on this
-        # host). Remote-home expansion isn't supported yet, and env values are
-        # injected shell-quoted so a remote shell won't expand ``~`` either —
-        # rather than silently launch under a literal ``~`` dir (wrong account),
-        # reject a ``~``-relative remote config_dir until that lands. Absolute
-        # remote paths are fine.
+        # host) via the stdlib. Env values are injected shell-quoted so a
+        # remote shell won't expand ``~`` itself — a remote ``~``-relative
+        # config_dir is expanded here from the cached remote home instead
+        # (warmed ahead of this call by an async call site; this method stays
+        # synchronous and only reads the cache).
         if launch_target is None:
             config_dir = os.path.expanduser(config_dir)
         elif config_dir.startswith("~"):
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    f"account profile {account_profile_id!r} uses a '~'-relative "
-                    "config_dir on a remote launch target; use an absolute path "
-                    "(remote home expansion is not yet supported)"
-                ),
+            tilde_prefix, remainder = self._split_tilde_config_dir(config_dir)
+            resolved_home = self._remote_home_cache.get(
+                (launch_target.id, tilde_prefix)
             )
+            if not resolved_home:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "could not resolve remote home for expansion; use an "
+                        "absolute config_dir or ensure the target is reachable"
+                    ),
+                )
+            config_dir = resolved_home.rstrip("/") + remainder
         env = dict(launch_env)
         env[config_dir_key] = config_dir
         return env, profile.label
+
+    @staticmethod
+    def _split_tilde_config_dir(config_dir: str) -> tuple[str, str]:
+        """Split a ``~``-relative path into its tilde prefix and remainder.
+
+        ``"~/.codex-work"`` -> ``("~", "/.codex-work")``; ``"~alice/x"`` ->
+        ``("~alice", "/x")``; bare ``"~"`` -> ``("~", "")``. Mirrors how
+        ``os.path.expanduser`` scopes the expansion to the first path segment.
+        """
+        head, sep, tail = config_dir.partition("/")
+        return head, (sep + tail if sep else "")
+
+    async def _ensure_remote_home_cached(
+        self, launch_target: SshLaunchTargetConfig, tilde_prefix: str = "~"
+    ) -> None:
+        """Resolve and cache ``launch_target``'s remote home for ``tilde_prefix``.
+
+        Auth-agnostic: uses ``launch_target.ssh_capture`` (a plain SSH round
+        trip that transparently reuses the ControlMaster socket for
+        password-auth targets) rather than ``_require_live_master`` /
+        ``connect_launch_target``, both of which are password-only and would
+        never warm a key-auth target (the ``ssh_auth`` default). Bare ``~``
+        resolves via ``$HOME``; a ``~user`` prefix resolves via shell tilde
+        expansion for that user. No-op on cache hit; leaves the cache cold
+        (for the synchronous 400 in ``_apply_account_profile_env``) when the
+        target is unreachable or reports no home.
+        """
+        cache_key = (launch_target.id, tilde_prefix)
+        if cache_key in self._remote_home_cache:
+            return
+        remote_cmd = "echo $HOME" if tilde_prefix == "~" else f"echo {tilde_prefix}"
+        resolved = (await launch_target.ssh_capture(remote_cmd)).strip()
+        if resolved:
+            self._remote_home_cache[cache_key] = resolved
 
     def _ensure_profile_config_dir_ready(
         self,

--- a/backend/tests/test_account_doctor.py
+++ b/backend/tests/test_account_doctor.py
@@ -23,10 +23,14 @@ from waypoint.backends.account_profiles import (
 )
 from waypoint.backends.base import ConfigDirReadinessReporting
 from waypoint.backends.bootstrap import build_default_registry
+from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
 from waypoint.cli import app
 from waypoint.client import WaypointClient
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.runtime import SessionRuntime
 from waypoint.schemas import AccountProbeResult
 from waypoint.settings import Settings
+from waypoint.storage import Storage
 
 runner = CliRunner()
 
@@ -173,6 +177,93 @@ def test_static_checks_skip_filesystem_when_remote(tmp_path: Path) -> None:
     assert _check(checks, "config_dir_exists").detail == (
         "skipped: unsupported on a remote launch target"
     )
+
+
+# ── remote doctor: do-not-regress readiness surface ─────────────────────────
+#
+# ``account_profile_static_checks`` can't stat a remote dir (no launch
+# target), so it skips its filesystem checks entirely for a remote profile.
+# ``SessionRuntime.account_doctor`` fills that gap with a real, best-effort
+# remote existence check (see ``_remote_config_dir_check``) — the do-not-
+# regress surface for a remote switch, while the interactive-onboarding
+# readiness verdict stays a documented follow-up (no remote implementation).
+
+
+def _runtime_with_target(
+    tmp_path: Path, profiles: dict[str, Any], target: SshLaunchTargetConfig
+) -> SessionRuntime:
+    settings = Settings.model_validate(
+        {
+            "data_dir": str(tmp_path / "data"),
+            "plugin_configs": {"claude_code": {"account_profiles": profiles}},
+            "ssh_targets": [target.model_dump()],
+        }
+    )
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+def _target(target_id: str = "d") -> SshLaunchTargetConfig:
+    return SshLaunchTargetConfig(id=target_id, name=target_id, ssh_destination="u@d")
+
+
+async def test_remote_doctor_reports_existing_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = _target()
+    runtime = _runtime_with_target(
+        tmp_path,
+        {"work": {"label": "Work", "config_dir": "/remote/.claude-work"}},
+        target,
+    )
+    monkeypatch.setattr(RemoteTranscriptFilesystem, "exists", lambda self, path: True)
+
+    reports = await runtime.account_doctor(backend="claude_code", launch_target_id="d")
+    check = _check(reports[0].checks, "remote_config_dir_exists")
+    assert check.ok is True
+    assert "exists" in (check.detail or "")
+
+
+async def test_remote_doctor_flags_missing_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target = _target()
+    runtime = _runtime_with_target(
+        tmp_path,
+        {"work": {"label": "Work", "config_dir": "/remote/.claude-work"}},
+        target,
+    )
+    monkeypatch.setattr(RemoteTranscriptFilesystem, "exists", lambda self, path: False)
+
+    reports = await runtime.account_doctor(backend="claude_code", launch_target_id="d")
+    check = _check(reports[0].checks, "remote_config_dir_exists")
+    assert check.ok is False
+    assert "missing" in (check.detail or "")
+
+
+async def test_remote_doctor_flags_unresolved_tilde_config_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The cache is never warmed here (no call to ``_ensure_remote_home_cached``),
+    # mirroring an unreachable target — the check must fail closed rather than
+    # guess at a literal ``~`` path, and must not even attempt the remote stat.
+    target = _target()
+    runtime = _runtime_with_target(
+        tmp_path, {"work": {"label": "Work", "config_dir": "~/.claude-work"}}, target
+    )
+    called = False
+
+    def _unexpected_exists(self: RemoteTranscriptFilesystem, path: str) -> bool:
+        nonlocal called
+        called = True
+        return True
+
+    monkeypatch.setattr(RemoteTranscriptFilesystem, "exists", _unexpected_exists)
+
+    reports = await runtime.account_doctor(backend="claude_code", launch_target_id="d")
+    check = _check(reports[0].checks, "remote_config_dir_exists")
+    assert check.ok is False
+    assert "resolve remote home" in (check.detail or "")
+    assert called is False
 
 
 # ── HTTP endpoints ──────────────────────────────────────────────────────────

--- a/backend/tests/test_account_probe_env.py
+++ b/backend/tests/test_account_probe_env.py
@@ -4,14 +4,27 @@ Phase 3a. Rate-limit probes previously ran with the process env, so a session
 under a non-default CLAUDE_CONFIG_DIR/CODEX_HOME (e.g. a switched account
 profile) bucketed under the wrong account. ``account_lookup_env`` mirrors the
 session's env and is threaded into the probes.
+
+Phase 3b (goal 3, remote): the remote probe path dropped ``launch_env``
+entirely and always probed the launch target's default account, so a remote
+profile switch had no way to verify the *selected* profile's account before
+switching. ``launch_env`` is now threaded through the remote probe helpers and
+the shared remote probe cache is keyed by ``(target_id, config_dir)`` instead
+of target id alone.
 """
 
+import asyncio
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import pytest
 
+from waypoint.backends.claude_code import rate_limits as claude_rate_limits
+from waypoint.backends.codex import rate_limits as codex_rate_limits
+from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.runtime import SessionRuntime
+from waypoint.schemas import SessionRateLimitUsage
 from waypoint.settings import Settings
 from waypoint.storage import Storage
 
@@ -19,6 +32,16 @@ from waypoint.storage import Storage
 def _runtime(tmp_path: Path) -> SessionRuntime:
     settings = Settings(data_dir=tmp_path / "data")
     return SessionRuntime(settings, Storage(settings.database_path))
+
+
+def _ssh_target(target_id: str = "rover") -> SshLaunchTargetConfig:
+    return SshLaunchTargetConfig(
+        id=target_id,
+        name=target_id,
+        ssh_destination="user@rover.lan",
+        ssh_args=[],
+        remote_shell="",
+    )
 
 
 # ── account_lookup_env ──────────────────────────────────────────────────────
@@ -112,3 +135,144 @@ async def test_codex_probe_uses_session_config_dir(
         runtime, None, cwd="/x", launch_env={"CODEX_HOME": "/work"}
     )
     assert captured["env"]["CODEX_HOME"] == "/work"
+
+
+# ── remote probe threads launch_env (goal 3) ─────────────────────────────────
+
+
+async def test_claude_probe_remote_threads_launch_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin: Any = runtime.registry.get("claude_code")
+    target = _ssh_target()
+    captured: dict[str, Any] = {}
+
+    async def fake_remote_shared(
+        launch_target: Any, *, launch_env: Any = None, force: bool = False
+    ) -> None:
+        captured["launch_target"] = launch_target
+        captured["launch_env"] = launch_env
+        return None
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.probe_claude_usage_remote_shared",
+        fake_remote_shared,
+    )
+    await plugin.probe_account_rate_limit(
+        runtime, target, cwd="/x", launch_env={"CLAUDE_CONFIG_DIR": "/team/acct-a"}
+    )
+    assert captured["launch_target"] is target
+    assert captured["launch_env"]["CLAUDE_CONFIG_DIR"] == "/team/acct-a"
+
+
+async def test_codex_probe_remote_threads_launch_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin: Any = runtime.registry.get("codex")
+    target = _ssh_target()
+    captured: dict[str, Any] = {}
+
+    async def fake_remote(
+        launch_target: Any, *, binary: str = "codex", launch_env: Any = None
+    ) -> None:
+        captured["launch_target"] = launch_target
+        captured["launch_env"] = launch_env
+        return None
+
+    monkeypatch.setattr(
+        "waypoint.backends.codex.plugin.probe_codex_usage_remote", fake_remote
+    )
+    await plugin.probe_account_rate_limit(
+        runtime, target, cwd="/x", launch_env={"CODEX_HOME": "/team/acct-b"}
+    )
+    assert captured["launch_target"] is target
+    assert captured["launch_env"]["CODEX_HOME"] == "/team/acct-b"
+
+
+# ── remote probe command carries the profile's config dir via extra_env ────
+
+
+async def test_claude_remote_probe_command_carries_config_dir_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _ssh_target()
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self, data: bytes) -> tuple[bytes, bytes]:
+            return b'{"error": "no_credentials"}\n', b""
+
+    async def fake_exec(*argv: str, **kwargs: Any) -> _FakeProc:
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    await claude_rate_limits.probe_claude_usage_remote(
+        target, launch_env={"CLAUDE_CONFIG_DIR": "/team/acct-a"}
+    )
+    remote_command = captured["argv"][-1]
+    assert "CLAUDE_CONFIG_DIR=/team/acct-a" in remote_command
+
+
+async def test_codex_remote_probe_command_carries_config_dir_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _ssh_target()
+    captured: dict[str, Any] = {}
+
+    class _FakeProc:
+        returncode = 0
+
+        async def communicate(self, data: bytes) -> tuple[bytes, bytes]:
+            return b'{"error": "no_data"}\n', b""
+
+    async def fake_exec(*argv: str, **kwargs: Any) -> _FakeProc:
+        captured["argv"] = argv
+        return _FakeProc()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    await codex_rate_limits.probe_codex_usage_remote(
+        target, binary="codex", launch_env={"CODEX_HOME": "/team/acct-b"}
+    )
+    remote_command = captured["argv"][-1]
+    assert "CODEX_HOME=/team/acct-b" in remote_command
+
+
+# ── shared remote probe cache is keyed by (target_id, config_dir) ──────────
+
+
+async def test_claude_remote_shared_cache_distinguishes_config_dirs_on_one_target(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = _ssh_target()
+    calls: list[str | None] = []
+
+    async def fake_probe(
+        launch_target: Any, *, launch_env: Any = None, timeout_seconds: float = 30.0
+    ) -> SessionRateLimitUsage:
+        calls.append((launch_env or {}).get("CLAUDE_CONFIG_DIR"))
+        return SessionRateLimitUsage(source="claude_code", updated_at=datetime.now(UTC))
+
+    monkeypatch.setattr(claude_rate_limits, "probe_claude_usage_remote", fake_probe)
+    monkeypatch.setattr(
+        claude_rate_limits,
+        "_SHARED_PROBE_CACHE",
+        claude_rate_limits.SharedRateLimitProbeCache(),
+    )
+
+    await claude_rate_limits.probe_claude_usage_remote_shared(
+        target, launch_env={"CLAUDE_CONFIG_DIR": "/team/acct-a"}
+    )
+    await claude_rate_limits.probe_claude_usage_remote_shared(
+        target, launch_env={"CLAUDE_CONFIG_DIR": "/team/acct-b"}
+    )
+    # Repeats a config_dir already probed above: served from cache, no new call.
+    await claude_rate_limits.probe_claude_usage_remote_shared(
+        target, launch_env={"CLAUDE_CONFIG_DIR": "/team/acct-a"}
+    )
+
+    assert calls == ["/team/acct-a", "/team/acct-b"]

--- a/backend/tests/test_account_profile_selection.py
+++ b/backend/tests/test_account_profile_selection.py
@@ -128,10 +128,33 @@ def test_overlay_rejects_unknown_profile(tmp_path: Path) -> None:
     assert exc.value.status_code == 400
 
 
-def test_overlay_rejects_tilde_config_dir_on_remote(tmp_path: Path) -> None:
-    # ``~`` can't be expanded to the remote home yet and won't be shell-expanded
-    # in the injected env, so a remote profile with a ``~`` config_dir is
-    # rejected rather than silently launching under a literal ``~`` dir.
+async def test_overlay_expands_tilde_config_dir_on_remote_with_warm_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A warm remote-home cache (populated by ``_ensure_remote_home_cached``,
+    # normally called eagerly by an async launch path) lets the synchronous
+    # overlay expand ``~`` against the remote home instead of rejecting it.
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    target = SshLaunchTargetConfig(id="d", name="d", ssh_destination="u@d")
+
+    async def fake_ssh_capture(self: SshLaunchTargetConfig, remote_cmd: str) -> str:
+        assert remote_cmd == "echo $HOME"
+        return "/home/alice\n"
+
+    monkeypatch.setattr(SshLaunchTargetConfig, "ssh_capture", fake_ssh_capture)
+    await runtime._ensure_remote_home_cached(target)
+
+    env, label = runtime._apply_account_profile_env("codex", {}, "work", target)
+    assert env["CODEX_HOME"] == "/home/alice/.codex-work"
+    assert label == "Work"
+
+
+def test_overlay_rejects_tilde_config_dir_on_remote_with_cold_cache(
+    tmp_path: Path,
+) -> None:
+    # No warm cache entry (target unreachable, or never resolved) still
+    # rejects a ``~``-relative remote config_dir rather than launching under
+    # a literal ``~`` dir.
     runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
     target = SshLaunchTargetConfig(id="d", name="d", ssh_destination="u@d")
     with pytest.raises(HTTPException) as exc:

--- a/backend/tests/test_account_profile_selection.py
+++ b/backend/tests/test_account_profile_selection.py
@@ -149,6 +149,35 @@ async def test_overlay_expands_tilde_config_dir_on_remote_with_warm_cache(
     assert label == "Work"
 
 
+async def test_warm_remote_home_for_profile_lets_overlay_expand_tilde(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The helper every non-switch entry point (create/import/probe) calls
+    # before the synchronous overlay warms the profile's tilde prefix, so a
+    # ``~``-relative remote config_dir resolves instead of 400ing on a cold
+    # cache — the regression the review caught.
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    target = SshLaunchTargetConfig(id="d", name="d", ssh_destination="u@d")
+
+    async def fake_ssh_capture(self: SshLaunchTargetConfig, remote_cmd: str) -> str:
+        return "/home/alice\n"
+
+    monkeypatch.setattr(SshLaunchTargetConfig, "ssh_capture", fake_ssh_capture)
+    await runtime._warm_remote_home_for_profile(target, "codex", "work")
+
+    env, _ = runtime._apply_account_profile_env("codex", {}, "work", target)
+    assert env["CODEX_HOME"] == "/home/alice/.codex-work"
+
+
+async def test_warm_remote_home_for_profile_noop_for_local_target(
+    tmp_path: Path,
+) -> None:
+    runtime, _ = _runtime(tmp_path, codex=_codex_profiles())
+    # No SSH, no cache write; a local target is a plain no-op.
+    await runtime._warm_remote_home_for_profile(None, "codex", "work")
+    assert runtime._remote_home_cache == {}
+
+
 def test_overlay_rejects_tilde_config_dir_on_remote_with_cold_cache(
     tmp_path: Path,
 ) -> None:

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -54,6 +54,9 @@ class _StubPlugin:
     ) -> list[Any]:
         return []
 
+    def native_thread_artifact_glob(self, session: Any) -> str | None:
+        return None
+
     def on_session_deleted(self, runtime: Any, session: Any) -> None:
         return None
 

--- a/backend/tests/test_rate_limits.py
+++ b/backend/tests/test_rate_limits.py
@@ -611,7 +611,7 @@ def test_probe_claude_usage_remote_parses_messages_headers(
         "expires_at": None,
     }
 
-    async def _fake_runner(launch_target, timeout_seconds):
+    async def _fake_runner(launch_target, timeout_seconds, launch_env=None):
         assert launch_target.ssh_destination == "user@rover.lan"
         return payload
 
@@ -648,7 +648,7 @@ def test_probe_claude_usage_remote_parses_oauth_usage_payload(
         "expires_at": None,
     }
 
-    async def _fake_runner(launch_target, timeout_seconds):
+    async def _fake_runner(launch_target, timeout_seconds, launch_env=None):
         return payload
 
     monkeypatch.setattr(
@@ -668,7 +668,7 @@ def test_probe_claude_usage_remote_ignores_windowless_usage_payload(
     # The remote script only emits the usage variant when it carries a window,
     # but if a window-less usage payload ever arrives the backend returns None
     # cleanly rather than misrouting into the malformed-payload branch.
-    async def _fake_runner(launch_target, timeout_seconds):
+    async def _fake_runner(launch_target, timeout_seconds, launch_env=None):
         return {"usage": {}, "oauth_account_notes": ["org: lumid"], "expires_at": None}
 
     monkeypatch.setattr(
@@ -682,7 +682,7 @@ def test_probe_claude_usage_remote_ignores_windowless_usage_payload(
 def test_probe_claude_usage_remote_handles_expired_sentinel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _fake_runner(launch_target, timeout_seconds):
+    async def _fake_runner(launch_target, timeout_seconds, launch_env=None):
         return {
             "error": "expired",
             "expires_at": 1700000000.0,
@@ -707,7 +707,7 @@ def test_probe_claude_usage_remote_handles_expired_sentinel(
 def test_probe_claude_usage_remote_handles_no_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _fake_runner(launch_target, timeout_seconds):
+    async def _fake_runner(launch_target, timeout_seconds, launch_env=None):
         return {"error": "no_credentials"}
 
     monkeypatch.setattr(
@@ -721,7 +721,7 @@ def test_probe_claude_usage_remote_handles_no_credentials(
 def test_probe_claude_usage_remote_surfaces_401_as_expired(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _fake_runner(launch_target, timeout_seconds):
+    async def _fake_runner(launch_target, timeout_seconds, launch_env=None):
         return {
             "status": 401,
             "headers": {},
@@ -743,7 +743,7 @@ def test_probe_claude_usage_remote_surfaces_401_as_expired(
 def test_probe_codex_usage_remote_parses_oauth_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _fake_runner(launch_target, binary, timeout_seconds):
+    async def _fake_runner(launch_target, binary, timeout_seconds, launch_env=None):
         return {
             "payload": {
                 "plan_type": "pro",
@@ -780,7 +780,7 @@ def test_probe_codex_usage_remote_falls_back_to_status_text(
         "Weekly limit: 80% left, resets at 2026-05-11 00:00 UTC\n"
     )
 
-    async def _fake_runner(launch_target, binary, timeout_seconds):
+    async def _fake_runner(launch_target, binary, timeout_seconds, launch_env=None):
         return {"status_text": status_text}
 
     monkeypatch.setattr(
@@ -797,7 +797,7 @@ def test_probe_codex_usage_remote_falls_back_to_status_text(
 def test_probe_codex_usage_remote_returns_none_for_no_data(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _fake_runner(launch_target, binary, timeout_seconds):
+    async def _fake_runner(launch_target, binary, timeout_seconds, launch_env=None):
         return {"error": "no_data"}
 
     monkeypatch.setattr(
@@ -836,7 +836,7 @@ def test_probe_codex_usage_remote_falls_back_when_oauth_payload_is_empty(
 ) -> None:
     status_text = "5h limit: 12% used (resets in 1h)\nWeekly limit: 80% left\n"
 
-    async def _fake_runner(launch_target, binary, timeout_seconds):
+    async def _fake_runner(launch_target, binary, timeout_seconds, launch_env=None):
         return {
             "payload": {
                 "rate_limit": None,
@@ -864,8 +864,20 @@ def test_probe_cache_keys_distinguish_local_and_remote() -> None:
 
     assert local_default != local_scoped
     assert local_scoped == "local:/tmp/acct-a"
-    assert remote == "remote:rover"
+    assert remote == "remote:rover:~"
     assert remote != local_default and remote != local_scoped
+
+
+def test_remote_probe_cache_key_distinguishes_config_dirs_on_one_target() -> None:
+    target = _ssh_target()
+    default_key = _remote_probe_cache_key(target)
+    scoped_key = _remote_probe_cache_key(target, {"CLAUDE_CONFIG_DIR": "/team/alice"})
+    other_scoped_key = _remote_probe_cache_key(
+        target, {"CLAUDE_CONFIG_DIR": "/team/bob"}
+    )
+
+    assert default_key != scoped_key != other_scoped_key
+    assert scoped_key == "remote:rover:/team/alice"
 
 
 def _usage_snapshot(used: float) -> SessionRateLimitUsage:

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -20,6 +20,7 @@ from typing import Any, cast
 import pytest
 
 from waypoint.backends.tmux.plugin import TmuxPlugin
+from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
 
 
@@ -54,6 +55,10 @@ class _FakeAgentPlugin:
         self.capabilities = SimpleNamespace(
             config_dir_env_var="CLAUDE_CONFIG_DIR" if pregenerates else "CODEX_HOME"
         )
+        # Records each ``conversation_exists`` call so remote-resume tests can
+        # assert the switched profile's config dir and launch target were
+        # threaded through, not silently dropped for a remote session.
+        self.conversation_exists_calls: list[dict[str, Any]] = []
 
     def launch_flags(
         self,
@@ -107,6 +112,13 @@ class _FakeAgentPlugin:
         launch_target: Any,
         config_dir: str | None = None,
     ) -> bool:
+        self.conversation_exists_calls.append(
+            {
+                "thread_id": thread_id,
+                "launch_target": launch_target,
+                "config_dir": config_dir,
+            }
+        )
         return self.exists
 
     async def capture_thread_id(
@@ -207,9 +219,13 @@ class _FakeRuntime:
         # via storage.get_session, so the storage stub returns whatever
         # is set on this map.
         self.sessions_by_id: dict[str, Any] = {}
+        # Remote-resume tests populate this so ``_find_launch_target``
+        # resolves a real launch target instead of the local (``None``)
+        # default.
+        self.launch_targets_by_id: dict[str, Any] = {}
 
-    def _find_launch_target(self, _lt_id: str | None) -> None:
-        return None
+    def _find_launch_target(self, lt_id: str | None) -> Any:
+        return self.launch_targets_by_id.get(lt_id) if lt_id else None
 
     def _default_launch_env(self, backend: str, launch_target: Any) -> dict[str, str]:
         return {}
@@ -218,7 +234,7 @@ class _FakeRuntime:
         self,
         backend: str,
         args: list[str],
-        _lt: Any,
+        launch_target: Any,
         _cwd: str,
         *,
         allocate_tty: bool = False,
@@ -229,6 +245,7 @@ class _FakeRuntime:
             {
                 "backend": backend,
                 "args": args,
+                "launch_target": launch_target,
                 "allocate_tty": allocate_tty,
                 "session_id": session_id,
                 "launch_env": launch_env,
@@ -352,6 +369,71 @@ async def test_restore_session_claude_keeps_thread_id_across_terminate_cycles(
     # Both cycles must request a remote PTY — otherwise the remote
     # claude flips to ``--print`` mode and errors on the missing stdin.
     assert [call["allocate_tty"] for call in runtime.command_calls] == [True, True]
+
+
+@pytest.mark.asyncio
+async def test_restore_session_remote_resume_uses_switched_config_dir(
+    plugin: TmuxPlugin,
+    tmp_path: Path,
+) -> None:
+    """Remote (agent, transport) resume: the switched profile's config dir
+    and the launch target must reach both the resume-existence check and the
+    rebuilt launch command — otherwise a remote reconnect reads the wrong
+    (default) config dir, never finds the thread, and relaunches into a
+    fresh conversation under the wrong account.
+
+    Mirrors the local two-cycle reconnect test above, but for a session
+    pinned to an SSH launch target with a switched ``CLAUDE_CONFIG_DIR``.
+    """
+    uuid_str = "00000000-0000-0000-0000-000000000002"
+    target = SshLaunchTargetConfig(id="d", name="d", ssh_destination="u@d")
+    agent = _FakeAgentPlugin(pregenerates=True, exists=True)
+    runtime = _FakeRuntime(inner_plugin=agent)
+    runtime.launch_targets_by_id["d"] = target
+
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="sess-remote",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="t",
+        cwd="/Users/me/proj",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        launch_target_id="d",
+        launch_env={"CLAUDE_CONFIG_DIR": "/home/alice/.claude-work"},
+        transport_state={
+            "tmux_session": "sess-remote-old",
+            "thread_id": uuid_str,
+            "launch_args": ["--session-id", uuid_str],
+        },
+        raw_log_path=str(tmp_path / "sess-remote.raw.log"),
+        structured_log_path=str(tmp_path / "sess-remote.events.jsonl"),
+    )
+    await plugin.restore_session(cast(Any, runtime), session)
+
+    # The existence check that decides --resume vs --session-id must be
+    # scoped to the target and the switched remote config dir.
+    exists_call = agent.conversation_exists_calls[-1]
+    assert exists_call["launch_target"] is target
+    assert exists_call["config_dir"] == "/home/alice/.claude-work"
+
+    # The rebuilt command must carry the same launch target (so it goes out
+    # over SSH) and a remote PTY (``-tt``, or the remote claude falls back to
+    # ``--print`` and errors on the missing stdin).
+    command_call = runtime.command_calls[-1]
+    assert command_call["launch_target"] is target
+    assert command_call["allocate_tty"] is True
+    assert command_call["launch_env"] == {
+        "CLAUDE_CONFIG_DIR": "/home/alice/.claude-work"
+    }
+
+    state = runtime.updates[-1]["transport_state"]
+    assert state["launch_args"] == ["--resume", uuid_str]
+    assert state["thread_id"] == uuid_str
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -411,7 +411,12 @@ def test_ensure_thread_available_dispatches_through_custom_fs(tmp_path: Path) ->
         native_thread_store="projects",
         fs=fs,
     )
-    assert fs.calls == [("glob_artifacts", (session, plugin, str(target)))]
+    # Config-dir expansion also dispatches through the seam (so a remote fs
+    # expands against the remote home, not the backend host's), then discovery.
+    assert fs.calls == [
+        ("expanduser", (str(target),)),
+        ("glob_artifacts", (session, plugin, str(target))),
+    ]
 
 
 def test_copy_thread_on_switch_through_custom_fs_matches_default(

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -1,17 +1,20 @@
 """Native transcript availability policies (Phase 3b).
 
-Exercises the per-backend artifact locator and the local require_existing /
+Exercises the per-backend artifact locator and the require_existing /
 symlink_shared / copy_thread_on_switch policies against real claude_code/codex
-plugins with temporary config dirs.
+plugins with temporary config dirs, through the TranscriptFilesystem seam
+(local by default; a recording fake proves the policy code is IO-agnostic).
 """
 
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from waypoint.backends.base import BackendPlugin
 from waypoint.backends.bootstrap import build_default_registry
+from waypoint.backends.transcript_fs import LocalTranscriptFilesystem
 from waypoint.backends.transcripts import (
     TranscriptUnavailableError,
     ensure_symlink_shared,
@@ -21,6 +24,28 @@ from waypoint.backends.transcripts import (
 from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
 
 TID = "11111111-1111-1111-1111-111111111111"
+
+
+class _RecordingFilesystem:
+    """Wraps ``LocalTranscriptFilesystem``, logging every call.
+
+    Proves ``transcripts.py`` policy logic dispatches through ``fs`` rather
+    than reaching for ``pathlib``/``shutil`` directly — the property a remote
+    implementation depends on.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[Any, ...]]] = []
+        self._inner = LocalTranscriptFilesystem()
+
+    def __getattr__(self, name: str) -> Any:
+        target = getattr(self._inner, name)
+
+        def _recording(*args: Any, **kwargs: Any) -> Any:
+            self.calls.append((name, args))
+            return target(*args, **kwargs)
+
+        return _recording
 
 
 def _plugin(backend: str) -> BackendPlugin:
@@ -310,3 +335,129 @@ def test_setup_refuses_conflict_and_does_not_mutate(tmp_path: Path) -> None:
     assert store.is_dir() and not store.is_symlink()
     assert (store / "dup" / "f.jsonl").read_text() == "orig"
     assert not any(p.name.startswith("projects.bak-") for p in store.parent.iterdir())
+
+
+# ── native_thread_artifact_glob (discovery-pattern contract) ───────────────
+
+
+def test_native_thread_artifact_glob_claude() -> None:
+    pattern = _plugin("claude_code").native_thread_artifact_glob(
+        _session("claude_code")
+    )
+    assert pattern == f"projects/*/{TID}.jsonl"
+
+
+def test_native_thread_artifact_glob_codex() -> None:
+    pattern = _plugin("codex").native_thread_artifact_glob(_session("codex"))
+    assert pattern == f"sessions/*/*/*/rollout-*-{TID}.jsonl"
+
+
+def test_native_thread_artifact_glob_none_without_thread_id() -> None:
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="s1",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        title="t",
+        cwd="/repo/app",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/r",
+        structured_log_path="/e",
+        transport_state={},
+    )
+    assert _plugin("claude_code").native_thread_artifact_glob(session) is None
+
+
+def test_native_thread_artifact_glob_opencode_always_none() -> None:
+    assert _plugin("opencode").native_thread_artifact_glob(_session("opencode")) is None
+
+
+def test_glob_artifacts_matches_native_thread_artifacts(tmp_path: Path) -> None:
+    # The pattern-driven Path.glob discovery LocalTranscriptFilesystem uses must
+    # find exactly what the per-backend native_thread_artifacts locator finds.
+    config_dir = tmp_path / "config"
+    src = _write_claude_thread(config_dir)
+    plugin = _plugin("claude_code")
+    session = _session("claude_code")
+    fs = LocalTranscriptFilesystem()
+    assert fs.glob_artifacts(session, plugin, str(config_dir)) == [str(src)]
+    assert [
+        str(p) for p in plugin.native_thread_artifacts(session, str(config_dir))
+    ] == [str(src)]
+
+
+# ── TranscriptFilesystem seam ───────────────────────────────────────────────
+
+
+def test_ensure_thread_available_dispatches_through_custom_fs(tmp_path: Path) -> None:
+    # A drop-in fs (a recorder here; a remote implementation in a later phase)
+    # must be able to drive the whole require_existing policy on its own —
+    # proof the policy code never falls back to pathlib/shutil directly.
+    target = tmp_path / "target"
+    _write_claude_thread(target)
+    fs = _RecordingFilesystem()
+    plugin = _plugin("claude_code")
+    session = _session("claude_code")
+    ensure_thread_available(
+        plugin,
+        session,
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(target),
+        policy="require_existing",
+        shared_transcript_dir=None,
+        native_thread_store="projects",
+        fs=fs,
+    )
+    assert fs.calls == [("glob_artifacts", (session, plugin, str(target)))]
+
+
+def test_copy_thread_on_switch_through_custom_fs_matches_default(
+    tmp_path: Path,
+) -> None:
+    current = tmp_path / "current"
+    target = tmp_path / "target"
+    src = _write_codex_rollout(current)
+    fs = _RecordingFilesystem()
+    ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(current),
+        target_config_dir=str(target),
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+        fs=fs,
+    )
+    dest = target / src.relative_to(current)
+    assert dest.is_file()
+    assert oct(dest.stat().st_mode)[-3:] == "600"
+    # Every mutating op the policy performed went through the recorder, not a
+    # pathlib/shutil call the seam bypassed.
+    op_names = [name for name, _ in fs.calls]
+    assert "copy_file" in op_names
+    assert "mkdir" in op_names
+
+
+def test_symlink_shared_through_custom_fs_matches_default(tmp_path: Path) -> None:
+    shared = tmp_path / "shared"
+    (shared / "-repo-app").mkdir(parents=True)
+    (shared / "-repo-app" / f"{TID}.jsonl").write_text("{}")
+    target = tmp_path / "target"
+    fs = _RecordingFilesystem()
+    ensure_thread_available(
+        _plugin("claude_code"),
+        _session("claude_code"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(target),
+        policy="symlink_shared",
+        shared_transcript_dir=str(shared),
+        native_thread_store="projects",
+        fs=fs,
+    )
+    assert (target / "projects").is_symlink()
+    op_names = [name for name, _ in fs.calls]
+    assert "symlink" in op_names
+    assert "is_symlink" in op_names

--- a/backend/tests/test_transcripts_remote.py
+++ b/backend/tests/test_transcripts_remote.py
@@ -345,13 +345,68 @@ def test_remote_glob_artifacts_degrades_to_empty_on_transport_failure(
         )
 
 
-def test_remote_expanduser_leaves_tilde_intact() -> None:
-    # The remote fs must NOT expand ``~`` against the backend host — the remote
-    # helper script expands it against the remote home per op instead.
+def test_remote_expanduser_resolves_against_remote_home(
+    tmp_path: Path, fake_remote: _FakeRemote, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``~`` must resolve against the remote home (here tmp_path stands in), not
+    # the backend host, so downstream relative_to / symlink comparison see the
+    # same absolute form the glob/symlink ops produce. Absolute paths skip the
+    # round-trip entirely.
+    monkeypatch.setenv("HOME", str(tmp_path))
     fs = RemoteTranscriptFilesystem(_launch_target())
-    assert fs.expanduser("~/.codex-work") == "~/.codex-work"
-    assert fs.expanduser("~alice/x") == "~alice/x"
+    assert fs.expanduser("~/.codex-work") == str(tmp_path / ".codex-work")
     assert fs.expanduser("/abs/path") == "/abs/path"
+    assert ("expanduser", ("/abs/path",)) not in fake_remote.calls
+    assert ("expanduser", ("~/.codex-work",)) in fake_remote.calls
+
+
+def test_remote_copy_thread_on_switch_with_tilde_config_dir(
+    tmp_path: Path, fake_remote: _FakeRemote, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: a ~-relative remote config_dir under copy_thread_on_switch
+    # (codex's default) must not crash on relative_to — expanduser resolves the
+    # base to the same absolute form glob returns.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_codex_rollout(tmp_path / "cur")
+    ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir="~/cur",
+        target_config_dir="~/tgt",
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+        fs=RemoteTranscriptFilesystem(_launch_target()),
+    )
+    assert (tmp_path / "tgt" / "sessions").is_dir()
+
+
+def test_remote_symlink_shared_tilde_dir_matches_existing_symlink(
+    tmp_path: Path, fake_remote: _FakeRemote, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression: with a ~-relative shared_transcript_dir and a pre-existing
+    # symlink already pointing at the (absolute) shared dir, the idempotency
+    # check must see them as equal — not raise the misleading "symlink to … not
+    # the configured shared_transcript_dir". The thread isn't in shared here, so
+    # the flow still ends in the honest "still unavailable", proving the
+    # comparison passed rather than tripping the mismatch.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "shared").mkdir()
+    store = tmp_path / "target" / "projects"
+    store.parent.mkdir(parents=True)
+    store.symlink_to(tmp_path / "shared", target_is_directory=True)
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    with pytest.raises(TranscriptUnavailableError, match="still unavailable"):
+        ensure_thread_available(
+            _plugin("claude_code"),
+            _session("claude_code"),
+            current_config_dir="~/current",
+            target_config_dir=str(tmp_path / "target"),
+            policy="symlink_shared",
+            shared_transcript_dir="~/shared",
+            native_thread_store="projects",
+            fs=fs,
+        )
 
 
 def test_remote_script_ops_expand_tilde_against_the_running_host() -> None:

--- a/backend/tests/test_transcripts_remote.py
+++ b/backend/tests/test_transcripts_remote.py
@@ -343,3 +343,28 @@ def test_remote_glob_artifacts_degrades_to_empty_on_transport_failure(
             native_thread_store="projects",
             fs=fs,
         )
+
+
+def test_remote_expanduser_leaves_tilde_intact() -> None:
+    # The remote fs must NOT expand ``~`` against the backend host — the remote
+    # helper script expands it against the remote home per op instead.
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    assert fs.expanduser("~/.codex-work") == "~/.codex-work"
+    assert fs.expanduser("~alice/x") == "~alice/x"
+    assert fs.expanduser("/abs/path") == "/abs/path"
+
+
+def test_remote_script_ops_expand_tilde_against_the_running_host() -> None:
+    # Ops resolve ``~`` on the host that runs the script (the remote one in
+    # production; here the test host stands in), so a ``~``-relative config_dir
+    # reaches the right directory.
+    import json
+    import os
+
+    payload = _dispatch_script("exists", (os.path.expanduser("~"),))
+    line = payload.decode().split(script_mod.SENTINEL, 1)[1]
+    assert json.loads(line) == {"exists": True}
+    # A bare ``~`` must resolve the same way, not stat a literal "~" entry.
+    payload_tilde = _dispatch_script("exists", ("~",))
+    line_tilde = payload_tilde.decode().split(script_mod.SENTINEL, 1)[1]
+    assert json.loads(line_tilde) == {"exists": True}

--- a/backend/tests/test_transcripts_remote.py
+++ b/backend/tests/test_transcripts_remote.py
@@ -1,0 +1,345 @@
+"""RemoteTranscriptFilesystem against a fake command-capturing remote (no SSH).
+
+Exercises RemoteTranscriptFilesystem's real argv-building
+(``SshLaunchTargetConfig.build_remote_exec_args``) and sentinel/JSON parsing,
+with ``subprocess.run`` faked to dispatch the real vendored script
+(``transcript_fs_remote_script``) in-process against ``tmp_path`` standing in
+for the remote host. Mirrors test_transcripts.py's symlink_shared cases and
+copy_thread_on_switch path, but through the remote seam, asserting the
+sequence of emitted remote commands and fail-before-destroy ordering.
+"""
+
+import contextlib
+import io
+import json
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from waypoint.backends import transcript_fs_remote as remote_mod
+from waypoint.backends import transcript_fs_remote_script as script_mod
+from waypoint.backends.base import BackendPlugin
+from waypoint.backends.bootstrap import build_default_registry
+from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
+from waypoint.backends.transcripts import (
+    TranscriptUnavailableError,
+    ensure_symlink_shared,
+    ensure_thread_available,
+)
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+TID = "11111111-1111-1111-1111-111111111111"
+
+
+def _launch_target() -> SshLaunchTargetConfig:
+    return SshLaunchTargetConfig(
+        id="remote-1",
+        name="Remote",
+        ssh_destination="test-host",
+        ssh_bin="/bin/sh",
+    )
+
+
+def _plugin(backend: str) -> BackendPlugin:
+    return build_default_registry().get(backend)
+
+
+def _session(backend: str) -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id="s1",
+        backend=backend,
+        source=SessionSource.MANAGED,
+        title="t",
+        cwd="/repo/app",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/r",
+        structured_log_path="/e",
+        transport_state={"thread_id": TID},
+    )
+
+
+def _write_codex_rollout(config_dir: Path) -> Path:
+    day = config_dir / "sessions" / "2026" / "07" / "08"
+    day.mkdir(parents=True)
+    path = day / f"rollout-2026-07-08T00-00-00-{TID}.jsonl"
+    path.write_text("{}")
+    return path
+
+
+def _dispatch_script(op: str, args: tuple[str, ...]) -> bytes:
+    """Run the real vendored script's op dispatch in-process, capturing stdout."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        handler = script_mod.OPS.get(op)
+        if handler is None:
+            script_mod.emit({"error": "unknown op: " + op})
+        else:
+            try:
+                handler(*args)
+            except Exception as exc:  # mirror the script's top-level catch-all
+                script_mod.emit({"error": "internal: " + repr(exc)})
+    return buf.getvalue().encode("utf-8")
+
+
+class _FakeRemote:
+    """Captures every (op, args) RemoteTranscriptFilesystem issues.
+
+    Answers each by running the real vendored script's dispatch against the
+    real local filesystem (``tmp_path`` in tests stands in for the remote
+    root) — no SSH process, no real network, but genuine script logic and
+    genuine argv-building/sentinel-parsing on the ``RemoteTranscriptFilesystem``
+    side. ``force_error`` lets a test simulate a remote-side failure for one
+    call without touching the filesystem, to test fail-before-destroy.
+    """
+
+    def __init__(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self.calls: list[tuple[str, tuple[str, ...]]] = []
+        self._force_errors: dict[str, str] = {}
+        orig_build = SshLaunchTargetConfig.build_remote_exec_args
+
+        def _capturing_build(
+            target_self: SshLaunchTargetConfig,
+            command: list[str],
+            *args: object,
+            **kwargs: object,
+        ) -> tuple[str, ...]:
+            op, op_args = command[2], tuple(command[3:])
+            self.calls.append((op, op_args))
+            return orig_build(target_self, command, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(
+            SshLaunchTargetConfig, "build_remote_exec_args", _capturing_build
+        )
+
+        def _fake_run(
+            argv: tuple[str, ...],
+            *,
+            input: bytes | None = None,
+            capture_output: bool | None = None,
+            timeout: float | None = None,
+        ) -> subprocess.CompletedProcess[bytes]:
+            op, op_args = self.calls[-1]
+            if op in self._force_errors:
+                message = self._force_errors.pop(op)
+                stdout = (
+                    remote_mod.SENTINEL + json.dumps({"error": message}) + "\n"
+                ).encode("utf-8")
+            else:
+                stdout = _dispatch_script(op, op_args)
+            return subprocess.CompletedProcess(argv, 0, stdout=stdout, stderr=b"")
+
+        monkeypatch.setattr(remote_mod.subprocess, "run", _fake_run)
+
+    def force_error(self, op: str, message: str) -> None:
+        self._force_errors[op] = message
+
+
+@pytest.fixture
+def fake_remote(monkeypatch: pytest.MonkeyPatch) -> _FakeRemote:
+    return _FakeRemote(monkeypatch)
+
+
+# ── symlink_shared cases (mirrors test_transcripts.py, through the remote FS)
+
+
+def test_remote_symlink_shared_creates_symlink_when_missing(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    store = tmp_path / "target" / "projects"
+    shared = tmp_path / "shared"
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    ensure_symlink_shared(store, shared, fs=fs)
+    assert store.is_symlink()
+    assert store.resolve() == shared.resolve()
+    assert ("mkdir", (str(shared), "1", "1")) in fake_remote.calls
+    assert ("symlink", (str(store), str(shared))) in fake_remote.calls
+
+
+def test_remote_symlink_shared_idempotent_on_correct_symlink(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    store = tmp_path / "target" / "projects"
+    shared = tmp_path / "shared"
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    ensure_symlink_shared(store, shared, fs=fs)
+    fake_remote.calls.clear()
+    ensure_symlink_shared(store, shared, fs=fs)  # no error on second run
+    assert store.resolve() == shared.resolve()
+    assert ("symlink", (str(store), str(shared))) not in fake_remote.calls
+
+
+def test_remote_symlink_shared_rejects_wrong_symlink(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    store = tmp_path / "target" / "projects"
+    store.parent.mkdir(parents=True)
+    store.symlink_to(tmp_path / "elsewhere", target_is_directory=True)
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    with pytest.raises(TranscriptUnavailableError, match="not the configured"):
+        ensure_symlink_shared(store, tmp_path / "shared", fs=fs)
+
+
+def test_remote_symlink_shared_replaces_empty_real_dir(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    store = tmp_path / "target" / "projects"
+    store.mkdir(parents=True)
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    ensure_symlink_shared(store, tmp_path / "shared", fs=fs)
+    assert store.is_symlink()
+    assert ("rmdir", (str(store),)) in fake_remote.calls
+
+
+def test_remote_symlink_shared_refuses_nonempty_real_dir(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    store = tmp_path / "target" / "projects"
+    store.mkdir(parents=True)
+    (store / "keep.jsonl").write_text("{}")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    with pytest.raises(TranscriptUnavailableError, match="non-empty"):
+        ensure_symlink_shared(store, tmp_path / "shared", fs=fs)
+    # Fail-before-destroy: refused before any destructive rmdir/symlink call.
+    op_names = [name for name, _ in fake_remote.calls]
+    assert "rmdir" not in op_names
+    assert "symlink" not in op_names
+
+
+def test_remote_symlink_shared_end_to_end_makes_thread_visible(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    shared = tmp_path / "shared"
+    (shared / "-repo-app").mkdir(parents=True)
+    (shared / "-repo-app" / f"{TID}.jsonl").write_text("{}")
+    target = tmp_path / "target"
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    ensure_thread_available(
+        _plugin("claude_code"),
+        _session("claude_code"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(target),
+        policy="symlink_shared",
+        shared_transcript_dir=str(shared),
+        native_thread_store="projects",
+        fs=fs,
+    )
+    assert (target / "projects").is_symlink()
+    op_names = [name for name, _ in fake_remote.calls]
+    assert "glob" in op_names  # discovery + re-check both ran remotely
+
+
+# ── copy_thread_on_switch (remote) ──────────────────────────────────────────
+
+
+def test_remote_copy_thread_on_switch_copies_codex_rollout(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    current = tmp_path / "current"
+    target = tmp_path / "target"
+    src = _write_codex_rollout(current)
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(current),
+        target_config_dir=str(target),
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+        fs=fs,
+    )
+    dest = target / src.relative_to(current)
+    assert dest.is_file()
+    assert oct(dest.stat().st_mode)[-3:] == "600"
+    op_names = [name for name, _ in fake_remote.calls]
+    assert "copy_file" in op_names
+    assert "mkdir" in op_names
+    assert "glob" in op_names
+
+
+def test_remote_copy_thread_on_switch_rejects_when_source_missing(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    with pytest.raises(TranscriptUnavailableError, match="not found to copy"):
+        ensure_thread_available(
+            _plugin("codex"),
+            _session("codex"),
+            current_config_dir=str(tmp_path / "current"),
+            target_config_dir=str(tmp_path / "target"),
+            policy="copy_thread_on_switch",
+            shared_transcript_dir=None,
+            native_thread_store="sessions",
+            fs=fs,
+        )
+    # Fail-before-destroy: no copy/mkdir attempted when the source can't be found.
+    op_names = [name for name, _ in fake_remote.calls]
+    assert "copy_file" not in op_names
+    assert "mkdir" not in op_names
+
+
+def test_remote_copy_thread_on_switch_stops_before_copy_when_mkdir_fails(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    current = tmp_path / "current"
+    target = tmp_path / "target"
+    _write_codex_rollout(current)
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    fake_remote.force_error("mkdir", "permission denied")
+    with pytest.raises(TranscriptUnavailableError, match="permission denied"):
+        ensure_thread_available(
+            _plugin("codex"),
+            _session("codex"),
+            current_config_dir=str(current),
+            target_config_dir=str(target),
+            policy="copy_thread_on_switch",
+            shared_transcript_dir=None,
+            native_thread_store="sessions",
+            fs=fs,
+        )
+    # Fail-before-destroy: the failed mkdir stops the copy before it starts,
+    # and nothing was written under the target.
+    op_names = [name for name, _ in fake_remote.calls]
+    assert "copy_file" not in op_names
+    assert not target.exists()
+
+
+# ── transport-failure degradation ───────────────────────────────────────────
+
+
+def test_remote_glob_artifacts_degrades_to_empty_on_transport_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A read-only query op failing at the transport layer (not the remote
+    # logic) must degrade to "not found", not raise — fail-before-destroy
+    # relies on this feeding into the policy's own TranscriptUnavailableError
+    # rather than crashing with an unrelated exception.
+    monkeypatch.setattr(
+        SshLaunchTargetConfig,
+        "build_remote_exec_args",
+        lambda self, command, *a, **kw: ("ssh", "test-host", "python3 -"),
+    )
+    monkeypatch.setattr(
+        remote_mod.subprocess,
+        "run",
+        lambda *a, **kw: (_ for _ in ()).throw(subprocess.TimeoutExpired("ssh", 20)),
+    )
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    with pytest.raises(TranscriptUnavailableError, match="require_existing"):
+        ensure_thread_available(
+            _plugin("claude_code"),
+            _session("claude_code"),
+            current_config_dir=str(tmp_path / "current"),
+            target_config_dir=str(tmp_path / "target"),
+            policy="require_existing",
+            shared_transcript_dir=None,
+            native_thread_store="projects",
+            fs=fs,
+        )


### PR DESCRIPTION
## Purpose

Account/config-profile switching is **local-launch-target only** today: the transcript-availability step that gates a switch (`backends/transcripts.py`) is scoped "local only", the runtime skips it entirely for SSH targets, and a `~`-relative remote `config_dir` is rejected with a 400. This extends the switch to SSH launch targets — running the transcript policies (`require_existing`, `symlink_shared`, `copy_thread_on_switch`) over the same SSH control path the remote probes already use, expanding remote homes, and making the tmux-transport resume path work under a switched remote config dir — with no per-backend branching in the runtime or transports. Relates to #230.

## Changes

- `backend/src/waypoint/backends/transcript_fs.py` (new) — a `TranscriptFilesystem` protocol (`exists`/`is_dir`/`is_symlink`/`readlink`/`listdir`/`mkdir`/`chmod`/`rmdir`/`symlink`/`copy_file`/`glob_artifacts`) plus `LocalTranscriptFilesystem`, today's `pathlib`/`shutil` behavior exposed through the seam. The policy logic now runs unchanged whether the target profile is local or remote — only the IO backend differs.
- `backend/src/waypoint/backends/transcripts.py` — `ensure_thread_available` / `ensure_symlink_shared` / `copy_thread_artifacts` rewritten against the seam, taking an `fs` parameter that defaults to `LocalTranscriptFilesystem()`. Artifact discovery goes through `fs.glob_artifacts`, so no local `Path` ever leaks into a remote switch. Local behavior is byte-for-byte unchanged (proven by the existing suite).
- `backend/src/waypoint/backends/base.py`, `claude_code/plugin.py`, `codex/plugin.py`, `opencode/plugin.py`, `tmux/plugin.py`, `claude_tty/plugin.py` — new `native_thread_artifact_glob(session)` on the plugin contract: the config-dir-relative glob (`projects/*/<uuid>.jsonl`, `sessions/*/*/*/rollout-*-<uuid>.jsonl`) reusing the exact needle `conversation_exists` already checks, so local and remote discovery share one declared pattern per backend (opencode/tmux return `None`; claude_tty delegates to the wrapped agent).
- `backend/src/waypoint/backends/transcript_fs_remote.py`, `transcript_fs_remote_script.py` (new) — `RemoteTranscriptFilesystem` drives a single vendored stdlib helper script (piped to `python3 -`) over the existing SSH ControlMaster, so there is one remote command surface instead of a bespoke `ssh` per op. Query ops degrade to a safe "not found" on transport failure (a wrong turn still ends in a clean, non-destructive `TranscriptUnavailableError`); mutating ops raise on any failure. `copy_thread_on_switch` copies only the declared artifact set (parents `0700`, files `0600`) and read-back-verifies discoverability before returning. `shared_transcript_dir` remote-locality is validated implicitly by the `mkdir` the symlink policy already issues.
- `backend/src/waypoint/backends/claude_code/rate_limits.py`, `claude_code/plugin.py`, `codex/rate_limits.py`, `codex/plugin.py` — the remote account probe now threads `launch_env` down to `build_remote_exec_args(..., extra_env=launch_env)`, so the pre-switch `expected_account_key` check authenticates as the **selected profile's** account (the remote branch previously dropped the env and always probed the target's default account). The shared remote-probe cache is re-keyed by `(target_id, config_dir)` so two profiles on one host no longer alias.
- `backend/src/waypoint/runtime.py` — remote home expansion (`_ensure_remote_home_cached` resolves `$HOME`/`~user` via an auth-agnostic `ssh_capture`, cached per target + tilde prefix; `_apply_account_profile_env` stays synchronous and only reads the cache, expanding a `~`-relative remote `config_dir` instead of the old 400). The switch gains a prelude (`_require_live_master` for a clean 409 on a dead password master, then a cache-warm for the selected profile's tilde prefix) before `_apply_account_profile_env`, and the transcript step drops its `launch_target is None` gate to select `Local`/`Remote` FS by target while preserving the fail-before-destroy ordering. `accounts doctor` gains `_remote_config_dir_check` (remote config-dir existence over SSH).
- `backend/tests/` — `test_transcripts_remote.py` (new; the six `symlink_shared` cases + the copy path against a command-capturing fake remote FS, asserting emitted ops and fail-before-destroy ordering), `test_account_probe_env.py` (new; remote probe carries the profile config dir, distinct cache entries per dir), `test_account_doctor.py` (remote config-dir check), `test_tmux_plugin.py` (remote resume coverage), plus updates to `test_transcripts.py`, `test_account_profile_selection.py`, `test_rate_limits.py`, `test_backend_registry.py`.

## Design

The whole feature turns on a single seam. Rather than teach the policy code about SSH, `TranscriptFilesystem` isolates the six IO primitives the policies need; the runtime picks `LocalTranscriptFilesystem` or `RemoteTranscriptFilesystem` by launch target and the branching stops there — the policy code, the plugin discovery contract, and the fail-before-destroy contract are identical for both. The remote implementation is one vendored script over the existing ControlMaster (reused, never re-prompting a password target), chosen over N discrete `ssh` calls to cut round-trips and quoting hazards, mirroring `remote_probe_script.py`.

Remote home expansion had to keep `_apply_account_profile_env` synchronous — it has four call sites, one of them a sync method, so an SSH round-trip inside it would ripple async through the call graph. Instead an auth-agnostic async resolver warms a cache at existing await points (the switch prelude), and the sync overlay only reads it; a cold cache falls back to the documented 400. The warm uses `ssh_capture` (not `_require_live_master`/`connect_launch_target`, both password-only) so key-auth targets — the `ssh_auth` default — are covered.

The remote probe env fix is a prerequisite, not a nicety: without it the `expected_account_key` gate compares against the target's default account, so a remote switch to a non-default profile could never verify. macOS remote Claude stays *emergent*-disabled (the same-account probe refuses it when no `expected_account_key` is set) — there is no platform capability flag, and this PR does not change that. Interactive-onboarding remote **readiness** (the raising `ConfigDirValidating` guard) has no remote implementation yet; `accounts doctor` reports the remote config dir's existence so a remote switch doesn't silently launch into an onboarding hang, and the full interactive guard is a documented follow-up rather than scope creep.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- Real-SSH e2e of the remote-FS + remote-home layer against launch target `s0` (key auth): a throwaway remote dir exercised through every `RemoteTranscriptFilesystem` op (`mkdir`+`chmod`, `copy_file` with mode, `glob_artifacts`, `listdir`, `symlink`+`readlink`, `rmdir`, `exists`/`is_dir`/`is_symlink`) plus `ssh_capture` home resolution, then cleaned up.
- Backend restarted on this branch and confirmed healthy (new imports/switch-prelude/doctor wiring load and serve).

## Test Result

- Pre-commit — clean (`isort`, `black`, `ruff`, `codespell`, `mypy` all pass).
- `uv run pytest` — 1644 passed, 3 warnings (pre-existing, unrelated).
- Real-SSH e2e against `s0` — **passed**: `ssh_capture('echo $HOME') -> /home/noppanat`; every remote FS op verified over the live connection; `glob_artifacts` matched the exact claude-style pattern; temp dir cleaned up.
- **Not run:** full remote-switch-with-live-account e2e (transcript copy during a running remote session + resume). It needs a remote host with two provisioned Claude/Codex accounts under distinct config dirs — the RFC's explicit operator-responsibility non-goal — so the SSH filesystem/transport layer was exercised e2e instead.
- Convergence-loop plan review (two cold-context rounds) caught the sync/async ripple, the key-auth cache-warm gap, and the switch-prelude ordering before implementation.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched code that dispatches by plugin id: transcript ops dispatch through the `TranscriptFilesystem` seam + the `native_thread_artifact_glob` plugin contract with no per-backend branching; claude_code/codex host profiles, opencode/tmux return no pattern, claude_tty delegates.
- [x] No frontend changes (backend 400/409 details render in the existing error surfaces).
- [x] Not a breaking change.
- [ ] I have updated documentation or config examples if user-facing behavior changed — see note: `docs/account_profiles.md` describes remote support at a high level from the phase-1 RFC; a docs pass for the lifted `~`-remote restriction can follow if reviewers want it.

</details>
