### PR TITLE
feat: persist verified-account provenance on sessions

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1976,7 +1976,13 @@ class SessionRuntime:
             self._start_context_usage_source(refreshed)
             # Boot-restore re-probe is local-only, mirroring the completion
             # warming above (D3) — remote hosts aren't fanned out to at boot.
-            if refreshed.launch_target_id is None:
+            # Gated on a profile being set, same as launch/thread-import: an
+            # unconditional probe would mass-probe the provider's rate-limit
+            # endpoint for every no-profile session on every restart.
+            if (
+                refreshed.account_profile_id is not None
+                and refreshed.launch_target_id is None
+            ):
                 self._schedule_verified_account_probe(
                     refreshed.id,
                     refreshed.backend,
@@ -2227,14 +2233,17 @@ class SessionRuntime:
                     detail=f"failed to reattach session ({refreshed.status})",
                 )
             # Re-probe after the terminal-status check so a probe failure
-            # never converts a good reattach into a 400 (D3/D5).
-            self._schedule_verified_account_probe(
-                refreshed.id,
-                refreshed.backend,
-                refreshed.launch_env,
-                launch_target=self._find_launch_target(refreshed.launch_target_id),
-                cwd=refreshed.cwd,
-            )
+            # never converts a good reattach into a 400 (D3/D5). Gated on a
+            # profile being set, same as launch/thread-import/boot-restore —
+            # a no-profile session has nothing to re-verify.
+            if refreshed.account_profile_id is not None:
+                self._schedule_verified_account_probe(
+                    refreshed.id,
+                    refreshed.backend,
+                    refreshed.launch_env,
+                    launch_target=self._find_launch_target(refreshed.launch_target_id),
+                    cwd=refreshed.cwd,
+                )
             self._start_context_usage_source(refreshed)
             return refreshed
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -291,7 +291,7 @@ class SessionRuntime:
             CompletionCacheKey, asyncio.Task[list[CommandCompletion]]
         ] = {}
         # Fire-and-forget verified-account probes (launch, thread-import,
-        # reattach, boot-restore — D5). Tracked so a task isn't GC'd mid-flight;
+        # reattach, boot-restore). Tracked so a task isn't GC'd mid-flight;
         # discarded on done.
         self._account_probe_tasks: set[asyncio.Task[None]] = set()
         self.file_offsets: dict[str, int] = {}
@@ -772,7 +772,7 @@ class SessionRuntime:
     def _stamp_verified_account(
         self, session_id: str, probe: AccountProbeResult, probed_at: datetime
     ) -> None:
-        """Persist the verified-account triple from a probe result (D4).
+        """Persist the verified-account triple from a probe result.
 
         Shared by every population point (switch, launch, thread-import,
         reattach, boot-restore) so the write is always the same three fields.
@@ -793,7 +793,7 @@ class SessionRuntime:
         launch_target: SshLaunchTargetConfig | None,
         cwd: str,
     ) -> None:
-        """Fire-and-forget probe+stamp of ``verified_account_*`` (D5).
+        """Fire-and-forget probe+stamp of ``verified_account_*``.
 
         ``probe_account`` is a live, uncached HTTP call with up to a 30s
         timeout, so this always runs off the launch/reattach/restore response
@@ -821,7 +821,7 @@ class SessionRuntime:
         # Wraps the whole probe+stamp: a raised probe (timeout) or a
         # post-probe storage write (session deleted mid-probe) must never
         # fail the launch/reattach/restore this runs alongside. A ``None``
-        # probe result leaves the prior value untouched (R4) rather than
+        # probe result leaves the prior value untouched rather than
         # clobbering good provenance with a transient failure.
         try:
             probe = await probe_account(
@@ -1253,7 +1253,7 @@ class SessionRuntime:
                 account_profile_id=request.account_profile_id,
                 account_profile_label=account_profile_label,
             )
-            # Fire-and-forget verified-account probe+stamp (D5) — a no-profile
+            # Fire-and-forget verified-account probe+stamp — a no-profile
             # launch leaves verified_account_* None.
             self._schedule_verified_account_probe(
                 session.id,
@@ -1585,7 +1585,7 @@ class SessionRuntime:
                 account_profile_id=account_profile_id,
                 account_profile_label=account_profile_label,
             )
-            # Fire-and-forget verified-account probe+stamp (D5), parity with
+            # Fire-and-forget verified-account probe+stamp, parity with
             # ``create_session``.
             self._schedule_verified_account_probe(
                 session.id,
@@ -1975,7 +1975,7 @@ class SessionRuntime:
             self._warm_command_completions(refreshed, include_remote=False)
             self._start_context_usage_source(refreshed)
             # Boot-restore re-probe is local-only, mirroring the completion
-            # warming above (D3) — remote hosts aren't fanned out to at boot.
+            # warming above — remote hosts aren't fanned out to at boot.
             # Gated on a profile being set, same as launch/thread-import: an
             # unconditional probe would mass-probe the provider's rate-limit
             # endpoint for every no-profile session on every restart.
@@ -2233,9 +2233,9 @@ class SessionRuntime:
                     detail=f"failed to reattach session ({refreshed.status})",
                 )
             # Re-probe after the terminal-status check so a probe failure
-            # never converts a good reattach into a 400 (D3/D5). Gated on a
-            # profile being set, same as launch/thread-import/boot-restore —
-            # a no-profile session has nothing to re-verify.
+            # never converts a good reattach into a 400. Gated on a profile
+            # being set, same as launch/thread-import/boot-restore — a
+            # no-profile session has nothing to re-verify.
             if refreshed.account_profile_id is not None:
                 self._schedule_verified_account_probe(
                     refreshed.id,
@@ -2418,8 +2418,8 @@ class SessionRuntime:
                     detail="could not verify the target account before switching",
                 )
             # Stamp verified_account_* from the probe already run above — no
-            # second probe (D5's switch exception: this is the only
-            # synchronous stamp).
+            # second probe. Unlike the other population points, which probe
+            # off the response path, this is the only synchronous stamp.
             verified_account_fields = {
                 "verified_account_key": target_probe.account_key,
                 "verified_account_label": target_probe.account_label,
@@ -2516,7 +2516,7 @@ class SessionRuntime:
                         ) from exc
 
         # Clearing the profile (set -> None) is not ``profile_changing``, but a
-        # de-profiled session must not keep stale provenance (D6), so null the
+        # de-profiled session must not keep stale provenance, so null the
         # triple explicitly here; ``profile_changing`` already set the triple
         # above from the probe just run, and any other update (model/args-only)
         # leaves it empty so the persisted values are untouched.

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -290,6 +290,10 @@ class SessionRuntime:
         self._completion_refresh_tasks: dict[
             CompletionCacheKey, asyncio.Task[list[CommandCompletion]]
         ] = {}
+        # Fire-and-forget verified-account probes (launch, thread-import,
+        # reattach, boot-restore — D5). Tracked so a task isn't GC'd mid-flight;
+        # discarded on done.
+        self._account_probe_tasks: set[asyncio.Task[None]] = set()
         self.file_offsets: dict[str, int] = {}
         # Open append handles for per-session structured logs, kept around
         # so the streaming path doesn't reopen (and re-stat via get_session)
@@ -396,6 +400,13 @@ class SessionRuntime:
         for completion_task in completion_tasks:
             with suppress(asyncio.CancelledError):
                 await completion_task
+        account_probe_tasks = list(self._account_probe_tasks)
+        self._account_probe_tasks.clear()
+        for probe_task in account_probe_tasks:
+            probe_task.cancel()
+        for probe_task in account_probe_tasks:
+            with suppress(asyncio.CancelledError):
+                await probe_task
         if self._broadcast_flusher is not None:
             self._broadcast_flusher.cancel()
             with suppress(asyncio.CancelledError):
@@ -757,6 +768,78 @@ class SessionRuntime:
                 ),
             )
         return result
+
+    def _stamp_verified_account(
+        self, session_id: str, probe: AccountProbeResult, probed_at: datetime
+    ) -> None:
+        """Persist the verified-account triple from a probe result (D4).
+
+        Shared by every population point (switch, launch, thread-import,
+        reattach, boot-restore) so the write is always the same three fields.
+        """
+        self.storage.update_session(
+            session_id,
+            verified_account_key=probe.account_key,
+            verified_account_label=probe.account_label,
+            verified_account_probed_at=probed_at,
+        )
+
+    def _schedule_verified_account_probe(
+        self,
+        session_id: str,
+        backend: str,
+        env: dict[str, str],
+        *,
+        launch_target: SshLaunchTargetConfig | None,
+        cwd: str,
+    ) -> None:
+        """Fire-and-forget probe+stamp of ``verified_account_*`` (D5).
+
+        ``probe_account`` is a live, uncached HTTP call with up to a 30s
+        timeout, so this always runs off the launch/reattach/restore response
+        path. Tracked in ``_account_probe_tasks`` so the task isn't GC'd
+        mid-flight; discarded on done.
+        """
+        task = asyncio.create_task(
+            self._probe_and_stamp_verified_account(
+                session_id, backend, env, launch_target=launch_target, cwd=cwd
+            ),
+            name=f"verified-account-probe-{session_id}",
+        )
+        self._account_probe_tasks.add(task)
+        task.add_done_callback(self._account_probe_tasks.discard)
+
+    async def _probe_and_stamp_verified_account(
+        self,
+        session_id: str,
+        backend: str,
+        env: dict[str, str],
+        *,
+        launch_target: SshLaunchTargetConfig | None,
+        cwd: str,
+    ) -> None:
+        # Wraps the whole probe+stamp: a raised probe (timeout) or a
+        # post-probe storage write (session deleted mid-probe) must never
+        # fail the launch/reattach/restore this runs alongside. A ``None``
+        # probe result leaves the prior value untouched (R4) rather than
+        # clobbering good provenance with a transient failure.
+        try:
+            probe = await probe_account(
+                self, backend, env, launch_target=launch_target, cwd=cwd
+            )
+            if probe is None:
+                return
+            self._stamp_verified_account(session_id, probe, datetime.now(UTC))
+        except Exception:
+            log.exception(
+                "failed to probe/stamp verified account for session %s", session_id
+            )
+
+    async def _drain_account_probe_tasks(self) -> None:
+        """Test seam: await any in-flight verified-account probe tasks."""
+        tasks = list(self._account_probe_tasks)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     async def account_doctor(
         self,
@@ -1170,6 +1253,15 @@ class SessionRuntime:
                 account_profile_id=request.account_profile_id,
                 account_profile_label=account_profile_label,
             )
+            # Fire-and-forget verified-account probe+stamp (D5) — a no-profile
+            # launch leaves verified_account_* None.
+            self._schedule_verified_account_probe(
+                session.id,
+                request.backend,
+                effective_env,
+                launch_target=launch_target,
+                cwd=session.cwd,
+            )
         self._warm_command_completions(session)
         self._start_context_usage_source(session)
         return session
@@ -1492,6 +1584,15 @@ class SessionRuntime:
                 session.id,
                 account_profile_id=account_profile_id,
                 account_profile_label=account_profile_label,
+            )
+            # Fire-and-forget verified-account probe+stamp (D5), parity with
+            # ``create_session``.
+            self._schedule_verified_account_probe(
+                session.id,
+                backend,
+                launch_env,
+                launch_target=launch_target,
+                cwd=session.cwd,
             )
         return session
 
@@ -1873,6 +1974,16 @@ class SessionRuntime:
             # stale-while-revalidate on the first `/` press.
             self._warm_command_completions(refreshed, include_remote=False)
             self._start_context_usage_source(refreshed)
+            # Boot-restore re-probe is local-only, mirroring the completion
+            # warming above (D3) — remote hosts aren't fanned out to at boot.
+            if refreshed.launch_target_id is None:
+                self._schedule_verified_account_probe(
+                    refreshed.id,
+                    refreshed.backend,
+                    refreshed.launch_env,
+                    launch_target=None,
+                    cwd=refreshed.cwd,
+                )
 
     def _warm_command_completions(
         self, session: SessionRecord, *, include_remote: bool = True
@@ -2115,6 +2226,15 @@ class SessionRuntime:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail=f"failed to reattach session ({refreshed.status})",
                 )
+            # Re-probe after the terminal-status check so a probe failure
+            # never converts a good reattach into a 400 (D3/D5).
+            self._schedule_verified_account_probe(
+                refreshed.id,
+                refreshed.backend,
+                refreshed.launch_env,
+                launch_target=self._find_launch_target(refreshed.launch_target_id),
+                cwd=refreshed.cwd,
+            )
             self._start_context_usage_source(refreshed)
             return refreshed
 
@@ -2265,6 +2385,7 @@ class SessionRuntime:
 
         old_launch_env = dict(session.launch_env)
         config_dir_key = caps.config_dir_env_var
+        verified_account_fields: dict[str, Any] = {}
         if profile_changing:
             profile = self._require_account_profile(
                 session.backend, cast(str, request.account_profile_id), launch_target
@@ -2287,6 +2408,14 @@ class SessionRuntime:
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="could not verify the target account before switching",
                 )
+            # Stamp verified_account_* from the probe already run above — no
+            # second probe (D5's switch exception: this is the only
+            # synchronous stamp).
+            verified_account_fields = {
+                "verified_account_key": target_probe.account_key,
+                "verified_account_label": target_probe.account_label,
+                "verified_account_probed_at": datetime.now(UTC),
+            }
             if profile.expected_account_key:
                 if target_probe.account_key != profile.expected_account_key:
                     raise HTTPException(
@@ -2377,6 +2506,22 @@ class SessionRuntime:
                             detail=f"cannot switch account profile: {exc}",
                         ) from exc
 
+        # Clearing the profile (set -> None) is not ``profile_changing``, but a
+        # de-profiled session must not keep stale provenance (D6), so null the
+        # triple explicitly here; ``profile_changing`` already set the triple
+        # above from the probe just run, and any other update (model/args-only)
+        # leaves it empty so the persisted values are untouched.
+        if not profile_changing and (
+            "account_profile_id" in fields
+            and request.account_profile_id is None
+            and session.account_profile_id is not None
+        ):
+            verified_account_fields = {
+                "verified_account_key": None,
+                "verified_account_label": None,
+                "verified_account_probed_at": None,
+            }
+
         # Terminate → persist new settings → restore. terminate/restore cycle the
         # rate-limit watcher; restore rebuilds env from the persisted record, so
         # the account is fixed by the (already-verified) launch_env. Mark the
@@ -2395,6 +2540,7 @@ class SessionRuntime:
             launch_env=new_env,
             account_profile_id=selected_profile_id,
             account_profile_label=new_profile_label,
+            **verified_account_fields,
         )
         await plugin.restore_session(self, self.get_session(session.id))
         refreshed = self.get_session(session.id)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -240,6 +240,15 @@ class SessionRecord(BaseModel):
     # private launch_env, so the account is bound even if config changes later.
     account_profile_id: str | None = None
     account_profile_label: str | None = None
+    # Server-owned provenance from the last account probe (launch, switch,
+    # reattach, or boot-restore) — distinct from the client-selected
+    # ``account_profile_id``/``label`` above. ``key`` and ``label`` are
+    # diagnostic-only (the label is frequently an OAuth email) and excluded
+    # from the public dump; ``probed_at`` is a bare timestamp and safe to show
+    # as "account last verified <ago>".
+    verified_account_key: str | None = Field(default=None, exclude=True)
+    verified_account_label: str | None = Field(default=None, exclude=True)
+    verified_account_probed_at: datetime | None = None
 
 
 class EventRecord(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -366,6 +366,9 @@ class Storage:
         self._ensure_column("sessions", "preset_name", "TEXT")
         self._ensure_column("sessions", "account_profile_id", "TEXT")
         self._ensure_column("sessions", "account_profile_label", "TEXT")
+        self._ensure_column("sessions", "verified_account_key", "TEXT")
+        self._ensure_column("sessions", "verified_account_label", "TEXT")
+        self._ensure_column("sessions", "verified_account_probed_at", "TEXT")
         self._ensure_column(
             "scheduled_sessions", "config_overrides", "TEXT NOT NULL DEFAULT '[]'"
         )
@@ -1867,6 +1870,12 @@ class Storage:
         raw_pinned_at = payload.get("pinned_at")
         payload["pinned_at"] = (
             datetime.fromisoformat(raw_pinned_at) if raw_pinned_at else None
+        )
+        raw_verified_probed_at = payload.get("verified_account_probed_at")
+        payload["verified_account_probed_at"] = (
+            datetime.fromisoformat(raw_verified_probed_at)
+            if raw_verified_probed_at
+            else None
         )
         payload["status"] = SessionStatus(payload["status"])
         payload["launch_mode"] = payload.get("launch_mode") or "auto"

--- a/backend/src/waypoint/usage_dashboard.py
+++ b/backend/src/waypoint/usage_dashboard.py
@@ -35,15 +35,23 @@ def account_bucket_for(
     *,
     session_id: str,
     registry: _PluginRegistry,
+    verified_account_key: str | None = None,
+    verified_account_label: str | None = None,
 ) -> tuple[str, str]:
     """Return ``(account_key, account_label)`` for a snapshot.
 
-    Dispatches the account-scoping decision to the snapshot's agent plugin
-    (``rate_limit_account``). Falls back to a session-scoped key labelled
-    with the plugin's human name when the plugin declines (no account info)
-    or is unknown, so probes without org/email metadata still surface as
-    their own bucket instead of collapsing together.
+    Prefers the session's persisted ``verified_account_key``/``label`` (last
+    probed at launch/switch/reattach) when present — it's already in the same
+    ``{backend}:{identity}`` shape ``rate_limit_account`` produces, since both
+    derive from the same probe. Otherwise dispatches the account-scoping
+    decision to the snapshot's agent plugin (``rate_limit_account``), falling
+    back to a session-scoped key labelled with the plugin's human name when
+    the plugin declines (no account info) or is unknown, so probes without
+    org/email metadata still surface as their own bucket instead of
+    collapsing together.
     """
+    if verified_account_key is not None:
+        return verified_account_key, verified_account_label or verified_account_key
     plugin = (
         registry.get(snapshot.source) if registry.has_backend(snapshot.source) else None
     )
@@ -80,7 +88,11 @@ def build_dashboard(
         if snapshot is None:
             continue
         key, label = account_bucket_for(
-            snapshot, session_id=session.id, registry=registry
+            snapshot,
+            session_id=session.id,
+            registry=registry,
+            verified_account_key=session.verified_account_key,
+            verified_account_label=session.verified_account_label,
         )
         existing = buckets.get(key)
         if existing is None:

--- a/backend/tests/test_usage_dashboard.py
+++ b/backend/tests/test_usage_dashboard.py
@@ -38,6 +38,8 @@ def _session(
     backend: str,
     snapshot: SessionRateLimitUsage | None,
     updated_at: datetime | None = None,
+    verified_account_key: str | None = None,
+    verified_account_label: str | None = None,
 ) -> SessionRecord:
     now = updated_at or datetime.now(UTC)
     return SessionRecord(
@@ -53,6 +55,8 @@ def _session(
         raw_log_path=f"/tmp/{sid}.raw",
         structured_log_path=f"/tmp/{sid}.json",
         rate_limit_usage=snapshot,
+        verified_account_key=verified_account_key,
+        verified_account_label=verified_account_label,
     )
 
 
@@ -188,6 +192,67 @@ def test_build_dashboard_skips_sessions_without_snapshot(
     ]
     dashboard = build_dashboard(sessions, registry)
     assert dashboard.buckets == []
+
+
+def test_account_bucket_prefers_verified_key_over_derivation(
+    registry: BackendRegistry,
+) -> None:
+    # Persisted verified_account_key (from a past probe) wins even though the
+    # snapshot's own notes would derive a different account.
+    snap = _snapshot(
+        source="claude_code",
+        notes=["CLI OAuth", "org: Acme", "org tier: enterprise"],
+        updated_at=datetime.now(UTC),
+    )
+    key, label = account_bucket_for(
+        snap,
+        session_id="s1",
+        registry=registry,
+        verified_account_key="claude_code:Verified",
+        verified_account_label="Verified Org",
+    )
+    assert key == "claude_code:Verified"
+    assert label == "Verified Org"
+
+
+def test_account_bucket_verified_key_without_label_falls_back_to_key(
+    registry: BackendRegistry,
+) -> None:
+    snap = _snapshot(
+        source="claude_code", notes=["CLI OAuth"], updated_at=datetime.now(UTC)
+    )
+    key, label = account_bucket_for(
+        snap,
+        session_id="s1",
+        registry=registry,
+        verified_account_key="claude_code:Verified",
+    )
+    assert key == "claude_code:Verified"
+    assert label == "claude_code:Verified"
+
+
+def test_build_dashboard_buckets_on_verified_account_key(
+    registry: BackendRegistry,
+) -> None:
+    now = datetime.now(UTC)
+    snap = _snapshot(
+        source="claude_code",
+        notes=["org: Acme", "org tier: enterprise"],
+        updated_at=now,
+    )
+    sessions = [
+        _session(
+            sid="s1",
+            backend="claude_code",
+            snapshot=snap,
+            verified_account_key="claude_code:Verified",
+            verified_account_label="Verified Org",
+        ),
+    ]
+    dashboard = build_dashboard(sessions, registry)
+    assert len(dashboard.buckets) == 1
+    assert dashboard.buckets[0].account_key == "claude_code:Verified"
+    assert dashboard.buckets[0].account_label == "Verified Org"
 
 
 def test_build_dashboard_separates_backends_and_accounts(

--- a/backend/tests/test_verified_account_persistence.py
+++ b/backend/tests/test_verified_account_persistence.py
@@ -1,0 +1,730 @@
+"""Server-owned ``verified_account_*`` provenance on ``SessionRecord``.
+
+Covers the RFC (`tmp/rfcs/rfc-verified-account-persistence.md`): the switch
+path already probes and verifies the account a profile authenticates as, but
+the result was discarded. These tests cover persistence at each population
+point (launch, thread-import, switch, reattach, boot-restore), redaction, and
+that clients can never set the fields themselves.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from waypoint.backends.codex.schemas import CodexThreadImportRequest
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import (
+    AccountProbeResult,
+    LaunchSettingsUpdateRequest,
+    ScheduleCreateRequest,
+    SessionCreateRequest,
+    SessionPresetSpec,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _codex_profiles(**extra: Any) -> dict[str, object]:
+    return {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": "~/.codex-work",
+                "transcript_policy": "require_existing",
+                **extra,
+            }
+        }
+    }
+
+
+def _runtime(tmp_path: Path, **plugin_configs: object) -> SessionRuntime:
+    settings = Settings(data_dir=tmp_path / "data", plugin_configs=plugin_configs)
+    settings.ensure_dirs()
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+def _session(runtime: SessionRuntime, **kw: Any) -> SessionRecord:
+    # verified_account_* are never written by create_session's INSERT (they're
+    # only known post-probe, stamped via a follow-up update_session — same as
+    # account_profile_id historically); seed them the same way here.
+    verified_kwargs = {
+        key: kw.pop(key)
+        for key in (
+            "verified_account_key",
+            "verified_account_label",
+            "verified_account_probed_at",
+        )
+        if key in kw
+    }
+    now = datetime.now(UTC)
+    base: dict[str, Any] = dict(
+        id="s1",
+        backend="codex",
+        transport="codex_app_server",
+        source=SessionSource.MANAGED,
+        title="t",
+        cwd="/repo/app",
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/r",
+        structured_log_path="/e",
+        transport_state={"thread_id": "11111111-1111-1111-1111-111111111111"},
+    )
+    base.update(kw)
+    record = SessionRecord(**base)
+    runtime.storage.create_session(record)
+    if verified_kwargs:
+        record = runtime.storage.update_session(record.id, **verified_kwargs)
+    return record
+
+
+def _fake_probe(calls: list[Any], result: AccountProbeResult | None) -> Any:
+    async def fake(*_a: Any, **_k: Any) -> AccountProbeResult | None:
+        calls.append(1)
+        return result
+
+    return fake
+
+
+# ── Server-set-only ─────────────────────────────────────────────────────────
+
+
+def test_create_request_drops_verified_fields() -> None:
+    req = SessionCreateRequest(
+        backend="codex",
+        cwd="/tmp",
+        **{
+            "verified_account_key": "leaked",
+            "verified_account_label": "leaked",
+            "verified_account_probed_at": datetime.now(UTC),
+        },
+    )
+    assert "verified_account_key" not in req.model_dump()
+    assert not hasattr(req, "verified_account_key")
+
+
+def test_schedule_request_drops_verified_fields() -> None:
+    req = ScheduleCreateRequest(
+        backend="codex",
+        cwd="/tmp",
+        **{"verified_account_key": "leaked"},
+    )
+    assert "verified_account_key" not in req.model_dump()
+
+
+def test_preset_spec_drops_verified_fields() -> None:
+    spec = SessionPresetSpec(**{"verified_account_key": "leaked"})
+    assert "verified_account_key" not in spec.model_dump()
+
+
+def test_launch_settings_patch_drops_verified_fields() -> None:
+    req = LaunchSettingsUpdateRequest(
+        restart=True, **{"verified_account_key": "leaked"}
+    )
+    assert "verified_account_key" not in req.model_dump()
+
+
+def test_thread_import_request_drops_verified_fields() -> None:
+    req = CodexThreadImportRequest(thread_id="t", **{"verified_account_key": "leaked"})
+    assert "verified_account_key" not in req.model_dump()
+
+
+# ── Redaction ────────────────────────────────────────────────────────────────
+
+
+def test_verified_key_and_label_excluded_from_public_dump(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    session = _session(
+        runtime,
+        verified_account_key="codex:work@co",
+        verified_account_label="work@co",
+        verified_account_probed_at=datetime.now(UTC),
+    )
+    dumped = session.model_dump(mode="json")
+    assert "verified_account_key" not in dumped
+    assert "verified_account_label" not in dumped
+    assert dumped["verified_account_probed_at"] is not None
+
+
+# ── Storage round-trip ──────────────────────────────────────────────────────
+
+
+def test_storage_round_trips_verified_fields(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    probed_at = datetime.now(UTC)
+    _session(
+        runtime,
+        verified_account_key="codex:work@co",
+        verified_account_label="work@co",
+        verified_account_probed_at=probed_at,
+    )
+    got = runtime.storage.get_session("s1")
+    assert got is not None
+    assert got.verified_account_key == "codex:work@co"
+    assert got.verified_account_label == "work@co"
+    assert got.verified_account_probed_at == probed_at
+
+
+def test_storage_defaults_verified_fields_to_none(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime)
+    got = runtime.storage.get_session("s1")
+    assert got is not None
+    assert got.verified_account_key is None
+    assert got.verified_account_label is None
+    assert got.verified_account_probed_at is None
+
+
+# ── Switch: the only synchronous stamp ──────────────────────────────────────
+
+
+async def test_switch_stamps_from_existing_probe_with_no_second_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(
+        tmp_path, codex=_codex_profiles(expected_account_key="codex:work@co")
+    )
+    _session(runtime)
+    monkeypatch.setattr(
+        "waypoint.runtime.ensure_thread_available", lambda *a, **k: None
+    )
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:work@co", account_label="Work Co"),
+        ),
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, session: SessionRecord) -> None:
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+
+    refreshed = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(account_profile_id="work", restart=True)
+    )
+    # Synchronous: asserted immediately, no drain needed.
+    assert refreshed.verified_account_key == "codex:work@co"
+    assert refreshed.verified_account_label == "Work Co"
+    assert refreshed.verified_account_probed_at is not None
+    # Only the single gate probe ran — no second probe for the stamp.
+    assert len(calls) == 1
+
+
+async def test_switch_clearing_profile_nulls_verified_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        verified_account_key="codex:work@co",
+        verified_account_label="work@co",
+        verified_account_probed_at=datetime.now(UTC),
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, session: SessionRecord) -> None:
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+
+    refreshed = await runtime.update_launch_settings(
+        "s1",
+        LaunchSettingsUpdateRequest(account_profile_id=None, restart=True),
+    )
+    assert refreshed.account_profile_id is None
+    assert refreshed.verified_account_key is None
+    assert refreshed.verified_account_label is None
+    assert refreshed.verified_account_probed_at is None
+
+
+async def test_switch_model_only_edit_leaves_verified_fields_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    probed_at = datetime.now(UTC)
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        verified_account_key="codex:work@co",
+        verified_account_label="work@co",
+        verified_account_probed_at=probed_at,
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, session: SessionRecord) -> None:
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+
+    refreshed = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(env_set={"FOO": "bar"}, restart=True)
+    )
+    assert refreshed.verified_account_key == "codex:work@co"
+    assert refreshed.verified_account_label == "work@co"
+    assert refreshed.verified_account_probed_at == probed_at
+
+
+# ── Launch: fire-and-forget, tracked ────────────────────────────────────────
+
+
+async def test_launch_with_profile_stamps_after_draining(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    codex = runtime.registry.get("codex")
+    tmux = runtime.registry.fallback_for_managed_launch()
+    assert tmux is not None
+
+    async def fake_codex_create_session(
+        _rt: SessionRuntime,
+        request: SessionCreateRequest,
+        *,
+        session_id: str,
+        launch_target: Any,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+        git_meta: Any,
+        permission_mode: str | None,
+        resolved_model: str | None,
+        resolved_effort: str | None,
+    ) -> SessionRecord:
+        now = datetime.now(UTC)
+        session = SessionRecord(
+            id=session_id,
+            backend=request.backend,
+            source=SessionSource.MANAGED,
+            transport="codex_app_server",
+            title=title,
+            cwd=request.cwd,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"thread_id": "thread-1"},
+            launch_env=request.launch_env,
+        )
+        runtime.storage.create_session(session)
+        return session
+
+    monkeypatch.setattr(codex, "create_session", fake_codex_create_session)
+    monkeypatch.setattr(codex, "is_available_for_managed_launch", lambda _rt: True)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:work@co", account_label="Work Co"),
+        ),
+    )
+
+    session = await runtime.create_session(
+        SessionCreateRequest(
+            backend="codex",
+            cwd=str(tmp_path),
+            account_profile_id="work",
+            args=[],
+            source_mode=SessionSource.MANAGED,
+        )
+    )
+    # Fire-and-forget: not stamped the instant the call returns.
+    assert session.verified_account_key is None
+
+    await runtime._drain_account_probe_tasks()
+    refreshed = runtime.storage.get_session(session.id)
+    assert refreshed is not None
+    assert refreshed.verified_account_key == "codex:work@co"
+    assert refreshed.verified_account_label == "Work Co"
+    assert refreshed.verified_account_probed_at is not None
+    assert len(calls) == 1
+
+
+async def test_launch_without_profile_leaves_verified_fields_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    codex = runtime.registry.get("codex")
+
+    async def fake_codex_create_session(
+        _rt: SessionRuntime,
+        request: SessionCreateRequest,
+        *,
+        session_id: str,
+        launch_target: Any,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+        git_meta: Any,
+        permission_mode: str | None,
+        resolved_model: str | None,
+        resolved_effort: str | None,
+    ) -> SessionRecord:
+        now = datetime.now(UTC)
+        session = SessionRecord(
+            id=session_id,
+            backend=request.backend,
+            source=SessionSource.MANAGED,
+            transport="codex_app_server",
+            title=title,
+            cwd=request.cwd,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"thread_id": "thread-1"},
+            launch_env=request.launch_env,
+        )
+        runtime.storage.create_session(session)
+        return session
+
+    monkeypatch.setattr(codex, "create_session", fake_codex_create_session)
+    monkeypatch.setattr(codex, "is_available_for_managed_launch", lambda _rt: True)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls, AccountProbeResult(account_key="codex:x", account_label="x")
+        ),
+    )
+
+    session = await runtime.create_session(
+        SessionCreateRequest(
+            backend="codex",
+            cwd=str(tmp_path),
+            args=[],
+            source_mode=SessionSource.MANAGED,
+        )
+    )
+    await runtime._drain_account_probe_tasks()
+    refreshed = runtime.storage.get_session(session.id)
+    assert refreshed is not None
+    assert refreshed.verified_account_key is None
+    assert calls == []
+
+
+async def test_launch_probe_raising_does_not_fail_launch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    codex = runtime.registry.get("codex")
+
+    async def fake_codex_create_session(
+        _rt: SessionRuntime,
+        request: SessionCreateRequest,
+        *,
+        session_id: str,
+        launch_target: Any,
+        title: str,
+        raw_log: Any,
+        structured_log: Any,
+        git_meta: Any,
+        permission_mode: str | None,
+        resolved_model: str | None,
+        resolved_effort: str | None,
+    ) -> SessionRecord:
+        now = datetime.now(UTC)
+        session = SessionRecord(
+            id=session_id,
+            backend=request.backend,
+            source=SessionSource.MANAGED,
+            transport="codex_app_server",
+            title=title,
+            cwd=request.cwd,
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(structured_log),
+            transport_state={"thread_id": "thread-1"},
+            launch_env=request.launch_env,
+        )
+        runtime.storage.create_session(session)
+        return session
+
+    async def raising_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        raise TimeoutError("probe timed out")
+
+    monkeypatch.setattr(codex, "create_session", fake_codex_create_session)
+    monkeypatch.setattr(codex, "is_available_for_managed_launch", lambda _rt: True)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    monkeypatch.setattr("waypoint.runtime.probe_account", raising_probe)
+
+    session = await runtime.create_session(
+        SessionCreateRequest(
+            backend="codex",
+            cwd=str(tmp_path),
+            account_profile_id="work",
+            args=[],
+            source_mode=SessionSource.MANAGED,
+        )
+    )
+    assert session.status == SessionStatus.IDLE
+    await runtime._drain_account_probe_tasks()
+    refreshed = runtime.storage.get_session(session.id)
+    assert refreshed is not None
+    assert refreshed.verified_account_key is None
+
+
+# ── Thread import: parity with launch ───────────────────────────────────────
+
+
+async def test_thread_import_with_profile_stamps_after_draining(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    codex = runtime.registry.get("codex")
+
+    async def fake_import_thread(
+        _rt: SessionRuntime, request: Any, *, agent: str
+    ) -> SessionRecord:
+        now = datetime.now(UTC)
+        session = SessionRecord(
+            id="imported-1",
+            backend=agent,
+            source=SessionSource.MANAGED,
+            transport="codex_app_server",
+            title="imported",
+            cwd="/repo/app",
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/r",
+            structured_log_path="/e",
+            transport_state={"thread_id": request.thread_id},
+            launch_env=request.launch_env,
+        )
+        runtime.storage.create_session(session)
+        return session
+
+    monkeypatch.setattr(codex, "import_thread", fake_import_thread)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:work@co", account_label="Work Co"),
+        ),
+    )
+
+    session = await runtime.import_thread(
+        "codex", {"thread_id": "abc", "account_profile_id": "work"}
+    )
+    assert session.verified_account_key is None
+    await runtime._drain_account_probe_tasks()
+    refreshed = runtime.storage.get_session(session.id)
+    assert refreshed is not None
+    assert refreshed.verified_account_key == "codex:work@co"
+    assert len(calls) == 1
+
+
+# ── Reattach ─────────────────────────────────────────────────────────────────
+
+
+async def test_reattach_reprobes_and_overwrites_stale_value(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    session = _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        verified_account_key="codex:stale@co",
+        verified_account_label="stale@co",
+        verified_account_probed_at=datetime.now(UTC),
+    )
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:fresh@co", account_label="fresh@co"),
+        ),
+    )
+
+    refreshed = await runtime._reattach_session(session)
+    # Fire-and-forget: not yet stamped.
+    assert refreshed.verified_account_key == "codex:stale@co"
+
+    await runtime._drain_account_probe_tasks()
+    final = runtime.storage.get_session(session.id)
+    assert final is not None
+    assert final.verified_account_key == "codex:fresh@co"
+    assert final.verified_account_label == "fresh@co"
+    assert len(calls) == 1
+
+
+async def test_reattach_probe_raising_does_not_fail_reattach(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    session = _session(runtime)
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+
+    async def raising_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        raise TimeoutError("probe timed out")
+
+    monkeypatch.setattr("waypoint.runtime.probe_account", raising_probe)
+
+    refreshed = await runtime._reattach_session(session)
+    assert refreshed.status == SessionStatus.IDLE
+    await runtime._drain_account_probe_tasks()
+    final = runtime.storage.get_session(session.id)
+    assert final is not None
+    assert final.verified_account_key is None
+
+
+# ── Boot-restore ─────────────────────────────────────────────────────────────
+
+
+async def test_boot_restore_local_session_reprobes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    session = _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        verified_account_key="codex:stale@co",
+        verified_account_label="stale@co",
+        verified_account_probed_at=datetime.now(UTC),
+    )
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    monkeypatch.setattr(runtime, "_start_context_usage_source", lambda *_a, **_k: None)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:fresh@co", account_label="fresh@co"),
+        ),
+    )
+
+    await runtime._restore_session_and_warm_completions(plugin, session)
+    await runtime._drain_account_probe_tasks()
+    final = runtime.storage.get_session(session.id)
+    assert final is not None
+    assert final.verified_account_key == "codex:fresh@co"
+    assert len(calls) == 1
+
+
+async def test_boot_restore_failed_probe_leaves_prior_value_untouched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    probed_at = datetime.now(UTC)
+    session = _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        verified_account_key="codex:good@co",
+        verified_account_label="good@co",
+        verified_account_probed_at=probed_at,
+    )
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    monkeypatch.setattr(runtime, "_start_context_usage_source", lambda *_a, **_k: None)
+    monkeypatch.setattr("waypoint.runtime.probe_account", _fake_probe([], None))
+
+    await runtime._restore_session_and_warm_completions(plugin, session)
+    await runtime._drain_account_probe_tasks()
+    final = runtime.storage.get_session(session.id)
+    assert final is not None
+    assert final.verified_account_key == "codex:good@co"
+    assert final.verified_account_label == "good@co"
+    assert final.verified_account_probed_at == probed_at
+
+
+async def test_boot_restore_skips_remote_launch_targets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    session = _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        launch_target_id="devbox",
+    )
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    monkeypatch.setattr(runtime, "_start_context_usage_source", lambda *_a, **_k: None)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:fresh@co", account_label="fresh@co"),
+        ),
+    )
+
+    await runtime._restore_session_and_warm_completions(plugin, session)
+    await runtime._drain_account_probe_tasks()
+    assert calls == []

--- a/backend/tests/test_verified_account_persistence.py
+++ b/backend/tests/test_verified_account_persistence.py
@@ -600,8 +600,8 @@ async def test_reattach_reprobes_and_overwrites_stale_value(
 async def test_reattach_probe_raising_does_not_fail_reattach(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    runtime = _runtime(tmp_path)
-    session = _session(runtime)
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    session = _session(runtime, account_profile_id="work", account_profile_label="Work")
     plugin = runtime.registry.plugin_for(session)
 
     async def fake_terminate(*_a: Any, **_k: Any) -> None:
@@ -624,6 +624,41 @@ async def test_reattach_probe_raising_does_not_fail_reattach(
     final = runtime.storage.get_session(session.id)
     assert final is not None
     assert final.verified_account_key is None
+
+
+async def test_reattach_without_profile_does_not_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Gated on a profile being set, same as launch/thread-import/boot-restore
+    # (a no-profile session has nothing to re-verify, and this avoids a live
+    # probe against every plain session's reattach).
+    runtime = _runtime(tmp_path)
+    session = _session(runtime)
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:fresh@co", account_label="fresh@co"),
+        ),
+    )
+
+    refreshed = await runtime._reattach_session(session)
+    await runtime._drain_account_probe_tasks()
+    final = runtime.storage.get_session(refreshed.id)
+    assert final is not None
+    assert final.verified_account_key is None
+    assert calls == []
 
 
 # ── Boot-restore ─────────────────────────────────────────────────────────────
@@ -696,6 +731,39 @@ async def test_boot_restore_failed_probe_leaves_prior_value_untouched(
     assert final.verified_account_key == "codex:good@co"
     assert final.verified_account_label == "good@co"
     assert final.verified_account_probed_at == probed_at
+
+
+async def test_boot_restore_without_profile_does_not_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A no-profile session is stable across a restart: verified_account_*
+    # stays None rather than getting stamped only after the first restart,
+    # and boot doesn't mass-probe the provider for every plain session.
+    runtime = _runtime(tmp_path)
+    session = _session(runtime)
+    plugin = runtime.registry.plugin_for(session)
+
+    async def fake_restore(_rt: Any, s: SessionRecord) -> None:
+        runtime.storage.update_session(s.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *_a, **_k: None)
+    monkeypatch.setattr(runtime, "_start_context_usage_source", lambda *_a, **_k: None)
+    calls: list[Any] = []
+    monkeypatch.setattr(
+        "waypoint.runtime.probe_account",
+        _fake_probe(
+            calls,
+            AccountProbeResult(account_key="codex:fresh@co", account_label="fresh@co"),
+        ),
+    )
+
+    await runtime._restore_session_and_warm_completions(plugin, session)
+    await runtime._drain_account_probe_tasks()
+    final = runtime.storage.get_session(session.id)
+    assert final is not None
+    assert final.verified_account_key is None
+    assert calls == []
 
 
 async def test_boot_restore_skips_remote_launch_targets(

--- a/backend/tests/test_verified_account_persistence.py
+++ b/backend/tests/test_verified_account_persistence.py
@@ -1,10 +1,10 @@
 """Server-owned ``verified_account_*`` provenance on ``SessionRecord``.
 
-Covers the RFC (`tmp/rfcs/rfc-verified-account-persistence.md`): the switch
-path already probes and verifies the account a profile authenticates as, but
-the result was discarded. These tests cover persistence at each population
-point (launch, thread-import, switch, reattach, boot-restore), redaction, and
-that clients can never set the fields themselves.
+The switch path already probes and verifies the account a profile
+authenticates as, but the result was discarded. These tests cover
+persistence at each population point (launch, thread-import, switch,
+reattach, boot-restore), redaction, and that clients can never set the
+fields themselves.
 """
 
 from datetime import UTC, datetime


### PR DESCRIPTION
## Purpose

The switch path already **probes and verifies** the account a profile authenticates as before committing a switch, but the probe result was discarded. This persists the verified account as read-only, server-owned provenance on the session record (`verified_account_key` / `verified_account_label` / `verified_account_probed_at`), so diagnostics and the usage dashboard can show *which account a session actually runs as* (as of the last probe), not just *which profile id was selected*. It closes the phase-1 distinction between client-selected fields (`account_profile_id`/`label`) and server-verified fields. Implements the RFC in `tmp/rfcs/rfc-verified-account-persistence.md`. Relates to #230 (task #32).

## Changes

- `backend/src/waypoint/schemas.py` — three fields on `SessionRecord`: `verified_account_key` and `verified_account_label` are `Field(exclude=True)` (diagnostic-only; the probe label is frequently an OAuth email), `verified_account_probed_at` is public (a bare timestamp, safe to show as "last verified").
- `backend/src/waypoint/storage.py` — three additive `TEXT` column migrations via `_ensure_column`; datetime hydration of `verified_account_probed_at` in `_session_from_row`. Writes go through the generic `update_session` path; the `create_session` INSERT is untouched (values are stamped post-probe).
- `backend/src/waypoint/runtime.py` — a shared `_stamp_verified_account` writer plus `_schedule_verified_account_probe` / `_probe_and_stamp_verified_account`, tracked in a new `_account_probe_tasks` set (drained in `stop()`) so a fire-and-forget probe isn't GC'd. Wired at all population points: launch and thread-import (fire-and-forget, gated on a profile being selected), profile switch (synchronous, reusing the probe already run for the gate — no second probe; nulls the triple when a profile is cleared), and reattach / boot-restore (fire-and-forget, profile-gated, boot-restore local-only).
- `backend/src/waypoint/usage_dashboard.py` — `account_bucket_for` / `build_dashboard` bucket on the persisted `verified_account_key` when present, falling back to the existing `rate_limit_account(snapshot)` derivation otherwise.
- `backend/tests/test_verified_account_persistence.py` (new) + `backend/tests/test_usage_dashboard.py` — server-set-only (fields ignored on create/PATCH/preset/schedule), redaction (key/label absent from the public dump, `probed_at` present), storage round-trip, per-population-point stamping, profile-clearing nulls the triple, a raising launch probe does not fail the launch, and dashboard bucketing prefers the verified key.

## Design

Non-input by construction: the fields live only on `SessionRecord`, never on any request/spec model, so a client can't set them. Redaction reuses the existing `Field(exclude=True)` mechanism (as with `launch_env`); a deployment that wants a public per-session label uses the already-public `account_profile_label`. The switch stamp is the only synchronous one because it reuses the probe already run for the `expected_account_key` gate; every other point defers to a tracked background task, since `probe_account` is a live `force=True` call with a 30s timeout ceiling — not cheap — and a raised probe must never fail the launch/reattach it runs alongside. All four deferred points are gated on a profile being selected (matching launch), so a no-profile session stays `None` everywhere and a service restart doesn't mass-probe the provider's rate-limit endpoint for every session. Point-in-time only: the fields reflect the last probe and go stale if credentials are re-authenticated out-of-band until the next switch/reattach.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit — clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- `uv run pytest` — 1686 passed, 3 warnings (pre-existing, unrelated).
- No end-to-end run: this is backend persistence behind unit-testable seams and the RFC did not call for an e2e suite.
- The plan was converged through two cold-context review rounds, which caught the raising/blocking launch probe, the fire-and-forget task-GC hazard, the unbound `target_probe` on non-profile settings updates, and the stale-fields-on-clear case before implementation.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] No per-backend branching added: population points dispatch through the existing `probe_account` registry path and the usage-dashboard `rate_limit_account` plugin method; no claude_code/codex/opencode `if` branches.
- [x] No frontend changes (the `probed_at` field flows to the existing optional `Session` type with no TS change; verified key/label are redacted from the public dump).
- [x] Not a breaking change (all fields default to `None`; old rows read back `None`).
- [ ] Docs: `docs/account_profiles.md` describes profiles and probing broadly; a provenance note can follow if reviewers want it.

</details>