### PR TITLE
feat: recursively merge populated transcript stores on setup-transcripts

### DIFF
--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -133,17 +133,18 @@ def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
 
     The sequence is data-safe against loss: (1) a recursive pre-flight builds the
     full plan and refuses before touching anything if any leaf genuinely
-    conflicts; (2) new files/links are copied into a temp staging sibling of
-    ``shared`` and verified against their source; (3) each staged entry is
-    renamed into ``shared`` (re-checking the destination is still absent first);
-    (4) the original ``store`` is renamed to a timestamped backup (a complete
-    snapshot, not an emptied husk); (5) ``store`` becomes the symlink. The
-    original ``store`` is never touched until every entry is safely in ``shared``,
-    so no transcript is lost. The per-entry rename in step 3 is not a single
-    atomic commit, so a process death partway through can leave some entries
-    already under ``shared``; a re-run then reports only those new destinations as
-    conflicts (identical leaves dedup cleanly) and the operator finishes the move
-    by hand — the original data is still intact in ``store``.
+    conflicts; (2) new files and links are copied into a temp staging sibling of
+    ``shared`` and every staged file is verified byte-for-byte against its source;
+    (3) each staged entry is renamed into ``shared`` (re-checking the destination
+    is still absent first); (4) the original ``store`` is renamed to a timestamped
+    backup (a complete snapshot, not an emptied husk); (5) ``store`` becomes the
+    symlink. The original ``store`` is never touched until every entry is safely in
+    ``shared``, so no transcript is lost. The per-entry rename in step 3 is not a
+    single atomic commit, so a process death partway through can leave some
+    entries already under ``shared``; because those are byte-identical copies of
+    the still-intact source, simply re-running resumes cleanly — the already-moved
+    leaves deduplicate and the rest copy in. The retained ``.wp-migrate-*`` staging
+    dir from the interrupted run is then orphaned and safe to delete.
     """
     shared_dir = shared_dir.expanduser()
     if store_dir.is_symlink() and store_dir.resolve() == shared_dir.resolve():

--- a/backend/src/waypoint/backends/transcripts.py
+++ b/backend/src/waypoint/backends/transcripts.py
@@ -18,8 +18,11 @@ the same policy code unchanged. Raises :class:`TranscriptUnavailableError`,
 which the runtime maps to a 400 (nothing is terminated when it fires).
 """
 
+import filecmp
 import logging
+import os
 import shutil
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path, PurePosixPath
@@ -104,13 +107,6 @@ def ensure_symlink_shared(
     fs.symlink(store, shared)
 
 
-def _pin_tree_perms(root: Path) -> None:
-    """Lock a copied transcript tree to 0700 dirs / 0600 files."""
-    root.chmod(0o700)
-    for path in root.rglob("*"):
-        path.chmod(0o700 if path.is_dir() else 0o600)
-
-
 def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
     """Make ``store_dir`` a symlink to ``shared_dir``, migrating existing content.
 
@@ -119,27 +115,35 @@ def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
     its contents into the shared dir before replacing it with the symlink. The
     other five cases delegate to :func:`ensure_symlink_shared`. Returns a list of
     the actions taken (for reporting); raises :class:`TranscriptUnavailableError`
-    on a same-named conflict or a symlink pointing elsewhere.
+    on a genuine leaf conflict or a symlink pointing elsewhere.
 
     This is the local-only migration CLI (``waypoint accounts
     setup-transcripts``), not part of the account-profile switch flow that
     goes remote — its data-safe migration (staged copy, atomic rename,
     timestamped backup) has no remote counterpart in scope, so it stays on
-    ``pathlib``/``shutil`` directly rather than the ``TranscriptFilesystem``
-    seam.
+    ``pathlib``/``os``/``shutil`` directly rather than the
+    ``TranscriptFilesystem`` seam.
 
-    For the populated case the sequence is data-safe against loss: (1) a conflict
-    pre-flight refuses before touching anything if any top-level entry already
-    exists under ``shared``; (2) contents are copied into a temp sibling of
-    ``shared`` (removed afterward) and then renamed into place, so a mid-copy
-    failure leaves both ``store`` and ``shared`` intact; (3) the original
-    ``store`` is renamed to a timestamped backup (a complete snapshot, not an
-    emptied husk); (4) ``store`` becomes the symlink. The original ``store`` is
-    never touched until every entry is safely in ``shared``, so no transcript is
-    lost. The per-entry rename in step 2 is not a single atomic commit, so a
-    process death partway through can leave some entries already under ``shared``;
-    a re-run then reports those as conflicts and the operator finishes the move by
-    hand — the original data is still intact in ``store``.
+    For the populated case the merge is *recursive and conflict-aware*: two
+    stores may share directory ancestors (the common Codex ``sessions/YYYY/...``
+    and Claude ``projects/<project>/...`` layouts) as long as their leaf files do
+    not truly collide. A byte-identical leaf at the same relative path is
+    deduplicated (the shared copy is retained); only a differing file, a
+    file/directory type mismatch, or a diverging symlink target is a conflict.
+
+    The sequence is data-safe against loss: (1) a recursive pre-flight builds the
+    full plan and refuses before touching anything if any leaf genuinely
+    conflicts; (2) new files/links are copied into a temp staging sibling of
+    ``shared`` and verified against their source; (3) each staged entry is
+    renamed into ``shared`` (re-checking the destination is still absent first);
+    (4) the original ``store`` is renamed to a timestamped backup (a complete
+    snapshot, not an emptied husk); (5) ``store`` becomes the symlink. The
+    original ``store`` is never touched until every entry is safely in ``shared``,
+    so no transcript is lost. The per-entry rename in step 3 is not a single
+    atomic commit, so a process death partway through can leave some entries
+    already under ``shared``; a re-run then reports only those new destinations as
+    conflicts (identical leaves dedup cleanly) and the operator finishes the move
+    by hand — the original data is still intact in ``store``.
     """
     shared_dir = shared_dir.expanduser()
     if store_dir.is_symlink() and store_dir.resolve() == shared_dir.resolve():
@@ -150,40 +154,188 @@ def setup_transcripts_symlink(store_dir: Path, shared_dir: Path) -> list[str]:
     return [f"linked {store_dir} -> {shared_dir}"]
 
 
+_MAX_REPORTED_CONFLICTS = 10
+
+
+@dataclass
+class _MigrationPlan:
+    """A recursive merge plan keyed by relative path (paths only, no contents)."""
+
+    dirs_to_create: list[PurePosixPath] = field(default_factory=list)
+    files_to_copy: list[PurePosixPath] = field(default_factory=list)
+    symlinks_to_create: list[tuple[PurePosixPath, str]] = field(default_factory=list)
+    dedup_count: int = 0
+    conflicts: list[tuple[PurePosixPath, str]] = field(default_factory=list)
+
+
+def _classify_into_plan(
+    src: Path, dst: Path, rel: PurePosixPath, plan: _MigrationPlan
+) -> None:
+    """Classify one source entry against its shared-store counterpart.
+
+    Never follows symlinks (uses ``lstat``/``lexists`` semantics): a symlink is a
+    leaf regardless of its target's type, and a broken destination symlink counts
+    as present, not absent. Recurses into merged directories.
+    """
+    dst_absent = not os.path.lexists(dst)
+    if src.is_symlink():
+        target = os.readlink(src)
+        if dst_absent:
+            plan.symlinks_to_create.append((rel, target))
+        elif dst.is_symlink() and os.readlink(dst) == target:
+            plan.dedup_count += 1
+        elif dst.is_symlink():
+            plan.conflicts.append((rel, "different symlink targets"))
+        else:
+            kind = "directory" if dst.is_dir() else "file"
+            plan.conflicts.append((rel, f"source symlink, shared {kind}"))
+        return
+    if src.is_dir():
+        if dst_absent:
+            plan.dirs_to_create.append(rel)
+            _walk_into_plan(src, dst, rel, plan)
+        elif dst.is_dir() and not dst.is_symlink():
+            _walk_into_plan(src, dst, rel, plan)
+        else:
+            kind = "symlink" if dst.is_symlink() else "file"
+            plan.conflicts.append((rel, f"source directory, shared {kind}"))
+        return
+    if src.is_file():
+        if dst_absent:
+            plan.files_to_copy.append(rel)
+        elif dst.is_symlink():
+            plan.conflicts.append((rel, "source file, shared symlink"))
+        elif dst.is_dir():
+            plan.conflicts.append((rel, "source file, shared directory"))
+        elif filecmp.cmp(src, dst, shallow=False):
+            plan.dedup_count += 1
+        else:
+            plan.conflicts.append((rel, "different regular files"))
+        return
+    plan.conflicts.append((rel, "unsupported entry type"))
+
+
+def _walk_into_plan(
+    src_dir: Path, dst_dir: Path, rel_dir: PurePosixPath, plan: _MigrationPlan
+) -> None:
+    for entry in sorted(os.scandir(src_dir), key=lambda e: e.name):
+        rel = rel_dir / entry.name
+        _classify_into_plan(Path(entry.path), dst_dir / entry.name, rel, plan)
+
+
+def _build_migration_plan(store_dir: Path, shared_dir: Path) -> _MigrationPlan:
+    plan = _MigrationPlan()
+    _walk_into_plan(store_dir, shared_dir, PurePosixPath(), plan)
+    return plan
+
+
+def _conflict_error(
+    store_dir: Path, shared_dir: Path, conflicts: list[tuple[PurePosixPath, str]]
+) -> TranscriptUnavailableError:
+    ordered = sorted(conflicts)
+    lines = [f"{rel} ({reason})" for rel, reason in ordered[:_MAX_REPORTED_CONFLICTS]]
+    extra = len(ordered) - len(lines)
+    if extra > 0:
+        lines.append(f"... and {extra} more")
+    detail = "\n".join(lines)
+    return TranscriptUnavailableError(
+        f"cannot migrate {store_dir} into {shared_dir}: "
+        f"{len(ordered)} conflicting paths:\n{detail}"
+    )
+
+
+def _mkdir_pinned(path: Path) -> None:
+    """Create ``path`` and any missing ancestors, pinning each level to 0700.
+
+    ``os.makedirs(mode=...)`` applies the mode only to the leaf (and umask-masks
+    it), so intermediate levels would land at 0755 — pin each level explicitly.
+    """
+    if path.exists():
+        return
+    _mkdir_pinned(path.parent)
+    path.mkdir()
+    path.chmod(0o700)
+
+
 def _migrate_populated_store(store_dir: Path, shared_dir: Path) -> list[str]:
     shared_dir.mkdir(parents=True, exist_ok=True)
     shared_dir.chmod(0o700)
 
-    entries = sorted(store_dir.iterdir(), key=lambda p: p.name)
-    conflicts = [e.name for e in entries if (shared_dir / e.name).exists()]
-    if conflicts:
-        raise TranscriptUnavailableError(
-            f"cannot migrate {store_dir} into {shared_dir}: these entries already "
-            f"exist in the shared dir: {', '.join(sorted(conflicts))}"
-        )
+    plan = _build_migration_plan(store_dir, shared_dir)
+    if plan.conflicts:
+        raise _conflict_error(store_dir, shared_dir, plan.conflicts)
 
-    # Copy into a temp sibling first, then rename each entry into place, so a
-    # failed copy never leaves partial entries under the shared dir. The staging
-    # dir is removed on any failure so a re-run isn't blocked by an orphan.
+    # Stage new files/links in a temp sibling of ``shared`` and verify them
+    # against their source before touching ``shared`` — a failure here leaves both
+    # stores intact and the staging dir is cleaned up. ``merge_started`` flips once
+    # the mutation phase begins: a failure from then on retains the staging dir for
+    # recovery diagnosis (``shared`` may be partially populated).
     staging = shared_dir.parent / f".wp-migrate-{_timestamp()}"
     if staging.exists():
         raise TranscriptUnavailableError(f"migration staging dir {staging} exists")
+    _mkdir_pinned(staging)
+    merge_started = False
     try:
-        shutil.copytree(store_dir, staging, symlinks=True)
-        _pin_tree_perms(staging)
-        for entry in sorted(staging.iterdir(), key=lambda p: p.name):
-            entry.rename(shared_dir / entry.name)
-    finally:
-        shutil.rmtree(staging, ignore_errors=True)
+        for rel in plan.dirs_to_create:
+            _mkdir_pinned(staging / rel)
+        for rel in plan.files_to_copy:
+            dest = staging / rel
+            _mkdir_pinned(dest.parent)
+            shutil.copyfile(store_dir / rel, dest)
+            dest.chmod(0o600)
+        for rel, target in plan.symlinks_to_create:
+            dest = staging / rel
+            _mkdir_pinned(dest.parent)
+            os.symlink(target, dest)
+
+        for rel in plan.files_to_copy:
+            if not filecmp.cmp(store_dir / rel, staging / rel, shallow=False):
+                raise TranscriptUnavailableError(
+                    f"staged copy of {rel} did not match its source; aborting"
+                )
+
+        merge_started = True
+        _merge_staged_into_shared(plan, staging, shared_dir)
+    except Exception:
+        if not merge_started:
+            shutil.rmtree(staging, ignore_errors=True)
+        raise
+    shutil.rmtree(staging, ignore_errors=True)
 
     backup = store_dir.parent / f"{store_dir.name}.bak-{_timestamp()}"
     store_dir.rename(backup)
     store_dir.symlink_to(shared_dir, target_is_directory=True)
+
+    copied = len(plan.files_to_copy) + len(plan.symlinks_to_create)
     return [
-        f"migrated {len(entries)} entries from {store_dir} into {shared_dir}",
+        f"migrated {copied} files ({plan.dedup_count} deduplicated, "
+        f"{len(plan.dirs_to_create)} dirs created) from {store_dir} into "
+        f"{shared_dir}",
         f"backed up the original dir to {backup}",
         f"linked {store_dir} -> {shared_dir}",
     ]
+
+
+def _merge_staged_into_shared(
+    plan: _MigrationPlan, staging: Path, shared_dir: Path
+) -> None:
+    """Rename staged entries into ``shared`` in sorted relative-path order.
+
+    Each destination was proven absent during preflight; re-check with ``lexists``
+    before every rename to catch a concurrent change and abort loudly rather than
+    overwrite.
+    """
+    for rel in sorted(plan.dirs_to_create):
+        _mkdir_pinned(shared_dir / rel)
+    moves = plan.files_to_copy + [rel for rel, _ in plan.symlinks_to_create]
+    for rel in sorted(moves):
+        dest = shared_dir / rel
+        if os.path.lexists(dest):
+            raise TranscriptUnavailableError(
+                f"destination {rel} appeared during migration; aborting before "
+                f"overwrite (staged copies are in {staging})"
+            )
+        (staging / rel).rename(dest)
 
 
 def _timestamp() -> str:

--- a/backend/tests/test_account_doctor.py
+++ b/backend/tests/test_account_doctor.py
@@ -415,6 +415,54 @@ async def test_setup_transcripts_endpoint_migrates(
     assert (shared / "p" / "t.jsonl").read_text() == "thread"
 
 
+@pytest.mark.asyncio
+async def test_setup_transcripts_endpoint_recursive_merge(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A populated shared dir that shares the project-dir ancestor with the store
+    # but no leaf transcript: the recursive merge must succeed and the profile
+    # must report ready afterwards.
+    cfg = _onboarded_claude_dir(tmp_path / "work")
+    (cfg / "projects" / "shared-proj").mkdir(parents=True)
+    (cfg / "projects" / "shared-proj" / "a.jsonl").write_text("from-store")
+    shared = tmp_path / "shared"
+    (shared / "shared-proj").mkdir(parents=True)
+    (shared / "shared-proj" / "b.jsonl").write_text("already-shared")
+    settings = _settings(
+        tmp_path,
+        {
+            "work": {
+                "label": "Work",
+                "config_dir": str(cfg),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(shared),
+            }
+        },
+    )
+    app = create_app(settings)
+    headers = {"Authorization": f"Bearer {app.state.context.tokens.issue().token}"}
+
+    resp = await _post(
+        app, "/api/backends/claude_code/accounts/work/setup-transcripts", headers, {}
+    )
+    assert resp.status_code == 200
+    actions = resp.json()["actions"]
+    assert any("migrated 1 files" in a for a in actions)
+    assert any("backed up" in a for a in actions)
+    # Both leaves are visible through the merged symlink.
+    assert (cfg / "projects").is_symlink()
+    assert (shared / "shared-proj" / "a.jsonl").read_text() == "from-store"
+    assert (shared / "shared-proj" / "b.jsonl").read_text() == "already-shared"
+
+    async def fake_probe(*args: Any, **kwargs: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="claude_code:acme", account_label="Acme")
+
+    monkeypatch.setattr(runtime_module, "probe_account", fake_probe)
+    doctor = await _get(app, "/api/backends/claude_code/accounts/doctor", headers)
+    checks = {c["name"]: c for c in doctor.json()[0]["checks"]}
+    assert checks["transcript_setup"]["ok"] is True
+
+
 # ── CLI verbs ───────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -561,6 +561,50 @@ def test_setup_mid_merge_failure_retains_staging(
     assert len(list(staging[0].glob("f*.jsonl"))) >= 1
 
 
+def test_setup_rerun_after_mid_merge_completes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from waypoint.backends import transcripts as tr
+
+    store = tmp_path / "config" / "sessions"
+    store.mkdir(parents=True)
+    for i in range(3):
+        (store / f"f{i}.jsonl").write_text(f"x{i}")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    # Unique timestamps so the failed run's staging and the re-run's staging/backup
+    # don't collide on a same-second name.
+    stamps = iter(f"ts{n}" for n in range(10))
+    monkeypatch.setattr(tr, "_timestamp", lambda: next(stamps))
+
+    real_rename = Path.rename
+    state = {"fail": True, "n": 0}
+
+    def flaky_rename(self: Path, target: Any) -> Any:
+        if state["fail"] and ".wp-migrate-" in str(self):
+            state["n"] += 1
+            if state["n"] == 2:
+                raise OSError("simulated mid-merge failure")
+        return real_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", flaky_rename)
+    with pytest.raises(OSError, match="simulated mid-merge failure"):
+        setup_transcripts_symlink(store, shared)
+    assert store.is_dir() and not store.is_symlink()
+    assert len(list(shared.glob("f*.jsonl"))) == 1  # one leaf already moved
+
+    # Operator simply re-runs: the already-moved leaf deduplicates, the rest copy.
+    state["fail"] = False
+    actions = setup_transcripts_symlink(store, shared)
+
+    assert store.is_symlink()
+    for i in range(3):
+        assert (store / f"f{i}.jsonl").read_text() == f"x{i}"
+    assert any("migrated 2 files (1 deduplicated" in a for a in actions)
+    assert any(p.name.startswith("sessions.bak-") for p in store.parent.iterdir())
+
+
 # ── native_thread_artifact_glob (discovery-pattern contract) ───────────────
 
 

--- a/backend/tests/test_transcripts.py
+++ b/backend/tests/test_transcripts.py
@@ -6,6 +6,7 @@ plugins with temporary config dirs, through the TranscriptFilesystem seam
 (local by default; a recording fake proves the policy code is IO-agnostic).
 """
 
+import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -356,19 +357,208 @@ def test_setup_migrates_populated_dir_with_backup(tmp_path: Path) -> None:
 
 
 def test_setup_refuses_conflict_and_does_not_mutate(tmp_path: Path) -> None:
+    # A shared directory ancestor (dup/) is fine to share; only the differing
+    # leaf transcript is a genuine conflict.
     store = tmp_path / "config" / "projects"
     (store / "dup").mkdir(parents=True)
     (store / "dup" / "f.jsonl").write_text("orig")
     shared = tmp_path / "shared"
     (shared / "dup").mkdir(parents=True)
+    (shared / "dup" / "f.jsonl").write_text("different")
 
-    with pytest.raises(TranscriptUnavailableError, match="dup"):
+    with pytest.raises(
+        TranscriptUnavailableError, match=r"dup/f\.jsonl \(different regular files\)"
+    ):
         setup_transcripts_symlink(store, shared)
 
     # Nothing moved: store is still the original real dir, no symlink, no backup.
     assert store.is_dir() and not store.is_symlink()
     assert (store / "dup" / "f.jsonl").read_text() == "orig"
+    assert (shared / "dup" / "f.jsonl").read_text() == "different"
     assert not any(p.name.startswith("projects.bak-") for p in store.parent.iterdir())
+
+
+def test_setup_merges_codex_date_trees(tmp_path: Path) -> None:
+    # Both stores hold sessions/2026/... but their leaf rollouts differ — the
+    # old top-level "2026" collision must no longer block the merge.
+    store = tmp_path / "config" / "sessions"
+    (store / "2026" / "07" / "10").mkdir(parents=True)
+    (store / "2026" / "07" / "10" / "rollout-A.jsonl").write_text("thread-a")
+    shared = tmp_path / "shared"
+    (shared / "2026" / "01" / "01").mkdir(parents=True)
+    (shared / "2026" / "01" / "01" / "rollout-B.jsonl").write_text("thread-b")
+
+    actions = setup_transcripts_symlink(store, shared)
+
+    assert store.is_symlink()
+    assert (store / "2026" / "07" / "10" / "rollout-A.jsonl").read_text() == "thread-a"
+    assert (store / "2026" / "01" / "01" / "rollout-B.jsonl").read_text() == "thread-b"
+    # A deep intermediate directory created by the merge is pinned 0700, not just
+    # the direct child — guards the os.makedirs mode-only-on-leaf trap.
+    assert (shared / "2026" / "07").stat().st_mode & 0o777 == 0o700
+    assert (shared / "2026" / "07" / "10").stat().st_mode & 0o777 == 0o700
+    assert (
+        shared / "2026" / "07" / "10" / "rollout-A.jsonl"
+    ).stat().st_mode & 0o777 == 0o600
+    backups = [p for p in store.parent.iterdir() if p.name.startswith("sessions.bak-")]
+    assert len(backups) == 1
+    assert any("migrated 1 files" in a for a in actions)
+    assert any("0 deduplicated" in a for a in actions)
+
+
+def test_setup_merges_claude_project_trees(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "projects"
+    (store / "proj-a").mkdir(parents=True)
+    (store / "proj-a" / f"{TID}.jsonl").write_text("a")
+    shared = tmp_path / "shared"
+    (shared / "proj-b").mkdir(parents=True)
+    (shared / "proj-b" / "other.jsonl").write_text("b")
+
+    setup_transcripts_symlink(store, shared)
+
+    assert store.is_symlink()
+    assert sorted(p.name for p in shared.iterdir()) == ["proj-a", "proj-b"]
+    assert (shared / "proj-a" / f"{TID}.jsonl").read_text() == "a"
+
+
+def test_setup_deduplicates_identical_leaf(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "sessions"
+    (store / "d").mkdir(parents=True)
+    (store / "d" / "same.jsonl").write_text("identical")
+    (store / "d" / "new.jsonl").write_text("fresh")
+    shared = tmp_path / "shared"
+    (shared / "d").mkdir(parents=True)
+    (shared / "d" / "same.jsonl").write_text("identical")
+
+    actions = setup_transcripts_symlink(store, shared)
+
+    assert store.is_symlink()
+    assert (shared / "d" / "same.jsonl").read_text() == "identical"
+    assert (shared / "d" / "new.jsonl").read_text() == "fresh"
+    assert any("migrated 1 files (1 deduplicated" in a for a in actions)
+    assert any(p.name.startswith("sessions.bak-") for p in store.parent.iterdir())
+
+
+def test_setup_conflict_on_file_vs_directory(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "sessions"
+    (store / "x").mkdir(parents=True)
+    (store / "x" / "leaf").write_text("iamafile")
+    shared = tmp_path / "shared"
+    (shared / "x" / "leaf").mkdir(parents=True)  # dest is a directory
+
+    with pytest.raises(
+        TranscriptUnavailableError,
+        match=r"x/leaf \(source file, shared directory\)",
+    ):
+        setup_transcripts_symlink(store, shared)
+    assert store.is_dir() and not store.is_symlink()
+
+
+def test_setup_symlink_dedup_and_conflict(tmp_path: Path) -> None:
+    # Same-target child symlink dedups; a preserved symlink lands when the dest
+    # is absent; a diverging target is a conflict.
+    store = tmp_path / "config" / "sessions"
+    store.mkdir(parents=True)
+    (store / "same").symlink_to("target")
+    (store / "kept").symlink_to("elsewhere")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    (shared / "same").symlink_to("target")
+
+    actions = setup_transcripts_symlink(store, shared)
+    assert store.is_symlink()
+    assert os.readlink(shared / "kept") == "elsewhere"
+    assert any("1 deduplicated" in a for a in actions)
+
+    # A diverging symlink target is a conflict.
+    store2 = tmp_path / "config2" / "sessions"
+    store2.mkdir(parents=True)
+    (store2 / "s").symlink_to("one")
+    shared2 = tmp_path / "shared2"
+    shared2.mkdir()
+    (shared2 / "s").symlink_to("two")
+    with pytest.raises(
+        TranscriptUnavailableError, match=r"s \(different symlink targets\)"
+    ):
+        setup_transcripts_symlink(store2, shared2)
+
+
+def test_setup_conflict_diagnostic_is_bounded_and_path_only(tmp_path: Path) -> None:
+    store = tmp_path / "config" / "sessions"
+    store.mkdir(parents=True)
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    for i in range(15):
+        (store / f"f{i:02d}.jsonl").write_text(f"source-{i}")
+        (shared / f"f{i:02d}.jsonl").write_text(f"shared-{i}")
+
+    with pytest.raises(TranscriptUnavailableError) as excinfo:
+        setup_transcripts_symlink(store, shared)
+    msg = str(excinfo.value)
+    assert "15 conflicting paths" in msg
+    assert "... and 5 more" in msg  # bounded to first 10
+    assert "f00.jsonl (different regular files)" in msg
+    # Deterministic ordering: f09 listed, f10 not (only first 10 sorted paths).
+    assert "f09.jsonl" in msg and "f10.jsonl" not in msg
+    # No transcript contents leak into diagnostics.
+    assert "source-" not in msg and "shared-" not in msg
+
+
+def test_setup_verify_failure_leaves_source_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from waypoint.backends import transcripts as tr
+
+    # Distinct relative paths (no dest collisions) so the planner makes zero
+    # filecmp calls — only the verify step does, which we force to fail.
+    store = tmp_path / "config" / "sessions"
+    (store / "d").mkdir(parents=True)
+    (store / "d" / "a.jsonl").write_text("a")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    monkeypatch.setattr(tr.filecmp, "cmp", lambda *a, **k: False)
+    with pytest.raises(TranscriptUnavailableError, match="did not match its source"):
+        setup_transcripts_symlink(store, shared)
+
+    assert store.is_dir() and not store.is_symlink()
+    assert (store / "d" / "a.jsonl").read_text() == "a"
+    assert list(shared.iterdir()) == []  # shared untouched
+    assert not any(p.name.startswith(".wp-migrate-") for p in shared.parent.iterdir())
+
+
+def test_setup_mid_merge_failure_retains_staging(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = tmp_path / "config" / "sessions"
+    store.mkdir(parents=True)
+    for i in range(3):
+        (store / f"f{i}.jsonl").write_text(f"x{i}")
+    shared = tmp_path / "shared"
+    shared.mkdir()
+
+    real_rename = Path.rename
+    calls = {"n": 0}
+
+    def flaky_rename(self: Path, target: Any) -> Any:
+        # Fail on the second staged move — shared is partially populated by then.
+        if ".wp-migrate-" in str(self):
+            calls["n"] += 1
+            if calls["n"] == 2:
+                raise OSError("simulated mid-merge failure")
+        return real_rename(self, target)
+
+    monkeypatch.setattr(Path, "rename", flaky_rename)
+    with pytest.raises(OSError, match="simulated mid-merge failure"):
+        setup_transcripts_symlink(store, shared)
+
+    # Source intact; shared partially populated; staging retained for recovery.
+    assert store.is_dir() and not store.is_symlink()
+    assert {p.name for p in store.iterdir()} == {"f0.jsonl", "f1.jsonl", "f2.jsonl"}
+    assert len(list(shared.glob("f*.jsonl"))) == 1
+    staging = [p for p in shared.parent.iterdir() if p.name.startswith(".wp-migrate-")]
+    assert len(staging) == 1
+    assert len(list(staging[0].glob("f*.jsonl"))) >= 1
 
 
 # ── native_thread_artifact_glob (discovery-pattern contract) ───────────────

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -170,14 +170,49 @@ summary from the same checklist, minus the live account probe — run
 **`setup-transcripts`** performs the guarded conversion a `symlink_shared`
 profile needs: it makes `<config_dir>/<native-store>` a symlink to the shared
 dir, and when a populated real directory is already there it migrates the
-contents in (refusing same-named conflicts, keeping a timestamped backup of the
-original) before replacing it with the symlink. It is idempotent on a correct
+contents in before replacing it with the symlink. It is idempotent on a correct
 symlink and never runs implicitly during a switch:
 
 ```bash
 waypoint accounts setup-transcripts claude_code work
 waypoint accounts setup-transcripts codex work --shared-dir ~/.waypoint/codex-sessions
 ```
+
+The migration is a **recursive, conflict-aware merge**, so two stores may share
+directory ancestors — the usual Codex `sessions/YYYY/MM/DD/…` and Claude
+`projects/<project>/…` layouts — as long as their leaf transcript files do not
+truly collide:
+
+- A source file whose destination path is absent is copied in.
+- A byte-identical file at the same relative path is **deduplicated** (the shared
+  copy is retained), reported in the action summary.
+- A differing file, a file/directory type mismatch, or a diverging symlink target
+  is a **conflict**. Conflicts abort the whole migration before anything is
+  copied, renamed, or backed up. The error lists a bounded, deterministic set of
+  relative conflict paths (never transcript contents), for example:
+
+  ```text
+  cannot migrate ~/.codex-nus/sessions into ~/.codex/sessions: 2 conflicting paths:
+  2026/07/10/rollout-abc.jsonl (different regular files)
+  2026/07/11 (source file, shared directory)
+  ```
+
+The success summary reports the copied-file count, deduplicated-file count,
+directories created, the timestamped backup location, and the symlink
+destination. The original store is renamed to `<native-store>.bak-<timestamp>`
+(a complete snapshot) and is **never deleted automatically**.
+
+**Stop active sessions first.** A migration copies files while agents may still
+be writing to the source store; the command verifies each staged copy against its
+source but cannot take a filesystem snapshot, so a session writing mid-migration
+can still lose that in-flight write. Migrate only stores that are idle.
+
+**Recovery.** New files are staged in a temporary `.wp-migrate-<timestamp>`
+sibling of the shared dir and verified before any merge begins. On failure before
+the source rename the original store is left untouched. If the process dies
+mid-merge, the original store still exists intact, the staging directory is retained
+for inspection, and a re-run reports only the already-moved destinations as
+conflicts — finish the move by hand from the retained source/staging state.
 
 Each command has an HTTP endpoint behind it
 (`GET .../accounts/{profile}/probe`, `GET .../accounts/doctor`,

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -210,9 +210,12 @@ can still lose that in-flight write. Migrate only stores that are idle.
 **Recovery.** New files are staged in a temporary `.wp-migrate-<timestamp>`
 sibling of the shared dir and verified before any merge begins. On failure before
 the source rename the original store is left untouched. If the process dies
-mid-merge, the original store still exists intact, the staging directory is retained
-for inspection, and a re-run reports only the already-moved destinations as
-conflicts — finish the move by hand from the retained source/staging state.
+mid-merge, the original store still exists intact and the staging directory is
+retained for inspection. Because the files already moved into the shared dir are
+byte-identical copies of the still-present source, simply re-running
+`setup-transcripts` resumes cleanly: the already-moved leaves deduplicate and the
+remaining files copy in. The orphaned `.wp-migrate-<timestamp>` directory from the
+interrupted run can be deleted after a successful re-run.
 
 Each command has an HTTP endpoint behind it
 (`GET .../accounts/{profile}/probe`, `GET .../accounts/doctor`,


### PR DESCRIPTION
## Purpose

`waypoint accounts setup-transcripts` rejected any populated shared transcript dir whose top-level entry name matched the native store — so the normal Codex `sessions/YYYY/MM/DD/…` and Claude `projects/<project>/…` layouts failed the moment both trees shared a date or project ancestor, even when no leaf transcript actually collided. Operators hit `these entries already exist in the shared dir: 2026` and were forced into error-prone manual merges. This makes the guarded migration a recursive, conflict-aware merge that only refuses at the leaf where data can genuinely conflict.

## Changes

- `backend/src/waypoint/backends/transcripts.py` — replace the top-level same-name rejection in `_migrate_populated_store` with a recursive planner (`_build_migration_plan`) and a staged copy/verify/merge executor. Absent leaves are copied, byte-identical leaves are deduplicated, and only differing files, file/directory type mismatches, or diverging symlink targets are conflicts. Conflicts abort before any mutation with a bounded, deterministic, path-only diagnostic. Child symlinks are never followed while planning (`lstat`/`lexists` semantics); new directories are pinned `0700` per level and files `0600`; the source store is untouched until every staged copy verifies.
- `backend/tests/test_transcripts.py`, `backend/tests/test_account_doctor.py` — cover Codex date trees and Claude project trees merging on shared ancestors, identical-leaf dedup, file/dir and symlink-target conflicts, bounded path-only diagnostics, verify-failure rollback, mid-merge staging retention, and an API-level recursive merge that reports the profile ready via `accounts doctor`. The old top-level-conflict test is rewritten to assert a genuine differing-leaf conflict.
- `docs/account_profiles.md` — document the recursive merge, dedup and conflict output, action-summary counts, timestamped backup, the stop-active-sessions caution, and staging/recovery on an interrupted migration.

## Design

A preflight walk (`os.scandir`, never following symlinks) builds a plan keyed by relative path, classifying each source entry against its shared-store counterpart. File identity uses `filecmp.cmp(shallow=False)` — a size precheck then chunked content comparison — so memory stays proportional to path count and no digest is ever surfaced. Execution stages new files/links in a temporary `.wp-migrate-<timestamp>` sibling of the shared dir, verifies each staged copy against its source, then renames entries into the shared tree (re-checking each destination is still absent to catch concurrent writes) before renaming the source store to a timestamped backup and creating the symlink. The original store is never touched until every copy verifies, so a crash leaves it intact; a failure after the merge begins retains the staging dir for recovery. The endpoint response stays a text-compatible action list (counts encoded in the strings), so no client upgrade is required.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- E2E: restarted the backend onto this branch with `waypointctl`; confirmed the live `waypoint accounts setup-transcripts` CLI reaches the deployed code (idempotent no-op on the already-linked `codex/nus` profile); and drove the deployed migration against the exact reported `~/.codex-nus/sessions` vs `~/.codex/sessions` `2026`-collision layout on a throwaway tree — distinct rollouts merged, an identical leaf deduplicated, backup + symlink + `0700`/`0600` perms verified, and a differing leaf aborted pre-mutation with a path-only diagnostic.

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1747 passed, 3 pre-existing/unrelated warnings.
- E2E: reported collision now merges; conflict/dedup/backup/perms all verified on disk; live CLI reaches the deployed branch.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `AGENTS.md`.
- [x] My PR title is a Conventional Commit and all commits are signed off.
- [x] I have run the backend checks and full test suite.
- [x] I have added focused regression tests.
- [ ] No frontend changes.
- [x] No plugin/transport contract or per-backend runtime/API dispatch was introduced.
- [x] I have updated user-facing documentation (`docs/account_profiles.md`).

</details>