### PR TITLE
feat: elevate account profile to session context in the web UI

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6115,6 +6115,15 @@ html[data-theme="light"] .composer-tune-restart-apply {
   cursor: progress;
 }
 
+/* Session-context header at the top of the settings popover: the account
+   profile as session identity, divided from the quick-tuning fields below. */
+.composer-tune-context {
+  display: grid;
+  gap: 8px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
 /* Assistant lifecycle footer (backend switch / clear context / terminate). */
 .composer-tune-lifecycle {
   display: grid;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8663,10 +8663,43 @@ html[data-theme="light"] .term-compose-send {
   min-width: 0;
 }
 
-.launch-body-grid {
+/* The launch form as a flat instrument panel: captioned field groups stacked
+   with a touch more air between sections than within, so context/subject/tuning
+   read as distinct without boxing them into nested cards. */
+.launch-sections {
   display: grid;
-  gap: 12px;
+  gap: 18px;
   min-width: 0;
+}
+
+.launch-section {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+/* Same mono micro-label register as the preset bar's caption, one step up in
+   the hierarchy — the labels read as one series across the whole form. */
+.launch-section-caption {
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--muted);
+}
+
+/* Compact target hint under the session-context row (remote launch targets). */
+.launch-section-hint {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--muted-soft);
+}
+
+.launch-section-hint strong {
+  color: var(--text);
+  font-weight: 600;
 }
 
 .field-grid-row {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8891,6 +8891,20 @@ html[data-theme="light"] .preset-select {
   color: var(--muted);
 }
 
+/* The account profile reads in its own hue everywhere it appears — here it
+   matches the header/list account-profile badge so a preset visibly captures
+   session identity, not just tuning. */
+.preset-summary-chip.is-profile {
+  color: var(--accent-cool, var(--accent));
+}
+
+/* A captured profile the current catalogue no longer offers: muted and struck
+   so it reads as unavailable, the same signal an unsupported backend gets. */
+.preset-summary-chip.is-unavailable {
+  color: var(--muted-soft);
+  text-decoration: line-through;
+}
+
 .preset-summary-dot {
   width: 3px;
   height: 3px;

--- a/frontend/src/components/AccountProfilePicker.tsx
+++ b/frontend/src/components/AccountProfilePicker.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { AccountProfile } from "@/lib/types";
+
+interface AccountProfilePickerProps {
+  profiles: AccountProfile[];
+  value: string;
+  onChange: (id: string) => void;
+  disabled?: boolean;
+  // Copy for the no-profile option. "Account" overpromises (the frontend only
+  // knows the configured profile, not the verified account), and plain
+  // "Default" collides with default preset/model/effort — so callers name the
+  // fallback explicitly, e.g. "Service default".
+  defaultLabel?: string;
+  label?: string;
+  // Wrapper class so the same control reads as a flat launch ``.field`` or a
+  // composer ``.composer-tune-field`` depending on where it's mounted.
+  fieldClassName?: string;
+}
+
+// The account/config-profile selector shared by the launch context block and
+// the running-session switch flow. Presentational only: it renders the profile
+// as session identity and leaves the destructive/restart semantics to callers.
+export function AccountProfilePicker({
+  profiles,
+  value,
+  onChange,
+  disabled,
+  defaultLabel = "Service default",
+  label = "Account profile",
+  fieldClassName = "field",
+}: AccountProfilePickerProps) {
+  // Keep a currently-selected id visible even if it has dropped out of the
+  // catalogue (a historical profile), so the control never silently blanks.
+  const missing = value !== "" && !profiles.some((profile) => profile.id === value);
+  return (
+    <label className={fieldClassName}>
+      <span>{label}</span>
+      <select
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+      >
+        <option value="">{defaultLabel}</option>
+        {profiles.map((profile) => (
+          <option key={profile.id} value={profile.id}>
+            {profile.label}
+          </option>
+        ))}
+        {missing ? (
+          <option value={value}>{value}</option>
+        ) : null}
+      </select>
+    </label>
+  );
+}

--- a/frontend/src/components/AccountProfilePicker.tsx
+++ b/frontend/src/components/AccountProfilePicker.tsx
@@ -7,10 +7,7 @@ interface AccountProfilePickerProps {
   value: string;
   onChange: (id: string) => void;
   disabled?: boolean;
-  // Copy for the no-profile option. "Account" overpromises (the frontend only
-  // knows the configured profile, not the verified account), and plain
-  // "Default" collides with default preset/model/effort — so callers name the
-  // fallback explicitly, e.g. "Service default".
+  // Copy for the no-profile option: the agent's default config/account.
   defaultLabel?: string;
   label?: string;
   // Wrapper class so the same control reads as a flat launch ``.field`` or a
@@ -26,7 +23,7 @@ export function AccountProfilePicker({
   value,
   onChange,
   disabled,
-  defaultLabel = "Service default",
+  defaultLabel = "Default",
   label = "Account profile",
   fieldClassName = "field",
 }: AccountProfilePickerProps) {

--- a/frontend/src/components/AgentTransportPicker.tsx
+++ b/frontend/src/components/AgentTransportPicker.tsx
@@ -84,48 +84,6 @@ export function TransportPicker({
   );
 }
 
-interface AgentTransportPickerProps {
-  agents: Backend[];
-  agent: Backend;
-  onAgentChange: (backend: Backend) => void;
-  transport: SessionTransport;
-  onTransportChange: (transport: SessionTransport) => void;
-  catalog: BackendCatalog;
-}
-
-// The shared agent-primary launch control: an agent dropdown followed by the
-// transport dropdown for the chosen agent. New, Resume, and Schedule all render
-// this so the launch vocabulary stays identical across panels.
-export function AgentTransportPicker({
-  agents,
-  agent,
-  onAgentChange,
-  transport,
-  onTransportChange,
-  catalog,
-}: AgentTransportPickerProps) {
-  const transports = useMemo(
-    () => agentTransports(agent, catalog),
-    [agent, catalog],
-  );
-  return (
-    <>
-      <AgentPicker
-        agents={agents}
-        value={agent}
-        onChange={onAgentChange}
-        catalog={catalog}
-      />
-      <TransportPicker
-        transports={transports}
-        value={transport}
-        onChange={onTransportChange}
-        catalog={catalog}
-      />
-    </>
-  );
-}
-
 // Transport state that tracks the selected agent: it defaults to the agent's
 // preferred transport and re-clamps whenever the agent changes so a transport
 // carried over from another agent never sticks. Returns the live transport set

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -239,7 +239,7 @@ export function useLaunchForm({
 
   // Drop a selected profile the current backend/target doesn't offer (e.g. a
   // preset carrying a profile valid elsewhere) so the launch never submits an
-  // id the server would reject; falls back to the service-default option.
+  // id the server would reject; falls back to the default option.
   useEffect(() => {
     if (
       accountProfileId &&

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -356,7 +356,6 @@ export function LaunchFormFields({
           onAccountProfileChange={form.setAccountProfileId}
           targetLabel={targetLabel}
           catalog={catalog}
-          disabled={busy}
         />
       </section>
 

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -10,10 +10,7 @@ import {
   useState,
 } from "react";
 
-import {
-  AgentTransportPicker,
-  useTransportForAgent,
-} from "@/components/AgentTransportPicker";
+import { useTransportForAgent } from "@/components/AgentTransportPicker";
 import { EffortPicker } from "@/components/EffortPicker";
 import {
   formatLaunchEnv,
@@ -21,6 +18,7 @@ import {
   parseLaunchEnv,
 } from "@/components/LaunchOptions";
 import { ModelPicker } from "@/components/ModelPicker";
+import { SessionContextFields } from "@/components/SessionContextFields";
 import { WorkingDirectoryField } from "@/components/WorkingDirectoryField";
 import type { BackendCatalog } from "@/lib/backends";
 import { permissionModesFor } from "@/lib/backends";
@@ -241,7 +239,7 @@ export function useLaunchForm({
 
   // Drop a selected profile the current backend/target doesn't offer (e.g. a
   // preset carrying a profile valid elsewhere) so the launch never submits an
-  // id the server would reject; falls back to the "Default" option.
+  // id the server would reject; falls back to the service-default option.
   useEffect(() => {
     if (
       accountProfileId &&
@@ -323,9 +321,12 @@ interface LaunchFormFieldsProps {
   onClearCwdError?: () => void;
 }
 
-// The shared input block for New and Schedule: agent/transport picker, the
-// working directory + title rows, the permission/model/effort row, and the
-// collapsible Advanced section.
+// The shared input block for New and Schedule, ordered by the settings
+// hierarchy: session context (agent/account profile/interface) selects the
+// agent namespace and config root, then session subject (cwd/title), then
+// runtime tuning (permission/model/effort) constrained by that context, then
+// the collapsible Advanced section. Mono section captions group the fields as
+// a flat instrument panel — not nested cards.
 export function LaunchFormFields({
   form,
   host,
@@ -341,16 +342,26 @@ export function LaunchFormFields({
   onClearCwdError,
 }: LaunchFormFieldsProps) {
   return (
-    <>
-      <AgentTransportPicker
-        agents={supportedBackends}
-        agent={form.backend}
-        onAgentChange={form.changeBackend}
-        transport={form.transport}
-        onTransportChange={form.setTransport}
-        catalog={catalog}
-      />
-      <div className="launch-body-grid">
+    <div className="launch-sections">
+      <section className="launch-section">
+        <span className="launch-section-caption">Session context</span>
+        <SessionContextFields
+          agents={supportedBackends}
+          agent={form.backend}
+          onAgentChange={form.changeBackend}
+          transport={form.transport}
+          onTransportChange={form.setTransport}
+          accountProfiles={form.accountProfiles}
+          accountProfileId={form.accountProfileId}
+          onAccountProfileChange={form.setAccountProfileId}
+          targetLabel={targetLabel}
+          catalog={catalog}
+          disabled={busy}
+        />
+      </section>
+
+      <section className="launch-section">
+        <span className="launch-section-caption">Session</span>
         <WorkingDirectoryField
           cwd={form.cwd}
           onChange={form.setCwd}
@@ -367,6 +378,10 @@ export function LaunchFormFields({
             placeholder="Optional"
           />
         </label>
+      </section>
+
+      <section className="launch-section">
+        <span className="launch-section-caption">Tuning</span>
         <div className="field-grid-row">
           {form.permissionOptions.length > 0 ? (
             <label className="field">
@@ -378,22 +393,6 @@ export function LaunchFormFields({
                 {form.permissionOptions.map((option) => (
                   <option key={option.id} value={option.id}>
                     {option.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-          ) : null}
-          {form.accountProfiles.length > 0 ? (
-            <label className="field">
-              <span>Account</span>
-              <select
-                value={form.accountProfileId}
-                onChange={(event) => form.setAccountProfileId(event.target.value)}
-              >
-                <option value="">Default</option>
-                {form.accountProfiles.map((profile) => (
-                  <option key={profile.id} value={profile.id}>
-                    {profile.label}
                   </option>
                 ))}
               </select>
@@ -421,7 +420,8 @@ export function LaunchFormFields({
             />
           ) : null}
         </div>
-      </div>
+      </section>
+
       <LaunchOptionsDetails
         mode="new"
         supportsCustomArgs={form.supportsCustomArgs}
@@ -434,6 +434,6 @@ export function LaunchFormFields({
         onLaunchEnvChange={form.setLaunchEnvText}
         formBusy={busy}
       />
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/PresetBar.tsx
+++ b/frontend/src/components/PresetBar.tsx
@@ -7,25 +7,52 @@ import type { LaunchForm } from "@/components/LaunchFormFields";
 import { humaniseBackend } from "@/lib/backends";
 import { trapTabFocus } from "@/lib/keyboard";
 import type {
+  AccountProfile,
   Backend,
   SessionPresetSpec,
   SessionPresetSummary,
   SessionPresetWriteRequest,
 } from "@/lib/types";
 
+interface SummaryChip {
+  text: string;
+  className?: string;
+  title?: string;
+}
+
 // A compact key=value summary of what a preset spec pins, in the badge/mono
 // vocabulary: the backend rides an owner-hue badge, the rest are muted chips.
-// Used only in the save sheet's captures readout.
-function SpecSummary({ spec }: { spec: SessionPresetSummary["spec"] }) {
-  const chips: string[] = [];
-  if (spec.model) chips.push(spec.model);
-  if (spec.effort) chips.push(spec.effort);
-  if (spec.permission_mode) chips.push(spec.permission_mode);
-  if (spec.account_profile_id) chips.push(spec.account_profile_id);
+// The account profile rides the account hue (session identity, not tuning), and
+// resolves to its label from the current catalogue — an id no longer offered
+// falls back to the raw id marked unavailable. Used only in the save sheet's
+// captures readout.
+function SpecSummary({
+  spec,
+  profiles,
+}: {
+  spec: SessionPresetSummary["spec"];
+  profiles: AccountProfile[];
+}) {
+  const chips: SummaryChip[] = [];
+  if (spec.model) chips.push({ text: spec.model });
+  if (spec.effort) chips.push({ text: spec.effort });
+  if (spec.permission_mode) chips.push({ text: spec.permission_mode });
+  if (spec.account_profile_id) {
+    const matched = profiles.find((p) => p.id === spec.account_profile_id);
+    chips.push(
+      matched
+        ? { text: matched.label, className: "is-profile" }
+        : {
+            text: spec.account_profile_id,
+            className: "is-profile is-unavailable",
+            title: "Account profile no longer available",
+          },
+    );
+  }
   const envCount = spec.launch_env_keys?.length ?? 0;
-  if (envCount) chips.push(`${envCount} env`);
+  if (envCount) chips.push({ text: `${envCount} env` });
   const argsCount = spec.args?.length ?? 0;
-  if (argsCount) chips.push(`${argsCount} arg${argsCount > 1 ? "s" : ""}`);
+  if (argsCount) chips.push({ text: `${argsCount} arg${argsCount > 1 ? "s" : ""}` });
   return (
     <span className="preset-summary">
       {spec.backend ? (
@@ -34,9 +61,13 @@ function SpecSummary({ spec }: { spec: SessionPresetSummary["spec"] }) {
         </span>
       ) : null}
       {chips.map((chip, i) => (
-        <span key={`${i}-${chip}`} className="preset-summary-chip">
+        <span
+          key={`${i}-${chip.text}`}
+          className={`preset-summary-chip${chip.className ? ` ${chip.className}` : ""}`}
+          title={chip.title}
+        >
           {i > 0 || spec.backend ? <span className="preset-summary-dot" /> : null}
-          {chip}
+          {chip.text}
         </span>
       ))}
     </span>
@@ -295,6 +326,7 @@ export function PresetSaveActions({
         <PresetSaveModal
           seedDefault={seedDefault}
           spec={formSpec(form, launchTargetId)}
+          profiles={form.accountProfiles}
           onClose={() => setSaveOpen(false)}
           onSave={async (payload) => {
             setBusy(true);
@@ -320,6 +352,7 @@ export function PresetSaveActions({
 interface PresetSaveModalProps {
   seedDefault: boolean;
   spec: SessionPresetSpec;
+  profiles: AccountProfile[];
   onClose: () => void;
   onSave: (payload: SessionPresetWriteRequest) => Promise<void>;
 }
@@ -331,6 +364,7 @@ interface PresetSaveModalProps {
 function PresetSaveModal({
   seedDefault,
   spec,
+  profiles,
   onClose,
   onSave,
 }: PresetSaveModalProps) {
@@ -345,6 +379,7 @@ function PresetSaveModal({
     model: spec.model,
     effort: spec.effort,
     permission_mode: spec.permission_mode,
+    account_profile_id: spec.account_profile_id,
     launch_env_keys: Object.keys(spec.launch_env ?? {}),
     args: spec.args,
   };
@@ -444,8 +479,10 @@ function PresetSaveModal({
             />
           </label>
           <div className="preset-modal-captures">
-            <span className="preset-modal-captures-label">Captures</span>
-            <SpecSummary spec={summarySpec} />
+            <span className="preset-modal-captures-label">
+              Captures session context + tuning
+            </span>
+            <SpecSummary spec={summarySpec} profiles={profiles} />
           </div>
           <label className="preset-modal-check">
             <input

--- a/frontend/src/components/ScheduledSessionsPanel.tsx
+++ b/frontend/src/components/ScheduledSessionsPanel.tsx
@@ -176,7 +176,7 @@ function ScheduleRow({
         {schedule.account_profile_label ? (
           <span
             className="badge account-profile"
-            title={`Account: ${schedule.account_profile_label}`}
+            title={`Account profile: ${schedule.account_profile_label}`}
           >
             {schedule.account_profile_label}
           </span>

--- a/frontend/src/components/SessionContextFields.tsx
+++ b/frontend/src/components/SessionContextFields.tsx
@@ -21,7 +21,6 @@ interface SessionContextFieldsProps {
   // hint so the context reads "which host / account / interface".
   targetLabel: string | null;
   catalog: BackendCatalog;
-  disabled?: boolean;
 }
 
 // The top-of-form session context: agent, account profile (only when the agent
@@ -40,7 +39,6 @@ export function SessionContextFields({
   onAccountProfileChange,
   targetLabel,
   catalog,
-  disabled,
 }: SessionContextFieldsProps) {
   const transports = useMemo(
     () => agentTransports(agent, catalog),
@@ -60,7 +58,6 @@ export function SessionContextFields({
             profiles={accountProfiles}
             value={accountProfileId}
             onChange={onAccountProfileChange}
-            disabled={disabled}
           />
         ) : null}
         <TransportPicker

--- a/frontend/src/components/SessionContextFields.tsx
+++ b/frontend/src/components/SessionContextFields.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { AccountProfilePicker } from "@/components/AccountProfilePicker";
+import { AgentPicker, TransportPicker } from "@/components/AgentTransportPicker";
+import type { BackendCatalog } from "@/lib/backends";
+import { agentTransports } from "@/lib/backends";
+import { AccountProfile, Backend, SessionTransport } from "@/lib/types";
+
+interface SessionContextFieldsProps {
+  agents: Backend[];
+  agent: Backend;
+  onAgentChange: (backend: Backend) => void;
+  transport: SessionTransport;
+  onTransportChange: (transport: SessionTransport) => void;
+  accountProfiles: AccountProfile[];
+  accountProfileId: string;
+  onAccountProfileChange: (id: string) => void;
+  // Non-null only when a remote/SSH launch target is active; shown as a compact
+  // hint so the context reads "which host / account / interface".
+  targetLabel: string | null;
+  catalog: BackendCatalog;
+  disabled?: boolean;
+}
+
+// The top-of-form session context: agent, account profile (only when the agent
+// exposes profiles), and interface — the choices that select the agent
+// namespace, config root, credentials, and host path before any session
+// subject or runtime tuning. Ordered agent -> account profile -> interface to
+// match the settings-hierarchy dependency order.
+export function SessionContextFields({
+  agents,
+  agent,
+  onAgentChange,
+  transport,
+  onTransportChange,
+  accountProfiles,
+  accountProfileId,
+  onAccountProfileChange,
+  targetLabel,
+  catalog,
+  disabled,
+}: SessionContextFieldsProps) {
+  const transports = useMemo(
+    () => agentTransports(agent, catalog),
+    [agent, catalog],
+  );
+  return (
+    <>
+      <div className="field-grid-row">
+        <AgentPicker
+          agents={agents}
+          value={agent}
+          onChange={onAgentChange}
+          catalog={catalog}
+        />
+        {accountProfiles.length > 0 ? (
+          <AccountProfilePicker
+            profiles={accountProfiles}
+            value={accountProfileId}
+            onChange={onAccountProfileChange}
+            disabled={disabled}
+          />
+        ) : null}
+        <TransportPicker
+          transports={transports}
+          value={transport}
+          onChange={onTransportChange}
+          catalog={catalog}
+        />
+      </div>
+      {targetLabel ? (
+        <p className="launch-section-hint">
+          target: <strong>{targetLabel}</strong>
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2566,10 +2566,9 @@ const ReplyComposer = memo(function ReplyComposer({
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
   const [pendingEffort, setPendingEffort] = useState<string | null>(null);
-  // Account-profile switch: a lifecycle action opened from the overflow menu.
-  // The pick is staged here and applied only after the explicit restart
+  // Account-profile switch, staged in the settings popover's session-context
+  // section: the pick lives here and is applied only after the explicit restart
   // confirmation, never straight from a select change.
-  const [profileSwitchOpen, setProfileSwitchOpen] = useState(false);
   const [pendingAccountProfileId, setPendingAccountProfileId] =
     useState<string | null>(null);
   // iMessage-style leading actions: ⊕ + 📎 collapse to a single ›-chevron via
@@ -2583,7 +2582,6 @@ const ReplyComposer = memo(function ReplyComposer({
   const composerRef = useRef<HTMLElement | null>(null);
   const overflowRef = useRef<HTMLDivElement | null>(null);
   const tuneRef = useRef<HTMLDivElement | null>(null);
-  const profileSwitchRef = useRef<HTMLDivElement | null>(null);
 
   // Auto-grow the field to fit its content: a single line by default (so the
   // pill matches the flanking buttons), growing as the draft wraps up to the
@@ -2707,27 +2705,13 @@ const ReplyComposer = memo(function ReplyComposer({
     };
   }, [tuneOpen]);
 
+  // Drop any staged profile pick when the settings popover closes, so reopening
+  // it always starts from the session's current profile.
   useEffect(() => {
-    if (!profileSwitchOpen) {
-      return;
+    if (!tuneOpen) {
+      setPendingAccountProfileId(null);
     }
-    function onPointer(event: PointerEvent) {
-      if (!profileSwitchRef.current) return;
-      if (profileSwitchRef.current.contains(event.target as Node)) return;
-      setProfileSwitchOpen(false);
-    }
-    function onKey(event: globalThis.KeyboardEvent) {
-      if (event.key === "Escape") {
-        setProfileSwitchOpen(false);
-      }
-    }
-    window.addEventListener("pointerdown", onPointer);
-    window.addEventListener("keydown", onKey);
-    return () => {
-      window.removeEventListener("pointerdown", onPointer);
-      window.removeEventListener("keydown", onKey);
-    };
-  }, [profileSwitchOpen]);
+  }, [tuneOpen]);
 
   async function handleSend() {
     const text = draft.trim();
@@ -2877,9 +2861,6 @@ const ReplyComposer = memo(function ReplyComposer({
     await onEffortChange(value);
   };
 
-  // Account-profile switching is a session-identity lifecycle action, not turn
-  // tuning — it lives in the overflow menu's staged switch flow, so it doesn't
-  // gate the quick-tuning gear or appear in its summary.
   const hasAccountPicker = supportsAccountSwitch && accountProfiles.length > 0;
   const currentProfileId = accountProfileId ?? "";
   const profileSwitchValue = pendingAccountProfileId ?? currentProfileId;
@@ -2891,22 +2872,21 @@ const ReplyComposer = memo(function ReplyComposer({
   const pendingProfileLabel =
     accountProfiles.find((profile) => profile.id === profileSwitchValue)?.label ??
     profileSwitchValue;
-  const openProfileSwitch = () => {
-    setOverflowOpen(false);
-    setPendingAccountProfileId(currentProfileId);
-    setProfileSwitchOpen(true);
-  };
   const confirmProfileSwitch = async () => {
     if (!profileSwitchDiffers) return;
     await onAccountChange(profileSwitchValue);
-    setProfileSwitchOpen(false);
+    setTuneOpen(false);
     setPendingAccountProfileId(null);
   };
   const assistantOps = assistant ? assistantControls : null;
+  // The account profile lives in the settings popover as a separated
+  // session-context section (kept out of the quick-tuning summary), so it also
+  // makes the gear worth opening when no other tuning control exists.
   const tuneVisible =
     modeOptions.length > 0 ||
     hasModelPicker ||
     hasEffortPicker ||
+    hasAccountPicker ||
     assistantOps !== null;
   // Backend the assistant controls target — the picked one, or the current.
   const assistantTargetBackend = pendingBackend ?? session?.backend ?? null;
@@ -3311,57 +3291,48 @@ const ReplyComposer = memo(function ReplyComposer({
                     </div>
                   </div>
                 ) : null}
+                {hasAccountPicker ? (
+                  <div className="composer-tune-lifecycle">
+                    <AccountProfilePicker
+                      profiles={accountProfiles}
+                      value={profileSwitchValue}
+                      onChange={(id) => setPendingAccountProfileId(id)}
+                      disabled={accountBusy}
+                      fieldClassName="composer-tune-field"
+                    />
+                    {profileSwitchDiffers ? (
+                      <div className="composer-tune-confirm">
+                        <p>
+                          Restart this session with{" "}
+                          <strong>{pendingProfileLabel}</strong>? The current
+                          turn is interrupted, the backend process restarts, and
+                          the session resumes from the selected profile&apos;s
+                          config and transcript store.
+                        </p>
+                        <div className="composer-tune-confirm-actions">
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-cancel"
+                            onClick={() => setPendingAccountProfileId(null)}
+                            disabled={accountBusy}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-apply"
+                            onClick={() => void confirmProfileSwitch()}
+                            disabled={accountBusy}
+                          >
+                            {accountBusy ? "Restarting…" : "Restart session"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
             ) : null}
-          </div>
-        ) : null}
-        {hasAccountPicker && profileSwitchOpen ? (
-          <div className="composer-tune composer-profile-switch" ref={profileSwitchRef}>
-            <div
-              className="composer-tune-popover"
-              role="dialog"
-              aria-label="Switch account profile"
-            >
-              <AccountProfilePicker
-                profiles={accountProfiles}
-                value={profileSwitchValue}
-                onChange={(id) => setPendingAccountProfileId(id)}
-                disabled={accountBusy}
-                fieldClassName="composer-tune-field"
-              />
-              {profileSwitchDiffers ? (
-                <div className="composer-tune-confirm">
-                  <p>
-                    Restart this session with{" "}
-                    <strong>{pendingProfileLabel}</strong>? The current turn is
-                    interrupted, the backend process restarts, and the session
-                    resumes from the selected profile&apos;s config and
-                    transcript store.
-                  </p>
-                  <div className="composer-tune-confirm-actions">
-                    <button
-                      type="button"
-                      className="composer-tune-confirm-cancel"
-                      onClick={() => {
-                        setProfileSwitchOpen(false);
-                        setPendingAccountProfileId(null);
-                      }}
-                      disabled={accountBusy}
-                    >
-                      Cancel
-                    </button>
-                    <button
-                      type="button"
-                      className="composer-tune-confirm-apply"
-                      onClick={() => void confirmProfileSwitch()}
-                      disabled={accountBusy}
-                    >
-                      {accountBusy ? "Restarting…" : "Restart session"}
-                    </button>
-                  </div>
-                </div>
-              ) : null}
-            </div>
           </div>
         ) : null}
         {agentBusy ? (
@@ -3580,18 +3551,6 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">◷</span>
                     Schedule message…
                   </button>
-                  {hasAccountPicker ? (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className="composer-overflow-item"
-                      disabled={accountBusy}
-                      onClick={openProfileSwitch}
-                    >
-                      <span className="glyph">⊙</span>
-                      Switch profile…
-                    </button>
-                  ) : null}
                   {workspacePreviewEnabled ? (
                     <button
                       type="button"

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -4310,6 +4310,14 @@ function SessionHeader({
         <span className={`badge ${headerAgent}`}>
           {humaniseBackend(headerAgent, catalog)}
         </span>
+        {session.account_profile_label ? (
+          <span
+            className="badge account-profile"
+            title={`Account profile: ${session.account_profile_label}`}
+          >
+            {session.account_profile_label}
+          </span>
+        ) : null}
         {!assistant && showHeaderTransport ? (
           <span className={`badge transport ${session.transport}`}>
             {transportLabel(session.transport, catalog)}
@@ -4323,14 +4331,6 @@ function SessionHeader({
         {session.effort ? (
           <span className="badge effort" title={`Effort: ${session.effort}`}>
             {session.effort}
-          </span>
-        ) : null}
-        {session.account_profile_label ? (
-          <span
-            className="badge account-profile"
-            title={`Account: ${session.account_profile_label}`}
-          >
-            {session.account_profile_label}
           </span>
         ) : null}
         {!assistant ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -88,6 +88,7 @@ import {
   PaperclipIcon,
   useAttachments,
 } from "@/components/AttachmentTray";
+import { AccountProfilePicker } from "@/components/AccountProfilePicker";
 import { ScheduleMessageModal } from "@/components/ScheduleMessageModal";
 import { ScheduledMessagesDock } from "@/components/ScheduledMessagesDock";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
@@ -683,26 +684,18 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     };
   }, [host, token, sessionId, sessionHostsProfiles, handleAuthFailure]);
 
+  // Restart the session under a different account profile. The destructive
+  // restart is confirmed explicitly by the composer's staged switch flow before
+  // this runs, so it performs the switch directly. Phase 1 switches between
+  // named profiles only; clearing back to the default config dir isn't a
+  // meaningful switch (it resolves to the same account and would be rejected),
+  // so an empty or unchanged pick is a no-op.
   const handleAccountProfileChange = useCallback(
     async (nextProfileId: string) => {
-      // Phase 1 offers switching between named profiles only; clearing back to
-      // the default config dir isn't a meaningful switch (it would resolve to
-      // the same account and be rejected), so an empty pick is a no-op.
       if (!session || !nextProfileId) {
         return;
       }
       if (nextProfileId === (session.account_profile_id ?? "")) {
-        return;
-      }
-      const label =
-        accountSettings?.account_profiles.find((p) => p.id === nextProfileId)
-          ?.label ?? nextProfileId;
-      if (
-        !window.confirm(
-          `Switch this session to the "${label}" account? It restarts and ` +
-            "resumes the current thread under the new config dir.",
-        )
-      ) {
         return;
       }
       setAccountBusy(true);
@@ -727,7 +720,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         setAccountBusy(false);
       }
     },
-    [host, token, session, accountSettings, handleAuthFailure],
+    [host, token, session, handleAuthFailure],
   );
 
   const flushPendingEvents = useCallback(() => {
@@ -2573,6 +2566,12 @@ const ReplyComposer = memo(function ReplyComposer({
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
   const [pendingEffort, setPendingEffort] = useState<string | null>(null);
+  // Account-profile switch: a lifecycle action opened from the overflow menu.
+  // The pick is staged here and applied only after the explicit restart
+  // confirmation, never straight from a select change.
+  const [profileSwitchOpen, setProfileSwitchOpen] = useState(false);
+  const [pendingAccountProfileId, setPendingAccountProfileId] =
+    useState<string | null>(null);
   // iMessage-style leading actions: ⊕ + 📎 collapse to a single ›-chevron via
   // CSS (:focus-within) so focusing the field never triggers a React re-render
   // that could drop focus mid-gesture. The chevron re-opens them by forcing
@@ -2584,6 +2583,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const composerRef = useRef<HTMLElement | null>(null);
   const overflowRef = useRef<HTMLDivElement | null>(null);
   const tuneRef = useRef<HTMLDivElement | null>(null);
+  const profileSwitchRef = useRef<HTMLDivElement | null>(null);
 
   // Auto-grow the field to fit its content: a single line by default (so the
   // pill matches the flanking buttons), growing as the draft wraps up to the
@@ -2706,6 +2706,28 @@ const ReplyComposer = memo(function ReplyComposer({
       window.removeEventListener("keydown", onKey);
     };
   }, [tuneOpen]);
+
+  useEffect(() => {
+    if (!profileSwitchOpen) {
+      return;
+    }
+    function onPointer(event: PointerEvent) {
+      if (!profileSwitchRef.current) return;
+      if (profileSwitchRef.current.contains(event.target as Node)) return;
+      setProfileSwitchOpen(false);
+    }
+    function onKey(event: globalThis.KeyboardEvent) {
+      if (event.key === "Escape") {
+        setProfileSwitchOpen(false);
+      }
+    }
+    window.addEventListener("pointerdown", onPointer);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("pointerdown", onPointer);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [profileSwitchOpen]);
 
   async function handleSend() {
     const text = draft.trim();
@@ -2855,13 +2877,36 @@ const ReplyComposer = memo(function ReplyComposer({
     await onEffortChange(value);
   };
 
+  // Account-profile switching is a session-identity lifecycle action, not turn
+  // tuning — it lives in the overflow menu's staged switch flow, so it doesn't
+  // gate the quick-tuning gear or appear in its summary.
   const hasAccountPicker = supportsAccountSwitch && accountProfiles.length > 0;
+  const currentProfileId = accountProfileId ?? "";
+  const profileSwitchValue = pendingAccountProfileId ?? currentProfileId;
+  // A switch is offered only to a named profile that isn't the current one —
+  // phase 1 doesn't switch back to the service default (it resolves to the same
+  // account), so staging it shows no confirm.
+  const profileSwitchDiffers =
+    profileSwitchValue !== "" && profileSwitchValue !== currentProfileId;
+  const pendingProfileLabel =
+    accountProfiles.find((profile) => profile.id === profileSwitchValue)?.label ??
+    profileSwitchValue;
+  const openProfileSwitch = () => {
+    setOverflowOpen(false);
+    setPendingAccountProfileId(currentProfileId);
+    setProfileSwitchOpen(true);
+  };
+  const confirmProfileSwitch = async () => {
+    if (!profileSwitchDiffers) return;
+    await onAccountChange(profileSwitchValue);
+    setProfileSwitchOpen(false);
+    setPendingAccountProfileId(null);
+  };
   const assistantOps = assistant ? assistantControls : null;
   const tuneVisible =
     modeOptions.length > 0 ||
     hasModelPicker ||
     hasEffortPicker ||
-    hasAccountPicker ||
     assistantOps !== null;
   // Backend the assistant controls target — the picked one, or the current.
   const assistantTargetBackend = pendingBackend ?? session?.backend ?? null;
@@ -2954,12 +2999,6 @@ const ReplyComposer = memo(function ReplyComposer({
     }
     if (hasEffortPicker) {
       parts.push(currentEffort ? effortLabel(currentEffort) : "Default");
-    }
-    if (hasAccountPicker) {
-      const matched = accountProfiles.find(
-        (profile) => profile.id === (accountProfileId ?? ""),
-      );
-      parts.push(matched?.label ?? "Default");
     }
     return parts.join(" · ") || "Settings";
   })();
@@ -3110,31 +3149,6 @@ const ReplyComposer = memo(function ReplyComposer({
                           {option.label}
                         </option>
                       ))}
-                    </select>
-                  </label>
-                ) : null}
-                {hasAccountPicker ? (
-                  <label className="composer-tune-field">
-                    <span>Account</span>
-                    <select
-                      value={accountProfileId ?? ""}
-                      onChange={(event) =>
-                        void onAccountChange(event.target.value)
-                      }
-                      disabled={accountBusy || disabled}
-                    >
-                      {accountProfileId ? null : (
-                        <option value="">Default</option>
-                      )}
-                      {accountProfiles.map((profile) => (
-                        <option key={profile.id} value={profile.id}>
-                          {profile.label}
-                        </option>
-                      ))}
-                      {accountProfileId &&
-                      !accountProfiles.some((p) => p.id === accountProfileId) ? (
-                        <option value={accountProfileId}>{accountProfileId}</option>
-                      ) : null}
                     </select>
                   </label>
                 ) : null}
@@ -3299,6 +3313,55 @@ const ReplyComposer = memo(function ReplyComposer({
                 ) : null}
               </div>
             ) : null}
+          </div>
+        ) : null}
+        {hasAccountPicker && profileSwitchOpen ? (
+          <div className="composer-tune composer-profile-switch" ref={profileSwitchRef}>
+            <div
+              className="composer-tune-popover"
+              role="dialog"
+              aria-label="Switch account profile"
+            >
+              <AccountProfilePicker
+                profiles={accountProfiles}
+                value={profileSwitchValue}
+                onChange={(id) => setPendingAccountProfileId(id)}
+                disabled={accountBusy}
+                fieldClassName="composer-tune-field"
+              />
+              {profileSwitchDiffers ? (
+                <div className="composer-tune-confirm">
+                  <p>
+                    Restart this session with{" "}
+                    <strong>{pendingProfileLabel}</strong>? The current turn is
+                    interrupted, the backend process restarts, and the session
+                    resumes from the selected profile&apos;s config and
+                    transcript store.
+                  </p>
+                  <div className="composer-tune-confirm-actions">
+                    <button
+                      type="button"
+                      className="composer-tune-confirm-cancel"
+                      onClick={() => {
+                        setProfileSwitchOpen(false);
+                        setPendingAccountProfileId(null);
+                      }}
+                      disabled={accountBusy}
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      className="composer-tune-confirm-apply"
+                      onClick={() => void confirmProfileSwitch()}
+                      disabled={accountBusy}
+                    >
+                      {accountBusy ? "Restarting…" : "Restart session"}
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
           </div>
         ) : null}
         {agentBusy ? (
@@ -3517,6 +3580,18 @@ const ReplyComposer = memo(function ReplyComposer({
                     <span className="glyph">◷</span>
                     Schedule message…
                   </button>
+                  {hasAccountPicker ? (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="composer-overflow-item"
+                      disabled={accountBusy}
+                      onClick={openProfileSwitch}
+                    >
+                      <span className="glyph">⊙</span>
+                      Switch profile…
+                    </button>
+                  ) : null}
                   {workspacePreviewEnabled ? (
                     <button
                       type="button"

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2865,7 +2865,7 @@ const ReplyComposer = memo(function ReplyComposer({
   const currentProfileId = accountProfileId ?? "";
   const profileSwitchValue = pendingAccountProfileId ?? currentProfileId;
   // A switch is offered only to a named profile that isn't the current one —
-  // phase 1 doesn't switch back to the service default (it resolves to the same
+  // phase 1 doesn't switch back to the default (it resolves to the same
   // account), so staging it shows no confirm.
   const profileSwitchDiffers =
     profileSwitchValue !== "" && profileSwitchValue !== currentProfileId;
@@ -3013,6 +3013,46 @@ const ReplyComposer = memo(function ReplyComposer({
                 role="dialog"
                 aria-label="Session settings"
               >
+                {hasAccountPicker ? (
+                  <div className="composer-tune-context">
+                    <AccountProfilePicker
+                      profiles={accountProfiles}
+                      value={profileSwitchValue}
+                      onChange={(id) => setPendingAccountProfileId(id)}
+                      disabled={accountBusy}
+                      fieldClassName="composer-tune-field"
+                    />
+                    {profileSwitchDiffers ? (
+                      <div className="composer-tune-confirm">
+                        <p>
+                          Restart this session with{" "}
+                          <strong>{pendingProfileLabel}</strong>? The current
+                          turn is interrupted, the backend process restarts, and
+                          the session resumes from the selected profile&apos;s
+                          config and transcript store.
+                        </p>
+                        <div className="composer-tune-confirm-actions">
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-cancel"
+                            onClick={() => setPendingAccountProfileId(null)}
+                            disabled={accountBusy}
+                          >
+                            Cancel
+                          </button>
+                          <button
+                            type="button"
+                            className="composer-tune-confirm-apply"
+                            onClick={() => void confirmProfileSwitch()}
+                            disabled={accountBusy}
+                          >
+                            {accountBusy ? "Restarting…" : "Restart session"}
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
                 {assistantOps && session ? (
                   <label className="composer-tune-field">
                     <span>Agent</span>
@@ -3289,46 +3329,6 @@ const ReplyComposer = memo(function ReplyComposer({
                         </button>
                       </div>
                     </div>
-                  </div>
-                ) : null}
-                {hasAccountPicker ? (
-                  <div className="composer-tune-lifecycle">
-                    <AccountProfilePicker
-                      profiles={accountProfiles}
-                      value={profileSwitchValue}
-                      onChange={(id) => setPendingAccountProfileId(id)}
-                      disabled={accountBusy}
-                      fieldClassName="composer-tune-field"
-                    />
-                    {profileSwitchDiffers ? (
-                      <div className="composer-tune-confirm">
-                        <p>
-                          Restart this session with{" "}
-                          <strong>{pendingProfileLabel}</strong>? The current
-                          turn is interrupted, the backend process restarts, and
-                          the session resumes from the selected profile&apos;s
-                          config and transcript store.
-                        </p>
-                        <div className="composer-tune-confirm-actions">
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-cancel"
-                            onClick={() => setPendingAccountProfileId(null)}
-                            disabled={accountBusy}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-apply"
-                            onClick={() => void confirmProfileSwitch()}
-                            disabled={accountBusy}
-                          >
-                            {accountBusy ? "Restarting…" : "Restart session"}
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
                   </div>
                 ) : null}
               </div>

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -219,7 +219,10 @@ export function SessionList({
               <span className="badge neutral">{session.launch_target_id}</span>
             ) : null}
             {session.account_profile_label ? (
-              <span className="badge account-profile">
+              <span
+                className="badge account-profile"
+                title={`Account profile: ${session.account_profile_label}`}
+              >
                 {session.account_profile_label}
               </span>
             ) : null}


### PR DESCRIPTION
## Purpose

PR #242 exposed account/config-profile selection in the web UI, but placed it as a peer of permission mode, model, and effort — framing a profile as per-turn tuning when it is actually higher in the session hierarchy (it selects the backend config root, authenticated account, transcript store, model catalogue, and discovery scope). This reorganizes the UI so a profile reads as **session context/identity**: on New/Schedule it sits directly under the agent and above interface/tuning, and on a running session it becomes an explicit restart-scoped switch rather than a raw `<select>` change. Implements the RFC in `tmp/rfcs/rfc-profile-selection-ui-hierarchy.md`. Relates to #230.

## Changes

- `frontend/src/components/AccountProfilePicker.tsx` (new) — reusable profile selector; renamed control label `Account` → `Account profile` (no-profile option stays `Default`), reused by both the launch form and the running-session switch.
- `frontend/src/components/SessionContextFields.tsx` (new) — the top-of-form session-context block (agent · account profile · interface, plus a compact remote-target hint), replacing the standalone `AgentTransportPicker` composite.
- `frontend/src/components/LaunchFormFields.tsx` — group the form into flat mono-captioned sections in dependency order: Session context → Session (cwd/title) → Tuning (permission/model/effort) → Advanced; account profile moves out of the tuning grid.
- `frontend/src/components/PresetBar.tsx` — the save-sheet "Captures" readout now includes the account profile as a labelled chip in the account hue (previously omitted / raw id), marks an id the catalogue no longer offers as unavailable, and states that a preset pins session context + tuning.
- `frontend/src/components/SessionDetail.tsx` — drop the account profile from the composer quick-tuning summary and its select; switching now lives in a session-context section at the top of the settings popover with a staged pick and an explicit restart confirmation, so nothing switches from a raw select change; retire the `window.confirm`. Reorder the session-header badges so the account profile leads as identity metadata.
- `frontend/src/components/SessionList.tsx`, `frontend/src/components/ScheduledSessionsPanel.tsx` — title the profile badge `Account profile: <label>`.
- `frontend/src/app/globals.css` — flat section captions/hint for the launch form and the preset profile-chip hue/unavailable treatment, both themes from tokens.

## Design

The whole change is a UI reorganization around the settings hierarchy; there are no backend contract changes. Two seams keep it disciplined: a reusable `AccountProfilePicker` used in both the flat launch `.field` context and the composer's glass popover, and a `SessionContextFields` block shared by the launch-like surfaces. The design follows the repo's flat-instrument + scoped-glass system — captioned flat field groups (not nested cards) in the launch form, and the staged switch reusing the existing `.composer-tune-confirm` pattern inside the glass settings popover.

Live switching was first placed in the composer overflow menu (the RFC's preferred option) but moved into the settings popover as a clearly-separated section for discoverability — the gear the user already opens to tune permission/model/effort now also carries the profile switch, divided from the quick-tuning fields and kept out of the tuning summary.

Profile-scoped discovery refetch (fetching models/threads for the selected profile on change) is intentionally **out of scope**: it depends on `rfc-discovery-with-profile.md`, which is still Draft — the `/models` and `/threads` endpoints do not yet accept `account_profile_id`. This PR delivers the visual hierarchy that makes model/thread discovery read as downstream of the profile, resets stay defensive, and leaves the wiring additive for when that RFC lands. The Resume/import flow's profile picker is deferred to the same RFC (importing under a profile is the exact bug it owns).

## Test Plan

- `cd frontend && npx tsc --noEmit`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Redeployed the frontend and drove the deployed app with Playwright at mobile width in both themes: the New launch form section order (Session context → Session → Tuning) with the Account profile picker, and the settings popover's separated Account profile section revealing the staged restart confirmation.

## Test Result

- `tsc --noEmit` — clean.
- `npm run lint` — clean.
- `npm run build` — succeeded.
- Manual/visual — **passed** in dark and light: launch form renders the captioned hierarchy with `Account profile` / `Default`; the settings popover leads with a divided Account profile section then quick tuning, and staging a different profile reveals the restart confirmation with the consequence copy and Cancel / Restart session actions. The profile is absent from the quick-tuning summary; the header badge leads with the profile.
- **Not run:** no automated frontend test/e2e suite exists in this repo (per `AGENTS.md`), so verification is type/lint/build plus the deployed-app visual pass above.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] Frontend-only change — the backend Python pre-commit hooks had no files to check (codespell passed).
- [ ] No automated frontend test harness exists in this repo; validated via type/lint/build and a deployed-app visual pass instead.
- [x] I verified the relevant suites: `cd frontend && npm run lint && npm run build` (backend/`waypointctl` untouched).
- [x] No coding-agent plugin/transport or plugin-id dispatch code was touched (frontend UI only).
- [x] Frontend change — ran `cd frontend && npm run lint && npm run build` and verified dark/light theme parity.
- [x] Not a breaking change.
- [x] No `.env`/config/docs changes needed — no user-facing backend behavior changed.

</details>
