### PR TITLE
feat: sync the terminal surface to the Claude TUI theme

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -30,6 +30,7 @@ from waypoint.backends.account_profiles import (
     backend_hosts_account_profiles,
     redacted_profile_metadata,
 )
+from waypoint.backends.base import TerminalAppearance, TerminalAppearanceResolving
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.backends.tmux.renderer import (
     Osc52Extractor,
@@ -1756,38 +1757,52 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         adapter = context.runtime.tmux
         raw_log_path = Path(session.raw_log_path)
 
-        # Resizable transports wait for the client's initial resize frame so
-        # the seed is rendered at the viewport's dimensions. Non-resizable
-        # transports (claude_tty) have their size fixed by the pane manager;
-        # query the actual dimensions instead.
+        # Read the client's opening control frame. Every version-2 client sends
+        # a universal ``hello`` first, carrying its protocol version and — for a
+        # resizable pane — its viewport dimensions. A legacy client sends the
+        # old resize-only frame (resizable panes) or nothing (fixed-grid panes).
+        # We read one frame for every pane so a fixed-grid TUI (claude_tty) can
+        # opt into version 2 and receive the appearance frame too. A stale v1
+        # fixed-grid tab that sends nothing simply times out into version 1.
+        client_protocol = 1
+        viewport_cols = 0
+        viewport_rows = 0
+        handshake: Any = None
+        try:
+            first = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
+            handshake = json.loads(first)
+        except WebSocketDisconnect:
+            # Client closed during the handshake; nothing left to seed.
+            return
+        except (TimeoutError, json.JSONDecodeError):
+            handshake = None
+        if isinstance(handshake, dict):
+            htype = handshake.get("type")
+            if htype == "hello":
+                try:
+                    if int(handshake.get("terminal_protocol", 1)) >= 2:
+                        client_protocol = 2
+                except (TypeError, ValueError):
+                    pass
+            if htype in ("hello", "resize"):
+                try:
+                    viewport_cols = int(handshake.get("cols", 0))
+                    viewport_rows = int(handshake.get("rows", 0))
+                except (TypeError, ValueError):
+                    viewport_cols = viewport_rows = 0
+
+        # Resizable transports render the seed at the client's viewport;
+        # non-resizable transports (claude_tty) have their size fixed by the
+        # pane manager, so query the actual dimensions instead.
         cols = 80
         rows = 24
         if terminal_resizable:
-            viewport_cols = 0
-            viewport_rows = 0
-            try:
-                first = await asyncio.wait_for(websocket.receive_text(), timeout=1.0)
-                handshake = json.loads(first)
-                if handshake.get("type") == "resize":
-                    try:
-                        viewport_cols = int(handshake.get("cols", 0))
-                        viewport_rows = int(handshake.get("rows", 0))
-                    except (TypeError, ValueError):
-                        viewport_cols = viewport_rows = 0
-                    if viewport_cols > 0 and viewport_rows > 0:
-                        with suppress(TmuxError):
-                            await adapter.resize_window(
-                                tmux_session, viewport_cols, viewport_rows
-                            )
-                            await adapter.resize_pane(
-                                pane, viewport_cols, viewport_rows
-                            )
-            except WebSocketDisconnect:
-                # Client closed during the handshake; nothing left to seed.
-                return
-            except (TimeoutError, json.JSONDecodeError):
-                # No handshake — fall through with default viewport.
-                pass
+            if viewport_cols > 0 and viewport_rows > 0:
+                with suppress(TmuxError):
+                    await adapter.resize_window(
+                        tmux_session, viewport_cols, viewport_rows
+                    )
+                    await adapter.resize_pane(pane, viewport_cols, viewport_rows)
             cols = viewport_cols or 80
             rows = viewport_rows or 24
             # Give the pane process a beat to handle SIGWINCH and emit its
@@ -1801,6 +1816,36 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             # the diff encoding matches what the pane produces.
             with suppress(TmuxError):
                 cols, rows = await adapter.pane_dimensions(pane)
+
+        # For a version-2 client, resolve the agent's effective terminal
+        # appearance and send it before any size/seed frame so xterm selects the
+        # matching light/dark surface up front. WebSocket frames are ordered and
+        # the browser applies this synchronously in an earlier message handler
+        # than the seed write, so no acknowledgement round-trip is needed. A
+        # legacy (version-1) client never opted in and receives no appearance
+        # frame — keeping the byte stream identical to the prior protocol. The
+        # plugin owns the resolution; a plugin without the protocol, or an
+        # unresolved value, falls back to the existing dark presentation.
+        if client_protocol >= 2:
+            appearance = TerminalAppearance.DARK
+            if isinstance(plugin, TerminalAppearanceResolving):
+                try:
+                    resolved = await plugin.terminal_appearance(
+                        context.runtime, session
+                    )
+                except Exception:
+                    resolved = TerminalAppearance.UNKNOWN
+                if resolved in (TerminalAppearance.LIGHT, TerminalAppearance.DARK):
+                    appearance = resolved
+                else:
+                    log.debug(
+                        "terminal appearance fallback to dark (session=%s)",
+                        session_id,
+                    )
+            with suppress(Exception):
+                await websocket.send_text(
+                    json.dumps({"type": "appearance", "appearance": appearance.value})
+                )
 
         # Server-side terminal emulator: bytes from the pane go through
         # pyte, which maintains the authoritative screen state. The

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
 from datetime import datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -167,6 +168,49 @@ class PaneSubmitConfirming(Protocol):
         was sent. Agents that render input literally check that ``sent_text``
         no longer occupies the composer; ones that collapse it (Claude pastes an
         image to an ``[Image]`` chip) check that the composer is empty instead."""
+        ...
+
+
+class TerminalAppearance(StrEnum):
+    """Light/dark surface a terminal pane should adopt for an agent's TUI.
+
+    ``UNKNOWN`` is the safe-degradation value: the plugin could not resolve the
+    agent's effective theme (no preference, ``auto``, malformed/unreadable config,
+    an unsupported theme form, or a blocked remote probe). Generic terminal code
+    maps ``UNKNOWN`` — and any plugin that does not implement
+    :class:`TerminalAppearanceResolving` — to the existing dark presentation, so
+    the enum never leaks a third value onto the wire.
+    """
+
+    LIGHT = "light"
+    DARK = "dark"
+    UNKNOWN = "unknown"
+
+
+@runtime_checkable
+class TerminalAppearanceResolving(Protocol):
+    """An agent that can resolve the light/dark surface its terminal pane wants.
+
+    Per-session and profile-scoped — deliberately *not* a
+    :class:`BackendCapabilities` field: the result varies with the session's
+    account profile and the user's native agent theme preference, and can change
+    after a ``/theme`` swap. The terminal websocket narrows to this protocol
+    (``isinstance``) and asks the resolved plugin for the appearance before it
+    seeds the pane; a plugin without the protocol keeps the dark default.
+
+    A generic transport that wraps an arbitrary agent (the tmux pane wrapper)
+    implements this by delegating to its inner agent plugin through the same
+    protocol, so a new agent gains terminal theme sync by implementing
+    :meth:`terminal_appearance` alone — no change to the wrapper, the websocket,
+    or the frontend.
+    """
+
+    async def terminal_appearance(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> TerminalAppearance:
+        """Resolve the appearance for ``session``'s terminal pane, reading only
+        the session's profile-scoped agent configuration. Must degrade to
+        ``UNKNOWN`` (never raise) on any missing/malformed/unreadable input."""
         ...
 
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -24,6 +24,7 @@ from waypoint.backends.base import (
     ConfigDirNotReadyError,
     ConfigDirReadiness,
     DefaultLaunchContract,
+    TerminalAppearance,
     config_dir_for,
 )
 from waypoint.backends.capabilities import (
@@ -62,6 +63,10 @@ from waypoint.backends.claude_code.schemas import (
 from waypoint.backends.claude_code.support import (
     ClaudeSupportBundle,
     ensure_claude_support_bundle,
+)
+from waypoint.backends.claude_code.terminal_theme import classify_effective_appearance
+from waypoint.backends.claude_code.terminal_theme_remote import (
+    probe_terminal_appearance_remote,
 )
 from waypoint.backends.claude_code.threads import (
     UUID_RE,
@@ -305,6 +310,34 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # not literally on screen — emptiness is the only reliable signal.
         # Shared with claude_tty, which wraps the same TUI.
         return composer_is_empty(pane_text)
+
+    async def terminal_appearance(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> TerminalAppearance:
+        # Resolve the effective native Claude theme for this session's terminal
+        # pane, reading only the session's profile-scoped config. Degrades to
+        # UNKNOWN (→ dark) on anything unresolvable; never raises.
+        config_dir = config_dir_for(self.capabilities, session.launch_env)
+        target = runtime._find_launch_target(session.launch_target_id)
+        if target is not None:
+            # A remote session's theme lives on the target, under its launch
+            # env. Never read the local server's config for it (profile
+            # isolation). Honor the shared SSH circuit-breaker: a password
+            # target with no live ControlMaster would otherwise make every
+            # terminal open block on an unreachable-host probe.
+            if runtime.remote_probe_blocked(session.launch_target_id):
+                return TerminalAppearance.UNKNOWN
+            appearance = await probe_terminal_appearance_remote(
+                target, session.cwd, launch_env=dict(session.launch_env)
+            )
+        else:
+            appearance = await asyncio.to_thread(
+                classify_effective_appearance, config_dir, session.cwd
+            )
+        try:
+            return TerminalAppearance(appearance)
+        except ValueError:
+            return TerminalAppearance.UNKNOWN
 
     def setup(self, runtime: "SessionRuntime") -> None:
         # Build the host-side support bundle, the CLI adapter, and the remote

--- a/backend/src/waypoint/backends/claude_code/terminal_theme.py
+++ b/backend/src/waypoint/backends/claude_code/terminal_theme.py
@@ -131,9 +131,15 @@ def _classify_custom(slug: str, theme_root: Path) -> str:
     if "base" not in data:
         return DARK
     base = data.get("base")
-    if not isinstance(base, str):
-        return UNKNOWN
-    return classify_theme(base, theme_root)
+    # ``base`` inherits from a built-in theme, so only the six literal built-in
+    # values are accepted — never another ``custom:`` form. Mapping directly
+    # (rather than back through ``classify_theme``) also rules out unbounded
+    # recursion on a self-referential base.
+    if base in _LIGHT_THEMES:
+        return LIGHT
+    if base in _DARK_THEMES:
+        return DARK
+    return UNKNOWN
 
 
 def classify_theme(preference: str | None, theme_root: Path) -> str:

--- a/backend/src/waypoint/backends/claude_code/terminal_theme.py
+++ b/backend/src/waypoint/backends/claude_code/terminal_theme.py
@@ -1,0 +1,194 @@
+"""Classify a Claude Code session's effective light/dark terminal surface.
+
+This module is **stdlib-only and imports nothing from ``waypoint``** on purpose:
+the exact same file is fed to ``python3 -`` over SSH as the remote theme probe
+(see ``terminal_theme_remote.py``), so there is one canonical classifier with no
+hand-maintained remote copy to drift. All public functions return plain strings
+(``"light"`` / ``"dark"`` / ``"unknown"``); the plugin wraps the result into
+``waypoint.backends.base.TerminalAppearance``.
+
+Resolution reads only the session's profile-scoped Claude configuration and never
+issues ``/theme``, mutates a file, or returns config contents/paths/slugs to its
+caller. It classifies the theme's declared light/dark *base* — it does not recolor
+Claude's emitted ANSI/truecolor cells.
+
+Precedence for the effective ``theme`` value (first present wins), mirroring
+Claude's documented file-settings precedence excluding the command-line and
+enterprise-managed sources Waypoint cannot inspect:
+
+1. ``<cwd>/.claude/settings.local.json``   (local project)
+2. ``<cwd>/.claude/settings.json``         (shared project)
+3. ``<settings home>/settings.json``       (user)
+4. ``<legacy home>/.claude.json`` ``theme`` (pre-2.1.119 compatibility fallback)
+
+where ``<settings home>`` is ``CLAUDE_CONFIG_DIR`` when a profile is active else
+``~/.claude``, and ``<legacy home>`` is ``CLAUDE_CONFIG_DIR`` else ``~`` (the CLI
+keeps its legacy ``.claude.json`` in ``$HOME`` when the var is unset, but inside
+the dir when it is set).
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+LIGHT = "light"
+DARK = "dark"
+UNKNOWN = "unknown"
+
+# Built-in Claude theme preferences and the six custom-theme ``base`` values.
+_LIGHT_THEMES = frozenset({"light", "light-ansi", "light-daltonized"})
+_DARK_THEMES = frozenset({"dark", "dark-ansi", "dark-daltonized"})
+
+_CUSTOM_PREFIX = "custom:"
+# A user custom theme slug. Deliberately narrow: rejects path traversal and
+# separators so a slug can never escape the theme directory.
+_SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+# A custom theme file we are willing to read; anything larger is treated as
+# hostile/corrupt and resolves to unknown.
+_MAX_CUSTOM_THEME_BYTES = 64 * 1024
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    """Load ``path`` as a JSON object, or ``None`` if absent/unreadable/not a dict.
+
+    A regular-file check keeps us from opening a fifo/device; malformed JSON and
+    read errors degrade to ``None`` so a higher-precedence bad file never masks a
+    valid lower-precedence one.
+    """
+    try:
+        if not path.is_file():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _theme_value(obj: dict[str, Any] | None) -> str | None:
+    if obj is None:
+        return None
+    value = obj.get("theme")
+    return value if isinstance(value, str) and value else None
+
+
+def _settings_home(config_dir: str | None) -> Path:
+    return Path(config_dir).expanduser() if config_dir else Path.home() / ".claude"
+
+
+def _legacy_config_file(config_dir: str | None) -> Path:
+    if config_dir:
+        return Path(config_dir).expanduser() / ".claude.json"
+    return Path.home() / ".claude.json"
+
+
+def read_theme_preference(config_dir: str | None, cwd: str | None) -> str | None:
+    """The first ``theme`` value across the precedence chain, or ``None``.
+
+    Reads project settings only when ``cwd`` is given; always consults the user
+    settings and the legacy ``.claude.json`` fallback.
+    """
+    candidates: list[Path] = []
+    if cwd:
+        project = Path(cwd).expanduser() / ".claude"
+        candidates.append(project / "settings.local.json")
+        candidates.append(project / "settings.json")
+    candidates.append(_settings_home(config_dir) / "settings.json")
+    for path in candidates:
+        theme = _theme_value(_read_json_object(path))
+        if theme is not None:
+            return theme
+    return _theme_value(_read_json_object(_legacy_config_file(config_dir)))
+
+
+def _classify_custom(slug: str, theme_root: Path) -> str:
+    """Resolve a user ``custom:<slug>`` theme's declared base.
+
+    Rejects an out-of-spec slug, a file that resolves outside ``theme_root``
+    (symlink escape), a non-regular file, and an oversized file — all as
+    ``unknown``. Reads only ``base``; an omitted base is Claude's documented
+    ``dark`` default, any other value is ``unknown``.
+    """
+    if not _SLUG_RE.match(slug):
+        return UNKNOWN
+    path = theme_root / f"{slug}.json"
+    try:
+        if not path.is_file():
+            return UNKNOWN
+        resolved = path.resolve()
+        root = theme_root.resolve()
+        if root not in resolved.parents:
+            return UNKNOWN
+        if resolved.stat().st_size > _MAX_CUSTOM_THEME_BYTES:
+            return UNKNOWN
+        data = json.loads(resolved.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return UNKNOWN
+    if not isinstance(data, dict):
+        return UNKNOWN
+    if "base" not in data:
+        return DARK
+    base = data.get("base")
+    if not isinstance(base, str):
+        return UNKNOWN
+    return classify_theme(base, theme_root)
+
+
+def classify_theme(preference: str | None, theme_root: Path) -> str:
+    """Map a theme preference string to ``light`` / ``dark`` / ``unknown``.
+
+    ``theme_root`` is ``<settings home>/themes`` — the directory user custom
+    themes live in. ``auto``, an absent/empty preference, plugin-contributed
+    ``custom:<plugin>:<slug>`` forms, and any unrecognized value are ``unknown``.
+    """
+    if not preference:
+        return UNKNOWN
+    if preference in _LIGHT_THEMES:
+        return LIGHT
+    if preference in _DARK_THEMES:
+        return DARK
+    if preference.startswith(_CUSTOM_PREFIX):
+        rest = preference[len(_CUSTOM_PREFIX) :]
+        # ``custom:<plugin>:<slug>`` (a colon in the remainder) is a
+        # plugin-contributed theme; resolving it would require a profile-scoped
+        # enabled-plugin cache path Claude does not document. Unknown in v1.
+        if ":" in rest:
+            return UNKNOWN
+        return _classify_custom(rest, theme_root)
+    return UNKNOWN
+
+
+def classify_effective_appearance(config_dir: str | None, cwd: str | None) -> str:
+    """Top-level entry: resolve then classify the session's effective theme."""
+    preference = read_theme_preference(config_dir, cwd)
+    theme_root = _settings_home(config_dir) / "themes"
+    return classify_theme(preference, theme_root)
+
+
+def _main() -> int:
+    """Remote-probe entry point: print ``{"appearance": "..."}`` and exit 0.
+
+    ``CLAUDE_CONFIG_DIR`` carries the profile (absent = default home). The cwd is
+    passed via ``WAYPOINT_TERMINAL_THEME_CWD`` rather than the process cwd so a
+    stale/deleted remote project dir cannot fail the probe — user/legacy settings
+    still resolve.
+    """
+    config_dir = os.environ.get("CLAUDE_CONFIG_DIR") or None
+    cwd = os.environ.get("WAYPOINT_TERMINAL_THEME_CWD") or None
+    if cwd is None:
+        try:
+            cwd = os.getcwd()
+        except OSError:
+            cwd = None
+    try:
+        appearance = classify_effective_appearance(config_dir, cwd)
+    except Exception:
+        appearance = UNKNOWN
+    sys.stdout.write(json.dumps({"appearance": appearance}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/src/waypoint/backends/claude_code/terminal_theme_remote.py
+++ b/backend/src/waypoint/backends/claude_code/terminal_theme_remote.py
@@ -1,0 +1,96 @@
+"""Resolve a remote Claude session's terminal appearance over SSH.
+
+Runs the canonical stdlib-only classifier (``terminal_theme.py``) on the launch
+target through the same ``python3 -`` mechanism the rate-limit probe uses, under
+the session's launch environment so a work-profile session reads the *remote*
+profile's theme rather than the Waypoint server's. Every failure mode
+(unreachable host, missing interpreter, timeout, non-zero exit, malformed output)
+degrades to ``UNKNOWN`` and logs only a category — never the captured stderr,
+which could carry a config path.
+"""
+
+import asyncio
+import importlib.resources
+import json
+import logging
+from typing import Any
+
+from waypoint.backends.claude_code.terminal_theme import UNKNOWN
+from waypoint.launch_targets import SshLaunchTargetConfig
+
+log = logging.getLogger("waypoint.claude_code.terminal_theme")
+
+_PROBE_TIMEOUT_SECONDS = 3.0
+
+# Env var the remote classifier reads for the session cwd (see terminal_theme).
+# Passed through the launch env rather than a `cd` so a stale remote project dir
+# cannot fail the probe.
+_CWD_ENV_VAR = "WAYPOINT_TERMINAL_THEME_CWD"
+
+_SCRIPT_BYTES: bytes | None = None
+
+
+def _script_bytes() -> bytes:
+    global _SCRIPT_BYTES
+    if _SCRIPT_BYTES is None:
+        _SCRIPT_BYTES = (
+            importlib.resources.files("waypoint.backends.claude_code")
+            .joinpath("terminal_theme.py")
+            .read_bytes()
+        )
+    return _SCRIPT_BYTES
+
+
+async def probe_terminal_appearance_remote(
+    launch_target: SshLaunchTargetConfig,
+    cwd: str | None,
+    *,
+    launch_env: dict[str, str] | None = None,
+    timeout_seconds: float = _PROBE_TIMEOUT_SECONDS,
+) -> str:
+    """Return ``"light"`` / ``"dark"`` / ``"unknown"`` for a remote session.
+
+    Never raises; any failure resolves to ``"unknown"``.
+    """
+    extra_env = dict(launch_env or {})
+    if cwd:
+        extra_env[_CWD_ENV_VAR] = cwd
+    argv = launch_target.build_remote_exec_args(["python3", "-"], extra_env=extra_env)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError:
+        log.warning("remote terminal-theme probe failed to spawn ssh")
+        return UNKNOWN
+    try:
+        stdout, _stderr = await asyncio.wait_for(
+            proc.communicate(_script_bytes()), timeout=timeout_seconds
+        )
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
+        log.warning("remote terminal-theme probe timed out")
+        return UNKNOWN
+    if proc.returncode != 0:
+        # Deliberately omit stderr: a traceback can carry a config path.
+        log.warning(
+            f"remote terminal-theme probe exited non-zero (rc={proc.returncode})"
+        )
+        return UNKNOWN
+    text = stdout.decode("utf-8", errors="replace").strip()
+    if not text:
+        log.warning("remote terminal-theme probe produced no output")
+        return UNKNOWN
+    try:
+        decoded: Any = json.loads(text.splitlines()[-1])
+    except json.JSONDecodeError:
+        log.warning("remote terminal-theme probe produced non-JSON output")
+        return UNKNOWN
+    appearance = decoded.get("appearance") if isinstance(decoded, dict) else None
+    if appearance in ("light", "dark", "unknown"):
+        return appearance
+    return UNKNOWN

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -34,7 +34,10 @@ from typing import TYPE_CHECKING, Any
 from fastapi import HTTPException, status
 from pydantic import BaseModel, Field
 
-from waypoint.backends.base import config_dir_for
+from waypoint.backends.base import (
+    TerminalAppearance,
+    config_dir_for,
+)
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.claude_code import side_question as _sq
 from waypoint.backends.claude_code.commands import list_claude_command_completions
@@ -244,6 +247,13 @@ class ClaudeTtyPlugin:
         # collapses the paste to a chip, so emptiness — not the sent text — is
         # the signal.
         return pane_dialog.composer_is_empty(pane_text)
+
+    async def terminal_appearance(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> TerminalAppearance:
+        # Delegate to the composed Claude agent so this tty-tail transport and
+        # claude_code cannot drift on theme resolution.
+        return await self._claude.terminal_appearance(runtime, session)
 
     def on_session_deleted(
         self, runtime: "SessionRuntime", session: SessionRecord

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -19,7 +19,11 @@ from typing import TYPE_CHECKING, Any, Never
 from fastapi import HTTPException, status
 from pydantic import BaseModel
 
-from waypoint.backends.base import AgentLaunchContract
+from waypoint.backends.base import (
+    AgentLaunchContract,
+    TerminalAppearance,
+    TerminalAppearanceResolving,
+)
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
@@ -195,6 +199,20 @@ class TmuxPlugin:
     def native_thread_id(self, session: SessionRecord) -> str | None:
         thread_id = session.transport_state.get("thread_id")
         return thread_id if isinstance(thread_id, str) else None
+
+    async def terminal_appearance(
+        self, runtime: "SessionRuntime", session: SessionRecord
+    ) -> TerminalAppearance:
+        # Terminal theme is the wrapped agent's knowledge. Delegate to the inner
+        # agent through the same protocol so a new agent gains theme sync by
+        # implementing ``terminal_appearance`` alone; an agent that doesn't (or a
+        # bare attached pane with no wrapped agent) keeps the dark default.
+        if session.backend == self.id:
+            return TerminalAppearance.UNKNOWN
+        inner = runtime.registry.get(session.backend)
+        if isinstance(inner, TerminalAppearanceResolving):
+            return await inner.terminal_appearance(runtime, session)
+        return TerminalAppearance.UNKNOWN
 
     def native_thread_artifacts(
         self, session: SessionRecord, config_dir: str | None = None

--- a/backend/tests/test_terminal_theme.py
+++ b/backend/tests/test_terminal_theme.py
@@ -1,0 +1,414 @@
+"""Tests for Claude terminal appearance resolution.
+
+Covers the pure classifier (``terminal_theme``) across the full source/precedence
+matrix, the remote probe driver's failure modes, and plugin protocol delegation
+(claude_code local path, claude_tty delegation, tmux generic inner delegation).
+"""
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from waypoint.backends.base import TerminalAppearance
+from waypoint.backends.claude_code.plugin import ClaudeCodePlugin
+from waypoint.backends.claude_code.terminal_theme import (
+    classify_effective_appearance,
+    classify_theme,
+    read_theme_preference,
+)
+from waypoint.backends.claude_code.terminal_theme_remote import (
+    probe_terminal_appearance_remote,
+)
+from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin
+from waypoint.backends.tmux.plugin import TmuxPlugin
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+
+_NOW = datetime(2026, 7, 11, tzinfo=UTC)
+
+
+# ─── Pure classifier: built-in preferences ───
+
+
+@pytest.mark.parametrize(
+    "preference,expected",
+    [
+        ("light", "light"),
+        ("light-ansi", "light"),
+        ("light-daltonized", "light"),
+        ("dark", "dark"),
+        ("dark-ansi", "dark"),
+        ("dark-daltonized", "dark"),
+        ("auto", "unknown"),
+        ("", "unknown"),
+        (None, "unknown"),
+        ("nonsense", "unknown"),
+        ("custom:plug:slug", "unknown"),  # plugin-contributed form
+    ],
+)
+def test_classify_builtin(
+    preference: str | None, expected: str, tmp_path: Path
+) -> None:
+    assert classify_theme(preference, tmp_path / "themes") == expected
+
+
+# ─── Pure classifier: source precedence ───
+
+
+def _write(path: Path, obj: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(obj), encoding="utf-8")
+
+
+def test_precedence_local_over_shared_over_user(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    cwd = tmp_path / "proj"
+    _write(cfg / "settings.json", {"theme": "light"})
+    _write(cwd / ".claude" / "settings.json", {"theme": "dark"})
+    _write(cwd / ".claude" / "settings.local.json", {"theme": "light"})
+    # local project wins
+    assert read_theme_preference(str(cfg), str(cwd)) == "light"
+    # remove local -> shared project wins
+    (cwd / ".claude" / "settings.local.json").unlink()
+    assert read_theme_preference(str(cfg), str(cwd)) == "dark"
+    # remove shared -> user settings win
+    (cwd / ".claude" / "settings.json").unlink()
+    assert read_theme_preference(str(cfg), str(cwd)) == "light"
+
+
+def test_legacy_claude_json_fallback(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    cfg.mkdir()
+    # no settings.json anywhere -> legacy <config_dir>/.claude.json
+    _write(cfg / ".claude.json", {"theme": "dark-ansi"})
+    assert classify_effective_appearance(str(cfg), None) == "dark"
+
+
+def test_settings_json_beats_legacy(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "settings.json", {"theme": "light"})
+    _write(cfg / ".claude.json", {"theme": "dark"})
+    assert classify_effective_appearance(str(cfg), None) == "light"
+
+
+def test_malformed_higher_precedence_does_not_mask_lower(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    cwd = tmp_path / "proj"
+    (cwd / ".claude").mkdir(parents=True)
+    (cwd / ".claude" / "settings.local.json").write_text("{not json", encoding="utf-8")
+    _write(cfg / "settings.json", {"theme": "light"})
+    assert classify_effective_appearance(str(cfg), str(cwd)) == "light"
+
+
+def test_default_home_when_no_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    # settings.json under ~/.claude
+    _write(home / ".claude" / "settings.json", {"theme": "light"})
+    assert classify_effective_appearance(None, None) == "light"
+    # legacy ~/.claude.json is in HOME, not ~/.claude
+    (home / ".claude" / "settings.json").unlink()
+    _write(home / ".claude.json", {"theme": "dark"})
+    assert classify_effective_appearance(None, None) == "dark"
+
+
+def test_no_cwd_skips_project_settings(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "settings.json", {"theme": "dark"})
+    assert classify_effective_appearance(str(cfg), None) == "dark"
+
+
+# ─── Pure classifier: custom themes ───
+
+
+def test_custom_theme_base(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "themes" / "mine.json", {"base": "light"})
+    _write(cfg / "settings.json", {"theme": "custom:mine"})
+    assert classify_effective_appearance(str(cfg), None) == "light"
+
+
+def test_custom_theme_omitted_base_is_dark(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "themes" / "mine.json", {})
+    _write(cfg / "settings.json", {"theme": "custom:mine"})
+    assert classify_effective_appearance(str(cfg), None) == "dark"
+
+
+@pytest.mark.parametrize("base", ["mauve", "", 123, None])
+def test_custom_theme_bad_base_unknown(tmp_path: Path, base: Any) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "themes" / "mine.json", {"base": base})
+    assert classify_theme("custom:mine", cfg / "themes") == "unknown"
+
+
+@pytest.mark.parametrize("slug", ["../evil", "a/b", "..", ".", "with space", ""])
+def test_custom_theme_unsafe_slug_unknown(tmp_path: Path, slug: str) -> None:
+    (tmp_path / "themes").mkdir()
+    assert classify_theme(f"custom:{slug}", tmp_path / "themes") == "unknown"
+
+
+def test_custom_theme_symlink_escape_unknown(tmp_path: Path) -> None:
+    outside = tmp_path / "outside.json"
+    outside.write_text('{"base":"light"}', encoding="utf-8")
+    themes = tmp_path / "themes"
+    themes.mkdir()
+    link = themes / "evil.json"
+    try:
+        link.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks unsupported")
+    assert classify_theme("custom:evil", themes) == "unknown"
+
+
+def test_custom_theme_oversize_unknown(tmp_path: Path) -> None:
+    themes = tmp_path / "themes"
+    themes.mkdir()
+    (themes / "big.json").write_text(
+        '{"base":"light","pad":"' + "x" * (64 * 1024) + '"}', encoding="utf-8"
+    )
+    assert classify_theme("custom:big", themes) == "unknown"
+
+
+def test_custom_theme_missing_file_unknown(tmp_path: Path) -> None:
+    (tmp_path / "themes").mkdir()
+    assert classify_theme("custom:absent", tmp_path / "themes") == "unknown"
+
+
+# ─── Remote probe: runs the canonical script standalone (no waypoint imports) ───
+
+
+def test_remote_script_runs_standalone(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "settings.json", {"theme": "light"})
+    script = (
+        Path(__file__).resolve().parents[1]
+        / "src/waypoint/backends/claude_code/terminal_theme.py"
+    ).read_text()
+    out = subprocess.run(
+        [sys.executable, "-"],
+        input=script,
+        capture_output=True,
+        text=True,
+        env={"CLAUDE_CONFIG_DIR": str(cfg)},
+    )
+    assert out.returncode == 0
+    assert json.loads(out.stdout.splitlines()[-1]) == {"appearance": "light"}
+
+
+# ─── Remote probe driver: failure modes resolve to unknown ───
+
+
+class _FakeTarget:
+    def __init__(self, argv: list[str]) -> None:
+        self._argv = argv
+        self.captured_env: dict[str, str] = {}
+
+    def build_remote_exec_args(
+        self,
+        command: list[str],
+        cwd: str | None = None,
+        *,
+        extra_env: dict[str, str] | None = None,
+    ) -> tuple[str, ...]:
+        self.captured_env = dict(extra_env or {})
+        return tuple(self._argv)
+
+
+def _as_target(fake: _FakeTarget) -> SshLaunchTargetConfig:
+    return cast(SshLaunchTargetConfig, fake)
+
+
+def _as_runtime(fake: "_FakeRuntime") -> SessionRuntime:
+    return cast(SessionRuntime, fake)
+
+
+@pytest.mark.asyncio
+async def test_remote_probe_light() -> None:
+    target = _FakeTarget([sys.executable, "-c", "import sys; print(sys.stdin.read())"])
+    # Feed a script on stdin that just echoes a light verdict.
+    target._argv = [sys.executable, "-c", 'print(\'{"appearance":"light"}\')']
+    result = await probe_terminal_appearance_remote(
+        _as_target(target), "/work", launch_env={"CLAUDE_CONFIG_DIR": "/x"}
+    )
+    assert result == "light"
+    assert target.captured_env["WAYPOINT_TERMINAL_THEME_CWD"] == "/work"
+    assert target.captured_env["CLAUDE_CONFIG_DIR"] == "/x"
+
+
+@pytest.mark.asyncio
+async def test_remote_probe_nonzero_unknown() -> None:
+    target = _FakeTarget([sys.executable, "-c", "import sys; sys.exit(3)"])
+    assert (
+        await probe_terminal_appearance_remote(_as_target(target), None, launch_env={})
+        == "unknown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_probe_invalid_json_unknown() -> None:
+    target = _FakeTarget([sys.executable, "-c", "print('garbage')"])
+    assert (
+        await probe_terminal_appearance_remote(_as_target(target), None, launch_env={})
+        == "unknown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_probe_missing_binary_unknown() -> None:
+    target = _FakeTarget(["/nonexistent/python-binary-xyz"])
+    assert (
+        await probe_terminal_appearance_remote(_as_target(target), None, launch_env={})
+        == "unknown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_remote_probe_timeout_unknown() -> None:
+    target = _FakeTarget([sys.executable, "-c", "import time; time.sleep(5)"])
+    assert (
+        await probe_terminal_appearance_remote(
+            _as_target(target), None, launch_env={}, timeout_seconds=0.3
+        )
+        == "unknown"
+    )
+
+
+# ─── Plugin protocol delegation ───
+
+
+def _session(
+    *,
+    backend: str,
+    transport: str,
+    cwd: str,
+    launch_env: dict[str, str] | None = None,
+    launch_target_id: str | None = None,
+) -> SessionRecord:
+    return SessionRecord(
+        id="s1",
+        backend=backend,
+        source=SessionSource.MANAGED,
+        transport=transport,
+        title="t",
+        cwd=cwd,
+        status=SessionStatus.IDLE,
+        created_at=_NOW,
+        updated_at=_NOW,
+        last_event_at=_NOW,
+        raw_log_path="/tmp/raw.log",
+        structured_log_path="/tmp/structured.log",
+        launch_env=launch_env or {},
+        launch_target_id=launch_target_id,
+    )
+
+
+class _FakeRuntime:
+    def __init__(self, target: Any = None, blocked: bool = False) -> None:
+        self._target = target
+        self._blocked = blocked
+        self.registry: Any = None
+
+    def _find_launch_target(self, launch_target_id: str | None) -> Any:
+        return self._target
+
+    def remote_probe_blocked(self, launch_target_id: str | None) -> bool:
+        return self._blocked
+
+
+@pytest.mark.asyncio
+async def test_claude_code_local_resolves(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "settings.json", {"theme": "light"})
+    session = _session(
+        backend="claude_code",
+        transport="claude_cli",
+        cwd=str(tmp_path),
+        launch_env={"CLAUDE_CONFIG_DIR": str(cfg)},
+    )
+    plugin = ClaudeCodePlugin()
+    result = await plugin.terminal_appearance(_as_runtime(_FakeRuntime()), session)
+    assert result == TerminalAppearance.LIGHT
+
+
+@pytest.mark.asyncio
+async def test_claude_code_remote_blocked_is_unknown(tmp_path: Path) -> None:
+    session = _session(
+        backend="claude_code",
+        transport="claude_cli",
+        cwd=str(tmp_path),
+        launch_target_id="remote-1",
+    )
+    plugin = ClaudeCodePlugin()
+    runtime = _FakeRuntime(target=object(), blocked=True)
+    result = await plugin.terminal_appearance(_as_runtime(runtime), session)
+    assert result == TerminalAppearance.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_claude_tty_delegates_to_claude(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "settings.json", {"theme": "dark"})
+    session = _session(
+        backend="claude_code",
+        transport="claude_tty",
+        cwd=str(tmp_path),
+        launch_env={"CLAUDE_CONFIG_DIR": str(cfg)},
+    )
+    plugin = ClaudeTtyPlugin()
+    result = await plugin.terminal_appearance(_as_runtime(_FakeRuntime()), session)
+    assert result == TerminalAppearance.DARK
+
+
+class _Registry:
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    def get(self, backend_id: str) -> Any:
+        return self._inner
+
+
+@pytest.mark.asyncio
+async def test_tmux_delegates_to_inner_claude(tmp_path: Path) -> None:
+    cfg = tmp_path / "cfg"
+    _write(cfg / "settings.json", {"theme": "light"})
+    session = _session(
+        backend="claude_code",
+        transport="tmux",
+        cwd=str(tmp_path),
+        launch_env={"CLAUDE_CONFIG_DIR": str(cfg)},
+    )
+    runtime = _FakeRuntime()
+    runtime.registry = _Registry(ClaudeCodePlugin())
+    result = await TmuxPlugin().terminal_appearance(_as_runtime(runtime), session)
+    assert result == TerminalAppearance.LIGHT
+
+
+@pytest.mark.asyncio
+async def test_tmux_non_resolving_agent_is_unknown(tmp_path: Path) -> None:
+    class _Bare:
+        pass
+
+    session = _session(backend="codex", transport="tmux", cwd=str(tmp_path))
+    runtime = _FakeRuntime()
+    runtime.registry = _Registry(_Bare())
+    result = await TmuxPlugin().terminal_appearance(_as_runtime(runtime), session)
+    assert result == TerminalAppearance.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_tmux_bare_pane_is_unknown(tmp_path: Path) -> None:
+    session = _session(backend="tmux", transport="tmux", cwd=str(tmp_path))
+    result = await TmuxPlugin().terminal_appearance(
+        _as_runtime(_FakeRuntime()), session
+    )
+    assert result == TerminalAppearance.UNKNOWN

--- a/backend/tests/test_terminal_theme.py
+++ b/backend/tests/test_terminal_theme.py
@@ -144,7 +144,7 @@ def test_custom_theme_omitted_base_is_dark(tmp_path: Path) -> None:
     assert classify_effective_appearance(str(cfg), None) == "dark"
 
 
-@pytest.mark.parametrize("base", ["mauve", "", 123, None])
+@pytest.mark.parametrize("base", ["mauve", "", 123, None, "custom:other", "auto"])
 def test_custom_theme_bad_base_unknown(tmp_path: Path, base: Any) -> None:
     cfg = tmp_path / "cfg"
     _write(cfg / "themes" / "mine.json", {"base": base})

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -393,6 +393,37 @@ async def post_approval(self, runtime, session) -> None: ...
   any structured approval response (Claude syncs the permission-mode pill when
   an ExitPlanMode approval flips the mode out of "plan").
 
+### Terminal appearance (optional)
+
+A terminal pane is a host for an opaque TUI, so its light/dark surface should
+follow the *agent's own theme*, not Waypoint's app theme toggle. An agent opts
+into this by implementing the `TerminalAppearanceResolving` protocol from
+[`base.py`](../backend/src/waypoint/backends/base.py):
+
+```python
+async def terminal_appearance(self, runtime, session) -> TerminalAppearance: ...
+```
+
+It is a `@runtime_checkable` optional protocol, **not** a `BackendCapabilities`
+field: the answer is per-session and profile-scoped (it varies with the account
+profile's config dir and the user's native theme preference, and changes after a
+`/theme` swap), so it cannot live on the immutable capability descriptor. The
+terminal websocket narrows to the protocol with `isinstance` and asks the
+resolved plugin for the surface before it seeds the pane; a plugin that does not
+implement it — or a resolved `UNKNOWN` — keeps the existing dark default. The
+enum is `LIGHT`/`DARK`/`UNKNOWN`; only the first two ever reach the wire.
+
+Resolution must read only the session's profile-scoped config, never mutate the
+agent's preference, and degrade to `UNKNOWN` (never raise) on anything missing,
+malformed, unreadable, or remote-unreachable. Claude implements it in
+[`claude_code/terminal_theme.py`](../backend/src/waypoint/backends/claude_code/terminal_theme.py),
+a stdlib-only classifier that doubles as the SSH remote probe so local and
+remote resolution share one implementation. `claude_tty` delegates to its
+composed Claude agent, and the generic `tmux` wrapper delegates to its inner
+agent through the same protocol — so a new agent (Codex, OpenCode) gains
+terminal theme sync by implementing `terminal_appearance` alone, with no change
+to the wrapper, the websocket, or the frontend.
+
 ## Token & context usage
 
 Waypoint tracks two independent token measurements, both agent-owned at the

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8134,9 +8134,12 @@ html[data-theme="light"] .term-bar-action.primary {
   flex: 0 0 auto;
 }
 
-/* The stage stays dark in both app themes, matching XTerminal's fixed dark
- * palette — TUI truecolor output is tuned for a dark ground and cannot be
- * remapped, so a light stage renders it illegibly. */
+/* The stage surface follows the running agent's TUI theme, not the Waypoint app
+ * theme: xterm selects a light or dark palette from the appearance the server
+ * resolves, and the stage background must match xterm's own ground exactly.
+ * Dark is the default; ``.term-stage--light`` is applied when the agent's theme
+ * is light. Both backgrounds are terminal-specific literals — deliberately not
+ * app-theme tokens — so the stage never tracks the web chrome's light/dark. */
 .term-stage {
   position: relative;
   flex: 1 1 auto;
@@ -8144,6 +8147,10 @@ html[data-theme="light"] .term-bar-action.primary {
   display: flex;
   background: #060810;
   overflow: hidden;
+}
+
+.term-stage--light {
+  background: #faf7f0;
 }
 
 .term-stage-host {
@@ -8183,62 +8190,15 @@ html[data-theme="light"] .term-bar-action.primary {
   border-radius: var(--radius-pill);
 }
 
-/* Light theme — override xterm.js v6 inline color strings. v6's DOM
-   renderer writes inline ``background-color``/``color`` on each
-   indexed cell, bypassing the ``xterm-bg-*`` / ``xterm-fg-*`` class
-   rules that ``ITheme.extendedAnsi`` is supposed to drive — so the
-   bg-bar that claude_code draws around a user message (xterm index
-   237/238) and its pure-white emphasis text (index 231) render
-   straight from the default xterm 256-color palette against cream.
-   Two inline-style formats are emitted depending on which path
-   fires inside the row factory: ``rgb(R, G, B)`` with spaces, and
-   compact ``#hex``. Match both. */
-html[data-theme="light"] .xterm-rows span[style*="background-color: rgb(58, 58, 58)"],
-html[data-theme="light"] .xterm-rows span[style*="background-color:#3a3a3a"] {
-  background-color: #bcb4a1 !important;
-}
-html[data-theme="light"] .xterm-rows span[style*="background-color: rgb(68, 68, 68)"],
-html[data-theme="light"] .xterm-rows span[style*="background-color:#444444"] {
-  background-color: #b3ab99 !important;
-}
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(255, 255, 255)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#ffffff"],
-html[data-theme="light"] .xterm-rows span[style*="color:#fff;"] {
-  color: #1c1914 !important;
-}
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(148, 148, 148)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#949494"] {
-  color: #6c665a !important;
-}
-/* CC code-identifier accent (xterm index 153, #afd7ff). The pale blue
-   sits below readable contrast against cream; bump to the light-theme
-   ``brightBlue`` so the colour cue survives without going slate. */
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(175, 215, 255)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#afd7ff"] {
-  color: #3a87ba !important;
-}
-/* Codex TUI accents. Codex emits 24-bit RGB for its model picker /
-   path / status text, and xterm v6 also inlines ANSI 3/6 as literal
-   ``#cdcd00`` / ``#00cdcd`` instead of consulting LIGHT_THEME.yellow
-   / cyan — same renderer behaviour we work around for the 256-color
-   indexed cells above. All four land below readable contrast on
-   cream; remap to the theme's yellow / green / cyan. */
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(246, 226, 183)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#f6e2b7"] {
-  color: #aa6618 !important;
-}
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(171, 223, 167)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#abdfa7"] {
-  color: #257a50 !important;
-}
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(205, 205, 0)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#cdcd00"] {
-  color: #aa6618 !important;
-}
-html[data-theme="light"] .xterm-rows span[style*="color: rgb(0, 205, 205)"],
-html[data-theme="light"] .xterm-rows span[style*="color:#00cdcd"] {
-  color: #1e7a8e !important;
-}
+/* The terminal surface follows the agent's TUI theme (``.term-stage--light``),
+   not the Waypoint app theme, so xterm's own light/dark ``ITheme`` — including
+   its explicit ``extendedAnsi`` palette — drives cell colours. The former
+   ``html[data-theme="light"] .xterm-rows`` inline-style overrides were removed:
+   they coupled terminal colours to the web chrome, which is exactly what this
+   feature decouples. If xterm's DOM renderer is later shown to bypass
+   ``extendedAnsi`` for a specific indexed cell on the light surface, add a
+   narrowly scoped ``.term-stage--light .xterm-rows span[...]`` rule here,
+   documented with the observed index/colour. */
 
 .term-jump {
   position: absolute;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1455,6 +1455,12 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // Bumped to reconnect the terminal WS: on EXITED → live transitions and
   // when the pane target (tmux_pane) changes under a running session.
   const [terminalEpoch, setTerminalEpoch] = useState(0);
+  // The light/dark surface the connected pane should show, resolved from the
+  // agent's own TUI theme by the server. Connection state, not app state:
+  // dark until the appearance frame arrives, reset to dark on each reconnect.
+  const [terminalAppearance, setTerminalAppearance] = useState<
+    "light" | "dark"
+  >("dark");
   const prevSessionExitedRef = useRef(sessionExited);
   useEffect(() => {
     if (prevSessionExitedRef.current && !sessionExited) {
@@ -1500,30 +1506,42 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
 
     function connect() {
       terminalRef.current?.reset();
+      // Baseline the surface to dark before every (re)connect so a prior light
+      // session, transport, or profile can never bleed into a new one — the
+      // server re-sends the appearance frame if this connection is light.
+      terminalRef.current?.setAppearance("dark");
+      setTerminalAppearance("dark");
+      const resizable = !!paneTransport && terminalResizable(paneTransport, catalog);
       socket = connectTerminalSocket(host, token, sessionId, {
         onOpen: () => {
           attempt = 0;
-          // Push the current viewport size so tmux resizes the pane to
-          // match — otherwise xterm renders the seed at whatever pane size
-          // the agent last used. Read the live ref because the term may
-          // not have mounted at connect() time; the closure captured null
-          // would silently skip this resize and leave the pane stuck at
-          // xterm's default 80x24 if fit() produces the same dims and
-          // never fires onResize. Non-resizable panes (claude_tty) own their
-          // geometry server-side and must never be resized from here, so skip
-          // the seed resize entirely for them.
-          if (!paneTransport || !terminalResizable(paneTransport, catalog)) {
-            return;
-          }
+          // Opt into terminal protocol v2 with a universal hello so the server
+          // sends the appearance frame. Resizable panes carry their viewport so
+          // tmux resizes the pane to match; fixed-grid panes (claude_tty) own
+          // their geometry server-side and send the hello without dimensions.
+          // Read the live ref because the term may not have mounted at
+          // connect() time.
+          if (socket?.readyState !== WebSocket.OPEN) return;
           const term = terminalRef.current;
-          const cols = term?.cols();
-          const rows = term?.rows();
-          if (cols && rows && socket?.readyState === WebSocket.OPEN) {
-            socket.send(JSON.stringify({ type: "resize", cols, rows }));
-          }
+          const cols = resizable ? term?.cols() : undefined;
+          const rows = resizable ? term?.rows() : undefined;
+          socket.send(
+            JSON.stringify({
+              type: "hello",
+              terminal_protocol: 2,
+              ...(cols && rows ? { cols, rows } : {}),
+            }),
+          );
         },
         onChunk: (text) => {
           terminalRef.current?.write(text);
+        },
+        onAppearance: (appearance) => {
+          // Applied imperatively before the seed write (ordering guarantees the
+          // seed renders on the right surface), plus stored so re-renders and
+          // the stage background stay consistent.
+          terminalRef.current?.setAppearance(appearance);
+          setTerminalAppearance(appearance);
         },
         onResize: (cols, rows) => {
           // Fixed-grid panes (claude_tty) are pinned server-side; match our
@@ -1979,6 +1997,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           keyInjection={canInjectKeys}
           terminalRef={terminalRef}
           terminalDims={terminalDims}
+          terminalAppearance={terminalAppearance}
           sessionExited={sessionExited}
           dormantReattach={dormantReattach}
           // The Terminal tab is presented fullscreen (sticky, viewport-filling)

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -25,6 +25,8 @@ interface SessionTerminalViewProps {
   keyInjection: boolean;
   terminalRef: MutableRefObject<XTerminalHandle | null>;
   terminalDims: { cols: number; rows: number } | null;
+  // Light/dark surface for the pane, resolved from the agent's TUI theme.
+  terminalAppearance: "light" | "dark";
   sessionExited: boolean;
   dormantReattach: boolean;
   termMenuOpen: boolean;
@@ -77,6 +79,7 @@ export function SessionTerminalView({
   keyInjection,
   terminalRef,
   terminalDims,
+  terminalAppearance,
   sessionExited,
   dormantReattach,
   termMenuOpen,
@@ -296,7 +299,11 @@ export function SessionTerminalView({
           ) : null}
         </div>
       </div>
-      <div className="term-stage">
+      <div
+        className={`term-stage${
+          terminalAppearance === "light" ? " term-stage--light" : ""
+        }`}
+      >
         <div className="term-stage-host" role="log" aria-live="polite">
           <XTerminal
             // Remount when the transport (and thus fit mode) changes — autoFit
@@ -305,6 +312,7 @@ export function SessionTerminalView({
             ref={terminalRef}
             readOnly={!interactive}
             autoFit={!fixedGrid}
+            appearance={terminalAppearance}
             onData={interactive ? onTerminalInput : undefined}
             onResize={onTerminalResize}
             onScrollChange={interactive ? onTerminalScrollChange : undefined}

--- a/frontend/src/components/XTerminal.tsx
+++ b/frontend/src/components/XTerminal.tsx
@@ -4,8 +4,13 @@ import { forwardRef, useEffect, useImperativeHandle, useRef } from "react";
 
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { ITheme, Terminal } from "@xterm/xterm";
+import { Terminal } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
+
+import {
+  type TerminalAppearance,
+  terminalThemeFor,
+} from "@/lib/terminalTheme";
 
 export interface XTerminalHandle {
   write(data: string): void;
@@ -16,6 +21,10 @@ export interface XTerminalHandle {
   rows(): number;
   focus(): void;
   scrollToBottom(): void;
+  // Select the light/dark surface. The connection layer calls this on the
+  // appearance control frame before writing the seed, and resets it to dark
+  // before every (re)connect so a prior light session can't bleed through.
+  setAppearance(appearance: TerminalAppearance): void;
 }
 
 interface XTerminalProps {
@@ -33,36 +42,12 @@ interface XTerminalProps {
   // by SessionDetail to surface a "jump to live" pill once the viewport
   // has slipped into the scrollback.
   onScrollChange?: (isAtBottom: boolean) => void;
+  // The light/dark surface for this pane. Defaults to dark so the terminal
+  // always mounts on the safe ground; the connection layer overrides it via
+  // the imperative handle once the server resolves the agent's theme.
+  appearance?: TerminalAppearance;
   className?: string;
 }
-
-/* The terminal is a dark instrument in both app themes: TUIs emit truecolor
- * output tuned for a dark ground (e.g. Claude Code's diff backgrounds), and
- * only the 16 ANSI palette slots can be remapped — rendering that output on
- * a light background is illegible no matter the palette. */
-const TERMINAL_THEME: ITheme = {
-  background: "#060810",
-  foreground: "#e7ecf3",
-  cursor: "#e0bb73",
-  cursorAccent: "#0a0d12",
-  selectionBackground: "rgba(200, 169, 106, 0.30)",
-  black: "#0a0d12",
-  red: "#e26c70",
-  green: "#6cc99a",
-  yellow: "#d99a4a",
-  blue: "#8fb3d6",
-  magenta: "#c8a3eb",
-  cyan: "#6cc4d6",
-  white: "#e7ecf3",
-  brightBlack: "#6f7a8c",
-  brightRed: "#ff8a8e",
-  brightGreen: "#8ee0b3",
-  brightYellow: "#e0bb73",
-  brightBlue: "#b0cfee",
-  brightMagenta: "#dcc1f0",
-  brightCyan: "#9adeec",
-  brightWhite: "#f5f7fb",
-};
 
 
 export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
@@ -73,6 +58,7 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       onData,
       onResize,
       onScrollChange,
+      appearance = "dark",
       className,
     },
     ref,
@@ -110,10 +96,10 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
         // browser.
         cursorBlink: false,
         cursorStyle: "underline",
+        theme: terminalThemeFor(appearance),
         scrollback: 20000,
         allowProposedApi: true,
         disableStdin: readOnly,
-        theme: TERMINAL_THEME,
       });
       const fit = autoFit ? new FitAddon() : null;
       if (fit) term.loadAddon(fit);
@@ -230,6 +216,17 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       term.options.disableStdin = readOnly;
     }, [readOnly]);
 
+    // Declarative backstop for the imperative setAppearance below: keep the
+    // live theme in sync when the prop changes across re-renders. A repaint of
+    // the visible grid is needed because xterm's DOM renderer bakes colours
+    // into each cell, so a theme swap alone leaves already-painted cells stale.
+    useEffect(() => {
+      const term = termRef.current;
+      if (!term) return;
+      term.options.theme = terminalThemeFor(appearance);
+      term.refresh(0, term.rows - 1);
+    }, [appearance]);
+
     useImperativeHandle(ref, () => ({
       write: (data: string) => {
         termRef.current?.write(data);
@@ -265,6 +262,12 @@ export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(
       focus: () => termRef.current?.focus(),
       scrollToBottom: () => {
         termRef.current?.scrollToBottom();
+      },
+      setAppearance: (appearance: TerminalAppearance) => {
+        const term = termRef.current;
+        if (!term) return;
+        term.options.theme = terminalThemeFor(appearance);
+        term.refresh(0, term.rows - 1);
       },
     }));
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1638,6 +1638,11 @@ interface TerminalSocketHandlers {
   // in-band resize ops. The client applies it via term.resize() so its grid
   // matches the cell-positioned stream.
   onResize?: (cols: number, rows: number) => void;
+  // Version-2 servers send a ``{type:"appearance"}`` frame before the seed so
+  // the pane selects the light/dark surface matching the agent's TUI theme.
+  // Applied synchronously here (in an earlier message handler than the seed),
+  // so no acknowledgement is needed.
+  onAppearance?: (appearance: "light" | "dark") => void;
   onAuthFailure?: () => void;
   // Backend sends 4410 when the underlying tmux pane has exited. The
   // user has to click Reconnect explicitly; we don't auto-retry.
@@ -1663,6 +1668,10 @@ export function connectTerminalSocket(
         const msg = JSON.parse(event.data);
         if (msg?.type === "size" && typeof msg.cols === "number" && typeof msg.rows === "number") {
           handlers.onResize?.(msg.cols, msg.rows);
+          return;
+        }
+        if (msg?.type === "appearance" && (msg.appearance === "light" || msg.appearance === "dark")) {
+          handlers.onAppearance?.(msg.appearance);
           return;
         }
       } catch {

--- a/frontend/src/lib/terminalTheme.ts
+++ b/frontend/src/lib/terminalTheme.ts
@@ -1,0 +1,96 @@
+import { ITheme } from "@xterm/xterm";
+
+// The light/dark surface a terminal pane adopts, resolved from the running
+// agent's own theme preference and delivered over the terminal websocket. This
+// is independent of Waypoint's app theme toggle: the pane hosts an opaque TUI,
+// so it follows the TUI's ground, not the web chrome's.
+export type TerminalAppearance = "light" | "dark";
+
+// The fixed xterm 256-colour palette for indices 16-255 (the 6×6×6 colour cube
+// then the 24-step grayscale ramp). These indices carry no light/dark
+// semantics — they are absolute colours a TUI addresses directly — so both
+// themes share them, and we set them explicitly rather than leaning on xterm's
+// renderer-specific defaults.
+function buildExtendedAnsi(): string[] {
+  const hex = (n: number) => n.toString(16).padStart(2, "0");
+  const rgb = (r: number, g: number, b: number) => `#${hex(r)}${hex(g)}${hex(b)}`;
+  const levels = [0, 95, 135, 175, 215, 255];
+  const out: string[] = [];
+  for (let r = 0; r < 6; r++) {
+    for (let g = 0; g < 6; g++) {
+      for (let b = 0; b < 6; b++) {
+        out.push(rgb(levels[r], levels[g], levels[b]));
+      }
+    }
+  }
+  for (let i = 0; i < 24; i++) {
+    const v = 8 + i * 10;
+    out.push(rgb(v, v, v));
+  }
+  return out;
+}
+
+const EXTENDED_ANSI = buildExtendedAnsi();
+
+// The dark surface — the historical Waypoint terminal look. TUIs emit truecolor
+// output tuned for a dark ground (e.g. Claude Code's diff backgrounds), so this
+// remains the safe default and the fallback whenever appearance is unknown.
+export const DARK_TERMINAL_THEME: ITheme = {
+  background: "#060810",
+  foreground: "#e7ecf3",
+  cursor: "#e0bb73",
+  cursorAccent: "#0a0d12",
+  selectionBackground: "rgba(200, 169, 106, 0.30)",
+  black: "#0a0d12",
+  red: "#e26c70",
+  green: "#6cc99a",
+  yellow: "#d99a4a",
+  blue: "#8fb3d6",
+  magenta: "#c8a3eb",
+  cyan: "#6cc4d6",
+  white: "#e7ecf3",
+  brightBlack: "#6f7a8c",
+  brightRed: "#ff8a8e",
+  brightGreen: "#8ee0b3",
+  brightYellow: "#e0bb73",
+  brightBlue: "#b0cfee",
+  brightMagenta: "#dcc1f0",
+  brightCyan: "#9adeec",
+  brightWhite: "#f5f7fb",
+  extendedAnsi: EXTENDED_ANSI,
+};
+
+// The light surface — a warm off-white ground with dark default text, matching
+// a native light TUI theme. The 16 base slots are darkened/saturated for
+// contrast on the light ground; crucially the white/brightWhite slots resolve
+// to dark values so a TUI's white-on-default emphasis stays readable (light
+// text on a light ground would vanish). Truecolor cells the TUI emits are left
+// untouched — only the palette and surface change.
+export const LIGHT_TERMINAL_THEME: ITheme = {
+  background: "#faf7f0",
+  foreground: "#1c1914",
+  cursor: "#b8820e",
+  cursorAccent: "#faf7f0",
+  selectionBackground: "rgba(184, 130, 14, 0.25)",
+  black: "#2b2b2b",
+  red: "#c0392b",
+  green: "#2f8f4e",
+  yellow: "#a6791f",
+  blue: "#2d6bb8",
+  magenta: "#9b4dca",
+  cyan: "#1e8a9e",
+  white: "#4a453b",
+  brightBlack: "#6c665a",
+  brightRed: "#d0503f",
+  brightGreen: "#3aa860",
+  brightYellow: "#b8820e",
+  brightBlue: "#3a87ba",
+  brightMagenta: "#b56fd8",
+  brightCyan: "#2aa5bb",
+  brightWhite: "#1c1914",
+  extendedAnsi: EXTENDED_ANSI,
+};
+
+export function terminalThemeFor(appearance: TerminalAppearance): ITheme {
+  return appearance === "light" ? LIGHT_TERMINAL_THEME : DARK_TERMINAL_THEME;
+}


### PR DESCRIPTION
## Purpose

A Waypoint terminal pane renders every session on a fixed dark surface, so a user whose native Claude Code theme is light gets dark text on a dark pane. This makes a Claude-backed terminal pane adopt the light/dark *surface* of the effective Claude TUI theme, resolved per session from that session's profile-scoped Claude config — without issuing `/theme`, editing the user's preference, or coupling the pane to Waypoint's app theme toggle (the pane hosts an opaque TUI, so it follows the TUI's ground, not the web chrome's). Claude's emitted ANSI/truecolor cells are left untouched; only xterm's default palette and surface are selected to match. Implements the profile-aware Claude terminal theme sync RFC. The mechanism is agent-agnostic so Codex/OpenCode can adopt sync later by implementing one method (not done here).

## Changes

### Backend
- `backends/base.py` — add a `TerminalAppearance` enum (`light`/`dark`/`unknown`) and an optional, `@runtime_checkable` `TerminalAppearanceResolving` protocol. It is deliberately not a `BackendCapabilities` field: the answer is per-session and profile-scoped and changes after a `/theme` swap.
- `backends/claude_code/terminal_theme.py` (new) — a stdlib-only Claude theme classifier (settings.local → shared → user → legacy `.claude.json`, plus user custom-theme `base`, with slug/symlink/size guards). Being import-free, the same module doubles as the SSH remote probe, so local and remote resolution share one implementation. `terminal_theme_remote.py` (new) drives it via the existing `python3 -` probe mechanism with a bounded timeout and redacted logging.
- `backends/claude_code/plugin.py`, `backends/claude_tty/plugin.py`, `backends/tmux/plugin.py` — Claude implements the protocol (guarding the remote branch on the `remote_probe_blocked` circuit-breaker); `claude_tty` delegates to its composed Claude agent; the generic tmux wrapper delegates to its inner agent through the same protocol, so a future agent gains sync by implementing `terminal_appearance` alone.
- `api.py` — the terminal websocket reads a universal v2 `hello` frame on every connection and, for a v2 client, sends a `{"type":"appearance"}` control frame before the size/seed frames. WebSocket ordering plus the browser's serial message handling make an acknowledgement unnecessary. Legacy v1 clients never send `hello`, never receive the frame, and keep a byte-identical stream.
- `tests/test_terminal_theme.py` (new) — 44 cases over the full source/precedence matrix, custom-theme bases, unsafe slug/symlink/oversize, `auto`/unknown/malformed, legacy fallback, remote-probe failure modes, and protocol delegation through claude_code/claude_tty/tmux.

### Frontend
- `lib/terminalTheme.ts` (new) — light and dark xterm `ITheme`s sharing the fixed 256-colour extended palette; the light theme darkens the palette (including the white slots) for contrast on a light ground.
- `components/XTerminal.tsx` — an `appearance` prop selects the theme at mount and a `setAppearance` handle applies it live; `lib/api.ts` parses the appearance control frame and the client sends the v2 `hello` on open; `SessionDetail`/`SessionTerminalView` thread the per-connection appearance through, re-baselining to dark on each reconnect so a prior light session can't bleed through.
- `app/globals.css` — the `.term-stage` background follows a terminal-appearance modifier (terminal-specific colours, not app-theme tokens); the former `html[data-theme="light"] .xterm-rows` overrides are removed since the terminal no longer tracks the web chrome.

### Docs
- `docs/coding_agent_plugins.md` — document the optional `TerminalAppearanceResolving` protocol and why terminal appearance is per-session rather than a capability field.

## Design

Terminal appearance is agent knowledge, so it lives behind an optional plugin protocol the generic terminal websocket narrows to with `isinstance` — the same pattern as the existing `ConfigDirValidating`/`PaneSubmitConfirming` protocols — rather than a `backend == "claude_code"` branch. `UNKNOWN`, a plugin without the protocol, and a blocked remote probe all map to the existing dark presentation, so degradation is safe and the wire only ever carries `light`/`dark`. The RFC's `appearance_ready` acknowledgement, `4412` close code, and one-second gate were dropped: the server sends `appearance` before the seed on one ordered socket and the browser applies it in an earlier `onmessage` handler than the seed write, so the seed always renders on the resolved surface with no handshake — and since the pane mounts dark and re-baselines to dark before every reconnect, there is never an unknown-surface seed to guard against.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- E2E: restarted the stack onto this branch with `waypointctl`; connected the live terminal websocket and asserted a light-configured Claude project resolves `appearance:"light"`, a dark-configured session resolves `appearance:"dark"` (both before the seed), and a legacy v1 client (no `hello`) receives no appearance frame; drove the deployed app with Playwright and confirmed the light session renders the cream surface with legible dark text while a dark session is unchanged.

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1854 passed, 3 pre-existing/unrelated warnings.
- Frontend lint and production build: passed.
- E2E: `appearance` frame resolved `light`/`dark` correctly on the deployed backend and preceded the seed; v1 clients got no appearance frame; Playwright showed `.term-stage--light` at `#faf7f0` with readable dark text and the dark stage unchanged at `#060810` — no illegible indexed cells, so no CSS compatibility rule was needed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] This is not a breaking change.
- [x] I have updated documentation (`docs/coding_agent_plugins.md`) for the new plugin protocol.

</details>
