### PR TITLE
fix: order pin before settings on session cards

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9259,11 +9259,25 @@ html[data-theme="light"] .preset-modal-overlay {
   color: var(--accent);
 }
 
+/* Settings shares pin's neutral mono treatment (without the pinned state). */
+.settings-link {
+  align-self: flex-start;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.settings-link:hover:not(:disabled) {
+  color: var(--accent-strong);
+}
+
 /* Session-card actions (and the scheduled-panel row Cancel/Dismiss, via
    .action-chip) are bare mono text actions; color alone separates pin
    (neutral→gold) from terminate/delete/cancel (danger-red). Padding keeps
    the touch target without drawing a chip around it. */
 .session-card-actions .link-button.pin-link,
+.session-card-actions .link-button.settings-link,
 .session-card-actions .link-button.danger-link,
 .link-button.action-chip {
   align-self: center;
@@ -9275,6 +9289,7 @@ html[data-theme="light"] .preset-modal-overlay {
 }
 
 .session-card-actions .link-button.pin-link:hover:not(:disabled),
+.session-card-actions .link-button.settings-link:hover:not(:disabled),
 .session-card-actions .link-button.danger-link:hover:not(:disabled),
 .link-button.action-chip:hover:not(:disabled) {
   background: color-mix(in srgb, currentColor 10%, transparent);

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -291,15 +291,6 @@ export function SessionList({
           </p>
         </div>
         <div className="session-card-actions">
-          {onOpenSettings ? (
-            <button
-              className="link-button"
-              type="button"
-              onClick={(event) => handleOpenSettings(event, session)}
-            >
-              {"⚙︎ Settings"}
-            </button>
-          ) : null}
           {onSetPinned ? (
             <button
               className={`link-button pin-link ${pinned ? "active" : ""}`}
@@ -308,6 +299,15 @@ export function SessionList({
               aria-pressed={pinned}
             >
               {pinned ? "★ Pinned" : "☆ Pin"}
+            </button>
+          ) : null}
+          {onOpenSettings ? (
+            <button
+              className="link-button settings-link"
+              type="button"
+              onClick={(event) => handleOpenSettings(event, session)}
+            >
+              {"⚙︎ Settings"}
             </button>
           ) : null}
           {onTerminate && session.status !== "exited" ? (


### PR DESCRIPTION
## Purpose

On the home-page session cards the new **Settings** action landed to the left of **Pin** and rendered as a bare link — inconsistent with the other card actions. Put Pin first and give Settings the same hover affordance as its neighbors.

## Changes

- `frontend/src/components/SessionList.tsx` — reorder the card action row to Pin → Settings → Terminate/Delete.
- `frontend/src/app/globals.css` — add a neutral `settings-link` variant so the Settings button gets the same padded chip and `currentColor` hover background as `.pin-link`/`.danger-link` (mono, muted → gold on hover) instead of a plain accent link.

## Test Plan

- `cd frontend && npm run lint && npm run build`
- Redeployed the frontend with `waypointctl`; confirmed on the deployed home page that the action order is Pin → Settings → Delete and the Settings button shows the same hover chip background as Pin and Delete.

## Test Result

- Frontend lint and production build: passed.
- Verified in-app (Playwright, both actions render in order with matching hover treatment).

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [ ] Backend checks not applicable (frontend-only change).
- [ ] No tests needed (presentational reorder + styling).
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (derives from tokens).
- [ ] This is not a breaking change.
- [ ] No user-facing documentation change needed.

</details>