### PR TITLE
feat: switch a managed session's transport from Session settings

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -671,8 +671,12 @@ class ClaudeTtyPlugin:
 
         launch_target = runtime._find_launch_target(session.launch_target_id)
         stored_args = state.get("launch_args")
+        # After a transport switch the state is reset to the neutral native-thread
+        # handoff (no launch_args); fall back to the persisted custom args so they
+        # survive the switch. Model/effort/permission are inherited via --resume
+        # (scrubbed here as on every reconnect).
         base_args = _scrub_session_args(
-            stored_args if isinstance(stored_args, list) else []
+            stored_args if isinstance(stored_args, list) else list(session.args)
         )
 
         effective_thread_id: str | None = None

--- a/backend/src/waypoint/backends/registry.py
+++ b/backend/src/waypoint/backends/registry.py
@@ -85,6 +85,24 @@ class BackendRegistry:
     def plugin_for(self, session: SessionRecord) -> BackendPlugin:
         return self.resolve(session.backend, session.transport)
 
+    def capabilities_for_pair(
+        self, backend_id: str, transport_id: str
+    ) -> BackendCapabilities:
+        """Compose the capabilities of an arbitrary ``(agent, transport)`` pair.
+
+        The agent axis comes from ``get(backend_id)`` and the transport axis
+        from ``for_transport(transport_id)`` — the same composition
+        :meth:`capabilities_for` does for a session, but for a pair that may not
+        yet be persisted (e.g. projecting a switch target). Raises ``KeyError``
+        for an unknown agent or transport.
+        """
+        agent = self.get(backend_id)
+        transport_owner = self.for_transport(transport_id)
+        return BackendCapabilities.from_split(
+            agent.capabilities.agent_capabilities(),
+            transport_owner.capabilities.transport_capabilities(),
+        )
+
     def capabilities_for(self, session: SessionRecord) -> BackendCapabilities:
         """Compose the session's capabilities from its (agent, transport) axes.
 
@@ -101,12 +119,7 @@ class BackendRegistry:
         this equals the flat descriptor; for a wrapped pair it reflects
         what the pair can actually do.
         """
-        agent = self.get(session.backend)
-        transport_owner = self.for_transport(session.transport)
-        return BackendCapabilities.from_split(
-            agent.capabilities.agent_capabilities(),
-            transport_owner.capabilities.transport_capabilities(),
-        )
+        return self.capabilities_for_pair(session.backend, session.transport)
 
     def supported_transports(self, backend_id: str) -> tuple[str, ...]:
         """Transport ids the named agent declares it can be driven over."""

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -463,7 +463,19 @@ class TmuxPlugin:
         thread_id = state.get("thread_id")
         stored_args = state.get("launch_args")
         if not isinstance(stored_args, list):
-            stored_args = []
+            # No stored launch args — the usual after a transport switch reset
+            # the state to the neutral native-thread handoff. Reconstruct the
+            # managed flags and custom args from the persisted session fields via
+            # the agent contract so the resumed pane keeps model/effort/
+            # permission and custom args (they live only in launch_args).
+            stored_args = [
+                *inner.launch_flags(
+                    model=session.model,
+                    effort=session.effort,
+                    permission_mode=session.permission_mode,
+                ),
+                *session.args,
+            ]
         # A captured thread_id is only useful if the inner CLI has
         # actually persisted the conversation to disk. ``claude
         # --session-id <uuid>`` doesn't create the session file until

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -27,6 +27,7 @@ from waypoint.backends.account_profiles import (
     resolve_account_profiles,
 )
 from waypoint.backends.base import (
+    AgentLaunchContract,
     ConfigDirNotReadyError,
     ConfigDirValidating,
     DefaultConfigDirProviding,
@@ -98,6 +99,7 @@ from waypoint.schemas import (
     SessionStatus,
     TokenUsageInit,
     TokenUsageRecord,
+    TransportSettingsOption,
 )
 from waypoint.settings import Settings
 from waypoint.ssh_master import SshMasterManager, SshMasterStatus
@@ -2333,6 +2335,64 @@ class SessionRuntime:
             self._session_locks[session_id] = lock
         return lock
 
+    def _transport_switch_options(
+        self, session: SessionRecord, caps: BackendCapabilities
+    ) -> list[TransportSettingsOption]:
+        """Project the interfaces a session may safely switch to.
+
+        Switching is offered only for a managed session whose agent has a
+        resumable native store (``native_thread_store`` — Claude/Codex, not
+        OpenCode or a bare attached pane) and declares more than one usable
+        transport. Each option carries the restart-scoped launch capabilities of
+        the resulting ``(agent, transport)`` pair so the modal can gate advanced
+        fields while an Interface change is staged. The current transport is
+        listed first so the controlled select is valid before any change.
+        """
+        if session.source == SessionSource.ATTACHED_TMUX:
+            return []
+        # An agent with no resumable native store cannot prove a switch keeps the
+        # conversation, so it advertises none (agent-agnostic OpenCode exclusion).
+        if not caps.native_thread_store:
+            return []
+        safe_targets: list[str] = []
+        for transport_id in self.registry.supported_transports(session.backend):
+            if transport_id == session.transport:
+                continue
+            try:
+                pair_caps = self.registry.capabilities_for_pair(
+                    session.backend, transport_id
+                )
+            except KeyError:
+                continue
+            if not pair_caps.supports_reattach_after_exit:
+                continue
+            safe_targets.append(transport_id)
+        if not safe_targets:
+            return []
+        options: list[TransportSettingsOption] = []
+        for transport_id in [session.transport, *safe_targets]:
+            try:
+                pair_caps = self.registry.capabilities_for_pair(
+                    session.backend, transport_id
+                )
+            except KeyError:
+                continue
+            options.append(
+                TransportSettingsOption(
+                    id=transport_id,
+                    supports_launch_settings_with_restart=(
+                        pair_caps.supports_launch_settings_with_restart
+                        and pair_caps.supports_reattach_after_exit
+                    ),
+                    supports_account_profile_with_restart=(
+                        pair_caps.supports_account_profile_with_restart
+                    ),
+                    supports_custom_args=pair_caps.supports_custom_cli_args,
+                    supports_config_overrides=pair_caps.supports_config_overrides,
+                )
+            )
+        return options
+
     def get_launch_settings(self, session_id: str) -> LaunchSettingsResponse:
         session = self.get_session(session_id)
         caps = self.registry.capabilities_for(session)
@@ -2343,11 +2403,20 @@ class SessionRuntime:
         # A bare attached tmux pane advertises the restart capability at the
         # transport level, but Waypoint does not own the process, so it cannot
         # honestly restart-and-resume it. Mirror the runtime gate here.
+        is_attached_tmux = session.source == SessionSource.ATTACHED_TMUX
         supports_launch_settings_with_restart = (
             caps.supports_launch_settings_with_restart
             and caps.supports_reattach_after_exit
-            and session.source != SessionSource.ATTACHED_TMUX
+            and not is_attached_tmux
         )
+        # An attached pane's derived account-profile capability is True (its
+        # agent has a config-dir env var), but Waypoint doesn't own the process,
+        # so force it false — else the modal renders a profile picker it can't
+        # honestly apply (the terminal overflow now opens this modal).
+        supports_account_profile_with_restart = (
+            caps.supports_account_profile_with_restart and not is_attached_tmux
+        )
+        transport_options = self._transport_switch_options(session, caps)
         config_dir_env_var = caps.config_dir_env_var
         protected_launch_env_keys = ["WAYPOINT_SESSION_ID"]
         if config_dir_env_var and session.account_profile_id:
@@ -2370,11 +2439,13 @@ class SessionRuntime:
             supports_custom_args=caps.supports_custom_cli_args,
             supports_config_overrides=caps.supports_config_overrides,
             supports_account_profile_with_restart=(
-                caps.supports_account_profile_with_restart
+                supports_account_profile_with_restart
             ),
             supports_launch_settings_with_restart=(
                 supports_launch_settings_with_restart
             ),
+            transport_options=transport_options,
+            supports_transport_switch_with_restart=len(transport_options) > 1,
             requires_restart=True,
         )
 
@@ -2410,8 +2481,27 @@ class SessionRuntime:
     ) -> SessionRecord:
         session = self.get_session(session_id)
         plugin = self.registry.plugin_for(session)
+        agent_plugin = self.registry.get(session.backend)
         caps = self.registry.capabilities_for(session)
+        target_transport = (
+            request.transport
+            if "transport" in request.model_fields_set and request.transport is not None
+            else session.transport
+        )
+        transport_changing = target_transport != session.transport
+        # Gate restart-scoped capability checks on the pair the session will run
+        # as after the switch; operate/terminate the current process through the
+        # current pair. For a non-switch these are the same composed caps.
+        gate_caps = (
+            self.registry.capabilities_for_pair(session.backend, target_transport)
+            if transport_changing
+            else caps
+        )
         fresh_thread_restarter: FreshThreadRestarting | None = None
+        turn_flushed = False
+        # A pending approval/question can't be carried to another interface; note
+        # its cancellation so the transition is observable in the transcript.
+        had_pending_input = session.status == SessionStatus.WAITING_INPUT
         if session.status == SessionStatus.STARTING:
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -2425,9 +2515,25 @@ class SessionRuntime:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="cannot change launch settings for an attached tmux session",
             )
+        if transport_changing:
+            # Only interfaces the server projects as safe targets are accepted;
+            # recompute under the lock rather than trusting the client. The set
+            # excludes attached panes, agents without a resumable native store
+            # (OpenCode), and single-usable-transport agents.
+            valid_targets = {
+                option.id for option in self._transport_switch_options(session, caps)
+            }
+            if target_transport not in valid_targets:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"cannot switch {session.backend} to interface "
+                        f"{target_transport!r}: not an offered switch target"
+                    ),
+                )
         if not (
-            caps.supports_launch_settings_with_restart
-            and caps.supports_reattach_after_exit
+            gate_caps.supports_launch_settings_with_restart
+            and gate_caps.supports_reattach_after_exit
         ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -2451,11 +2557,47 @@ class SessionRuntime:
             and request.account_profile_id != session.account_profile_id
             and request.account_profile_id is not None
         )
-        if profile_changing and not caps.supports_account_profile_with_restart:
+        if profile_changing and not gate_caps.supports_account_profile_with_restart:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"{session.backend} does not support account-profile switching",
             )
+
+        native_thread_id: str | None = None
+        if transport_changing:
+            # v1 requires a durably-persisted native thread: the switch is a pure
+            # resume onto the target interface. Non-destructive, so run before any
+            # teardown — an unpersisted thread is rejected while the session is
+            # untouched (FR5: never silently start fresh over recorded events).
+            native_thread_id = agent_plugin.native_thread_id(session)
+            thread_config_dir = config_dir_for(caps, session.launch_env)
+            # A native-thread-store agent (gated by the switch-options projection)
+            # implements the launch contract; guard for mypy and defensiveness.
+            persisted = (
+                bool(native_thread_id)
+                and isinstance(agent_plugin, AgentLaunchContract)
+                and await agent_plugin.conversation_exists(
+                    cast(str, native_thread_id),
+                    session.cwd,
+                    launch_target,
+                    config_dir=thread_config_dir,
+                )
+            )
+            if not persisted:
+                if self._has_durable_conversation(session.id):
+                    detail = (
+                        "cannot switch interface: the native thread has no "
+                        "persisted transcript but this session has conversation "
+                        "events, so switching would lose context"
+                    )
+                else:
+                    detail = (
+                        "cannot switch interface: send a message first so the "
+                        "conversation is persisted before changing interface"
+                    )
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail=detail
+                )
 
         if launch_target is not None:
             # Clean 409 ``ssh-master-required`` for a dead password master
@@ -2580,6 +2722,7 @@ class SessionRuntime:
                     session.id, status=SessionStatus.INTERRUPTED
                 )
                 await self.transport_for(session).flush_before_restart(session)
+                turn_flushed = True
             if config_dir_key:
                 # ``config_dir_for`` reads only launch_env — no ``os.environ``
                 # fallback for remote (the backend host's env is meaningless on
@@ -2661,6 +2804,32 @@ class SessionRuntime:
                 "verified_account_probed_at": None,
             }
 
+        # Flush a running turn before teardown for any restart-resume that hasn't
+        # already (the profile branch flushes after account-verify). A transport
+        # switch of a RUNNING/WAITING session interrupts here so the native
+        # transcript includes the settled final turn at handoff.
+        if not turn_flushed and session.status in {
+            SessionStatus.RUNNING,
+            SessionStatus.WAITING_INPUT,
+        }:
+            await self.transport_for(session).interrupt(session)
+            session = self.storage.update_session(
+                session.id, status=SessionStatus.INTERRUPTED
+            )
+            await self.transport_for(session).flush_before_restart(session)
+            turn_flushed = True
+
+        # For a transport switch, reset transport_state to the neutral,
+        # agent-owned handoff payload (the native thread id) and discard the old
+        # driver's pane/adapter keys; the target transport rebuilds its own state
+        # in restore_session from this id plus the persisted launch fields.
+        transport_state_fields: dict[str, Any] = {}
+        if transport_changing:
+            transport_state_fields["transport"] = target_transport
+            transport_state_fields["transport_state"] = (
+                {"thread_id": native_thread_id} if native_thread_id else {}
+            )
+
         # Terminate → persist new settings → restore. terminate/restore cycle the
         # rate-limit watcher; restore rebuilds env from the persisted record, so
         # the account is fixed by the (already-verified) launch_env. Mark the
@@ -2668,7 +2837,8 @@ class SessionRuntime:
         # transport (claude_tty) only relaunches on an EXITED reattach — without
         # this it would take the boot-time branch, keep the dead pane, and reject
         # the next input with "can't find pane". Native transports (claude_cli,
-        # codex) relaunch unconditionally, so this is a no-op for them.
+        # codex) relaunch unconditionally, so this is a no-op for them. The old
+        # (current) plugin tears down; the target plugin restores.
         await plugin.terminate_session(self, session)
         await self._cancel_context_usage_source(session.id)
         self.storage.update_session(
@@ -2679,15 +2849,17 @@ class SessionRuntime:
             launch_env=new_env,
             account_profile_id=selected_profile_id,
             account_profile_label=new_profile_label,
+            **transport_state_fields,
             **verified_account_fields,
         )
         restored_session = self.get_session(session.id)
+        target_plugin = self.registry.resolve(session.backend, target_transport)
         if fresh_thread_restarter is not None:
             await fresh_thread_restarter.restart_unpersisted_session(
                 self, restored_session
             )
         else:
-            await plugin.restore_session(self, restored_session)
+            await target_plugin.restore_session(self, restored_session)
         refreshed = self.get_session(session.id)
         if refreshed.status in {SessionStatus.EXITED, SessionStatus.ERROR}:
             # Restore failed: keep the new settings on the record (per the RFC —
@@ -2702,12 +2874,22 @@ class SessionRuntime:
                 ),
             )
         self._start_context_usage_source(refreshed)
-        note = (
-            f"Session restarted with account profile {new_profile_label}"
-            if selected_profile_id is not None and profile_changing
-            else "Session restarted with new launch settings"
-        )
+        if transport_changing:
+            note = (
+                f"Session interface changed from {plugin.label} to "
+                f"{target_plugin.label}"
+            )
+        elif selected_profile_id is not None and profile_changing:
+            note = f"Session restarted with account profile {new_profile_label}"
+        else:
+            note = "Session restarted with new launch settings"
         await self._record_system_event(session.id, note)
+        if transport_changing and had_pending_input:
+            await self._record_system_event(
+                session.id,
+                "Pending approval was cancelled by the interface change; "
+                "re-run the request on the new interface if needed",
+            )
         await self._broadcast_session_list()
         return self.get_session(session.id)
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -2364,7 +2364,12 @@ class SessionRuntime:
                 )
             except KeyError:
                 continue
-            if not pair_caps.supports_reattach_after_exit:
+            # Use the same predicate the switch gate enforces, so a projected
+            # target can't be rejected with a confusing 400 on apply.
+            if not (
+                pair_caps.supports_reattach_after_exit
+                and pair_caps.supports_launch_settings_with_restart
+            ):
                 continue
             safe_targets.append(transport_id)
         if not safe_targets:
@@ -2775,6 +2780,21 @@ class SessionRuntime:
                                     "cannot switch account profile: the native thread "
                                     "has no persisted transcript but this session has "
                                     "conversation events, so starting fresh would lose context"
+                                ),
+                            )
+                        if transport_changing:
+                            # A fresh restart resumes nothing, so it can't hand a
+                            # thread across a transport boundary; the fresh path
+                            # would also run on the current plugin, not the target.
+                            # Reject the combined change rather than relaunch the
+                            # target transport with the source driver.
+                            await self._broadcast_session_list()
+                            raise HTTPException(
+                                status_code=status.HTTP_400_BAD_REQUEST,
+                                detail=(
+                                    "cannot combine an interface switch with a profile "
+                                    "change that starts a fresh thread; switch the "
+                                    "interface and the profile in separate steps"
                                 ),
                             )
                         if not isinstance(plugin, FreshThreadRestarting):

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -754,12 +754,33 @@ class LaunchSettingsUpdateRequest(BaseModel):
     session in phase 1.
     """
 
+    # When set and different from the session's current transport, the session
+    # is restarted onto the selected interface, keeping its native thread. Must
+    # be a transport the session's agent declares and the server projects as a
+    # safe target; the runtime rejects anything else.
+    transport: SessionTransportId | None = None
     account_profile_id: str | None = None
     args: list[str] | None = None
     config_overrides: list[str] | None = None
     env_set: dict[str, str] = Field(default_factory=dict)
     env_unset: list[str] = Field(default_factory=list)
     restart: bool = False
+
+
+class TransportSettingsOption(BaseModel):
+    """A transport the session may switch to, with the restart-scoped launch
+    capabilities of the resulting (agent, transport) pair.
+
+    The server is authoritative: the modal populates its Interface selector from
+    this list and reads the selected option's flags while a switch is staged,
+    using the live backend catalog only for labels/presentation.
+    """
+
+    id: SessionTransportId
+    supports_launch_settings_with_restart: bool = False
+    supports_account_profile_with_restart: bool = False
+    supports_custom_args: bool = False
+    supports_config_overrides: bool = False
 
 
 class LaunchSettingsResponse(BaseModel):
@@ -789,6 +810,12 @@ class LaunchSettingsResponse(BaseModel):
     # True only when the session's (agent, transport) can restart-and-resume
     # AND Waypoint owns the process (i.e. not a bare attached tmux pane).
     supports_launch_settings_with_restart: bool = False
+    # Interfaces this session may switch to (includes the current transport
+    # first, then every safe target). Empty when switching isn't offered
+    # (attached tmux, OpenCode, single-usable-transport agents, unpersisted
+    # thread). The frontend must not infer switchability from the catalog alone.
+    transport_options: list[TransportSettingsOption] = Field(default_factory=list)
+    supports_transport_switch_with_restart: bool = False
     requires_restart: bool = True
 
 

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -236,6 +236,40 @@ async def test_restart_rebuilds_resume_flags_preserving_custom_args() -> None:
     assert captured["start_at_end"] is True
 
 
+async def test_restore_reconstructs_custom_args_when_launch_args_absent() -> None:
+    # Transport-switch handoff: the runtime resets transport_state to the neutral
+    # {thread_id} (no launch_args). claude_tty restore must fall back to the
+    # persisted custom args so they survive the switch (model/effort/permission
+    # are inherited via --resume).
+    plugin = ClaudeTtyPlugin()
+    captured = _stub_lifecycle(plugin)
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="sess-switch",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="claude_tty",
+        title="test",
+        cwd="/tmp",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/structured.log",
+        transport_state={"thread_id": "thread-1"},  # neutral handoff
+        model="opus",
+        args=["--verbose"],
+    )
+    runtime, _ = _restart_runtime()
+
+    await plugin.restore_session(runtime, session)
+
+    built_args = runtime._command_for_backend.call_args.args[1]
+    assert built_args == ["--resume", "thread-1", "--verbose"]
+    assert captured["start_at_end"] is True
+
+
 async def test_restart_into_plan_stashes_pre_plan_mode() -> None:
     plugin = ClaudeTtyPlugin()
     _stub_lifecycle(plugin)

--- a/backend/tests/test_launch_settings.py
+++ b/backend/tests/test_launch_settings.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 
 from waypoint.backends.account_profiles import probe_account
+from waypoint.backends.transcripts import ThreadAvailability
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     AccountProbeResult,
@@ -352,6 +353,59 @@ async def test_switch_rejected_when_thread_unpersisted_event_free(
         )
     assert getattr(exc.value, "status_code", None) == 400
     assert "send a message first" in str(getattr(exc.value, "detail", ""))
+    assert terminated == []
+
+
+async def test_combined_profile_and_transport_fresh_start_is_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A combined profile+transport change where the thread is persisted under the
+    # current config dir (D4 passes) but doesn't survive the profile move
+    # (UNPERSISTED at target) and is event-free would otherwise fall into the
+    # fresh-restart path — which resumes nothing and runs on the *current*
+    # plugin. Reject the combination before any teardown instead.
+    profiles = {
+        "account_profiles": {
+            "work": {
+                "label": "Work",
+                "config_dir": str(tmp_path / "codex-target"),
+                "transcript_policy": "symlink_shared",
+                "shared_transcript_dir": str(tmp_path / "shared"),
+                "expected_account_key": "codex:work@co",
+            }
+        }
+    }
+    runtime = _runtime(tmp_path, codex=profiles)
+    _session(runtime, launch_env={"CODEX_HOME": str(tmp_path / "codex-current")})
+    plugin = runtime.registry.resolve("codex", "codex_app_server")
+    terminated: list[bool] = []
+
+    async def spy_terminate(*_a: Any, **_k: Any) -> None:
+        terminated.append(True)
+
+    async def yes(*_a: Any, **_k: Any) -> bool:
+        return True
+
+    async def fake_probe(*_a: Any, **_k: Any) -> AccountProbeResult:
+        return AccountProbeResult(account_key="codex:work@co", account_label="work@co")
+
+    monkeypatch.setattr(plugin, "terminate_session", spy_terminate)
+    monkeypatch.setattr(runtime.registry.get("codex"), "conversation_exists", yes)
+    monkeypatch.setattr("waypoint.runtime.probe_account", fake_probe)
+    monkeypatch.setattr(
+        "waypoint.runtime.ensure_thread_available",
+        lambda *a, **k: ThreadAvailability.UNPERSISTED,
+    )
+
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1",
+            LaunchSettingsUpdateRequest(
+                transport="tmux", account_profile_id="work", restart=True
+            ),
+        )
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "separate steps" in str(getattr(exc.value, "detail", ""))
     assert terminated == []
 
 

--- a/backend/tests/test_launch_settings.py
+++ b/backend/tests/test_launch_settings.py
@@ -115,6 +115,285 @@ async def test_probe_account_none_when_no_account_key(
 # ── GET projection ───────────────────────────────────────────────────────────
 
 
+# ── transport-switch projection ──────────────────────────────────────────────
+
+
+def test_transport_options_projected_for_claude(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="claude_code", transport="claude_cli")
+    resp = runtime.get_launch_settings("s1")
+    ids = [opt.id for opt in resp.transport_options]
+    # Current transport first, then every safe target.
+    assert ids[0] == "claude_cli"
+    assert set(ids) == {"claude_cli", "claude_tty", "tmux"}
+    assert resp.supports_transport_switch_with_restart is True
+
+
+def test_transport_options_projected_for_codex(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="codex", transport="codex_app_server")
+    resp = runtime.get_launch_settings("s1")
+    ids = [opt.id for opt in resp.transport_options]
+    assert ids[0] == "codex_app_server"
+    assert set(ids) == {"codex_app_server", "tmux"}
+    assert resp.supports_transport_switch_with_restart is True
+
+
+def test_transport_options_empty_for_opencode(tmp_path: Path) -> None:
+    # OpenCode has no resumable native store, so no safe handoff is advertised.
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="opencode", transport="opencode_http")
+    resp = runtime.get_launch_settings("s1")
+    assert resp.transport_options == []
+    assert resp.supports_transport_switch_with_restart is False
+
+
+def test_transport_options_empty_for_attached_tmux(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="tmux",
+        transport="tmux",
+        source=SessionSource.ATTACHED_TMUX,
+    )
+    resp = runtime.get_launch_settings("s1")
+    assert resp.transport_options == []
+    assert resp.supports_transport_switch_with_restart is False
+
+
+def test_attached_tmux_forces_account_profile_restart_false(tmp_path: Path) -> None:
+    # A claude/codex attached pane's agent has a config-dir env var, so the
+    # derived account-profile capability is True — but Waypoint doesn't own the
+    # process, so the projection must force it false (the terminal now opens the
+    # modal, which gates its profile picker purely on this flag).
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="claude_code",
+        transport="tmux",
+        source=SessionSource.ATTACHED_TMUX,
+    )
+    resp = runtime.get_launch_settings("s1")
+    assert resp.supports_account_profile_with_restart is False
+    assert resp.supports_launch_settings_with_restart is False
+    assert resp.transport_options == []
+
+
+# ── transport-switch lifecycle ────────────────────────────────────────────────
+
+
+async def test_switch_rejects_unknown_target_transport(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="claude_code", transport="claude_cli")
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1",
+            LaunchSettingsUpdateRequest(transport="codex_app_server", restart=True),
+        )
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "not an offered switch target" in str(getattr(exc.value, "detail", ""))
+
+
+async def test_switch_rejects_opencode(tmp_path: Path) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="opencode", transport="opencode_http")
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1", LaunchSettingsUpdateRequest(transport="tmux", restart=True)
+        )
+    assert getattr(exc.value, "status_code", None) == 400
+
+
+async def _persist_thread(
+    monkeypatch: pytest.MonkeyPatch, runtime: SessionRuntime
+) -> None:
+    async def yes(*_a: Any, **_k: Any) -> bool:
+        return True
+
+    for backend in ("claude_code", "codex"):
+        monkeypatch.setattr(runtime.registry.get(backend), "conversation_exists", yes)
+
+
+async def test_switch_persists_transport_and_resets_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="claude_code",
+        transport="claude_cli",
+        status=SessionStatus.IDLE,
+        transport_state={"thread_id": TID, "slash_commands": ["/x"]},
+    )
+    await _persist_thread(monkeypatch, runtime)
+    old_plugin = runtime.registry.resolve("claude_code", "claude_cli")
+    target_plugin = runtime.registry.resolve("claude_code", "claude_tty")
+    seen: dict[str, Any] = {}
+
+    async def fake_terminate(_self_rt: Any, _session: SessionRecord) -> None:
+        seen["terminated"] = True
+
+    async def fake_restore(_self_rt: Any, session: SessionRecord) -> None:
+        seen["restored_on"] = target_plugin.id
+        seen["restore_status"] = session.status
+        seen["restore_transport"] = session.transport
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(old_plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(target_plugin, "restore_session", fake_restore)
+
+    updated = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(transport="claude_tty", restart=True)
+    )
+
+    assert seen["terminated"] is True
+    assert seen["restored_on"] == "claude_tty"
+    assert seen["restore_status"] == SessionStatus.EXITED
+    assert seen["restore_transport"] == "claude_tty"
+    assert updated.transport == "claude_tty"
+    # Neutral handoff: only the agent-owned native thread id survives.
+    assert updated.transport_state == {"thread_id": TID}
+
+
+async def test_codex_switch_to_tmux(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="codex",
+        transport="codex_app_server",
+        status=SessionStatus.IDLE,
+        model="gpt-5-codex",
+        args=["--foo"],
+    )
+    await _persist_thread(monkeypatch, runtime)
+    old_plugin = runtime.registry.resolve("codex", "codex_app_server")
+    target_plugin = runtime.registry.resolve("codex", "tmux")
+    seen: dict[str, Any] = {}
+
+    async def fake_terminate(_self_rt: Any, _session: SessionRecord) -> None:
+        seen["terminated"] = True
+
+    async def fake_restore(_self_rt: Any, session: SessionRecord) -> None:
+        seen["restored_on"] = target_plugin.id
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(old_plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(target_plugin, "restore_session", fake_restore)
+
+    updated = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(transport="tmux", restart=True)
+    )
+
+    assert seen == {"terminated": True, "restored_on": "tmux"}
+    assert updated.transport == "tmux"
+    # Persisted tuning/args are retained on the record across the switch.
+    assert updated.model == "gpt-5-codex"
+    assert updated.args == ["--foo"]
+
+
+async def test_switch_rejected_when_thread_unpersisted_with_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="claude_code", transport="claude_cli")
+    runtime.storage.append_event(
+        EventRecord(
+            session_id="s1",
+            ts=datetime.now(UTC),
+            kind=EventKind.USER_INPUT,
+            text="hello",
+            metadata={"submit": True},
+            sequence=runtime.storage.next_sequence("s1"),
+        )
+    )
+    plugin = runtime.registry.resolve("claude_code", "claude_cli")
+    terminated: list[bool] = []
+
+    async def spy_terminate(*_a: Any, **_k: Any) -> None:
+        terminated.append(True)
+
+    async def no(*_a: Any, **_k: Any) -> bool:
+        return False
+
+    monkeypatch.setattr(plugin, "terminate_session", spy_terminate)
+    monkeypatch.setattr(runtime.registry.get("claude_code"), "conversation_exists", no)
+
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1", LaunchSettingsUpdateRequest(transport="claude_tty", restart=True)
+        )
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "would lose context" in str(getattr(exc.value, "detail", ""))
+    assert terminated == []
+
+
+async def test_switch_rejected_when_thread_unpersisted_event_free(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    _session(runtime, backend="claude_code", transport="claude_cli")
+    plugin = runtime.registry.resolve("claude_code", "claude_cli")
+    terminated: list[bool] = []
+
+    async def spy_terminate(*_a: Any, **_k: Any) -> None:
+        terminated.append(True)
+
+    async def no(*_a: Any, **_k: Any) -> bool:
+        return False
+
+    monkeypatch.setattr(plugin, "terminate_session", spy_terminate)
+    monkeypatch.setattr(runtime.registry.get("claude_code"), "conversation_exists", no)
+
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1", LaunchSettingsUpdateRequest(transport="claude_tty", restart=True)
+        )
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "send a message first" in str(getattr(exc.value, "detail", ""))
+    assert terminated == []
+
+
+async def test_switch_interrupts_running_before_terminate(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    _session(
+        runtime,
+        backend="claude_code",
+        transport="claude_cli",
+        status=SessionStatus.RUNNING,
+    )
+    await _persist_thread(monkeypatch, runtime)
+    old_plugin = runtime.registry.resolve("claude_code", "claude_cli")
+    target_plugin = runtime.registry.resolve("claude_code", "claude_tty")
+    order: list[str] = []
+
+    class FakeTransport:
+        async def interrupt(self, _session: SessionRecord) -> None:
+            order.append("interrupt")
+
+        async def flush_before_restart(self, _session: SessionRecord) -> None:
+            order.append("flush")
+
+    monkeypatch.setattr(runtime, "transport_for", lambda _s: FakeTransport())
+
+    async def fake_terminate(_self_rt: Any, _session: SessionRecord) -> None:
+        order.append("terminate")
+
+    async def fake_restore(_self_rt: Any, session: SessionRecord) -> None:
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(old_plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(target_plugin, "restore_session", fake_restore)
+
+    await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(transport="claude_tty", restart=True)
+    )
+    assert order == ["interrupt", "flush", "terminate"]
+
+
 def test_get_launch_settings_projection(tmp_path: Path) -> None:
     runtime = _runtime(tmp_path, codex=_codex_profiles())
     _session(

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -372,6 +372,51 @@ async def test_restore_session_claude_keeps_thread_id_across_terminate_cycles(
 
 
 @pytest.mark.asyncio
+async def test_restore_reconstructs_launch_args_from_session_fields(
+    plugin: TmuxPlugin,
+    tmp_path: Path,
+) -> None:
+    """Transport-switch handoff: the runtime resets transport_state to the
+    neutral ``{thread_id}`` (no ``launch_args``). Restore must reconstruct the
+    managed flags and custom args from the persisted session fields via the
+    agent contract, so a switch *into* tmux keeps model/permission + custom args
+    (they live only in ``launch_args``)."""
+    uuid_str = "00000000-0000-0000-0000-000000000009"
+    agent = _FakeAgentPlugin(pregenerates=True, exists=True)
+    runtime = _FakeRuntime(inner_plugin=agent)
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id="sess-switch",
+        backend="claude_code",
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="t",
+        cwd="/Users/me/proj",
+        status=SessionStatus.EXITED,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        model="sonnet",
+        permission_mode="plan",
+        args=["--verbose"],
+        transport_state={"thread_id": uuid_str},  # neutral handoff, no launch_args
+        raw_log_path=str(tmp_path / "s.raw.log"),
+        structured_log_path=str(tmp_path / "s.events.jsonl"),
+    )
+    await plugin.restore_session(cast(Any, runtime), session)
+    state = runtime.updates[-1]["transport_state"]
+    assert state["launch_args"] == [
+        "--resume",
+        uuid_str,
+        "--model",
+        "sonnet",
+        "--permission-mode",
+        "plan",
+        "--verbose",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_restore_session_remote_resume_uses_switched_config_dir(
     plugin: TmuxPlugin,
     tmp_path: Path,

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -27,7 +27,6 @@ import {
   fetchBackendModels,
   fetchEvents,
   fetchSession,
-  fetchLaunchSettings,
   forkSession,
   isAuthError,
   postAction,
@@ -39,7 +38,6 @@ import {
   setSessionPermissionMode,
   setSessionPinned,
   setSessionTitle,
-  updateLaunchSettings,
 } from "@/lib/api";
 import {
   agentTransports,
@@ -127,7 +125,6 @@ import {
   EventRecord,
   SessionCommandInvocation,
   SessionEnvelope,
-  SessionLaunchSettings,
   SessionRecord,
   SessionTransport,
   SideQuestion,
@@ -433,13 +430,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [defaultEffort, setDefaultEffort] = useState<string | null>(null);
   const [modelBusy, setModelBusy] = useState(false);
   const [effortBusy, setEffortBusy] = useState(false);
-  const [accountBusy, setAccountBusy] = useState(false);
-  // Restart-applied launch settings, fetched lazily for backends that host
-  // account profiles — the only source of the target-merged profile list and
-  // the supports_account_profile_with_restart gate (both absent from the
-  // session record and the serialized capabilities).
-  const [accountSettings, setAccountSettings] =
-    useState<SessionLaunchSettings | null>(null);
   const [rateLimitRefreshBusy, setRateLimitRefreshBusy] = useState(false);
   const [approvalPageIndex, setApprovalPageIndex] = useState(0);
   const [hasOlderEvents, setHasOlderEvents] = useState(false);
@@ -663,75 +653,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       }
     },
     [host, token, session, handleAuthFailure, confirmTurnInterrupt],
-  );
-
-  // Fetch launch settings once the session's backend is known to host account
-  // profiles, to populate the switch control's option list and gate. Static
-  // per session, so keyed on id/backend only (not the poll-churned session ref).
-  const sessionHostsProfiles = Boolean(
-    sessionBackend && catalog.accountProfilesFor(sessionBackend).length > 0,
-  );
-  useEffect(() => {
-    if (!sessionId || !sessionHostsProfiles) {
-      setAccountSettings(null);
-      return;
-    }
-    let cancelled = false;
-    fetchLaunchSettings(host, token, sessionId)
-      .then((settings) => {
-        if (!cancelled) setAccountSettings(settings);
-      })
-      .catch((settingsError) => {
-        if (cancelled) return;
-        if (isAuthError(settingsError)) {
-          handleAuthFailure();
-          return;
-        }
-        // Non-fatal: without settings the switch control just stays hidden.
-        setAccountSettings(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [host, token, sessionId, sessionHostsProfiles, handleAuthFailure]);
-
-  // Restart the session under a different account profile. The destructive
-  // restart is confirmed explicitly by the composer's staged switch flow before
-  // this runs, so it performs the switch directly. Phase 1 switches between
-  // named profiles only; clearing back to the default config dir isn't a
-  // meaningful switch (it resolves to the same account and would be rejected),
-  // so an empty or unchanged pick is a no-op.
-  const handleAccountProfileChange = useCallback(
-    async (nextProfileId: string) => {
-      if (!session || !nextProfileId) {
-        return;
-      }
-      if (nextProfileId === (session.account_profile_id ?? "")) {
-        return;
-      }
-      setAccountBusy(true);
-      setError("");
-      try {
-        const updated = await updateLaunchSettings(host, token, session.id, {
-          account_profile_id: nextProfileId,
-          restart: true,
-        });
-        setSession(updated);
-      } catch (switchError) {
-        if (isAuthError(switchError)) {
-          handleAuthFailure();
-          return;
-        }
-        setError(
-          switchError instanceof Error
-            ? switchError.message
-            : "failed to switch account",
-        );
-      } finally {
-        setAccountBusy(false);
-      }
-    },
-    [host, token, session, handleAuthFailure],
   );
 
   const flushPendingEvents = useCallback(() => {
@@ -2089,6 +2010,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onTerminate={terminate}
           onRemoveFromList={removeFromList}
           onSwitchSession={openSwitcher}
+          onOpenSettings={() => setSettingsOpen(true)}
           onError={setError}
         />
       ) : null}
@@ -2376,13 +2298,6 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           }}
           onDelete={removeFromList}
           onInterrupt={interruptSession}
-          accountProfiles={accountSettings?.account_profiles ?? []}
-          accountProfileId={session?.account_profile_id ?? null}
-          supportsAccountSwitch={
-            accountSettings?.supports_account_profile_with_restart ?? false
-          }
-          accountBusy={accountBusy}
-          onAccountChange={handleAccountProfileChange}
           onModeChange={handlePermissionModeChange}
           onModelChange={handleModelChange}
           onEffortChange={handleEffortChange}
@@ -2466,13 +2381,6 @@ interface ReplyComposerProps {
   currentModel: string | null;
   currentEffort: string | null;
   effortBusy: boolean;
-  // Account/config profiles the running session can switch between (target-
-  // merged), the current selection, whether the (agent, transport) supports a
-  // restart-applied switch, and the in-flight flag.
-  accountProfiles: AccountProfile[];
-  accountProfileId: string | null;
-  supportsAccountSwitch: boolean;
-  accountBusy: boolean;
   permissionMode: string | null;
   transport: SessionTransport | null;
   catalog: BackendCatalog;
@@ -2481,7 +2389,6 @@ interface ReplyComposerProps {
   // UX so the user knows the session will restart, vs. Codex which
   // applies inline.
   effortRequiresConfirm: boolean;
-  onAccountChange: (profileId: string) => void | Promise<void>;
   onDelete: () => void | Promise<void>;
   onInterrupt: () => void | Promise<void>;
   onModeChange: (mode: string) => void | Promise<void>;
@@ -2530,10 +2437,6 @@ const ReplyComposer = memo(function ReplyComposer({
   currentModel,
   currentEffort,
   effortBusy,
-  accountProfiles,
-  accountProfileId,
-  supportsAccountSwitch,
-  accountBusy,
   permissionMode,
   transport,
   catalog,
@@ -2541,7 +2444,6 @@ const ReplyComposer = memo(function ReplyComposer({
   hasToolRuns,
   toolRunsExpanded,
   onToggleToolRuns,
-  onAccountChange,
   onDelete,
   onInterrupt,
   onModeChange,
@@ -2597,11 +2499,6 @@ const ReplyComposer = memo(function ReplyComposer({
   // — staged here until the user confirms via the Apply button. `null` means
   // no pending change.
   const [pendingEffort, setPendingEffort] = useState<string | null>(null);
-  // Account-profile switch, staged in the settings popover's session-context
-  // section: the pick lives here and is applied only after the explicit restart
-  // confirmation, never straight from a select change.
-  const [pendingAccountProfileId, setPendingAccountProfileId] =
-    useState<string | null>(null);
   // iMessage-style leading actions: ⊕ + 📎 collapse to a single ›-chevron via
   // CSS (:focus-within) so focusing the field never triggers a React re-render
   // that could drop focus mid-gesture. The chevron re-opens them by forcing
@@ -2734,14 +2631,6 @@ const ReplyComposer = memo(function ReplyComposer({
       window.removeEventListener("pointerdown", onPointer);
       window.removeEventListener("keydown", onKey);
     };
-  }, [tuneOpen]);
-
-  // Drop any staged profile pick when the settings popover closes, so reopening
-  // it always starts from the session's current profile.
-  useEffect(() => {
-    if (!tuneOpen) {
-      setPendingAccountProfileId(null);
-    }
   }, [tuneOpen]);
 
   async function handleSend() {
@@ -2892,32 +2781,14 @@ const ReplyComposer = memo(function ReplyComposer({
     await onEffortChange(value);
   };
 
-  const hasAccountPicker = supportsAccountSwitch && accountProfiles.length > 0;
-  const currentProfileId = accountProfileId ?? "";
-  const profileSwitchValue = pendingAccountProfileId ?? currentProfileId;
-  // A switch is offered only to a named profile that isn't the current one —
-  // phase 1 doesn't switch back to the default (it resolves to the same
-  // account), so staging it shows no confirm.
-  const profileSwitchDiffers =
-    profileSwitchValue !== "" && profileSwitchValue !== currentProfileId;
-  const pendingProfileLabel =
-    accountProfiles.find((profile) => profile.id === profileSwitchValue)?.label ??
-    profileSwitchValue;
-  const confirmProfileSwitch = async () => {
-    if (!profileSwitchDiffers) return;
-    await onAccountChange(profileSwitchValue);
-    setTuneOpen(false);
-    setPendingAccountProfileId(null);
-  };
   const assistantOps = assistant ? assistantControls : null;
-  // The account profile lives in the settings popover as a separated
-  // session-context section (kept out of the quick-tuning summary), so it also
-  // makes the gear worth opening when no other tuning control exists.
+  // Account-profile switching for a regular session moved to the Session
+  // settings modal (opened from the overflow menu); the quick-tuning popover
+  // keeps only inline tuning and the assistant replacement controls.
   const tuneVisible =
     modeOptions.length > 0 ||
     hasModelPicker ||
     hasEffortPicker ||
-    hasAccountPicker ||
     assistantOps !== null;
   // Backend the assistant controls target — the picked one, or the current.
   const assistantTargetBackend = pendingBackend ?? session?.backend ?? null;
@@ -3080,47 +2951,6 @@ const ReplyComposer = memo(function ReplyComposer({
                 role="dialog"
                 aria-label="Session settings"
               >
-                {hasAccountPicker ? (
-                  <div className="composer-tune-context">
-                    <AccountProfilePicker
-                      profiles={accountProfiles}
-                      value={profileSwitchValue}
-                      onChange={(id) => setPendingAccountProfileId(id)}
-                      disabled={accountBusy}
-                      fieldClassName="composer-tune-field"
-                    />
-                    {profileSwitchDiffers ? (
-                      <div className="composer-tune-confirm">
-                        <p>
-                          Restart this session with{" "}
-                          <strong>{pendingProfileLabel}</strong>? The current
-                          turn is interrupted, the backend process restarts, and
-                          the session resumes from the selected profile&apos;s config
-                          and transcript store. For Codex, a thread with no
-                          persisted transcript starts fresh.
-                        </p>
-                        <div className="composer-tune-confirm-actions">
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-cancel"
-                            onClick={() => setPendingAccountProfileId(null)}
-                            disabled={accountBusy}
-                          >
-                            Cancel
-                          </button>
-                          <button
-                            type="button"
-                            className="composer-tune-confirm-apply"
-                            onClick={() => void confirmProfileSwitch()}
-                            disabled={accountBusy}
-                          >
-                            {accountBusy ? "Restarting…" : "Restart session"}
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
                 {assistantOps && session ? (
                   <label className="composer-tune-field">
                     <span>Agent</span>

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -107,6 +107,7 @@ export function SessionSettingsModal({
     partialSuccess,
     session: current,
     launchSettings,
+    caps,
     models,
     defaultModelLabel,
     title,
@@ -118,6 +119,7 @@ export function SessionSettingsModal({
     configOverridesText,
     existingEnv,
     newEnv,
+    transport,
     assistantBackend,
     assistantTransport,
     assistantThreadId,
@@ -126,6 +128,9 @@ export function SessionSettingsModal({
     applyDisabled,
     launchFieldsAvailable,
     launchFieldsDisabledReason,
+    transportOptions,
+    transportSwitchAvailable,
+    transportChanged,
     hiddenEnvKeys,
     setTitle,
     setPermissionMode,
@@ -137,6 +142,7 @@ export function SessionSettingsModal({
     setExistingEnvOp,
     setExistingEnvValue,
     setNewEnv,
+    setTransport,
     setAssistantBackend,
     setAssistantTransport,
     setAssistantThreadId,
@@ -231,18 +237,43 @@ export function SessionSettingsModal({
   }, [models, model]);
   const accountProfiles = launchSettings?.account_profiles ?? [];
 
-  const showPermission = permissionModes.length > 0;
-  const showModel = models.length > 0 || model !== null;
+  // The transport option describing the current-or-staged interface; drives the
+  // restart-scoped gates so a staged switch reflects the target pair.
+  const activeTransportOption = transportOptions.find(
+    (option) => option.id === (transport ?? current?.transport ?? session.transport),
+  );
+
+  // Tuning controls are gated on the composed (current-or-staged) transport's
+  // inline capability — hidden, not merely disabled, when the transport can't
+  // apply them (e.g. a tmux-wrapped/terminal-only pair) — and suppressed while
+  // an interface switch is staged (it can't ride the same restart).
+  const showPermission =
+    !transportChanged &&
+    Boolean(caps?.supports_set_permission_mode_inline) &&
+    permissionModes.length > 0;
+  const showModel =
+    !transportChanged &&
+    Boolean(caps?.supports_set_model_inline) &&
+    (models.length > 0 || model !== null);
   // Mirror the launch panel's ModelPicker: surface a pre-existing custom model
   // (from an older session/schedule) that isn't in the discovered list.
   const modelEntries =
     model && !models.some((m) => m.id === model)
       ? [{ id: model, label: `Custom · ${model}` }, ...models]
       : models;
-  const showEffort = effortOptions.length > 0 || effort !== null;
+  const showEffort =
+    !transportChanged &&
+    Boolean(
+      caps?.supports_set_effort_inline || caps?.supports_set_effort_with_restart,
+    ) &&
+    (effortOptions.length > 0 || effort !== null);
   const showAccountProfile =
     accountProfiles.length > 0 &&
-    Boolean(launchSettings?.supports_account_profile_with_restart);
+    Boolean(
+      transportChanged
+        ? activeTransportOption?.supports_account_profile_with_restart
+        : launchSettings?.supports_account_profile_with_restart,
+    );
 
   const assistantAgents = isAssistant
     ? launchableAgents(assistant?.backends.map((b) => b.id) ?? [], catalog)
@@ -412,6 +443,37 @@ export function SessionSettingsModal({
                       {threads.map((t) => (
                         <option key={t.id} value={t.id}>
                           {t.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                </section>
+              ) : null}
+
+              {/* Interface (transport) — an in-place switch for a managed,
+                  non-assistant session. Placed in the context group before
+                  Account profile, mirroring the launch panel's hierarchy. The
+                  server projects the safe targets; the catalog supplies labels. */}
+              {transportSwitchAvailable ? (
+                <section className="settings-group">
+                  <div className="settings-group-caption">Interface</div>
+                  <div className="settings-field">
+                    <label
+                      className="settings-field-label"
+                      htmlFor="settings-transport"
+                    >
+                      Interface
+                    </label>
+                    <select
+                      id="settings-transport"
+                      className="settings-input"
+                      value={transport ?? current?.transport ?? session.transport}
+                      onChange={(e) => setTransport(e.target.value)}
+                      disabled={busy}
+                    >
+                      {transportOptions.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {transportLabel(option.id, catalog) ?? option.id}
                         </option>
                       ))}
                     </select>

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -64,6 +64,7 @@ interface SessionTerminalViewProps {
   onTerminate: () => void | Promise<void>;
   onRemoveFromList: () => void | Promise<void>;
   onSwitchSession: () => void;
+  onOpenSettings: () => void;
   onError: (message: string) => void;
 }
 
@@ -101,6 +102,7 @@ export function SessionTerminalView({
   onTerminate,
   onRemoveFromList,
   onSwitchSession,
+  onOpenSettings,
   onError,
 }: SessionTerminalViewProps) {
   const catalog = useBackendCatalog(host || null, token || null, null);
@@ -246,6 +248,20 @@ export function SessionTerminalView({
                 <span className="glyph">⇄</span>
                 Switch session…
               </button>
+              {session ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="composer-overflow-item"
+                  onClick={() => {
+                    closeMenu();
+                    onOpenSettings();
+                  }}
+                >
+                  <span className="glyph">⚙︎</span>
+                  Session settings…
+                </button>
+              ) : null}
               {session && !sessionExited ? (
                 <>
                   <div className="composer-overflow-separator" />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -441,13 +441,31 @@ export interface SessionLaunchSettings {
   // True only when the (agent, transport) can restart-and-resume AND Waypoint
   // owns the process (false for a bare attached tmux pane).
   supports_launch_settings_with_restart: boolean;
+  // Interfaces the session may switch to (current transport first, then safe
+  // targets). Empty when switching isn't offered. The server is authoritative;
+  // the catalog supplies only labels.
+  transport_options: TransportSettingsOption[];
+  supports_transport_switch_with_restart: boolean;
   // Whether applying a change requires restarting the session (true in phase 1).
   requires_restart: boolean;
+}
+
+// One interface a session may switch to, with the restart-scoped launch
+// capabilities of the resulting (agent, transport) pair.
+export interface TransportSettingsOption {
+  id: SessionTransport;
+  supports_launch_settings_with_restart: boolean;
+  supports_account_profile_with_restart: boolean;
+  supports_custom_args: boolean;
+  supports_config_overrides: boolean;
 }
 
 // PATCH body for the same endpoint; omitted fields are left unchanged. `restart`
 // must be true to switch a running session (phase 1).
 export interface LaunchSettingsUpdate {
+  // When set and different from the current transport, restart the session onto
+  // the selected interface, keeping its native thread.
+  transport?: SessionTransport;
   account_profile_id?: string | null;
   args?: string[];
   config_overrides?: string[];

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -540,9 +540,7 @@ export function useSessionSettings(
     const willInterruptTurn = restartCount > 0 && running;
 
     if (transportChanged) {
-      warnings.push(
-        "The session will restart and resume through the selected interface, keeping its conversation.",
-      );
+      warnings.push("Restarts the session.");
     } else if (restartCount > 1) {
       warnings.push(
         `Applying these changes will restart the session ${restartCount} times and resume it.`,

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -540,7 +540,7 @@ export function useSessionSettings(
     const willInterruptTurn = restartCount > 0 && running;
 
     if (transportChanged) {
-      warnings.push("Restarts the session.");
+      warnings.push("The session will be restarted.");
     } else if (restartCount > 1) {
       warnings.push(
         `Applying these changes will restart the session ${restartCount} times and resume it.`,

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -540,7 +540,7 @@ export function useSessionSettings(
     const willInterruptTurn = restartCount > 0 && running;
 
     if (transportChanged) {
-      warnings.push("The session will be restarted.");
+      warnings.push("The session will be restarted, keeping its conversation.");
     } else if (restartCount > 1) {
       warnings.push(
         `Applying these changes will restart the session ${restartCount} times and resume it.`,

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -20,6 +20,7 @@ import type {
   LaunchSettingsUpdate,
   SessionLaunchSettings,
   SessionRecord,
+  TransportSettingsOption,
 } from "@/lib/types";
 
 // Editing model for an existing (redacted) env key. Its stored value is never
@@ -109,6 +110,8 @@ export interface SessionSettingsController {
   configOverridesText: string;
   existingEnv: ExistingEnvEntry[];
   newEnv: NewEnvEntry[];
+  // Non-assistant staged interface (transport) for an in-place switch.
+  transport: string | null;
   // Assistant-only staged replacement target (agent / interface / thread).
   assistantBackend: Backend | null;
   assistantTransport: string | null;
@@ -121,6 +124,10 @@ export interface SessionSettingsController {
   applyDisabled: boolean;
   launchFieldsAvailable: boolean;
   launchFieldsDisabledReason: string | null;
+  // Interfaces this session may switch to (empty when switching isn't offered).
+  transportOptions: TransportSettingsOption[];
+  transportSwitchAvailable: boolean;
+  transportChanged: boolean;
   // Keys hidden from raw env editing for the *staged* profile.
   hiddenEnvKeys: string[];
 
@@ -135,6 +142,7 @@ export interface SessionSettingsController {
   setExistingEnvOp: (key: string, op: EnvKeyOp) => void;
   setExistingEnvValue: (key: string, value: string) => void;
   setNewEnv: (entries: NewEnvEntry[]) => void;
+  setTransport: (value: string) => void;
   setAssistantBackend: (backend: Backend) => void;
   setAssistantTransport: (transport: string) => void;
   setAssistantThreadId: (threadId: string | null) => void;
@@ -198,6 +206,7 @@ export function useSessionSettings(
   const [configOverridesText, setConfigOverridesText] = useState("");
   const [existingEnv, setExistingEnv] = useState<ExistingEnvEntry[]>([]);
   const [newEnv, setNewEnv] = useState<NewEnvEntry[]>([]);
+  const [transportState, setTransportState] = useState<string | null>(null);
   const [assistantBackend, setAssistantBackendState] = useState<Backend | null>(
     null,
   );
@@ -216,10 +225,16 @@ export function useSessionSettings(
   const transport = candidate?.transport;
   const launchTargetId = candidate?.launch_target_id ?? null;
 
+  // Non-assistant sessions gate every field on the *staged* interface so a
+  // pending switch immediately reflects the target pair's capabilities; the
+  // assistant keeps its own (current) pair — its interface change is a
+  // replacement, handled separately.
+  const effectiveTransport =
+    !isAssistant && transportState ? transportState : transport;
   const caps = useMemo(() => {
-    if (!catalog || !backend || !transport) return undefined;
-    return catalog.capsFor(backend, transport);
-  }, [catalog, backend, transport]);
+    if (!catalog || !backend || !effectiveTransport) return undefined;
+    return catalog.capsFor(backend, effectiveTransport);
+  }, [catalog, backend, effectiveTransport]);
 
   const resetDraft = useCallback(
     (record: SessionRecord, settings: SessionLaunchSettings | null) => {
@@ -239,6 +254,7 @@ export function useSessionSettings(
           .map((key) => ({ key, op: "keep" as EnvKeyOp, value: "" })),
       );
       setNewEnv([]);
+      setTransportState(record.transport);
       setAssistantBackendState(record.backend);
       setAssistantTransportState(record.transport);
       setAssistantThreadIdState(null);
@@ -332,6 +348,10 @@ export function useSessionSettings(
     );
   }, []);
 
+  const setTransport = useCallback((value: string) => {
+    setTransportState(value);
+  }, []);
+
   const setAssistantBackend = useCallback((value: Backend) => {
     setAssistantBackendState(value);
     // Switching agent invalidates a staged interface/thread from the old agent.
@@ -345,10 +365,29 @@ export function useSessionSettings(
     setAssistantThreadIdState(value);
   }, []);
 
-  // ── availability / capability gating ──────────────────────────────────────
-  const launchFieldsAvailable = Boolean(
-    launchSettings?.supports_launch_settings_with_restart,
+  // ── transport switch (non-assistant in-place interface change) ─────────────
+  const transportOptions = launchSettings?.transport_options ?? [];
+  const transportSwitchAvailable = Boolean(
+    !isAssistant &&
+      launchSettings?.supports_transport_switch_with_restart &&
+      transportOptions.length > 1,
   );
+  const transportChanged = Boolean(
+    transportSwitchAvailable &&
+      transportState !== null &&
+      session !== null &&
+      transportState !== session.transport,
+  );
+  // While a switch is staged, advanced fields follow the *target* pair's
+  // restart-scoped capability; otherwise the response's own flag.
+  const selectedTransportOption = transportOptions.find(
+    (option) => option.id === (transportState ?? session?.transport),
+  );
+
+  // ── availability / capability gating ──────────────────────────────────────
+  const launchFieldsAvailable = transportChanged
+    ? Boolean(selectedTransportOption?.supports_launch_settings_with_restart)
+    : Boolean(launchSettings?.supports_launch_settings_with_restart);
   const assistantReplacementStaged = Boolean(
     isAssistant &&
       session &&
@@ -418,14 +457,19 @@ export function useSessionSettings(
   const titleChanged = Boolean(
     session && title.trim() && title.trim() !== session.title,
   );
+  // Inline tuning is suppressed while an interface switch is staged (the target
+  // pair may not support it, and it can't be applied in the same restart), so
+  // these read false during a staged switch — matching the hidden controls.
   const permissionChanged = Boolean(
-    session && (permissionMode ?? null) !== (session.permission_mode ?? null),
+    session &&
+      !transportChanged &&
+      (permissionMode ?? null) !== (session.permission_mode ?? null),
   );
   const modelChanged = Boolean(
-    session && (model ?? null) !== (session.model ?? null),
+    session && !transportChanged && (model ?? null) !== (session.model ?? null),
   );
   const effortChanged = Boolean(
-    session && (effort ?? null) !== (session.effort ?? null),
+    session && !transportChanged && (effort ?? null) !== (session.effort ?? null),
   );
   const profileChanged = Boolean(
     session &&
@@ -447,12 +491,16 @@ export function useSessionSettings(
     !assistantReplacementStaged &&
     (profileChanged || argsChanged || configChanged || envChanged);
 
+  // Any change carried by the single launch-settings PATCH (interface switch
+  // plus batched restart-scoped edits).
+  const restartLaunchChanged = launchChanged || transportChanged;
+
   const dirty =
     titleChanged ||
     permissionChanged ||
     modelChanged ||
     effortChanged ||
-    launchChanged ||
+    restartLaunchChanged ||
     assistantReplacementStaged;
 
   // ── change plan ───────────────────────────────────────────────────────────
@@ -486,12 +534,16 @@ export function useSessionSettings(
         tuneRestarts += 1;
       }
     }
-    const restartCount = (launchChanged ? 1 : 0) + tuneRestarts;
+    const restartCount = (restartLaunchChanged ? 1 : 0) + tuneRestarts;
     const running =
       session?.status === "running" || session?.status === "waiting_input";
     const willInterruptTurn = restartCount > 0 && running;
 
-    if (restartCount > 1) {
+    if (transportChanged) {
+      warnings.push(
+        "The session will restart and resume through the selected interface, keeping its conversation.",
+      );
+    } else if (restartCount > 1) {
       warnings.push(
         `Applying these changes will restart the session ${restartCount} times and resume it.`,
       );
@@ -517,7 +569,8 @@ export function useSessionSettings(
     modelChanged,
     effortChanged,
     permissionChanged,
-    launchChanged,
+    restartLaunchChanged,
+    transportChanged,
     profileChanged,
     session,
     dirty,
@@ -573,9 +626,11 @@ export function useSessionSettings(
         return true;
       }
 
-      // 3. All restart-scoped launch changes in one PATCH.
-      if (launchChanged) {
+      // 3. The interface switch and all restart-scoped launch changes in one
+      //    PATCH.
+      if (restartLaunchChanged) {
         const update: LaunchSettingsUpdate = { restart: true };
+        if (transportChanged && transportState) update.transport = transportState;
         if (profileChanged) update.account_profile_id = accountProfileId;
         if (argsChanged) update.args = stagedArgs;
         if (configChanged) update.config_overrides = stagedConfig;
@@ -647,7 +702,9 @@ export function useSessionSettings(
     assistantTransport,
     assistantThreadId,
     accountProfileId,
-    launchChanged,
+    restartLaunchChanged,
+    transportChanged,
+    transportState,
     profileChanged,
     argsChanged,
     stagedArgs,
@@ -685,6 +742,7 @@ export function useSessionSettings(
     configOverridesText,
     existingEnv,
     newEnv,
+    transport: transportState,
     assistantBackend,
     assistantTransport,
     assistantThreadId,
@@ -694,6 +752,9 @@ export function useSessionSettings(
     applyDisabled,
     launchFieldsAvailable,
     launchFieldsDisabledReason,
+    transportOptions,
+    transportSwitchAvailable,
+    transportChanged,
     hiddenEnvKeys,
     setTitle,
     setPermissionMode,
@@ -705,6 +766,7 @@ export function useSessionSettings(
     setExistingEnvOp,
     setExistingEnvValue,
     setNewEnv,
+    setTransport,
     setAssistantBackend,
     setAssistantTransport,
     setAssistantThreadId,


### PR DESCRIPTION
## Purpose

Transport is a property of *how* an agent is driven, not of the conversation itself, but there was no lifecycle operation to change a managed session's transport after creation. This lets a managed, non-assistant Claude/Codex session change its **Interface** from the Session settings modal — claude_tty ⇄ claude_cli ⇄ tmux for Claude, codex_app_server ⇄ tmux for Codex — keeping the same Waypoint session record and native thread, in one restart-and-resume. It also finishes the settings-consolidation started in #275 by removing the regular composer's duplicate account-profile picker, so the modal is the single surface for restart-scoped changes, and exposes that modal from the terminal overflow menu with capability-gated fields. Implements the session transport switching RFC (`rfc-session-transport-switching`).

## Changes

### Backend
- `backend/src/waypoint/schemas.py` — add `transport` to `LaunchSettingsUpdateRequest`; add `TransportSettingsOption` and project `transport_options` + `supports_transport_switch_with_restart` on `LaunchSettingsResponse`.
- `backend/src/waypoint/backends/registry.py` — factor `capabilities_for_pair(backend, transport)` out of `capabilities_for` so target-pair capabilities can be composed for a not-yet-persisted pair.
- `backend/src/waypoint/runtime.py` — project the safe switch targets in `get_launch_settings` (offered only when the agent has a resumable `native_thread_store`, so OpenCode and attached panes advertise none with no per-agent branching; attached panes also force `supports_account_profile_with_restart` false). Extend `_update_launch_settings_locked`: gate restart-scoped checks on the target pair, require a durably-persisted native thread before any teardown (v1 rejects an unpersisted switch rather than starting fresh), hoist the interrupt/flush so a running turn settles before teardown for a transport-only switch too, terminate on the current driver, reset `transport_state` to the neutral native-thread handoff, persist the target transport, and restore through the target plugin. The old→new interface transition is recorded as a system event.
- `backend/src/waypoint/backends/tmux/plugin.py`, `backend/src/waypoint/backends/claude_tty/plugin.py` — when `launch_args` is absent from `transport_state` (as after a switch resets it to the neutral handoff), reconstruct the base launch args from the persisted session fields via the agent launch contract, so a switch *into* a pane transport keeps model/effort/permission and custom args.
- `backend/tests/test_launch_settings.py`, `test_tmux_plugin.py`, `test_claude_tty_controls.py` — cover the switch-target projection, the lifecycle (persist + neutral reset, terminate-old/restore-target, reject unpersisted before teardown, interrupt/flush ordering), and the pane-transport arg reconstruction.

### Frontend
- `frontend/src/lib/types.ts`, `frontend/src/lib/useSessionSettings.ts` — add the `transport` PATCH field and `transport_options`; stage a non-assistant interface switch in the controller, deriving capabilities from the staged pair (the assistant keeps its own pair), suppressing inline tuning while a switch is staged, and sending the transport with any batched restart-scoped edits in one PATCH.
- `frontend/src/components/SessionSettingsModal.tsx` — render an **Interface** selector (in the context group before Account profile) from the server-projected targets; gate model/effort/permission on the composed (current-or-staged) transport's inline capability — hidden, not disabled, when unsupported or while a switch is staged.
- `frontend/src/components/SessionTerminalView.tsx`, `frontend/src/components/SessionDetail.tsx` — add a `Session settings…` entry to the terminal overflow menu wired to the existing modal, and remove the regular composer's account-profile picker and its dedicated launch-settings fetch (keeping the account-profile badge and the assistant replacement controls).

## Design

The switch reuses the existing `PATCH /api/sessions/{id}/launch-settings` terminate-persist-restore boundary rather than adding a new endpoint or a parallel handoff protocol. The agent-owned state that must survive is just the native thread id, already exposed agent-agnostically via `native_thread_id`; the runtime resets `transport_state` to that neutral payload and each target transport rebuilds its own state in `restore_session` (structured targets from the persisted session fields directly, pane targets by reconstructing launch args through the agent launch contract). Switchability is a capability signal (`native_thread_store`), not a hard-coded matrix, so OpenCode is excluded without naming it and a future resumable transport is included for free. v1 requires a persisted native thread, which keeps the switch a pure resume and sidesteps any fresh-restart-across-transports edge; FR6's optional fresh-start is deferred. No `backend === …` / agent-name branch is introduced in the runtime or the frontend.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- E2E: restarted the stack onto this branch with `waypointctl`; verified the live launch-settings projection lists the safe targets for a real claude_tty session (claude_tty/claude_cli/tmux) and none for OpenCode/attached; switched a throwaway Claude session over the deployed API claude_tty→claude_cli (resumed, conversation preserved, a follow-up turn answered on the new interface) then claude_cli→tmux (relaunched with reconstructed model/effort/permission + custom args); drove the deployed app with Playwright — the terminal overflow opens `Session settings…`, the Interface selector renders (Emulated/Chat/Terminal), and staging a switch hides the tuning controls and shows the restart-resume warning, in both themes.

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1809 passed, 3 pre-existing/unrelated warnings.
- Frontend lint and production build: passed.
- E2E: both transport switches resumed on the deployed backend with the conversation preserved and correct system notes; pane-target reconstruction preserved model/effort/permission + custom args; modal Interface selector, terminal-overflow entry, and tuning-suppression gating all verified in dark and light themes.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] This is not a breaking change.
- [ ] No user-facing config/docs changes required beyond the existing settings-editor documentation.

</details>