### PR TITLE
feat: scope discovery (models, threads, import, delete) to the account profile

### DIFF
--- a/.agents/skills/waypoint/references/auth-config.md
+++ b/.agents/skills/waypoint/references/auth-config.md
@@ -22,7 +22,10 @@ rather than guessing.
 Claude and Codex sessions can run under named account/config-dir profiles and
 switch between them without restarting the service. List them with `waypoint
 accounts list`, pick one at launch with `--account-profile`, and switch a running
-session with `waypoint sessions set-account <session-id> <profile>`.
+session with `waypoint sessions set-account <session-id> <profile>`. Discovery is
+profile-scoped too: pass `--account-profile` to `waypoint models` and `waypoint
+backends threads` so the listed models/threads match the account a session will
+launch under (omit it for the process-default store).
 
 Verify and set up a profile from the CLI:
 

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -386,6 +386,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         backend: str,
         _: Annotated[str, Depends(token_dependency())],
         launch_target_id: Annotated[str | None, Query()] = None,
+        account_profile_id: Annotated[str | None, Query()] = None,
     ) -> Any:
         if not context.runtime.registry.has_backend(backend):
             raise HTTPException(
@@ -404,7 +405,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             return {"threads": []}
         threads = [
             thread.model_dump(mode="json")
-            for thread in await plugin.list_threads(context.runtime, launch_target_id)
+            for thread in await plugin.list_threads(
+                context.runtime, launch_target_id, account_profile_id
+            )
         ]
         return {"threads": threads}
 
@@ -439,6 +442,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         thread_id: str,
         _: Annotated[str, Depends(token_dependency())],
         launch_target_id: Annotated[str | None, Query()] = None,
+        account_profile_id: Annotated[str | None, Query()] = None,
     ) -> Any:
         if not context.runtime.registry.has_backend(backend):
             raise HTTPException(
@@ -466,7 +470,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                     ),
                 )
         deleted = await plugin.delete_thread(
-            context.runtime, thread_id, launch_target_id
+            context.runtime, thread_id, launch_target_id, account_profile_id
         )
         if not deleted:
             raise HTTPException(
@@ -1377,6 +1381,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
         launch_target_id: Annotated[str | None, Query()] = None,
         include_hidden: Annotated[bool, Query()] = False,
+        account_profile_id: Annotated[str | None, Query()] = None,
     ) -> Any:
         if not context.runtime.registry.has_backend(backend):
             raise HTTPException(
@@ -1385,12 +1390,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             )
         # Fall back to the local catalogue when the password-auth target isn't
         # connected, rather than SSHing to an unreachable host for model probes.
+        # Drop the profile with it: a profile scoped to the now-nulled remote
+        # target would mis-resolve against the local profile set.
         if context.runtime.remote_probe_blocked(launch_target_id):
             launch_target_id = None
+            account_profile_id = None
         return await context.runtime.list_backend_models(
             backend,
             launch_target_id=launch_target_id,
             include_hidden=include_hidden,
+            account_profile_id=account_profile_id,
         )
 
     @app.post("/api/sessions/{session_id}/pin")

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -275,8 +275,15 @@ class BackendPlugin(Protocol):
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
-        """Return the model catalogue payload served by ``/api/backends/{id}/models``."""
+        """Return the model catalogue payload served by ``/api/backends/{id}/models``.
+
+        ``account_profile_id`` scopes the discovery to a named account profile's
+        config dir (via ``runtime.discovery_env``) so a live catalogue reflects
+        the account the session will launch under; ``None`` uses the process
+        default. Backends with a static catalogue may ignore it.
+        """
         ...
 
     async def list_command_completions(
@@ -301,12 +308,15 @@ class BackendPlugin(Protocol):
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[Any]:
         """Return importable thread summaries for this backend.
 
         Each plugin returns its own summary type (CodexThreadSummary,
         ClaudeThreadSummary). The API serialises via ``model_dump`` so
-        the wire shape is plugin-controlled.
+        the wire shape is plugin-controlled. ``account_profile_id`` scopes the
+        enumeration to a named account profile's config dir (via
+        ``runtime.discovery_env``); ``None`` uses the process default.
         """
         ...
 
@@ -328,12 +338,15 @@ class BackendPlugin(Protocol):
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
         """Delete a resumable backend-side thread's on-disk transcript.
 
         Returns ``True`` when a transcript matching ``thread_id`` was found
         and removed, ``False`` when none matched. ``launch_target_id`` selects
-        the SSH target whose store to delete from (``None`` = local). Only
+        the SSH target whose store to delete from (``None`` = local);
+        ``account_profile_id`` scopes to a named account profile's config dir
+        (via ``runtime.discovery_env``), ``None`` = process default. Only
         invoked for plugins that advertise
         ``capabilities.supports_thread_delete``; the API gates on it first.
         """

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -1431,10 +1431,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         account_profile_id: str | None = None,
     ) -> bool:
         if launch_target_id is None:
-            launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
-            env = await runtime.discovery_env(
-                self.id, launch_target, account_profile_id
-            )
+            env = await runtime.discovery_env(self.id, None, account_profile_id)
             config_dir = config_dir_for(self.capabilities, env)
             return await asyncio.to_thread(
                 delete_local_claude_thread, thread_id, config_dir

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -751,6 +751,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         config = self._config(runtime)
         default_model = config.default_model_id
@@ -1393,6 +1394,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[ClaudeThreadSummary]:
         if self.adapter is None:
             return []
@@ -1422,6 +1424,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
         if launch_target_id is None:
             return await asyncio.to_thread(delete_local_claude_thread, thread_id)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -1406,13 +1406,17 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             if not thread_id:
                 continue
             imported.add((session.launch_target_id, thread_id))
+        launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
         if launch_target_id is None:
-            infos = await asyncio.to_thread(list_local_claude_threads)
+            env = await runtime.discovery_env(
+                self.id, launch_target, account_profile_id
+            )
+            config_dir = config_dir_for(self.capabilities, env)
+            infos = await asyncio.to_thread(list_local_claude_threads, config_dir)
         else:
-            target = runtime._resolve_launch_target(launch_target_id, self.id)
-            if target is None or self.thread_enumerator is None:
+            if launch_target is None or self.thread_enumerator is None:
                 return []
-            infos = await self.thread_enumerator.list(target)
+            infos = await self.thread_enumerator.list(launch_target)
         return [
             self._thread_summary(info)
             for info in infos
@@ -1427,7 +1431,14 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         account_profile_id: str | None = None,
     ) -> bool:
         if launch_target_id is None:
-            return await asyncio.to_thread(delete_local_claude_thread, thread_id)
+            launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
+            env = await runtime.discovery_env(
+                self.id, launch_target, account_profile_id
+            )
+            config_dir = config_dir_for(self.capabilities, env)
+            return await asyncio.to_thread(
+                delete_local_claude_thread, thread_id, config_dir
+            )
         target = runtime._resolve_launch_target(launch_target_id, self.id)
         if target is None:
             return False
@@ -1546,7 +1557,10 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # Resolve thread metadata first; cwd is needed for both the
         # direct (Claude SDK) and tmux_wrapper paths.
         if launch_target is None:
-            info = await asyncio.to_thread(find_local_claude_thread, request.thread_id)
+            config_dir = config_dir_for(self.capabilities, request.launch_env)
+            info = await asyncio.to_thread(
+                find_local_claude_thread, request.thread_id, config_dir
+            )
         else:
             if self.thread_enumerator is None:
                 raise HTTPException(

--- a/backend/src/waypoint/backends/claude_code/threads.py
+++ b/backend/src/waypoint/backends/claude_code/threads.py
@@ -105,13 +105,13 @@ def encode_project_dir(cwd: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]", "-", cwd)
 
 
-def list_local_claude_threads() -> list[ClaudeThreadInfo]:
+def list_local_claude_threads(config_dir: str | None = None) -> list[ClaudeThreadInfo]:
     """Enumerate resumable Claude sessions on the local filesystem.
 
     Returns one entry per ``<uuid>.jsonl`` transcript that has at least
     one user prompt. Sorted by ``updated_at`` descending.
     """
-    root = claude_projects_root()
+    root = claude_projects_root(config_dir)
     if not root.is_dir():
         return []
     results: list[ClaudeThreadInfo] = []
@@ -148,12 +148,14 @@ def local_claude_thread_artifacts(
     ]
 
 
-def find_local_claude_thread(thread_id: str) -> ClaudeThreadInfo | None:
+def find_local_claude_thread(
+    thread_id: str, config_dir: str | None = None
+) -> ClaudeThreadInfo | None:
     """Locate a single transcript by its session UUID, regardless of which
     encoded-cwd directory it landed in."""
     if not UUID_RE.match(thread_id):
         return None
-    root = claude_projects_root()
+    root = claude_projects_root(config_dir)
     if not root.is_dir():
         return None
     for project_dir in root.iterdir():
@@ -168,13 +170,13 @@ def find_local_claude_thread(thread_id: str) -> ClaudeThreadInfo | None:
     return None
 
 
-def delete_local_claude_thread(thread_id: str) -> bool:
+def delete_local_claude_thread(thread_id: str, config_dir: str | None = None) -> bool:
     """Remove a single transcript by its session UUID, regardless of which
     encoded-cwd directory it landed in. The UUID check also guards against
     path/shell injection. Returns True iff a file was removed."""
     if not UUID_RE.match(thread_id):
         return False
-    root = claude_projects_root()
+    root = claude_projects_root(config_dir)
     if not root.is_dir():
         return False
     for project_dir in root.iterdir():

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -325,6 +325,7 @@ class ClaudeTtyPlugin:
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         config = self._config(runtime)
         default_model = config.default_model_id
@@ -1275,6 +1276,7 @@ class ClaudeTtyPlugin:
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[ClaudeThreadSummary]:
         # Remote enumeration is a follow-up; only the local store is read here.
         if launch_target_id is not None:
@@ -1288,6 +1290,7 @@ class ClaudeTtyPlugin:
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
         # Deletion is offered by the claude_code plugin; this tty-tail driver
         # leaves supports_thread_delete False so the API never routes here.

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1281,7 +1281,10 @@ class ClaudeTtyPlugin:
         # Remote enumeration is a follow-up; only the local store is read here.
         if launch_target_id is not None:
             return []
-        infos = await asyncio.to_thread(list_local_claude_threads)
+        launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
+        env = await runtime.discovery_env(self.id, launch_target, account_profile_id)
+        config_dir = config_dir_for(self.capabilities, env)
+        infos = await asyncio.to_thread(list_local_claude_threads, config_dir)
         imported = self._imported_thread_ids(runtime)
         return [self._thread_summary(info) for info in infos if info.id not in imported]
 
@@ -1312,7 +1315,10 @@ class ClaudeTtyPlugin:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="remote import not yet supported for claude_tty",
             )
-        info = await asyncio.to_thread(find_local_claude_thread, request.thread_id)
+        config_dir = self._config_dir_from_env(request.launch_env)
+        info = await asyncio.to_thread(
+            find_local_claude_thread, request.thread_id, config_dir
+        )
         if info is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -37,6 +37,7 @@ from waypoint.backends.capabilities import (
 from waypoint.backends.codex.adapter import (
     ClientFactory,
     CodexAppServerAdapter,
+    _apply_codex_args,
     default_client_factory,
 )
 from waypoint.backends.codex.history import turns_to_events
@@ -469,7 +470,14 @@ class CodexPlugin(DefaultLaunchContract):
             return False
         needle = f"-{thread_id}.jsonl"
         if launch_target_id is None:
-            home = Path(os.environ.get("CODEX_HOME") or "~/.codex").expanduser()
+            launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
+            env = await runtime.discovery_env(
+                self.id, launch_target, account_profile_id
+            )
+            config_dir = config_dir_for(self.capabilities, env)
+            home = Path(
+                config_dir or os.environ.get("CODEX_HOME") or "~/.codex"
+            ).expanduser()
             sessions_dir = home / "sessions"
             if not sessions_dir.is_dir():
                 return False
@@ -1376,7 +1384,12 @@ class CodexPlugin(DefaultLaunchContract):
     ) -> ClientFactory | None:
         launch_target = runtime._find_launch_target(launch_target_id)
         if launch_target is None:
-            return None
+            return _apply_codex_args(
+                None,
+                tuple(custom_args or ()),
+                tuple(custom_config_overrides or ()),
+                launch_env,
+            )
         return build_remote_codex_client_factory(
             launch_target,
             cli_args=tuple(custom_args or ()),
@@ -1397,10 +1410,12 @@ class CodexPlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         launch_target_id: str | None,
         operation: Callable[[CodexClient], Awaitable[Any]],
+        launch_env: dict[str, str] | None = None,
     ) -> Any:
         default_cwd = self.client_cwd(runtime, launch_target_id)
         client_factory: ClientFactory = (
-            self.client_factory(runtime, launch_target_id) or default_client_factory
+            self.client_factory(runtime, launch_target_id, launch_env=launch_env)
+            or default_client_factory
         )
         client = client_factory(default_cwd, _deny_approval)
         try:
@@ -1418,6 +1433,7 @@ class CodexPlugin(DefaultLaunchContract):
         launch_target_id: str | None,
         *,
         include_turns: bool = False,
+        launch_env: dict[str, str] | None = None,
     ) -> Any:
         runtime._resolve_launch_target(launch_target_id, self.id)
 
@@ -1429,7 +1445,7 @@ class CodexPlugin(DefaultLaunchContract):
 
         try:
             return await self.run_client_operation(
-                runtime, launch_target_id, operation=operation
+                runtime, launch_target_id, operation=operation, launch_env=launch_env
             )
         except Exception as exc:  # noqa: BLE001
             raise HTTPException(
@@ -1472,7 +1488,8 @@ class CodexPlugin(DefaultLaunchContract):
         launch_target_id: str | None = None,
         account_profile_id: str | None = None,
     ) -> list[CodexThreadSummary]:
-        runtime._resolve_launch_target(launch_target_id, self.id)
+        launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
+        env = await runtime.discovery_env(self.id, launch_target, account_profile_id)
         imported: set[tuple[str | None, str]] = set()
         for session in runtime.storage.list_sessions():
             if session.backend != self.id:
@@ -1496,7 +1513,7 @@ class CodexPlugin(DefaultLaunchContract):
                 cursor = response.next_cursor
 
         threads = await self.run_client_operation(
-            runtime, launch_target_id, operation=operation
+            runtime, launch_target_id, operation=operation, launch_env=env
         )
         summaries = [
             self._thread_summary(thread)
@@ -1616,6 +1633,7 @@ class CodexPlugin(DefaultLaunchContract):
             request.thread_id,
             request.launch_target_id,
             include_turns=request.import_history,
+            launch_env=request.launch_env,
         )
         if thread.ephemeral:
             raise HTTPException(
@@ -1752,10 +1770,14 @@ class CodexPlugin(DefaultLaunchContract):
         default_model = config.default_model_id
         default_effort = config.default_effort
         cwd = self.client_cwd(runtime, launch_target_id)
+        launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
+        env = await runtime.discovery_env(self.id, launch_target, account_profile_id)
         try:
             response = await self._require_adapter().list_models(
                 cwd=cwd,
-                client_factory_override=self.client_factory(runtime, launch_target_id),
+                client_factory_override=self.client_factory(
+                    runtime, launch_target_id, launch_env=env
+                ),
                 include_hidden=include_hidden,
             )
         except Exception as exc:  # noqa: BLE001

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -461,6 +461,7 @@ class CodexPlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
         # Guard against malformed ids: a non-UUID can't match a rollout file
         # and must never be interpolated into the remote shell command.
@@ -1469,6 +1470,7 @@ class CodexPlugin(DefaultLaunchContract):
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[CodexThreadSummary]:
         runtime._resolve_launch_target(launch_target_id, self.id)
         imported: set[tuple[str | None, str]] = set()
@@ -1744,6 +1746,7 @@ class CodexPlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         config = self._config(runtime)
         default_model = config.default_model_id

--- a/backend/src/waypoint/backends/opencode/plugin.py
+++ b/backend/src/waypoint/backends/opencode/plugin.py
@@ -849,12 +849,31 @@ class OpenCodePlugin(DefaultLaunchContract):
         # the announcement path entirely.
         return ""
 
+    async def _reject_account_profile(
+        self,
+        runtime: "SessionRuntime",
+        launch_target_id: str | None,
+        account_profile_id: str | None,
+    ) -> None:
+        # OpenCode has no config-dir env var, so a profile can't scope its
+        # server-owned store. Route a selected profile through the generic
+        # resolver so the rejection matches the launch path (400) rather than
+        # being silently ignored; ``None`` is a no-op.
+        if account_profile_id is None:
+            return
+        launch_target = runtime._resolve_launch_target(launch_target_id, self.id)
+        await runtime.discovery_env(self.id, launch_target, account_profile_id)
+
     async def list_models(
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
+        await self._reject_account_profile(
+            runtime, launch_target_id, account_profile_id
+        )
         adapters = list(reversed(self._adapters_for_launch_target(launch_target_id)))
         if not adapters:
             adapters = [
@@ -1463,7 +1482,11 @@ class OpenCodePlugin(DefaultLaunchContract):
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[OpenCodeThreadSummary]:
+        await self._reject_account_profile(
+            runtime, launch_target_id, account_profile_id
+        )
         adapters = self._adapters_for_launch_target(launch_target_id)
         if not adapters:
             adapters = [
@@ -1520,7 +1543,11 @@ class OpenCodePlugin(DefaultLaunchContract):
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
+        await self._reject_account_profile(
+            runtime, launch_target_id, account_profile_id
+        )
         # OpenCode keeps sessions in its server's own store, so deletion is a
         # `DELETE /session/{id}` against that server (the adapter routes it
         # locally or over SSH) rather than a transcript unlink. A launch target

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -238,6 +238,7 @@ class TmuxPlugin:
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         return {
             "backend": self.id,
@@ -720,6 +721,7 @@ class TmuxPlugin:
         self,
         runtime: "SessionRuntime",
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[Any]:
         return []
 
@@ -728,6 +730,7 @@ class TmuxPlugin:
         runtime: "SessionRuntime",
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
         # No deletable transcript store; supports_thread_delete is False so the
         # API never routes here.

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -268,12 +268,24 @@ def backends_threads(
             "(e.g. a remote host or worktree)."
         ),
     ] = None,
+    account_profile: Annotated[
+        str | None,
+        typer.Option(
+            "--account-profile",
+            help="Resolve importable threads for this account/config profile "
+            "(agent backends that host profiles only; see `accounts list`).",
+        ),
+    ] = None,
 ) -> None:
     """List a backend's importable threads."""
     _emit(
         _settings_from_ctx(ctx),
         lambda c: {
-            "threads": c.list_threads(backend, launch_target_id=launch_target_id)
+            "threads": c.list_threads(
+                backend,
+                launch_target_id=launch_target_id,
+                account_profile_id=account_profile,
+            )
         },
     )
 
@@ -296,6 +308,14 @@ def models(
         bool,
         typer.Option("--include-hidden", help="Include models the backend hides."),
     ] = False,
+    account_profile: Annotated[
+        str | None,
+        typer.Option(
+            "--account-profile",
+            help="Resolve models for this account/config profile (agent "
+            "backends that host profiles only; see `accounts list`).",
+        ),
+    ] = None,
 ) -> None:
     """List the models a backend offers (its ids, labels, and reasoning efforts).
 
@@ -310,6 +330,7 @@ def models(
                 backend,
                 launch_target_id=launch_target_id,
                 include_hidden=include_hidden,
+                account_profile_id=account_profile,
             )
         catalogues: list[dict[str, Any]] = []
         for descriptor in c.list_backends():
@@ -322,6 +343,7 @@ def models(
                         backend_id,
                         launch_target_id=launch_target_id,
                         include_hidden=include_hidden,
+                        account_profile_id=account_profile,
                     )
                 )
             except WaypointError as exc:

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -249,12 +249,15 @@ class WaypointClient:
         *,
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         params: dict[str, Any] = {}
         if launch_target_id is not None:
             params["launch_target_id"] = launch_target_id
         if include_hidden:
             params["include_hidden"] = include_hidden
+        if account_profile_id is not None:
+            params["account_profile_id"] = account_profile_id
         data: dict[str, Any] = self._request(
             "GET", f"/api/backends/{backend}/models", params=params or None
         ).json()
@@ -328,15 +331,19 @@ class WaypointClient:
         return data
 
     def list_threads(
-        self, backend: str, *, launch_target_id: str | None = None
+        self,
+        backend: str,
+        *,
+        launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        params = (
-            {"launch_target_id": launch_target_id}
-            if launch_target_id is not None
-            else None
-        )
+        params: dict[str, Any] = {}
+        if launch_target_id is not None:
+            params["launch_target_id"] = launch_target_id
+        if account_profile_id is not None:
+            params["account_profile_id"] = account_profile_id
         data: list[dict[str, Any]] = self._request(
-            "GET", f"/api/backends/{backend}/threads", params=params
+            "GET", f"/api/backends/{backend}/threads", params=params or None
         ).json()["threads"]
         return data
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -678,6 +678,35 @@ class SessionRuntime:
         plugin = self.registry.get(backend)
         return {**os.environ, **launch_env, **plugin.extra_env}
 
+    async def discovery_env(
+        self,
+        backend: str,
+        launch_target: SshLaunchTargetConfig | None,
+        account_profile_id: str | None,
+    ) -> dict[str, str]:
+        """Env for session-less discovery (models, threads, import, delete).
+
+        Mirrors the launch overlay for the read side: the backend's default env
+        with the selected profile's ``config_dir`` overlaid on the config-dir
+        env var, returned as an ``account_lookup_env`` so a probe resolves the
+        same account a session would launch under. ``account_profile_id=None``
+        yields the process-default store (back-compat). Warms the remote-home
+        cache first so a ``~``-relative remote ``config_dir`` doesn't hit a cold
+        cache and 400 — remote profile scoping otherwise inherits the
+        remote-switching constraints (task #33). Unknown profile, or a backend
+        without a config-dir env var, are rejected with 400 via
+        ``_apply_account_profile_env``.
+        """
+        if account_profile_id is not None and launch_target is not None:
+            await self._warm_remote_home_for_profile(
+                launch_target, backend, account_profile_id
+            )
+        base = self._default_launch_env(backend, launch_target)
+        env, _ = self._apply_account_profile_env(
+            backend, base, account_profile_id, launch_target
+        )
+        return self.account_lookup_env(backend, env)
+
     def _profile_launch_env(
         self,
         backend: str,
@@ -2781,6 +2810,7 @@ class SessionRuntime:
         backend: str,
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         if not self.registry.has_backend(backend):
             raise HTTPException(
@@ -2792,6 +2822,7 @@ class SessionRuntime:
             self,
             launch_target_id=launch_target_id,
             include_hidden=include_hidden,
+            account_profile_id=account_profile_id,
         )
 
     async def set_title(self, session_id: str, title: str) -> SessionRecord:

--- a/backend/tests/test_backend_registry.py
+++ b/backend/tests/test_backend_registry.py
@@ -84,6 +84,7 @@ class _StubPlugin:
         runtime: Any,
         launch_target_id: str | None = None,
         include_hidden: bool = False,
+        account_profile_id: str | None = None,
     ) -> dict[str, Any]:
         return {}
 
@@ -161,6 +162,7 @@ class _StubPlugin:
         self,
         runtime: Any,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> list[Any]:
         return []
 
@@ -174,6 +176,7 @@ class _StubPlugin:
         runtime: Any,
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> bool:
         return False
 

--- a/backend/tests/test_claude_threads.py
+++ b/backend/tests/test_claude_threads.py
@@ -225,3 +225,84 @@ def test_delete_local_claude_thread_rejects_invalid_uuid(claude_root) -> None:
     assert delete_local_claude_thread("../etc/passwd") is False
     assert delete_local_claude_thread("not-a-uuid") is False
     assert other.exists()
+
+
+def test_list_local_claude_threads_config_dir_scopes_to_profile(
+    claude_root, tmp_path
+) -> None:
+    """A ``config_dir`` argument must scope discovery to that profile's store,
+    not the default ``CLAUDE_CONFIG_DIR`` — the default-store thread must not
+    leak into a profile-scoped listing, or vice versa."""
+    default_project = claude_root / "-tmp-default"
+    default_id = "11111111-1111-4111-8111-111111111111"
+    _write_transcript(
+        default_project / f"{default_id}.jsonl",
+        [_make_user_record(cwd="/tmp/default", text="default account")],
+    )
+
+    profile_dir = tmp_path / "profile-a"
+    profile_project = profile_dir / "projects" / "-tmp-profile"
+    profile_id = "22222222-2222-4222-8222-222222222222"
+    _write_transcript(
+        profile_project / f"{profile_id}.jsonl",
+        [_make_user_record(cwd="/tmp/profile", text="profile account")],
+    )
+
+    default_results = list_local_claude_threads()
+    assert [info.id for info in default_results] == [default_id]
+
+    profile_results = list_local_claude_threads(config_dir=str(profile_dir))
+    assert [info.id for info in profile_results] == [profile_id]
+
+
+def test_find_local_claude_thread_config_dir_scopes_to_profile(
+    claude_root, tmp_path
+) -> None:
+    default_id = "33333333-3333-4333-8333-333333333333"
+    _write_transcript(
+        claude_root / "-tmp-default" / f"{default_id}.jsonl",
+        [_make_user_record(cwd="/tmp/default", text="default account")],
+    )
+
+    profile_dir = tmp_path / "profile-b"
+    profile_id = "44444444-4444-4444-8444-444444444444"
+    _write_transcript(
+        profile_dir / "projects" / "-tmp-profile" / f"{profile_id}.jsonl",
+        [_make_user_record(cwd="/tmp/profile", text="profile account")],
+    )
+
+    assert find_local_claude_thread(profile_id) is None
+    found = find_local_claude_thread(profile_id, config_dir=str(profile_dir))
+    assert found is not None
+    assert found.id == profile_id
+
+    assert find_local_claude_thread(default_id, config_dir=str(profile_dir)) is None
+
+
+def test_delete_local_claude_thread_config_dir_targets_profile(
+    claude_root, tmp_path
+) -> None:
+    default_id = "55555555-5555-4555-8555-555555555555"
+    default_transcript = claude_root / "-tmp-default" / f"{default_id}.jsonl"
+    _write_transcript(
+        default_transcript,
+        [_make_user_record(cwd="/tmp/default", text="default account")],
+    )
+
+    profile_dir = tmp_path / "profile-c"
+    profile_id = "66666666-6666-4666-8666-666666666666"
+    profile_transcript = (
+        profile_dir / "projects" / "-tmp-profile" / f"{profile_id}.jsonl"
+    )
+    _write_transcript(
+        profile_transcript,
+        [_make_user_record(cwd="/tmp/profile", text="profile account")],
+    )
+
+    # Deleting the profile-scoped id without config_dir must not touch it.
+    assert delete_local_claude_thread(profile_id) is False
+    assert profile_transcript.exists()
+
+    assert delete_local_claude_thread(profile_id, config_dir=str(profile_dir)) is True
+    assert not profile_transcript.exists()
+    assert default_transcript.exists()

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -510,10 +510,11 @@ async def test_list_threads_dedups_imported(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr(
         plugin_mod,
         "list_local_claude_threads",
-        lambda: [_thread_info("t-a"), _thread_info("t-b")],
+        lambda config_dir=None: [_thread_info("t-a"), _thread_info("t-b")],
     )
     plugin = ClaudeTtyPlugin()
     runtime = MagicMock()
+    runtime.discovery_env = AsyncMock(return_value={})
     runtime.storage.list_sessions.return_value = [
         _make_session(session_id="s1", thread_id="t-a"),
     ]
@@ -590,7 +591,9 @@ async def test_import_thread_resumes_and_starts_tailer(
 ) -> None:
     info = _thread_info("imp-1")
     info.cwd = str(tmp_path)
-    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: info)
+    monkeypatch.setattr(
+        plugin_mod, "find_local_claude_thread", lambda thread_id, config_dir=None: info
+    )
     plugin = ClaudeTtyPlugin()
     captured = _stub_lifecycle(plugin)
 
@@ -636,7 +639,9 @@ async def test_import_thread_persists_resolving_agent_backend(
     # driver's own id, while the transport stays claude_tty.
     info = _thread_info("imp-2")
     info.cwd = str(tmp_path)
-    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: info)
+    monkeypatch.setattr(
+        plugin_mod, "find_local_claude_thread", lambda thread_id, config_dir=None: info
+    )
     plugin = ClaudeTtyPlugin()
     _stub_lifecycle(plugin)
 
@@ -668,7 +673,9 @@ async def test_import_thread_persists_resolving_agent_backend(
 async def test_import_thread_missing_raises_404(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: None)
+    monkeypatch.setattr(
+        plugin_mod, "find_local_claude_thread", lambda thread_id, config_dir=None: None
+    )
     plugin = ClaudeTtyPlugin()
     runtime = MagicMock()
 
@@ -683,7 +690,9 @@ async def test_import_thread_already_imported_raises_400(
 ) -> None:
     info = _thread_info("dup-1")
     info.cwd = str(tmp_path)
-    monkeypatch.setattr(plugin_mod, "find_local_claude_thread", lambda thread_id: info)
+    monkeypatch.setattr(
+        plugin_mod, "find_local_claude_thread", lambda thread_id, config_dir=None: info
+    )
     plugin = ClaudeTtyPlugin()
     runtime = MagicMock()
     runtime.storage.list_sessions.return_value = [

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -302,12 +302,16 @@ def test_list_models_passes_params(
     state: dict = {}
     with _client(_settings(tmp_path), state) as client:
         payload = client.list_models(
-            "claude_code", launch_target_id="lt1", include_hidden=True
+            "claude_code",
+            launch_target_id="lt1",
+            include_hidden=True,
+            account_profile_id="work",
         )
     assert payload["backend"] == "claude_code"
     assert payload["default_model_id"] == "opus"
     assert state["models_params"]["launch_target_id"] == "lt1"
     assert state["models_params"]["include_hidden"] == "true"
+    assert state["models_params"]["account_profile_id"] == "work"
 
 
 def test_list_models_omits_default_params(
@@ -326,9 +330,14 @@ def test_list_threads_passes_params(
     monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
     state: dict = {}
     with _client(_settings(tmp_path), state) as client:
-        threads = client.list_threads("claude_code", launch_target_id="lt1")
+        threads = client.list_threads(
+            "claude_code", launch_target_id="lt1", account_profile_id="work"
+        )
     assert threads == [{"id": "thread-1", "title": "Alpha", "cwd": "/tmp/repo"}]
-    assert state["threads_params"] == {"launch_target_id": "lt1"}
+    assert state["threads_params"] == {
+        "launch_target_id": "lt1",
+        "account_profile_id": "work",
+    }
 
 
 def test_import_thread_sends_raw_body(

--- a/backend/tests/test_codex_discovery_profile.py
+++ b/backend/tests/test_codex_discovery_profile.py
@@ -1,0 +1,152 @@
+"""Unit tests for codex list_threads/list_models CODEX_HOME profile scoping.
+
+``delete_thread`` scoping is covered in ``test_codex_thread_delete.py``. These
+tests cover the live-RPC paths (list_threads, list_models) whose local client
+factory previously dropped ``launch_env``, so a selected account profile's
+CODEX_HOME never reached the app-server subprocess.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+from waypoint.backends.codex.adapter import CodexAppServerAdapter
+from waypoint.backends.codex.plugin import CodexPlugin, CodexPluginConfig
+from waypoint.launch_targets import SshLaunchTargetConfig
+
+
+class _FakeThreadListResponse:
+    def __init__(self, data: list[Any], next_cursor: str | None = None) -> None:
+        self.data = data
+        self.next_cursor = next_cursor
+
+
+class _FakeClient:
+    """Stands in for ``CodexClient``: start/initialize/close are no-ops."""
+
+    def __init__(self, thread_list_response: _FakeThreadListResponse) -> None:
+        self._thread_list_response = thread_list_response
+
+    def start(self) -> None:
+        return None
+
+    def initialize(self) -> None:
+        return None
+
+    def thread_list(self, _params: dict[str, Any]) -> _FakeThreadListResponse:
+        return self._thread_list_response
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeStorage:
+    def list_sessions(self) -> list[Any]:
+        return []
+
+
+class _FakeSettings:
+    default_cwd = "~"
+
+    def plugin_config(self, _backend: str) -> CodexPluginConfig:
+        return CodexPluginConfig()
+
+
+class _FakeRuntime:
+    """A minimal runtime stub exposing only what discovery methods touch."""
+
+    def __init__(self, discovery_env: dict[str, str]) -> None:
+        self.storage = _FakeStorage()
+        self.settings = _FakeSettings()
+        self._discovery_env = discovery_env
+
+    def _resolve_launch_target(
+        self, _launch_target_id: str | None, _backend: str
+    ) -> SshLaunchTargetConfig | None:
+        return None
+
+    def _find_launch_target(
+        self, _launch_target_id: str | None
+    ) -> SshLaunchTargetConfig | None:
+        return None
+
+    async def discovery_env(
+        self,
+        _backend: str,
+        _launch_target: SshLaunchTargetConfig | None,
+        _account_profile_id: str | None,
+    ) -> dict[str, str]:
+        return self._discovery_env
+
+
+@pytest.mark.asyncio
+async def test_list_threads_routes_profile_env_into_client_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = CodexPlugin()
+    captured: dict[str, Any] = {}
+    fake_client = _FakeClient(_FakeThreadListResponse([]))
+
+    def fake_client_factory(
+        runtime: Any,
+        launch_target_id: str | None,
+        custom_args: list[str] | None = None,
+        custom_config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
+    ) -> Any:
+        captured["launch_env"] = launch_env
+        return lambda cwd, approval_handler: fake_client
+
+    monkeypatch.setattr(plugin, "client_factory", fake_client_factory)
+
+    runtime = _FakeRuntime({"CODEX_HOME": "/fake/profile/home"})
+    threads = await plugin.list_threads(cast(Any, runtime), account_profile_id="acct-1")
+
+    assert threads == []
+    assert captured["launch_env"] == {"CODEX_HOME": "/fake/profile/home"}
+
+
+@pytest.mark.asyncio
+async def test_list_models_routes_profile_env_into_client_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = CodexPlugin()
+    plugin.adapter = CodexAppServerAdapter(
+        emit_event=cast(Any, lambda *_args, **_kwargs: None),
+    )
+    captured: dict[str, Any] = {}
+
+    def fake_client_factory(
+        runtime: Any,
+        launch_target_id: str | None,
+        custom_args: list[str] | None = None,
+        custom_config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
+    ) -> Any:
+        # The returned override is what actually carries the profile's env to
+        # the live RPC; a truthy sentinel exercises adapter.list_models'
+        # "override provided" branch instead of falling back to its default.
+        captured["launch_env"] = launch_env
+        return lambda cwd, approval_handler: None
+
+    monkeypatch.setattr(plugin, "client_factory", fake_client_factory)
+
+    class _FakeModelListResponse:
+        data: list[Any] = []
+
+    async def fake_adapter_list_models(
+        self: CodexAppServerAdapter,
+        cwd: str = "~",
+        client_factory_override: Any = None,
+        include_hidden: bool = False,
+    ) -> _FakeModelListResponse:
+        assert client_factory_override is not None
+        return _FakeModelListResponse()
+
+    monkeypatch.setattr(CodexAppServerAdapter, "list_models", fake_adapter_list_models)
+
+    runtime = _FakeRuntime({"CODEX_HOME": "/fake/profile/home"})
+    result = await plugin.list_models(cast(Any, runtime), account_profile_id="acct-1")
+
+    assert result["models"] == []
+    assert captured["launch_env"] == {"CODEX_HOME": "/fake/profile/home"}

--- a/backend/tests/test_codex_thread_delete.py
+++ b/backend/tests/test_codex_thread_delete.py
@@ -12,21 +12,37 @@ from waypoint.launch_targets import SshLaunchTargetConfig
 if TYPE_CHECKING:
     from waypoint.runtime import SessionRuntime
 
-# The local delete path never touches the runtime; a typed null keeps mypy
-# happy without standing up a real SessionRuntime.
-_NO_RUNTIME = cast("SessionRuntime", None)
 
+def _runtime_resolving(
+    target: SshLaunchTargetConfig | None, discovery_env: dict[str, str] | None = None
+) -> "SessionRuntime":
+    """A minimal runtime whose ``_resolve_launch_target``/``discovery_env`` are stubbed.
 
-def _runtime_resolving(target: SshLaunchTargetConfig | None) -> "SessionRuntime":
-    """A minimal runtime whose ``_resolve_launch_target`` yields ``target``."""
+    The local delete path resolves ``discovery_env`` even when no profile is
+    selected (it falls back to the process default), so every test needs both
+    methods rather than a bare ``None`` runtime.
+    """
 
     class _Runtime:
         def _resolve_launch_target(
-            self, _launch_target_id: str, _backend: str
+            self, _launch_target_id: str | None, _backend: str
         ) -> SshLaunchTargetConfig | None:
             return target
 
+        async def discovery_env(
+            self,
+            _backend: str,
+            _launch_target: SshLaunchTargetConfig | None,
+            _account_profile_id: str | None,
+        ) -> dict[str, str]:
+            return discovery_env or {}
+
     return cast("SessionRuntime", _Runtime())
+
+
+# The local delete path with no profile selected falls back to the process
+# env, exactly like the pre-profile-scoping behavior these tests pin.
+_NO_RUNTIME = _runtime_resolving(None)
 
 
 @pytest.fixture
@@ -142,3 +158,28 @@ async def test_delete_thread_remote_rejects_non_uuid_without_ssh(
         is False
     )
     assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_delete_thread_local_scopes_to_profile_config_dir(
+    plugin: CodexPlugin,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A selected account profile must resolve rollouts from its own CODEX_HOME,
+    # not the process-default one the bare $CODEX_HOME env var points at.
+    default_home = tmp_path / "default"
+    profile_home = tmp_path / "profile"
+    default_home.mkdir()
+    profile_home.mkdir()
+    monkeypatch.setenv("CODEX_HOME", str(default_home))
+
+    thread_id = str(uuid.uuid4())
+    default_rollout = _make_rollout(default_home, thread_id)
+    profile_rollout = _make_rollout(profile_home, thread_id)
+
+    runtime = _runtime_resolving(None, discovery_env={"CODEX_HOME": str(profile_home)})
+
+    assert await plugin.delete_thread(runtime, thread_id, account_profile_id="acct-1")
+    assert not profile_rollout.exists()
+    assert default_rollout.exists()

--- a/backend/tests/test_discovery_env.py
+++ b/backend/tests/test_discovery_env.py
@@ -1,0 +1,83 @@
+"""Session-less discovery env resolution (``SessionRuntime.discovery_env``).
+
+Discovery (models, threads, import, delete) has no ``launch_env`` to carry a
+profile, so it resolves one from a ``(backend, launch_target, profile)`` triple
+through the same overlay the launch path uses — so discovery and launch can
+never disagree on the config dir.
+"""
+
+import os
+
+import pytest
+from fastapi import HTTPException
+
+from waypoint.runtime import SessionRuntime
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _runtime(tmp_path) -> SessionRuntime:
+    settings = Settings(
+        data_dir=tmp_path / "data",
+        plugin_configs={
+            "codex": {
+                "account_profiles": {
+                    "personal": {
+                        "label": "Personal",
+                        "config_dir": "~/.codex-personal",
+                    },
+                    "abs": {"label": "Abs", "config_dir": "/srv/codex-abs"},
+                }
+            }
+        },
+    )
+    settings.ensure_dirs()
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+@pytest.mark.asyncio
+async def test_discovery_env_none_profile_is_default_store(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    env = await runtime.discovery_env("codex", None, None)
+    # Back-compat: no profile ⇒ the default lookup env, which never pins a
+    # profile-scoped CODEX_HOME (only what the ambient process/env already set).
+    assert env.get("CODEX_HOME") == os.environ.get("CODEX_HOME")
+
+
+@pytest.mark.asyncio
+async def test_discovery_env_overlays_profile_config_dir(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    env = await runtime.discovery_env("codex", None, "personal")
+    assert env["CODEX_HOME"] == os.path.expanduser("~/.codex-personal")
+
+    abs_env = await runtime.discovery_env("codex", None, "abs")
+    assert abs_env["CODEX_HOME"] == "/srv/codex-abs"
+
+
+@pytest.mark.asyncio
+async def test_discovery_env_matches_launch_overlay(tmp_path) -> None:
+    """Discovery and launch must resolve the same config dir for the same inputs."""
+    runtime = _runtime(tmp_path)
+    discovery = await runtime.discovery_env("codex", None, "personal")
+    launch = runtime.account_lookup_env(
+        "codex", runtime._profile_launch_env("codex", "personal", None)
+    )
+    assert discovery == launch
+
+
+@pytest.mark.asyncio
+async def test_discovery_env_unknown_profile_400(tmp_path) -> None:
+    runtime = _runtime(tmp_path)
+    with pytest.raises(HTTPException) as exc:
+        await runtime.discovery_env("codex", None, "nope")
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_discovery_env_backend_without_config_dir_env_var_400(tmp_path) -> None:
+    """OpenCode has no config-dir env var, so a profile can't scope it — 400,
+    matching the launch path (never a silent accept)."""
+    runtime = _runtime(tmp_path)
+    with pytest.raises(HTTPException) as exc:
+        await runtime.discovery_env("opencode", None, "personal")
+    assert exc.value.status_code == 400

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -2703,7 +2703,7 @@ async def test_list_importable_claude_threads_filters_existing_session(
 
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.list_local_claude_threads",
-        lambda: [info_existing, info_new],
+        lambda config_dir=None: [info_existing, info_new],
     )
 
     threads = await runtime.registry.get("claude_code").list_threads(runtime)
@@ -2834,7 +2834,7 @@ async def test_import_claude_thread_creates_session_and_resumes(
 
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.find_local_claude_thread",
-        lambda thread_id: info if thread_id == info.id else None,
+        lambda thread_id, config_dir=None: info if thread_id == info.id else None,
     )
 
     session = await runtime.registry.get("claude_code").import_thread(
@@ -3083,7 +3083,7 @@ async def test_import_claude_thread_terminal_supersedes_launch_mode(
     )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.find_local_claude_thread",
-        lambda thread_id: info if thread_id == info.id else None,
+        lambda thread_id, config_dir=None: info if thread_id == info.id else None,
     )
     tmux = runtime.registry.fallback_for_managed_launch()
     assert tmux is not None
@@ -3129,7 +3129,7 @@ async def test_import_claude_thread_native_supersedes_tmux_launch_mode(
     )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.find_local_claude_thread",
-        lambda thread_id: info if thread_id == info.id else None,
+        lambda thread_id, config_dir=None: info if thread_id == info.id else None,
     )
     tmux = runtime.registry.fallback_for_managed_launch()
     assert tmux is not None
@@ -3166,7 +3166,7 @@ async def test_import_thread_transport_none_matches_default(
     )
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.find_local_claude_thread",
-        lambda thread_id: info if thread_id == info.id else None,
+        lambda thread_id, config_dir=None: info if thread_id == info.id else None,
     )
 
     session = await runtime.import_thread("claude_code", {"thread_id": info.id})
@@ -3237,7 +3237,7 @@ async def test_import_claude_thread_missing_returns_404(monkeypatch, tmp_path) -
     _claude_plugin(runtime).adapter = cast(Any, FakeClaudeAdapter())
     monkeypatch.setattr(
         "waypoint.backends.claude_code.plugin.find_local_claude_thread",
-        lambda _thread_id: None,
+        lambda _thread_id, config_dir=None: None,
     )
 
     from fastapi import HTTPException

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import ANY
 
 import pytest
 from fastapi import HTTPException
@@ -1239,9 +1240,12 @@ async def test_handle_input_reattaches_exited_codex_session(tmp_path) -> None:
     )
 
     # Reattach uses the stored thread_id to resume the existing Codex thread,
-    # then the input forwards through the freshly attached client.
+    # then the input forwards through the freshly attached client. The
+    # factory slot (index 3) is now always a real env-carrying closure for
+    # local codex launches (previously ``None``, relying on the adapter to
+    # rebuild it) — see CodexPlugin.client_factory's local-env fix.
     assert fake.restore_calls == [
-        ("sess", "/tmp/project", "thread-resume", None, None, None)
+        ("sess", "/tmp/project", "thread-resume", ANY, None, None)
     ]
     # Stale adapter state is torn down before the respawn so we don't orphan
     # a client/process keyed under the same session id.
@@ -1269,7 +1273,7 @@ async def test_resume_reattaches_exited_session(tmp_path) -> None:
     # Relaunched via restore (no input forwarded), and never poked the dead pane.
     # Reattach leaves it IDLE (alive, ready), not RUNNING — no turn was started.
     assert fake.restore_calls == [
-        ("sess", "/tmp/project", "thread-resume", None, None, None)
+        ("sess", "/tmp/project", "thread-resume", ANY, None, None)
     ]
     assert fake.inputs == []
     assert updated.status == SessionStatus.IDLE
@@ -2622,6 +2626,7 @@ async def test_import_codex_thread_for_remote_target_uses_thread_cwd(
         launch_target_id: str | None,
         *,
         include_turns: bool = False,
+        launch_env: dict[str, str] | None = None,
     ) -> Any:
         assert thread_id == "thread-9"
         assert launch_target_id == "devbox"

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -187,6 +187,21 @@ waypoint presets create --name work-claude --backend claude_code --account-profi
 waypoint sessions import codex --thread-id <uuid> --account-profile work
 ```
 
+Discovery is profile-scoped too, so listing matches the account a session will
+launch under. Pass `--account-profile` to the two discovery commands (and it
+flows through `import`/thread-delete), otherwise they resolve the process-default
+store:
+
+```bash
+waypoint models claude_code --account-profile work            # models the profile's account offers
+waypoint backends threads claude_code --account-profile work  # resumable threads in the profile's store
+```
+
+In the web UI the launch/schedule panel re-scopes its model catalogue and
+resumable-thread list to the selected profile, and importing or resuming a listed
+thread carries that profile. Remote (SSH launch target) profile-scoped discovery
+is not yet wired — a remote list resolves the target's default store.
+
 Inspect a session's restart-applied launch settings (env is redacted to keys):
 
 ```bash

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -327,15 +327,32 @@ describing the swap (Claude's restart-to-pick-up-new-effort path); return
 ### Discovery
 
 ```python
-async def list_models(self, runtime, launch_target_id=None, include_hidden=False) -> dict: ...
-async def list_threads(self, runtime, launch_target_id=None) -> list[Any]: ...
+async def list_models(self, runtime, launch_target_id=None, include_hidden=False, account_profile_id=None) -> dict: ...
+async def list_threads(self, runtime, launch_target_id=None, account_profile_id=None) -> list[Any]: ...
 async def import_thread(self, runtime, request) -> SessionRecord: ...
+async def delete_thread(self, runtime, thread_id, launch_target_id=None, account_profile_id=None) -> bool: ...
 ```
 
 `list_models` returns the same payload shape `/api/backends/{id}/models`
 serves to the frontend (`{models, default_model_id, default_model_label,
 default_effort, supports_free_text}`). `list_threads` returns plugin-specific
 summary objects; the API serialises via `model_dump`.
+
+The optional `account_profile_id` scopes this session-less discovery to a named
+account profile: the runtime resolves it to the profile's config-dir env via
+`runtime.discovery_env(backend, launch_target, account_profile_id)` — the
+read-side mirror of the launch overlay — and each plugin derives its own config
+dir from that env with `config_dir_for(self.capabilities, env)`, so a listing,
+import, or delete resolves the same store a session launched under that profile
+would. `import_thread` reads it off `request` (the runtime has already applied
+the profile env into `request.launch_env` before dispatch). `None` is the
+process default (back-compat). Resolution is generic — no per-backend branching
+in `runtime.py`/`api.py`; an agent without a `config_dir_env_var` rejects a
+non-`None` profile with 400, matching launch. Claude's model catalogue is static
+so scoping is a no-op there; Codex's is a live per-account RPC that runs under
+the resolved env. Remote (SSH launch target) profile scoping is not yet wired —
+the remote branches read the target's default store (see
+[`account_profiles.md`](account_profiles.md)).
 
 `import_thread` adopts an externally-created native thread into a brand-new
 session. When the import request's `import_history` flag is set (it defaults to

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -765,6 +765,14 @@ export default function HomePage() {
       const payload = {
         thread_id: threadId,
         launch_target_id: activeLaunchTargetId || null,
+        // Import under the same account profile that scoped the resumable-thread
+        // list the user picked from — otherwise the runtime reads the default
+        // store and 404s on a profile-scoped thread. The runtime overlays the
+        // profile's config dir onto launch_env from this id (profile-wins).
+        account_profile_id:
+          backend === activeFormBackend
+            ? activeFormAccountProfileId || null
+            : null,
         cwd,
         // An explicit transport supersedes launch_mode at the import API, so
         // pin the chosen transport and leave the launch mode on "auto".
@@ -812,6 +820,9 @@ export default function HomePage() {
         backend,
         threadId,
         launchTargetId ?? activeLaunchTargetId ?? null,
+        // Delete from the same profile store the list was scoped to; without it
+        // the runtime resolves the default store and no thread matches (404).
+        backend === activeFormBackend ? activeFormAccountProfileId || null : null,
       );
       setThreadsByBackend((current) => ({
         ...current,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -162,6 +162,21 @@ export default function HomePage() {
   const [threadsByBackend, setThreadsByBackend] = useState<
     Record<Backend, ThreadSummary[]>
   >({});
+  // The launch form's live (backend, accountProfileId) selection, reported by
+  // LaunchPanel — threads are fetched here app-globally, decoupled from the
+  // form, so this is how the active backend's fetch re-scopes to the
+  // selected profile.
+  const [activeFormBackend, setActiveFormBackend] = useState<Backend | null>(null);
+  const [activeFormAccountProfileId, setActiveFormAccountProfileId] = useState<
+    string | null
+  >(null);
+  const handleDiscoveryScopeChange = useCallback(
+    (backend: Backend, accountProfileId: string | null) => {
+      setActiveFormBackend(backend);
+      setActiveFormAccountProfileId(accountProfileId);
+    },
+    [],
+  );
   const [loadingByBackend, setLoadingByBackend] = useState<
     Record<Backend, boolean>
   >({});
@@ -453,18 +468,24 @@ export default function HomePage() {
     setThreadsByBackend((current) => {
       const next: Record<Backend, ThreadSummary[]> = {};
       for (const id of ids) {
-        next[id] = current[id] ?? [];
+        // The active form backend is re-scoping to (or away from) a
+        // profile — drop its stale list so a slow request can't show the
+        // previous profile's threads.
+        next[id] = id === activeFormBackend ? [] : current[id] ?? [];
       }
       return next;
     });
     for (const id of ids) {
       setLoadingByBackend((current) => ({ ...current, [id]: true }));
+      const accountProfileId =
+        id === activeFormBackend ? activeFormAccountProfileId || undefined : undefined;
       fetchBackendThreads<ThreadSummary>(
         host,
         token,
         id,
         {
           launchTargetId: activeLaunchTargetId || undefined,
+          accountProfileId,
         },
       )
         .then((threads) => {
@@ -498,6 +519,8 @@ export default function HomePage() {
     };
   }, [
     activeLaunchTargetId,
+    activeFormBackend,
+    activeFormAccountProfileId,
     host,
     launchTargets,
     discoveryBackendsKey,
@@ -1087,6 +1110,7 @@ export default function HomePage() {
           catalog={catalog}
           threadsByBackend={threadsByBackend}
           loadingByBackend={loadingByBackend}
+          onDiscoveryScopeChange={handleDiscoveryScopeChange}
           onDeleteThread={handleDeleteThread}
           onAttach={handleAttach}
           onCreate={handleCreate}

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -398,11 +398,12 @@ export function LaunchFormFields({
             </label>
           ) : null}
           <ModelPicker
-            key={`${form.backend}:${launchTargetId ?? "local"}`}
+            key={`${form.backend}:${launchTargetId ?? "local"}:${form.accountProfileId || "default"}`}
             host={host}
             token={token}
             backend={form.backend}
             launchTargetId={launchTargetId}
+            accountProfileId={form.accountProfileId}
             value={form.model}
             onChange={form.setModel}
             onAuthFailure={onAuthFailure}

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -57,6 +57,10 @@ interface LaunchPanelProps {
   catalog: BackendCatalog;
   threadsByBackend: Record<Backend, ThreadSummary[]>;
   loadingByBackend: Record<Backend, boolean>;
+  // Reports the form's live (backend, accountProfileId) selection so the
+  // caller can re-scope the resumable-thread fetch to the selected profile —
+  // thread discovery is fetched app-globally, decoupled from this form.
+  onDiscoveryScopeChange?: (backend: Backend, accountProfileId: string | null) => void;
   onCreate: (
     backend: Backend,
     cwd: string,
@@ -119,6 +123,7 @@ export function LaunchPanel({
   catalog,
   threadsByBackend,
   loadingByBackend,
+  onDiscoveryScopeChange,
   onCreate,
   onAttach,
   onImportThread,
@@ -143,6 +148,11 @@ export function LaunchPanel({
     launchTargetId,
     catalog,
   });
+
+  useEffect(() => {
+    onDiscoveryScopeChange?.(form.backend, form.accountProfileId || null);
+  }, [form.backend, form.accountProfileId, onDiscoveryScopeChange]);
+
   const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
   const presetHydratedRef = useRef(false);
 

--- a/frontend/src/components/ModelPicker.tsx
+++ b/frontend/src/components/ModelPicker.tsx
@@ -10,6 +10,7 @@ interface ModelPickerProps {
   token: string;
   backend: Backend;
   launchTargetId: string | null;
+  accountProfileId?: string | null;
   value: string;
   onChange: (value: string) => void;
   onAuthFailure?: () => void;
@@ -29,6 +30,7 @@ export function ModelPicker({
   token,
   backend,
   launchTargetId,
+  accountProfileId,
   value,
   onChange,
   onAuthFailure,
@@ -42,7 +44,7 @@ export function ModelPicker({
 
   useEffect(() => {
     let cancelled = false;
-    fetchBackendModels(host, token, backend, { launchTargetId })
+    fetchBackendModels(host, token, backend, { launchTargetId, accountProfileId })
       .then((response) => {
         if (cancelled) return;
         setOptions(response.models);
@@ -61,7 +63,7 @@ export function ModelPicker({
     return () => {
       cancelled = true;
     };
-  }, [host, token, backend, launchTargetId, onAuthFailure, onModelsLoaded]);
+  }, [host, token, backend, launchTargetId, accountProfileId, onAuthFailure, onModelsLoaded]);
 
   // Surface a custom-named model the caller already has even if it's not in
   // the curated list — covers schedules / sessions cloned from older state.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,11 +78,14 @@ export async function fetchBackendThreads<T = unknown>(
   host: string,
   token: string,
   backend: string,
-  options: { launchTargetId?: string | null } = {},
+  options: { launchTargetId?: string | null; accountProfileId?: string | null } = {},
 ): Promise<T[]> {
   const params = new URLSearchParams();
   if (options.launchTargetId) {
     params.set("launch_target_id", options.launchTargetId);
+  }
+  if (options.accountProfileId) {
+    params.set("account_profile_id", options.accountProfileId);
   }
   const suffix = params.size ? `?${params.toString()}` : "";
   const response = await fetch(
@@ -395,10 +398,14 @@ export async function deleteThread(
   backend: string,
   threadId: string,
   launchTargetId?: string | null,
+  accountProfileId?: string | null,
 ): Promise<void> {
   const params = new URLSearchParams();
   if (launchTargetId) {
     params.set("launch_target_id", launchTargetId);
+  }
+  if (accountProfileId) {
+    params.set("account_profile_id", accountProfileId);
   }
   const suffix = params.size ? `?${params.toString()}` : "";
   const response = await fetch(
@@ -564,6 +571,7 @@ export async function fetchBackendModels(
   options: {
     launchTargetId?: string | null;
     includeHidden?: boolean;
+    accountProfileId?: string | null;
   } = {},
 ): Promise<BackendModelListResponse> {
   const params = new URLSearchParams();
@@ -572,6 +580,9 @@ export async function fetchBackendModels(
   }
   if (options.includeHidden) {
     params.set("include_hidden", "true");
+  }
+  if (options.accountProfileId) {
+    params.set("account_profile_id", options.accountProfileId);
   }
   const suffix = params.size ? `?${params.toString()}` : "";
   const response = await fetch(`${host}/api/backends/${backend}/models${suffix}`, {


### PR DESCRIPTION
## Purpose

A launched or switched session already resolves every per-session on-disk op through its profile config dir (the `config_dir_for` / `launch_env` chokepoint, #241/#246–#249). But the session-less **discovery** surfaces — listing models, enumerating resumable threads, importing a thread, deleting a thread — still resolved the process-default config dir, because they have no `launch_env` to carry a profile. The user-visible bug: selecting a profile in the launch panel and importing/resuming a thread listed the **default** account's threads, not the profile's, and a subsequent resume/delete then operated on the wrong account's store. This threads an explicit account-profile selector through those surfaces so discovery matches the account a session will actually launch under. Implements the RFC in `tmp/rfcs/rfc-discovery-with-profile.md`. Relates to #230 (task #31).

## Changes

- `backend/src/waypoint/runtime.py` — new `discovery_env(backend, launch_target, account_profile_id)`: the read-side mirror of the launch overlay (`_default_launch_env` → `_apply_account_profile_env` → `account_lookup_env`), so discovery and launch can never disagree on the config dir. Async so it warms the remote-home cache first (a `~`-relative remote `config_dir` would otherwise 400 on a cold cache once the UI starts sending a profile). `account_profile_id=None` yields today's default store; an unknown profile 400s via `_require_account_profile`. `list_backend_models` gains an `account_profile_id` passthrough.
- `backend/src/waypoint/api.py` — `account_profile_id` query param on `GET /models`, `GET /threads`, and `DELETE /threads/{id}`, threaded to the plugin/runtime. When `remote_probe_blocked` nulls `launch_target_id`, the profile is nulled with it (a profile scoped to a now-nulled remote target would mis-resolve).
- `backend/src/waypoint/backends/base.py` — `account_profile_id` added to the `list_models` / `list_threads` / `delete_thread` `BackendPlugin` protocol methods (all optional, back-compatible).
- `backend/src/waypoint/backends/claude_code/{plugin.py,threads.py}` — `list_local_claude_threads` / `find_local_claude_thread` / `delete_local_claude_thread` gain a `config_dir` passthrough into `claude_projects_root(config_dir)`; `list_threads` / `delete_thread` resolve it via `discovery_env`, and `import_thread` scopes its history read via `config_dir_for(self.capabilities, request.launch_env)` (the runtime already applied the profile env there). Static model catalogue is profile-independent (no-op).
- `backend/src/waypoint/backends/claude_tty/plugin.py` — same scoping on its own `list_threads` / `import_thread` bodies (it composes claude_code but defines these directly).
- `backend/src/waypoint/backends/codex/plugin.py` — local client-factory path now threads `launch_env` (profile `CODEX_HOME`) into the live `thread_list` / `list_models` / import RPCs instead of dropping it; `delete_thread` resolves `config_dir` from the profile instead of reading `os.environ["CODEX_HOME"]`.
- `backend/src/waypoint/backends/opencode/plugin.py`, `backend/src/waypoint/backends/tmux/plugin.py` — opencode routes a selected profile through `discovery_env` so a non-`None` profile 400s (no `config_dir_env_var`), matching the launch path rather than silently ignoring it; tmux (generic wrapper, empty discovery) accepts the param as a no-op.
- `backend/src/waypoint/cli.py`, `backend/src/waypoint/client.py` — `--account-profile` on `waypoint models` and `waypoint backends threads`; the client helpers forward `account_profile_id` as a query param.
- `frontend/src/lib/api.ts`, `frontend/src/components/ModelPicker.tsx`, `frontend/src/components/LaunchFormFields.tsx`, `frontend/src/components/LaunchPanel.tsx`, `frontend/src/app/page.tsx` — `fetchBackendModels` / `fetchBackendThreads` accept `accountProfileId`; the model catalogue remounts on profile change; the resumable-thread list (fetched app-globally in `page.tsx`, previously keyed only on launch target) re-scopes to the launch form's selected profile via a discovery-scope callback, resetting the stale list before refetch.
- `backend/tests/` — `test_discovery_env.py` (overlay equivalence to launch, `None` back-compat, unknown-profile and no-config-dir 400s), `test_claude_threads.py` (config-dir scoping actually filters list/find/delete), `test_codex_discovery_profile.py` (profile `CODEX_HOME` scoping), plus updates to `test_client.py`, `test_runtime.py`, `test_backend_registry.py`.

## Design

No per-backend branching in `runtime.py` / `api.py`: `discovery_env` is generic, and each plugin derives its own config dir from the resolved env via `config_dir_for(self.capabilities, env)` — the same chokepoint the per-session ops use. The import path deliberately reuses the profile env the runtime already applied to `request.launch_env` rather than re-calling `discovery_env`, so it doesn't re-validate or re-warm. Remote profile-scoped discovery is a non-goal (task #33): the async warm only prevents the cold-cache 400 — the remote enumeration/delete branches still read the remote default store — so selecting a remote profile does not (yet) scope remote discovery, by design.

The work was split from a converged, cold-context-reviewed plan into a green foundation (the `discovery_env` resolver + protocol + API + all five plugin signatures) followed by four file-partitioned worker branches (claude, codex, cli, frontend), each independently reviewed before a linear fast-forward integration.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- Redeployed the stack on this branch and ran a deployed-app e2e: the `waypoint backends threads` / `models` CLI with `--account-profile`, the raw HTTP endpoints with a Bearer token, and a Playwright pass at mobile width driving the launch panel's Account profile select.

## Test Result

- Pre-commit — clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- `uv run pytest` — 1661 passed, 3 warnings (pre-existing, unrelated).
- `npm run lint` / `npm run build` — clean / succeeded.
- Deployed-app e2e — **passed**: `backends threads claude_code --account-profile work` (config dir `~/.claude-test`) returned **3** threads vs **181** for the default/`personal` (`~/.claude`) profile; an unknown profile returned **400** (`unknown account profile 'bogus'`); `models --account-profile work` returned the static catalogue. Same results over raw HTTP with a Bearer token. In the deployed UI, switching the Account profile select to "Test" fired `GET /api/backends/claude_code/models?account_profile_id=work` **and** `/threads?account_profile_id=work` — both the catalogue and the resumable-thread list re-scope on profile change.
- **Not run:** codex live-account discovery e2e (no codex account profile is configured on this host) — covered by `test_codex_discovery_profile.py` instead; remote profile-scoped discovery (RFC non-goal).
- Note: the deployed page logs a pre-existing React #418 (theme/timestamp hydration); this branch adds no server-rendered text (all touched components are `"use client"`, additions are effects/handlers/query params), so it is not introduced here.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched the plugin discovery contract: `list_models` / `list_threads` / `delete_thread` gained `account_profile_id` across all backends with no per-backend branching in the runtime/API; claude_code/codex scope by config dir, opencode 400s (no config-dir env var), tmux no-ops. Verified claude_code, codex, opencode via the deployed-app e2e / suite.
- [x] Frontend change — ran `cd frontend && npm run lint && npm run build` and verified the launch panel in the deployed app.
- [x] Not a breaking change (the new param is optional everywhere; `None` preserves prior behavior).
- [ ] Docs: `docs/account_profiles.md` covers profiles broadly; a discovery-scoping note can follow if reviewers want it.

</details>