### PR TITLE
feat: make assistant lifecycle profile-aware

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -310,6 +310,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return await context.runtime.reset_assistant(
             backend=body.backend,
             transport=body.transport,
+            account_profile_id=body.account_profile_id,
+            account_profile_supplied="account_profile_id" in body.model_fields_set,
             model=body.model,
             effort=body.effort,
             permission_mode=body.permission_mode,
@@ -326,6 +328,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             backend=body.backend,
             thread_id=body.thread_id,
             launch_target_id=body.launch_target_id,
+            account_profile_id=body.account_profile_id,
         )
 
     @app.post("/api/assistant/terminate", response_model=AssistantSummary)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1356,6 +1356,7 @@ class SessionRuntime:
             effort=assistant.effort,
             permission_mode=assistant.permission_mode,
             transport=assistant.transport,
+            account_profile_id=assistant.account_profile_id,
         )
         self.assistant_session_id = created.id
 
@@ -1367,6 +1368,7 @@ class SessionRuntime:
         effort: str | None,
         permission_mode: str | None,
         transport: str | None,
+        account_profile_id: str | None = None,
     ) -> SessionRecord:
         plugin = self.registry.get(backend)
         validated_mode = (
@@ -1383,6 +1385,7 @@ class SessionRuntime:
             effort=effort,
             permission_mode=validated_mode,
             transport=transport,
+            account_profile_id=account_profile_id,
         )
         session = await self.create_session(request)
         return self.storage.update_session(
@@ -1421,6 +1424,8 @@ class SessionRuntime:
             backend=session.backend,
             transport=session.transport,
             native_thread_id=plugin.native_thread_id(session),
+            account_profile_id=session.account_profile_id,
+            account_profile_label=session.account_profile_label,
             status=session.status,
             supports_reattach=plugin.capabilities.supports_reattach_after_exit,
         )
@@ -1439,6 +1444,8 @@ class SessionRuntime:
         *,
         backend: str | None = None,
         transport: str | None = None,
+        account_profile_id: str | None = None,
+        account_profile_supplied: bool = False,
         model: str | None = None,
         effort: str | None = None,
         permission_mode: str | None = None,
@@ -1481,6 +1488,12 @@ class SessionRuntime:
                 permission_mode if permission_mode is not None else old.permission_mode
             )
             transport = transport if transport is not None else old.transport
+        if account_profile_supplied:
+            selected_profile_id = account_profile_id
+        elif old is not None and chosen == old.backend:
+            selected_profile_id = old.account_profile_id
+        else:
+            selected_profile_id = None
         # Spawn the replacement before touching the current thread so a failed
         # launch (e.g. a misconfigured backend) leaves the live, pinned
         # assistant intact rather than orphaning the pointer at a stopped row.
@@ -1490,6 +1503,7 @@ class SessionRuntime:
             effort=effort,
             permission_mode=permission_mode,
             transport=transport,
+            account_profile_id=selected_profile_id,
         )
         self.assistant_session_id = created.id
         await self._retire_previous_assistant(old, created.id)
@@ -1602,6 +1616,7 @@ class SessionRuntime:
         backend: str,
         thread_id: str,
         launch_target_id: str | None = None,
+        account_profile_id: str | None = None,
     ) -> AssistantSummary:
         """Adopt an existing backend-native thread as the assistant singleton.
 
@@ -1624,7 +1639,12 @@ class SessionRuntime:
         # assistant always adopts a thread over the agent's native transport,
         # so no transport is pinned here.
         imported = await self.import_thread(
-            backend, {"thread_id": thread_id, "launch_target_id": launch_target_id}
+            backend,
+            {
+                "thread_id": thread_id,
+                "launch_target_id": launch_target_id,
+                "account_profile_id": account_profile_id,
+            },
         )
         adopted = self.storage.update_session(
             imported.id, source=SessionSource.ASSISTANT, pinned_at=datetime.now(UTC)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -1506,7 +1506,7 @@ class SessionRuntime:
         """Rebuild the assistant on a fresh thread (clear context / switch backend).
 
         Clearing context keeps the *current* thread's backend and live config
-        (model / effort / permission mode / transport), so a context wipe
+        (model / effort / permission mode / transport / account profile), so a context wipe
         doesn't silently revert tuning done from the UI; only an explicit
         ``backend`` switch overrides them, since model/effort/transport are
         backend-specific. waypoint.yaml only seeds the first creation, when no

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -47,6 +47,7 @@ from waypoint.backends.transcript_fs import (
 from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
 from waypoint.backends.transcripts import (
     TranscriptUnavailableError,
+    ensure_symlink_shared,
     ensure_thread_available,
     setup_transcripts_symlink,
 )
@@ -656,6 +657,52 @@ class SessionRuntime:
                 detail=f"account profile {account_profile_id!r} is not set up: {exc}",
             ) from exc
 
+    async def _ensure_new_session_profile_transcript_store(
+        self,
+        backend: str,
+        launch_env: Mapping[str, str],
+        account_profile_id: str | None,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> None:
+        """Prepare a ``symlink_shared`` store before a profile-scoped launch.
+
+        A new thread has no prior transcript to transfer, but its first agent
+        process will create the native store. Establish the configured symlink
+        first so that process writes directly into the shared tree. The guarded
+        helper refuses a populated real directory; migrating existing user data
+        remains the explicit ``accounts setup-transcripts`` operation.
+        """
+        if account_profile_id is None:
+            return
+        profile = self._require_account_profile(
+            backend, account_profile_id, launch_target
+        )
+        if profile.transcript_policy != "symlink_shared":
+            return
+        caps = self.registry.get(backend).capabilities
+        if caps.native_thread_store is None:
+            return
+        config_dir = config_dir_for(caps, launch_env)
+        if config_dir is None:
+            return
+        fs: TranscriptFilesystem = (
+            LocalTranscriptFilesystem()
+            if launch_target is None
+            else RemoteTranscriptFilesystem(launch_target)
+        )
+        try:
+            await asyncio.to_thread(
+                ensure_symlink_shared,
+                Path(fs.expanduser(config_dir)) / caps.native_thread_store,
+                Path(fs.expanduser(cast(str, profile.shared_transcript_dir))),
+                fs=fs,
+            )
+        except TranscriptUnavailableError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"cannot prepare account profile transcripts: {exc}",
+            ) from exc
+
     def _agent_process_env(
         self,
         backend: str,
@@ -1213,6 +1260,12 @@ class SessionRuntime:
         self._ensure_profile_config_dir_ready(
             request.backend,
             plugin.capabilities,
+            effective_env,
+            request.account_profile_id,
+            launch_target,
+        )
+        await self._ensure_new_session_profile_transcript_store(
+            request.backend,
             effective_env,
             request.account_profile_id,
             launch_target,

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -416,6 +416,10 @@ class AssistantSummary(BaseModel):
     # Surfaced alongside ``session_id`` so a user can recover the thread
     # outside the app. ``None`` when the backend has no resumable id.
     native_thread_id: str | None = None
+    # Redacted account/config profile identity of the live assistant. This
+    # deliberately excludes its config-dir path and account key.
+    account_profile_id: str | None = None
+    account_profile_label: str | None = None
     status: SessionStatus
     # Whether the backend can revive this thread after it exits. Drives the
     # assistant UI's choice between offering Reattach and only Clear context.
@@ -430,6 +434,9 @@ class AssistantResetRequest(BaseModel):
     # default on a backend switch).
     backend: BackendId | None = None
     transport: SessionTransportId | None = None
+    # Omitted means infer from the current assistant for a same-backend reset;
+    # explicit null means launch under the backend's default account.
+    account_profile_id: str | None = None
     model: str | None = None
     effort: str | None = None
     permission_mode: str | None = None
@@ -441,6 +448,8 @@ class AssistantAttachRequest(BaseModel):
     backend: BackendId
     thread_id: str
     launch_target_id: str | None = None
+    # The profile that owns the thread being imported.
+    account_profile_id: str | None = None
 
 
 PresetName = Annotated[str, StringConstraints(min_length=1, strip_whitespace=True)]

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -84,6 +84,9 @@ class AssistantConfig(BaseModel):
     enabled: bool = True
     # ``None`` resolves to the top-level ``default_backend`` at bootstrap.
     backend: BackendId | None = None
+    # Named account/config profile for the first assistant thread. A live
+    # assistant remains the source of truth across redeploys.
+    account_profile_id: str | None = None
     model: str | None = None
     effort: str | None = None
     # Transport the agent is driven over. ``None`` lets the agent pick its

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1960,6 +1960,7 @@ async def test_create_session_direct_mode_uses_requested_backend(
         account_profile_id="work",
     )
     session = await runtime.create_session(request)
+    # Re-enter the preflight with the correct symlink already in place.
     second_session = await runtime.create_session(request)
 
     assert create_calls == [

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1950,24 +1950,73 @@ async def test_create_session_direct_mode_uses_requested_backend(
         runtime, "_warm_command_completions", lambda *_args, **_kwargs: None
     )
 
-    session = await runtime.create_session(
-        SessionCreateRequest(
-            backend="codex",
-            cwd=str(tmp_path),
-            launch_mode=LaunchMode.DIRECT,
-            title="Direct launch",
-            args=[],
-            source_mode=SessionSource.MANAGED,
-            account_profile_id="work",
-        )
+    request = SessionCreateRequest(
+        backend="codex",
+        cwd=str(tmp_path),
+        launch_mode=LaunchMode.DIRECT,
+        title="Direct launch",
+        args=[],
+        source_mode=SessionSource.MANAGED,
+        account_profile_id="work",
     )
+    session = await runtime.create_session(request)
+    second_session = await runtime.create_session(request)
 
-    assert create_calls == [(session.id, LaunchMode.DIRECT)]
+    assert create_calls == [
+        (session.id, LaunchMode.DIRECT),
+        (second_session.id, LaunchMode.DIRECT),
+    ]
     assert session.backend == "codex"
     assert session.transport == "codex_app_server"
     assert session.cwd == str(tmp_path)
     assert (profile_dir / "sessions").is_symlink()
     assert (profile_dir / "sessions").resolve() == shared_dir
+
+
+@pytest.mark.asyncio
+async def test_create_session_rejects_populated_symlink_shared_store(
+    monkeypatch, tmp_path
+) -> None:
+    runtime, _, settings = make_runtime(tmp_path)
+    codex = runtime.registry.get("codex")
+    profile_dir = tmp_path / "codex-work"
+    shared_dir = tmp_path / "codex-shared-sessions"
+    store_dir = profile_dir / "sessions"
+    store_dir.mkdir(parents=True)
+    (store_dir / "existing.jsonl").write_text("existing", encoding="utf-8")
+    settings.plugin_configs["codex"] = codex.config_schema.model_validate(
+        {
+            "account_profiles": {
+                "work": {
+                    "label": "Work",
+                    "config_dir": str(profile_dir),
+                    "transcript_policy": "symlink_shared",
+                    "shared_transcript_dir": str(shared_dir),
+                }
+            }
+        }
+    )
+    monkeypatch.setattr(codex, "is_available_for_managed_launch", lambda _rt: True)
+    monkeypatch.setattr(
+        codex,
+        "create_session",
+        lambda *_args, **_kwargs: pytest.fail("profile preflight must run first"),
+    )
+
+    with pytest.raises(
+        HTTPException, match="cannot prepare account profile transcripts"
+    ):
+        await runtime.create_session(
+            SessionCreateRequest(
+                backend="codex",
+                cwd=str(tmp_path),
+                launch_mode=LaunchMode.DIRECT,
+                title="Blocked launch",
+                args=[],
+                source_mode=SessionSource.MANAGED,
+                account_profile_id="work",
+            )
+        )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1890,6 +1890,20 @@ async def test_create_session_direct_mode_uses_requested_backend(
 ) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
     codex = runtime.registry.get("codex")
+    profile_dir = tmp_path / "codex-work"
+    shared_dir = tmp_path / "codex-shared-sessions"
+    settings.plugin_configs["codex"] = codex.config_schema.model_validate(
+        {
+            "account_profiles": {
+                "work": {
+                    "label": "Work",
+                    "config_dir": str(profile_dir),
+                    "transcript_policy": "symlink_shared",
+                    "shared_transcript_dir": str(shared_dir),
+                }
+            }
+        }
+    )
     tmux = runtime.registry.fallback_for_managed_launch()
     assert tmux is not None
     create_calls: list[tuple[str, LaunchMode]] = []
@@ -1944,6 +1958,7 @@ async def test_create_session_direct_mode_uses_requested_backend(
             title="Direct launch",
             args=[],
             source_mode=SessionSource.MANAGED,
+            account_profile_id="work",
         )
     )
 
@@ -1951,6 +1966,8 @@ async def test_create_session_direct_mode_uses_requested_backend(
     assert session.backend == "codex"
     assert session.transport == "codex_app_server"
     assert session.cwd == str(tmp_path)
+    assert (profile_dir / "sessions").is_symlink()
+    assert (profile_dir / "sessions").resolve() == shared_dir
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -4391,7 +4391,11 @@ async def test_assistant_first_boot_seeds_config_transport(tmp_path) -> None:
     # resolution itself (None => the agent default) is covered by the
     # create_session default-transport tests.
     runtime, storage, settings = make_runtime(tmp_path)
-    settings.assistant = AssistantConfig(backend="claude_code", transport="claude_cli")
+    settings.assistant = AssistantConfig(
+        backend="claude_code",
+        transport="claude_cli",
+        account_profile_id="work",
+    )
     captured: dict[str, Any] = {}
 
     async def _fake_create(backend: str, **kwargs: Any) -> SessionRecord:
@@ -4412,6 +4416,7 @@ async def test_assistant_first_boot_seeds_config_transport(tmp_path) -> None:
 
     assert runtime.assistant_session_id == "claude-fresh"
     assert captured["transport"] == "claude_cli"
+    assert captured["account_profile_id"] == "work"
 
 
 @pytest.mark.asyncio
@@ -4448,6 +4453,11 @@ async def test_assistant_summary_reports_native_thread_id(tmp_path) -> None:
         status=SessionStatus.IDLE,
         transport="codex_app_server",
     )
+    storage.update_session(
+        "codex-assistant",
+        account_profile_id="work",
+        account_profile_label="Work",
+    )
     runtime.assistant_session_id = "codex-assistant"
 
     summary = runtime.assistant_summary()
@@ -4457,6 +4467,8 @@ async def test_assistant_summary_reports_native_thread_id(tmp_path) -> None:
     assert summary.backend == "codex"
     assert summary.transport == "codex_app_server"
     assert summary.native_thread_id == "thread-1"
+    assert summary.account_profile_id == "work"
+    assert summary.account_profile_label == "Work"
     assert summary.status == SessionStatus.IDLE
     assert (
         summary.supports_reattach
@@ -4647,6 +4659,7 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
         effort: Any,
         permission_mode: Any,
         transport: Any,
+        account_profile_id: Any = None,
     ) -> SessionRecord:
         captured.update(
             backend=backend,
@@ -4654,6 +4667,7 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
             effort=effort,
             permission_mode=permission_mode,
             transport=transport,
+            account_profile_id=account_profile_id,
         )
         return _make_assistant_row(
             storage,
@@ -4680,6 +4694,7 @@ async def test_reset_assistant_rebuilds_thread_and_keeps_old(tmp_path) -> None:
         "effort": None,
         "permission_mode": None,
         "transport": None,
+        "account_profile_id": None,
     }
     old = storage.get_session("codex-old")
     assert old is not None
@@ -4705,7 +4720,12 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
         cwd=str(runtime._assistant_workspace_dir()),
     )
     storage.update_session(
-        "codex-live", model="gpt-5", effort="high", permission_mode="full-access"
+        "codex-live",
+        model="gpt-5",
+        effort="high",
+        permission_mode="full-access",
+        account_profile_id="work",
+        account_profile_label="Work",
     )
     runtime.assistant_session_id = "codex-live"
 
@@ -4723,6 +4743,7 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
         effort: Any,
         permission_mode: Any,
         transport: Any,
+        account_profile_id: Any = None,
     ) -> SessionRecord:
         captured.update(
             backend=backend,
@@ -4730,6 +4751,7 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
             effort=effort,
             permission_mode=permission_mode,
             transport=transport,
+            account_profile_id=account_profile_id,
         )
         return _make_assistant_row(
             storage,
@@ -4752,6 +4774,7 @@ async def test_reset_assistant_clear_context_inherits_live_config(tmp_path) -> N
         "effort": "high",
         "permission_mode": "full-access",
         "transport": "codex_app_server",
+        "account_profile_id": "work",
     }
 
 
@@ -4779,6 +4802,7 @@ async def test_reset_assistant_keeps_current_thread_when_create_fails(tmp_path) 
         effort: Any,
         permission_mode: Any,
         transport: Any,
+        account_profile_id: Any = None,
     ) -> SessionRecord:
         raise RuntimeError("spawn failed")
 
@@ -4792,6 +4816,96 @@ async def test_reset_assistant_keeps_current_thread_when_create_fails(tmp_path) 
     assert row is not None
     assert row.source == SessionSource.ASSISTANT
     assert row.status == SessionStatus.IDLE
+
+
+@pytest.mark.asyncio
+async def test_reset_assistant_explicit_profile_overrides_live_profile(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-live",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    storage.update_session(
+        "codex-live",
+        account_profile_id="personal",
+        account_profile_label="Personal",
+    )
+    runtime.assistant_session_id = "codex-live"
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(backend: str, **kwargs: Any) -> SessionRecord:
+        captured.update(backend=backend, **kwargs)
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="codex-new",
+            backend="codex",
+            status=SessionStatus.STARTING,
+            transport="codex_app_server",
+            cwd=str(runtime._assistant_workspace_dir()),
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime.reset_assistant(
+        account_profile_id="work",
+        account_profile_supplied=True,
+    )
+
+    assert captured["account_profile_id"] == "work"
+
+
+@pytest.mark.asyncio
+async def test_reset_assistant_explicit_default_does_not_inherit_profile(
+    tmp_path,
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    settings.assistant = AssistantConfig(backend="codex")
+    _make_assistant_row(
+        storage,
+        settings,
+        session_id="codex-live",
+        backend="codex",
+        status=SessionStatus.IDLE,
+        transport="codex_app_server",
+        cwd=str(runtime._assistant_workspace_dir()),
+    )
+    storage.update_session(
+        "codex-live",
+        account_profile_id="work",
+        account_profile_label="Work",
+    )
+    runtime.assistant_session_id = "codex-live"
+    captured: dict[str, Any] = {}
+
+    async def _fake_create(backend: str, **kwargs: Any) -> SessionRecord:
+        captured.update(backend=backend, **kwargs)
+        return _make_assistant_row(
+            storage,
+            settings,
+            session_id="codex-new",
+            backend="codex",
+            status=SessionStatus.STARTING,
+            transport="codex_app_server",
+            cwd=str(runtime._assistant_workspace_dir()),
+        )
+
+    runtime._create_assistant_session = _fake_create  # type: ignore[method-assign]
+
+    await runtime.reset_assistant(
+        account_profile_id=None,
+        account_profile_supplied=True,
+    )
+
+    assert captured["account_profile_id"] is None
 
 
 @pytest.mark.asyncio
@@ -4889,6 +5003,18 @@ async def test_attach_assistant_adopts_imported_thread(tmp_path, monkeypatch) ->
     # demotes the previous thread to a normal stopped session.
     runtime, storage, settings = make_runtime(tmp_path)
     settings.assistant = AssistantConfig(backend="codex")
+    settings.plugin_configs["codex"] = runtime.registry.get(
+        "codex"
+    ).config_schema.model_validate(
+        {
+            "account_profiles": {
+                "work": {
+                    "label": "Work",
+                    "config_dir": str(tmp_path / "codex-work"),
+                }
+            }
+        }
+    )
     _make_assistant_row(
         storage,
         settings,
@@ -4909,6 +5035,7 @@ async def test_attach_assistant_adopts_imported_thread(tmp_path, monkeypatch) ->
         rt: Any, request: Any, *, agent: str | None = None
     ) -> SessionRecord:
         assert request.thread_id == "thread-xyz"
+        assert request.account_profile_id == "work"
         assert agent == "codex"
         # import_thread persists a MANAGED session living in the thread's own cwd.
         session = make_session(
@@ -4923,7 +5050,11 @@ async def test_attach_assistant_adopts_imported_thread(tmp_path, monkeypatch) ->
 
     monkeypatch.setattr(runtime.registry.get("codex"), "import_thread", _fake_import)
 
-    summary = await runtime.attach_assistant(backend="codex", thread_id="thread-xyz")
+    summary = await runtime.attach_assistant(
+        backend="codex",
+        thread_id="thread-xyz",
+        account_profile_id="work",
+    )
 
     assert summary.session_id == "codex-imported"
     assert runtime.assistant_session_id == "codex-imported"

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -102,6 +102,7 @@ plugin_configs:
 # assistant:
 #   enabled: true
 #   backend: claude_code          # defaults to `default_backend`
+#   account_profile_id: work      # named config/account profile for first creation
 #   model: opus                   # must exist in the backend's catalogue
 #   effort: high                  # ignored by backends without an effort knob
 #   permission_mode: bypassPermissions  # backend default (usually prompts) if unset

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -114,6 +114,14 @@ directory first). So point profiles at a shared directory on fresh or empty
 config dirs. If the thread still isn't visible after linking, the switch is
 rejected before the session is touched.
 
+When Waypoint launches a **new** session under a `symlink_shared` profile, it
+performs that guarded missing-or-empty setup before the agent starts, so the new
+thread is written to the shared tree from its first event. This does not affect a
+Codex or Claude process launched outside Waypoint: its config-dir environment
+causes the agent itself to create a normal native-store directory. Run
+`accounts setup-transcripts` before using such a populated profile for a
+restart-and-resume switch.
+
 The tradeoff versus `copy_thread_on_switch`: one shared tree means the accounts
 have **no transcript isolation** — every profile sees every thread — whereas
 copying keeps independent trees and duplicates only the switched thread.

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -21,18 +21,21 @@ Add an `assistant` block to `waypoint.yaml` (see `backend/waypoint.example.yaml`
 assistant:
   enabled: true                       # omit the whole block to disable
   backend: claude_code                # defaults to `default_backend`
+  account_profile_id: work            # named account/config profile for first creation
   transport: claude_cli               # the agent's default interface if unset
   model: opus                         # must exist in the backend's catalogue
   effort: high                        # ignored by backends without an effort knob
   permission_mode: bypassPermissions  # see the security note below
 ```
 
-`backend`, `transport`, `model`, `effort`, and `permission_mode` seed the
-thread; they can be changed live from the assistant page, so treat them as
-defaults rather than a lockdown. `transport` must be one of the agent's
-supported interfaces; omitting it uses the agent's default (the Emulated
-chat interface for Claude Code). The block is enabled by default when present —
-set `enabled: false` to keep the config but turn the assistant off.
+`backend`, `account_profile_id`, `transport`, `model`, `effort`, and
+`permission_mode` seed the thread; they can be changed live from the assistant
+page, so treat them as defaults rather than a lockdown. The profile selects the
+backend's named config/account root and is validated like any other session
+launch. `transport` must be one of the agent's supported interfaces; omitting it
+uses the agent's default (the Emulated chat interface for Claude Code). The
+block is enabled by default when present — set `enabled: false` to keep the
+config but turn the assistant off.
 
 The assistant always runs in a managed working directory (`<data_dir>/assistant`),
 so it has no `cwd` setting. The runtime links repo-tracked assistant assets into
@@ -63,20 +66,20 @@ The **settings popover** (⚙, next to the composer) holds configuration. Changi
 the agent, the interface, or picking a thread there stages an inline confirm,
 since each replaces the conversation:
 
-- **Agent** — rebuild the assistant on a different coding agent. The
+- **Agent / Interface** — rebuild the assistant on a different coding agent or
+  interface. When the target agent hosts profiles, choose its **New conversation
+  account** for the replacement. The
   conversation cannot migrate between agents, so this starts a fresh thread at
   the new agent's default interface, model, effort, and permission mode.
-- **Interface** — rebuild the assistant over a different transport (Chat /
-  Emulated / Terminal, whatever the agent supports). The transport is fixed at
-  launch, so changing it also starts a fresh thread. Shown only when the agent
-  supports more than one interface; it defaults to the agent's default (Emulated
-  for Claude Code).
 - **Resume thread** — attach the assistant to an existing backend-native thread
-  (one discovered by the chosen agent's thread enumeration). The thread is
-  imported as-is over the agent's native interface: it resumes its own
+  (one discovered by the chosen agent and New conversation account). The thread
+  is imported as-is over the agent's native interface: it resumes its own
   conversation and working directory, so the assistant charter — which lives in
   the managed workspace — does **not** apply, and the **Interface** picker does
   not. Offered only for agents that support thread discovery and import.
+- **Account** — restart and resume the current assistant conversation under a
+  different named profile. This is the normal running-session account switch;
+  it keeps the same conversation rather than creating a replacement.
 - **Model / effort / permission mode** — applied live to the running thread; no
   context is lost.
 
@@ -84,7 +87,7 @@ The **overflow menu** (⋯) holds the standalone lifecycle actions, mirroring
 where ordinary sessions keep terminate/delete:
 
 - **Clear context** — start a fresh thread on the same agent and interface,
-  keeping the live model/effort/permission mode.
+  keeping the live model/effort/permission mode and account profile.
 - **Terminate / Reattach** — stop the thread (keeping it the pinned singleton)
   and later revive the same conversation. Reattach is offered only when the
   backend can resume after exit.

--- a/frontend/src/app/assistant/page.tsx
+++ b/frontend/src/app/assistant/page.tsx
@@ -161,23 +161,42 @@ export default function AssistantPage() {
     () => ({
       backends,
       supportsReattach: assistant?.supports_reattach ?? false,
-      onSwitchBackend: (backend: Backend, transport: SessionTransport) =>
-        applyControl(() => resetAssistant(host, token, { backend, transport })),
-      onAttachThread: (backend: Backend, threadId: string) =>
+      accountProfilesFor: (backend: Backend) => catalog.accountProfilesFor(backend),
+      onSwitchBackend: (
+        backend: Backend,
+        transport: SessionTransport,
+        accountProfileId: string | null,
+      ) =>
         applyControl(() =>
-          attachAssistant(host, token, { backend, thread_id: threadId }),
+          resetAssistant(host, token, {
+            backend,
+            transport,
+            account_profile_id: accountProfileId,
+          }),
+        ),
+      onAttachThread: (
+        backend: Backend,
+        threadId: string,
+        accountProfileId: string | null,
+      ) =>
+        applyControl(() =>
+          attachAssistant(host, token, {
+            backend,
+            thread_id: threadId,
+            account_profile_id: accountProfileId,
+          }),
         ),
       onClearContext: () => applyControl(() => resetAssistant(host, token, {})),
       onTerminate: () => applyControl(() => terminateAssistant(host, token)),
       onReattach: () => applyControl(() => reattachAssistant(host, token)),
-      listThreads: async (backend: Backend) => {
+      listThreads: async (backend: Backend, accountProfileId: string | null) => {
         try {
           const threads = await fetchBackendThreads<{
             id: string;
             title?: string | null;
             updated_at?: string | number | null;
             preview?: string | null;
-          }>(host, token, backend);
+          }>(host, token, backend, { accountProfileId });
           return threads.map((thread) => ({
             id: thread.id,
             title: thread.title || thread.id,
@@ -186,13 +205,14 @@ export default function AssistantPage() {
           }));
         } catch (err) {
           if (isAuthError(err)) handleAuthFailure();
-          return [];
+          throw err;
         }
       },
     }),
     [
       backends,
       assistant?.supports_reattach,
+      catalog,
       host,
       token,
       applyControl,

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -273,20 +273,29 @@ export interface AssistantThreadOption {
 // controls.
 export interface AssistantControls {
   backends: BackendDescriptor[];
+  accountProfilesFor: (backend: Backend) => AccountProfile[];
   supportsReattach: boolean;
   // Rebuild the assistant on the chosen agent and transport. Changing either
   // starts a fresh thread, since the transport is fixed at launch.
   onSwitchBackend: (
     backend: Backend,
     transport: SessionTransport,
+    accountProfileId: string | null,
   ) => Promise<void> | void;
-  onAttachThread: (backend: Backend, threadId: string) => Promise<void> | void;
+  onAttachThread: (
+    backend: Backend,
+    threadId: string,
+    accountProfileId: string | null,
+  ) => Promise<void> | void;
   onClearContext: () => Promise<void> | void;
   onTerminate: () => Promise<void> | void;
   onReattach: () => Promise<void> | void;
   // Lists importable threads for a backend (empty when discovery unsupported or
   // it fails); used to populate the "resume an existing thread" picker.
-  listThreads: (backend: Backend) => Promise<AssistantThreadOption[]>;
+  listThreads: (
+    backend: Backend,
+    accountProfileId: string | null,
+  ) => Promise<AssistantThreadOption[]>;
 }
 
 interface SessionDetailProps {
@@ -2560,6 +2569,11 @@ const ReplyComposer = memo(function ReplyComposer({
   // newly-picked agent's default once a different agent is staged).
   const [pendingTransport, setPendingTransport] =
     useState<SessionTransport | null>(null);
+  // Undefined means derive from the current assistant (or the default account
+  // for a staged backend change). Null is an explicit Default account choice.
+  const [pendingAssistantProfileId, setPendingAssistantProfileId] = useState<
+    string | null | undefined
+  >(undefined);
   const [selectedThreadId, setSelectedThreadId] = useState("");
   const [threadOptions, setThreadOptions] = useState<AssistantThreadOption[]>([]);
   // Pending effort for backends that need a session restart to apply (Claude)
@@ -2890,6 +2904,22 @@ const ReplyComposer = memo(function ReplyComposer({
     assistantOps !== null;
   // Backend the assistant controls target — the picked one, or the current.
   const assistantTargetBackend = pendingBackend ?? session?.backend ?? null;
+  const assistantTargetProfiles =
+    assistantOps && assistantTargetBackend
+      ? assistantOps.accountProfilesFor(assistantTargetBackend)
+      : [];
+  const assistantTargetProfileId =
+    pendingAssistantProfileId !== undefined
+      ? pendingAssistantProfileId
+      : pendingBackend
+        ? null
+        : (session?.account_profile_id ?? null);
+  const assistantTargetProfileLabel =
+    assistantTargetProfiles.find(
+      (profile) => profile.id === assistantTargetProfileId,
+    )?.label ?? "Default account";
+  const showAssistantTargetProfilePicker =
+    Boolean(assistantOps && session) && assistantTargetProfiles.length > 0;
   const assistantTargetCaps =
     assistantOps && assistantTargetBackend
       ? assistantOps.backends.find((b) => b.id === assistantTargetBackend)
@@ -2923,7 +2953,8 @@ const ReplyComposer = memo(function ReplyComposer({
       assistantTargetBackend &&
       assistantTargetTransport &&
       (assistantTargetBackend !== session.backend ||
-        assistantTargetTransport !== session.transport),
+        assistantTargetTransport !== session.transport ||
+        assistantTargetProfileId !== (session.account_profile_id ?? null)),
   );
   // Load resumable threads for the target backend when the popover is open.
   useEffect(() => {
@@ -2937,13 +2968,31 @@ const ReplyComposer = memo(function ReplyComposer({
       return;
     }
     let cancelled = false;
-    void assistantOps.listThreads(assistantTargetBackend).then((threads) => {
-      if (!cancelled) setThreadOptions(threads);
-    });
+    void assistantOps
+      .listThreads(assistantTargetBackend, assistantTargetProfileId)
+      .then((threads) => {
+        if (!cancelled) setThreadOptions(threads);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          onError(
+            error instanceof Error
+              ? error.message
+              : "Failed to load resumable threads",
+          );
+        }
+      });
     return () => {
       cancelled = true;
     };
-  }, [tuneOpen, assistantOps, assistantCanAttach, assistantTargetBackend]);
+  }, [
+    tuneOpen,
+    assistantOps,
+    assistantCanAttach,
+    assistantTargetBackend,
+    assistantTargetProfileId,
+    onError,
+  ]);
   const runAssistantAction = async (action: () => Promise<void> | void) => {
     if (assistantBusy) return;
     setAssistantBusy(true);
@@ -2955,6 +3004,7 @@ const ReplyComposer = memo(function ReplyComposer({
       setAssistantConfirm(null);
       setPendingBackend(null);
       setPendingTransport(null);
+      setPendingAssistantProfileId(undefined);
       setSelectedThreadId("");
     } catch (err) {
       onError(err instanceof Error ? err.message : "Action failed");
@@ -3068,10 +3118,12 @@ const ReplyComposer = memo(function ReplyComposer({
                         setPendingTransport(null);
                         if (next === session.backend) {
                           setPendingBackend(null);
+                          setPendingAssistantProfileId(undefined);
                           setAssistantConfirm(null);
                           return;
                         }
                         setPendingBackend(next);
+                        setPendingAssistantProfileId(null);
                         // Stage the confirm only once the new agent's default
                         // interface resolves; until the catalog loads it would
                         // be set but not renderable.
@@ -3088,6 +3140,28 @@ const ReplyComposer = memo(function ReplyComposer({
                       ))}
                     </select>
                   </label>
+                ) : null}
+                {showAssistantTargetProfilePicker ? (
+                  <AccountProfilePicker
+                    profiles={assistantTargetProfiles}
+                    value={assistantTargetProfileId ?? ""}
+                    onChange={(id) => {
+                      const nextProfileId = id || null;
+                      setSelectedThreadId("");
+                      setPendingAssistantProfileId(nextProfileId);
+                      setAssistantConfirm(
+                        assistantSwitchDiffers ||
+                          nextProfileId !== (session?.account_profile_id ?? null)
+                          ? "switch"
+                          : null,
+                      );
+                      onError("");
+                    }}
+                    disabled={assistantBusy}
+                    defaultLabel="Default account"
+                    label="New conversation account"
+                    fieldClassName="composer-tune-field"
+                  />
                 ) : null}
                 {assistantOps && session && assistantTransportOptions.length > 1 ? (
                   <label className="composer-tune-field">
@@ -3246,6 +3320,8 @@ const ReplyComposer = memo(function ReplyComposer({
                               catalog,
                             ).name
                           }
+                          {" · "}
+                          {assistantTargetProfileLabel}
                         </strong>
                         ? This starts a new conversation; the current one is kept
                         as a stopped session.
@@ -3257,6 +3333,7 @@ const ReplyComposer = memo(function ReplyComposer({
                           onClick={() => {
                             setPendingBackend(null);
                             setPendingTransport(null);
+                            setPendingAssistantProfileId(undefined);
                             setAssistantConfirm(null);
                             onError("");
                           }}
@@ -3272,6 +3349,7 @@ const ReplyComposer = memo(function ReplyComposer({
                               assistantOps.onSwitchBackend(
                                 assistantTargetBackend,
                                 assistantTargetTransport,
+                                assistantTargetProfileId,
                               ),
                             )
                           }
@@ -3320,6 +3398,7 @@ const ReplyComposer = memo(function ReplyComposer({
                               assistantOps.onAttachThread(
                                 assistantTargetBackend,
                                 selectedThreadId,
+                                assistantTargetProfileId,
                               ),
                             )
                           }

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -290,8 +290,8 @@ export interface AssistantControls {
   onClearContext: () => Promise<void> | void;
   onTerminate: () => Promise<void> | void;
   onReattach: () => Promise<void> | void;
-  // Lists importable threads for a backend (empty when discovery unsupported or
-  // it fails); used to populate the "resume an existing thread" picker.
+  // Lists importable threads for a backend; the caller surfaces discovery
+  // failures in the composer settings popover.
   listThreads: (
     backend: Backend,
     accountProfileId: string | null,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -294,6 +294,8 @@ export interface AssistantSummary {
   // UI label it and preselect it in the settings popover.
   transport: SessionTransport;
   native_thread_id: string | null;
+  account_profile_id: string | null;
+  account_profile_label: string | null;
   status: SessionStatus;
   // Whether the backend can revive the thread after it exits — drives the
   // choice between offering Reattach and only Clear context.
@@ -303,6 +305,7 @@ export interface AssistantSummary {
 export interface AssistantResetRequest {
   backend?: Backend;
   transport?: SessionTransport | null;
+  account_profile_id?: string | null;
   model?: string | null;
   effort?: string | null;
   permission_mode?: string | null;
@@ -312,6 +315,7 @@ export interface AssistantAttachRequest {
   backend: Backend;
   thread_id: string;
   launch_target_id?: string | null;
+  account_profile_id?: string | null;
 }
 
 export interface MeResponse {


### PR DESCRIPTION
## Purpose

Complete profile-aware Personal Assistant lifecycle behavior around the existing in-place running-session account switch: seed an assistant from a configured profile, retain it for Clear context, choose the profile for replacement conversations, and scope resumable-thread discovery and import to that profile. Addresses #230 for the Personal Assistant flow.

## Changes

- Add `assistant.account_profile_id` as a validated creation seed and expose the live assistant profile in its summary.
- Preserve the same-backend profile when clearing context, while allowing an explicit default-account or named-profile override.
- Thread the selected profile through assistant reset, thread discovery, and native-thread import.
- Add a separate **New conversation account** selector for assistant replacement and attach flows; retain the existing **Account** picker for the in-place restart-and-resume switch.
- Document configuration and lifecycle semantics, and add focused runtime coverage.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint`
- `cd frontend && npm exec --yes --package=node@20 -- node ./node_modules/next/dist/bin/next build`
- Restarted the stack with `waypointctl`; confirmed backend/frontend health and verified the deployed assistant summary endpoint returns the new profile fields.

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1728 passed, 3 pre-existing/unrelated warnings.
- Frontend lint and production build: passed (the host Node 18 is below Next 16's requirement, so the build used temporary Node 20.20.2).
- Stack E2E: backend and frontend healthy after restart; deployed assistant summary returned profile identity fields.
- Profile-specific live switching was not exercised because the existing assistant is an OpenCode session with no configured account profiles; runtime tests cover profile propagation, inheritance, default override, and profile-scoped import.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `AGENTS.md`.
- [x] My PR title is a Conventional Commit and all commits are signed off.
- [x] I have run the backend checks and full test suite.
- [x] I have added focused regression tests.
- [x] I have run frontend lint and a production build.
- [x] I have updated user-facing configuration and lifecycle documentation.
- [x] No plugin/transport contract or per-backend runtime/API dispatch was introduced.

</details>