### PR TITLE
feat: honor local_bin for local codex launches

### DIFF
--- a/backend/src/waypoint/backends/codex/__init__.py
+++ b/backend/src/waypoint/backends/codex/__init__.py
@@ -1,3 +1,6 @@
+from waypoint.backends.codex import (  # noqa: F401  (installs SDK enum tolerance on import)
+    _sdk_compat,
+)
 from waypoint.backends.codex.permission_modes import (
     CODEX_PERMISSION_MODE_SPECS,
     CODEX_PERMISSION_PRESETS,

--- a/backend/src/waypoint/backends/codex/_sdk_compat.py
+++ b/backend/src/waypoint/backends/codex/_sdk_compat.py
@@ -1,0 +1,75 @@
+"""Runtime tolerance shims for a codex CLI newer than the pinned SDK.
+
+The pinned ``openai-codex`` SDK ships generated Pydantic models whose enums are
+frozen at the SDK's release. A codex binary ahead of that release (e.g. a system
+install selected via ``local_bin``) can return enum values the SDK has never
+heard of. The SDK's typed RPC path validates responses strictly
+(``client.request`` -> ``model_validate`` with no fallback), so an unknown value
+raises ``ValidationError`` and breaks model discovery, launch, and turns.
+
+``ReasoningEffort`` is the enum that grows in practice (codex 0.144.0 added
+``max`` and ``ultra``). We make it an "open" enum: an unknown string value
+resolves to a freshly registered member that preserves the string, instead of
+raising. The value flows through Waypoint as a plain string, so nothing else
+needs to change.
+
+Scoped deliberately to ``ReasoningEffort`` -- the only enum observed to skew --
+rather than every SDK enum, so a genuinely malformed response still fails loudly.
+Extending to another enum later is a one-line ``_open_enum`` call. Remove this
+module once the pinned SDK catches up to the CLI.
+"""
+
+import threading
+from enum import Enum
+
+from openai_codex.generated.v2_all import ReasoningEffort
+
+_lock = threading.Lock()
+_SENTINEL = "_waypoint_open_enum"
+
+# Effort values known to exist in newer codex CLIs but missing from the pinned
+# SDK enum. Pre-seeded eagerly (single-threaded, at install) so the common case
+# never mutates the enum from the SDK reader thread at runtime.
+_KNOWN_NEW_REASONING_EFFORTS = ("max", "ultra")
+
+
+def _open_enum(enum_cls: type[Enum]) -> None:
+    """Make *enum_cls* accept unknown string values by registering them lazily.
+
+    Idempotent. The registration write is guarded by ``_lock`` with a
+    double-check so concurrent first-sights of a new value from the SDK reader
+    thread don't double-insert.
+    """
+    if getattr(enum_cls, _SENTINEL, False):
+        return
+
+    def _missing_(cls: type[Enum], value: object) -> "Enum | None":
+        if not isinstance(value, str):
+            return None
+        with _lock:
+            existing = cls._value2member_map_.get(value)
+            if existing is not None:
+                return existing
+            member = object.__new__(cls)
+            member._name_ = value.upper().replace("-", "_")
+            member._value_ = value
+            cls._value2member_map_[value] = member
+            cls._member_map_.setdefault(member._name_, member)
+            return member
+
+    enum_cls._missing_ = classmethod(_missing_)  # type: ignore[assignment]
+    setattr(enum_cls, _SENTINEL, True)
+
+
+def install_reasoning_effort_tolerance() -> None:
+    """Open ``ReasoningEffort`` and pre-seed the known-new effort values.
+
+    Idempotent. Invoked on import of this module (below) so the shim is active
+    before any ``CodexClient`` validates a response.
+    """
+    _open_enum(ReasoningEffort)
+    for value in _KNOWN_NEW_REASONING_EFFORTS:
+        ReasoningEffort(value)
+
+
+install_reasoning_effort_tolerance()

--- a/backend/src/waypoint/backends/codex/_sdk_compat.py
+++ b/backend/src/waypoint/backends/codex/_sdk_compat.py
@@ -55,6 +55,10 @@ def _open_enum(enum_cls: type[Enum]) -> None:
             member._value_ = value
             cls._value2member_map_[value] = member
             cls._member_map_.setdefault(member._name_, member)
+            # Keep iteration (`list(cls)`) consistent with lookup so a
+            # fabricated member is a first-class value, not just resolvable.
+            if member._name_ not in cls._member_names_:
+                cls._member_names_.append(member._name_)
             return member
 
     enum_cls._missing_ = classmethod(_missing_)  # type: ignore[assignment]

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -60,6 +60,7 @@ def _apply_codex_args(
     cli_args: tuple[str, ...],
     config_overrides: tuple[str, ...],
     launch_env: dict[str, str] | None = None,
+    local_bin: str | None = None,
 ) -> ClientFactory | None:
     """Wrap *base* so it injects *cli_args* / *config_overrides* into local launches.
 
@@ -72,8 +73,14 @@ def _apply_codex_args(
     we have to fall back to ``launch_args_override`` and assemble the argv
     ourselves so the raw flags reach codex; otherwise we use the simpler
     ``config_overrides`` slot.
+
+    *local_bin* is the resolved absolute path to a system codex binary
+    (already existence-checked by the caller). ``None`` means "use the binary
+    bundled with the pinned openai-codex SDK". A non-None value forces the
+    local factory to be built even with no other args so the configured
+    binary is honored.
     """
-    if not cli_args and not config_overrides and not launch_env:
+    if not cli_args and not config_overrides and not launch_env and not local_bin:
         return base
     if base is not None:
         # Remote factory — args were baked in at construction; return as-is.
@@ -81,7 +88,7 @@ def _apply_codex_args(
 
     def _local(cwd: str, approval_handler: ApprovalCallback) -> CodexClient:
         if cli_args:
-            argv: list[str] = [str(_resolve_codex_bin(CodexConfig()))]
+            argv: list[str] = [local_bin or str(_resolve_codex_bin(CodexConfig()))]
             argv.extend(cli_args)
             for kv in config_overrides:
                 argv.extend(["--config", kv])
@@ -98,6 +105,7 @@ def _apply_codex_args(
             )
         return CodexClient(
             config=CodexConfig(
+                codex_bin=local_bin,
                 cwd=cwd,
                 client_name="waypoint",
                 client_title="Waypoint",

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -67,7 +67,7 @@ from waypoint.backends.plugin_config import (
 )
 from waypoint.backends.tmux.plugin import TmuxPlugin
 from waypoint.git_meta import GitMeta
-from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.launch_targets import SshLaunchTargetConfig, _resolve_local_binary
 from waypoint.schemas import (
     CommandCompletion,
     CompletionDispatch,
@@ -1384,11 +1384,21 @@ class CodexPlugin(DefaultLaunchContract):
     ) -> ClientFactory | None:
         launch_target = runtime._find_launch_target(launch_target_id)
         if launch_target is None:
+            configured_bin = self._config(runtime).local_bin
+            try:
+                resolved_bin = (
+                    _resolve_local_binary(configured_bin) if configured_bin else None
+                )
+            except FileNotFoundError as exc:
+                raise FileNotFoundError(
+                    f"codex local_bin not found: {configured_bin!r}"
+                ) from exc
             return _apply_codex_args(
                 None,
                 tuple(custom_args or ()),
                 tuple(custom_config_overrides or ()),
                 launch_env,
+                local_bin=resolved_bin,
             )
         return build_remote_codex_client_factory(
             launch_target,

--- a/backend/tests/fixtures/codex_model_list_0144.json
+++ b/backend/tests/fixtures/codex_model_list_0144.json
@@ -1,0 +1,155 @@
+{
+  "data": [
+    {
+      "id": "gpt-5.5",
+      "model": "gpt-5.5",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.5",
+      "description": "Frontier model for complex coding, research, and real-world work.",
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": true,
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": true
+    },
+    {
+      "id": "gpt-5.6-terra",
+      "model": "gpt-5.6-terra",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.6-Terra",
+      "description": "Balanced agentic coding model for everyday work.",
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "max",
+          "description": "Maximum reasoning depth for the hardest problems"
+        },
+        {
+          "reasoningEffort": "ultra",
+          "description": "Maximum reasoning with automatic task delegation"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": false,
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": false
+    },
+    {
+      "id": "gpt-5.6-luna",
+      "model": "gpt-5.6-luna",
+      "upgrade": null,
+      "upgradeInfo": null,
+      "availabilityNux": null,
+      "displayName": "GPT-5.6-Luna",
+      "description": "Fast and affordable agentic coding model.",
+      "hidden": false,
+      "supportedReasoningEfforts": [
+        {
+          "reasoningEffort": "low",
+          "description": "Fast responses with lighter reasoning"
+        },
+        {
+          "reasoningEffort": "medium",
+          "description": "Balances speed and reasoning depth for everyday tasks"
+        },
+        {
+          "reasoningEffort": "high",
+          "description": "Greater reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "xhigh",
+          "description": "Extra high reasoning depth for complex problems"
+        },
+        {
+          "reasoningEffort": "max",
+          "description": "Maximum reasoning depth for the hardest problems"
+        }
+      ],
+      "defaultReasoningEffort": "medium",
+      "inputModalities": [
+        "text",
+        "image"
+      ],
+      "supportsPersonality": false,
+      "additionalSpeedTiers": [
+        "fast"
+      ],
+      "serviceTiers": [
+        {
+          "id": "priority",
+          "name": "Fast",
+          "description": "1.5x speed, increased usage"
+        }
+      ],
+      "defaultServiceTier": null,
+      "isDefault": false
+    }
+  ],
+  "nextCursor": null
+}

--- a/backend/tests/fixtures/codex_thread_start_max_0144.json
+++ b/backend/tests/fixtures/codex_thread_start_max_0144.json
@@ -1,0 +1,54 @@
+{
+  "thread": {
+    "id": "019f4850-3c73-7dd1-a69d-ee4c8b40f3ab",
+    "extra": null,
+    "sessionId": "019f4850-3c73-7dd1-a69d-ee4c8b40f3ab",
+    "forkedFromId": null,
+    "parentThreadId": null,
+    "preview": "",
+    "ephemeral": false,
+    "historyMode": "legacy",
+    "modelProvider": "openai",
+    "createdAt": 1783624646,
+    "updatedAt": 1783624646,
+    "recencyAt": 1783624646,
+    "status": {
+      "type": "idle"
+    },
+    "path": "/home/noppanat/.codex-nus/sessions/2026/07/10/rollout-2026-07-10T03-17-25-019f4850-3c73-7dd1-a69d-ee4c8b40f3ab.jsonl",
+    "cwd": "/home/noppanat/waypoint",
+    "cliVersion": "0.144.0",
+    "source": "vscode",
+    "threadSource": null,
+    "agentNickname": null,
+    "agentRole": null,
+    "gitInfo": null,
+    "name": null,
+    "turns": []
+  },
+  "model": "gpt-5.5",
+  "modelProvider": "openai",
+  "serviceTier": null,
+  "cwd": "/home/noppanat/waypoint",
+  "runtimeWorkspaceRoots": [
+    "/home/noppanat/waypoint"
+  ],
+  "instructionSources": [
+    "/home/noppanat/waypoint/AGENTS.md"
+  ],
+  "approvalPolicy": "on-request",
+  "approvalsReviewer": "user",
+  "sandbox": {
+    "type": "workspaceWrite",
+    "writableRoots": [],
+    "networkAccess": false,
+    "excludeTmpdirEnvVar": false,
+    "excludeSlashTmp": false
+  },
+  "activePermissionProfile": {
+    "id": ":workspace",
+    "extends": null
+  },
+  "reasoningEffort": "max",
+  "multiAgentMode": "explicitRequestOnly"
+}

--- a/backend/tests/test_codex_local_bin.py
+++ b/backend/tests/test_codex_local_bin.py
@@ -1,0 +1,49 @@
+import shutil
+
+from waypoint.backends.codex.adapter import _apply_codex_args
+
+_REAL_BIN = shutil.which("env") or "/usr/bin/env"
+
+
+def _deny(_method: str, _params: dict[str, object] | None) -> dict[str, object]:
+    return {}
+
+
+def test_local_bin_sets_codex_bin_without_cli_args() -> None:
+    factory = _apply_codex_args(None, (), (), None, local_bin=_REAL_BIN)
+    assert factory is not None
+    client = factory("/tmp", _deny)
+    assert client.config.codex_bin == _REAL_BIN
+    assert client.config.launch_args_override is None
+
+
+def test_local_bin_leads_argv_with_cli_args() -> None:
+    factory = _apply_codex_args(None, ("--verbose",), (), None, local_bin=_REAL_BIN)
+    assert factory is not None
+    client = factory("/tmp", _deny)
+    override = client.config.launch_args_override
+    assert override is not None
+    assert override[0] == _REAL_BIN
+    assert "--verbose" in override
+    assert override[-3:] == ("app-server", "--listen", "stdio://")
+
+
+def test_unset_local_bin_with_no_args_returns_base() -> None:
+    assert _apply_codex_args(None, (), (), None, local_bin=None) is None
+
+
+def test_unset_local_bin_leaves_codex_bin_none_for_sdk_fallback() -> None:
+    factory = _apply_codex_args(None, (), ('model="gpt-5"',), None, local_bin=None)
+    assert factory is not None
+    client = factory("/tmp", _deny)
+    assert client.config.codex_bin is None
+
+
+def test_remote_base_factory_is_returned_verbatim() -> None:
+    sentinel = object()
+
+    def base(_cwd: str, _handler: object) -> object:
+        return sentinel
+
+    factory = _apply_codex_args(base, ("--verbose",), (), None, local_bin=_REAL_BIN)  # type: ignore[arg-type]
+    assert factory is base

--- a/backend/tests/test_codex_local_bin.py
+++ b/backend/tests/test_codex_local_bin.py
@@ -1,12 +1,32 @@
 import shutil
+from typing import Any, cast
+
+import pytest
 
 from waypoint.backends.codex.adapter import _apply_codex_args
+from waypoint.backends.codex.plugin import CodexPlugin, CodexPluginConfig
 
 _REAL_BIN = shutil.which("env") or "/usr/bin/env"
 
 
 def _deny(_method: str, _params: dict[str, object] | None) -> dict[str, object]:
     return {}
+
+
+class _FakeSettings:
+    def __init__(self, config: CodexPluginConfig) -> None:
+        self._config = config
+
+    def plugin_config(self, _backend: str) -> CodexPluginConfig:
+        return self._config
+
+
+class _FakeRuntime:
+    def __init__(self, config: CodexPluginConfig) -> None:
+        self.settings = _FakeSettings(config)
+
+    def _find_launch_target(self, _launch_target_id: str | None) -> None:
+        return None
 
 
 def test_local_bin_sets_codex_bin_without_cli_args() -> None:
@@ -47,3 +67,22 @@ def test_remote_base_factory_is_returned_verbatim() -> None:
 
     factory = _apply_codex_args(base, ("--verbose",), (), None, local_bin=_REAL_BIN)  # type: ignore[arg-type]
     assert factory is base
+
+
+def test_client_factory_resolves_path_name_to_absolute() -> None:
+    runtime = _FakeRuntime(CodexPluginConfig(local_bin="env"))
+    factory = CodexPlugin().client_factory(cast(Any, runtime), None)
+    assert factory is not None
+    client = factory("/tmp", _deny)
+    assert client.config.codex_bin == shutil.which("env")
+
+
+def test_client_factory_returns_base_when_local_bin_unset() -> None:
+    runtime = _FakeRuntime(CodexPluginConfig())
+    assert CodexPlugin().client_factory(cast(Any, runtime), None) is None
+
+
+def test_client_factory_wraps_unresolvable_local_bin_error() -> None:
+    runtime = _FakeRuntime(CodexPluginConfig(local_bin="waypoint-no-such-codex-bin"))
+    with pytest.raises(FileNotFoundError, match="codex local_bin not found"):
+        CodexPlugin().client_factory(cast(Any, runtime), None)

--- a/backend/tests/test_codex_sdk_compat.py
+++ b/backend/tests/test_codex_sdk_compat.py
@@ -29,6 +29,21 @@ def _load(name: str) -> dict:
     return json.loads((_FIXTURES / f"{name}.json").read_text())
 
 
+@pytest.fixture(autouse=True)
+def _restore_reasoning_effort() -> Any:
+    """Undo enum members fabricated by a test so the process-global enum
+    doesn't leak throwaway values into later tests."""
+    value_map = dict(ReasoningEffort._value2member_map_)
+    member_map = dict(ReasoningEffort._member_map_)
+    names = list(ReasoningEffort._member_names_)
+    yield
+    ReasoningEffort._value2member_map_.clear()
+    ReasoningEffort._value2member_map_.update(value_map)
+    ReasoningEffort._member_map_.clear()
+    ReasoningEffort._member_map_.update(member_map)
+    ReasoningEffort._member_names_[:] = names
+
+
 def test_model_list_with_unknown_efforts_validates_and_preserves_values() -> None:
     response = ModelListResponse.model_validate(_load("codex_model_list_0144"))
     efforts = {
@@ -50,6 +65,8 @@ def test_unknown_effort_resolves_to_string_preserving_member() -> None:
     assert ReasoningEffort("ultra").value == "ultra"
     # A value not seen before is tolerated too (future CLI additions).
     assert ReasoningEffort("hyper").value == "hyper"
+    # Fabricated members are first-class: iteration surfaces them.
+    assert ReasoningEffort("hyper") in list(ReasoningEffort)
 
 
 def test_shim_is_idempotent_and_identity_stable() -> None:

--- a/backend/tests/test_codex_sdk_compat.py
+++ b/backend/tests/test_codex_sdk_compat.py
@@ -1,0 +1,128 @@
+"""Tolerance for a codex CLI whose enums are ahead of the pinned SDK.
+
+Fixtures are real responses captured from codex 0.144.0 (which advertises the
+``max``/``ultra`` reasoning efforts the pinned SDK's ``ReasoningEffort`` enum does
+not know). Importing the codex package installs the tolerance shim.
+"""
+
+import json
+import threading
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from openai_codex.generated.v2_all import (
+    ModelListResponse,
+    ReasoningEffort,
+    ThreadStartResponse,
+)
+
+import waypoint.backends.codex  # noqa: F401  (installs the shim on import)
+from waypoint.backends.codex._sdk_compat import install_reasoning_effort_tolerance
+from waypoint.backends.codex.adapter import CodexAppServerAdapter
+from waypoint.backends.codex.plugin import CodexPlugin, CodexPluginConfig
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((_FIXTURES / f"{name}.json").read_text())
+
+
+def test_model_list_with_unknown_efforts_validates_and_preserves_values() -> None:
+    response = ModelListResponse.model_validate(_load("codex_model_list_0144"))
+    efforts = {
+        option.reasoning_effort.value
+        for model in response.data
+        for option in (model.supported_reasoning_efforts or [])
+    }
+    assert {"max", "ultra"} <= efforts
+
+
+def test_thread_start_at_max_validates_and_preserves_effort() -> None:
+    response = ThreadStartResponse.model_validate(_load("codex_thread_start_max_0144"))
+    assert response.reasoning_effort is not None
+    assert response.reasoning_effort.value == "max"
+
+
+def test_unknown_effort_resolves_to_string_preserving_member() -> None:
+    assert ReasoningEffort("max").value == "max"
+    assert ReasoningEffort("ultra").value == "ultra"
+    # A value not seen before is tolerated too (future CLI additions).
+    assert ReasoningEffort("hyper").value == "hyper"
+
+
+def test_shim_is_idempotent_and_identity_stable() -> None:
+    install_reasoning_effort_tolerance()
+    install_reasoning_effort_tolerance()
+    assert ReasoningEffort("max") is ReasoningEffort("max")
+
+
+def test_unknown_effort_round_trips_through_json_serialization() -> None:
+    response = ThreadStartResponse.model_validate(_load("codex_thread_start_max_0144"))
+    dumped = response.model_dump(mode="json", by_alias=True)
+    assert dumped["reasoningEffort"] == "max"
+
+
+def test_concurrent_resolution_of_new_values_is_safe() -> None:
+    values = [f"effort_{i}" for i in range(50)]
+    resolved: dict[str, str] = {}
+
+    def worker(value: str) -> None:
+        resolved[value] = ReasoningEffort(value).value
+
+    threads = [threading.Thread(target=worker, args=(v,)) for v in values]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert resolved == {value: value for value in values}
+
+
+class _FakeSettings:
+    default_cwd = "~"
+
+    def plugin_config(self, _backend: str) -> CodexPluginConfig:
+        return CodexPluginConfig()
+
+
+class _FakeRuntime:
+    settings = _FakeSettings()
+
+    def _find_launch_target(self, _launch_target_id: str | None) -> None:
+        return None
+
+    def _resolve_launch_target(
+        self, _launch_target_id: str | None, _backend: str
+    ) -> None:
+        return None
+
+    async def discovery_env(
+        self, _backend: str, _launch_target: Any, _account_profile_id: str | None
+    ) -> dict[str, str]:
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_list_models_surfaces_unknown_efforts_through_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = CodexPlugin()
+    plugin.adapter = CodexAppServerAdapter(emit_event=cast(Any, lambda *a, **k: None))
+    response = ModelListResponse.model_validate(_load("codex_model_list_0144"))
+
+    async def fake_adapter_list_models(
+        _self: CodexAppServerAdapter,
+        cwd: str = "~",
+        client_factory_override: Any = None,
+        include_hidden: bool = False,
+    ) -> ModelListResponse:
+        return response
+
+    monkeypatch.setattr(plugin, "client_factory", lambda *a, **k: lambda *_a: None)
+    monkeypatch.setattr(CodexAppServerAdapter, "list_models", fake_adapter_list_models)
+
+    result = await plugin.list_models(cast(Any, _FakeRuntime()))
+    efforts = {e for model in result["models"] for e in model["supported_efforts"]}
+    assert {"max", "ultra"} <= efforts

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -44,7 +44,9 @@ plugin_configs:
   codex:
     # default_model_id: gpt-5
     # default_effort: high
-    # local_bin: /opt/codex/bin/codex   # path on the local host; falls back to `codex`
+    # local_bin: /opt/codex/bin/codex   # absolute path or PATH name (e.g. `codex`) of a
+    #                                    #   system codex to launch locally. Unset uses the
+    #                                    #   binary bundled with the pinned openai-codex SDK.
     # env:                              # editable defaults surfaced in the launch panel
     #   OPENAI_API_KEY: sk-your-key
     # cli_args:                              # raw flags for `codex …` before `app-server`


### PR DESCRIPTION
## Purpose

Let the Codex plugin drive a **system-installed `codex`** for local sessions, and make that usable even when the system CLI is **newer than the pinned `openai-codex` SDK**.

Two coupled parts:

1. **Honor `local_bin`.** The `local_bin` setting was documented and fed the rate-limit probe, but the actual local session launch ignored it — the app-server `CodexClient` was built from a bare `CodexConfig`, so the SDK's resolver always fell back to the `codex_cli_bin` binary bundled in the pinned SDK wheel. There was no way to point local sessions at a PATH/absolute `codex`.
2. **Tolerate a CLI ahead of the SDK.** Once you point `local_bin` at a modern `codex` (e.g. 0.144.0), the SDK's strict typed-response validation 502'd model discovery — the CLI advertises reasoning efforts (`max`, `ultra`) the pinned SDK's generated `ReasoningEffort` enum doesn't know — and would likewise have broken launch/resume at those efforts. Part 1 is useless for a modern CLI without this.

## Changes

### local_bin
- `backend/src/waypoint/backends/codex/plugin.py` — `client_factory`'s local branch resolves `local_bin` via `_resolve_local_binary` (absolute/`~` path or PATH name) and passes the resolved absolute path to `_apply_codex_args`. A set-but-unresolvable value raises a clear, codex-scoped `FileNotFoundError` rather than silently launching a different binary.
- `backend/src/waypoint/backends/codex/adapter.py` — `_apply_codex_args` takes a `local_bin` argument, treats a non-`None` value as a trigger to build the local factory (so a plain session no longer short-circuits to the bundled-bin default), and threads it into the launch `CodexConfig` — as `codex_bin` on the plain path and as `argv[0]` on the `launch_args_override` path.
- `backend/waypoint.example.yaml` — corrects the codex `local_bin` comment (it falls back to the SDK-bundled binary, not PATH `codex`); documents that it accepts an absolute path or a PATH name.

### SDK tolerance
- `backend/src/waypoint/backends/codex/_sdk_compat.py` (new) — an import-time shim that makes the SDK's `ReasoningEffort` an "open" enum: an unknown string value resolves (via `_missing_`) to a freshly registered member that **preserves the string**, instead of raising. Known-new values (`max`, `ultra`) are pre-seeded eagerly; genuinely-new future values register lazily under a lock (the SDK reader thread parses notifications concurrently). Scoped to the one enum observed to skew, with a one-line path to open another if needed.
- `backend/src/waypoint/backends/codex/__init__.py` — imports the shim so it installs before any `CodexClient` validates a response.

### Tests
- `backend/tests/test_codex_local_bin.py` — `_apply_codex_args` plumbing and `client_factory` resolution (PATH-name → absolute, unset short-circuit, wrapped error).
- `backend/tests/test_codex_sdk_compat.py` + `backend/tests/fixtures/codex_model_list_0144.json`, `codex_thread_start_max_0144.json` — **real** responses captured from codex 0.144.0: `ModelListResponse`/`ThreadStartResponse` validate after the shim and preserve `max`/`ultra`; value round-trips through JSON; shim is idempotent, identity-stable, and thread-safe under concurrent resolution; and `max`/`ultra` surface through `plugin.list_models`.

## Design

**local_bin** is resolved in the plugin (which owns config); the adapter only plumbs the already-resolved path into `CodexConfig`. Resolution uses `_resolve_local_binary` because the SDK does a *literal* `Path`-existence check on `codex_bin` (no PATH lookup), so a bare name must become absolute first. A falsy value preserves the current behavior — the SDK-bundled binary — deliberately (not PATH `codex`) so the pinned SDK's known-good app-server protocol is the default; opting into `local_bin` is the operator's choice for a binary they know is compatible.

**SDK tolerance** is an open-enum shim rather than a discovery-only workaround (e.g. raw-parsing `model_list`): `ReasoningEffort` is embedded across model-list, thread, and turn/config responses, so the shim fixes discovery **and** launch/resume/turns in one contained place, preserving the real value end-to-end (effort flows through Waypoint as a plain string — `supported_efforts`, the launch `model_reasoning_effort`, the API, and the frontend all treat it opaquely). Empirically confirmed against the live 0.144.0 binary: `thread/start` at effort `max` fails validation with the shim off and passes with it on, and no other enum (`sandbox`, `approvalPolicy`, `approvalsReviewer`, `serviceTier`) is skewed in 0.144.0. Remove the shim once the pinned SDK catches up.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- Live e2e against the running stack with a system codex 0.144.0 configured as `local_bin`: `waypoint models codex` and `waypoint models codex --account-profile nus`.

## Test Result

- Pre-commit — clean (`isort`, `black`, `ruff check`, `codespell`, `mypy`).
- `uv run pytest` — 1726 passed, 3 warnings (pre-existing, unrelated).
- Live e2e — both `waypoint models codex` and `--account-profile nus` return successfully (previously **502**); efforts are `[high, low, max, medium, ultra, xhigh]` with `max`/`ultra` on `gpt-5.6-terra`/`gpt-5.6-luna`.
- **Not run:** a live turn at effort `max` (would spend account quota). The launch RPC itself (`thread/start` at `max`) is covered by the real-response regression fixture; a live turn is recommended as a manual check.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `AGENTS.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`). `waypointctl` was not touched.
- [x] Touched a coding-agent backend (codex) but changed no plugin/transport contract or plugin-id dispatch: it wires the existing `local_bin` field into the codex local launch and adds an SDK-compat shim scoped to the codex package, with no per-backend branching in the runtime, API, or transports.
- [x] No frontend changes.
- [x] Not a breaking change (unset `local_bin` preserves the bundled-binary default; the enum shim only widens what is accepted).
- [x] I have updated documentation for the user-facing config surface (`backend/waypoint.example.yaml`).

</details>