### PR TITLE
feat: tail remote claude_tty transcripts over the SSH seam

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/byte_source.py
+++ b/backend/src/waypoint/backends/claude_tty/byte_source.py
@@ -1,0 +1,249 @@
+"""Transcript byte sources for the claude_tty tailer.
+
+A byte source abstracts *where* a Claude JSONL transcript lives so the tailer's
+cursor / partial-record logic stays storage-independent. A local session reads
+the file directly off the shared ``~/.claude/projects`` tree; a session on an
+SSH launch target reads it over the existing ``RemoteTranscriptFilesystem``
+seam — discovering the file by the Claude thread-artifact glob (never by
+encoding a possibly non-canonical remote cwd) and reading bounded byte ranges.
+
+Every read returns a :class:`TranscriptRead`. ``observed=False`` means "nothing
+actionable this tick" — a pre-first-turn missing file, an unresolved remote
+glob, a throttled poll, or a transport error backing off; the tailer does
+nothing (no offset advance, no discontinuity, no status change). ``observed=
+True`` (even with empty ``data``) means the tailer has a valid file observation
+and may parse and run its truncation checks. A source **never raises**: a
+background tailer loop treats a raised exception as fatal, so all remote failure
+modes degrade to an unobserved read that retries with backoff.
+"""
+
+import logging
+import posixpath
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+from waypoint.backends.claude_code.threads import (
+    claude_projects_root,
+    encode_project_dir,
+)
+from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
+from waypoint.launch_targets import SshLaunchTargetConfig
+
+if TYPE_CHECKING:
+    from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
+    from waypoint.runtime import SessionRuntime
+
+log = logging.getLogger("waypoint.backends.claude_tty")
+
+_STEADY_INTERVAL = 1.0  # seconds between remote reads at steady state
+_MAX_BACKOFF = 10.0  # cap on the exponential error backoff
+_READ_LIMIT = 256 * 1024  # max bytes fetched per remote read
+
+
+def transcript_path(cwd: str, session_uuid: str, config_dir: str | None = None) -> Path:
+    """Return the Claude TUI's JSONL transcript path for a local session.
+
+    Resolves the store root and the encoded project-dir name through the same
+    helpers thread discovery uses, so the tailed path matches where the CLI
+    actually writes — including for cwds with non-slash special characters
+    (hidden dirs, worktrees). ``config_dir`` is the session's
+    ``CLAUDE_CONFIG_DIR`` (e.g. an account profile's); pass it or the path
+    resolves under the default ``~/.claude`` and the tailer reads the wrong
+    file for a profile-scoped session — the session then never leaves
+    ``running`` because no transcript records reach the normalizer.
+    """
+    return (
+        claude_projects_root(config_dir)
+        / encode_project_dir(cwd)
+        / f"{session_uuid}.jsonl"
+    )
+
+
+class TranscriptRead:
+    """The result of one poll of a transcript byte source.
+
+    ``size`` and ``identity`` (``(device, inode)``) describe the file at read
+    time so the tailer can detect a truncation (size drops below its cursor) or
+    a replacement (identity changes) without re-reading the whole file.
+    """
+
+    __slots__ = ("observed", "data", "size", "identity")
+
+    def __init__(
+        self,
+        *,
+        observed: bool = False,
+        data: bytes = b"",
+        size: int | None = None,
+        identity: tuple[int, int] | None = None,
+    ) -> None:
+        self.observed = observed
+        self.data = data
+        self.size = size
+        self.identity = identity
+
+
+class TranscriptByteSource(Protocol):
+    def read_from(
+        self, offset: int, *, metadata_only: bool = False, force: bool = False
+    ) -> TranscriptRead:
+        """Read from ``offset``.
+
+        ``metadata_only`` asks for size + identity without fetching the body
+        (start-at-end priming). ``force`` bypasses a source's poll-cadence gate
+        (used by the tailer's terminal drain on session exit).
+        """
+        ...
+
+
+class LocalTranscriptByteSource:
+    """Reads a transcript straight off the local filesystem."""
+
+    def __init__(self, cwd: str, thread_id: str, config_dir: str | None) -> None:
+        self._path = transcript_path(cwd, thread_id, config_dir)
+
+    def read_from(
+        self, offset: int, *, metadata_only: bool = False, force: bool = False
+    ) -> TranscriptRead:
+        try:
+            st = self._path.stat()
+        except OSError:
+            # Missing before the first turn (or a transient stat error): keep
+            # polling without disturbing the cursor. ``force`` is a no-op — a
+            # local read is already unthrottled.
+            return TranscriptRead(observed=False)
+        identity = (st.st_dev, st.st_ino)
+        if metadata_only:
+            return TranscriptRead(observed=True, size=st.st_size, identity=identity)
+        try:
+            with self._path.open("rb") as fh:
+                fh.seek(offset)
+                data = fh.read()
+        except OSError:
+            return TranscriptRead(observed=False)
+        return TranscriptRead(
+            observed=True, data=data, size=st.st_size, identity=identity
+        )
+
+
+class RemoteClaudeTranscriptByteSource:
+    """Reads a remote Claude transcript over the SSH filesystem seam.
+
+    Discovers the transcript once by the Claude thread-artifact glob
+    (``projects/*/<uuid>.jsonl``) under the session's config-dir root, then
+    services each poll with a bounded ``read_range``. Throttles to a
+    steady-state cadence and backs off exponentially on error; the tailer loop
+    keeps ticking for its own pane/dialog work while this source no-ops between
+    reads, so SSH stays to roughly one request per second per active tailer.
+    """
+
+    def __init__(
+        self,
+        runtime: "SessionRuntime",
+        session_id: str,
+        plugin: "ClaudeTtyPlugin",
+        launch_target: SshLaunchTargetConfig,
+        config_dir: str | None,
+    ) -> None:
+        self._runtime = runtime
+        self._session_id = session_id
+        self._plugin = plugin
+        self._fs = RemoteTranscriptFilesystem(launch_target)
+        self._launch_target_id = launch_target.id
+        self._config_dir = config_dir
+        self._path: str | None = None
+        self._config_root: str | None = None
+        self._next_read_at = 0.0  # monotonic deadline; 0 = read immediately
+        self._backoff = _STEADY_INTERVAL
+        self._warned: set[str] = set()
+
+    def read_from(
+        self, offset: int, *, metadata_only: bool = False, force: bool = False
+    ) -> TranscriptRead:
+        if not force and time.monotonic() < self._next_read_at:
+            return TranscriptRead(observed=False)
+        try:
+            return self._read(offset, metadata_only)
+        except Exception:
+            # A raised remote/transport error must never kill the tailer loop
+            # (RFC req 8). ``expanduser`` on a relative config dir can raise;
+            # everything degrades to an unobserved read with error backoff.
+            self._schedule(error=True)
+            self._warn_once("read-error", "remote transcript read failed")
+            return TranscriptRead(observed=False)
+
+    def _read(self, offset: int, metadata_only: bool) -> TranscriptRead:
+        if self._path is None:
+            resolved = self._resolve()
+            if resolved is None:
+                # A clean glob miss is expected until Claude writes after the
+                # first turn: keep the steady cadence rather than backing off.
+                self._schedule(error=False)
+                return TranscriptRead(observed=False)
+            self._path = resolved
+        limit = 0 if metadata_only else _READ_LIMIT
+        read = self._fs.read_range(self._path, offset, limit)
+        if read is None:
+            self._schedule(error=True)
+            self._warn_once("read-error", "remote transcript read failed")
+            return TranscriptRead(observed=False)
+        self._schedule(error=False)
+        return TranscriptRead(
+            observed=True,
+            data=read.data,
+            size=read.size,
+            identity=(read.device, read.inode),
+        )
+
+    def _resolve(self) -> str | None:
+        session = self._runtime.storage.get_session(self._session_id)
+        if session is None:
+            return None
+        config_root = self._resolved_config_root(session.cwd)
+        matches = self._fs.glob_artifacts(session, self._plugin, config_root)
+        if not matches:
+            return None
+        if len(matches) > 1:
+            # A UUID is unique under projects/; more than one match is
+            # ambiguous — refuse to pick rather than tail an arbitrary file.
+            self._warn_once("multi-match", "multiple transcripts matched one thread")
+            return None
+        return matches[0]
+
+    def _resolved_config_root(self, cwd: str) -> str:
+        if self._config_root is not None:
+            return self._config_root
+        cfg = self._config_dir
+        if cfg is None:
+            root = "~/.claude"
+        elif cfg.startswith("/") or cfg.startswith("~"):
+            root = cfg
+        else:
+            # A relative CLAUDE_CONFIG_DIR resolves against the session's remote
+            # cwd, mirroring the launch's ``cd cwd`` before it inherits the env
+            # var — never against Waypoint's cwd or the SSH login dir.
+            base = self._fs.expanduser(cwd) if cwd.startswith("~") else cwd
+            root = posixpath.join(base, cfg)
+        self._config_root = root
+        return root
+
+    def _schedule(self, *, error: bool) -> None:
+        self._backoff = (
+            min(self._backoff * 2, _MAX_BACKOFF) if error else _STEADY_INTERVAL
+        )
+        self._next_read_at = time.monotonic() + self._backoff
+
+    def _warn_once(self, category: str, message: str) -> None:
+        if category in self._warned:
+            return
+        self._warned.add(category)
+        log.warning(
+            message,
+            extra={
+                "session_id": self._session_id,
+                "launch_target_id": self._launch_target_id,
+                "category": category,
+                "retry_delay": round(self._backoff, 1),
+            },
+        )

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -59,6 +59,11 @@ from waypoint.backends.claude_code.threads import (
 )
 from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
+from waypoint.backends.claude_tty.byte_source import (
+    LocalTranscriptByteSource,
+    RemoteClaudeTranscriptByteSource,
+    TranscriptByteSource,
+)
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
@@ -491,13 +496,24 @@ class ClaudeTtyPlugin:
         *,
         start_at_end: bool = False,
         config_dir: str | None = None,
+        launch_target: SshLaunchTargetConfig | None = None,
     ) -> None:
         if session_id in self._tailer_tasks:
             return
+        # A local session tails the shared projects tree directly; a session on
+        # an SSH launch target reads its transcript over the remote filesystem
+        # seam. The selection lives here in the transport plugin so the runtime
+        # stays unaware of Claude-specific transcript storage.
+        source: TranscriptByteSource
+        if launch_target is None:
+            source = LocalTranscriptByteSource(cwd, thread_id, config_dir)
+        else:
+            source = RemoteClaudeTranscriptByteSource(
+                runtime, session_id, self, launch_target, config_dir
+            )
         tailer = TranscriptTailer(
             session_id=session_id,
-            session_uuid=thread_id,
-            cwd=cwd,
+            source=source,
             runtime=runtime,
             plugin=self,
             start_at_end=start_at_end,
@@ -613,6 +629,7 @@ class ClaudeTtyPlugin:
             thread_id,
             request.cwd,
             config_dir=self._config_dir_from_env(request.launch_env),
+            launch_target=launch_target,
         )
         self._spawn_rate_limit_watcher(runtime, session)
         return runtime.get_session(session.id)
@@ -635,6 +652,7 @@ class ClaudeTtyPlugin:
                     session.cwd,
                     start_at_end=True,
                     config_dir=self._config_dir(session),
+                    launch_target=runtime._find_launch_target(session.launch_target_id),
                 )
             else:
                 log.warning(
@@ -737,6 +755,7 @@ class ClaudeTtyPlugin:
             session.cwd,
             start_at_end=effective_thread_id is not None,
             config_dir=self._config_dir(session),
+            launch_target=launch_target,
         )
         self._spawn_rate_limit_watcher(runtime, session)
 
@@ -846,6 +865,7 @@ class ClaudeTtyPlugin:
             new_thread_id,
             session.cwd,
             config_dir=self._config_dir(new_session),
+            launch_target=launch_target,
         )
         self._spawn_rate_limit_watcher(runtime, new_session)
         return runtime.get_session(new_session_id)
@@ -1040,6 +1060,7 @@ class ClaudeTtyPlugin:
             session.cwd,
             start_at_end=resumed,
             config_dir=self._config_dir(session),
+            launch_target=launch_target,
         )
         return True
 
@@ -1154,6 +1175,7 @@ class ClaudeTtyPlugin:
                 new_session.cwd,
                 start_at_end=True,
                 config_dir=self._config_dir(new_session),
+                launch_target=launch_target,
             )
             self._spawn_rate_limit_watcher(runtime, new_session)
         except Exception:

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -10,10 +10,10 @@ frontend can surface them.
 """
 
 import asyncio
+import functools
 import json
 import logging
 import uuid
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from waypoint.backends.claude_code.adapter import (
@@ -21,12 +21,12 @@ from waypoint.backends.claude_code.adapter import (
     claude_token_usage_record,
 )
 from waypoint.backends.claude_code.normalize import format_approval_text
-from waypoint.backends.claude_code.threads import (
-    claude_projects_root,
-    encode_project_dir,
-)
 from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
+from waypoint.backends.claude_tty.byte_source import (
+    TranscriptByteSource,
+    transcript_path,
+)
 from waypoint.backends.claude_tty.normalize import TranscriptNormalizer
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.schemas import EventKind, SessionRecord, SessionStatus
@@ -37,29 +37,17 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("waypoint.backends.claude_tty")
 
+# ``transcript_path`` moved to ``byte_source`` (where the local source uses it);
+# re-exported here for callers/tests that still import it from the tailer.
+__all__ = ["TranscriptTailer", "transcript_path"]
+
 _POLL_INTERVAL = 0.5  # seconds between transcript polls
 _PANE_CHECK_INTERVAL = 10.0  # seconds between tmux pane liveness checks
 _DIALOG_POLL_INTERVAL = 1.0  # seconds between live-pane dialog captures
 _DIALOG_STABLE_TICKS = 2  # consecutive identical captures before surfacing
-
-
-def transcript_path(cwd: str, session_uuid: str, config_dir: str | None = None) -> Path:
-    """Return the Claude TUI's JSONL transcript path for the given session.
-
-    Resolves the store root and the encoded project-dir name through the same
-    helpers thread discovery uses, so the tailed path matches where the CLI
-    actually writes — including for cwds with non-slash special characters
-    (hidden dirs, worktrees). ``config_dir`` is the session's
-    ``CLAUDE_CONFIG_DIR`` (e.g. an account profile's); pass it or the path
-    resolves under the default ``~/.claude`` and the tailer reads the wrong
-    file for a profile-scoped session — the session then never leaves
-    ``running`` because no transcript records reach the normalizer.
-    """
-    return (
-        claude_projects_root(config_dir)
-        / encode_project_dir(cwd)
-        / f"{session_uuid}.jsonl"
-    )
+# Protective cap on the unparsed trailing buffer: a JSONL record that never
+# completes past this size is dropped rather than grown without bound.
+_MAX_PARTIAL_BYTES = 8 * 1024 * 1024
 
 
 class TranscriptTailer:
@@ -74,8 +62,7 @@ class TranscriptTailer:
     def __init__(
         self,
         session_id: str,
-        session_uuid: str,
-        cwd: str,
+        source: TranscriptByteSource,
         runtime: "SessionRuntime",
         plugin: "ClaudeTtyPlugin",
         *,
@@ -83,15 +70,20 @@ class TranscriptTailer:
         config_dir: str | None = None,
     ) -> None:
         self._session_id = session_id
-        self._path = transcript_path(cwd, session_uuid, config_dir)
+        self._source = source
         self._runtime = runtime
         self._plugin = plugin
         self._normalizer = TranscriptNormalizer(config_dir)
         self._pane_check_elapsed = 0.0
         self._dialog_check_elapsed = 0.0
-        self._offset = (
-            self._path.stat().st_size if start_at_end and self._path.exists() else 0
-        )
+        # Cursor state, source-independent. ``start_at_end`` is applied lazily on
+        # the first successful observation (see ``_drain``), never here — the
+        # constructor runs on the event loop and must not do IO.
+        self._start_at_end = start_at_end
+        self._primed = False
+        self._fetch_offset = 0
+        self._partial = b""
+        self._identity: tuple[int, int] | None = None
         self._context_usage_signature: (
             tuple[int, int | None, tuple[tuple[str, int], ...]] | None
         ) = None
@@ -107,29 +99,78 @@ class TranscriptTailer:
         # the question screen.
         self._question_dismissed: bool = False
 
-    def _read_new_bytes(self) -> bytes:
-        if not self._path.exists():
-            return b""
-        try:
-            with self._path.open("rb") as fh:
-                fh.seek(self._offset)
-                return fh.read()
-        except OSError:
-            return b""
-
-    async def _drain(self) -> None:
-        data = await asyncio.to_thread(self._read_new_bytes)
-        if not data:
+    async def _drain(self, *, force: bool = False) -> None:
+        # The priming tick fetches size + identity only (no body) so start-at-end
+        # never downloads history; ``force`` bypasses a remote source's poll
+        # cadence (terminal drain on exit).
+        metadata_only = self._start_at_end and not self._primed
+        read = await asyncio.to_thread(
+            functools.partial(
+                self._source.read_from,
+                self._fetch_offset,
+                metadata_only=metadata_only,
+                force=force,
+            )
+        )
+        if not read.observed:
             return
 
-        lines = data.split(b"\n")
-        consumed = len(data)
-        # If the file ends without a trailing newline the last element is a
-        # partial record; rewind so it is re-read on the next poll.
-        if not data.endswith(b"\n"):
-            partial = lines.pop()
-            consumed -= len(partial)
-        self._offset += consumed
+        # First observation: record identity and, for start-at-end, jump to the
+        # current end without parsing (records already on disk are in the DB).
+        # This is correct regardless of whether the source resolved at
+        # construction time, so a transient boot-time miss never replays history.
+        if not self._primed:
+            self._primed = True
+            self._identity = read.identity
+            if self._start_at_end:
+                self._fetch_offset = read.size or 0
+                self._partial = b""
+                return
+
+        # Truncation (size shrank below the cursor) or replacement (file identity
+        # changed): the store cannot dedup a replay, so skip the ambiguous bytes,
+        # jump to the new end, and record one content-free note. Never re-read.
+        identity_changed = (
+            self._identity is not None
+            and read.identity is not None
+            and read.identity != self._identity
+        )
+        truncated = read.size is not None and read.size < self._fetch_offset
+        if identity_changed or truncated:
+            self._partial = b""
+            self._fetch_offset = read.size or 0
+            self._identity = read.identity
+            log.warning(
+                "transcript discontinuity; skipping to end",
+                extra={
+                    "session_id": self._session_id,
+                    "reason": "identity_changed" if identity_changed else "truncated",
+                },
+            )
+            await self._runtime._record_system_event(
+                self._session_id,
+                "Transcript was replaced or truncated; resuming from its end.",
+            )
+            return
+
+        self._identity = read.identity or self._identity
+        if not read.data:
+            return
+
+        buf = self._partial + read.data
+        self._fetch_offset += len(read.data)
+        parts = buf.split(b"\n")
+        # A trailing element without a newline is an incomplete record; keep it
+        # for the next read. ``split`` always yields a final element (b"" when
+        # ``buf`` ends in a newline), so this uniformly handles both cases.
+        self._partial = parts[-1]
+        lines = parts[:-1]
+        if len(self._partial) > _MAX_PARTIAL_BYTES:
+            log.warning(
+                "transcript partial record exceeded cap; dropping",
+                extra={"session_id": self._session_id},
+            )
+            self._partial = b""
 
         for raw_line in lines:
             line = raw_line.strip()
@@ -455,15 +496,16 @@ class TranscriptTailer:
 
                 if session.status in (SessionStatus.EXITED, SessionStatus.ERROR):
                     # One final drain in case records landed between the status
-                    # check and this point.
-                    await self._drain()
+                    # check and this point. ``force`` bypasses a remote source's
+                    # poll cadence so a tail written in the last second isn't lost.
+                    await self._drain(force=True)
                     return
 
                 self._pane_check_elapsed += _POLL_INTERVAL
                 if self._pane_check_elapsed >= _PANE_CHECK_INTERVAL:
                     self._pane_check_elapsed = 0.0
                     if not await self._pane_alive():
-                        await self._drain()
+                        await self._drain(force=True)
                         await self._runtime._record_system_event(
                             self._session_id,
                             "Claude TUI session exited",

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -10,7 +10,6 @@ frontend can surface them.
 """
 
 import asyncio
-import functools
 import json
 import logging
 import uuid
@@ -105,12 +104,10 @@ class TranscriptTailer:
         # cadence (terminal drain on exit).
         metadata_only = self._start_at_end and not self._primed
         read = await asyncio.to_thread(
-            functools.partial(
-                self._source.read_from,
-                self._fetch_offset,
-                metadata_only=metadata_only,
-                force=force,
-            )
+            self._source.read_from,
+            self._fetch_offset,
+            metadata_only=metadata_only,
+            force=force,
         )
         if not read.observed:
             return

--- a/backend/src/waypoint/backends/transcript_fs_remote.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote.py
@@ -29,10 +29,13 @@ symlink or copy is attempted — mirroring how the local implementation never
 special-cases this either.
 """
 
+import base64
+import binascii
 import importlib.resources
 import json
 import logging
 import subprocess
+from dataclasses import dataclass
 from typing import Any
 
 from waypoint.backends.transcripts import TranscriptUnavailableError
@@ -43,6 +46,23 @@ log = logging.getLogger("waypoint.backends.transcript_fs_remote")
 
 SENTINEL = "__WP_FS_BEGIN__"
 DEFAULT_TIMEOUT_SECONDS = 20.0
+
+
+@dataclass(frozen=True)
+class RemoteRead:
+    """One bounded read of a remote file: bytes plus size and stable identity.
+
+    ``size`` is the file's length at read time and ``(device, inode)`` its
+    identity, so a caller polling by offset can detect truncation (size drops
+    below its cursor) or replacement (identity changes) without downloading the
+    whole file.
+    """
+
+    data: bytes
+    size: int
+    device: int
+    inode: int
+
 
 _SCRIPT_BYTES: bytes | None = None
 
@@ -93,6 +113,35 @@ class RemoteTranscriptFilesystem:
             return []
         paths = self._run("glob", config_dir, pattern).get("paths", [])
         return paths if isinstance(paths, list) else []
+
+    def read_range(self, path: str, offset: int, limit: int) -> RemoteRead | None:
+        """Read up to ``limit`` bytes of ``path`` starting at ``offset``.
+
+        Read-only and never raises: any failure — transport, malformed payload,
+        undecodable base64 — degrades to ``None`` (an unavailable read). A live
+        transcript tailer polls this on a background loop, so a raised exception
+        would kill the loop; ``None`` lets it retry with backoff instead. The
+        decoded payload is capped to ``limit`` defensively.
+        """
+        result = self._run("read_range", path, str(offset), str(limit))
+        if "error" in result:
+            return None
+        size = result.get("size")
+        device = result.get("device")
+        inode = result.get("inode")
+        data_b64 = result.get("data_b64")
+        if (
+            not isinstance(size, int)
+            or not isinstance(device, int)
+            or not isinstance(inode, int)
+            or not isinstance(data_b64, str)
+        ):
+            return None
+        try:
+            data = base64.b64decode(data_b64, validate=True)
+        except (binascii.Error, ValueError):
+            return None
+        return RemoteRead(data=data[:limit], size=size, device=device, inode=inode)
 
     # -- mutating ops: raise on any failure, transport or remote
 

--- a/backend/src/waypoint/backends/transcript_fs_remote_script.py
+++ b/backend/src/waypoint/backends/transcript_fs_remote_script.py
@@ -18,6 +18,8 @@ Output schema (always one line, ``SENTINEL`` immediately followed by JSON,
     {"target": str} | {"error": str}            # readlink
     {"entries": [str, ...]} | {"error": str}    # listdir
     {"paths": [str, ...]}                       # glob
+    {"size": int, "device": int, "inode": int,  # read_range
+     "data_b64": str} | {"error": str}
 
 and mutating ops (mkdir, chmod, rmdir, symlink, copy_file):
 
@@ -29,10 +31,12 @@ and mutating ops (mkdir, chmod, rmdir, symlink, copy_file):
 # remote Python 3.8+ interpreter that actually executes this script.
 from __future__ import annotations
 
+import base64
 import glob as _glob
 import json
 import os
 import shutil
+import stat as _stat
 import sys
 from collections.abc import Callable
 
@@ -143,6 +147,42 @@ def op_glob(config_dir, pattern):
     emit({"paths": matches})
 
 
+def op_read_range(path, offset, limit):
+    # Bounded, read-only tail: seek to ``offset`` and read at most ``limit``
+    # bytes of a regular file, returning the file's size and stable identity
+    # (device, inode) so the caller can detect truncation/replacement. Bytes
+    # travel only inside ``data_b64`` — nothing raw is ever printed.
+    p = _u(path)
+    try:
+        want_offset = max(0, int(offset))
+        want_limit = max(0, int(limit))
+    except (TypeError, ValueError):
+        emit({"error": "offset and limit must be integers"})
+        return
+    try:
+        st = os.stat(p)
+        if not _stat.S_ISREG(st.st_mode):
+            emit({"error": "not a regular file: " + p})
+            return
+        if want_limit == 0:
+            data = b""
+        else:
+            with open(p, "rb") as fh:
+                fh.seek(want_offset)
+                data = fh.read(want_limit)
+    except OSError as exc:
+        emit({"error": str(exc)})
+        return
+    emit(
+        {
+            "size": st.st_size,
+            "device": st.st_dev,
+            "inode": st.st_ino,
+            "data_b64": base64.b64encode(data).decode("ascii"),
+        }
+    )
+
+
 def op_expanduser(path):
     # Resolve ``~`` against the remote home so the caller's policy logic
     # (relative_to, symlink-target comparison) works with absolute paths that
@@ -162,6 +202,7 @@ OPS: dict[str, Callable[..., None]] = {
     "symlink": op_symlink,
     "copy_file": op_copy_file,
     "glob": op_glob,
+    "read_range": op_read_range,
     "expanduser": op_expanduser,
 }
 

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -21,6 +21,10 @@ import pytest
 from fastapi import HTTPException
 
 from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
+from waypoint.backends.claude_tty.byte_source import (
+    LocalTranscriptByteSource,
+    TranscriptRead,
+)
 from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
@@ -63,6 +67,23 @@ def _make_session(
     )
 
 
+class _ScriptedSource:
+    """Hands over queued reads, then reports nothing observed."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._reads = [
+            TranscriptRead(observed=True, data=chunk, size=len(chunk), identity=(1, 1))
+            for chunk in chunks
+        ]
+
+    def read_from(
+        self, offset: int, *, metadata_only: bool = False, force: bool = False
+    ) -> TranscriptRead:
+        if self._reads:
+            return self._reads.pop(0)
+        return TranscriptRead(observed=False)
+
+
 def _make_tailer(
     plugin: ClaudeTtyPlugin,
     runtime: MagicMock,
@@ -70,8 +91,7 @@ def _make_tailer(
 ) -> TranscriptTailer:
     return TranscriptTailer(
         session_id=session_id,
-        session_uuid="thread-1",
-        cwd="/nonexistent",
+        source=LocalTranscriptByteSource("/nonexistent", "thread-1", None),
         runtime=runtime,
         plugin=plugin,
     )
@@ -455,7 +475,7 @@ async def test_question_drain_registers_pending() -> None:
         },
     }
     data = (json.dumps(record) + "\n").encode()
-    tailer._read_new_bytes = lambda: data  # type: ignore[method-assign]
+    tailer._source = _ScriptedSource([data])
 
     await tailer._drain()
 
@@ -584,6 +604,7 @@ async def _run_exited_reconnect(resumes: bool) -> bool:
         *,
         start_at_end: bool = False,
         config_dir: str | None = None,
+        launch_target: object = None,
     ) -> None:
         captured["start_at_end"] = start_at_end
 

--- a/backend/tests/test_claude_tty_byte_source.py
+++ b/backend/tests/test_claude_tty_byte_source.py
@@ -260,3 +260,39 @@ def test_remote_exception_does_not_raise(monkeypatch) -> None:
     read = src.read_from(0)  # must not raise
     assert read.observed is False
     assert src._backoff > 1.0  # error backoff engaged
+
+
+# ── source selection at the plugin boundary ──────────────────────────────────
+
+
+def _capture_source(monkeypatch, **start_kwargs) -> object:
+    from waypoint.backends.claude_tty import plugin as plugin_mod
+
+    captured: dict[str, object] = {}
+
+    class _FakeTailer:
+        def __init__(self, **kwargs: object) -> None:
+            captured.update(kwargs)
+
+        def run(self) -> None:  # pragma: no cover - never awaited
+            return None
+
+    monkeypatch.setattr(plugin_mod, "TranscriptTailer", _FakeTailer)
+    monkeypatch.setattr(plugin_mod.asyncio, "create_task", lambda coro: MagicMock())
+    plugin = plugin_mod.ClaudeTtyPlugin()
+    plugin._start_tailer(MagicMock(), "s1", TID, "/repo/app", **start_kwargs)
+    return captured["source"]
+
+
+def test_start_tailer_builds_local_source_without_target(monkeypatch) -> None:
+    source = _capture_source(monkeypatch, config_dir="/cfg", launch_target=None)
+    assert isinstance(source, bs.LocalTranscriptByteSource)
+
+
+def test_start_tailer_builds_remote_source_with_target(monkeypatch) -> None:
+    source = _capture_source(
+        monkeypatch, config_dir="/home/u/.claude-work", launch_target=_launch_target()
+    )
+    assert isinstance(source, bs.RemoteClaudeTranscriptByteSource)
+    assert source._config_dir == "/home/u/.claude-work"
+    assert source._launch_target_id == "remote-1"

--- a/backend/tests/test_claude_tty_byte_source.py
+++ b/backend/tests/test_claude_tty_byte_source.py
@@ -1,0 +1,262 @@
+"""Unit tests for claude_tty transcript byte sources."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from waypoint.backends.claude_tty import byte_source as bs
+from waypoint.backends.claude_tty.byte_source import (
+    LocalTranscriptByteSource,
+    RemoteClaudeTranscriptByteSource,
+)
+from waypoint.backends.transcript_fs_remote import RemoteRead
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+TID = "11111111-1111-1111-1111-111111111111"
+
+
+def _session(cwd: str = "/repo/app") -> SessionRecord:
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id="s1",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="claude_tty",
+        title="t",
+        cwd=cwd,
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/r",
+        structured_log_path="/e",
+        transport_state={"thread_id": TID},
+    )
+
+
+def _launch_target() -> SshLaunchTargetConfig:
+    return SshLaunchTargetConfig(
+        id="remote-1", name="Remote", ssh_destination="host", ssh_bin="/bin/sh"
+    )
+
+
+# ── Local source ─────────────────────────────────────────────────────────────
+
+
+def test_local_missing_file_is_unobserved(tmp_path: Path) -> None:
+    src = LocalTranscriptByteSource.__new__(LocalTranscriptByteSource)
+    src._path = tmp_path / "nope.jsonl"
+    read = src.read_from(0)
+    assert read.observed is False
+
+
+def test_local_reads_data_size_identity(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b"line one\nline two\n")
+    src = LocalTranscriptByteSource.__new__(LocalTranscriptByteSource)
+    src._path = path
+    read = src.read_from(0)
+    assert read.observed is True
+    assert read.data == b"line one\nline two\n"
+    assert read.size == 18
+    st = path.stat()
+    assert read.identity == (st.st_dev, st.st_ino)
+
+
+def test_local_honors_offset(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b"0123456789")
+    src = LocalTranscriptByteSource.__new__(LocalTranscriptByteSource)
+    src._path = path
+    read = src.read_from(4)
+    assert read.data == b"456789"
+
+
+def test_local_metadata_only_does_not_read_body(tmp_path: Path) -> None:
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b"0123456789")
+    src = LocalTranscriptByteSource.__new__(LocalTranscriptByteSource)
+    src._path = path
+    read = src.read_from(0, metadata_only=True)
+    assert read.observed is True
+    assert read.data == b""
+    assert read.size == 10
+    assert read.identity is not None
+
+
+# ── Remote source ────────────────────────────────────────────────────────────
+
+
+class _FakeFs:
+    def __init__(self) -> None:
+        self.glob_result: list[str] = []
+        self.read_result: RemoteRead | None = None
+        self.glob_calls = 0
+        self.read_calls: list[tuple[str, int, int]] = []
+        self.expand: dict[str, str] = {}
+
+    def glob_artifacts(
+        self, session: object, plugin: object, config_dir: str
+    ) -> list[str]:
+        self.glob_calls += 1
+        self.last_config_dir = config_dir
+        return list(self.glob_result)
+
+    def read_range(self, path: str, offset: int, limit: int) -> RemoteRead | None:
+        self.read_calls.append((path, offset, limit))
+        return self.read_result
+
+    def expanduser(self, path: str) -> str:
+        return self.expand.get(path, path)
+
+
+def _remote_source(
+    fs: _FakeFs, session: SessionRecord, config_dir: str | None = None
+) -> RemoteClaudeTranscriptByteSource:
+    runtime = MagicMock()
+    runtime.storage.get_session.return_value = session
+    src = RemoteClaudeTranscriptByteSource(
+        runtime, session.id, MagicMock(), _launch_target(), config_dir
+    )
+    src._fs = fs  # type: ignore[assignment]
+    return src
+
+
+def test_remote_discovery_miss_is_unobserved_steady(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 100.0)
+    fs = _FakeFs()  # empty glob result
+    src = _remote_source(fs, _session())
+    read = src.read_from(0)
+    assert read.observed is False
+    assert fs.glob_calls == 1
+    # steady cadence: next read ~1s out
+    assert src._next_read_at == 101.0
+
+
+def test_remote_resolves_then_reads(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+    fs.glob_result = ["/home/u/.claude/projects/-repo-app/" + TID + ".jsonl"]
+    fs.read_result = RemoteRead(data=b"hello\n", size=6, device=1, inode=2)
+    src = _remote_source(fs, _session())
+    read = src.read_from(0)
+    assert read.observed is True
+    assert read.data == b"hello\n"
+    assert read.size == 6
+    assert read.identity == (1, 2)
+    # path cached: a second read does not re-glob
+    src._next_read_at = 0.0
+    src.read_from(6)
+    assert fs.glob_calls == 1
+    assert fs.read_calls[-1] == (fs.glob_result[0], 6, 256 * 1024)
+
+
+def test_remote_multi_match_refuses(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+    fs.glob_result = ["/a/" + TID + ".jsonl", "/b/" + TID + ".jsonl"]
+    src = _remote_source(fs, _session())
+    read = src.read_from(0)
+    assert read.observed is False
+    assert src._path is None
+
+
+def test_remote_read_none_backs_off(monkeypatch) -> None:
+    t = {"now": 0.0}
+    monkeypatch.setattr(bs.time, "monotonic", lambda: t["now"])
+    fs = _FakeFs()
+    fs.glob_result = ["/p/" + TID + ".jsonl"]
+    fs.read_result = None  # read failure
+    src = _remote_source(fs, _session())
+    src.read_from(0)
+    first = src._next_read_at
+    t["now"] = first
+    src.read_from(0)
+    second = src._next_read_at
+    # exponential: second interval strictly larger than the first
+    assert (second - t["now"]) > (first - 0.0)
+
+
+def test_remote_backoff_capped(monkeypatch) -> None:
+    t = {"now": 0.0}
+    monkeypatch.setattr(bs.time, "monotonic", lambda: t["now"])
+    fs = _FakeFs()
+    fs.glob_result = ["/p/" + TID + ".jsonl"]
+    fs.read_result = None
+    src = _remote_source(fs, _session())
+    for _ in range(20):
+        t["now"] = src._next_read_at
+        src.read_from(0)
+    assert src._backoff <= 10.0
+
+
+def test_remote_cadence_throttles(monkeypatch) -> None:
+    t = {"now": 0.0}
+    monkeypatch.setattr(bs.time, "monotonic", lambda: t["now"])
+    fs = _FakeFs()
+    fs.glob_result = ["/p/" + TID + ".jsonl"]
+    fs.read_result = RemoteRead(data=b"", size=0, device=1, inode=2)
+    src = _remote_source(fs, _session())
+    src.read_from(0)
+    calls_after_first = len(fs.read_calls)
+    # within the interval, a non-forced read is throttled (no SSH)
+    t["now"] = src._next_read_at - 0.01
+    read = src.read_from(0)
+    assert read.observed is False
+    assert len(fs.read_calls) == calls_after_first
+    # force bypasses the gate
+    read = src.read_from(0, force=True)
+    assert read.observed is True
+    assert len(fs.read_calls) == calls_after_first + 1
+
+
+def test_remote_metadata_only_uses_zero_limit(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+    fs.glob_result = ["/p/" + TID + ".jsonl"]
+    fs.read_result = RemoteRead(data=b"", size=42, device=1, inode=2)
+    src = _remote_source(fs, _session())
+    read = src.read_from(0, metadata_only=True)
+    assert read.observed is True
+    assert read.size == 42
+    assert fs.read_calls[-1][2] == 0  # limit
+
+
+def test_remote_config_root_default(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+    src = _remote_source(fs, _session(), config_dir=None)
+    src.read_from(0)
+    assert fs.last_config_dir == "~/.claude"
+
+
+def test_remote_config_root_absolute(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+    src = _remote_source(fs, _session(), config_dir="/home/u/.claude-work")
+    src.read_from(0)
+    assert fs.last_config_dir == "/home/u/.claude-work"
+
+
+def test_remote_config_root_relative_joins_remote_cwd(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+    fs.expand["~/repo"] = "/home/u/repo"
+    src = _remote_source(fs, _session(cwd="~/repo"), config_dir=".claude-rel")
+    src.read_from(0)
+    assert fs.last_config_dir == "/home/u/repo/.claude-rel"
+
+
+def test_remote_exception_does_not_raise(monkeypatch) -> None:
+    monkeypatch.setattr(bs.time, "monotonic", lambda: 0.0)
+    fs = _FakeFs()
+
+    def _boom(*a: object, **k: object) -> list[str]:
+        raise RuntimeError("ssh exploded")
+
+    fs.glob_artifacts = _boom  # type: ignore[method-assign]
+    src = _remote_source(fs, _session())
+    read = src.read_from(0)  # must not raise
+    assert read.observed is False
+    assert src._backoff > 1.0  # error backoff engaged

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -99,10 +99,12 @@ def _stub_lifecycle(plugin: ClaudeTtyPlugin) -> dict[str, object]:
         *,
         start_at_end: bool = False,
         config_dir: str | None = None,
+        launch_target: object = None,
     ) -> None:
         captured["tailer_thread_id"] = thread_id
         captured["start_at_end"] = start_at_end
         captured["tailer_config_dir"] = config_dir
+        captured["tailer_launch_target"] = launch_target
 
     plugin._start_tailer = _fake_start_tailer  # type: ignore[method-assign]
     plugin._spawn_rate_limit_watcher = MagicMock()  # type: ignore[method-assign]

--- a/backend/tests/test_claude_tty_tailer.py
+++ b/backend/tests/test_claude_tty_tailer.py
@@ -2,12 +2,34 @@
 
 import json
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from waypoint.backends.claude_tty.byte_source import TranscriptRead
 from waypoint.backends.claude_tty.tailer import TranscriptTailer, transcript_path
 from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+
+class _FakeSource:
+    """A byte source that hands over fed bytes once, modeling a growing file."""
+
+    def __init__(self) -> None:
+        self._pending = b""
+        self._size = 0
+
+    def feed(self, data: bytes) -> None:
+        self._pending = data
+
+    def read_from(
+        self, offset: int, *, metadata_only: bool = False, force: bool = False
+    ) -> TranscriptRead:
+        data = b"" if metadata_only else self._pending
+        self._pending = b""
+        self._size += len(data)
+        return TranscriptRead(
+            observed=True, data=data, size=self._size, identity=(1, 1)
+        )
 
 
 def test_transcript_path_honors_config_dir() -> None:
@@ -53,19 +75,23 @@ def _make_runtime(session: SessionRecord) -> MagicMock:
     runtime._emit_adapter_event = AsyncMock()
     runtime.update_session_fields = AsyncMock()
     runtime.publish_token_usage_record = AsyncMock()
+    runtime._record_system_event = AsyncMock()
     return runtime
 
 
-def _make_tailer(runtime: MagicMock, session_id: str = "sess-1") -> TranscriptTailer:
+def _make_tailer(
+    runtime: MagicMock, session_id: str = "sess-1"
+) -> tuple[TranscriptTailer, _FakeSource]:
     plugin = MagicMock()
     plugin._pending_questions = {}
-    return TranscriptTailer(
+    source = _FakeSource()
+    tailer = TranscriptTailer(
         session_id=session_id,
-        session_uuid="thread-1",
-        cwd="/nonexistent",
+        source=source,
         runtime=runtime,
         plugin=plugin,
     )
+    return tailer, source
 
 
 def _jsonl(*records: dict) -> bytes:
@@ -94,15 +120,13 @@ def _assistant_record(
 async def test_drain_publishes_context_usage_on_assistant_record() -> None:
     session = _make_session()
     runtime = _make_runtime(session)
-    tailer = _make_tailer(runtime)
+    tailer, source = _make_tailer(runtime)
 
     record = _assistant_record(
         usage={"input_tokens": 15, "cache_read_input_tokens": 4, "output_tokens": 6}
     )
-    data = _jsonl(record)
-
-    with patch.object(tailer, "_read_new_bytes", return_value=data):
-        await tailer._drain()
+    source.feed(_jsonl(record))
+    await tailer._drain()
 
     runtime.update_session_fields.assert_called_once()
     call_kwargs = runtime.update_session_fields.call_args
@@ -118,15 +142,13 @@ async def test_drain_publishes_context_usage_on_assistant_record() -> None:
 async def test_drain_dedupes_unchanged_context_usage() -> None:
     session = _make_session()
     runtime = _make_runtime(session)
-    tailer = _make_tailer(runtime)
+    tailer, source = _make_tailer(runtime)
 
     usage = {"input_tokens": 10, "output_tokens": 5}
     record1 = _assistant_record(message_id="msg_1", usage=usage)
     record2 = _assistant_record(message_id="msg_2", usage=usage)
-    data = _jsonl(record1, record2)
-
-    with patch.object(tailer, "_read_new_bytes", return_value=data):
-        await tailer._drain()
+    source.feed(_jsonl(record1, record2))
+    await tailer._drain()
 
     # Same (used_tokens, context_window_tokens) — only one publish
     assert runtime.update_session_fields.call_count == 1
@@ -136,14 +158,13 @@ async def test_drain_dedupes_unchanged_context_usage() -> None:
 async def test_drain_publishes_again_when_usage_changes() -> None:
     session = _make_session()
     runtime = _make_runtime(session)
-    tailer = _make_tailer(runtime)
+    tailer, source = _make_tailer(runtime)
 
     record1 = _assistant_record(
         message_id="msg_1", usage={"input_tokens": 10, "output_tokens": 5}
     )
-    data1 = _jsonl(record1)
-    with patch.object(tailer, "_read_new_bytes", return_value=data1):
-        await tailer._drain()
+    source.feed(_jsonl(record1))
+    await tailer._drain()
 
     assert runtime.update_session_fields.call_count == 1
     first_used = runtime.update_session_fields.call_args.kwargs[
@@ -153,12 +174,141 @@ async def test_drain_publishes_again_when_usage_changes() -> None:
     record2 = _assistant_record(
         message_id="msg_2", usage={"input_tokens": 20, "output_tokens": 8}
     )
-    data2 = _jsonl(record2)
-    with patch.object(tailer, "_read_new_bytes", return_value=data2):
-        await tailer._drain()
+    source.feed(_jsonl(record2))
+    await tailer._drain()
 
     assert runtime.update_session_fields.call_count == 2
     second_used = runtime.update_session_fields.call_args.kwargs[
         "context_usage"
     ].used_tokens
     assert second_used > first_used
+
+
+class _ScriptedSource:
+    """Returns a queued list of reads, then unobserved."""
+
+    def __init__(self, reads: list[TranscriptRead]) -> None:
+        self._reads = list(reads)
+
+    def read_from(
+        self, offset: int, *, metadata_only: bool = False, force: bool = False
+    ) -> TranscriptRead:
+        if self._reads:
+            return self._reads.pop(0)
+        return TranscriptRead(observed=False)
+
+
+@pytest.mark.asyncio
+async def test_partial_record_carries_across_reads() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    full = _jsonl(_assistant_record())
+    mid = len(full) // 2
+    source = _ScriptedSource(
+        [
+            TranscriptRead(observed=True, data=full[:mid], size=mid, identity=(1, 1)),
+            TranscriptRead(
+                observed=True, data=full[mid:], size=len(full), identity=(1, 1)
+            ),
+        ]
+    )
+    tailer = TranscriptTailer(
+        session_id="sess-1", source=source, runtime=runtime, plugin=plugin
+    )
+    await tailer._drain()  # first half: incomplete record, no emit
+    assert runtime.update_session_fields.call_count == 0
+    await tailer._drain()  # second half completes the record
+    assert runtime.update_session_fields.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_start_at_end_skips_history_then_emits_append() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    history = _jsonl(_assistant_record(message_id="old"))
+    append = _jsonl(_assistant_record(message_id="new"))
+    source = _ScriptedSource(
+        [
+            # prime: start-at-end fetches metadata only; body (if any) discarded
+            TranscriptRead(
+                observed=True, data=history, size=len(history), identity=(1, 1)
+            ),
+            TranscriptRead(
+                observed=True,
+                data=append,
+                size=len(history) + len(append),
+                identity=(1, 1),
+            ),
+        ]
+    )
+    tailer = TranscriptTailer(
+        session_id="sess-1",
+        source=source,
+        runtime=runtime,
+        plugin=plugin,
+        start_at_end=True,
+    )
+    await tailer._drain()  # prime: no historical replay
+    assert runtime.update_session_fields.call_count == 0
+    await tailer._drain()  # append emitted once
+    assert runtime.update_session_fields.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_truncation_records_note_and_skips_replay() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    first = _jsonl(_assistant_record(message_id="a"))
+    source = _ScriptedSource(
+        [
+            TranscriptRead(observed=True, data=first, size=len(first), identity=(1, 1)),
+            # file shrank below the cursor: truncation
+            TranscriptRead(observed=True, data=b"", size=3, identity=(1, 1)),
+        ]
+    )
+    tailer = TranscriptTailer(
+        session_id="sess-1", source=source, runtime=runtime, plugin=plugin
+    )
+    await tailer._drain()
+    assert runtime.update_session_fields.call_count == 1
+    await tailer._drain()
+    runtime._record_system_event.assert_awaited_once()
+    # no re-parse: still exactly one context-usage publish
+    assert runtime.update_session_fields.call_count == 1
+    assert tailer._fetch_offset == 3
+
+
+@pytest.mark.asyncio
+async def test_replacement_identity_change_skips_replay() -> None:
+    session = _make_session()
+    runtime = _make_runtime(session)
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    first = _jsonl(_assistant_record(message_id="a"))
+    source = _ScriptedSource(
+        [
+            TranscriptRead(observed=True, data=first, size=len(first), identity=(1, 1)),
+            # new inode → replacement; a fresh full transcript must not replay
+            TranscriptRead(
+                observed=True,
+                data=_jsonl(_assistant_record(message_id="b")),
+                size=999,
+                identity=(2, 2),
+            ),
+        ]
+    )
+    tailer = TranscriptTailer(
+        session_id="sess-1", source=source, runtime=runtime, plugin=plugin
+    )
+    await tailer._drain()
+    assert runtime.update_session_fields.call_count == 1
+    await tailer._drain()
+    runtime._record_system_event.assert_awaited_once()
+    assert runtime.update_session_fields.call_count == 1
+    assert tailer._fetch_offset == 999

--- a/backend/tests/test_transcripts_remote.py
+++ b/backend/tests/test_transcripts_remote.py
@@ -410,6 +410,137 @@ def test_remote_symlink_shared_tilde_dir_matches_existing_symlink(
     assert result == ThreadAvailability.UNPERSISTED
 
 
+# ── read_range ──────────────────────────────────────────────────────────────
+
+
+def test_remote_read_range_reads_bytes_and_reports_identity(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / f"{TID}.jsonl"
+    target.write_bytes(b"line one\nline two\n")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range(str(target), 0, 256 * 1024)
+    assert read is not None
+    assert read.data == b"line one\nline two\n"
+    assert read.size == 18
+    st = target.stat()
+    assert read.device == st.st_dev
+    assert read.inode == st.st_ino
+
+
+def test_remote_read_range_honors_offset(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / "t.jsonl"
+    target.write_bytes(b"0123456789")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range(str(target), 4, 256 * 1024)
+    assert read is not None
+    assert read.data == b"456789"
+    assert read.size == 10
+
+
+def test_remote_read_range_caps_to_limit(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / "t.jsonl"
+    target.write_bytes(b"0123456789")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range(str(target), 0, 4)
+    assert read is not None
+    assert read.data == b"0123"
+    # size still reflects the whole file, not the capped read
+    assert read.size == 10
+
+
+def test_remote_read_range_metadata_only_with_zero_limit(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / "t.jsonl"
+    target.write_bytes(b"0123456789")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range(str(target), 0, 0)
+    assert read is not None
+    assert read.data == b""
+    assert read.size == 10
+
+
+def test_remote_read_range_offset_past_eof_returns_empty(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / "t.jsonl"
+    target.write_bytes(b"0123456789")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range(str(target), 50, 256 * 1024)
+    assert read is not None
+    assert read.data == b""
+    assert read.size == 10
+
+
+def test_remote_read_range_binary_round_trip(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / "t.jsonl"
+    payload = bytes(range(256))
+    target.write_bytes(payload)
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range(str(target), 0, 256 * 1024)
+    assert read is not None
+    assert read.data == payload
+
+
+def test_remote_read_range_missing_file_returns_none(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    assert fs.read_range(str(tmp_path / "nope.jsonl"), 0, 256 * 1024) is None
+
+
+def test_remote_read_range_directory_returns_none(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    assert fs.read_range(str(tmp_path), 0, 256 * 1024) is None
+
+
+def test_remote_read_range_malformed_response_returns_none(
+    tmp_path: Path, fake_remote: _FakeRemote
+) -> None:
+    target = tmp_path / "t.jsonl"
+    target.write_bytes(b"data")
+    fake_remote.force_error("read_range", "boom")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    assert fs.read_range(str(target), 0, 256 * 1024) is None
+
+
+def test_remote_read_range_transport_failure_returns_none(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        SshLaunchTargetConfig,
+        "build_remote_exec_args",
+        lambda self, command, *a, **kw: ("ssh", "test-host", "python3 -"),
+    )
+    monkeypatch.setattr(
+        remote_mod.subprocess,
+        "run",
+        lambda *a, **kw: (_ for _ in ()).throw(subprocess.TimeoutExpired("ssh", 20)),
+    )
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    assert fs.read_range("/whatever", 0, 256 * 1024) is None
+
+
+def test_remote_read_range_expands_tilde(
+    tmp_path: Path, fake_remote: _FakeRemote, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "t.jsonl").write_bytes(b"hi")
+    fs = RemoteTranscriptFilesystem(_launch_target())
+    read = fs.read_range("~/t.jsonl", 0, 256 * 1024)
+    assert read is not None
+    assert read.data == b"hi"
+
+
 def test_remote_script_ops_expand_tilde_against_the_running_host() -> None:
     # Ops resolve ``~`` on the host that runs the script (the remote one in
     # production; here the test host stands in), so a ``~``-relative config_dir


### PR DESCRIPTION
## Purpose

A remote Claude Code TUI (`claude_tty`) session was silently blind: Waypoint starts the TUI on the SSH target through a local tmux pane, but the tailer then opened the expected Claude JSONL transcript on the machine running Waypoint. The remote `claude` process writes that file on the SSH target, so the tailer saw no records and the Waypoint transcript stayed empty — no assistant output, tool activity, approvals, or context telemetry — even though the pane was controllable. This makes a remote `claude_tty` session read its transcript on its SSH target and emit the same canonical events a local session does. Implements the RFC "Remote Claude TUI Transcript Tailing".

## Changes

### Backend
- `backends/transcript_fs_remote_script.py` — add a read-only `read_range <path> <offset> <limit>` op to the vendored remote helper, returning the requested bytes as base64 plus the file's size and stable `(device, inode)` identity. Stdlib-only, py3.8-safe; raw bytes never leave the base64 field.
- `backends/transcript_fs_remote.py` — add a `RemoteRead` result and `RemoteTranscriptFilesystem.read_range()`. It validates the payload and never raises: every failure (transport, malformed payload, undecodable base64) degrades to `None`, so a background tailer retries rather than dies.
- `backends/claude_tty/byte_source.py` (new) — a `TranscriptByteSource` abstraction. `LocalTranscriptByteSource` reads the shared projects tree as before; `RemoteClaudeTranscriptByteSource` discovers a remote transcript by the Claude thread-artifact glob (`projects/*/<uuid>.jsonl`, never by encoding a possibly non-canonical remote cwd) and services each poll with a bounded `read_range`, throttling to ~1 req/s with exponential error backoff (cap 10s). A source never raises — any remote/transport error, including a relative-config-dir `expanduser`, becomes an unobserved read.
- `backends/claude_tty/tailer.py` — drive `TranscriptTailer` off the byte source. Cursor state is now a source-independent fetch offset plus a carried partial-record buffer and a file identity. Start-at-end primes metadata-only on the first observation (no history download, no replay even if discovery transiently misses at boot); a truncation (size shrinks below the cursor) or replacement (identity changes) skips to the new end and records one content-free note rather than replaying events the store cannot dedup; the terminal drain forces a final read past the poll cadence. Local behavior is unchanged.
- `backends/claude_tty/plugin.py` — `_start_tailer` selects a local source for local sessions and a remote one when the session has a launch target, threading the target through every lifecycle path (create, boot-restore, EXITED-reconnect, fork, restart-with-args, side-question promotion; import stays local). Selection lives in the transport plugin; the runtime stays agent-agnostic.

### Tests
- `tests/test_transcripts_remote.py` — `read_range` cases through the existing fake-remote harness: offset, cap, metadata-only (limit 0), past-EOF, binary round-trip, identity, missing file, directory, malformed response, transport failure, tilde expansion.
- `tests/test_claude_tty_byte_source.py` (new) — local source parity; remote discovery miss / resolve / multi-match refusal / read-failure backoff / cap / cadence throttle + force / metadata-only / config-root resolution (default, absolute, relative→remote cwd) / never-raises; and `_start_tailer` source selection per target.
- `tests/test_claude_tty_tailer.py` — partial-record carry across reads, start-at-end skips history then emits an append once, truncation and identity-change discontinuities record a note and skip replay.

## Design

The recommended RFC approach (Option 1): extend the already-tested remote filesystem seam with a bounded read primitive and adapt the tailer to a byte-source seam, keeping the canonical `TranscriptNormalizer`, event store, approval cards, and frontend rendering untouched. Discovery is by thread UUID (globally unique under `projects/`) rather than by a locally encoded cwd, so a symlinked worktree or `~/repo` spelling on the remote can't misdirect it. One deliberate deviation from the RFC's implementation guide: instead of a second remote helper op to resolve a relative `CLAUDE_CONFIG_DIR`, the remote source reuses the existing `expanduser` op (`None`→`~/.claude`; absolute/`~` pass through; relative joins the remote cwd), closing the same gap with less remote surface. The approval/question path is untouched — it continues to read the live tmux pane, per the RFC's scope.

## Test Plan

- `cd backend && uv run pre-commit run --all-files` — clean (black, isort, ruff, codespell, mypy).
- `cd backend && uv run pytest` — 1795 passed.
- End-to-end against a live key-auth SSH target: launched a remote `claude_tty` session, sent a prompt driving a Bash tool call. The user turn, assistant text, the Bash `tool_call` + `tool_result`, and both `context_usage` and per-turn `session_token_usage` telemetry each appeared exactly once; the tool ran on the remote host. A settings restart (model swap → restart-with-resume) replayed nothing (content-event count unchanged) and the next turn emitted once.

## Test Result

Backend `1795 passed`; pre-commit clean. Live remote e2e: content events `{user_input, agent_output, tool_call: Bash, tool_result}` each once, telemetry populated (`context_usage.used_tokens` and `session_token_usage.tracked_turns=2`, `coverage=entire_waypoint_session`); post-resume counts unchanged with a clean second turn.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work. (Change is contained to the claude_tty transport and the shared remote-read primitive; no per-backend dispatch branch added.)
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional). (No frontend change.)
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above. (Not a breaking change.)
- [ ] I have updated documentation or config examples (`.env.example`, `backend/waypoint.example.yaml`, `docs/`) if user-facing behavior changed. (No config/API surface change.)

</details>