### PR TITLE
docs: document the ContextUsageRebasing plugin protocol

### DIFF
--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -457,6 +457,40 @@ than guessing. `display_total_tokens` is supplied only when the provider's
 categories do not overlap (Claude sums; Codex uses `totalTokens`; OpenCode
 omits it), so the UI never synthesizes an unsafe grand total.
 
+### Context-window rebase (optional)
+
+Sometimes only the *denominator* of the current context window changes, with no
+fresh usage payload to trigger a republish — a model swap or a transport switch.
+An agent opts into rebasing the stored snapshot in place by implementing the
+`ContextUsageRebasing` protocol from
+[`base.py`](../backend/src/waypoint/backends/base.py):
+
+```python
+def rebase_context_usage(self, session, *, model=None) -> SessionContextUsage | None: ...
+```
+
+Like `TerminalAppearanceResolving`, it is a `@runtime_checkable` optional
+protocol rather than a `BackendCapabilities` field, and it is **dispatched on the
+agent plugin** (`registry.get(session.backend)`), so one implementation covers
+every transport the agent runs over and an agent that doesn't implement it simply
+no-ops — no `backend == …` branch in the runtime. It is pure and data-only: it
+reads the session's durable `model` (or an explicit override), recomputes only
+`context_window_tokens`, and returns the rebased snapshot — `None` when there is
+nothing to rebase. It must key off the durable selection, never a resolved
+provider id, and clear the window (`context_window_tokens = None`) for an unknown
+selection rather than fabricating a default; returning the unchanged snapshot when
+the window already matches lets the runtime no-op idempotently (so an adapter that
+already refreshed in-place is not double-broadcast).
+
+The runtime invokes it after an explicit inline model change and after a transport
+switch restores, under the session lifecycle lock and before the state broadcast.
+This is a Claude concern: Claude's catalogue distinguishes `opus[1m]` (1M) from
+`opus`/`claude-opus-4-8` (200K), and the transcript records only the resolved base
+id, so the durable selection is the sole source of the `[1m]` entitlement. Codex
+and OpenCode take their window from the provider directly (Codex's `token_count`
+`model_context_window`, OpenCode's per-model lookup), so they neither implement
+the protocol nor need it.
+
 ## The claude_tty composition
 
 `claude_tty` is the clearest illustration of the (agent, transport) split: it


### PR DESCRIPTION
## Purpose

Docs-only follow-up to #285 (merged as 5c14f22), which added the optional `ContextUsageRebasing` plugin protocol but did not document it. The plugin guide already documents the analogous optional `TerminalAppearanceResolving` protocol, so this brings the new one to parity for the next person extending an agent.

## Changes

### Docs
- `docs/coding_agent_plugins.md` — add a "Context-window rebase (optional)" subsection under "Token & context usage": the protocol signature, why it's a `@runtime_checkable` protocol rather than a `BackendCapabilities` field, that it's dispatched on the agent plugin (`registry.get(session.backend)`) so one implementation covers every transport with no `backend == …` branch, its pure/data-only/idempotent/clear-not-fabricate contract and durable-model-not-resolved-id rule, the two runtime call sites (inline model change, transport-switch restore), and why it's Claude-specific (the `[1m]` entitlement is absent from the transcript, whereas Codex/OpenCode read the window from the provider).

## Design

No code change. Placed in the existing "Token & context usage" section and written to mirror the "Terminal appearance (optional)" entry's structure and depth, so the two optional protocols read consistently.

## Test Plan

- `cd backend && uv run pre-commit run codespell --files docs/coding_agent_plugins.md`

## Test Result

- codespell: passed. Docs-only change — no code, tests, or build affected.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [ ] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues. (Docs-only; ran `codespell` on the changed file.)
- [ ] I have added or updated tests covering my changes (if applicable). (Docs-only — no tests.)
- [ ] I have verified the relevant suites pass locally. (Docs-only — no code paths changed.)
- [ ] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work. (No code change; documents an existing protocol.)
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional). (No frontend change.)
- [ ] Not a breaking change.
- [x] I have updated documentation (`docs/coding_agent_plugins.md`).

</details>
