### PR TITLE
fix: tolerate unknown Codex thread item types on session reattach

### DIFF
--- a/backend/src/waypoint/backends/codex/_sdk_compat.py
+++ b/backend/src/waypoint/backends/codex/_sdk_compat.py
@@ -93,7 +93,7 @@ install_reasoning_effort_tolerance()
 _THREAD_ITEM_SENTINEL = "_waypoint_thread_item_tolerant"
 
 
-def _known_thread_item_types(union: object) -> frozenset[str]:
+def _known_thread_item_types(union: typing.Any) -> frozenset[str]:
     """Collect the ``type`` literal of every member of the ``ThreadItem`` union.
 
     Raises if any member contributes no string literal -- the set is load-bearing
@@ -145,12 +145,15 @@ def _referenced_models(cls: type[BaseModel]) -> set[type[BaseModel]]:
     return out
 
 
-def _thread_item_containers() -> list[type[BaseModel]]:
-    """Every generated model that transitively embeds ``ThreadItem``.
+def _thread_item_containers() -> tuple[list[type[BaseModel]], int]:
+    """Every generated model transitively embedding ``ThreadItem``, plus the
+    longest containment chain length from ``ThreadItem`` to a container.
 
-    Only these need rebuilding when the union is widened; the SDK ships ~660
-    models but ~25 contain a thread item, so scoping the rebuild keeps the
-    import-time cost negligible.
+    Only these models need rebuilding when the union is widened; the SDK ships
+    ~660 models but ~25 contain a thread item, so scoping the rebuild keeps the
+    import-time cost negligible. The chain length is the number of rebuild passes
+    needed to propagate the widened union to the deepest container, so callers
+    size the rebuild to the actual graph rather than a fixed guess.
     """
     models = [
         obj
@@ -172,10 +175,23 @@ def _thread_item_containers() -> list[type[BaseModel]]:
             if parent not in containers:
                 containers.add(parent)
                 frontier.append(parent)
-    return list(containers)
+
+    depth_memo: dict[type[BaseModel], int] = {}
+
+    def _chain_depth(node: type[BaseModel], on_path: frozenset[type[BaseModel]]) -> int:
+        longest = 0
+        for parent in parents.get(node, ()):
+            if parent in on_path:  # cycle guard; the container graph is a DAG
+                continue
+            if parent not in depth_memo:
+                depth_memo[parent] = _chain_depth(parent, on_path | {parent})
+            longest = max(longest, 1 + depth_memo[parent])
+        return longest
+
+    depth = _chain_depth(ThreadItem, frozenset({ThreadItem}))
+    return list(containers), depth
 
 
-_THREAD_ITEM_REBUILD_PASSES = 6
 _PROBE_UNKNOWN_TYPE = "_waypointUnknownItemProbe"
 
 
@@ -213,13 +229,14 @@ def install_thread_item_tolerance() -> None:
     _v2.UnknownThreadItem = UnknownThreadItem  # type: ignore[attr-defined]
 
     _rebuild(ThreadItem)
-    containers = _thread_item_containers()
+    containers, depth = _thread_item_containers()
     # ThreadItem sits at the bottom of a containment DAG
-    # (ThreadItem -> Turn -> Thread -> *Response / *Notification). Each pass
-    # propagates the widened union one level up; the SDK's depth is ~4, so a few
-    # passes reach a fixpoint. Order-independent (and cycle-safe) rather than
-    # relying on a topological sort of the SDK's shape.
-    for _ in range(_THREAD_ITEM_REBUILD_PASSES):
+    # (ThreadItem -> Turn -> Thread -> *Response / *Notification). Rebuilding all
+    # containers once propagates the widened union one level up; repeating for the
+    # DAG's depth reaches a fixpoint regardless of iteration order. Deriving the
+    # pass count from the measured depth means a future SDK that deepens the graph
+    # cannot silently outrun a hard-coded count.
+    for _ in range(max(1, depth)):
         for cls in containers:
             _rebuild(cls)
 

--- a/backend/src/waypoint/backends/codex/_sdk_compat.py
+++ b/backend/src/waypoint/backends/codex/_sdk_compat.py
@@ -1,28 +1,39 @@
 """Runtime tolerance shims for a codex CLI newer than the pinned SDK.
 
-The pinned ``openai-codex`` SDK ships generated Pydantic models whose enums are
-frozen at the SDK's release. A codex binary ahead of that release (e.g. a system
-install selected via ``local_bin``) can return enum values the SDK has never
-heard of. The SDK's typed RPC path validates responses strictly
-(``client.request`` -> ``model_validate`` with no fallback), so an unknown value
-raises ``ValidationError`` and breaks model discovery, launch, and turns.
+The pinned ``openai-codex`` SDK ships generated Pydantic models frozen at the
+SDK's release. A codex binary ahead of that release (e.g. a system install
+selected via ``local_bin``) can return values the SDK has never heard of. The
+SDK's typed RPC path validates responses strictly (``client.request`` ->
+``model_validate`` with no fallback), so an unknown value raises
+``ValidationError`` and breaks model discovery, launch, turns, and resume.
 
-``ReasoningEffort`` is the enum that grows in practice (codex 0.144.0 added
+Two skews are handled here:
+
+``ReasoningEffort`` -- the enum that grows in practice (codex 0.144.0 added
 ``max`` and ``ultra``). We make it an "open" enum: an unknown string value
 resolves to a freshly registered member that preserves the string, instead of
-raising. The value flows through Waypoint as a plain string, so nothing else
-needs to change.
+raising.
 
-Scoped deliberately to ``ReasoningEffort`` -- the only enum observed to skew --
-rather than every SDK enum, so a genuinely malformed response still fails loudly.
-Extending to another enum later is a one-line ``_open_enum`` call. Remove this
-module once the pinned SDK catches up to the CLI.
+``ThreadItem`` -- the discriminated-ish union of thread item types. A newer CLI
+emits item types the pinned union does not model (e.g. ``subAgentActivity``),
+which makes ``thread/resume``, ``thread/read``, and ``thread/fork`` responses
+fail to validate and reattach return 400. We widen the union in place with an
+``UnknownThreadItem`` fallback that preserves the whole item payload, so an
+unknown type degrades to a generic passthrough instead of failing the response.
+An after-validator rejects the *known* type literals so a genuinely malformed
+known item still fails loudly.
+
+Both shims are scoped deliberately -- a genuinely malformed response still fails
+loudly. Remove this module once the pinned SDK catches up to the CLI.
 """
 
 import threading
+import typing
 from enum import Enum
 
-from openai_codex.generated.v2_all import ReasoningEffort
+import openai_codex.generated.v2_all as _v2
+from openai_codex.generated.v2_all import ReasoningEffort, ThreadItem
+from pydantic import BaseModel, ConfigDict, model_validator
 
 _lock = threading.Lock()
 _SENTINEL = "_waypoint_open_enum"
@@ -77,3 +88,153 @@ def install_reasoning_effort_tolerance() -> None:
 
 
 install_reasoning_effort_tolerance()
+
+
+_THREAD_ITEM_SENTINEL = "_waypoint_thread_item_tolerant"
+
+
+def _known_thread_item_types(union: object) -> frozenset[str]:
+    """Collect the ``type`` literal of every member of the ``ThreadItem`` union.
+
+    Raises if any member contributes no string literal -- the set is load-bearing
+    (it is the only thing that stops a malformed *known* item from binding to the
+    ``UnknownThreadItem`` fallback), so a broken derivation must fail loudly at
+    install time rather than silently degrade the guarantee.
+    """
+    members = typing.get_args(union)
+    known: set[str] = set()
+    for member in members:
+        field = getattr(member, "model_fields", {}).get("type")
+        literals = typing.get_args(field.annotation) if field is not None else ()
+        contributed = {value for value in literals if isinstance(value, str)}
+        if not contributed:
+            raise RuntimeError(
+                f"ThreadItem union member {member!r} exposes no 'type' literal; "
+                "cannot distinguish known from unknown thread items."
+            )
+        known |= contributed
+    if len(known) < len(members):
+        raise RuntimeError(
+            f"ThreadItem type-literal derivation is incomplete "
+            f"({len(known)} literals for {len(members)} members)."
+        )
+    return frozenset(known)
+
+
+def _rebuild(cls: type[BaseModel]) -> None:
+    cls.__pydantic_complete__ = False
+    if "__pydantic_core_schema__" in cls.__dict__:
+        delattr(cls, "__pydantic_core_schema__")
+    cls.model_rebuild(force=True)
+
+
+def _referenced_models(cls: type[BaseModel]) -> set[type[BaseModel]]:
+    """The generated models a model refers to directly in its field annotations."""
+    out: set[type[BaseModel]] = set()
+    for field in cls.model_fields.values():
+        stack: list[object] = [field.annotation]
+        while stack:
+            annotation = stack.pop()
+            if (
+                isinstance(annotation, type)
+                and issubclass(annotation, BaseModel)
+                and annotation.__module__ == _v2.__name__
+            ):
+                out.add(annotation)
+            stack.extend(typing.get_args(annotation))
+    return out
+
+
+def _thread_item_containers() -> list[type[BaseModel]]:
+    """Every generated model that transitively embeds ``ThreadItem``.
+
+    Only these need rebuilding when the union is widened; the SDK ships ~660
+    models but ~25 contain a thread item, so scoping the rebuild keeps the
+    import-time cost negligible.
+    """
+    models = [
+        obj
+        for name in dir(_v2)
+        for obj in (getattr(_v2, name),)
+        if isinstance(obj, type)
+        and issubclass(obj, BaseModel)
+        and obj.__module__ == _v2.__name__
+    ]
+    parents: dict[type[BaseModel], set[type[BaseModel]]] = {}
+    for model in models:
+        for child in _referenced_models(model):
+            parents.setdefault(child, set()).add(model)
+
+    containers: set[type[BaseModel]] = set()
+    frontier: list[type[BaseModel]] = [ThreadItem]
+    while frontier:
+        for parent in parents.get(frontier.pop(), ()):
+            if parent not in containers:
+                containers.add(parent)
+                frontier.append(parent)
+    return list(containers)
+
+
+_THREAD_ITEM_REBUILD_PASSES = 6
+_PROBE_UNKNOWN_TYPE = "_waypointUnknownItemProbe"
+
+
+def install_thread_item_tolerance() -> None:
+    """Widen ``ThreadItem`` in place so unknown item types survive validation.
+
+    Idempotent. The union is mutated on the existing ``ThreadItem`` class (its
+    identity is preserved) so every parent model's already-resolved
+    ``list[ThreadItem]`` annotation keeps pointing at it; a forced rebuild of the
+    parents then recompiles them against the widened union.
+    """
+    if getattr(ThreadItem, _THREAD_ITEM_SENTINEL, False):
+        return
+
+    original_union = ThreadItem.model_fields["root"].annotation
+    known_types = _known_thread_item_types(original_union)
+
+    class UnknownThreadItem(BaseModel):
+        """Fallback member preserving a thread item whose ``type`` the pinned SDK
+        union does not model. ``extra='allow'`` keeps the entire payload so the
+        item round-trips through ``model_dump`` for downstream rendering."""
+
+        model_config = ConfigDict(extra="allow", populate_by_name=True)
+        type: str
+
+        @model_validator(mode="after")
+        def _reject_known_types(self) -> "UnknownThreadItem":
+            if self.type in known_types:
+                raise ValueError(f"{self.type!r} is a known thread item type")
+            return self
+
+    # Runtime union widening: the annotation swap is invisible to static typing.
+    widened_union = original_union | UnknownThreadItem
+    ThreadItem.model_fields["root"].annotation = widened_union  # type: ignore[assignment]
+    _v2.UnknownThreadItem = UnknownThreadItem  # type: ignore[attr-defined]
+
+    _rebuild(ThreadItem)
+    containers = _thread_item_containers()
+    # ThreadItem sits at the bottom of a containment DAG
+    # (ThreadItem -> Turn -> Thread -> *Response / *Notification). Each pass
+    # propagates the widened union one level up; the SDK's depth is ~4, so a few
+    # passes reach a fixpoint. Order-independent (and cycle-safe) rather than
+    # relying on a topological sort of the SDK's shape.
+    for _ in range(_THREAD_ITEM_REBUILD_PASSES):
+        for cls in containers:
+            _rebuild(cls)
+
+    # Tripwire: prove propagation actually took. ``Turn`` embeds
+    # ``list[ThreadItem]`` and needs no enum-heavy payload to validate.
+    ThreadItem.model_validate({"type": _PROBE_UNKNOWN_TYPE, "id": "_probe"})
+    _v2.Turn.model_validate(
+        {
+            "id": "_probe",
+            "status": "completed",
+            "items": [{"type": _PROBE_UNKNOWN_TYPE, "id": "_probe"}],
+        }
+    )
+
+    setattr(ThreadItem, _THREAD_ITEM_SENTINEL, True)
+
+
+install_thread_item_tolerance()

--- a/backend/tests/test_codex_sdk_compat.py
+++ b/backend/tests/test_codex_sdk_compat.py
@@ -11,14 +11,22 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
+from openai_codex.generated.notification_registry import NOTIFICATION_MODELS
 from openai_codex.generated.v2_all import (
+    ItemStartedNotification,
     ModelListResponse,
     ReasoningEffort,
+    ThreadResumeResponse,
     ThreadStartResponse,
+    Turn,
 )
+from pydantic import ValidationError
 
 import waypoint.backends.codex  # noqa: F401  (installs the shim on import)
-from waypoint.backends.codex._sdk_compat import install_reasoning_effort_tolerance
+from waypoint.backends.codex._sdk_compat import (
+    install_reasoning_effort_tolerance,
+    install_thread_item_tolerance,
+)
 from waypoint.backends.codex.adapter import CodexAppServerAdapter
 from waypoint.backends.codex.plugin import CodexPlugin, CodexPluginConfig
 
@@ -143,3 +151,108 @@ async def test_list_models_surfaces_unknown_efforts_through_plugin(
     result = await plugin.list_models(cast(Any, _FakeRuntime()))
     efforts = {e for model in result["models"] for e in model["supported_efforts"]}
     assert {"max", "ultra"} <= efforts
+
+
+# ── ThreadItem union tolerance ──────────────────────────────────────────────
+# A codex CLI ahead of the pinned SDK emits thread item types the SDK's
+# ``ThreadItem`` union does not model (observed: ``subAgentActivity``), which made
+# ``thread/resume`` responses fail validation and reattach return 400.
+
+_UNKNOWN_ITEM = {
+    "type": "subAgentActivity",
+    "id": "item-x1",
+    "path": "/root/plan_review",
+    "detail": {"nested": "kept"},
+}
+_KNOWN_ITEM = {"type": "reasoning", "id": "item-r1", "text": "thinking"}
+
+
+def _thread_resume_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "approvalPolicy": "never",
+        "approvalsReviewer": "user",
+        "cwd": "/workspace",
+        "model": "gpt-5-codex",
+        "modelProvider": "openai",
+        "sandbox": {"type": "readOnly"},
+        "thread": {
+            "cliVersion": "0.139.0",
+            "createdAt": 1_700_000_000,
+            "cwd": "/workspace",
+            "ephemeral": False,
+            "id": "th-1",
+            "modelProvider": "openai",
+            "preview": "hi",
+            "sessionId": "sess-1",
+            "source": "cli",
+            "status": {"type": "idle"},
+            "updatedAt": 1_700_000_010,
+            "turns": [{"id": "turn-1", "status": "completed", "items": items}],
+        },
+    }
+
+
+def test_thread_resume_with_unknown_item_validates_and_preserves() -> None:
+    response = ThreadResumeResponse.model_validate(
+        _thread_resume_payload([_KNOWN_ITEM, _UNKNOWN_ITEM])
+    )
+    known, unknown = response.thread.turns[0].items
+    assert type(known.root).__name__ == "ReasoningThreadItem"
+    assert type(unknown.root).__name__ == "UnknownThreadItem"
+    # The whole unknown payload round-trips for downstream rendering.
+    assert unknown.root.model_dump(by_alias=True) == _UNKNOWN_ITEM
+
+
+def test_known_item_still_binds_to_strict_member() -> None:
+    turn = Turn.model_validate(
+        {"id": "t", "status": "completed", "items": [_KNOWN_ITEM]}
+    )
+    assert type(turn.items[0].root).__name__ == "ReasoningThreadItem"
+
+
+def test_malformed_known_item_still_fails_loudly() -> None:
+    # A known ``type`` with required fields missing must NOT be masked by the
+    # unknown-item fallback; it should raise as before the shim.
+    with pytest.raises(ValidationError):
+        Turn.model_validate(
+            {
+                "id": "t",
+                "status": "completed",
+                "items": [{"type": "commandExecution", "id": "c"}],
+            }
+        )
+
+
+def test_thread_item_tolerance_is_idempotent() -> None:
+    # Re-invoking the installer is a no-op (guarded by a sentinel) and does not
+    # corrupt the union.
+    install_thread_item_tolerance()
+    install_thread_item_tolerance()
+    turn = Turn.model_validate(
+        {"id": "t", "status": "completed", "items": [_UNKNOWN_ITEM]}
+    )
+    assert type(turn.items[0].root).__name__ == "UnknownThreadItem"
+
+
+def test_unknown_item_in_live_notification_validates_and_unwraps() -> None:
+    # ``item/started`` carries a ``ThreadItem`` and drives every live turn. After
+    # widening, an unknown item validates into the typed notification (instead of
+    # the SDK's UnknownNotification fallback); the item must still unwrap to the
+    # same raw dict the normalizer consumes.
+    notification = ItemStartedNotification.model_validate(
+        {
+            "itemId": "item-x1",
+            "startedAtMs": 1,
+            "threadId": "th-1",
+            "turnId": "turn-1",
+            "item": _UNKNOWN_ITEM,
+        }
+    )
+    dumped = notification.model_dump(by_alias=True)
+    assert dumped["item"] == _UNKNOWN_ITEM  # RootModel serializes as its root
+
+
+def test_unknown_notification_method_still_falls_back_to_unknown() -> None:
+    # The shim must not tighten the notification method dispatch: a genuinely
+    # unknown method still has no model and degrades to UnknownNotification.
+    assert "waypoint/nonexistent/method" not in NOTIFICATION_MODELS

--- a/backend/tests/test_import_history_codex.py
+++ b/backend/tests/test_import_history_codex.py
@@ -89,6 +89,31 @@ def test_command_execution_item_synthesizes_paired_tool_call_and_result() -> Non
     assert result.metadata["method"] == "item/completed"
 
 
+def test_unknown_item_type_becomes_preserved_passthrough_event() -> None:
+    # A thread item whose type the pinned SDK does not model (e.g. a newer CLI's
+    # subAgentActivity) must import as a generic passthrough note carrying the raw
+    # item, not be dropped and not crash the whole import.
+    turn = _turn(
+        items=[
+            {
+                "type": "subAgentActivity",
+                "id": "item-x1",
+                "path": "/root/plan_review",
+                "detail": {"nested": "kept"},
+            }
+        ]
+    )
+    events = turns_to_events([turn], "sess-1")
+    assert len(events) == 1
+    event = events[0]
+    assert event.kind == EventKind.SYSTEM_NOTE
+    assert "subAgentActivity" in event.text
+    assert event.metadata["item_type"] == "subAgentActivity"
+    item = event.metadata["payload"]["item"]
+    assert item["path"] == "/root/plan_review"
+    assert item["detail"] == {"nested": "kept"}
+
+
 def test_multiple_turns_preserve_sequence_order() -> None:
     first = _turn(
         id="turn1",


### PR DESCRIPTION
## Purpose

Reattaching a managed Codex session could fail with a 400. A codex CLI ahead of the pinned `openai-codex==0.1.0b3` SDK emits thread item types the SDK's `ThreadItem` union does not model (observed: `subAgentActivity`), so `thread/resume`, `thread/read`, and `thread/fork` responses failed strict pydantic validation (`ThreadResumeResponse`: 44 validation errors) and `POST /api/sessions/{id}/reattach` returned 400. This makes the SDK boundary tolerant of unknown item types: an unknown type degrades to a preserved generic passthrough instead of failing the whole response, and stays resilient to future new item types rather than just `subAgentActivity`.

## Changes

### Backend
- `backend/src/waypoint/backends/codex/_sdk_compat.py` — add `install_thread_item_tolerance()` alongside the existing enum shim. It widens the `ThreadItem` union in place with an `UnknownThreadItem` fallback (`extra="allow"`, so the whole item payload round-trips through `model_dump`), then force-rebuilds only the ~25 generated models that transitively embed `ThreadItem` so the widened union propagates up to the response/notification models. Mutation is in place (class identity preserved) because parents cache a resolved `list[ThreadItem]` annotation; reassigning the class would not propagate. An after-validator rejects the known type literals — derived from the union members and asserted complete at install — so a genuinely malformed *known* item still fails loudly. A post-install tripwire proves the propagation actually took.
- `backend/tests/test_codex_sdk_compat.py` — `ThreadResumeResponse`/`Turn` validate and preserve an unknown item; known items still bind to their strict member; a malformed known item still raises; the shim is idempotent; the live `item/started` notification path validates and unwraps an unknown item, and an unknown notification *method* still falls back to `UnknownNotification`.
- `backend/tests/test_import_history_codex.py` — an unknown item type imports as a generic passthrough `SYSTEM_NOTE` carrying the raw item in `metadata.payload.item`, rather than being dropped or crashing the import.

## Design

The fix sits at the SDK model layer, not the endpoint, so every strict-validation path (resume, read, fork, and the live turn notifications) is covered without a per-path branch. The render layer already degrades unknown item types — `normalize.py`'s formatters fall back to `Started/Completed {item_type}` and `history.py` routes through them — so only the parse layer needed changing; the widened union simply lets an unknown item reach that existing fallback with its `type` intact. The rebuild is scoped to `ThreadItem`'s transitive containers to keep the one-time import cost negligible (~140ms). The shim is a deliberate, narrow tolerance (documented for removal once the pinned SDK catches up to the CLI); malformed known payloads are intentionally left to fail loudly.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- E2E: restarted the stack onto this branch with `waypointctl`, then reattached the codex session that originally produced the 400 (`codex-16c088ab`) over the deployed API and confirmed it resumed its native thread and processed a follow-up turn.

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1863 passed.
- E2E: `codex-16c088ab` transitioned `error → running`, resumed thread `019f4fdd…` (the thread carrying the `subAgentActivity` item), and `POST /input` returned 200 with no `ValidationError` in the backend log — the exact operation that previously returned 400.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [ ] I did not change the frontend.
- [ ] This is not a breaking change.
- [ ] No user-facing config/docs changes required.

</details>
