### PR TITLE
feat: add compact session read output

### DIFF
--- a/.agents/skills/waypoint-comms/SKILL.md
+++ b/.agents/skills/waypoint-comms/SKILL.md
@@ -67,5 +67,6 @@ without a prompt each time.
   exchange has what it needs.
 - The board is pull-based — read your channels at turn boundaries, or an entry
   sits unseen (see `references/blackboard.md`).
-- Ground every claim about a reply in `waypoint sessions events` output, and
+- Ground every claim about a reply in compact session events output
+  (`waypoint sessions events <id> --compact`), and
   every claim about shared state in `waypoint board read` output.

--- a/.agents/skills/waypoint-comms/references/send-and-reply.md
+++ b/.agents/skills/waypoint-comms/references/send-and-reply.md
@@ -41,15 +41,17 @@ Poll the target to a settled status, then read its conversational output:
 
 ```bash
 waypoint sessions show <target-id>     # poll until idle / waiting_input / exited
+waypoint sessions output <target-id> --messages 20 --compact
 waypoint sessions output <target-id> --messages 20 --text
 ```
 
-Use `sessions output` for normal replies. If the reply seems missing, or the
-target is blocked on an approval/question, inspect
-`waypoint sessions events <target-id> --messages 20 --coalesce`. Use raw
-`events` only for exact stream debugging or transport/TUI artifacts such as
-`raw_terminal_chunk`. This path does not disturb your own turn: you choose when
-to look.
+Use `sessions output --compact` for normal structured replies, or `--text` when
+you only need assistant text. If the reply seems missing, or the target is
+blocked on an approval/question, inspect
+`waypoint sessions events <target-id> --messages 20 --compact`. Use
+`events --coalesce` or raw `events` only for full metadata, exact stream
+debugging, or transport/TUI artifacts such as `raw_terminal_chunk`. This path
+does not disturb your own turn: you choose when to look.
 
 ## Push: the answer arrives in your input (you set `reply-to`)
 

--- a/.agents/skills/waypoint-research/references/waypoint-playbook.md
+++ b/.agents/skills/waypoint-research/references/waypoint-playbook.md
@@ -174,7 +174,7 @@ Read logs and verify from git:
 
 ```bash
 waypoint board log "$channel"
-waypoint sessions events <sid>
+waypoint sessions events <sid> --compact
 git -C <agent-worktree> status --short
 git -C <agent-worktree> rev-parse HEAD
 ```

--- a/.agents/skills/waypoint-subagents/references/collect-and-steer.md
+++ b/.agents/skills/waypoint-subagents/references/collect-and-steer.md
@@ -6,16 +6,18 @@ decide whether it is done or needs another turn.
 ## Read output
 
 ```bash
-waypoint sessions output <session-id> --messages 40
+waypoint sessions output <session-id> --messages 40 --compact
 waypoint sessions output <session-id> --messages 40 --text
-waypoint sessions events <session-id> --messages 40 --coalesce       # structured JSON
-waypoint sessions events <session-id> --before-sequence <sequence>   # page back JSON
+waypoint sessions events <session-id> --messages 40 --compact        # routine structured JSON
+waypoint sessions events <session-id> --before-sequence <sequence> --compact
+waypoint sessions events <session-id> --messages 40 --coalesce       # full metadata JSON
 ```
 
 Use `sessions output` for the child's normal answer, and add `--text` when you
-only need assistant text. Use `events --coalesce` for structured JSON reads,
-including tool context and pending approvals/questions. Use raw `events` only
-for exact stream debugging or transport/TUI artifacts such as
+only need assistant text. Use `events --compact` for routine structured JSON
+reads, including tool context and pending approvals/questions. Use
+`events --coalesce` when you need full event metadata. Use raw `events` only for
+exact stream debugging or transport/TUI artifacts such as
 `raw_terminal_chunk`.
 
 Quote only the minimum transcript text needed to justify your conclusion;

--- a/.agents/skills/waypoint-subagents/references/permissions.md
+++ b/.agents/skills/waypoint-subagents/references/permissions.md
@@ -89,23 +89,27 @@ for those, reap and respawn remains the only path.
 ## Service a child's approvals
 
 When a child sits in `waiting_input`, it may be blocked on an approval. Read it
-from the child's coalesced events, then decide:
+from the child's compact events, then decide:
 
 ```bash
-waypoint sessions events <child-id> --messages 20 --coalesce   # find the approval_request
+waypoint sessions events <child-id> --messages 20 --compact    # find the approval_request
 waypoint sessions approve <child-id> <decision> [--approval-id <id>]
 ```
 
-Use raw `events` only if you need exact event ordering, duplicate diagnosis, or
-per-chunk metadata.
+Use `events --coalesce` or raw `events` only if you need full metadata, exact
+event ordering, duplicate diagnosis, or per-chunk metadata.
 
-The `approval_request` event metadata tells you the kind:
+The compact `approval_request` event gives you the summary text, `tool`,
+`approval_id`, and status. If the summary is not enough to decide, rerun with
+`--coalesce` to inspect the full metadata before approving:
 
-- **Tool-use approval** (`method: can_use_tool`) — carries `tool_name`,
-  `tool_input`, and `approval_id`. Decide per the tool and its inputs.
+- **Tool-use approval** — compact output carries `tool` and `approval_id`;
+  coalesced metadata also carries `method: can_use_tool`, `tool_input`, and any
+  permission suggestions. Decide per the tool and its inputs.
 - **Plan approval** (backends with `supports_plan_approval`, e.g. codex) —
-  carries a plan to accept or reject; decisions include `acceptForSession` to
-  stop re-prompting for the rest of the session.
+  compact text summarizes the plan approval; coalesced metadata carries the
+  full backend details when needed. Decisions include `acceptForSession` to stop
+  re-prompting for the rest of the session.
 
 Valid `<decision>` values are backend-specific — take them from
 `approval_decisions` in `waypoint backends` (e.g. `approve`/`decline`, plus
@@ -118,15 +122,16 @@ Do not approve destructive, privileged, or unclear requests on a child's behalf
 ## Service a child's questions
 
 A child can also block on a **question** (an `AskUserQuestion` prompt), which is
-distinct from an approval and is serviced through a different command. It
-surfaces in the child's events as a `tool_call` whose metadata has
-`tool_name: AskUserQuestion` (carrying the question text and options under
-`payload.input.questions`); on some backends the child also reports
-`waiting_input`. There is no `approval_request` for it, so `sessions approve`
-will not release it.
+distinct from an approval and is serviced through a different command. In
+compact events it surfaces as a `tool_call` with `tool: AskUserQuestion`,
+readable question/options in `text`, and an `item_id` you can pass as
+`--tool-use-id` when needed. If you need the original structured question shape,
+rerun with `--coalesce` and inspect `payload.input.questions`. On some backends
+the child also reports `waiting_input`. There is no `approval_request` for it,
+so `sessions approve` will not release it.
 
 ```bash
-waypoint sessions events <child-id> --messages 20 --coalesce   # find the AskUserQuestion tool_call
+waypoint sessions events <child-id> --messages 20 --compact    # find the AskUserQuestion tool_call
 waypoint sessions answer-question <child-id> --answer "<your answer>"
 ```
 

--- a/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
+++ b/.agents/skills/waypoint-subagents/references/spawn-and-poll.md
@@ -109,13 +109,14 @@ It maps the outcome to a process exit code so it composes in `&&` chains:
 
 ```bash
 waypoint sessions wait "$sid" --until exited,error --timeout 600 \
-  && waypoint sessions output "$sid" --messages 40
+  && waypoint sessions output "$sid" --messages 40 --compact
 ```
 
 After `wait`, use `sessions output` for the child's normal answer. If the child
-stopped in `waiting_input`, inspect `sessions events "$sid" --coalesce` for a
-pending approval or question. Use raw `events` only for exact stream debugging,
-missing output, or transport/TUI artifacts.
+stopped in `waiting_input`, inspect `sessions events "$sid" --compact` for a
+pending approval or question. Use `events --coalesce` when you need full
+metadata such as tool inputs or structured question payloads. Use raw `events`
+only for exact stream debugging, missing output, or transport/TUI artifacts.
 
 To watch a child's transcript live instead of blocking silently, stream events
 as NDJSON (one compact JSON object per line) until a terminal status or Ctrl+C:

--- a/.agents/skills/waypoint-workqueue/references/playbook.md
+++ b/.agents/skills/waypoint-workqueue/references/playbook.md
@@ -199,5 +199,5 @@ git (ground truth for code), the log is the narrative.
    resume steering them.
 
 > **`waypoint sessions send` may report a transport timeout even when the input
-> landed.** Confirm via `waypoint sessions events <sid>` before resending — a
-> duplicate message can cause a worker to execute a task twice.
+> landed.** Confirm via `waypoint sessions events <sid> --compact` before
+> resending — a duplicate message can cause a worker to execute a task twice.

--- a/.agents/skills/waypoint/references/sessions-approvals.md
+++ b/.agents/skills/waypoint/references/sessions-approvals.md
@@ -9,10 +9,10 @@ waypoint sessions approve <session-id> <decision> --text <message>
 ```
 
 Read the pending request from
-`waypoint sessions events <session-id> --messages 20 --coalesce` before
+`waypoint sessions events <session-id> --messages 20 --compact` before
 approving. If multiple approvals are pending, pass `--approval-id` when the
-transcript exposes one. Use raw `events` only if you need exact event ordering,
-duplicate diagnosis, or per-chunk metadata.
+transcript exposes one. Use `events --coalesce` or raw `events` only if you need
+full metadata, exact event ordering, duplicate diagnosis, or per-chunk metadata.
 
 Do not approve destructive, privileged, or unclear requests without user
 confirmation.

--- a/.agents/skills/waypoint/references/sessions-read.md
+++ b/.agents/skills/waypoint/references/sessions-read.md
@@ -5,21 +5,25 @@ Use these commands to ground answers in live Waypoint state:
 ```bash
 waypoint sessions list
 waypoint sessions show <session-id>
-waypoint sessions output <session-id> --messages 40
+waypoint sessions output <session-id> --messages 40 --compact
 waypoint sessions output <session-id> --messages 40 --text
-waypoint sessions events <session-id> --messages 40 --coalesce
-waypoint sessions events <session-id> --before-sequence <sequence> --coalesce
+waypoint sessions events <session-id> --messages 40 --compact
+waypoint sessions events <session-id> --before-sequence <sequence> --compact
+waypoint sessions events <session-id> --messages 40 --coalesce  # full metadata
 waypoint sessions events <session-id> --messages 40              # raw events
 waypoint sessions events <session-id> --follow
 ```
 
 `list` is the starting point for broad questions. Use `show` for one session's
 metadata. Use `output` for the conversational transcript or the agent's answer;
-`--text` is best when you want only the concatenated assistant text for shell
-piping or quick reading.
+`--compact` is the routine agent-readable transcript view, including user and
+assistant turns without raw backend metadata. `--text` is best when you want only
+the concatenated assistant text for shell piping or quick reading.
 
-Use `events --coalesce` for settled structured JSON reads, including tool
-context, approvals, and questions. Coalescing only merges streaming
+Use `events --compact` for routine settled structured reads, including tool
+context, approvals, and questions without raw backend payloads. Compact events
+coalesce streaming deltas into logical events. Use `events --coalesce` when you
+need the full event envelope and metadata. Coalescing only merges streaming
 `agent_output` and `tool_result` deltas with the same `item_id`;
 `approval_request` and `tool_call` records stay visible.
 

--- a/.agents/skills/waypoint/references/sessions-steer.md
+++ b/.agents/skills/waypoint/references/sessions-steer.md
@@ -42,4 +42,4 @@ waypoint sessions terminate <session-id>
 ```
 
 After sending input or control signals, re-check state with `waypoint sessions
-show <session-id>` or `waypoint sessions events <session-id> --messages N`.
+show <session-id>` or `waypoint sessions events <session-id> --messages N --compact`.

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -1367,12 +1367,26 @@ def sessions_events(
             help="(--no-follow only) Coalesce streaming deltas into logical events.",
         ),
     ] = False,
+    compact: Annotated[
+        bool,
+        typer.Option(
+            "--compact",
+            help=(
+                "Print a compact agent-readable event view without raw backend "
+                "metadata. Implies --coalesce and cannot be combined with --follow."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Show a session's transcript, or stream live events with --follow.
 
     Pass one or more SESSION_IDs, or use --spawned-by / --mine with --follow
     to resolve the set dynamically from the running server.
     """
+    if compact and follow:
+        typer.echo("error: --compact is not supported with --follow yet", err=True)
+        raise typer.Exit(code=1)
+
     if follow:
         try:
             asyncio.run(
@@ -1400,10 +1414,12 @@ def sessions_events(
         page = c.get_events(
             session_id, messages=messages, before_sequence=before_sequence
         )
-        if coalesce:
+        if coalesce or compact:
             from waypoint.events import coalesce_events
 
             page["events"] = coalesce_events(page["events"])
+        if compact:
+            return _compact_events_page(page)
         return page
 
     _emit(
@@ -1415,6 +1431,71 @@ def sessions_events(
 def _conversation_events(events_page: dict[str, Any]) -> list[dict[str, Any]]:
     visible = {"user_input", "agent_output"}
     return [event for event in events_page["events"] if event.get("kind") in visible]
+
+
+_COMPACT_METADATA_KEYS: dict[str, str] = {
+    "item_id": "item_id",
+    "item_type": "item_type",
+    "tool_name": "tool",
+    "status": "status",
+    "approval_id": "approval_id",
+    "question_id": "question_id",
+}
+
+
+def _lift_compact_metadata(event: dict[str, Any], target: dict[str, Any]) -> None:
+    metadata = event.get("metadata")
+    if not isinstance(metadata, dict):
+        return
+    for source, dest in _COMPACT_METADATA_KEYS.items():
+        value = metadata.get(source)
+        if value not in (None, ""):
+            target[dest] = value
+
+
+def _compact_event(event: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "seq": event.get("sequence"),
+        "kind": event.get("kind"),
+        "text": event.get("text", ""),
+    }
+    _lift_compact_metadata(event, compact)
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+def _compact_message(event: dict[str, Any]) -> dict[str, Any]:
+    role = "user" if event.get("kind") == "user_input" else "assistant"
+    compact: dict[str, Any] = {
+        "seq": event.get("sequence"),
+        "role": role,
+        "text": event.get("text", ""),
+    }
+    metadata = event.get("metadata")
+    if event.get("kind") == "agent_output" and isinstance(metadata, dict):
+        item_id = metadata.get("item_id")
+        if item_id not in (None, ""):
+            compact["item_id"] = item_id
+    return {key: value for key, value in compact.items() if value is not None}
+
+
+def _compact_events_page(events_page: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "events": [_compact_event(event) for event in events_page["events"]]
+    }
+    if "has_more" in events_page:
+        compact["has_more"] = events_page["has_more"]
+    return compact
+
+
+def _compact_transcript_page(events_page: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "messages": [
+            _compact_message(event) for event in _conversation_events(events_page)
+        ]
+    }
+    if "has_more" in events_page:
+        compact["has_more"] = events_page["has_more"]
+    return compact
 
 
 @sessions_app.command("wait")
@@ -2311,8 +2392,25 @@ def sessions_output(
             help="Return all raw event deltas without coalescing.",
         ),
     ] = False,
+    compact: Annotated[
+        bool,
+        typer.Option(
+            "--compact",
+            help=(
+                "Print a compact agent-readable transcript as messages without "
+                "raw backend metadata."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Show just the conversational transcript from a session."""
+    if compact and text:
+        typer.echo("error: --compact cannot be combined with --text", err=True)
+        raise typer.Exit(code=1)
+    if compact and raw:
+        typer.echo("error: --compact cannot be combined with --raw", err=True)
+        raise typer.Exit(code=1)
+
     if text:
         page = _run_client(
             _settings_from_ctx(ctx),
@@ -2337,6 +2435,8 @@ def sessions_output(
             from waypoint.events import coalesce_events
 
             page["events"] = coalesce_events(page["events"])
+        if compact:
+            return _compact_transcript_page(page)
         return {"events": _conversation_events(page)}
 
     _emit(

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1054,6 +1054,110 @@ def test_sessions_output_text_prints_only_agent_output(
     assert result.stdout == "hello\n\n world"
 
 
+def test_sessions_output_compact_returns_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/events":
+            return httpx.Response(
+                200,
+                json={
+                    "events": [
+                        {"kind": "status_update", "text": "busy", "sequence": 1},
+                        {"kind": "user_input", "text": "question", "sequence": 2},
+                        {
+                            "kind": "agent_output",
+                            "text": "answ",
+                            "sequence": 3,
+                            "metadata": {
+                                "item_id": "msg-1",
+                                "payload": {"verbose": True},
+                            },
+                        },
+                        {
+                            "kind": "agent_output",
+                            "text": "er",
+                            "sequence": 4,
+                            "metadata": {
+                                "item_id": "msg-1",
+                                "payload": {"verbose": True},
+                            },
+                        },
+                        {"kind": "tool_result", "text": "ignored", "sequence": 5},
+                    ],
+                    "has_more": True,
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "output",
+            "s1",
+            "--compact",
+        ],
+    )
+    assert result.exit_code == 0
+
+    assert json.loads(result.stdout) == {
+        "messages": [
+            {"seq": 2, "role": "user", "text": "question"},
+            {
+                "seq": 4,
+                "role": "assistant",
+                "text": "answer",
+                "item_id": "msg-1",
+            },
+        ],
+        "has_more": True,
+    }
+
+
+def test_sessions_output_compact_rejects_text(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "output",
+            "s1",
+            "--compact",
+            "--text",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--compact cannot be combined with --text" in result.output
+
+
+def test_sessions_output_compact_rejects_raw(tmp_path: Path) -> None:
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "output",
+            "s1",
+            "--compact",
+            "--raw",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--compact cannot be combined with --raw" in result.output
+
+
 def test_answer_question_rejects_malformed_answers_json(tmp_path: Path) -> None:
     result = runner.invoke(
         app,

--- a/backend/tests/test_cli_coalesce.py
+++ b/backend/tests/test_cli_coalesce.py
@@ -105,3 +105,148 @@ def test_sessions_events_coalesce(
     data = json.loads(result.stdout)
     assert len(data["events"]) == 1
     assert data["events"][0]["text"] == "answer"
+
+
+def test_sessions_events_compact_coalesces_and_lifts_minimal_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = CliRunner()
+    state: dict[str, object] = {}
+
+    def _config(p: Path) -> Path:
+        cf = p / "waypoint.toml"
+        cf.write_text('core:\n  url: "http://t"')
+        return cf
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/sessions/s1/events":
+            state["events_params"] = dict(request.url.params)
+            return httpx.Response(
+                200,
+                json={
+                    "events": [
+                        {
+                            "kind": "agent_output",
+                            "text": "answ",
+                            "sequence": 1,
+                            "metadata": {
+                                "item_id": "msg-1",
+                                "status": "running",
+                                "payload": {"large": True},
+                            },
+                        },
+                        {
+                            "kind": "agent_output",
+                            "text": "er",
+                            "sequence": 2,
+                            "metadata": {
+                                "item_id": "msg-1",
+                                "status": "idle",
+                                "payload": {"large": True},
+                            },
+                        },
+                        {
+                            "kind": "tool_call",
+                            "text": "",
+                            "sequence": 3,
+                            "metadata": {
+                                "item_id": "tool-1",
+                                "item_type": "commandExecution",
+                                "tool_name": "Bash",
+                                "status": "running",
+                                "payload": {"command": "secret-ish"},
+                            },
+                        },
+                        {
+                            "kind": "approval_request",
+                            "text": "Approve command?",
+                            "sequence": 4,
+                            "metadata": {
+                                "approval_id": "approval-1",
+                                "status": "waiting_input",
+                                "payload": {"details": "verbose"},
+                            },
+                        },
+                    ],
+                    "has_more": True,
+                    "latest_todo": {
+                        "kind": "system_note",
+                        "text": "todo",
+                        "sequence": 99,
+                    },
+                },
+            )
+        return httpx.Response(404)
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "sessions",
+            "events",
+            "s1",
+            "--before-sequence",
+            "10",
+            "--compact",
+        ],
+    )
+    assert result.exit_code == 0
+
+    data = json.loads(result.stdout)
+    assert data == {
+        "events": [
+            {
+                "seq": 2,
+                "kind": "agent_output",
+                "text": "answer",
+                "item_id": "msg-1",
+                "status": "idle",
+            },
+            {
+                "seq": 3,
+                "kind": "tool_call",
+                "text": "",
+                "item_id": "tool-1",
+                "item_type": "commandExecution",
+                "tool": "Bash",
+                "status": "running",
+            },
+            {
+                "seq": 4,
+                "kind": "approval_request",
+                "text": "Approve command?",
+                "status": "waiting_input",
+                "approval_id": "approval-1",
+            },
+        ],
+        "has_more": True,
+    }
+    assert state["events_params"] == {"before_sequence": "10"}
+
+
+def test_sessions_events_compact_rejects_follow(tmp_path: Path) -> None:
+    runner = CliRunner()
+    cf = tmp_path / "waypoint.toml"
+    cf.write_text('core:\n  url: "http://t"')
+
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(cf),
+            "sessions",
+            "events",
+            "s1",
+            "--compact",
+            "--follow",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--compact is not supported with --follow" in result.output


### PR DESCRIPTION
## Purpose

Adds compact, agent-readable output modes for the session read commands agents use most often. `waypoint sessions events --compact` keeps tool/approval/event context without raw backend payloads, while `waypoint sessions output --compact` returns a concise transcript-shaped `messages` list for user/assistant turns. This implements the RFC in `tmp/rfcs/rfc-compact-session-events.md`.

## Changes

- `backend/src/waypoint/cli.py` — add `--compact` to `sessions events` and `sessions output`, compact event/message formatters, minimal metadata lifting, and explicit conflict checks for `--follow`, `--text`, and `--raw`.
- `backend/tests/test_cli.py`, `backend/tests/test_cli_coalesce.py` — cover compact transcript output, compact event coalescing, `before_sequence` forwarding, `approval_id`/tool metadata lifting, empty-text operational events, `has_more`, and rejected flag combinations.
- `.agents/skills/waypoint/references/sessions-read.md` — recommend compact reads for routine agent session inspection while preserving full/coalesced/raw guidance for debugging.

## Design

The compact mode is CLI-only: the API and frontend continue to consume the full `EventRecord`/`EventsPageResponse` shape. `sessions events --compact` implies coalescing so streaming deltas collapse into logical events before raw metadata is dropped. `sessions output --compact` keeps the existing conversation filter but changes the top-level shape to `messages`, mapping `user_input` to `role: user` and `agent_output` to `role: assistant`.

The formatter builds fresh dictionaries and only lifts stable normalized metadata (`item_id`, `item_type`, `tool_name` as `tool`, `status`, `approval_id`, `question_id`). It intentionally omits `id`, `session_id`, `ts`, raw `metadata`, `metadata.payload`, and `latest_todo`; compact mode is a readability feature, not a security redaction boundary.

## Test Plan

- `cd backend && UV_CACHE_DIR=/tmp/waypoint-uv-cache uv run pytest tests/test_cli_coalesce.py tests/test_events.py tests/test_cli.py::test_sessions_output_compact_returns_messages tests/test_cli.py::test_sessions_output_compact_rejects_text tests/test_cli.py::test_sessions_output_compact_rejects_raw -q`
- `cd backend && UV_CACHE_DIR=/tmp/waypoint-uv-cache uv run pre-commit run --all-files`
- `cd backend && UV_CACHE_DIR=/tmp/waypoint-uv-cache uv run pytest`
- Live Waypoint CLI e2e against session `codex-06efb2ac`:
  - `waypoint sessions output codex-06efb2ac --messages 8 --compact`
  - `waypoint sessions events codex-06efb2ac --messages 8 --compact`
  - `waypoint sessions events codex-06efb2ac --messages 3 --before-sequence 999999999 --compact`
  - compact conflict guards for `output --compact --text` and `events --compact --follow`
- Waypoint subagent review with `claude-main` preset for the plan and implementation diff.

## Test Result

- Focused compact/session tests — 12 passed.
- Pre-commit — clean (`isort`, `black`, `ruff check`, `codespell`, `mypy`).
- `uv run pytest` — 1711 passed, 3 warnings (pre-existing/unrelated).
- Live `output --compact` e2e — returned top-level `has_more` + `messages`; message entries had compact keys (`item_id`, `role`, `seq`, `text`) and no `metadata` or `payload` anywhere.
- Live `events --compact` e2e — returned top-level `events` + `has_more`; event entries had `seq` and compact lifted fields, with no `metadata` or `payload` anywhere.
- Live compact size comparison on the same `events --messages 8` window — full `--coalesce`: 28,583 bytes; `--compact`: 9,277 bytes.
- Live `--before-sequence ... --compact` e2e — returned compact paginated events with no `metadata` or `payload`.
- Live conflict guards — `output --compact --text` failed with `error: --compact cannot be combined with --text`; `events --compact --follow` failed with `error: --compact is not supported with --follow yet`.
- Waypoint `claude-main` implementation review — verdict: Ship, no material correctness issues.
- Note: sandboxed black and an initial sandboxed broad pytest run stalled, so the final pre-commit and full pytest gates were rerun outside the sandbox and passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] No coding-agent plugin/transport contract or plugin-id dispatch code changed.
- [x] No frontend changes.
- [x] Not a breaking change (new flags are opt-in; default output is unchanged).
- [x] I have updated documentation for user-facing CLI behavior in the Waypoint session-read skill reference.

</details>