### PR TITLE
fix: suppress phantom "No response requested." turn after claude_tty resume

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -174,10 +174,20 @@ class TranscriptNormalizer:
         message_id = str(message.get("id") or "")
         usage: dict[str, Any] = message.get("usage") or {}
         stop_reason = str(message.get("stop_reason") or "")
+        output_tokens = int(usage.get("output_tokens") or 0)
 
         first_seen = message_id not in self._seen_message_ids
         if message_id:
             self._seen_message_ids.add(message_id)
+
+        # Resuming a thread (settings-change restart, reconnect, or compaction)
+        # relaunches the CLI with `--resume`, which injects a synthetic first
+        # turn with no model round-trip — a text-only message stamped
+        # stop_reason="stop_sequence" with zero output tokens (e.g. the literal
+        # "No response requested."). Suppress its text so the phantom reply
+        # never reaches the transcript; the result note below still fires, so
+        # the turn resolves to idle even if no real turn follows.
+        is_resume_noop = stop_reason == "stop_sequence" and output_tokens == 0
 
         events: list[NormalizedEvent] = []
         blocks = iter_content_blocks(message.get("content"))
@@ -189,7 +199,7 @@ class TranscriptNormalizer:
             bt = block.get("type")
             if bt == "text":
                 text = str(block.get("text") or "")
-                if text:
+                if text and not is_resume_noop:
                     had_text = True
                     events.append(
                         NormalizedEvent(
@@ -298,7 +308,6 @@ class TranscriptNormalizer:
             if message_id:
                 self._result_emitted_ids.add(message_id)
             usage_payload: dict[str, Any] = usage if first_seen else {}
-            output_tokens = int(usage.get("output_tokens") or 0)
             if stop_reason == "end_turn":
                 result_text = (
                     f"Turn complete · {output_tokens} output tokens"

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -49,6 +49,17 @@ from waypoint.schemas import EventKind, SessionStatus
 
 FILE_EDIT_TOOL_NAMES: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
 
+# The Claude CLI stamps locally-fabricated (non-model) messages with this model
+# id. It covers useful synthetic messages too (API-error notices, interrupted
+# partials), so the marker alone is not a suppression signal — it only gates the
+# exact placeholder strings below.
+SYNTHETIC_MODEL_ID = "<synthetic>"
+# Placeholder text the CLI substitutes for an empty assistant turn injected on a
+# `--resume` relaunch (settings-change restart, reconnect, or compaction). It is
+# a fixed CLI constant, and a synthetic message carrying exactly this text is
+# always the phantom — an interrupted partial or error notice has other text.
+RESUME_NOOP_TEXT = "No response requested."
+
 
 class NormalizedEvent:
     __slots__ = ("kind", "text", "metadata", "status")
@@ -181,13 +192,16 @@ class TranscriptNormalizer:
             self._seen_message_ids.add(message_id)
 
         # Resuming a thread (settings-change restart, reconnect, or compaction)
-        # relaunches the CLI with `--resume`, which injects a synthetic first
-        # turn with no model round-trip — a text-only message stamped
-        # stop_reason="stop_sequence" with zero output tokens (e.g. the literal
-        # "No response requested."). Suppress its text so the phantom reply
-        # never reaches the transcript; the result note below still fires, so
-        # the turn resolves to idle even if no real turn follows.
-        is_resume_noop = stop_reason == "stop_sequence" and output_tokens == 0
+        # relaunches the CLI with `--resume`, which injects a synthetic empty
+        # turn with no model round-trip whose text is the fixed placeholder
+        # "No response requested." — it pollutes the transcript as a phantom
+        # reply. It shares its shape (model="<synthetic>", stop_sequence, zero
+        # output tokens) with messages we must keep: interrupted partials and
+        # API-error notices are synthetic and zero-token too. Only the exact
+        # placeholder string on a synthetic message identifies the phantom, so
+        # match that and nothing structural. The result note below still fires,
+        # so the turn resolves to idle even if no real turn follows.
+        is_synthetic = str(message.get("model") or "") == SYNTHETIC_MODEL_ID
 
         events: list[NormalizedEvent] = []
         blocks = iter_content_blocks(message.get("content"))
@@ -199,7 +213,9 @@ class TranscriptNormalizer:
             bt = block.get("type")
             if bt == "text":
                 text = str(block.get("text") or "")
-                if text and not is_resume_noop:
+                if is_synthetic and text.strip() == RESUME_NOOP_TEXT:
+                    continue
+                if text:
                     had_text = True
                     events.append(
                         NormalizedEvent(

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -52,7 +52,7 @@ FILE_EDIT_TOOL_NAMES: frozenset[str] = frozenset({"Edit", "Write", "MultiEdit"})
 # The Claude CLI stamps locally-fabricated (non-model) messages with this model
 # id. It covers useful synthetic messages too (API-error notices, interrupted
 # partials), so the marker alone is not a suppression signal — it only gates the
-# exact placeholder strings below.
+# exact placeholder string below.
 SYNTHETIC_MODEL_ID = "<synthetic>"
 # Placeholder text the CLI substitutes for an empty assistant turn injected on a
 # `--resume` relaunch (settings-change restart, reconnect, or compaction). It is
@@ -185,22 +185,14 @@ class TranscriptNormalizer:
         message_id = str(message.get("id") or "")
         usage: dict[str, Any] = message.get("usage") or {}
         stop_reason = str(message.get("stop_reason") or "")
-        output_tokens = int(usage.get("output_tokens") or 0)
 
         first_seen = message_id not in self._seen_message_ids
         if message_id:
             self._seen_message_ids.add(message_id)
 
-        # Resuming a thread (settings-change restart, reconnect, or compaction)
-        # relaunches the CLI with `--resume`, which injects a synthetic empty
-        # turn with no model round-trip whose text is the fixed placeholder
-        # "No response requested." — it pollutes the transcript as a phantom
-        # reply. It shares its shape (model="<synthetic>", stop_sequence, zero
-        # output tokens) with messages we must keep: interrupted partials and
-        # API-error notices are synthetic and zero-token too. Only the exact
-        # placeholder string on a synthetic message identifies the phantom, so
-        # match that and nothing structural. The result note below still fires,
-        # so the turn resolves to idle even if no real turn follows.
+        # Suppress the resume phantom (see RESUME_NOOP_TEXT); the result note
+        # below still fires, so the turn resolves to idle even if no real turn
+        # follows.
         is_synthetic = str(message.get("model") or "") == SYNTHETIC_MODEL_ID
 
         events: list[NormalizedEvent] = []
@@ -324,6 +316,7 @@ class TranscriptNormalizer:
             if message_id:
                 self._result_emitted_ids.add(message_id)
             usage_payload: dict[str, Any] = usage if first_seen else {}
+            output_tokens = int(usage.get("output_tokens") or 0)
             if stop_reason == "end_turn":
                 result_text = (
                     f"Turn complete · {output_tokens} output tokens"

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -17,6 +17,7 @@ def _assistant_record(
     content: list[dict],
     stop_reason: str = "end_turn",
     usage: dict | None = None,
+    model: str = "claude-opus-4-8",
 ) -> dict:
     return {
         "type": "assistant",
@@ -25,6 +26,7 @@ def _assistant_record(
             "content": content,
             "stop_reason": stop_reason,
             "usage": usage or {"input_tokens": 10, "output_tokens": 5},
+            "model": model,
         },
     }
 
@@ -170,21 +172,27 @@ def test_no_result_when_tool_use_block_present_despite_end_turn() -> None:
     assert not any(e.metadata.get("method") == "result" for e in events)
 
 
-def test_resume_noop_turn_suppresses_phantom_text() -> None:
-    """A resumed thread's zero-token stop_sequence turn emits no agent_output.
-
-    The CLI injects a synthetic first turn after a `--resume` relaunch (e.g.
-    the literal "No response requested."); it must not pollute the transcript,
-    but the turn still resolves to idle.
-    """
-    norm = TranscriptNormalizer()
-    record = _assistant_record(
-        "msg1",
-        [_text_block("No response requested.")],
+def _synthetic_record(message_id: str, text: str) -> dict:
+    # The exact shape the CLI writes for a fabricated (non-model) turn: model
+    # "<synthetic>", stop_sequence, zero tokens. Phantom placeholders and real
+    # interrupted partials are indistinguishable except by their text.
+    return _assistant_record(
+        message_id,
+        [_text_block(text)],
         stop_reason="stop_sequence",
         usage={"input_tokens": 0, "output_tokens": 0},
+        model="<synthetic>",
     )
-    events = norm.process_record(record)
+
+
+def test_resume_noop_turn_suppresses_phantom_text() -> None:
+    """A synthetic "No response requested." turn emits no agent_output.
+
+    The CLI injects it after a `--resume` relaunch; it must not pollute the
+    transcript, but the turn still resolves to idle.
+    """
+    norm = TranscriptNormalizer()
+    events = norm.process_record(_synthetic_record("msg1", "No response requested."))
     assert not any(e.kind == EventKind.AGENT_OUTPUT for e in events)
     result_events = [e for e in events if e.metadata.get("method") == "result"]
     assert len(result_events) == 1
@@ -192,19 +200,55 @@ def test_resume_noop_turn_suppresses_phantom_text() -> None:
     assert result_events[0].metadata["stop_reason"] == "stop_sequence"
 
 
-def test_real_stop_sequence_turn_keeps_text() -> None:
-    """A stop_sequence turn with real output tokens is genuine — keep its text."""
+def test_interrupted_partial_is_not_suppressed() -> None:
+    """A synthetic turn is only the phantom when its text is the exact placeholder.
+
+    Interrupted partials and API-error notices share the phantom's shape
+    (synthetic model, stop_sequence, zero tokens); their real text must survive.
+    """
     norm = TranscriptNormalizer()
-    record = _assistant_record(
+    partial = norm.process_record(
+        _synthetic_record("msg1", "Git-based review works fine")
+    )
+    assert [e.text for e in partial if e.kind == EventKind.AGENT_OUTPUT] == [
+        "Git-based review works fine"
+    ]
+
+    error = norm.process_record(
+        _synthetic_record("msg2", "Please run /login · API Error: 401")
+    )
+    assert [e.text for e in error if e.kind == EventKind.AGENT_OUTPUT] == [
+        "Please run /login · API Error: 401"
+    ]
+
+
+def test_real_turn_with_placeholder_text_is_kept() -> None:
+    """A real model turn is never suppressed, even at zero tokens or that text.
+
+    Only the synthetic marker gates suppression, so a genuine model message
+    survives regardless of token count or wording.
+    """
+    norm = TranscriptNormalizer()
+    zero_token = _assistant_record(
         "msg1",
         [_text_block("Reached the boundary.")],
         stop_reason="stop_sequence",
-        usage={"input_tokens": 20, "output_tokens": 8},
+        usage={"input_tokens": 20, "output_tokens": 0},
     )
-    events = norm.process_record(record)
-    text_events = [e for e in events if e.kind == EventKind.AGENT_OUTPUT]
-    assert len(text_events) == 1
-    assert text_events[0].text == "Reached the boundary."
+    assert [
+        e.text
+        for e in norm.process_record(zero_token)
+        if e.kind == EventKind.AGENT_OUTPUT
+    ] == ["Reached the boundary."]
+
+    quoting = _assistant_record(
+        "msg2",
+        [_text_block("No response requested.")],
+        stop_reason="end_turn",
+    )
+    assert [
+        e.text for e in norm.process_record(quoting) if e.kind == EventKind.AGENT_OUTPUT
+    ] == ["No response requested."]
 
 
 # ── Usage deduplication ───────────────────────────────────────────────────────

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -170,6 +170,43 @@ def test_no_result_when_tool_use_block_present_despite_end_turn() -> None:
     assert not any(e.metadata.get("method") == "result" for e in events)
 
 
+def test_resume_noop_turn_suppresses_phantom_text() -> None:
+    """A resumed thread's zero-token stop_sequence turn emits no agent_output.
+
+    The CLI injects a synthetic first turn after a `--resume` relaunch (e.g.
+    the literal "No response requested."); it must not pollute the transcript,
+    but the turn still resolves to idle.
+    """
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1",
+        [_text_block("No response requested.")],
+        stop_reason="stop_sequence",
+        usage={"input_tokens": 0, "output_tokens": 0},
+    )
+    events = norm.process_record(record)
+    assert not any(e.kind == EventKind.AGENT_OUTPUT for e in events)
+    result_events = [e for e in events if e.metadata.get("method") == "result"]
+    assert len(result_events) == 1
+    assert result_events[0].status == SessionStatus.IDLE
+    assert result_events[0].metadata["stop_reason"] == "stop_sequence"
+
+
+def test_real_stop_sequence_turn_keeps_text() -> None:
+    """A stop_sequence turn with real output tokens is genuine — keep its text."""
+    norm = TranscriptNormalizer()
+    record = _assistant_record(
+        "msg1",
+        [_text_block("Reached the boundary.")],
+        stop_reason="stop_sequence",
+        usage={"input_tokens": 20, "output_tokens": 8},
+    )
+    events = norm.process_record(record)
+    text_events = [e for e in events if e.kind == EventKind.AGENT_OUTPUT]
+    assert len(text_events) == 1
+    assert text_events[0].text == "Reached the boundary."
+
+
 # ── Usage deduplication ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Purpose

An emulated Claude (claude_tty) session prints a phantom `No response requested.` line into its transcript when the session is restarted. Diagnosed from the session store: every occurrence follows a `--resume` relaunch of the TUI (settings-change restart, reconnect-on-reattach, or context compaction) and is followed by the real turn. The `No response requested.` message is fabricated by the Claude CLI, not by Waypoint (the string appears nowhere in the repo); the CLI stamps such synthetic messages with `model="<synthetic>"`. The normalizer forwarded that text block verbatim, so it landed in the transcript as a real reply. Confirmed on `transport=claude_tty`.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_tty/normalize.py` — in `_process_assistant`, suppress a text block only when the message is synthetic (`model == "<synthetic>"`) and its text is exactly the CLI placeholder `No response requested.`. The synthesized result note still fires, so the turn resolves to idle even if no real turn follows. Adds `SYNTHETIC_MODEL_ID` / `RESUME_NOOP_TEXT` module constants.
- `backend/tests/test_claude_tty_normalize.py` — the phantom placeholder is dropped but still yields one idle result note; an interrupted partial and a synthetic API-error notice (which share the phantom's exact shape) keep their text; a real model turn is never suppressed, even at zero output tokens or when it legitimately contains that wording.

## Design

The obvious discriminator — a zero-token `stop_sequence` turn — is wrong: inspecting the CLI binary shows `No response requested.` is one of several **synthetic** messages, and interrupted assistant partials and API-error notices (`Please run /login`, session-limit and 5xx notices) are emitted with the identical shape (`model="<synthetic>"`, `stop_reason="stop_sequence"`, `output_tokens == 0`). Those carry real, wanted content, and the phantom is structurally indistinguishable from them — same key set, same stop fields, same zero usage. The only reliable signal is the CLI's fixed placeholder constant, so suppression is gated on the synthetic marker **plus** the exact string and nothing structural. This cannot drop a genuine model turn (real model id, and never that exact synthetic pairing), an interrupted partial, or an error notice. Keeping the result note rather than dropping the whole turn preserves the idle transition, so the fix can't leave a session stuck RUNNING. Scoped to the confirmed path (`claude_tty`); the native `claude_cli` transport showed no instances and is unchanged.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit: clean (`isort`, `black`, `ruff`, `codespell`, `mypy`).
- Backend suite: 1885 passed (3 pre-existing/unrelated warnings).
- E2E: not run — a pure transcript-normalizer transform; the unit tests are built from the exact record shapes (phantom, interrupted partial, API-error notice, real turn) captured from real resumed sessions in the store, so there is no additional runtime surface to drive.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in \`CONTRIBUTING.md\`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (\`git commit -s\`).
- [x] I have run \`cd backend && uv run pre-commit run --all-files\` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (\`cd backend && uv run pytest\`).
- [ ] Transport-internal normalizer change only; the plugin/transport contract and plugin-id dispatch are untouched, and other backends (claude_code native, codex, opencode) are unaffected.
- [ ] I did not change the frontend.
- [ ] This is not a breaking change.
- [ ] No user-facing config/docs changes required.

</details>