### PR TITLE
fix: top-align the session-context field row so its controls line up

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8716,6 +8716,11 @@ html[data-theme="light"] .term-compose-send {
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(min(220px, 100%), 1fr));
   min-width: 0;
+  /* Size each field to its own content so a taller cell (e.g. Interface, which
+     carries a field hint) doesn't stretch its siblings and drop their controls
+     below its own — every control shares the same top edge, the hint hangs
+     below. */
+  align-items: start;
 }
 
 .launch-body-col {


### PR DESCRIPTION
## Purpose

In the launch panel's **Session context** row, the Interface `<select>` sat higher than the Agent and Account-profile selects (see the account-profile UI work in #260/#261). The Interface field carries a one-line hint the other two don't, so its grid cell is the tallest; the row's default `align-items: stretch` stretched the shorter cells and their inner `display: grid` auto-rows absorbed the slack, pushing those selects down. Relates to #230.

## Changes

- `frontend/src/app/globals.css` — add `align-items: start` to `.field-grid-row` so each field sizes to its own content instead of stretching to the tallest cell. Every control now shares the same top edge and a field hint simply hangs below.

## Design

Root cause is the interaction of two grids: `.field-grid-row` (the row) and `.field` (each label+control, itself `display: grid`). Under `stretch`, a shorter `.field` grew its auto-rows to fill the tallest cell, dropping its control. `align-items: start` is the minimal, idiomatic lever — it adds no chrome, color, or per-theme rule, so both themes are unaffected. The same latent misalignment existed in the other `.field-grid-row` user, the Tuning row (permission/model/effort), where `ModelPicker`/`EffortPicker` conditionally render hints; this fixes that row too.

## Test Plan

- `cd frontend && npm run lint`
- `cd frontend && npm run build`
- Redeployed the frontend and inspected the launch panel with Playwright at desktop width in both themes.

## Test Result

- `npm run lint` — clean.
- `npm run build` — succeeded.
- Visual — **passed** in dark and light: the Agent, Account profile, and Interface controls share the same top edge, and the Interface hint ("Emulated chat interface wrapping the TUI app.") hangs below without shifting the others.
- **Not run:** no automated frontend test/e2e suite exists in this repo (per `AGENTS.md`); verified via lint/build + the deployed-app visual pass.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] Frontend-only CSS change — the backend Python pre-commit hooks had no files to check (codespell passed on commit).
- [ ] No automated frontend test harness exists in this repo; validated via lint/build and a deployed-app visual pass in both themes instead.
- [x] I ran `cd frontend && npm run lint && npm run build`.
- [x] No coding-agent plugin/transport or plugin-id dispatch code was touched (CSS only).
- [x] Not a breaking change.

</details>