### PR TITLE
fix: restart unpersisted Codex threads on profile switch

### DIFF
--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -106,6 +106,26 @@ class ConfigDirValidating(Protocol):
 
 
 @runtime_checkable
+class FreshThreadRestarting(Protocol):
+    """An agent that can replace an unpersisted native thread after a switch."""
+
+    async def restart_unpersisted_session(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        """Start a fresh native thread for an already-persisted session row."""
+        ...
+
+
+@runtime_checkable
+class DefaultConfigDirProviding(Protocol):
+    """An agent that knows its local config directory when no env override exists."""
+
+    def default_config_dir(self) -> str | None:
+        """Return the local default config directory, if the agent has one."""
+        ...
+
+
+@runtime_checkable
 class PaneSubmitConfirming(Protocol):
     """A plugin that can read its tmux-wrapped TUI's composer to drive input
     reliably, against two failure modes of a raw ``send-keys`` submit:

--- a/backend/src/waypoint/backends/codex/plugin.py
+++ b/backend/src/waypoint/backends/codex/plugin.py
@@ -526,6 +526,9 @@ class CodexPlugin(DefaultLaunchContract):
             ),
         )
 
+    def default_config_dir(self) -> str | None:
+        return "~/.codex"
+
     def native_thread_id(self, session: SessionRecord) -> str | None:
         thread_id = session.transport_state.get("thread_id")
         return thread_id if isinstance(thread_id, str) else None
@@ -1040,6 +1043,24 @@ class CodexPlugin(DefaultLaunchContract):
                 status=SessionStatus.ERROR,
             )
             return
+        launch_target = runtime._find_launch_target(session.launch_target_id)
+        if not await self.conversation_exists(
+            thread_id,
+            session.cwd,
+            launch_target,
+            config_dir=config_dir_for(self.capabilities, session.launch_env),
+        ):
+            if runtime._has_durable_conversation(session.id):
+                runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
+                await runtime._record_system_event(
+                    session.id,
+                    "Codex session restore failed: the native rollout is missing "
+                    "for a session with recorded conversation events",
+                    status=SessionStatus.ERROR,
+                )
+                return
+            await self.restart_unpersisted_session(runtime, session)
+            return
         effective_cli_args = self._effective_args(
             runtime, session.launch_target_id, session.args
         )
@@ -1093,6 +1114,77 @@ class CodexPlugin(DefaultLaunchContract):
         await runtime._record_system_event(
             session.id,
             self.format_restore_message(runtime, session.cwd, session.launch_target_id),
+            status=SessionStatus.IDLE,
+        )
+
+    async def restart_unpersisted_session(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> None:
+        """Start a new Codex thread after a safe unpersisted profile switch."""
+        if (
+            session.launch_target_id
+            and runtime._find_launch_target(session.launch_target_id) is None
+        ):
+            runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
+            await runtime._record_system_event(
+                session.id,
+                f"Codex session launch target {session.launch_target_id} is no longer configured",
+                status=SessionStatus.ERROR,
+            )
+            return
+        effective_cli_args = self._effective_args(
+            runtime, session.launch_target_id, session.args
+        )
+        effective_config_overrides = self._effective_config_overrides(
+            runtime, session.launch_target_id, session.config_overrides
+        )
+        process_env = runtime._agent_process_env(
+            self.id, session.launch_env, session_id=session.id
+        )
+        try:
+            thread_id = await self._require_adapter().start_session(
+                session.id,
+                session.cwd,
+                self.client_factory(
+                    runtime,
+                    session.launch_target_id,
+                    custom_args=effective_cli_args,
+                    custom_config_overrides=effective_config_overrides,
+                    launch_env=process_env,
+                ),
+                model=session.model,
+                effort=session.effort,
+                custom_args=effective_cli_args,
+                config_overrides=effective_config_overrides,
+                launch_env=process_env,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.exception(
+                "codex fresh-thread restart failed",
+                extra={"session_id": session.id, "cwd": session.cwd},
+            )
+            runtime.storage.update_session(session.id, status=SessionStatus.ERROR)
+            await runtime._record_system_event(
+                session.id,
+                f"Codex fresh-thread restart failed: {exc}",
+                status=SessionStatus.ERROR,
+            )
+            return
+        runtime.storage.update_session(
+            session.id,
+            transport_state={**session.transport_state, "thread_id": thread_id},
+            status=SessionStatus.IDLE,
+        )
+        await self._register_rate_limit_probe(
+            runtime,
+            session.id,
+            session.cwd,
+            runtime._find_launch_target(session.launch_target_id),
+        )
+        await runtime._record_system_event(
+            session.id,
+            "Codex started a fresh thread because the previous thread had no "
+            "persisted transcript",
             status=SessionStatus.IDLE,
         )
 

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -21,6 +21,7 @@ which the runtime maps to a 400 (nothing is terminated when it fires).
 import logging
 import shutil
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
@@ -41,6 +42,25 @@ _LOCAL_FS = LocalTranscriptFilesystem()
 
 class TranscriptUnavailableError(Exception):
     """The target profile cannot see the native thread and policy can't fix it."""
+
+
+class ThreadAvailability(StrEnum):
+    """Native-thread state prepared for a profile switch."""
+
+    PERSISTED = "persisted"
+    UNPERSISTED = "unpersisted"
+
+
+def unpersisted_thread_error(policy: TranscriptPolicy) -> TranscriptUnavailableError:
+    """Return the legacy availability error for a backend that cannot restart fresh."""
+    if policy == "copy_thread_on_switch":
+        return TranscriptUnavailableError(
+            "source native thread artifact not found to copy"
+        )
+    return TranscriptUnavailableError(
+        "native thread still unavailable in the target profile after "
+        f"applying transcript_policy {policy!r}"
+    )
 
 
 def ensure_symlink_shared(
@@ -204,13 +224,13 @@ def ensure_thread_available(
     plugin: "BackendPlugin",
     session: SessionRecord,
     *,
-    current_config_dir: str,
+    current_config_dir: str | None,
     target_config_dir: str,
     policy: TranscriptPolicy,
     shared_transcript_dir: str | None,
     native_thread_store: str | None,
     fs: TranscriptFilesystem = _LOCAL_FS,
-) -> None:
+) -> ThreadAvailability:
     """Make the session's native thread visible under ``target_config_dir``.
 
     No-op when it's already visible. Otherwise applies ``policy`` and re-checks;
@@ -220,13 +240,23 @@ def ensure_thread_available(
     """
     target = fs.expanduser(target_config_dir)
     if fs.glob_artifacts(session, plugin, target):
-        return
+        return ThreadAvailability.PERSISTED
 
     if policy == "require_existing":
         raise TranscriptUnavailableError(
             "the target account profile cannot see the native thread transcript "
             "and transcript_policy is 'require_existing'"
         )
+    if not current_config_dir:
+        if policy == "copy_thread_on_switch":
+            raise TranscriptUnavailableError(
+                "cannot determine the current config dir to copy the thread from"
+            )
+        raise TranscriptUnavailableError(
+            "cannot determine the current config dir to verify the native thread"
+        )
+    current = fs.expanduser(current_config_dir)
+    source_artifacts = fs.glob_artifacts(session, plugin, current)
     if policy == "symlink_shared":
         if not shared_transcript_dir:
             raise TranscriptUnavailableError(
@@ -242,18 +272,16 @@ def ensure_thread_available(
             fs=fs,
         )
     elif policy == "copy_thread_on_switch":
-        current = fs.expanduser(current_config_dir)
-        artifacts = fs.glob_artifacts(session, plugin, current)
-        if not artifacts:
-            raise TranscriptUnavailableError(
-                "source native thread artifact not found to copy"
-            )
-        copy_thread_artifacts(artifacts, current, target, fs=fs)
+        if source_artifacts:
+            copy_thread_artifacts(source_artifacts, current, target, fs=fs)
     else:  # pragma: no cover - exhaustive over TranscriptPolicy
         raise TranscriptUnavailableError(f"unknown transcript policy {policy!r}")
 
-    if not fs.glob_artifacts(session, plugin, target):
-        raise TranscriptUnavailableError(
-            "native thread still unavailable in the target profile after "
-            f"applying transcript_policy {policy!r}"
-        )
+    if fs.glob_artifacts(session, plugin, target):
+        return ThreadAvailability.PERSISTED
+    if source_artifacts == [] and policy in {
+        "symlink_shared",
+        "copy_thread_on_switch",
+    }:
+        return ThreadAvailability.UNPERSISTED
+    raise unpersisted_thread_error(policy)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -29,6 +29,8 @@ from waypoint.backends.account_profiles import (
 from waypoint.backends.base import (
     ConfigDirNotReadyError,
     ConfigDirValidating,
+    DefaultConfigDirProviding,
+    FreshThreadRestarting,
     config_dir_for,
 )
 from waypoint.backends.capabilities import BackendCapabilities
@@ -46,10 +48,12 @@ from waypoint.backends.transcript_fs import (
 )
 from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
 from waypoint.backends.transcripts import (
+    ThreadAvailability,
     TranscriptUnavailableError,
     ensure_symlink_shared,
     ensure_thread_available,
     setup_transcripts_symlink,
+    unpersisted_thread_error,
 )
 from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
@@ -2373,12 +2377,20 @@ class SessionRuntime:
         async with lock:
             return await self._update_launch_settings_locked(session_id, request)
 
+    def _has_durable_conversation(self, session_id: str) -> bool:
+        """Whether a fresh native thread could discard visible conversation context."""
+        return any(
+            event.kind in {EventKind.USER_INPUT, EventKind.AGENT_OUTPUT}
+            for event in self.storage.list_events(session_id)
+        )
+
     async def _update_launch_settings_locked(
         self, session_id: str, request: LaunchSettingsUpdateRequest
     ) -> SessionRecord:
         session = self.get_session(session_id)
         plugin = self.registry.plugin_for(session)
         caps = self.registry.capabilities_for(session)
+        fresh_thread_restarter: FreshThreadRestarting | None = None
         if session.status == SessionStatus.STARTING:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -2549,16 +2561,11 @@ class SessionRuntime:
                     current_config_dir = current_config_dir or os.environ.get(
                         config_dir_key
                     )
+                    if current_config_dir is None and isinstance(
+                        plugin, DefaultConfigDirProviding
+                    ):
+                        current_config_dir = plugin.default_config_dir()
                 target_config_dir = config_dir_for(caps, new_env)
-                if (
-                    profile.transcript_policy == "copy_thread_on_switch"
-                    and not current_config_dir
-                ):
-                    await self._broadcast_session_list()
-                    raise HTTPException(
-                        status_code=status.HTTP_400_BAD_REQUEST,
-                        detail="cannot determine the current config dir to copy the thread from",
-                    )
                 if target_config_dir:
                     fs: TranscriptFilesystem = (
                         LocalTranscriptFilesystem()
@@ -2570,11 +2577,11 @@ class SessionRuntime:
                         # (~8-15 round-trips), which would freeze the event
                         # loop for every other session; the local fs is fast
                         # but wrapping uniformly keeps one code path.
-                        await asyncio.to_thread(
+                        transcript_availability = await asyncio.to_thread(
                             ensure_thread_available,
                             plugin,
                             session,
-                            current_config_dir=current_config_dir or target_config_dir,
+                            current_config_dir=current_config_dir,
                             target_config_dir=target_config_dir,
                             policy=profile.transcript_policy,
                             shared_transcript_dir=profile.shared_transcript_dir,
@@ -2587,6 +2594,27 @@ class SessionRuntime:
                             status_code=status.HTTP_400_BAD_REQUEST,
                             detail=f"cannot switch account profile: {exc}",
                         ) from exc
+                    if transcript_availability == ThreadAvailability.UNPERSISTED:
+                        if self._has_durable_conversation(session.id):
+                            await self._broadcast_session_list()
+                            raise HTTPException(
+                                status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=(
+                                    "cannot switch account profile: the native thread "
+                                    "has no persisted transcript but this session has "
+                                    "conversation events, so starting fresh would lose context"
+                                ),
+                            )
+                        if not isinstance(plugin, FreshThreadRestarting):
+                            await self._broadcast_session_list()
+                            raise HTTPException(
+                                status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=(
+                                    "cannot switch account profile: "
+                                    f"{unpersisted_thread_error(profile.transcript_policy)}"
+                                ),
+                            )
+                        fresh_thread_restarter = plugin
 
         # Clearing the profile (set -> None) is not ``profile_changing``, but a
         # de-profiled session must not keep stale provenance, so null the
@@ -2624,7 +2652,13 @@ class SessionRuntime:
             account_profile_label=new_profile_label,
             **verified_account_fields,
         )
-        await plugin.restore_session(self, self.get_session(session.id))
+        restored_session = self.get_session(session.id)
+        if fresh_thread_restarter is not None:
+            await fresh_thread_restarter.restart_unpersisted_session(
+                self, restored_session
+            )
+        else:
+            await plugin.restore_session(self, restored_session)
         refreshed = self.get_session(session.id)
         if refreshed.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
             # Restore failed: keep the new settings on the record (per the RFC —

--- a/backend/tests/test_codex_plugin.py
+++ b/backend/tests/test_codex_plugin.py
@@ -17,12 +17,14 @@ from waypoint.backends.codex.usage_source import (
     find_codex_rollout,
 )
 from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
 
 
 def test_config_dir_for_resolves_from_launch_env(plugin: CodexPlugin) -> None:
     # The chokepoint every per-session on-disk op resolves the profile dir through.
     assert config_dir_for(plugin.capabilities, {"CODEX_HOME": "/x"}) == "/x"
     assert config_dir_for(plugin.capabilities, {}) is None
+    assert plugin.default_config_dir() == "~/.codex"
 
 
 def test_find_codex_rollout_honors_codex_home(
@@ -72,6 +74,173 @@ def test_resume_args_codex_prepends_resume_subcommand(plugin: CodexPlugin) -> No
 
 def test_pregenerate_thread_id_codex_returns_none(plugin: CodexPlugin) -> None:
     assert plugin.pregenerate_thread_id() is None
+
+
+@pytest.mark.asyncio
+async def test_restart_unpersisted_session_starts_new_thread(
+    plugin: CodexPlugin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="sess-1",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        transport="codex_app_server",
+        title="t",
+        cwd="/repo",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/raw",
+        structured_log_path="/structured",
+        transport_state={"thread_id": "old-thread"},
+        launch_env={"CODEX_HOME": "/target-home"},
+    )
+    updates: list[dict[str, Any]] = []
+    events: list[tuple[str, str, SessionStatus]] = []
+
+    class _Storage:
+        def update_session(self, _session_id: str, **fields: Any) -> None:
+            updates.append(fields)
+
+    class _Runtime:
+        storage = _Storage()
+
+        def _find_launch_target(self, _target_id: str | None) -> None:
+            return None
+
+        def _agent_process_env(
+            self, _backend: str, launch_env: dict[str, str], *, session_id: str
+        ) -> dict[str, str]:
+            assert session_id == "sess-1"
+            return launch_env
+
+        async def _record_system_event(
+            self, _session_id: str, text: str, *, status: SessionStatus
+        ) -> None:
+            events.append((_session_id, text, status))
+
+    adapter = MagicMock()
+    adapter.start_session = AsyncMock(return_value="new-thread")
+    plugin.adapter = adapter
+    monkeypatch.setattr(plugin, "client_factory", MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr(plugin, "_effective_args", lambda *_a: ["--arg"])
+    monkeypatch.setattr(plugin, "_effective_config_overrides", lambda *_a: ["x=1"])
+    monkeypatch.setattr(plugin, "_register_rate_limit_probe", AsyncMock())
+
+    await plugin.restart_unpersisted_session(_Runtime(), session)  # type: ignore[arg-type]
+
+    adapter.start_session.assert_awaited_once()
+    assert adapter.start_session.await_args.kwargs["launch_env"] == {
+        "CODEX_HOME": "/target-home"
+    }
+    assert updates == [
+        {
+            "transport_state": {"thread_id": "new-thread"},
+            "status": SessionStatus.IDLE,
+        }
+    ]
+    assert events == [
+        (
+            "sess-1",
+            "Codex started a fresh thread because the previous thread had no "
+            "persisted transcript",
+            SessionStatus.IDLE,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_restore_session_starts_fresh_thread_when_rollout_is_missing(
+    plugin: CodexPlugin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="sess-1",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        transport="codex_app_server",
+        title="t",
+        cwd="/repo",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/raw",
+        structured_log_path="/structured",
+        transport_state={"thread_id": "old-thread"},
+    )
+    runtime = MagicMock()
+    runtime._find_launch_target.return_value = None
+    runtime._has_durable_conversation.return_value = False
+    monkeypatch.setattr(plugin, "conversation_exists", AsyncMock(return_value=False))
+    fresh_start = AsyncMock()
+    monkeypatch.setattr(plugin, "restart_unpersisted_session", fresh_start)
+
+    await plugin.restore_session(runtime, session)
+
+    fresh_start.assert_awaited_once_with(runtime, session)
+
+
+@pytest.mark.asyncio
+async def test_restore_session_rejects_missing_rollout_with_conversation_events(
+    plugin: CodexPlugin, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="sess-1",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        transport="codex_app_server",
+        title="t",
+        cwd="/repo",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/raw",
+        structured_log_path="/structured",
+        transport_state={"thread_id": "old-thread"},
+    )
+    updates: list[dict[str, Any]] = []
+    events: list[tuple[str, str, SessionStatus]] = []
+
+    class _Storage:
+        def update_session(self, _session_id: str, **fields: Any) -> None:
+            updates.append(fields)
+
+    class _Runtime:
+        storage = _Storage()
+
+        def _find_launch_target(self, _target_id: str | None) -> None:
+            return None
+
+        def _has_durable_conversation(self, _session_id: str) -> bool:
+            return True
+
+        async def _record_system_event(
+            self, _session_id: str, text: str, *, status: SessionStatus
+        ) -> None:
+            events.append((_session_id, text, status))
+
+    runtime = _Runtime()
+    monkeypatch.setattr(plugin, "conversation_exists", AsyncMock(return_value=False))
+    fresh_start = AsyncMock()
+    monkeypatch.setattr(plugin, "restart_unpersisted_session", fresh_start)
+
+    await plugin.restore_session(runtime, session)  # type: ignore[arg-type]
+
+    fresh_start.assert_not_awaited()
+    assert updates == [{"status": SessionStatus.ERROR}]
+    assert events == [
+        (
+            "sess-1",
+            "Codex session restore failed: the native rollout is missing for a "
+            "session with recorded conversation events",
+            SessionStatus.ERROR,
+        )
+    ]
 
 
 def test_codex_rollout_uuid_regex(plugin: CodexPlugin) -> None:

--- a/backend/tests/test_launch_settings.py
+++ b/backend/tests/test_launch_settings.py
@@ -17,6 +17,8 @@ from waypoint.backends.account_profiles import probe_account
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     AccountProbeResult,
+    EventKind,
+    EventRecord,
     LaunchSettingsUpdateRequest,
     SessionRateLimitUsage,
     SessionRecord,
@@ -529,3 +531,206 @@ async def test_update_aborts_tmux_switch_before_terminate_when_transcript_unavai
     assert "cannot switch account profile" in str(getattr(exc.value, "detail", ""))
     assert terminate_calls == []
     assert runtime.get_session("s1").status != SessionStatus.EXITED
+
+
+async def test_update_starts_fresh_codex_thread_when_transcript_is_unpersisted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_dir = tmp_path / "codex-current"
+    target_dir = tmp_path / "codex-target"
+    profiles = {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": str(target_dir),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(tmp_path / "shared"),
+                "expected_account_key": "codex:work@co",
+            }
+        }
+    }
+    runtime = _runtime(tmp_path, codex=profiles)
+    pinned_at = datetime.now(UTC)
+    _session(
+        runtime,
+        source=SessionSource.ASSISTANT,
+        title="Personal Assistant",
+        pinned_at=pinned_at,
+        launch_env={"CODEX_HOME": str(current_dir)},
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+    seen: dict[str, Any] = {}
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        seen["terminated"] = True
+
+    async def fake_fresh_start(_runtime: Any, session: SessionRecord) -> None:
+        seen["fresh_status"] = session.status
+        seen["fresh_home"] = session.launch_env["CODEX_HOME"]
+        runtime.storage.update_session(
+            session.id,
+            transport_state={**session.transport_state, "thread_id": "new-thread"},
+            status=SessionStatus.IDLE,
+        )
+
+    async def fake_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="codex:work@co", account_label="work@co")
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restart_unpersisted_session", fake_fresh_start)
+    monkeypatch.setattr("waypoint.runtime.probe_account", fake_probe)
+
+    updated = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(account_profile_id="work", restart=True)
+    )
+
+    assert seen == {
+        "terminated": True,
+        "fresh_status": SessionStatus.EXITED,
+        "fresh_home": str(target_dir),
+    }
+    assert updated.id == "s1"
+    assert updated.transport_state["thread_id"] == "new-thread"
+    assert updated.account_profile_id == "work"
+    assert updated.source == SessionSource.ASSISTANT
+    assert updated.title == "Personal Assistant"
+    assert updated.pinned_at == pinned_at
+    assert (target_dir / "sessions").is_symlink()
+
+
+async def test_update_uses_codex_default_source_home_when_env_is_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "codex-target"
+    profiles = {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": str(target_dir),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(tmp_path / "shared"),
+                "expected_account_key": "codex:work@co",
+            }
+        }
+    }
+    runtime = _runtime(tmp_path, codex=profiles)
+    _session(runtime)
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+    seen: dict[str, str] = {}
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_fresh_start(_runtime: Any, session: SessionRecord) -> None:
+        seen["home"] = session.launch_env["CODEX_HOME"]
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    async def fake_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="codex:work@co", account_label="work@co")
+
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restart_unpersisted_session", fake_fresh_start)
+    monkeypatch.setattr("waypoint.runtime.probe_account", fake_probe)
+
+    updated = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(account_profile_id="work", restart=True)
+    )
+
+    assert seen["home"] == str(target_dir)
+    assert updated.account_profile_id == "work"
+
+
+async def test_update_rejects_unpersisted_hookless_switch_before_terminate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_dir = tmp_path / "codex-current"
+    target_dir = tmp_path / "codex-target"
+    profiles = {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": str(target_dir),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(tmp_path / "shared"),
+                "expected_account_key": "codex:work@co",
+            }
+        }
+    }
+    runtime = _runtime(tmp_path, codex=profiles)
+    _session(
+        runtime,
+        transport="tmux",
+        launch_env={"CODEX_HOME": str(current_dir)},
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+    terminated: list[bool] = []
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        terminated.append(True)
+
+    async def fake_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="codex:work@co", account_label="work@co")
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr("waypoint.runtime.probe_account", fake_probe)
+
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1", LaunchSettingsUpdateRequest(account_profile_id="work", restart=True)
+        )
+
+    assert getattr(exc.value, "status_code", None) == 400
+    assert terminated == []
+    unchanged = runtime.get_session("s1")
+    assert unchanged.status == SessionStatus.IDLE
+    assert unchanged.launch_env["CODEX_HOME"] == str(current_dir)
+
+
+async def test_update_rejects_unpersisted_thread_with_conversation_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    current_dir = tmp_path / "codex-current"
+    target_dir = tmp_path / "codex-target"
+    profiles = {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": str(target_dir),
+                "transcript_policy": "copy_thread_on_switch",
+                "expected_account_key": "codex:work@co",
+            }
+        }
+    }
+    runtime = _runtime(tmp_path, codex=profiles)
+    _session(runtime, launch_env={"CODEX_HOME": str(current_dir)})
+    runtime.storage.append_event(
+        EventRecord(
+            session_id="s1",
+            ts=datetime.now(UTC),
+            kind=EventKind.USER_INPUT,
+            text="hello",
+            metadata={"submit": True},
+            sequence=runtime.storage.next_sequence("s1"),
+        )
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+    terminated: list[bool] = []
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        terminated.append(True)
+
+    async def fake_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="codex:work@co", account_label="work@co")
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr("waypoint.runtime.probe_account", fake_probe)
+
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1", LaunchSettingsUpdateRequest(account_profile_id="work", restart=True)
+        )
+
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "conversation events" in str(getattr(exc.value, "detail", ""))
+    assert terminated == []

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1224,10 +1224,18 @@ async def test_get_command_completions_returns_cache_while_refreshing(
 
 
 @pytest.mark.asyncio
-async def test_handle_input_reattaches_exited_codex_session(tmp_path) -> None:
+async def test_handle_input_reattaches_exited_codex_session(
+    tmp_path, monkeypatch
+) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
     fake = FakeCodexRuntimeAdapter()
-    _codex_plugin(runtime).adapter = cast(Any, fake)
+    plugin = _codex_plugin(runtime)
+    plugin.adapter = cast(Any, fake)
+
+    async def native_thread_exists(*_a: Any, **_k: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(plugin, "conversation_exists", native_thread_exists)
     session = make_session(
         settings,
         status=SessionStatus.EXITED,
@@ -1255,12 +1263,18 @@ async def test_handle_input_reattaches_exited_codex_session(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_resume_reattaches_exited_session(tmp_path) -> None:
+async def test_resume_reattaches_exited_session(tmp_path, monkeypatch) -> None:
     # The "Resume" endpoint on a terminated session must relaunch it, not send
     # Enter to the dead pane (which raised a 500). Mirror handle_input's guard.
     runtime, storage, settings = make_runtime(tmp_path)
     fake = FakeCodexRuntimeAdapter()
-    _codex_plugin(runtime).adapter = cast(Any, fake)
+    plugin = _codex_plugin(runtime)
+    plugin.adapter = cast(Any, fake)
+
+    async def native_thread_exists(*_a: Any, **_k: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(plugin, "conversation_exists", native_thread_exists)
     session = make_session(
         settings,
         status=SessionStatus.EXITED,
@@ -1318,7 +1332,9 @@ async def test_handle_input_reattaches_errored_claude_session(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reattach_terminates_before_restoring_codex(tmp_path) -> None:
+async def test_reattach_terminates_before_restoring_codex(
+    tmp_path, monkeypatch
+) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
 
     # Order-tracking fake: a stale stream emitting ERROR leaves the adapter's
@@ -1360,7 +1376,13 @@ async def test_reattach_terminates_before_restoring_codex(tmp_path) -> None:
 
     timeline: list[str] = []
     fake = TimelineFake(timeline)
-    _codex_plugin(runtime).adapter = cast(Any, fake)
+    plugin = _codex_plugin(runtime)
+    plugin.adapter = cast(Any, fake)
+
+    async def native_thread_exists(*_a: Any, **_k: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(plugin, "conversation_exists", native_thread_exists)
     session = make_session(
         settings,
         status=SessionStatus.ERROR,

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -17,6 +17,7 @@ from waypoint.backends.bootstrap import build_default_registry
 from waypoint.backends.registry import reset_registry_for_tests
 from waypoint.backends.transcript_fs import LocalTranscriptFilesystem
 from waypoint.backends.transcripts import (
+    ThreadAvailability,
     TranscriptUnavailableError,
     ensure_symlink_shared,
     ensure_thread_available,
@@ -165,17 +166,17 @@ def test_copy_thread_on_switch_leaves_preexisting_dirs_untouched(
     assert oct((target / "sessions").stat().st_mode)[-3:] == "700"
 
 
-def test_copy_thread_on_switch_rejects_when_source_missing(tmp_path: Path) -> None:
-    with pytest.raises(TranscriptUnavailableError, match="not found to copy"):
-        ensure_thread_available(
-            _plugin("codex"),
-            _session("codex"),
-            current_config_dir=str(tmp_path / "current"),
-            target_config_dir=str(tmp_path / "target"),
-            policy="copy_thread_on_switch",
-            shared_transcript_dir=None,
-            native_thread_store="sessions",
-        )
+def test_copy_thread_on_switch_reports_unpersisted_source(tmp_path: Path) -> None:
+    result = ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(tmp_path / "target"),
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+    )
+    assert result == ThreadAvailability.UNPERSISTED
 
 
 # ── symlink_shared (guarded conversion) ─────────────────────────────────────
@@ -242,21 +243,53 @@ def test_symlink_shared_end_to_end_makes_thread_visible(tmp_path: Path) -> None:
     )
 
 
-def test_symlink_shared_rechecks_and_rejects_when_shared_lacks_thread(
+def test_symlink_shared_reports_unpersisted_when_shared_lacks_thread(
     tmp_path: Path,
 ) -> None:
-    # Shared dir is empty, so after symlinking the thread still isn't visible;
-    # the re-check turns that into a clear failure rather than a false success.
-    with pytest.raises(TranscriptUnavailableError, match="still unavailable"):
+    # An empty shared store means the source thread was never persisted. The
+    # runtime decides whether the agent can safely start a fresh native thread.
+    result = ensure_thread_available(
+        _plugin("claude_code"),
+        _session("claude_code"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(tmp_path / "target"),
+        policy="symlink_shared",
+        shared_transcript_dir=str(tmp_path / "shared"),
+        native_thread_store="projects",
+    )
+    assert result == ThreadAvailability.UNPERSISTED
+
+
+def test_symlink_shared_reports_unpersisted_source_after_setup(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    result = ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(target),
+        policy="symlink_shared",
+        shared_transcript_dir=str(tmp_path / "shared"),
+        native_thread_store="sessions",
+    )
+    assert result == ThreadAvailability.UNPERSISTED
+    assert (target / "sessions").is_symlink()
+
+
+def test_symlink_shared_rejects_unknown_source_before_target_setup(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target"
+    with pytest.raises(TranscriptUnavailableError, match="cannot determine"):
         ensure_thread_available(
-            _plugin("claude_code"),
-            _session("claude_code"),
-            current_config_dir=str(tmp_path / "current"),
-            target_config_dir=str(tmp_path / "target"),
+            _plugin("codex"),
+            _session("codex"),
+            current_config_dir=None,
+            target_config_dir=str(target),
             policy="symlink_shared",
             shared_transcript_dir=str(tmp_path / "shared"),
-            native_thread_store="projects",
+            native_thread_store="sessions",
         )
+    assert not (target / "sessions").exists()
 
 
 # ── setup_transcripts_symlink (accounts setup-transcripts) ──────────────────

--- a/backend/tests/test_transcripts_remote.py
+++ b/backend/tests/test_transcripts_remote.py
@@ -24,6 +24,7 @@ from waypoint.backends.base import BackendPlugin
 from waypoint.backends.bootstrap import build_default_registry
 from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
 from waypoint.backends.transcripts import (
+    ThreadAvailability,
     TranscriptUnavailableError,
     ensure_symlink_shared,
     ensure_thread_available,
@@ -264,22 +265,22 @@ def test_remote_copy_thread_on_switch_copies_codex_rollout(
     assert "glob" in op_names
 
 
-def test_remote_copy_thread_on_switch_rejects_when_source_missing(
+def test_remote_copy_thread_on_switch_reports_unpersisted_source(
     tmp_path: Path, fake_remote: _FakeRemote
 ) -> None:
     fs = RemoteTranscriptFilesystem(_launch_target())
-    with pytest.raises(TranscriptUnavailableError, match="not found to copy"):
-        ensure_thread_available(
-            _plugin("codex"),
-            _session("codex"),
-            current_config_dir=str(tmp_path / "current"),
-            target_config_dir=str(tmp_path / "target"),
-            policy="copy_thread_on_switch",
-            shared_transcript_dir=None,
-            native_thread_store="sessions",
-            fs=fs,
-        )
-    # Fail-before-destroy: no copy/mkdir attempted when the source can't be found.
+    result = ensure_thread_available(
+        _plugin("codex"),
+        _session("codex"),
+        current_config_dir=str(tmp_path / "current"),
+        target_config_dir=str(tmp_path / "target"),
+        policy="copy_thread_on_switch",
+        shared_transcript_dir=None,
+        native_thread_store="sessions",
+        fs=fs,
+    )
+    assert result == ThreadAvailability.UNPERSISTED
+    # No copy/mkdir is attempted when there is no source artifact.
     op_names = [name for name, _ in fake_remote.calls]
     assert "copy_file" not in op_names
     assert "mkdir" not in op_names
@@ -388,25 +389,25 @@ def test_remote_symlink_shared_tilde_dir_matches_existing_symlink(
     # symlink already pointing at the (absolute) shared dir, the idempotency
     # check must see them as equal — not raise the misleading "symlink to … not
     # the configured shared_transcript_dir". The thread isn't in shared here, so
-    # the flow still ends in the honest "still unavailable", proving the
-    # comparison passed rather than tripping the mismatch.
+    # the flow returns UNPERSISTED, proving the comparison passed rather than
+    # tripping the mismatch.
     monkeypatch.setenv("HOME", str(tmp_path))
     (tmp_path / "shared").mkdir()
     store = tmp_path / "target" / "projects"
     store.parent.mkdir(parents=True)
     store.symlink_to(tmp_path / "shared", target_is_directory=True)
     fs = RemoteTranscriptFilesystem(_launch_target())
-    with pytest.raises(TranscriptUnavailableError, match="still unavailable"):
-        ensure_thread_available(
-            _plugin("claude_code"),
-            _session("claude_code"),
-            current_config_dir="~/current",
-            target_config_dir=str(tmp_path / "target"),
-            policy="symlink_shared",
-            shared_transcript_dir="~/shared",
-            native_thread_store="projects",
-            fs=fs,
-        )
+    result = ensure_thread_available(
+        _plugin("claude_code"),
+        _session("claude_code"),
+        current_config_dir="~/current",
+        target_config_dir=str(tmp_path / "target"),
+        policy="symlink_shared",
+        shared_transcript_dir="~/shared",
+        native_thread_store="projects",
+        fs=fs,
+    )
+    assert result == ThreadAvailability.UNPERSISTED
 
 
 def test_remote_script_ops_expand_tilde_against_the_running_host() -> None:

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -240,7 +240,13 @@ The switch is **restart-and-resume**: Waypoint verifies the target account,
 flushes any running turn, makes the thread available under the target config dir
 per the transcript policy, terminates the session, persists the new profile, and
 restores it — resuming the *same* thread under the new `CLAUDE_CONFIG_DIR` /
-`CODEX_HOME`.
+`CODEX_HOME`. A fresh Codex thread has an ID before it has a native rollout
+file. With `symlink_shared` or `copy_thread_on_switch`, Waypoint may safely
+start a replacement thread under the selected profile only when it has no
+persisted native artifact and Waypoint has no user or agent conversation events.
+It preserves the Waypoint session and assistant identity, but the native thread
+starts fresh. A missing artifact after conversation events, or under
+`require_existing`, remains a pre-restart error.
 
 - Eligibility is derived from the session's **composed `(agent, transport)`
   pair**, not from whichever plugin happens to own the transport: the agent

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3078,8 +3078,9 @@ const ReplyComposer = memo(function ReplyComposer({
                           Restart this session with{" "}
                           <strong>{pendingProfileLabel}</strong>? The current
                           turn is interrupted, the backend process restarts, and
-                          the session resumes from the selected profile&apos;s
-                          config and transcript store.
+                          the session resumes from the selected profile&apos;s config
+                          and transcript store. For Codex, a thread with no
+                          persisted transcript starts fresh.
                         </p>
                         <div className="composer-tune-confirm-actions">
                           <button


### PR DESCRIPTION
## Summary
- distinguish persisted and unpersisted native threads during account-profile switching
- start a fresh Codex thread only when no durable conversation events exist; preserve the Waypoint session and assistant identity
- recover unpersisted Codex sessions cleanly after backend restart while retaining fail-loud behavior for sessions with conversation events
- resolve the default Codex source home as ~/.codex when no CODEX_HOME override is persisted

## Verification
- uv run pytest -q
- uv run pre-commit run --all-files
- npm run lint
- Node 20 Next production build
- E2E: launched disposable codex-e6139261 via authenticated waypoint CLI; sessions set-account codex-e6139261 nus succeeded with a new thread ID and fresh-thread system note; backend restart recovered it with another fresh thread and no resume failure. The disposable session was deleted afterward.

Closes #230