### PR TITLE
feat: add a full session settings editor

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -2338,6 +2338,20 @@ class SessionRuntime:
         profiles = redacted_profile_metadata(
             self.settings, session.backend, launch_target
         )
+        # A bare attached tmux pane advertises the restart capability at the
+        # transport level, but Waypoint does not own the process, so it cannot
+        # honestly restart-and-resume it. Mirror the runtime gate here.
+        supports_launch_settings_with_restart = (
+            caps.supports_launch_settings_with_restart
+            and caps.supports_reattach_after_exit
+            and session.source != SessionSource.ATTACHED_TMUX
+        )
+        config_dir_env_var = caps.config_dir_env_var
+        protected_launch_env_keys = ["WAYPOINT_SESSION_ID"]
+        if config_dir_env_var and session.account_profile_id:
+            # The selected profile owns its config-dir key; it must not be
+            # editable as a raw env var while that profile is active.
+            protected_launch_env_keys.append(config_dir_env_var)
         return LaunchSettingsResponse(
             backend=session.backend,
             transport=session.transport,
@@ -2349,10 +2363,15 @@ class SessionRuntime:
             config_overrides=list(session.config_overrides),
             # Redacted: only the env keys, never their (possibly secret) values.
             launch_env_keys=sorted(session.launch_env.keys()),
+            protected_launch_env_keys=protected_launch_env_keys,
+            config_dir_env_var=config_dir_env_var,
             supports_custom_args=caps.supports_custom_cli_args,
             supports_config_overrides=caps.supports_config_overrides,
             supports_account_profile_with_restart=(
                 caps.supports_account_profile_with_restart
+            ),
+            supports_launch_settings_with_restart=(
+                supports_launch_settings_with_restart
             ),
             requires_restart=True,
         )
@@ -2395,6 +2414,14 @@ class SessionRuntime:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="cannot change launch settings while the session is STARTING",
+            )
+        if session.source == SessionSource.ATTACHED_TMUX:
+            # Waypoint does not own the process behind a bare attached pane, so
+            # it cannot restart-and-resume it; the transport still advertises
+            # the restart capability, so guard here rather than trusting caps.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="cannot change launch settings for an attached tmux session",
             )
         if not (
             caps.supports_launch_settings_with_restart

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -703,9 +703,21 @@ class LaunchSettingsResponse(BaseModel):
     args: list[str] = Field(default_factory=list)
     config_overrides: list[str] = Field(default_factory=list)
     launch_env_keys: list[str] = Field(default_factory=list)
+    # Keys the client must never edit or remove: runtime-owned
+    # (WAYPOINT_SESSION_ID) plus the profile-owned config-dir key when a
+    # profile is currently selected. Metadata only — the runtime validates
+    # every patch regardless of what a client hides.
+    protected_launch_env_keys: list[str] = Field(default_factory=list)
+    # The agent's config-dir env var (CLAUDE_CONFIG_DIR / CODEX_HOME), or None.
+    # Lets the client hide the profile-owned key for whichever profile is
+    # currently selected or staged, without hard-coding the name.
+    config_dir_env_var: str | None = None
     supports_custom_args: bool = False
     supports_config_overrides: bool = False
     supports_account_profile_with_restart: bool = False
+    # True only when the session's (agent, transport) can restart-and-resume
+    # AND Waypoint owns the process (i.e. not a bare attached tmux pane).
+    supports_launch_settings_with_restart: bool = False
     requires_restart: bool = True
 
 

--- a/backend/tests/test_launch_settings.py
+++ b/backend/tests/test_launch_settings.py
@@ -134,6 +134,67 @@ def test_get_launch_settings_projection(tmp_path: Path) -> None:
     # Redacted: keys only, never values.
     assert resp.launch_env_keys == ["CODEX_HOME", "SECRET"]
     assert resp.supports_account_profile_with_restart is True
+    assert resp.supports_launch_settings_with_restart is True
+    assert resp.config_dir_env_var == "CODEX_HOME"
+    # WAYPOINT_SESSION_ID is always runtime-owned; the config-dir key is
+    # profile-owned while a profile is selected. Neither value ever leaks.
+    assert "WAYPOINT_SESSION_ID" in resp.protected_launch_env_keys
+    assert "CODEX_HOME" in resp.protected_launch_env_keys
+    assert "SECRET" not in resp.protected_launch_env_keys
+
+
+def test_get_launch_settings_omits_config_dir_key_when_no_profile(
+    tmp_path: Path,
+) -> None:
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    _session(runtime, launch_env={"CODEX_HOME": "/x"})
+    resp = runtime.get_launch_settings("s1")
+    # No profile selected → config-dir key is not profile-owned; only the
+    # runtime-owned key is protected.
+    assert resp.protected_launch_env_keys == ["WAYPOINT_SESSION_ID"]
+    assert resp.config_dir_env_var == "CODEX_HOME"
+
+
+def test_get_launch_settings_attached_tmux_disables_restart(tmp_path: Path) -> None:
+    # A bare attached pane advertises the restart capability at the transport
+    # level, but Waypoint does not own the process; the projection must be
+    # honest so the client gates the editor correctly.
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="tmux",
+        transport="tmux",
+        source=SessionSource.ATTACHED_TMUX,
+    )
+    resp = runtime.get_launch_settings("s1")
+    assert resp.supports_launch_settings_with_restart is False
+
+
+def test_get_launch_settings_opencode_disables_restart(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="opencode", transport="opencode_http")
+    resp = runtime.get_launch_settings("s1")
+    assert resp.supports_launch_settings_with_restart is False
+
+
+async def test_update_rejects_env_edit_for_attached_tmux_pane(tmp_path: Path) -> None:
+    # The gap the capability gate alone misses: an env-only edit on an attached
+    # pane passes every capability gate (tmux transport flips restart on) but
+    # Waypoint does not own the process. The server must reject it regardless of
+    # what a client hides.
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="tmux",
+        transport="tmux",
+        source=SessionSource.ATTACHED_TMUX,
+    )
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1",
+            LaunchSettingsUpdateRequest(env_set={"HTTP_PROXY": "x"}, restart=True),
+        )
+    assert getattr(exc.value, "status_code", None) == 400
 
 
 def test_update_session_round_trips_list_columns(tmp_path: Path) -> None:

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -9,7 +9,11 @@ for Codex) plus a policy for how a running session's transcript follows it.
 You can pick a profile when launching, scheduling, or presetting a session, and
 switch a *running* session between profiles without restarting the Waypoint
 service — the session terminates and resumes the same thread under the new
-config dir (restart-and-resume).
+config dir (restart-and-resume). For a running session the profile picker lives
+in the **Session settings** editor (opened from the composer overflow `+` menu
+or a session card's settings action), alongside the other restart-scoped launch
+settings; staging a profile switch there batches into the same restart, and the
+editor warns before an active turn is interrupted.
 
 Only the agent backends that own a config-dir env var host profiles today:
 **`claude_code` and `codex`**. `opencode` and the transport wrappers do not, and

--- a/docs/personal_assistant.md
+++ b/docs/personal_assistant.md
@@ -62,7 +62,19 @@ inspection is unaffected.
 
 ### Controls (assistant page)
 
-The **settings popover** (⚙, next to the composer) holds configuration. Changing
+The **Session settings** editor (opened from the composer overflow `+` menu)
+is the full editor for the assistant. It stages every safe change and applies
+them in one operation: title, tuning (model / effort / permission mode), account
+profile, and — for restart-capable agents — custom CLI args, config overrides,
+and launch-environment keys (add / replace / remove, values never shown).
+In-place changes restart-and-resume the same singleton; changing the agent,
+interface, or resuming a thread stages a replacement (the reset/attach
+lifecycle) and disables the advanced launch fields, since the replacement
+contract does not carry them. A single warning states the real restart /
+interrupt outcome before Apply.
+
+The **settings popover** (⚙, next to the composer) remains as a quick-tuning
+shortcut. Changing
 the agent, the interface, or picking a thread there stages an inline confirm,
 since each replaces the conversation:
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -6321,6 +6321,9 @@ html[data-theme="light"] .composer-tune-restart-apply {
   gap: 10px;
   padding: 9px 12px;
   border-radius: 6px;
+  /* Keep each label on one line; the shrink-to-fit popover grows to the widest
+   * item on desktop (the ≤640 full-width bottom sheet has room either way). */
+  white-space: nowrap;
   /* Subtle persistent background + border so each row reads as a discrete
    * button at rest (without it the row reads as plain text). */
   border: 1px solid var(--line);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11116,6 +11116,318 @@ html[data-theme="light"] .session-switcher-row.selected {
   }
 }
 
+/* ─── Session settings editor ─── */
+/* Glass chrome (the floating modal) wrapping flat, opaque instrument fields.
+   Every color derives from a token so both themes resolve with no override. */
+.settings-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  height: 100dvh;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  padding: 16px;
+}
+
+.settings-modal {
+  width: 100%;
+  max-width: min(560px, calc(100vw - 32px));
+  max-height: calc(100dvh - 64px);
+  min-height: 0;
+  background: var(--glass-bg-thick);
+  border: 1px solid var(--glass-line);
+  border-radius: var(--radius-glass);
+  box-shadow:
+    inset 0 1px 0 var(--glass-hi),
+    var(--shadow);
+  backdrop-filter: var(--glass-blur);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.settings-modal-header {
+  padding: 16px 18px 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.settings-modal-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-modal-context {
+  margin: 4px 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+  word-break: break-word;
+}
+
+.settings-modal-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.settings-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.settings-group-caption {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-soft);
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.settings-field-label {
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.settings-input {
+  width: 100%;
+  padding: 7px 9px;
+  background: var(--bg-input);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+}
+
+.settings-input:focus {
+  outline: none;
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line-strong));
+}
+
+.settings-input:disabled {
+  opacity: 0.55;
+}
+
+.settings-textarea {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  resize: vertical;
+}
+
+.settings-advanced-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 0;
+  background: none;
+  border: none;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+}
+
+.settings-advanced-caret {
+  color: var(--muted-soft);
+}
+
+.settings-advanced-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding-top: 4px;
+}
+
+.settings-env-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-env-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-env-key,
+.settings-env-key-input {
+  flex: 1 1 0;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-env-op {
+  flex: 0 0 auto;
+  width: auto;
+}
+
+.settings-env-value {
+  flex: 1 1 0;
+  min-width: 0;
+}
+
+.settings-env-redacted {
+  flex: 1 1 0;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--muted-soft);
+  letter-spacing: 0.15em;
+}
+
+.settings-env-remove {
+  flex: 0 0 auto;
+  padding: 4px 8px;
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.settings-env-remove:hover:not(:disabled) {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.settings-env-add {
+  align-self: flex-start;
+  padding: 5px 10px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 0.76rem;
+  cursor: pointer;
+}
+
+.settings-env-add:hover:not(:disabled) {
+  border-color: var(--line-strong);
+}
+
+.settings-modal-note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.settings-modal-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--danger);
+}
+
+.settings-modal-plan {
+  padding: 10px 18px;
+  border-top: 1px solid var(--line);
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+}
+
+.settings-modal-plan p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--warn);
+}
+
+.settings-modal-plan p + p {
+  margin-top: 4px;
+}
+
+.settings-modal-plan-error {
+  background: color-mix(in srgb, var(--danger) 10%, transparent);
+}
+
+.settings-modal-plan-error p {
+  color: var(--danger);
+}
+
+.settings-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--line);
+  background: var(--bg-input);
+}
+
+.settings-btn {
+  padding: 7px 16px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.settings-btn:hover:not(:disabled) {
+  border-color: var(--line-strong);
+  background: var(--bg-card);
+}
+
+.settings-btn:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.settings-btn-primary {
+  background: color-mix(in srgb, var(--accent) 22%, var(--bg-card-soft));
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line-strong));
+  color: var(--text);
+}
+
+.settings-btn-primary:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 32%, var(--bg-card-soft));
+}
+
+@media (max-width: 600px) {
+  /* The modal is sized/positioned inline from visualViewport (see
+     SessionSettingsModal.tsx). Env rows are too wide for a phone in one line,
+     so wrap: the key takes the full width, the action + value share the next. */
+  .settings-env-row {
+    flex-wrap: wrap;
+  }
+
+  .settings-env-key,
+  .settings-env-key-input {
+    flex: 1 1 100%;
+  }
+
+  .settings-env-op {
+    flex: 0 0 auto;
+  }
+
+  .settings-env-value,
+  .settings-env-redacted {
+    flex: 1 1 auto;
+  }
+}
+
 /* ─── Personal assistant ─── */
 /* Floating action button, fixed to the bottom-right of the home page for
    one-tap access. Collapses to a circular glyph on narrow/touch viewports. */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -11260,77 +11260,166 @@ html[data-theme="light"] .session-switcher-row.selected {
   padding-top: 4px;
 }
 
-.settings-env-list {
+/* Shared key/value env editor (EnvVarRows) — launch panel, resume panel, and
+   the settings modal. The input selectors carry two classes so they outrank the
+   launch panel's `.field input` rule and stay identically sized in every host. */
+.env-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.env-editor__rows {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
 
-.settings-env-row {
+.env-editor__row {
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-.settings-env-key,
-.settings-env-key-input {
+.env-editor .env-editor__input {
   flex: 1 1 0;
   min-width: 0;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-input);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--text);
   font-family: var(--font-mono);
-  font-size: 0.76rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.env-editor .env-editor__input--key {
+  flex: 2 1 0;
+}
+
+.env-editor .env-editor__input--value {
+  flex: 3 1 0;
+}
+
+.env-editor .env-editor__input::placeholder {
+  color: var(--muted-soft);
+}
+
+.env-editor .env-editor__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.env-editor .env-editor__input:disabled {
+  opacity: 0.55;
+}
+
+/* Read-only name of an already-configured variable (settings modal). */
+.env-editor__key-label {
+  flex: 2 1 0;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.settings-env-op {
+/* The keep/replace/remove select for a configured variable. */
+.env-editor .env-editor__op {
   flex: 0 0 auto;
   width: auto;
-}
-
-.settings-env-value {
-  flex: 1 1 0;
-  min-width: 0;
-}
-
-.settings-env-redacted {
-  flex: 1 1 0;
-  min-width: 0;
-  font-family: var(--font-mono);
-  font-size: 0.76rem;
-  color: var(--muted-soft);
-  letter-spacing: 0.15em;
-}
-
-.settings-env-remove {
-  flex: 0 0 auto;
-  padding: 4px 8px;
-  background: none;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  color: var(--muted);
-  cursor: pointer;
-}
-
-.settings-env-remove:hover:not(:disabled) {
-  border-color: var(--danger);
-  color: var(--danger);
-}
-
-.settings-env-add {
-  align-self: flex-start;
-  padding: 5px 10px;
-  background: var(--bg-card-soft);
+  padding: 8px 10px;
+  background: var(--bg-input);
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   color: var(--text);
-  font-size: 0.76rem;
-  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
 }
 
-.settings-env-add:hover:not(:disabled) {
-  border-color: var(--line-strong);
+.env-editor .env-editor__op:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.env-editor__redacted {
+  flex: 3 1 0;
+  min-width: 0;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--muted-soft);
+  letter-spacing: 0.18em;
+  padding: 8px 2px;
+}
+
+/* Quiet icon affordance — no box; reddens on hover. */
+.env-editor__remove {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--muted-soft);
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.env-editor__remove:hover:not(:disabled) {
+  color: var(--danger);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+}
+
+.env-editor__remove:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Ghost text action, not a filled chip. */
+.env-editor__add {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 2px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: color 120ms ease;
+}
+
+.env-editor__add:hover:not(:disabled) {
+  color: var(--accent);
+}
+
+.env-editor__add:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.env-editor__add-glyph {
+  font-size: 0.95rem;
+  line-height: 1;
 }
 
 .settings-modal-note {
@@ -11409,24 +11498,21 @@ html[data-theme="light"] .session-switcher-row.selected {
 }
 
 @media (max-width: 600px) {
-  /* The modal is sized/positioned inline from visualViewport (see
-     SessionSettingsModal.tsx). Env rows are too wide for a phone in one line,
-     so wrap: the key takes the full width, the action + value share the next. */
-  .settings-env-row {
+  /* Env rows are too wide for a phone in one line, so wrap: the key (or the
+     configured-key name) takes the full width, and the value + action share
+     the next line. */
+  .env-editor__row {
     flex-wrap: wrap;
   }
 
-  .settings-env-key,
-  .settings-env-key-input {
+  .env-editor .env-editor__input--key,
+  .env-editor__key-label {
     flex: 1 1 100%;
   }
 
-  .settings-env-op {
-    flex: 0 0 auto;
-  }
-
-  .settings-env-value,
-  .settings-env-redacted {
+  .env-editor .env-editor__input--value,
+  .env-editor .env-editor__op,
+  .env-editor__redacted {
     flex: 1 1 auto;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10640,7 +10640,10 @@ html[data-theme="light"] .advanced-section.open .advanced-toggle {
 }
 
 /* ── Terminal-style textarea ── */
-.advanced-args-field span {
+/* Scope to the direct-child label span only — the field also hosts the env
+   editor, whose nested spans (add glyph, key label) must not inherit the "$"
+   prefix or the label typography. */
+.advanced-args-field > span {
   font-family: var(--font-mono);
   font-size: 0.7rem;
   letter-spacing: 0.1em;
@@ -10650,11 +10653,11 @@ html[data-theme="light"] .advanced-section.open .advanced-toggle {
   gap: 5px;
 }
 
-html[data-theme="light"] .advanced-args-field span {
+html[data-theme="light"] .advanced-args-field > span {
   color: var(--muted);
 }
 
-.advanced-args-field span::before {
+.advanced-args-field > span::before {
   content: "$";
   color: var(--accent);
   font-size: 0.78rem;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import { LaunchPanel } from "@/components/LaunchPanel";
 import { LoginForm } from "@/components/LoginForm";
 import { SchedulePanel } from "@/components/SchedulePanel";
 import { SessionList } from "@/components/SessionList";
+import { SessionSettingsModal } from "@/components/SessionSettingsModal";
 import { SshConnectModal } from "@/components/SshConnectModal";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import { UsageDashboardSection } from "@/components/UsageDashboardSection";
@@ -135,6 +136,9 @@ export default function HomePage() {
   const [host, setHost] = useState("");
   const [token, setToken] = useState("");
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
+  const [settingsSession, setSettingsSession] = useState<SessionRecord | null>(
+    null,
+  );
   const [assistant, setAssistant] = useState<AssistantSummary | null>(null);
   const [error, setError] = useState("");
   // The working directory the last New launch was rejected for (400
@@ -1172,6 +1176,21 @@ export default function HomePage() {
           onTerminate={handleTerminate}
           onSetPinned={handleSetPinned}
           onSetTitle={handleSetTitle}
+          onOpenSettings={setSettingsSession}
+        />
+      ) : null}
+      {settingsSession ? (
+        <SessionSettingsModal
+          host={host}
+          token={token}
+          session={settingsSession}
+          onClose={() => setSettingsSession(null)}
+          onApplied={(updated) =>
+            setSessions((prev) =>
+              prev.map((s) => (s.id === updated.id ? updated : s)),
+            )
+          }
+          onAuthFailure={handleAuthFailure}
         />
       ) : null}
       {token && assistant ? (

--- a/frontend/src/components/EnvVarRows.tsx
+++ b/frontend/src/components/EnvVarRows.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 // Shared key/value environment-variable editor: one row per variable with a
-// name field, a value field, and a remove control, plus an "Add variable"
-// button. Used by the launch panel, the resume panel, and the session settings
-// modal so every env editor reads the same. Controlled — the parent owns the
-// entries and their conversion to/from a plain record.
+// name field, a value field, and a quiet remove control, plus a ghost "Add
+// variable" action. Used by the launch panel, the resume panel, and the session
+// settings modal so every env editor reads the same. Controlled — the parent
+// owns the entries and their conversion to/from a plain record.
+//
+// It owns its own `.env-editor` styling at a specificity that wins over the
+// launch panel's `.field input` rule, so its inputs are sized identically in
+// every host regardless of the surrounding form.
 
 export interface EnvEntry {
   id: number;
@@ -55,53 +59,68 @@ export function EnvVarRows({
   const remove = (id: number) => onChange(entries.filter((e) => e.id !== id));
 
   return (
-    <div className="settings-env-list">
-      {entries.map((entry) => (
-        <div className="settings-env-row" key={entry.id}>
-          <input
-            className="settings-input settings-env-key-input"
-            type="text"
-            value={entry.key}
-            onChange={(e) => update(entry.id, { key: e.target.value })}
-            placeholder="KEY"
-            disabled={disabled}
-            spellCheck={false}
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            aria-label="Variable name"
-          />
-          <input
-            className="settings-input settings-env-value"
-            type={valueType}
-            value={entry.value}
-            onChange={(e) => update(entry.id, { value: e.target.value })}
-            placeholder="value"
-            disabled={disabled}
-            spellCheck={false}
-            autoCapitalize="none"
-            autoComplete="off"
-            autoCorrect="off"
-            aria-label="Variable value"
-          />
-          <button
-            type="button"
-            className="settings-env-remove"
-            onClick={() => remove(entry.id)}
-            disabled={disabled}
-            aria-label="Remove variable"
-          >
-            ✕
-          </button>
+    <div className="env-editor">
+      {entries.length > 0 ? (
+        <div className="env-editor__rows">
+          {entries.map((entry) => (
+            <div className="env-editor__row" key={entry.id}>
+              <input
+                className="env-editor__input env-editor__input--key"
+                type="text"
+                value={entry.key}
+                onChange={(e) => update(entry.id, { key: e.target.value })}
+                placeholder="KEY"
+                disabled={disabled}
+                spellCheck={false}
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+                aria-label="Variable name"
+              />
+              <input
+                className="env-editor__input env-editor__input--value"
+                type={valueType}
+                value={entry.value}
+                onChange={(e) => update(entry.id, { value: e.target.value })}
+                placeholder="value"
+                disabled={disabled}
+                spellCheck={false}
+                autoCapitalize="none"
+                autoComplete="off"
+                autoCorrect="off"
+                aria-label="Variable value"
+              />
+              <button
+                type="button"
+                className="env-editor__remove"
+                onClick={() => remove(entry.id)}
+                disabled={disabled}
+                aria-label={`Remove ${entry.key || "variable"}`}
+                title="Remove"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" aria-hidden="true">
+                  <path
+                    d="M3 3l6 6M9 3l-6 6"
+                    stroke="currentColor"
+                    strokeWidth="1.4"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              </button>
+            </div>
+          ))}
         </div>
-      ))}
+      ) : null}
       <button
         type="button"
-        className="settings-env-add"
+        className="env-editor__add"
         onClick={add}
         disabled={disabled}
       >
-        + Add variable
+        <span className="env-editor__add-glyph" aria-hidden="true">
+          +
+        </span>
+        Add variable
       </button>
     </div>
   );

--- a/frontend/src/components/EnvVarRows.tsx
+++ b/frontend/src/components/EnvVarRows.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+// Shared key/value environment-variable editor: one row per variable with a
+// name field, a value field, and a remove control, plus an "Add variable"
+// button. Used by the launch panel, the resume panel, and the session settings
+// modal so every env editor reads the same. Controlled — the parent owns the
+// entries and their conversion to/from a plain record.
+
+export interface EnvEntry {
+  id: number;
+  key: string;
+  value: string;
+}
+
+interface EnvVarRowsProps {
+  entries: EnvEntry[];
+  onChange: (entries: EnvEntry[]) => void;
+  disabled?: boolean;
+  // Launch/resume enter fresh values in the clear (matching the old textarea);
+  // the settings modal masks newly-typed secrets.
+  valueType?: "text" | "password";
+}
+
+// Assign stable, monotonic ids so React keys survive edits and removals.
+export function recordToEntries(record: Record<string, string> | undefined): EnvEntry[] {
+  return Object.entries(record ?? {}).map(([key, value], index) => ({
+    id: index + 1,
+    key,
+    value,
+  }));
+}
+
+// Trim keys, drop empty keys, last value wins on a duplicate key — matching the
+// prior text-parser semantics.
+export function entriesToRecord(entries: EnvEntry[]): Record<string, string> {
+  const record: Record<string, string> = {};
+  for (const entry of entries) {
+    const key = entry.key.trim();
+    if (!key) continue;
+    record[key] = entry.value;
+  }
+  return record;
+}
+
+export function EnvVarRows({
+  entries,
+  onChange,
+  disabled,
+  valueType = "text",
+}: EnvVarRowsProps) {
+  const nextId = () => entries.reduce((max, e) => Math.max(max, e.id), 0) + 1;
+  const add = () => onChange([...entries, { id: nextId(), key: "", value: "" }]);
+  const update = (id: number, patch: Partial<Omit<EnvEntry, "id">>) =>
+    onChange(entries.map((e) => (e.id === id ? { ...e, ...patch } : e)));
+  const remove = (id: number) => onChange(entries.filter((e) => e.id !== id));
+
+  return (
+    <div className="settings-env-list">
+      {entries.map((entry) => (
+        <div className="settings-env-row" key={entry.id}>
+          <input
+            className="settings-input settings-env-key-input"
+            type="text"
+            value={entry.key}
+            onChange={(e) => update(entry.id, { key: e.target.value })}
+            placeholder="KEY"
+            disabled={disabled}
+            spellCheck={false}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            aria-label="Variable name"
+          />
+          <input
+            className="settings-input settings-env-value"
+            type={valueType}
+            value={entry.value}
+            onChange={(e) => update(entry.id, { value: e.target.value })}
+            placeholder="value"
+            disabled={disabled}
+            spellCheck={false}
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            aria-label="Variable value"
+          />
+          <button
+            type="button"
+            className="settings-env-remove"
+            onClick={() => remove(entry.id)}
+            disabled={disabled}
+            aria-label="Remove variable"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        className="settings-env-add"
+        onClick={add}
+        disabled={disabled}
+      >
+        + Add variable
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -13,10 +13,11 @@ import {
 import { useTransportForAgent } from "@/components/AgentTransportPicker";
 import { EffortPicker } from "@/components/EffortPicker";
 import {
-  formatLaunchEnv,
-  LaunchOptionsDetails,
-  parseLaunchEnv,
-} from "@/components/LaunchOptions";
+  type EnvEntry,
+  entriesToRecord,
+  recordToEntries,
+} from "@/components/EnvVarRows";
+import { LaunchOptionsDetails } from "@/components/LaunchOptions";
 import { ModelPicker } from "@/components/ModelPicker";
 import { SessionContextFields } from "@/components/SessionContextFields";
 import { WorkingDirectoryField } from "@/components/WorkingDirectoryField";
@@ -67,8 +68,8 @@ export interface LaunchForm {
   setCustomArgsText: (value: string) => void;
   configOverridesText: string;
   setConfigOverridesText: (value: string) => void;
-  launchEnvText: string;
-  setLaunchEnvText: (value: string) => void;
+  envEntries: EnvEntry[];
+  setEnvEntries: (entries: EnvEntry[]) => void;
   modelInfo: BackendModelListResponse | null;
   permissionOptions: ReturnType<typeof permissionModesFor>;
   supportsCustomArgs: boolean;
@@ -103,8 +104,8 @@ export function useLaunchForm({
   const [accountProfileId, setAccountProfileId] = useState("");
   const [customArgsText, setCustomArgsText] = useState("");
   const [configOverridesText, setConfigOverridesText] = useState("");
-  const [launchEnvText, setLaunchEnvText] = useState(() =>
-    formatLaunchEnv(defaultLaunchEnvByBackend[defaultBackend]),
+  const [envEntries, setEnvEntries] = useState<EnvEntry[]>(() =>
+    recordToEntries(defaultLaunchEnvByBackend[defaultBackend]),
   );
   const [modelInfo, setModelInfo] = useState<BackendModelListResponse | null>(null);
 
@@ -132,7 +133,7 @@ export function useLaunchForm({
     setEffort("");
     setModelInfo(null);
     setAccountProfileId("");
-    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[nextBackend]));
+    setEnvEntries(recordToEntries(defaultLaunchEnvByBackend[nextBackend]));
   }, [defaultLaunchEnvByBackend]);
 
   useEffect(() => {
@@ -141,7 +142,7 @@ export function useLaunchForm({
     setEffort("");
     setModelInfo(null);
     setAccountProfileId("");
-    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[defaultBackend]));
+    setEnvEntries(recordToEntries(defaultLaunchEnvByBackend[defaultBackend]));
   }, [defaultBackend, defaultLaunchEnvByBackend]);
 
   useEffect(() => {
@@ -161,7 +162,7 @@ export function useLaunchForm({
     setModel("");
     setModelInfo(null);
     setAccountProfileId("");
-    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[backend]));
+    setEnvEntries(recordToEntries(defaultLaunchEnvByBackend[backend]));
   }, [backend, launchTargetId, defaultLaunchEnvByBackend]);
 
   // Applying a preset that changes the backend triggers the reset effect above,
@@ -192,7 +193,7 @@ export function useLaunchForm({
         setModel(spec.model ?? "");
         setEffort(spec.effort ?? "");
         setAccountProfileId(spec.account_profile_id ?? "");
-        setLaunchEnvText(formatLaunchEnv(spec.launch_env ?? {}));
+        setEnvEntries(recordToEntries(spec.launch_env ?? {}));
         if (spec.transport) setTransport(spec.transport);
       };
       if (nextBackend !== backend) {
@@ -260,14 +261,14 @@ export function useLaunchForm({
     const configOverrides = supportsConfigOverrides
       ? configOverridesText.split("\n").map((value) => value.trim()).filter(Boolean)
       : [];
-    const launchEnv = parseLaunchEnv(launchEnvText);
+    const launchEnv = entriesToRecord(envEntries);
     return { args, configOverrides, launchEnv };
   }, [
     supportsCustomArgs,
     supportsConfigOverrides,
     customArgsText,
     configOverridesText,
-    launchEnvText,
+    envEntries,
   ]);
 
   return {
@@ -291,8 +292,8 @@ export function useLaunchForm({
     setCustomArgsText,
     configOverridesText,
     setConfigOverridesText,
-    launchEnvText,
-    setLaunchEnvText,
+    envEntries,
+    setEnvEntries,
     modelInfo,
     permissionOptions,
     supportsCustomArgs,
@@ -430,8 +431,8 @@ export function LaunchFormFields({
         onCustomArgsChange={form.setCustomArgsText}
         configOverridesText={form.configOverridesText}
         onConfigOverridesChange={form.setConfigOverridesText}
-        launchEnvText={form.launchEnvText}
-        onLaunchEnvChange={form.setLaunchEnvText}
+        envEntries={form.envEntries}
+        onEnvEntriesChange={form.setEnvEntries}
         formBusy={busy}
       />
     </div>

--- a/frontend/src/components/LaunchOptions.tsx
+++ b/frontend/src/components/LaunchOptions.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 
+import { EnvVarRows, type EnvEntry } from "@/components/EnvVarRows";
+
 export function GearGlyph() {
   return (
     <svg
@@ -32,8 +34,8 @@ interface LaunchOptionsDetailsProps {
   mode: "new" | "resume";
   supportsCustomArgs?: boolean;
   supportsConfigOverrides?: boolean;
-  launchEnvText?: string;
-  onLaunchEnvChange?: (value: string) => void;
+  envEntries?: EnvEntry[];
+  onEnvEntriesChange?: (entries: EnvEntry[]) => void;
   customArgsText?: string;
   onCustomArgsChange?: (value: string) => void;
   configOverridesText?: string;
@@ -45,8 +47,8 @@ export function LaunchOptionsDetails({
   mode,
   supportsCustomArgs,
   supportsConfigOverrides,
-  launchEnvText,
-  onLaunchEnvChange,
+  envEntries,
+  onEnvEntriesChange,
   customArgsText,
   onCustomArgsChange,
   configOverridesText,
@@ -54,7 +56,8 @@ export function LaunchOptionsDetails({
   formBusy,
 }: LaunchOptionsDetailsProps) {
   const [open, setOpen] = useState(false);
-  const showLaunchEnv = launchEnvText !== undefined && Boolean(onLaunchEnvChange);
+  const showLaunchEnv =
+    envEntries !== undefined && Boolean(onEnvEntriesChange);
   const showCustomArgs = mode === "new" && Boolean(supportsCustomArgs);
   const showConfigOverrides = mode === "new" && Boolean(supportsConfigOverrides);
   const showWarning = showLaunchEnv || showCustomArgs || showConfigOverrides;
@@ -79,20 +82,14 @@ export function LaunchOptionsDetails({
       <div className="advanced-body">
         <div className="advanced-body-inner">
           {showLaunchEnv ? (
-            <label className="field advanced-args-field">
+            <div className="field advanced-args-field">
               <span>Environment variables</span>
-              <textarea
-                rows={3}
-                value={launchEnvText ?? ""}
-                onChange={(e) => onLaunchEnvChange?.(e.target.value)}
-                placeholder={"One per line, e.g.\nOPENAI_API_KEY=sk-..."}
+              <EnvVarRows
+                entries={envEntries ?? []}
+                onChange={(next) => onEnvEntriesChange?.(next)}
                 disabled={formBusy}
-                spellCheck={false}
-                autoCapitalize="none"
-                autoComplete="off"
-                autoCorrect="off"
               />
-            </label>
+            </div>
           ) : null}
           {showCustomArgs ? (
             <label className="field advanced-args-field">
@@ -135,28 +132,4 @@ export function LaunchOptionsDetails({
       </div>
     </div>
   );
-}
-
-export function formatLaunchEnv(env: Record<string, string> | undefined): string {
-  return Object.entries(env ?? {})
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, value]) => `${key}=${value}`)
-    .join("\n");
-}
-
-export function parseLaunchEnv(text: string): Record<string, string> {
-  const env: Record<string, string> = {};
-  for (const rawLine of text.split("\n")) {
-    const line = rawLine.trim();
-    if (!line) continue;
-    const eq = line.indexOf("=");
-    if (eq === -1) {
-      env[line] = "";
-      continue;
-    }
-    const key = line.slice(0, eq).trim();
-    if (!key) continue;
-    env[key] = line.slice(eq + 1);
-  }
-  return env;
 }

--- a/frontend/src/components/ResumeThreadPanel.tsx
+++ b/frontend/src/components/ResumeThreadPanel.tsx
@@ -7,10 +7,11 @@ import {
   useTransportForAgent,
 } from "@/components/AgentTransportPicker";
 import {
-  formatLaunchEnv,
-  LaunchOptionsDetails,
-  parseLaunchEnv,
-} from "@/components/LaunchOptions";
+  type EnvEntry,
+  entriesToRecord,
+  recordToEntries,
+} from "@/components/EnvVarRows";
+import { LaunchOptionsDetails } from "@/components/LaunchOptions";
 import type { BackendCatalog } from "@/lib/backends";
 import { defaultTransportFor, humaniseBackend } from "@/lib/backends";
 import { matchesQuery, parseQuery } from "@/lib/search";
@@ -137,8 +138,8 @@ export function ResumeThreadPanel({
         ? preferredBackend
         : (supportedBackends[0] ?? preferredBackend)
       : filter;
-  const [launchEnvText, setLaunchEnvText] = useState(() =>
-    formatLaunchEnv(defaultLaunchEnvByBackend[transportAgent]),
+  const [envEntries, setEnvEntries] = useState<EnvEntry[]>(() =>
+    recordToEntries(defaultLaunchEnvByBackend[transportAgent]),
   );
   const [transport, setTransport, transports] = useTransportForAgent(
     transportAgent,
@@ -146,7 +147,7 @@ export function ResumeThreadPanel({
   );
 
   useEffect(() => {
-    setLaunchEnvText(formatLaunchEnv(defaultLaunchEnvByBackend[transportAgent]));
+    setEnvEntries(recordToEntries(defaultLaunchEnvByBackend[transportAgent]));
   }, [defaultLaunchEnvByBackend, transportAgent]);
 
   const isExpanded = expanded || query.trim().length > 0;
@@ -208,7 +209,7 @@ export function ResumeThreadPanel({
         : defaultTransportFor(thread.backend, catalog);
     const launchEnv =
       filter === thread.backend
-        ? parseLaunchEnv(launchEnvText)
+        ? entriesToRecord(envEntries)
         : { ...(defaultLaunchEnvByBackend[thread.backend] ?? {}) };
     setImportingId(thread.id);
     try {
@@ -284,8 +285,8 @@ export function ResumeThreadPanel({
       {filter !== "all" ? (
         <LaunchOptionsDetails
           mode="resume"
-          launchEnvText={launchEnvText}
-          onLaunchEnvChange={setLaunchEnvText}
+          envEntries={envEntries}
+          onEnvEntriesChange={setEnvEntries}
           formBusy={importingId !== null || deletingId !== null}
         />
       ) : null}

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3645,7 +3645,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       onOpenSettings();
                     }}
                   >
-                    <span className="glyph">⚙</span>
+                    <span className="glyph">{"⚙︎"}</span>
                     Session settings…
                   </button>
                   <button

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3063,7 +3063,7 @@ const ReplyComposer = memo(function ReplyComposer({
               onClick={() => setTuneOpen((open) => !open)}
             >
               <span className="composer-tune-glyph" aria-hidden>
-                ⚙
+                {"⚙︎"}
               </span>
               <span className="composer-tune-summary">{tuneSummary}</span>
               {effortPendingDiffers ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -92,6 +92,7 @@ import { AccountProfilePicker } from "@/components/AccountProfilePicker";
 import { ScheduleMessageModal } from "@/components/ScheduleMessageModal";
 import { ScheduledMessagesDock } from "@/components/ScheduledMessagesDock";
 import { SessionFilesPanel } from "@/components/SessionFilesPanel";
+import { SessionSettingsModal } from "@/components/SessionSettingsModal";
 import { WorkspaceFilesPanel } from "@/components/WorkspaceFilesPanel";
 import {
   WorkspaceFileLinkProvider,
@@ -346,6 +347,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // `events` and win the max-sequence comparison in `currentTaskEvent`.
   const [loadedTodoEvent, setLoadedTodoEvent] = useState<EventRecord | null>(null);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | undefined>(undefined);
   const [workspaceInitialDir, setWorkspaceInitialDir] = useState<string | undefined>(undefined);
   // Bumped on every open request so the panel re-reveals even when the target
@@ -2388,6 +2390,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onRateLimitRefresh={handleRateLimitRefresh}
           onReattach={reattach}
           onSwitchSession={openSwitcher}
+          onOpenSettings={() => setSettingsOpen(true)}
           onSend={onSendWithOptimistic}
           attachmentsEnabled={
             session ? supportsAttachments(session.backend, catalog) : false
@@ -2417,6 +2420,18 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           width={dockWidth}
           onResize={setDockWidth}
           onClose={() => setWorkspaceOpen(false)}
+        />
+      ) : null}
+      {settingsOpen && session ? (
+        <SessionSettingsModal
+          host={host}
+          token={token}
+          session={session}
+          onClose={() => setSettingsOpen(false)}
+          onApplied={setSession}
+          onAuthFailure={onAuthFailure}
+          isAssistant={assistant}
+          assistant={assistantControls ?? undefined}
         />
       ) : null}
     </section>
@@ -2476,6 +2491,7 @@ interface ReplyComposerProps {
   onRateLimitRefresh: () => void | Promise<void>;
   onReattach: () => void | Promise<void>;
   onSwitchSession: () => void;
+  onOpenSettings: () => void;
   onSend: (
     text: string,
     command?: SessionCommandInvocation,
@@ -2535,6 +2551,7 @@ const ReplyComposer = memo(function ReplyComposer({
   onRateLimitRefresh,
   onReattach,
   onSwitchSession,
+  onOpenSettings,
   onSend,
   attachmentsEnabled,
   onTerminate,
@@ -3618,6 +3635,18 @@ const ReplyComposer = memo(function ReplyComposer({
                   >
                     <span className="glyph">⇄</span>
                     Switch session…
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="composer-overflow-item"
+                    onClick={() => {
+                      setOverflowOpen(false);
+                      onOpenSettings();
+                    }}
+                  >
+                    <span className="glyph">⚙</span>
+                    Session settings…
                   </button>
                   <button
                     type="button"

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -25,6 +25,7 @@ interface SessionListProps {
   onTerminate?: (sessionId: string) => void | Promise<void>;
   onSetPinned?: (sessionId: string, pinned: boolean) => void | Promise<void>;
   onSetTitle?: (sessionId: string, title: string) => void | Promise<void>;
+  onOpenSettings?: (session: SessionRecord) => void;
 }
 
 const PAGE_SIZE = 10;
@@ -37,6 +38,7 @@ export function SessionList({
   onTerminate,
   onSetPinned,
   onSetTitle,
+  onOpenSettings,
 }: SessionListProps) {
   const [page, setPage] = useState(1);
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
@@ -88,6 +90,15 @@ export function SessionList({
     event.stopPropagation();
     setEditingSessionId(session.id);
     setDraftTitle(session.title);
+  }
+
+  function handleOpenSettings(
+    event: MouseEvent<HTMLButtonElement>,
+    session: SessionRecord,
+  ) {
+    event.preventDefault();
+    event.stopPropagation();
+    onOpenSettings?.(session);
   }
 
   function handleDraftKeyDown(
@@ -280,6 +291,15 @@ export function SessionList({
           </p>
         </div>
         <div className="session-card-actions">
+          {onOpenSettings ? (
+            <button
+              className="link-button"
+              type="button"
+              onClick={(event) => handleOpenSettings(event, session)}
+            >
+              ⚙ Settings
+            </button>
+          ) : null}
           {onSetPinned ? (
             <button
               className={`link-button pin-link ${pinned ? "active" : ""}`}

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -297,7 +297,7 @@ export function SessionList({
               type="button"
               onClick={(event) => handleOpenSettings(event, session)}
             >
-              ⚙ Settings
+              {"⚙︎ Settings"}
             </button>
           ) : null}
           {onSetPinned ? (

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -316,21 +316,6 @@ export function SessionSettingsModal({
             <p className="settings-modal-error">{loadError}</p>
           ) : (
             <>
-              {/* Title */}
-              <section className="settings-field">
-                <label className="settings-field-label" htmlFor="settings-title">
-                  Title
-                </label>
-                <input
-                  id="settings-title"
-                  className="settings-input"
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  disabled={busy}
-                />
-              </section>
-
               {/* Assistant agent / interface / resume */}
               {isAssistant && assistant ? (
                 <section className="settings-group">
@@ -414,6 +399,62 @@ export function SessionSettingsModal({
                   </div>
                 </section>
               ) : null}
+
+              {/* Account profile — kept with the context group (agent /
+                  interface / profile) above Session and Tuning, mirroring the
+                  launch panel's field hierarchy. */}
+              {showAccountProfile ? (
+                <section className="settings-group">
+                  <div className="settings-group-caption">Account profile</div>
+                  <div className="settings-field">
+                    <label
+                      className="settings-field-label"
+                      htmlFor="settings-profile"
+                    >
+                      Profile
+                    </label>
+                    <select
+                      id="settings-profile"
+                      className="settings-input"
+                      value={accountProfileId ?? ""}
+                      onChange={(e) =>
+                        setAccountProfileId(e.target.value || null)
+                      }
+                      disabled={busy || assistantReplacementStaged}
+                    >
+                      {/* A session may currently run under no profile; show a
+                          disabled placeholder so the value isn't orphaned.
+                          Clearing a profile to none is out of scope, so it
+                          can't be re-selected once a real profile is chosen. */}
+                      {accountProfileId === null ? (
+                        <option value="" disabled>
+                          No profile
+                        </option>
+                      ) : null}
+                      {accountProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.id}>
+                          {profile.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </section>
+              ) : null}
+
+              {/* Title */}
+              <section className="settings-field">
+                <label className="settings-field-label" htmlFor="settings-title">
+                  Title
+                </label>
+                <input
+                  id="settings-title"
+                  className="settings-input"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  disabled={busy}
+                />
+              </section>
 
               {/* Tuning */}
               {showPermission || showModel || showEffort ? (
@@ -518,45 +559,6 @@ export function SessionSettingsModal({
                       </select>
                     </div>
                   ) : null}
-                </section>
-              ) : null}
-
-              {/* Account profile */}
-              {showAccountProfile ? (
-                <section className="settings-group">
-                  <div className="settings-group-caption">Account profile</div>
-                  <div className="settings-field">
-                    <label
-                      className="settings-field-label"
-                      htmlFor="settings-profile"
-                    >
-                      Profile
-                    </label>
-                    <select
-                      id="settings-profile"
-                      className="settings-input"
-                      value={accountProfileId ?? ""}
-                      onChange={(e) =>
-                        setAccountProfileId(e.target.value || null)
-                      }
-                      disabled={busy || assistantReplacementStaged}
-                    >
-                      {/* A session may currently run under no profile; show a
-                          disabled placeholder so the value isn't orphaned.
-                          Clearing a profile to none is out of scope, so it
-                          can't be re-selected once a real profile is chosen. */}
-                      {accountProfileId === null ? (
-                        <option value="" disabled>
-                          No profile
-                        </option>
-                      ) : null}
-                      {accountProfiles.map((profile) => (
-                        <option key={profile.id} value={profile.id}>
-                          {profile.label}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
                 </section>
               ) : null}
 

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -289,6 +289,12 @@ export function SessionSettingsModal({
       launchFieldsAvailable ||
       launchFieldsDisabledReason !== null);
 
+  // Existing env keys the user can act on (profile-owned/runtime-owned keys are
+  // hidden and stay server-managed).
+  const visibleExistingEnv = existingEnv.filter(
+    (e) => !hiddenEnvKeys.includes(e.key),
+  );
+
   const content = (
     <div
       className="settings-modal-backdrop"
@@ -621,13 +627,9 @@ export function SessionSettingsModal({
                           <div className="settings-field-label">
                             Environment variables
                           </div>
-                          {existingEnv.filter(
-                            (e) => !hiddenEnvKeys.includes(e.key),
-                          ).length > 0 ? (
+                          {visibleExistingEnv.length > 0 ? (
                             <div className="settings-env-list">
-                              {existingEnv
-                                .filter((e) => !hiddenEnvKeys.includes(e.key))
-                                .map((entry) => (
+                              {visibleExistingEnv.map((entry) => (
                                   <div
                                     className="settings-env-row"
                                     key={entry.key}

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -107,7 +107,7 @@ export function SessionSettingsModal({
     session: current,
     launchSettings,
     models,
-    supportsFreeTextModel,
+    defaultModelLabel,
     title,
     permissionMode,
     model,
@@ -233,7 +233,13 @@ export function SessionSettingsModal({
   const accountProfiles = launchSettings?.account_profiles ?? [];
 
   const showPermission = permissionModes.length > 0;
-  const showModel = models.length > 0 || supportsFreeTextModel || model !== null;
+  const showModel = models.length > 0 || model !== null;
+  // Mirror the launch panel's ModelPicker: surface a pre-existing custom model
+  // (from an older session/schedule) that isn't in the discovered list.
+  const modelEntries =
+    model && !models.some((m) => m.id === model)
+      ? [{ id: model, label: `Custom · ${model}` }, ...models]
+      : models;
   const showEffort = effortOptions.length > 0 || effort !== null;
   const showAccountProfile =
     accountProfiles.length > 0 &&
@@ -498,46 +504,27 @@ export function SessionSettingsModal({
                       <label className="settings-field-label" htmlFor="settings-model">
                         Model
                       </label>
-                      {supportsFreeTextModel ? (
-                        // Editable combobox: pick a discovered model or type a
-                        // free-text id (backends that report supports_free_text).
-                        <>
-                          <input
-                            id="settings-model"
-                            className="settings-input"
-                            list="settings-model-options"
-                            value={model ?? ""}
-                            onChange={(e) => setModel(e.target.value || null)}
-                            placeholder="Model id"
-                            disabled={busy}
-                          />
-                          <datalist id="settings-model-options">
-                            {models.map((m) => (
-                              <option key={m.id} value={m.id}>
-                                {m.label}
-                              </option>
-                            ))}
-                          </datalist>
-                        </>
-                      ) : (
-                        <select
-                          id="settings-model"
-                          className="settings-input"
-                          value={model ?? ""}
-                          onChange={(e) => setModel(e.target.value || null)}
-                          disabled={busy}
-                        >
-                          {model !== null &&
-                          !models.some((m) => m.id === model) ? (
-                            <option value={model}>{model}</option>
-                          ) : null}
-                          {models.map((m) => (
-                            <option key={m.id} value={m.id}>
-                              {m.label}
-                            </option>
-                          ))}
-                        </select>
-                      )}
+                      {/* Same select-style picker as the launch panel's
+                          ModelPicker: a Default option, the discovered models,
+                          and a passthrough for a pre-existing custom value. */}
+                      <select
+                        id="settings-model"
+                        className="settings-input"
+                        value={model ?? ""}
+                        onChange={(e) => setModel(e.target.value || null)}
+                        disabled={busy}
+                      >
+                        <option value="">
+                          {defaultModelLabel
+                            ? `Default (${defaultModelLabel})`
+                            : "Default"}
+                        </option>
+                        {modelEntries.map((m) => (
+                          <option key={m.id} value={m.id}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </select>
                     </div>
                   ) : null}
                   {showEffort ? (

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { EnvVarRows } from "@/components/EnvVarRows";
 import type { AssistantControls } from "@/components/SessionDetail";
 import {
   agentTransports,
@@ -135,9 +136,7 @@ export function SessionSettingsModal({
     setConfigOverridesText,
     setExistingEnvOp,
     setExistingEnvValue,
-    addNewEnv,
-    updateNewEnv,
-    removeNewEnv,
+    setNewEnv,
     setAssistantBackend,
     setAssistantTransport,
     setAssistantThreadId,
@@ -622,104 +621,71 @@ export function SessionSettingsModal({
                           <div className="settings-field-label">
                             Environment variables
                           </div>
-                          <div className="settings-env-list">
-                            {existingEnv
-                              .filter((e) => !hiddenEnvKeys.includes(e.key))
-                              .map((entry) => (
-                                <div className="settings-env-row" key={entry.key}>
-                                  <span
-                                    className="settings-env-key"
-                                    title={entry.key}
+                          {existingEnv.filter(
+                            (e) => !hiddenEnvKeys.includes(e.key),
+                          ).length > 0 ? (
+                            <div className="settings-env-list">
+                              {existingEnv
+                                .filter((e) => !hiddenEnvKeys.includes(e.key))
+                                .map((entry) => (
+                                  <div
+                                    className="settings-env-row"
+                                    key={entry.key}
                                   >
-                                    {entry.key}
-                                  </span>
-                                  <select
-                                    className="settings-input settings-env-op"
-                                    value={entry.op}
-                                    onChange={(e) =>
-                                      setExistingEnvOp(
-                                        entry.key,
-                                        e.target
-                                          .value as typeof entry.op,
-                                      )
-                                    }
-                                    disabled={busy}
-                                    aria-label={`${entry.key} action`}
-                                  >
-                                    <option value="keep">Keep</option>
-                                    <option value="replace">Replace</option>
-                                    <option value="remove">Remove</option>
-                                  </select>
-                                  {entry.op === "replace" ? (
-                                    <input
-                                      className="settings-input settings-env-value"
-                                      type="password"
-                                      value={entry.value}
+                                    <span
+                                      className="settings-env-key"
+                                      title={entry.key}
+                                    >
+                                      {entry.key}
+                                    </span>
+                                    <select
+                                      className="settings-input settings-env-op"
+                                      value={entry.op}
                                       onChange={(e) =>
-                                        setExistingEnvValue(
+                                        setExistingEnvOp(
                                           entry.key,
-                                          e.target.value,
+                                          e.target.value as typeof entry.op,
                                         )
                                       }
-                                      placeholder="New value"
                                       disabled={busy}
-                                      aria-label={`${entry.key} new value`}
-                                    />
-                                  ) : (
-                                    <span className="settings-env-redacted">
-                                      ••••••
-                                    </span>
-                                  )}
-                                </div>
-                              ))}
-                            {newEnv.map((entry) => (
-                              <div className="settings-env-row" key={entry.id}>
-                                <input
-                                  className="settings-input settings-env-key-input"
-                                  type="text"
-                                  value={entry.key}
-                                  onChange={(e) =>
-                                    updateNewEnv(entry.id, {
-                                      key: e.target.value,
-                                    })
-                                  }
-                                  placeholder="KEY"
-                                  disabled={busy}
-                                  aria-label="New variable name"
-                                />
-                                <input
-                                  className="settings-input settings-env-value"
-                                  type="password"
-                                  value={entry.value}
-                                  onChange={(e) =>
-                                    updateNewEnv(entry.id, {
-                                      value: e.target.value,
-                                    })
-                                  }
-                                  placeholder="value"
-                                  disabled={busy}
-                                  aria-label="New variable value"
-                                />
-                                <button
-                                  type="button"
-                                  className="settings-env-remove"
-                                  onClick={() => removeNewEnv(entry.id)}
-                                  disabled={busy}
-                                  aria-label="Remove variable"
-                                >
-                                  ✕
-                                </button>
-                              </div>
-                            ))}
-                          </div>
-                          <button
-                            type="button"
-                            className="settings-env-add"
-                            onClick={addNewEnv}
+                                      aria-label={`${entry.key} action`}
+                                    >
+                                      <option value="keep">Keep</option>
+                                      <option value="replace">Replace</option>
+                                      <option value="remove">Remove</option>
+                                    </select>
+                                    {entry.op === "replace" ? (
+                                      <input
+                                        className="settings-input settings-env-value"
+                                        type="password"
+                                        value={entry.value}
+                                        onChange={(e) =>
+                                          setExistingEnvValue(
+                                            entry.key,
+                                            e.target.value,
+                                          )
+                                        }
+                                        placeholder="New value"
+                                        disabled={busy}
+                                        aria-label={`${entry.key} new value`}
+                                      />
+                                    ) : (
+                                      <span className="settings-env-redacted">
+                                        ••••••
+                                      </span>
+                                    )}
+                                  </div>
+                                ))}
+                            </div>
+                          ) : null}
+                          {/* New variables use the same key/value row editor as
+                              the launch panel; values mask as secrets here. */}
+                          <EnvVarRows
+                            entries={newEnv}
+                            onChange={setNewEnv}
+                            valueType="password"
                             disabled={busy}
-                          >
-                            + Add variable
-                          </button>
+                          />
                         </div>
                       </div>
                     )

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -184,6 +184,14 @@ export function SessionSettingsModal({
     };
   }, []);
 
+  // Invalidate the cached assistant thread list when the staged agent or
+  // account profile changes, so the Resume-thread dropdown can't offer (and
+  // attach) a thread that belongs to a different agent/profile.
+  useEffect(() => {
+    setThreads([]);
+    setThreadsLoaded(false);
+  }, [assistantBackend, accountProfileId]);
+
   useEffect(() => {
     if (!isMobile) return;
     const vv = window.visualViewport;

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -1,0 +1,744 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+import type { AssistantControls } from "@/components/SessionDetail";
+import {
+  agentTransports,
+  defaultTransportFor,
+  humaniseBackend,
+  launchableAgents,
+  permissionModesFor,
+  transportLabel,
+  useBackendCatalog,
+} from "@/lib/backends";
+import { trapTabFocus } from "@/lib/keyboard";
+import type { Backend, SessionRecord, SessionTransport } from "@/lib/types";
+import {
+  useSessionSettings,
+  type AssistantSettingsControls,
+} from "@/lib/useSessionSettings";
+
+export interface AssistantThreadOption {
+  id: string;
+  title: string;
+  updatedAt: string | null;
+  preview: string | null;
+}
+
+interface SessionSettingsModalProps {
+  host: string;
+  token: string;
+  session: SessionRecord;
+  onClose: () => void;
+  onApplied?: (session: SessionRecord) => void;
+  onAuthFailure?: () => void;
+  isAssistant?: boolean;
+  assistant?: AssistantControls;
+}
+
+function useIsMobile(): boolean {
+  const [isMobile] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(max-width: 600px)").matches,
+  );
+  return isMobile;
+}
+
+export function SessionSettingsModal({
+  host,
+  token,
+  session,
+  onClose,
+  onApplied,
+  onAuthFailure,
+  isAssistant,
+  assistant,
+}: SessionSettingsModalProps) {
+  const catalog = useBackendCatalog(host || null, token || null, null);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
+  const [mobileVV, setMobileVV] = useState<{
+    height: number;
+    width: number;
+    offsetTop: number;
+    offsetLeft: number;
+  } | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [threads, setThreads] = useState<AssistantThreadOption[]>([]);
+  const [threadsLoaded, setThreadsLoaded] = useState(false);
+
+  const assistantControls = useMemo<AssistantSettingsControls | undefined>(() => {
+    if (!isAssistant || !assistant) return undefined;
+    return {
+      onSwitchBackend: async (backend, transport, profileId) => {
+        await assistant.onSwitchBackend(
+          backend,
+          transport as SessionTransport,
+          profileId,
+        );
+      },
+      onAttachThread: async (backend, threadId, profileId) => {
+        await assistant.onAttachThread(backend, threadId, profileId);
+      },
+    };
+  }, [isAssistant, assistant]);
+
+  const controller = useSessionSettings({
+    host,
+    token,
+    open: true,
+    session,
+    catalog,
+    onApplied,
+    onAuthFailure,
+    isAssistant,
+    assistantControls,
+  });
+
+  const {
+    loading,
+    loadError,
+    applying,
+    applyError,
+    partialSuccess,
+    session: current,
+    launchSettings,
+    models,
+    supportsFreeTextModel,
+    title,
+    permissionMode,
+    model,
+    effort,
+    accountProfileId,
+    argsText,
+    configOverridesText,
+    existingEnv,
+    newEnv,
+    assistantBackend,
+    assistantTransport,
+    assistantThreadId,
+    assistantReplacementStaged,
+    plan,
+    applyDisabled,
+    launchFieldsAvailable,
+    launchFieldsDisabledReason,
+    hiddenEnvKeys,
+    setTitle,
+    setPermissionMode,
+    setModel,
+    setEffort,
+    setAccountProfileId,
+    setArgsText,
+    setConfigOverridesText,
+    setExistingEnvOp,
+    setExistingEnvValue,
+    addNewEnv,
+    updateNewEnv,
+    removeNewEnv,
+    setAssistantBackend,
+    setAssistantTransport,
+    setAssistantThreadId,
+    apply,
+  } = controller;
+
+  const busy = loading || applying;
+
+  const handleKeyDown = useCallback(
+    (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "Tab") {
+        trapTabFocus(e, modalRef.current, { preventWhenEmpty: true });
+      }
+    },
+    [busy, onClose],
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
+    return () =>
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
+  }, [handleKeyDown]);
+
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, []);
+
+  useEffect(() => {
+    const previous = document.activeElement as HTMLElement | null;
+    return () => {
+      if (previous && typeof previous.focus === "function") previous.focus();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isMobile) return;
+    const vv = window.visualViewport;
+    if (!vv) {
+      setMobileVV({
+        height: window.innerHeight,
+        width: window.innerWidth,
+        offsetTop: 0,
+        offsetLeft: 0,
+      });
+      return;
+    }
+    const update = () =>
+      setMobileVV({
+        height: vv.height,
+        width: vv.width,
+        offsetTop: vv.offsetTop,
+        offsetLeft: vv.offsetLeft,
+      });
+    update();
+    vv.addEventListener("resize", update);
+    vv.addEventListener("scroll", update);
+    return () => {
+      vv.removeEventListener("resize", update);
+      vv.removeEventListener("scroll", update);
+    };
+  }, [isMobile]);
+
+  // ── derived option lists ────────────────────────────────────────────────
+  const backend = current?.backend ?? session.backend;
+  const permissionModes = permissionModesFor(backend, catalog);
+  const effortOptions = useMemo(() => {
+    const selectedModel = models.find((m) => m.id === (model ?? ""));
+    if (selectedModel) return selectedModel.supported_efforts ?? [];
+    return Array.from(
+      new Set(models.flatMap((m) => m.supported_efforts ?? [])),
+    );
+  }, [models, model]);
+  const accountProfiles = launchSettings?.account_profiles ?? [];
+
+  const showPermission = permissionModes.length > 0;
+  const showModel = models.length > 0 || supportsFreeTextModel || model !== null;
+  const showEffort = effortOptions.length > 0 || effort !== null;
+  const showAccountProfile =
+    accountProfiles.length > 0 &&
+    Boolean(launchSettings?.supports_account_profile_with_restart);
+
+  const assistantAgents = isAssistant
+    ? launchableAgents(assistant?.backends.map((b) => b.id) ?? [], catalog)
+    : [];
+  const assistantTransportOptions =
+    isAssistant && assistantBackend
+      ? agentTransports(assistantBackend, catalog)
+      : [];
+
+  const loadThreads = useCallback(async () => {
+    if (!assistant || !assistantBackend) return;
+    setThreadsLoaded(true);
+    try {
+      const list = await assistant.listThreads(
+        assistantBackend,
+        accountProfileId,
+      );
+      setThreads(list as AssistantThreadOption[]);
+    } catch {
+      setThreads([]);
+    }
+  }, [assistant, assistantBackend, accountProfileId]);
+
+  const contextLine = useMemo(() => {
+    const parts = [
+      humaniseBackend(backend, catalog),
+      transportLabel(current?.transport ?? session.transport, catalog) ??
+        (current?.transport ?? session.transport),
+      current?.launch_target_id || "Local",
+      current?.cwd ?? session.cwd,
+    ];
+    return parts.filter(Boolean).join(" · ");
+  }, [backend, catalog, current, session]);
+
+  const onApply = useCallback(async () => {
+    const ok = await apply();
+    if (ok) onClose();
+  }, [apply, onClose]);
+
+  const advancedVisible =
+    !isAssistant &&
+    (launchSettings?.supports_custom_args ||
+      launchSettings?.supports_config_overrides ||
+      launchFieldsAvailable ||
+      launchFieldsDisabledReason !== null);
+
+  const content = (
+    <div
+      className="settings-modal-backdrop"
+      onPointerDown={(e) => {
+        if (e.target === e.currentTarget && !busy) onClose();
+      }}
+    >
+      <div
+        className="settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Session settings"
+        ref={modalRef}
+        style={
+          isMobile && mobileVV !== null
+            ? {
+                position: "fixed",
+                width: `${mobileVV.width * 0.92}px`,
+                height: `${mobileVV.height * 0.82}px`,
+                maxWidth: `${mobileVV.width * 0.92}px`,
+                maxHeight: `${mobileVV.height * 0.82}px`,
+                top: `${mobileVV.offsetTop + mobileVV.height * 0.09}px`,
+                left: `${mobileVV.offsetLeft + mobileVV.width * 0.04}px`,
+              }
+            : undefined
+        }
+      >
+        <header className="settings-modal-header">
+          <h2 className="settings-modal-title">Session settings</h2>
+          <p className="settings-modal-context">{contextLine}</p>
+        </header>
+
+        <div className="settings-modal-body">
+          {loading ? (
+            <p className="settings-modal-note">Loading settings…</p>
+          ) : loadError ? (
+            <p className="settings-modal-error">{loadError}</p>
+          ) : (
+            <>
+              {/* Title */}
+              <section className="settings-field">
+                <label className="settings-field-label" htmlFor="settings-title">
+                  Title
+                </label>
+                <input
+                  id="settings-title"
+                  className="settings-input"
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  disabled={busy}
+                />
+              </section>
+
+              {/* Assistant agent / interface / resume */}
+              {isAssistant && assistant ? (
+                <section className="settings-group">
+                  <div className="settings-group-caption">Assistant</div>
+                  <div className="settings-field">
+                    <label className="settings-field-label" htmlFor="settings-agent">
+                      Agent
+                    </label>
+                    <select
+                      id="settings-agent"
+                      className="settings-input"
+                      value={assistantBackend ?? backend}
+                      onChange={(e) =>
+                        setAssistantBackend(e.target.value as Backend)
+                      }
+                      disabled={busy}
+                    >
+                      {assistantAgents.map((id) => (
+                        <option key={id} value={id}>
+                          {humaniseBackend(id, catalog)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {assistantTransportOptions.length > 1 ? (
+                    <div className="settings-field">
+                      <label
+                        className="settings-field-label"
+                        htmlFor="settings-interface"
+                      >
+                        Interface
+                      </label>
+                      <select
+                        id="settings-interface"
+                        className="settings-input"
+                        value={
+                          assistantTransport ??
+                          defaultTransportFor(
+                            assistantBackend ?? backend,
+                            catalog,
+                          ) ??
+                          ""
+                        }
+                        onChange={(e) => setAssistantTransport(e.target.value)}
+                        disabled={busy}
+                      >
+                        {assistantTransportOptions.map((t) => (
+                          <option key={t} value={t}>
+                            {transportLabel(t, catalog) ?? t}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : null}
+                  <div className="settings-field">
+                    <label
+                      className="settings-field-label"
+                      htmlFor="settings-thread"
+                    >
+                      Resume thread
+                    </label>
+                    <select
+                      id="settings-thread"
+                      className="settings-input"
+                      value={assistantThreadId ?? ""}
+                      onFocus={() => {
+                        if (!threadsLoaded) void loadThreads();
+                      }}
+                      onChange={(e) =>
+                        setAssistantThreadId(e.target.value || null)
+                      }
+                      disabled={busy}
+                    >
+                      <option value="">New conversation</option>
+                      {threads.map((t) => (
+                        <option key={t.id} value={t.id}>
+                          {t.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </section>
+              ) : null}
+
+              {/* Tuning */}
+              {showPermission || showModel || showEffort ? (
+                <section className="settings-group">
+                  <div className="settings-group-caption">Tuning</div>
+                  {showPermission ? (
+                    <div className="settings-field">
+                      <label
+                        className="settings-field-label"
+                        htmlFor="settings-permission"
+                      >
+                        Permission mode
+                      </label>
+                      <select
+                        id="settings-permission"
+                        className="settings-input"
+                        value={permissionMode ?? ""}
+                        onChange={(e) =>
+                          setPermissionMode(e.target.value || null)
+                        }
+                        disabled={busy}
+                      >
+                        {permissionModes.map((mode) => (
+                          <option key={mode.id} value={mode.id}>
+                            {mode.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : null}
+                  {showModel ? (
+                    <div className="settings-field">
+                      <label className="settings-field-label" htmlFor="settings-model">
+                        Model
+                      </label>
+                      <select
+                        id="settings-model"
+                        className="settings-input"
+                        value={model ?? ""}
+                        onChange={(e) => setModel(e.target.value || null)}
+                        disabled={busy}
+                      >
+                        {model !== null &&
+                        !models.some((m) => m.id === model) ? (
+                          <option value={model}>{model}</option>
+                        ) : null}
+                        {models.map((m) => (
+                          <option key={m.id} value={m.id}>
+                            {m.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : null}
+                  {showEffort ? (
+                    <div className="settings-field">
+                      <label
+                        className="settings-field-label"
+                        htmlFor="settings-effort"
+                      >
+                        Reasoning effort
+                      </label>
+                      <select
+                        id="settings-effort"
+                        className="settings-input"
+                        value={effort ?? ""}
+                        onChange={(e) => setEffort(e.target.value || null)}
+                        disabled={busy}
+                      >
+                        {effort !== null &&
+                        !effortOptions.includes(effort) ? (
+                          <option value={effort}>{effort}</option>
+                        ) : null}
+                        {effortOptions.map((level) => (
+                          <option key={level} value={level}>
+                            {level}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  ) : null}
+                </section>
+              ) : null}
+
+              {/* Account profile */}
+              {showAccountProfile ? (
+                <section className="settings-group">
+                  <div className="settings-group-caption">Account profile</div>
+                  <div className="settings-field">
+                    <label
+                      className="settings-field-label"
+                      htmlFor="settings-profile"
+                    >
+                      Profile
+                    </label>
+                    <select
+                      id="settings-profile"
+                      className="settings-input"
+                      value={accountProfileId ?? ""}
+                      onChange={(e) =>
+                        setAccountProfileId(e.target.value || null)
+                      }
+                      disabled={busy || assistantReplacementStaged}
+                    >
+                      {accountProfiles.map((profile) => (
+                        <option key={profile.id} value={profile.id}>
+                          {profile.label}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </section>
+              ) : null}
+
+              {/* Advanced launch settings */}
+              {advancedVisible ? (
+                <section className="settings-group">
+                  <button
+                    type="button"
+                    className="settings-advanced-toggle"
+                    aria-expanded={advancedOpen}
+                    onClick={() => setAdvancedOpen((v) => !v)}
+                  >
+                    <span>Advanced</span>
+                    <span className="settings-advanced-caret">
+                      {advancedOpen ? "▾" : "▸"}
+                    </span>
+                  </button>
+                  {advancedOpen ? (
+                    launchFieldsDisabledReason ? (
+                      <p className="settings-modal-note">
+                        {launchFieldsDisabledReason}
+                      </p>
+                    ) : (
+                      <div className="settings-advanced-body">
+                        {launchSettings?.supports_custom_args ? (
+                          <div className="settings-field">
+                            <label
+                              className="settings-field-label"
+                              htmlFor="settings-args"
+                            >
+                              Custom CLI args
+                            </label>
+                            <textarea
+                              id="settings-args"
+                              className="settings-input settings-textarea"
+                              value={argsText}
+                              onChange={(e) => setArgsText(e.target.value)}
+                              placeholder="One argument per line"
+                              disabled={busy}
+                              rows={3}
+                            />
+                          </div>
+                        ) : null}
+                        {launchSettings?.supports_config_overrides ? (
+                          <div className="settings-field">
+                            <label
+                              className="settings-field-label"
+                              htmlFor="settings-config"
+                            >
+                              Config overrides
+                            </label>
+                            <textarea
+                              id="settings-config"
+                              className="settings-input settings-textarea"
+                              value={configOverridesText}
+                              onChange={(e) =>
+                                setConfigOverridesText(e.target.value)
+                              }
+                              placeholder={'key="value" per line'}
+                              disabled={busy}
+                              rows={3}
+                            />
+                          </div>
+                        ) : null}
+                        <div className="settings-field">
+                          <div className="settings-field-label">
+                            Environment variables
+                          </div>
+                          <div className="settings-env-list">
+                            {existingEnv
+                              .filter((e) => !hiddenEnvKeys.includes(e.key))
+                              .map((entry) => (
+                                <div className="settings-env-row" key={entry.key}>
+                                  <span
+                                    className="settings-env-key"
+                                    title={entry.key}
+                                  >
+                                    {entry.key}
+                                  </span>
+                                  <select
+                                    className="settings-input settings-env-op"
+                                    value={entry.op}
+                                    onChange={(e) =>
+                                      setExistingEnvOp(
+                                        entry.key,
+                                        e.target
+                                          .value as typeof entry.op,
+                                      )
+                                    }
+                                    disabled={busy}
+                                    aria-label={`${entry.key} action`}
+                                  >
+                                    <option value="keep">Keep</option>
+                                    <option value="replace">Replace</option>
+                                    <option value="remove">Remove</option>
+                                  </select>
+                                  {entry.op === "replace" ? (
+                                    <input
+                                      className="settings-input settings-env-value"
+                                      type="password"
+                                      value={entry.value}
+                                      onChange={(e) =>
+                                        setExistingEnvValue(
+                                          entry.key,
+                                          e.target.value,
+                                        )
+                                      }
+                                      placeholder="New value"
+                                      disabled={busy}
+                                      aria-label={`${entry.key} new value`}
+                                    />
+                                  ) : (
+                                    <span className="settings-env-redacted">
+                                      ••••••
+                                    </span>
+                                  )}
+                                </div>
+                              ))}
+                            {newEnv.map((entry) => (
+                              <div className="settings-env-row" key={entry.id}>
+                                <input
+                                  className="settings-input settings-env-key-input"
+                                  type="text"
+                                  value={entry.key}
+                                  onChange={(e) =>
+                                    updateNewEnv(entry.id, {
+                                      key: e.target.value,
+                                    })
+                                  }
+                                  placeholder="KEY"
+                                  disabled={busy}
+                                  aria-label="New variable name"
+                                />
+                                <input
+                                  className="settings-input settings-env-value"
+                                  type="password"
+                                  value={entry.value}
+                                  onChange={(e) =>
+                                    updateNewEnv(entry.id, {
+                                      value: e.target.value,
+                                    })
+                                  }
+                                  placeholder="value"
+                                  disabled={busy}
+                                  aria-label="New variable value"
+                                />
+                                <button
+                                  type="button"
+                                  className="settings-env-remove"
+                                  onClick={() => removeNewEnv(entry.id)}
+                                  disabled={busy}
+                                  aria-label="Remove variable"
+                                >
+                                  ✕
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                          <button
+                            type="button"
+                            className="settings-env-add"
+                            onClick={addNewEnv}
+                            disabled={busy}
+                          >
+                            + Add variable
+                          </button>
+                        </div>
+                      </div>
+                    )
+                  ) : null}
+                </section>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {plan.warnings.length > 0 && !loading ? (
+          <div className="settings-modal-plan" role="status">
+            {plan.warnings.map((warning, i) => (
+              <p key={i}>{warning}</p>
+            ))}
+          </div>
+        ) : null}
+
+        {applyError ? (
+          <div className="settings-modal-plan settings-modal-plan-error">
+            <p>
+              {partialSuccess
+                ? "Some changes were applied before this failed: "
+                : ""}
+              {applyError}
+            </p>
+          </div>
+        ) : null}
+
+        <footer className="settings-modal-footer">
+          <button
+            type="button"
+            className="settings-btn"
+            onClick={onClose}
+            disabled={applying}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="settings-btn settings-btn-primary"
+            onClick={onApply}
+            disabled={applyDisabled}
+          >
+            {applying ? "Applying…" : "Apply"}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+
+  return typeof document !== "undefined"
+    ? createPortal(content, document.body)
+    : null;
+}

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -176,6 +176,9 @@ export function SessionSettingsModal({
 
   useEffect(() => {
     const previous = document.activeElement as HTMLElement | null;
+    // Move focus into the dialog on open so the Tab trap engages immediately
+    // and screen readers announce it; the trigger has usually unmounted.
+    modalRef.current?.focus();
     return () => {
       if (previous && typeof previous.focus === "function") previous.focus();
     };
@@ -285,6 +288,7 @@ export function SessionSettingsModal({
         role="dialog"
         aria-modal="true"
         aria-label="Session settings"
+        tabIndex={-1}
         ref={modalRef}
         style={
           isMobile && mobileVV !== null
@@ -445,23 +449,46 @@ export function SessionSettingsModal({
                       <label className="settings-field-label" htmlFor="settings-model">
                         Model
                       </label>
-                      <select
-                        id="settings-model"
-                        className="settings-input"
-                        value={model ?? ""}
-                        onChange={(e) => setModel(e.target.value || null)}
-                        disabled={busy}
-                      >
-                        {model !== null &&
-                        !models.some((m) => m.id === model) ? (
-                          <option value={model}>{model}</option>
-                        ) : null}
-                        {models.map((m) => (
-                          <option key={m.id} value={m.id}>
-                            {m.label}
-                          </option>
-                        ))}
-                      </select>
+                      {supportsFreeTextModel ? (
+                        // Editable combobox: pick a discovered model or type a
+                        // free-text id (backends that report supports_free_text).
+                        <>
+                          <input
+                            id="settings-model"
+                            className="settings-input"
+                            list="settings-model-options"
+                            value={model ?? ""}
+                            onChange={(e) => setModel(e.target.value || null)}
+                            placeholder="Model id"
+                            disabled={busy}
+                          />
+                          <datalist id="settings-model-options">
+                            {models.map((m) => (
+                              <option key={m.id} value={m.id}>
+                                {m.label}
+                              </option>
+                            ))}
+                          </datalist>
+                        </>
+                      ) : (
+                        <select
+                          id="settings-model"
+                          className="settings-input"
+                          value={model ?? ""}
+                          onChange={(e) => setModel(e.target.value || null)}
+                          disabled={busy}
+                        >
+                          {model !== null &&
+                          !models.some((m) => m.id === model) ? (
+                            <option value={model}>{model}</option>
+                          ) : null}
+                          {models.map((m) => (
+                            <option key={m.id} value={m.id}>
+                              {m.label}
+                            </option>
+                          ))}
+                        </select>
+                      )}
                     </div>
                   ) : null}
                   {showEffort ? (
@@ -514,6 +541,15 @@ export function SessionSettingsModal({
                       }
                       disabled={busy || assistantReplacementStaged}
                     >
+                      {/* A session may currently run under no profile; show a
+                          disabled placeholder so the value isn't orphaned.
+                          Clearing a profile to none is out of scope, so it
+                          can't be re-selected once a real profile is chosen. */}
+                      {accountProfileId === null ? (
+                        <option value="" disabled>
+                          No profile
+                        </option>
+                      ) : null}
                       {accountProfiles.map((profile) => (
                         <option key={profile.id} value={profile.id}>
                           {profile.label}

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -628,20 +628,21 @@ export function SessionSettingsModal({
                             Environment variables
                           </div>
                           {visibleExistingEnv.length > 0 ? (
-                            <div className="settings-env-list">
-                              {visibleExistingEnv.map((entry) => (
+                            <div className="env-editor">
+                              <div className="env-editor__rows">
+                                {visibleExistingEnv.map((entry) => (
                                   <div
-                                    className="settings-env-row"
+                                    className="env-editor__row"
                                     key={entry.key}
                                   >
                                     <span
-                                      className="settings-env-key"
+                                      className="env-editor__key-label"
                                       title={entry.key}
                                     >
                                       {entry.key}
                                     </span>
                                     <select
-                                      className="settings-input settings-env-op"
+                                      className="env-editor__op"
                                       value={entry.op}
                                       onChange={(e) =>
                                         setExistingEnvOp(
@@ -658,7 +659,7 @@ export function SessionSettingsModal({
                                     </select>
                                     {entry.op === "replace" ? (
                                       <input
-                                        className="settings-input settings-env-value"
+                                        className="env-editor__input env-editor__input--value"
                                         type="password"
                                         value={entry.value}
                                         onChange={(e) =>
@@ -672,12 +673,13 @@ export function SessionSettingsModal({
                                         aria-label={`${entry.key} new value`}
                                       />
                                     ) : (
-                                      <span className="settings-env-redacted">
+                                      <span className="env-editor__redacted">
                                         ••••••
                                       </span>
                                     )}
                                   </div>
                                 ))}
+                              </div>
                             </div>
                           ) : null}
                           {/* New variables use the same key/value row editor as

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -404,9 +404,19 @@ export interface SessionLaunchSettings {
   args: string[];
   config_overrides: string[];
   launch_env_keys: string[];
+  // Keys the client must never edit or remove: runtime-owned
+  // (WAYPOINT_SESSION_ID) plus the profile-owned config-dir key while a
+  // profile is selected. Metadata only — the runtime validates every patch.
+  protected_launch_env_keys: string[];
+  // The agent's config-dir env var (CLAUDE_CONFIG_DIR / CODEX_HOME) or null,
+  // so the client can hide the profile-owned key for the staged profile.
+  config_dir_env_var?: string | null;
   supports_custom_args: boolean;
   supports_config_overrides: boolean;
   supports_account_profile_with_restart: boolean;
+  // True only when the (agent, transport) can restart-and-resume AND Waypoint
+  // owns the process (false for a bare attached tmux pane).
+  supports_launch_settings_with_restart: boolean;
   // Whether applying a change requires restarting the session (true in phase 1).
   requires_restart: boolean;
 }

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -97,7 +97,7 @@ export interface SessionSettingsController {
   launchSettings: SessionLaunchSettings | null;
   caps: BackendCapabilities | undefined;
   models: BackendModelOption[];
-  supportsFreeTextModel: boolean;
+  defaultModelLabel: string | null;
 
   // Draft state.
   title: string;
@@ -186,7 +186,9 @@ export function useSessionSettings(
   const [launchSettings, setLaunchSettings] =
     useState<SessionLaunchSettings | null>(null);
   const [models, setModels] = useState<BackendModelOption[]>([]);
-  const [supportsFreeTextModel, setSupportsFreeTextModel] = useState(false);
+  const [defaultModelLabel, setDefaultModelLabel] = useState<string | null>(
+    null,
+  );
 
   // Draft.
   const [title, setTitle] = useState("");
@@ -266,14 +268,14 @@ export function useSessionSettings(
         fetchLaunchSettings(host, token, sessionId).catch(() => null),
       ]);
       let modelList: BackendModelOption[] = [];
-      let freeText = false;
+      let defaultLabel: string | null = null;
       try {
         const resp = await fetchBackendModels(host, token, backend, {
           launchTargetId,
           accountProfileId: record.account_profile_id ?? null,
         });
         modelList = resp.models ?? [];
-        freeText = Boolean(resp.supports_free_text);
+        defaultLabel = resp.default_model_label ?? null;
       } catch {
         // Model discovery is best-effort; the picker degrades to the current
         // value when it fails (e.g. a backend with no live model list).
@@ -282,7 +284,7 @@ export function useSessionSettings(
       setSession(record);
       setLaunchSettings(settings);
       setModels(modelList);
-      setSupportsFreeTextModel(freeText);
+      setDefaultModelLabel(defaultLabel);
       resetDraft(record, settings);
     } catch (error) {
       if (currentToken !== loadToken.current) return;
@@ -699,7 +701,7 @@ export function useSessionSettings(
     launchSettings,
     caps,
     models,
-    supportsFreeTextModel,
+    defaultModelLabel,
     title,
     permissionMode,
     model,

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -56,6 +56,9 @@ export interface SettingsPlan {
 }
 
 // Assistant lifecycle actions the editor delegates to the existing controls.
+// Agent/interface change and native-thread adoption create a fresh assistant
+// (the reset/attach lifecycle); the modal stages the target and the controller
+// dispatches it here.
 export interface AssistantSettingsControls {
   onSwitchBackend: (
     backend: Backend,
@@ -106,6 +109,11 @@ export interface SessionSettingsController {
   configOverridesText: string;
   existingEnv: ExistingEnvEntry[];
   newEnv: NewEnvEntry[];
+  // Assistant-only staged replacement target (agent / interface / thread).
+  assistantBackend: Backend | null;
+  assistantTransport: string | null;
+  assistantThreadId: string | null;
+  assistantReplacementStaged: boolean;
 
   // Derived gates.
   dirty: boolean;
@@ -129,6 +137,9 @@ export interface SessionSettingsController {
   addNewEnv: () => void;
   updateNewEnv: (id: number, patch: Partial<Omit<NewEnvEntry, "id">>) => void;
   removeNewEnv: (id: number) => void;
+  setAssistantBackend: (backend: Backend) => void;
+  setAssistantTransport: (transport: string) => void;
+  setAssistantThreadId: (threadId: string | null) => void;
 
   reload: () => void;
   apply: () => Promise<boolean>;
@@ -188,6 +199,15 @@ export function useSessionSettings(
   const [existingEnv, setExistingEnv] = useState<ExistingEnvEntry[]>([]);
   const [newEnv, setNewEnv] = useState<NewEnvEntry[]>([]);
   const newEnvSeq = useRef(0);
+  const [assistantBackend, setAssistantBackendState] = useState<Backend | null>(
+    null,
+  );
+  const [assistantTransport, setAssistantTransportState] = useState<
+    string | null
+  >(null);
+  const [assistantThreadId, setAssistantThreadIdState] = useState<string | null>(
+    null,
+  );
 
   // Guards a late fetch from overwriting a newer load or an in-flight apply.
   const loadToken = useRef(0);
@@ -221,6 +241,9 @@ export function useSessionSettings(
       );
       setNewEnv([]);
       newEnvSeq.current = 0;
+      setAssistantBackendState(record.backend);
+      setAssistantTransportState(record.transport);
+      setAssistantThreadIdState(null);
     },
     [],
   );
@@ -334,6 +357,19 @@ export function useSessionSettings(
     setNewEnv((prev) => prev.filter((entry) => entry.id !== id));
   }, []);
 
+  const setAssistantBackend = useCallback((value: Backend) => {
+    setAssistantBackendState(value);
+    // Switching agent invalidates a staged interface/thread from the old agent.
+    setAssistantTransportState(null);
+    setAssistantThreadIdState(null);
+  }, []);
+  const setAssistantTransport = useCallback((value: string) => {
+    setAssistantTransportState(value);
+  }, []);
+  const setAssistantThreadId = useCallback((value: string | null) => {
+    setAssistantThreadIdState(value);
+  }, []);
+
   // ── availability / capability gating ──────────────────────────────────────
   const launchFieldsAvailable = Boolean(
     launchSettings?.supports_launch_settings_with_restart,
@@ -341,7 +377,10 @@ export function useSessionSettings(
   const assistantReplacementStaged = Boolean(
     isAssistant &&
       session &&
-      (backend !== session.backend || transport !== session.transport),
+      ((assistantBackend !== null && assistantBackend !== session.backend) ||
+        (assistantTransport !== null &&
+          assistantTransport !== session.transport) ||
+        (assistantThreadId !== null && assistantThreadId.length > 0)),
   );
   const launchFieldsDisabledReason = useMemo(() => {
     if (launchFieldsAvailable) {
@@ -533,16 +572,28 @@ export function useSessionSettings(
         onApplied?.(updated);
       }
 
-      // 2. Assistant replacement takes the place of the launch/tune steps.
+      // 2. Assistant replacement takes the place of the launch/tune steps: a
+      //    native-thread adoption when a thread is staged, otherwise an
+      //    agent/interface switch. Both create a fresh assistant and remount.
       if (assistantReplacementStaged) {
-        if (!assistantControls || !backend || !transport) {
+        if (!assistantControls) {
           throw new Error("assistant controls unavailable");
         }
-        await assistantControls.onSwitchBackend(
-          backend,
-          transport,
-          accountProfileId,
-        );
+        const targetBackend = assistantBackend ?? session.backend;
+        if (assistantThreadId) {
+          await assistantControls.onAttachThread(
+            targetBackend,
+            assistantThreadId,
+            accountProfileId,
+          );
+        } else {
+          const targetTransport = assistantTransport ?? session.transport;
+          await assistantControls.onSwitchBackend(
+            targetBackend,
+            targetTransport,
+            accountProfileId,
+          );
+        }
         return true;
       }
 
@@ -615,8 +666,9 @@ export function useSessionSettings(
     title,
     assistantReplacementStaged,
     assistantControls,
-    backend,
-    transport,
+    assistantBackend,
+    assistantTransport,
+    assistantThreadId,
     accountProfileId,
     launchChanged,
     profileChanged,
@@ -656,6 +708,10 @@ export function useSessionSettings(
     configOverridesText,
     existingEnv,
     newEnv,
+    assistantBackend,
+    assistantTransport,
+    assistantThreadId,
+    assistantReplacementStaged,
     dirty,
     plan,
     applyDisabled,
@@ -674,6 +730,9 @@ export function useSessionSettings(
     addNewEnv,
     updateNewEnv,
     removeNewEnv,
+    setAssistantBackend,
+    setAssistantTransport,
+    setAssistantThreadId,
     reload: load,
     apply,
   };

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -1,0 +1,680 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  fetchBackendModels,
+  fetchLaunchSettings,
+  fetchSession,
+  setSessionEffort,
+  setSessionModel,
+  setSessionPermissionMode,
+  setSessionTitle,
+  updateLaunchSettings,
+} from "@/lib/api";
+import type { BackendCatalog } from "@/lib/backends";
+import type {
+  Backend,
+  BackendCapabilities,
+  BackendModelOption,
+  LaunchSettingsUpdate,
+  SessionLaunchSettings,
+  SessionRecord,
+} from "@/lib/types";
+
+// Editing model for an existing (redacted) env key. Its stored value is never
+// fetched or prefilled: the user may keep it, replace it (typing a new value),
+// or remove it.
+export type EnvKeyOp = "keep" | "replace" | "remove";
+
+export interface ExistingEnvEntry {
+  key: string;
+  op: EnvKeyOp;
+  // Only meaningful when op === "replace"; empty otherwise. Never a stored value.
+  value: string;
+}
+
+export interface NewEnvEntry {
+  id: number;
+  key: string;
+  value: string;
+}
+
+export type SettingsPlanKind =
+  | "none"
+  | "inline"
+  | "restart-resume"
+  | "assistant-replace";
+
+export interface SettingsPlan {
+  kind: SettingsPlanKind;
+  // How many process restarts the plan will cause across the batched launch
+  // PATCH and any separately-applied tuning changes.
+  restartCount: number;
+  willInterruptTurn: boolean;
+  warnings: string[];
+}
+
+// Assistant lifecycle actions the editor delegates to the existing controls.
+export interface AssistantSettingsControls {
+  onSwitchBackend: (
+    backend: Backend,
+    transport: string,
+    accountProfileId: string | null,
+  ) => Promise<void>;
+  onAttachThread: (
+    backend: Backend,
+    threadId: string,
+    accountProfileId: string | null,
+  ) => Promise<void>;
+}
+
+export interface UseSessionSettingsParams {
+  host: string;
+  token: string;
+  open: boolean;
+  session: SessionRecord | null;
+  catalog?: BackendCatalog;
+  onApplied?: (session: SessionRecord) => void;
+  onAuthFailure?: () => void;
+  // Present only for the Personal Assistant; enables the replacement path.
+  isAssistant?: boolean;
+  assistantControls?: AssistantSettingsControls;
+}
+
+export interface SessionSettingsController {
+  loading: boolean;
+  loadError: string | null;
+  applying: boolean;
+  applyError: string | null;
+  // Set after a partial-success apply so the UI can show what still needs work.
+  partialSuccess: boolean;
+
+  session: SessionRecord | null;
+  launchSettings: SessionLaunchSettings | null;
+  caps: BackendCapabilities | undefined;
+  models: BackendModelOption[];
+  supportsFreeTextModel: boolean;
+
+  // Draft state.
+  title: string;
+  permissionMode: string | null;
+  model: string | null;
+  effort: string | null;
+  accountProfileId: string | null;
+  argsText: string;
+  configOverridesText: string;
+  existingEnv: ExistingEnvEntry[];
+  newEnv: NewEnvEntry[];
+
+  // Derived gates.
+  dirty: boolean;
+  plan: SettingsPlan;
+  applyDisabled: boolean;
+  launchFieldsAvailable: boolean;
+  launchFieldsDisabledReason: string | null;
+  // Keys hidden from raw env editing for the *staged* profile.
+  hiddenEnvKeys: string[];
+
+  // Draft mutators.
+  setTitle: (value: string) => void;
+  setPermissionMode: (value: string | null) => void;
+  setModel: (value: string | null) => void;
+  setEffort: (value: string | null) => void;
+  setAccountProfileId: (value: string | null) => void;
+  setArgsText: (value: string) => void;
+  setConfigOverridesText: (value: string) => void;
+  setExistingEnvOp: (key: string, op: EnvKeyOp) => void;
+  setExistingEnvValue: (key: string, value: string) => void;
+  addNewEnv: () => void;
+  updateNewEnv: (id: number, patch: Partial<Omit<NewEnvEntry, "id">>) => void;
+  removeNewEnv: (id: number) => void;
+
+  reload: () => void;
+  apply: () => Promise<boolean>;
+}
+
+function argsToText(args: string[]): string {
+  return args.join("\n");
+}
+
+function textToArgs(text: string): string[] {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function sameStringList(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+export function useSessionSettings(
+  params: UseSessionSettingsParams,
+): SessionSettingsController {
+  const {
+    host,
+    token,
+    open,
+    session: candidate,
+    catalog,
+    onApplied,
+    onAuthFailure,
+    isAssistant,
+    assistantControls,
+  } = params;
+
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+  const [partialSuccess, setPartialSuccess] = useState(false);
+
+  const [session, setSession] = useState<SessionRecord | null>(candidate);
+  const [launchSettings, setLaunchSettings] =
+    useState<SessionLaunchSettings | null>(null);
+  const [models, setModels] = useState<BackendModelOption[]>([]);
+  const [supportsFreeTextModel, setSupportsFreeTextModel] = useState(false);
+
+  // Draft.
+  const [title, setTitle] = useState("");
+  const [permissionMode, setPermissionMode] = useState<string | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+  const [effort, setEffort] = useState<string | null>(null);
+  const [accountProfileId, setAccountProfileId] = useState<string | null>(null);
+  const [argsText, setArgsText] = useState("");
+  const [configOverridesText, setConfigOverridesText] = useState("");
+  const [existingEnv, setExistingEnv] = useState<ExistingEnvEntry[]>([]);
+  const [newEnv, setNewEnv] = useState<NewEnvEntry[]>([]);
+  const newEnvSeq = useRef(0);
+
+  // Guards a late fetch from overwriting a newer load or an in-flight apply.
+  const loadToken = useRef(0);
+
+  const sessionId = candidate?.id ?? null;
+  const backend = candidate?.backend;
+  const transport = candidate?.transport;
+  const launchTargetId = candidate?.launch_target_id ?? null;
+
+  const caps = useMemo(() => {
+    if (!catalog || !backend || !transport) return undefined;
+    return catalog.capsFor(backend, transport);
+  }, [catalog, backend, transport]);
+
+  const resetDraft = useCallback(
+    (record: SessionRecord, settings: SessionLaunchSettings | null) => {
+      setTitle(record.title ?? "");
+      setPermissionMode(record.permission_mode ?? null);
+      setModel(record.model ?? null);
+      setEffort(record.effort ?? null);
+      setAccountProfileId(record.account_profile_id ?? null);
+      setArgsText(argsToText(settings?.args ?? record.args ?? []));
+      setConfigOverridesText(
+        argsToText(settings?.config_overrides ?? record.config_overrides ?? []),
+      );
+      const protectedKeys = new Set(settings?.protected_launch_env_keys ?? []);
+      setExistingEnv(
+        (settings?.launch_env_keys ?? [])
+          .filter((key) => !protectedKeys.has(key))
+          .map((key) => ({ key, op: "keep" as EnvKeyOp, value: "" })),
+      );
+      setNewEnv([]);
+      newEnvSeq.current = 0;
+    },
+    [],
+  );
+
+  const load = useCallback(async () => {
+    if (!sessionId || !backend) return;
+    const currentToken = ++loadToken.current;
+    setLoading(true);
+    setLoadError(null);
+    setApplyError(null);
+    setPartialSuccess(false);
+    try {
+      const [record, settings] = await Promise.all([
+        fetchSession(host, token, sessionId),
+        fetchLaunchSettings(host, token, sessionId).catch(() => null),
+      ]);
+      let modelList: BackendModelOption[] = [];
+      let freeText = false;
+      try {
+        const resp = await fetchBackendModels(host, token, backend, {
+          launchTargetId,
+          accountProfileId: record.account_profile_id ?? null,
+        });
+        modelList = resp.models ?? [];
+        freeText = Boolean(resp.supports_free_text);
+      } catch {
+        // Model discovery is best-effort; the picker degrades to the current
+        // value when it fails (e.g. a backend with no live model list).
+      }
+      if (currentToken !== loadToken.current) return;
+      setSession(record);
+      setLaunchSettings(settings);
+      setModels(modelList);
+      setSupportsFreeTextModel(freeText);
+      resetDraft(record, settings);
+    } catch (error) {
+      if (currentToken !== loadToken.current) return;
+      const message =
+        error instanceof Error ? error.message : "failed to load settings";
+      setLoadError(message);
+      if (message.toLowerCase().includes("auth")) onAuthFailure?.();
+    } finally {
+      if (currentToken === loadToken.current) setLoading(false);
+    }
+  }, [
+    host,
+    token,
+    sessionId,
+    backend,
+    launchTargetId,
+    resetDraft,
+    onAuthFailure,
+  ]);
+
+  useEffect(() => {
+    if (open) {
+      void load();
+    } else {
+      // Discard staged (possibly secret) state the moment the editor closes.
+      loadToken.current += 1;
+      setLaunchSettings(null);
+      setModels([]);
+      setExistingEnv([]);
+      setNewEnv([]);
+      setArgsText("");
+      setConfigOverridesText("");
+      setApplyError(null);
+      setLoadError(null);
+      setPartialSuccess(false);
+    }
+  }, [open, load]);
+
+  // ── env editing mutators ──────────────────────────────────────────────────
+  const setExistingEnvOp = useCallback((key: string, op: EnvKeyOp) => {
+    setExistingEnv((prev) =>
+      prev.map((entry) =>
+        entry.key === key
+          ? { ...entry, op, value: op === "replace" ? entry.value : "" }
+          : entry,
+      ),
+    );
+  }, []);
+
+  const setExistingEnvValue = useCallback((key: string, value: string) => {
+    setExistingEnv((prev) =>
+      prev.map((entry) =>
+        entry.key === key ? { ...entry, value, op: "replace" } : entry,
+      ),
+    );
+  }, []);
+
+  const addNewEnv = useCallback(() => {
+    setNewEnv((prev) => [
+      ...prev,
+      { id: ++newEnvSeq.current, key: "", value: "" },
+    ]);
+  }, []);
+
+  const updateNewEnv = useCallback(
+    (id: number, patch: Partial<Omit<NewEnvEntry, "id">>) => {
+      setNewEnv((prev) =>
+        prev.map((entry) =>
+          entry.id === id ? { ...entry, ...patch } : entry,
+        ),
+      );
+    },
+    [],
+  );
+
+  const removeNewEnv = useCallback((id: number) => {
+    setNewEnv((prev) => prev.filter((entry) => entry.id !== id));
+  }, []);
+
+  // ── availability / capability gating ──────────────────────────────────────
+  const launchFieldsAvailable = Boolean(
+    launchSettings?.supports_launch_settings_with_restart,
+  );
+  const assistantReplacementStaged = Boolean(
+    isAssistant &&
+      session &&
+      (backend !== session.backend || transport !== session.transport),
+  );
+  const launchFieldsDisabledReason = useMemo(() => {
+    if (launchFieldsAvailable) {
+      if (assistantReplacementStaged) {
+        return "Advanced launch settings can't be changed while switching the assistant's agent or interface.";
+      }
+      return null;
+    }
+    if (!launchSettings) return null;
+    if (session?.source === "attached_tmux") {
+      return "Waypoint doesn't own this attached tmux process, so its launch settings can't be edited.";
+    }
+    return `${backend ?? "This backend"} doesn't support restart-applied launch settings.`;
+  }, [
+    launchFieldsAvailable,
+    assistantReplacementStaged,
+    launchSettings,
+    session,
+    backend,
+  ]);
+
+  // The config-dir key is owned by whichever profile is *staged*; hide it from
+  // raw env editing while a profile is selected.
+  const hiddenEnvKeys = useMemo(() => {
+    const key = launchSettings?.config_dir_env_var;
+    return key && accountProfileId ? [key] : [];
+  }, [launchSettings?.config_dir_env_var, accountProfileId]);
+
+  // ── env patch computation (redaction-safe) ────────────────────────────────
+  const envPatch = useMemo(() => {
+    const envSet: Record<string, string> = {};
+    const envUnset: string[] = [];
+    const hidden = new Set(hiddenEnvKeys);
+    for (const entry of existingEnv) {
+      if (hidden.has(entry.key)) continue;
+      if (entry.op === "replace") {
+        // Only emit a value the user actually typed — never synthesize an
+        // empty value for an unchanged redacted key.
+        envSet[entry.key] = entry.value;
+      } else if (entry.op === "remove") {
+        envUnset.push(entry.key);
+      }
+    }
+    for (const entry of newEnv) {
+      const key = entry.key.trim();
+      if (!key || hidden.has(key)) continue;
+      envSet[key] = entry.value;
+    }
+    return { envSet, envUnset };
+  }, [existingEnv, newEnv, hiddenEnvKeys]);
+
+  // ── change detection ──────────────────────────────────────────────────────
+  const stagedArgs = useMemo(() => textToArgs(argsText), [argsText]);
+  const stagedConfig = useMemo(
+    () => textToArgs(configOverridesText),
+    [configOverridesText],
+  );
+
+  const titleChanged = Boolean(
+    session && title.trim() && title.trim() !== session.title,
+  );
+  const permissionChanged = Boolean(
+    session && (permissionMode ?? null) !== (session.permission_mode ?? null),
+  );
+  const modelChanged = Boolean(
+    session && (model ?? null) !== (session.model ?? null),
+  );
+  const effortChanged = Boolean(
+    session && (effort ?? null) !== (session.effort ?? null),
+  );
+  const profileChanged = Boolean(
+    session &&
+      (accountProfileId ?? null) !== (session.account_profile_id ?? null) &&
+      accountProfileId !== null,
+  );
+  const argsChanged = Boolean(
+    launchSettings && !sameStringList(stagedArgs, launchSettings.args),
+  );
+  const configChanged = Boolean(
+    launchSettings &&
+      !sameStringList(stagedConfig, launchSettings.config_overrides),
+  );
+  const envChanged =
+    Object.keys(envPatch.envSet).length > 0 || envPatch.envUnset.length > 0;
+
+  const launchChanged =
+    launchFieldsAvailable &&
+    !assistantReplacementStaged &&
+    (profileChanged || argsChanged || configChanged || envChanged);
+
+  const dirty =
+    titleChanged ||
+    permissionChanged ||
+    modelChanged ||
+    effortChanged ||
+    launchChanged ||
+    assistantReplacementStaged;
+
+  // ── change plan ───────────────────────────────────────────────────────────
+  const plan = useMemo<SettingsPlan>(() => {
+    const warnings: string[] = [];
+    if (assistantReplacementStaged) {
+      warnings.push(
+        "The assistant conversation will be replaced and preserved as a stopped session.",
+      );
+      return {
+        kind: "assistant-replace",
+        restartCount: 0,
+        willInterruptTurn: false,
+        warnings,
+      };
+    }
+
+    const interrupts = Boolean(caps?.settings_change_interrupts_turn);
+    let tuneRestarts = 0;
+    if (interrupts) {
+      tuneRestarts =
+        (modelChanged ? 1 : 0) +
+        (effortChanged ? 1 : 0) +
+        (permissionChanged ? 1 : 0);
+    } else {
+      if (
+        effortChanged &&
+        caps?.supports_set_effort_with_restart &&
+        !caps?.supports_set_effort_inline
+      ) {
+        tuneRestarts += 1;
+      }
+    }
+    const restartCount = (launchChanged ? 1 : 0) + tuneRestarts;
+    const running =
+      session?.status === "running" || session?.status === "waiting_input";
+    const willInterruptTurn = restartCount > 0 && running;
+
+    if (restartCount > 1) {
+      warnings.push(
+        `Applying these changes will restart the session ${restartCount} times and resume it.`,
+      );
+    } else if (restartCount === 1) {
+      warnings.push("The session process will restart and resume.");
+    }
+    if (willInterruptTurn) {
+      warnings.push("The current turn will be interrupted.");
+    }
+    if (profileChanged) {
+      warnings.push(
+        "Switching account profile restarts the session under the new profile. For Codex, a thread with no persisted transcript starts fresh.",
+      );
+    }
+
+    let kind: SettingsPlanKind = "none";
+    if (restartCount > 0) kind = "restart-resume";
+    else if (dirty) kind = "inline";
+    return { kind, restartCount, willInterruptTurn, warnings };
+  }, [
+    assistantReplacementStaged,
+    caps,
+    modelChanged,
+    effortChanged,
+    permissionChanged,
+    launchChanged,
+    profileChanged,
+    session,
+    dirty,
+  ]);
+
+  const applyDisabled = loading || applying || !dirty;
+
+  // ── apply ─────────────────────────────────────────────────────────────────
+  const apply = useCallback(async (): Promise<boolean> => {
+    if (!session || !sessionId) return false;
+    setApplying(true);
+    setApplyError(null);
+    setPartialSuccess(false);
+    // Freeze the load token so a stray refresh mid-apply can't clobber results.
+    const applyToken = ++loadToken.current;
+    let anySucceeded = false;
+    try {
+      // 1. Title first — a title failure stops before any process-changing work.
+      if (titleChanged) {
+        const updated = await setSessionTitle(
+          host,
+          token,
+          sessionId,
+          title.trim(),
+        );
+        anySucceeded = true;
+        setSession(updated);
+        onApplied?.(updated);
+      }
+
+      // 2. Assistant replacement takes the place of the launch/tune steps.
+      if (assistantReplacementStaged) {
+        if (!assistantControls || !backend || !transport) {
+          throw new Error("assistant controls unavailable");
+        }
+        await assistantControls.onSwitchBackend(
+          backend,
+          transport,
+          accountProfileId,
+        );
+        return true;
+      }
+
+      // 3. All restart-scoped launch changes in one PATCH.
+      if (launchChanged) {
+        const update: LaunchSettingsUpdate = { restart: true };
+        if (profileChanged) update.account_profile_id = accountProfileId;
+        if (argsChanged) update.args = stagedArgs;
+        if (configChanged) update.config_overrides = stagedConfig;
+        if (Object.keys(envPatch.envSet).length > 0) {
+          update.env_set = envPatch.envSet;
+        }
+        if (envPatch.envUnset.length > 0) update.env_unset = envPatch.envUnset;
+        const updated = await updateLaunchSettings(
+          host,
+          token,
+          sessionId,
+          update,
+        );
+        anySucceeded = true;
+        setSession(updated);
+        onApplied?.(updated);
+      }
+
+      // 4. Remaining inline tuning via their own endpoints: permission → model
+      //    → effort. Refresh after each.
+      if (permissionChanged && permissionMode !== null) {
+        const updated = await setSessionPermissionMode(
+          host,
+          token,
+          sessionId,
+          permissionMode,
+        );
+        anySucceeded = true;
+        setSession(updated);
+        onApplied?.(updated);
+      }
+      if (modelChanged) {
+        const updated = await setSessionModel(host, token, sessionId, model);
+        anySucceeded = true;
+        setSession(updated);
+        onApplied?.(updated);
+      }
+      if (effortChanged) {
+        const updated = await setSessionEffort(host, token, sessionId, effort);
+        anySucceeded = true;
+        setSession(updated);
+        onApplied?.(updated);
+      }
+      return true;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "failed to apply settings";
+      setApplyError(message);
+      // A later independent op failed after an earlier one succeeded: surface a
+      // truthful partial-success state and refresh, never roll back.
+      setPartialSuccess(anySucceeded);
+      if (message.toLowerCase().includes("auth")) onAuthFailure?.();
+      if (applyToken === loadToken.current) void load();
+      return false;
+    } finally {
+      setApplying(false);
+    }
+  }, [
+    session,
+    sessionId,
+    host,
+    token,
+    titleChanged,
+    title,
+    assistantReplacementStaged,
+    assistantControls,
+    backend,
+    transport,
+    accountProfileId,
+    launchChanged,
+    profileChanged,
+    argsChanged,
+    stagedArgs,
+    configChanged,
+    stagedConfig,
+    envPatch,
+    permissionChanged,
+    permissionMode,
+    modelChanged,
+    model,
+    effortChanged,
+    effort,
+    onApplied,
+    onAuthFailure,
+    load,
+  ]);
+
+  return {
+    loading,
+    loadError,
+    applying,
+    applyError,
+    partialSuccess,
+    session,
+    launchSettings,
+    caps,
+    models,
+    supportsFreeTextModel,
+    title,
+    permissionMode,
+    model,
+    effort,
+    accountProfileId,
+    argsText,
+    configOverridesText,
+    existingEnv,
+    newEnv,
+    dirty,
+    plan,
+    applyDisabled,
+    launchFieldsAvailable,
+    launchFieldsDisabledReason,
+    hiddenEnvKeys,
+    setTitle,
+    setPermissionMode,
+    setModel,
+    setEffort,
+    setAccountProfileId,
+    setArgsText,
+    setConfigOverridesText,
+    setExistingEnvOp,
+    setExistingEnvValue,
+    addNewEnv,
+    updateNewEnv,
+    removeNewEnv,
+    reload: load,
+    apply,
+  };
+}

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -248,13 +248,18 @@ export function useSessionSettings(
     [],
   );
 
-  const load = useCallback(async () => {
+  const load = useCallback(
+    async (opts?: { keepMessages?: boolean }) => {
     if (!sessionId || !backend) return;
     const currentToken = ++loadToken.current;
     setLoading(true);
     setLoadError(null);
-    setApplyError(null);
-    setPartialSuccess(false);
+    // A post-failure refresh keeps the apply error/partial-success banner
+    // visible; a normal (re)open clears it.
+    if (!opts?.keepMessages) {
+      setApplyError(null);
+      setPartialSuccess(false);
+    }
     try {
       const [record, settings] = await Promise.all([
         fetchSession(host, token, sessionId),
@@ -288,15 +293,9 @@ export function useSessionSettings(
     } finally {
       if (currentToken === loadToken.current) setLoading(false);
     }
-  }, [
-    host,
-    token,
-    sessionId,
-    backend,
-    launchTargetId,
-    resetDraft,
-    onAuthFailure,
-  ]);
+    },
+    [host, token, sessionId, backend, launchTargetId, resetDraft, onAuthFailure],
+  );
 
   useEffect(() => {
     if (open) {
@@ -418,8 +417,9 @@ export function useSessionSettings(
       if (hidden.has(entry.key)) continue;
       if (entry.op === "replace") {
         // Only emit a value the user actually typed — never synthesize an
-        // empty value for an unchanged redacted key.
-        envSet[entry.key] = entry.value;
+        // empty value for an unchanged redacted key. A blank Replace is treated
+        // as "keep" so it can't silently wipe a stored secret to "".
+        if (entry.value !== "") envSet[entry.key] = entry.value;
       } else if (entry.op === "remove") {
         envUnset.push(entry.key);
       }
@@ -649,10 +649,11 @@ export function useSessionSettings(
         error instanceof Error ? error.message : "failed to apply settings";
       setApplyError(message);
       // A later independent op failed after an earlier one succeeded: surface a
-      // truthful partial-success state and refresh, never roll back.
+      // truthful partial-success state and refresh, never roll back. The refresh
+      // must keep the error banner (load() otherwise clears it synchronously).
       setPartialSuccess(anySucceeded);
       if (message.toLowerCase().includes("auth")) onAuthFailure?.();
-      if (applyToken === loadToken.current) void load();
+      if (applyToken === loadToken.current) void load({ keepMessages: true });
       return false;
     } finally {
       setApplying(false);

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -134,9 +134,7 @@ export interface SessionSettingsController {
   setConfigOverridesText: (value: string) => void;
   setExistingEnvOp: (key: string, op: EnvKeyOp) => void;
   setExistingEnvValue: (key: string, value: string) => void;
-  addNewEnv: () => void;
-  updateNewEnv: (id: number, patch: Partial<Omit<NewEnvEntry, "id">>) => void;
-  removeNewEnv: (id: number) => void;
+  setNewEnv: (entries: NewEnvEntry[]) => void;
   setAssistantBackend: (backend: Backend) => void;
   setAssistantTransport: (transport: string) => void;
   setAssistantThreadId: (threadId: string | null) => void;
@@ -200,7 +198,6 @@ export function useSessionSettings(
   const [configOverridesText, setConfigOverridesText] = useState("");
   const [existingEnv, setExistingEnv] = useState<ExistingEnvEntry[]>([]);
   const [newEnv, setNewEnv] = useState<NewEnvEntry[]>([]);
-  const newEnvSeq = useRef(0);
   const [assistantBackend, setAssistantBackendState] = useState<Backend | null>(
     null,
   );
@@ -242,7 +239,6 @@ export function useSessionSettings(
           .map((key) => ({ key, op: "keep" as EnvKeyOp, value: "" })),
       );
       setNewEnv([]);
-      newEnvSeq.current = 0;
       setAssistantBackendState(record.backend);
       setAssistantTransportState(record.transport);
       setAssistantThreadIdState(null);
@@ -334,28 +330,6 @@ export function useSessionSettings(
         entry.key === key ? { ...entry, value, op: "replace" } : entry,
       ),
     );
-  }, []);
-
-  const addNewEnv = useCallback(() => {
-    setNewEnv((prev) => [
-      ...prev,
-      { id: ++newEnvSeq.current, key: "", value: "" },
-    ]);
-  }, []);
-
-  const updateNewEnv = useCallback(
-    (id: number, patch: Partial<Omit<NewEnvEntry, "id">>) => {
-      setNewEnv((prev) =>
-        prev.map((entry) =>
-          entry.id === id ? { ...entry, ...patch } : entry,
-        ),
-      );
-    },
-    [],
-  );
-
-  const removeNewEnv = useCallback((id: number) => {
-    setNewEnv((prev) => prev.filter((entry) => entry.id !== id));
   }, []);
 
   const setAssistantBackend = useCallback((value: Backend) => {
@@ -730,9 +704,7 @@ export function useSessionSettings(
     setConfigOverridesText,
     setExistingEnvOp,
     setExistingEnvValue,
-    addNewEnv,
-    updateNewEnv,
-    removeNewEnv,
+    setNewEnv,
     setAssistantBackend,
     setAssistantTransport,
     setAssistantThreadId,


### PR DESCRIPTION
## Purpose

Once a session exists, the composer's quick-tuning popover only exposes a subset of controls (permission mode, model, effort, account profile), and the advanced launch inputs — custom CLI args, config overrides, launch environment — can't be reviewed or changed at all. This adds one shared, capability-driven **Session settings** editor that makes every setting Waypoint can safely change on an existing session available in a single staged Apply, launched from the composer overflow menu and from home-page session cards. It serves Chat, Emulated, and managed Terminal presentations plus the Personal Assistant, dispatching purely from the composed `(agent, transport)` capabilities. Implements `tmp/rfcs/rfc-session-settings-editor.md`.

## Changes

### Backend
- `backend/src/waypoint/schemas.py` — extend `LaunchSettingsResponse` with `supports_launch_settings_with_restart`, `protected_launch_env_keys`, and `config_dir_env_var` so the client can gate the editor without hard-coding capability or key names.
- `backend/src/waypoint/runtime.py` — populate the new projection fields in `get_launch_settings` (the restart flag is projected honestly: a bare attached tmux pane advertises the transport-level capability but Waypoint doesn't own its process, so it projects `False`), and add an authoritative guard in `_update_launch_settings_locked` rejecting launch-settings edits for `ATTACHED_TMUX` sessions before any destructive step.
- `backend/tests/test_launch_settings.py` — cover the new projection fields, profile-owned vs runtime-owned protected keys, the honest attached-tmux/opencode projection, and a non-conditional 400 on an env-only edit to an attached pane.

### Frontend
- `frontend/src/lib/useSessionSettings.ts` — new controller hook: loads a fresh session record, launch-settings projection, and model list; stages title, tuning, account profile, args, config overrides, and redaction-safe env key operations; computes a change plan (inline / restart-resume / assistant-replace) with an honest restart count; and applies changes in order (title, one batched launch PATCH, then inline tuning) with partial-success handling and a stale-fetch guard. The env patch never emits an unchanged redacted key and never prefills a stored value.
- `frontend/src/components/SessionSettingsModal.tsx` — the accessible modal (portal, focus trap, Escape/backdrop close, mobile visualViewport sizing) rendering flat instrument fields inside glass chrome, with a single plan-warning banner before Apply.
- `frontend/src/components/SessionDetail.tsx`, `SessionList.tsx`, `app/page.tsx` — wire the composer overflow `Session settings…` item and the per-card settings action (which prevents card-link navigation); the assistant passes its lifecycle controls so agent/interface/thread changes route to reset/attach.
- `frontend/src/lib/types.ts`, `frontend/src/app/globals.css` — matching types and both-theme styles.

### Docs
- `docs/personal_assistant.md`, `docs/account_profiles.md` — point at the new editor as the place to review/change a running session's launch settings.

## Design

The existing `PATCH /api/sessions/{id}/launch-settings` terminate-persist-restore flow remains the atomic boundary for profile, args, config overrides, and env edits, so the editor batches all restart-scoped launch changes into one restart rather than one per field; model, permission, and effort keep their existing per-endpoint lifecycle and are applied after, with partial success surfaced truthfully and no implicit rollback (matching the runtime's restore-failure semantics). Environment secrecy is preserved end-to-end: the projection stays keys-only, the controller represents each existing key as configured-with-value-unavailable, and `env_set`/`env_unset` are computed from staged key operations so an unchanged redacted key is never resent. Capability gating is data-driven — no `backend === …` branch is introduced — and the attached-tmux case is guarded both in the projection and authoritatively on the server, since a client can forge disabled controls.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- E2E: restarted the stack onto this branch with `waypointctl`; verified the honest launch-settings projection over the live API for every composed backend/transport pair (codex/claude_code/claude_tty/claude_cli/tmux enable restart, opencode disabled, CODEX_HOME protected while a profile is active); drove the deployed app with Playwright at mobile width in both themes — opened the editor from a session card (URL unchanged, no navigation) and from the composer overflow, confirmed capability gating (codex config-overrides + account profile, none for claude_code), that no env value input is prefilled, Apply disabled with no change and enabled after an edit, and Cancel/Escape close.

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1752 passed, 3 pre-existing/unrelated warnings.
- Frontend lint and production build: passed.
- E2E: projection honest across all backend/transport pairs; card and composer entry points open the same modal; env redaction, dirty-state, and close behaviors verified; both themes render cleanly at mobile width. No live `attached_tmux` session existed to click, so that path is covered by the non-conditional backend unit tests (projection `False` + 400 guard).

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] This is not a breaking change.
- [x] I have updated documentation or config examples (`docs/`) if user-facing behavior changed.

</details>