### PR TITLE
feat: add the AI usage telemetry dashboard

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -15,6 +15,7 @@ from fastapi import (
     Header,
     HTTPException,
     Query,
+    Request,
     Response,
     UploadFile,
     WebSocket,
@@ -89,6 +90,15 @@ from waypoint.storage import (
     Storage,
 )
 from waypoint.tailnet import fetch_snapshot
+from waypoint.telemetry import aggregate as telemetry_aggregate
+from waypoint.telemetry import insights as telemetry_insights
+from waypoint.telemetry.api_models import (
+    InsightDismissResponse,
+    TelemetryInsightsResponse,
+    TokenGroupBy,
+)
+from waypoint.telemetry.facts import TelemetryFactKind
+from waypoint.telemetry.query import parse_range_filter
 from waypoint.usage_dashboard import build_dashboard
 from waypoint.workspace_git import git_file_diff, git_list_files, git_status
 from waypoint.workspace_preview import (
@@ -1078,6 +1088,99 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             context.runtime.list_sessions(), context.runtime.registry
         )
         return refreshed.model_dump(mode="json")
+
+    @app.get("/api/telemetry/overview")
+    async def telemetry_overview(
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        rng, flt = parse_range_filter(request, context.settings)
+        return telemetry_aggregate.build_overview(
+            context.storage, context.settings, rng, flt
+        ).model_dump(mode="json")
+
+    @app.get("/api/telemetry/tokens")
+    async def telemetry_tokens(
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+        group_by: Annotated[TokenGroupBy, Query()] = "time",
+    ) -> Any:
+        rng, flt = parse_range_filter(request, context.settings)
+        return telemetry_aggregate.build_tokens(
+            context.storage, rng, flt, group_by
+        ).model_dump(mode="json")
+
+    @app.get("/api/telemetry/activity")
+    async def telemetry_activity(
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        rng, flt = parse_range_filter(request, context.settings)
+        return telemetry_aggregate.build_activity(context.storage, rng, flt).model_dump(
+            mode="json"
+        )
+
+    @app.get("/api/telemetry/health")
+    async def telemetry_health(
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        rng, flt = parse_range_filter(request, context.settings)
+        return telemetry_aggregate.build_health(
+            context.storage, context.settings, rng, flt
+        ).model_dump(mode="json")
+
+    @app.get("/api/telemetry/drilldown")
+    async def telemetry_drilldown(
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+        kind: Annotated[TelemetryFactKind, Query()],
+        page: Annotated[int, Query(ge=1)] = 1,
+        page_size: Annotated[int, Query(ge=1, le=200)] = 50,
+    ) -> Any:
+        rng, flt = parse_range_filter(request, context.settings)
+        return telemetry_aggregate.build_drilldown(
+            context.storage, rng, flt, kind, page, page_size
+        ).model_dump(mode="json")
+
+    @app.get("/api/telemetry/insights")
+    async def telemetry_insights_list(
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        rng, flt = parse_range_filter(request, context.settings)
+        insights = telemetry_insights.compute_insights(
+            context.storage, context.settings, rng, flt
+        )
+        return TelemetryInsightsResponse(insights=insights).model_dump(mode="json")
+
+    @app.post("/api/telemetry/insights/{signature}/dismiss")
+    async def telemetry_insight_dismiss(
+        signature: str,
+        request: Request,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        rng, _flt = parse_range_filter(request, context.settings)
+        context.storage.telemetry.dismiss_insight(
+            signature, telemetry_aggregate.range_key(rng)
+        )
+        return InsightDismissResponse(signature=signature).model_dump(mode="json")
+
+    @app.get("/api/telemetry/settings")
+    async def telemetry_settings_view(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        return telemetry_aggregate.build_settings(
+            context.storage, context.settings
+        ).model_dump(mode="json")
+
+    @app.delete("/api/telemetry")
+    async def telemetry_delete(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        result = telemetry_aggregate.delete_all(context.storage)
+        context.runtime.mark_telemetry_dirty()
+        return result.model_dump(mode="json")
 
     @app.post("/api/sessions/{session_id}/terminate")
     async def session_terminate(

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -1927,7 +1927,9 @@ class ClaudeCliAdapter:
     ) -> None:
         if self._on_token_usage is None:
             return
-        record = claude_token_usage_record(record_id, snapshot)
+        record = claude_token_usage_record(
+            record_id, snapshot, model=state.resolved_model, effort=state.effort
+        )
         if record is None:
             return
         await self._on_token_usage(state.session_id, record, False)
@@ -2118,12 +2120,19 @@ def seed_context_usage_from_transcript(
 
 
 def claude_token_usage_record(
-    record_id: str, snapshot: SessionContextUsage
+    record_id: str,
+    snapshot: SessionContextUsage,
+    *,
+    model: str | None = None,
+    effort: str | None = None,
 ) -> TokenUsageRecord | None:
     """Per-turn ledger record from a Claude usage snapshot; ``None`` for an
     empty ``record_id`` (never aggregate an identity-less turn).
 
     Claude's categories don't overlap, so their sum is a safe grand total.
+    ``model``/``effort`` are the resolved values in effect for this turn
+    (telemetry's "actual model at turn time"); callers pass ``None`` when they
+    can't be resolved, never a guess.
     """
     if not record_id:
         return None
@@ -2134,6 +2143,8 @@ def claude_token_usage_record(
         observed_at=snapshot.updated_at,
         totals=totals,
         display_total_tokens=sum(totals.values()) or None,
+        model=model,
+        effort=effort,
     )
 
 

--- a/backend/src/waypoint/backends/claude_code/history.py
+++ b/backend/src/waypoint/backends/claude_code/history.py
@@ -46,6 +46,14 @@ async def read_local_claude_history(
     return convert_transcript_records(session_id, records)
 
 
+async def read_local_claude_token_usage_history(
+    thread_id: str,
+) -> list[TokenUsageRecord]:
+    """Read a local Claude transcript's per-turn ledger rows for thread-history import."""
+    records = await asyncio.to_thread(read_local_claude_transcript, thread_id)
+    return token_usage_records_from_history(records)
+
+
 def convert_transcript_records(
     session_id: str, records: list[dict[str, Any]]
 ) -> list[EventRecord]:

--- a/backend/src/waypoint/backends/claude_code/history.py
+++ b/backend/src/waypoint/backends/claude_code/history.py
@@ -22,6 +22,10 @@ import json
 from datetime import UTC, datetime
 from typing import Any
 
+from waypoint.backends.claude_code.adapter import (
+    _context_usage_snapshot_from_message,
+    claude_token_usage_record,
+)
 from waypoint.backends.claude_code.normalize import (
     is_injected_user_turn,
     iter_content_blocks,
@@ -31,7 +35,7 @@ from waypoint.backends.claude_code.threads import (
     parse_iso_timestamp,
     read_local_claude_transcript,
 )
-from waypoint.schemas import EventKind, EventRecord, SessionStatus
+from waypoint.schemas import EventKind, EventRecord, SessionStatus, TokenUsageRecord
 
 
 async def read_local_claude_history(
@@ -62,6 +66,35 @@ def convert_transcript_records(
         elif rec_type == "user":
             events.extend(_convert_user(session_id, record, ts))
     return events
+
+
+def token_usage_records_from_history(
+    records: list[dict[str, Any]],
+) -> list[TokenUsageRecord]:
+    """Per-turn ledger rows recoverable from a replayed Claude transcript.
+
+    Only ``assistant`` records carrying a usable ``usage`` block and a model
+    resolvable to a known context window produce a record (mirroring the live
+    normalizers' snapshot gate). ``effort`` is never recoverable from a
+    transcript record — it is a launch-time CLI flag with no per-message
+    trace — so imported turns always surface it as ``None`` rather than a
+    guess.
+    """
+    out: list[TokenUsageRecord] = []
+    for record in records:
+        if record.get("type") != "assistant":
+            continue
+        message: dict[str, Any] = record.get("message") or {}
+        model = str(message.get("model") or "") or None
+        usage: dict[str, Any] = message.get("usage") or {}
+        snapshot = _context_usage_snapshot_from_message(model, usage)
+        if snapshot is None:
+            continue
+        record_id = str(message.get("id") or record.get("uuid") or "")
+        token_record = claude_token_usage_record(record_id, snapshot, model=model)
+        if token_record is not None:
+            out.append(token_record)
+    return out
 
 
 def _convert_assistant(

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -42,7 +42,10 @@ from waypoint.backends.claude_code.commands import (
     CLAUDE_BUILTIN_SLASH_COMMANDS,
     list_claude_command_completions,
 )
-from waypoint.backends.claude_code.history import read_local_claude_history
+from waypoint.backends.claude_code.history import (
+    read_local_claude_history,
+    read_local_claude_token_usage_history,
+)
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
@@ -1772,6 +1775,16 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             reader=_read_thread_history,
             enabled=request.import_history,
         )
+        if launch_target is None and request.import_history:
+            # ``--resume`` continues the SDK session without re-emitting
+            # historical stream-json events, so this on-disk transcript read
+            # is the only source of per-turn model for the imported turns'
+            # ledger (mirrors the remote-skip guard above: no cheap remote
+            # transcript read exists yet).
+            for token_record in await read_local_claude_token_usage_history(info.id):
+                await runtime.publish_token_usage_record(
+                    session.id, token_record, publish=False
+                )
         await runtime._record_system_event(
             session.id,
             self.format_import_message(cwd, launch_target),

--- a/backend/src/waypoint/backends/claude_code/usage_source.py
+++ b/backend/src/waypoint/backends/claude_code/usage_source.py
@@ -95,11 +95,14 @@ class TranscriptContextUsageSource(ContextUsageSource):
         snapshot = _context_usage_snapshot_from_message(model, usage)
         if snapshot is None:
             return
-        # The ledger's model is the concrete resolved id, distinct from the
-        # alias above used for the window lookup; falls back to the
-        # transcript's resolved API id when the session record lacks it.
-        record_model = (session.resolved_model if session is not None else None) or (
-            str(message.get("model") or "") or None
+        # The ledger's model is the concrete resolved id for *this* turn, taken
+        # from the transcript message itself (authoritative "actual model at
+        # turn time", FR-4) — never the session's mutable latest ``resolved_model``,
+        # which would rewrite earlier turns onto the current model when the
+        # transcript is replayed from offset 0 after a resume. The session model
+        # is only a fallback for a message with no model field.
+        record_model = (str(message.get("model") or "") or None) or (
+            session.resolved_model if session is not None else None
         )
         effort = session.effort if session is not None else None
         # Key on the breakdown too, so a same-total/different-split turn refreshes.

--- a/backend/src/waypoint/backends/claude_code/usage_source.py
+++ b/backend/src/waypoint/backends/claude_code/usage_source.py
@@ -95,6 +95,13 @@ class TranscriptContextUsageSource(ContextUsageSource):
         snapshot = _context_usage_snapshot_from_message(model, usage)
         if snapshot is None:
             return
+        # The ledger's model is the concrete resolved id, distinct from the
+        # alias above used for the window lookup; falls back to the
+        # transcript's resolved API id when the session record lacks it.
+        record_model = (session.resolved_model if session is not None else None) or (
+            str(message.get("model") or "") or None
+        )
+        effort = session.effort if session is not None else None
         # Key on the breakdown too, so a same-total/different-split turn refreshes.
         sig = (
             snapshot.used_tokens,
@@ -108,7 +115,9 @@ class TranscriptContextUsageSource(ContextUsageSource):
         # context publish below won't (a deduped snapshot), so the aggregate
         # increment is never stranded, yet a changed turn still emits one frame.
         record_id = str(message.get("id") or record.get("uuid") or "")
-        token_record = claude_token_usage_record(record_id, snapshot)
+        token_record = claude_token_usage_record(
+            record_id, snapshot, model=record_model, effort=effort
+        )
         if token_record is not None:
             await self._runtime.publish_token_usage_record(
                 self._session_id, token_record, publish=not context_changed

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -42,7 +42,10 @@ from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.claude_code import side_question as _sq
 from waypoint.backends.claude_code.adapter import seed_context_usage_from_transcript
 from waypoint.backends.claude_code.commands import list_claude_command_completions
-from waypoint.backends.claude_code.history import read_local_claude_history
+from waypoint.backends.claude_code.history import (
+    read_local_claude_history,
+    read_local_claude_token_usage_history,
+)
 from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
@@ -1462,6 +1465,16 @@ class ClaudeTtyPlugin:
             reader=_read_thread_history,
             enabled=request.import_history,
         )
+        if request.import_history:
+            # Same on-disk transcript the event seed above just replayed;
+            # the resumed tailer starts at EOF (below), so this is the only
+            # source of per-turn model/effort for the imported turns' ledger.
+            for token_record in await read_local_claude_token_usage_history(
+                request.thread_id
+            ):
+                await runtime.publish_token_usage_record(
+                    session.id, token_record, publish=False
+                )
         await runtime._record_system_event(
             session.id,
             f"Imported stored Claude thread ({cwd})",

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -218,6 +218,13 @@ class TranscriptTailer:
         snapshot = _context_usage_snapshot_from_message(model, usage)
         if snapshot is None:
             return
+        # The ledger's model is the concrete resolved id, distinct from the
+        # alias above used for the window lookup; falls back to the
+        # transcript's resolved API id when the session record lacks it.
+        record_model = (session.resolved_model if session is not None else None) or (
+            str(message.get("model") or "") or None
+        )
+        effort = session.effort if session is not None else None
         # Key on the breakdown too, so a same-total/different-split turn refreshes.
         sig = (
             snapshot.used_tokens,
@@ -231,7 +238,9 @@ class TranscriptTailer:
         # context publish below won't (a deduped snapshot), so the aggregate
         # increment is never stranded, yet a changed turn still emits one frame.
         record_id = str(message.get("id") or record.get("uuid") or "")
-        token_record = claude_token_usage_record(record_id, snapshot)
+        token_record = claude_token_usage_record(
+            record_id, snapshot, model=record_model, effort=effort
+        )
         if token_record is not None:
             await self._runtime.publish_token_usage_record(
                 self._session_id, token_record, publish=not context_changed

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -218,11 +218,14 @@ class TranscriptTailer:
         snapshot = _context_usage_snapshot_from_message(model, usage)
         if snapshot is None:
             return
-        # The ledger's model is the concrete resolved id, distinct from the
-        # alias above used for the window lookup; falls back to the
-        # transcript's resolved API id when the session record lacks it.
-        record_model = (session.resolved_model if session is not None else None) or (
-            str(message.get("model") or "") or None
+        # The ledger's model is the concrete resolved id for *this* turn, taken
+        # from the transcript message itself (authoritative "actual model at
+        # turn time", FR-4) — never the session's mutable latest ``resolved_model``,
+        # which would rewrite earlier turns onto the current model when the
+        # transcript is replayed from offset 0 after a resume. The session model
+        # is only a fallback for a message with no model field.
+        record_model = (str(message.get("model") or "") or None) or (
+            session.resolved_model if session is not None else None
         )
         effort = session.effort if session is not None else None
         # Key on the breakdown too, so a same-total/different-split turn refreshes.

--- a/backend/src/waypoint/backends/codex/adapter.py
+++ b/backend/src/waypoint/backends/codex/adapter.py
@@ -774,7 +774,9 @@ class CodexAppServerAdapter:
     ) -> None:
         if self._on_token_usage is None:
             return
-        record = codex_token_usage_record(turn_id, snapshot)
+        record = codex_token_usage_record(
+            turn_id, snapshot, model=state.model, effort=state.effort
+        )
         if record is None:
             return
         await self._on_token_usage(state.session_id, record, True)
@@ -879,13 +881,20 @@ def _context_usage_snapshot_from_thread_token_usage(
 
 
 def codex_token_usage_record(
-    record_id: str, snapshot: SessionContextUsage
+    record_id: str,
+    snapshot: SessionContextUsage,
+    *,
+    model: str | None = None,
+    effort: str | None = None,
 ) -> TokenUsageRecord | None:
     """Per-turn ledger record from a Codex usage snapshot; ``None`` for an empty
     ``record_id`` (the native turn id).
 
     Codex categories overlap (cached input ⊆ input), so the grand total is the
     provider's ``totalTokens`` (the snapshot's ``used_tokens``), not their sum.
+    ``model``/``effort`` are the resolved values in effect for this turn
+    (telemetry's "actual model at turn time"); callers pass ``None`` when they
+    can't be resolved, never a guess.
     """
     if not record_id:
         return None
@@ -895,6 +904,8 @@ def codex_token_usage_record(
         observed_at=snapshot.updated_at,
         totals=dict(snapshot.breakdown),
         display_total_tokens=snapshot.used_tokens or None,
+        model=model,
+        effort=effort,
     )
 
 

--- a/backend/src/waypoint/backends/opencode/adapter.py
+++ b/backend/src/waypoint/backends/opencode/adapter.py
@@ -699,7 +699,10 @@ class OpenCodeAdapter:
         message_id = info.get("id")
         if self._on_token_usage is not None and isinstance(message_id, str):
             record = opencode_token_usage_record(
-                f"{state.opencode_session_id}:{message_id}", tokens
+                f"{state.opencode_session_id}:{message_id}",
+                tokens,
+                model=f"{provider_id}/{model_id}",
+                effort=state.effort,
             )
             if record is not None:
                 await self._on_token_usage(state.session_id, record, False)
@@ -1452,12 +1455,19 @@ def _context_usage_snapshot_from_message(
 
 
 def opencode_token_usage_record(
-    record_id: str, tokens: dict[str, Any]
+    record_id: str,
+    tokens: dict[str, Any],
+    *,
+    model: str | None = None,
+    effort: str | None = None,
 ) -> TokenUsageRecord | None:
     """Per-turn ledger record from an OpenCode assistant token dict.
 
     No ``display_total``: ``reasoning`` is a subset of ``output`` for some
-    providers, so a summed grand total isn't safe.
+    providers, so a summed grand total isn't safe. ``model``/``effort`` are
+    the resolved values in effect for this turn (telemetry's "actual model at
+    turn time"); callers pass ``None`` when they can't be resolved, never a
+    guess.
     """
     if not record_id:
         return None
@@ -1481,6 +1491,8 @@ def opencode_token_usage_record(
         observed_at=datetime.now(UTC),
         totals=totals,
         display_total_tokens=None,
+        model=model,
+        effort=effort,
     )
 
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -390,6 +390,36 @@ def usage(
     _emit(_settings_from_ctx(ctx), run)
 
 
+@app.command()
+def telemetry(
+    ctx: typer.Context,
+    preset: Annotated[
+        str | None,
+        typer.Option(help="Range preset: today|7d|30d|custom (default: 7d)."),
+    ] = None,
+    start: Annotated[
+        str | None,
+        typer.Option(help="Custom range start (YYYY-MM-DD or ISO datetime)."),
+    ] = None,
+    end: Annotated[
+        str | None,
+        typer.Option(help="Custom range end (YYYY-MM-DD or ISO datetime)."),
+    ] = None,
+    backend: Annotated[
+        list[str] | None,
+        typer.Option("--backend", help="Filter to this backend (repeatable)."),
+    ] = None,
+) -> None:
+    """Show the telemetry overview (tokens, sessions, turns, alerts) for a range."""
+
+    def run(c: WaypointClient) -> Any:
+        return c.get_telemetry_overview(
+            preset=preset, start=start, end=end, backends=backend
+        )
+
+    _emit(_settings_from_ctx(ctx), run)
+
+
 @app.command("help")
 def help_(
     json_output: Annotated[

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -974,3 +974,27 @@ class WaypointClient:
     def refresh_usage(self) -> dict[str, Any]:
         data: dict[str, Any] = self._request("POST", "/api/usage/refresh").json()
         return data
+
+    # ── telemetry ───────────────────────────────────────────────────────
+
+    def get_telemetry_overview(
+        self,
+        *,
+        preset: str | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        backends: list[str] | None = None,
+    ) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+        if preset is not None:
+            params["preset"] = preset
+        if start is not None:
+            params["start"] = start
+        if end is not None:
+            params["end"] = end
+        if backends:
+            params["backend"] = list(backends)
+        data: dict[str, Any] = self._request(
+            "GET", "/api/telemetry/overview", params=params or None
+        ).json()
+        return data

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -333,12 +333,6 @@ class SessionRuntime:
         # loop below is the only thing that publishes onto the broadcast hub.
         self._telemetry_dirty = asyncio.Event()
         self._telemetry_broadcast_task: asyncio.Task[None] | None = None
-        # Generic telemetry fact ingestion (CONTRACT.md §3). ``None`` when
-        # telemetry is disabled; otherwise the runtime feeds it from its
-        # event/session-update/token-ledger seams and owns its drain + prune.
-        self.telemetry_ingester: TelemetryIngester | None = (
-            TelemetryIngester(storage) if settings.telemetry_enabled else None
-        )
         # Sessions we've already emitted a CREATED lifecycle fact for this
         # process (the fact itself is idempotent in the store; this just avoids
         # re-enqueueing on every subsequent event).
@@ -349,6 +343,17 @@ class SessionRuntime:
         # assistant is disabled or its bootstrap failed.
         self.assistant_session_id: str | None = None
         self.registry = registry or get_registry()
+        # Generic telemetry fact ingestion (CONTRACT.md §3). ``None`` when
+        # telemetry is disabled; otherwise the runtime feeds it from its
+        # event/session-update/token-ledger seams and owns its drain + prune.
+        # Constructed after ``self.registry`` so it can resolve a rate-limit
+        # snapshot's account via a plugin's ``rate_limit_account`` for
+        # sessions with no verified-account probe (CC, profile-less Codex).
+        self.telemetry_ingester: TelemetryIngester | None = (
+            TelemetryIngester(storage, self.registry)
+            if settings.telemetry_enabled
+            else None
+        )
         self._transports: dict[str, TransportAdapter] = {
             plugin.transport_id: plugin.transport_view(self)
             for plugin in self.registry.all()

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -115,6 +115,11 @@ COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
 # immediately, so this only adds at most this much latency to the live
 # list/status updates a fast stream produces.
 SESSION_BROADCAST_DEBOUNCE_SECONDS = 0.25
+# Debounce window for the ``telemetry_update`` WS broadcast. Fact ingestion
+# can write in small bursts (a turn boundary derives several facts at once);
+# this collapses a burst into one notification per window rather than one
+# per fact write.
+TELEMETRY_BROADCAST_DEBOUNCE_SECONDS = 1.0
 # The per-session structured log (events.jsonl) is a write-only audit/debug
 # artifact; the SQLite store is the source of truth for replay. Flushing every
 # write turns the streaming path into a syscall per event, so we let the buffer
@@ -318,6 +323,11 @@ class SessionRuntime:
         self._session_list_dirty = False
         self._broadcast_wake = asyncio.Event()
         self._broadcast_flusher: asyncio.Task[None] | None = None
+        # Coalesced ``telemetry_update`` WS broadcast (CONTRACT.md §4). Whatever
+        # writes telemetry facts calls ``mark_telemetry_dirty()``; the debounced
+        # loop below is the only thing that publishes onto the broadcast hub.
+        self._telemetry_dirty = asyncio.Event()
+        self._telemetry_broadcast_task: asyncio.Task[None] | None = None
         # Id of the personal-assistant singleton, populated by
         # ``_ensure_assistant_session`` during ``start``. ``None`` when the
         # assistant is disabled or its bootstrap failed.
@@ -338,6 +348,9 @@ class SessionRuntime:
     async def start(self) -> None:
         self._broadcast_flusher = asyncio.create_task(
             self._session_broadcast_loop(), name="session-broadcast-flusher"
+        )
+        self._telemetry_broadcast_task = asyncio.create_task(
+            self._telemetry_broadcast_loop(), name="telemetry-broadcast-flusher"
         )
         for session in self.storage.list_sessions():
             # ERROR sessions get one passive restore attempt at boot — the
@@ -422,6 +435,11 @@ class SessionRuntime:
             with suppress(asyncio.CancelledError):
                 await self._broadcast_flusher
             self._broadcast_flusher = None
+        if self._telemetry_broadcast_task is not None:
+            self._telemetry_broadcast_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._telemetry_broadcast_task
+            self._telemetry_broadcast_task = None
         for entry in self._structured_log_handles.values():
             with suppress(Exception):
                 entry.handle.close()
@@ -3873,6 +3891,25 @@ class SessionRuntime:
             ),
             session_id=session_id,
         )
+
+    def mark_telemetry_dirty(self) -> None:
+        """Signal that telemetry facts changed; debounce-publishes ``telemetry_update``.
+
+        Called by whatever writes telemetry facts (the ingester's drain loop
+        wires this up) so the Telemetry page can refetch instead of polling.
+        The payload carries no data — every telemetry endpoint re-derives its
+        own view from the store on refetch.
+        """
+        self._telemetry_dirty.set()
+
+    async def _telemetry_broadcast_loop(self) -> None:
+        while True:
+            await self._telemetry_dirty.wait()
+            await asyncio.sleep(TELEMETRY_BROADCAST_DEBOUNCE_SECONDS)
+            self._telemetry_dirty.clear()
+            await self.broadcast.publish(
+                SessionEnvelope(type="telemetry_update", payload={})
+            )
 
     async def _session_broadcast_loop(self) -> None:
         while True:

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from time import monotonic
 from typing import Any, TextIO, cast
@@ -105,6 +105,7 @@ from waypoint.schemas import (
 from waypoint.settings import Settings
 from waypoint.ssh_master import SshMasterManager, SshMasterStatus
 from waypoint.storage import Storage
+from waypoint.telemetry.ingest import TelemetryIngester
 from waypoint.transports import TransportAdapter
 
 TMUX_TRANSPORT_ID = "tmux"
@@ -120,6 +121,10 @@ SESSION_BROADCAST_DEBOUNCE_SECONDS = 0.25
 # this collapses a burst into one notification per window rather than one
 # per fact write.
 TELEMETRY_BROADCAST_DEBOUNCE_SECONDS = 1.0
+# How often the runtime prunes telemetry facts/rollups past their retention
+# windows. Slow cadence — retention is measured in days/months, so a few hours
+# of lag is immaterial and keeps this off any hot path.
+TELEMETRY_MAINTENANCE_INTERVAL_SECONDS = 6 * 60 * 60
 # The per-session structured log (events.jsonl) is a write-only audit/debug
 # artifact; the SQLite store is the source of truth for replay. Flushing every
 # write turns the streaming path into a syscall per event, so we let the buffer
@@ -328,6 +333,17 @@ class SessionRuntime:
         # loop below is the only thing that publishes onto the broadcast hub.
         self._telemetry_dirty = asyncio.Event()
         self._telemetry_broadcast_task: asyncio.Task[None] | None = None
+        # Generic telemetry fact ingestion (CONTRACT.md §3). ``None`` when
+        # telemetry is disabled; otherwise the runtime feeds it from its
+        # event/session-update/token-ledger seams and owns its drain + prune.
+        self.telemetry_ingester: TelemetryIngester | None = (
+            TelemetryIngester(storage) if settings.telemetry_enabled else None
+        )
+        # Sessions we've already emitted a CREATED lifecycle fact for this
+        # process (the fact itself is idempotent in the store; this just avoids
+        # re-enqueueing on every subsequent event).
+        self._telemetry_created_seen: set[str] = set()
+        self._telemetry_maintenance_task: asyncio.Task[None] | None = None
         # Id of the personal-assistant singleton, populated by
         # ``_ensure_assistant_session`` during ``start``. ``None`` when the
         # assistant is disabled or its bootstrap failed.
@@ -352,6 +368,16 @@ class SessionRuntime:
         self._telemetry_broadcast_task = asyncio.create_task(
             self._telemetry_broadcast_loop(), name="telemetry-broadcast-flusher"
         )
+        if self.telemetry_ingester is not None:
+            await self.telemetry_ingester.start()
+            # Backfill and pruning run off the boot path so a large history
+            # never delays startup or blocks a turn.
+            asyncio.create_task(
+                self._run_telemetry_backfill(), name="telemetry-backfill"
+            )
+            self._telemetry_maintenance_task = asyncio.create_task(
+                self._telemetry_maintenance_loop(), name="telemetry-maintenance"
+            )
         for session in self.storage.list_sessions():
             # ERROR sessions get one passive restore attempt at boot — the
             # plugin's restore_session is responsible for tagging them
@@ -397,6 +423,13 @@ class SessionRuntime:
 
     async def stop(self) -> None:
         await self.scheduler.stop()
+        if self._telemetry_maintenance_task is not None:
+            self._telemetry_maintenance_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._telemetry_maintenance_task
+            self._telemetry_maintenance_task = None
+        if self.telemetry_ingester is not None:
+            await self.telemetry_ingester.stop()
         for task in self.monitor_tasks.values():
             task.cancel()
         for task in self.monitor_tasks.values():
@@ -3764,6 +3797,11 @@ class SessionRuntime:
         self, session_id: str, *, publish: bool = True, **updates: Any
     ) -> SessionRecord:
         session = self.storage.update_session(session_id, **updates)
+        if self.telemetry_ingester is not None and (
+            "context_usage" in updates or "rate_limit_usage" in updates
+        ):
+            self.telemetry_ingester.derive_from_session_update(session, updates)
+            self.mark_telemetry_dirty()
         if publish:
             self._publish_session_state(session_id)
         return session
@@ -3834,6 +3872,9 @@ class SessionRuntime:
                 exc_info=True,
             )
             return
+        if self.telemetry_ingester is not None:
+            self.telemetry_ingester.derive_from_token_record(session, record)
+            self.mark_telemetry_dirty()
         if publish:
             self._publish_session_state(session_id)
 
@@ -3855,7 +3896,26 @@ class SessionRuntime:
             ),
             session_id=event.session_id,
         )
+        self._derive_telemetry_from_event(event)
         self._publish_session_state(event.session_id)
+
+    def _derive_telemetry_from_event(self, event: EventRecord) -> None:
+        """Feed the telemetry ingester from the single event chokepoint.
+
+        Errors are swallowed inside the ingester's ``derive_from_*`` methods, so
+        a telemetry hiccup never affects event delivery.
+        """
+        ingester = self.telemetry_ingester
+        if ingester is None:
+            return
+        session = self.storage.get_session(event.session_id)
+        if session is None:
+            return
+        if session.id not in self._telemetry_created_seen:
+            self._telemetry_created_seen.add(session.id)
+            ingester.derive_from_session_created(session)
+        ingester.derive_from_event(session, event)
+        self.mark_telemetry_dirty()
 
     def _publish_session_state(self, session_id: str) -> None:
         # Streaming hot path: mark the session dirty and let the debounced
@@ -3910,6 +3970,35 @@ class SessionRuntime:
             await self.broadcast.publish(
                 SessionEnvelope(type="telemetry_update", payload={})
             )
+
+    async def _run_telemetry_backfill(self) -> None:
+        ingester = self.telemetry_ingester
+        if ingester is None:
+            return
+        try:
+            await ingester.backfill()
+            self.mark_telemetry_dirty()
+        except Exception:
+            log.debug("telemetry backfill failed", exc_info=True)
+
+    async def _telemetry_maintenance_loop(self) -> None:
+        """Prune expired facts/rollups on a slow cadence (runtime-owned, not a plugin hook)."""
+        interval_seconds = TELEMETRY_MAINTENANCE_INTERVAL_SECONDS
+        while True:
+            await asyncio.sleep(interval_seconds)
+            try:
+                now = datetime.now(UTC)
+                facts_before = now - timedelta(
+                    days=self.settings.telemetry_retention_days
+                )
+                rollups_before = now - timedelta(
+                    days=self.settings.telemetry_rollup_retention_months * 31
+                )
+                self.storage.telemetry.prune(
+                    facts_before=facts_before, rollups_before=rollups_before
+                )
+            except Exception:
+                log.debug("telemetry prune failed", exc_info=True)
 
     async def _session_broadcast_loop(self) -> None:
         while True:

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -197,6 +197,10 @@ class TokenUsageRecord(BaseModel):
     observed_at: datetime
     totals: dict[str, int] = Field(default_factory=dict)
     display_total_tokens: int | None = None
+    # The concrete model/effort in effect for this turn (telemetry's "actual
+    # model at turn time", FR-4). ``None`` when the plugin can't resolve one.
+    model: str | None = None
+    effort: str | None = None
 
 
 class TokenUsageInit(BaseModel):

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -141,18 +141,21 @@ class SessionContextUsage(BaseModel):
     breakdown: dict[str, int] = Field(default_factory=dict)
 
 
-# The category vocabulary an aggregate may carry. Normalization happens only at
-# the plugin's parse boundary; the ledger and aggregate never infer one category
-# from another, and missing provider fields stay absent rather than zero.
+# The 5 disjoint category buckets an aggregate (API-facing totals dict) may
+# carry. The ledger itself keeps storing each backend's raw, overlapping
+# native keys (``input_tokens``/``cachedInputTokens``/``cache.read``/…,
+# normalized only at each plugin's parse boundary) and is never backfilled
+# onto this vocabulary. The one documented exception to "never infer one
+# category from another" is the telemetry read layer's ``unify_tokens``
+# (``telemetry/tokens.py``), which folds those native keys onto these 5
+# buckets for display via a deterministic, source-keyed subset subtraction —
+# not a guess — so every aggregate response's totals always sum safely.
 TOKEN_USAGE_CATEGORIES = (
-    "input_tokens",
-    "cached_input_tokens",
-    "cache_read_tokens",
-    "cache_creation_tokens",
-    "cache_write_tokens",
-    "output_tokens",
-    "reasoning_output_tokens",
-    "reasoning_tokens",
+    "fresh_input",
+    "cache_read",
+    "cache_write",
+    "output",
+    "reasoning",
 )
 
 TokenUsageCoverage = Literal["entire_waypoint_session", "tracked_since", "partial"]

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -160,6 +160,14 @@ class Settings(BaseModel):
     # assistant is created. A present block is enabled unless it sets
     # ``enabled: false``.
     assistant: AssistantConfig | None = None
+    # Usage telemetry (session lifecycle/turn/tool/context/limit facts +
+    # daily rollups) backing the Telemetry dashboard.
+    telemetry_enabled: bool = True
+    telemetry_retention_days: int = 90
+    telemetry_rollup_retention_months: int = 13
+    # Context-window occupancy percent thresholds (low, elevated, critical)
+    # that drive the dashboard's context-pressure alerts/insight gates.
+    telemetry_context_thresholds: tuple[int, int, int] = (70, 90, 100)
 
     @field_validator("plugin_configs", mode="before")
     @classmethod
@@ -305,6 +313,27 @@ def _env_overrides() -> dict[str, Any]:
         overrides["write_structured_log"] = os.environ[
             "WAYPOINT_WRITE_STRUCTURED_LOG"
         ].lower() not in {"0", "false", "no", ""}
+    if "WAYPOINT_TELEMETRY_ENABLED" in os.environ:
+        overrides["telemetry_enabled"] = os.environ[
+            "WAYPOINT_TELEMETRY_ENABLED"
+        ].lower() not in {"0", "false", "no", ""}
+    if "WAYPOINT_TELEMETRY_RETENTION_DAYS" in os.environ:
+        overrides["telemetry_retention_days"] = int(
+            os.environ["WAYPOINT_TELEMETRY_RETENTION_DAYS"]
+        )
+    if "WAYPOINT_TELEMETRY_ROLLUP_RETENTION_MONTHS" in os.environ:
+        overrides["telemetry_rollup_retention_months"] = int(
+            os.environ["WAYPOINT_TELEMETRY_ROLLUP_RETENTION_MONTHS"]
+        )
+    if "WAYPOINT_TELEMETRY_CONTEXT_THRESHOLDS" in os.environ:
+        parts = os.environ["WAYPOINT_TELEMETRY_CONTEXT_THRESHOLDS"].split(",")
+        if len(parts) != 3:
+            raise ValueError(
+                "WAYPOINT_TELEMETRY_CONTEXT_THRESHOLDS must have 3 comma-separated values"
+            )
+        overrides["telemetry_context_thresholds"] = tuple(
+            int(part.strip()) for part in parts
+        )
     return overrides
 
 

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -168,6 +168,10 @@ class Settings(BaseModel):
     # Context-window occupancy percent thresholds (low, elevated, critical)
     # that drive the dashboard's context-pressure alerts/insight gates.
     telemetry_context_thresholds: tuple[int, int, int] = (70, 90, 100)
+    # FR-9: limit-snapshot facts always persist a pseudonymous ``account_key``;
+    # the human-readable ``account_label`` is only ever returned by the API
+    # when this is explicitly turned on (an opt-in local-labels carve-out).
+    telemetry_local_labels: bool = False
 
     @field_validator("plugin_configs", mode="before")
     @classmethod
@@ -334,6 +338,10 @@ def _env_overrides() -> dict[str, Any]:
         overrides["telemetry_context_thresholds"] = tuple(
             int(part.strip()) for part in parts
         )
+    if "WAYPOINT_TELEMETRY_LOCAL_LABELS" in os.environ:
+        overrides["telemetry_local_labels"] = os.environ[
+            "WAYPOINT_TELEMETRY_LOCAL_LABELS"
+        ].lower() not in {"0", "false", "no", ""}
     return overrides
 
 

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -40,6 +40,7 @@ from waypoint.schemas import (
     TokenUsageInit,
     TokenUsageRecord,
 )
+from waypoint.telemetry.store import TelemetryStore
 
 log = logging.getLogger("waypoint.storage")
 
@@ -183,6 +184,7 @@ class Storage:
         self.connection.execute("PRAGMA journal_mode=WAL")
         self.connection.execute("PRAGMA synchronous=NORMAL")
         self.connection.execute("PRAGMA busy_timeout=5000")
+        self.telemetry = TelemetryStore(self.connection, self._lock)
         self._init_db()
 
     def _init_db(self) -> None:
@@ -416,7 +418,12 @@ class Storage:
                 ON inbox_items(status);
             CREATE INDEX IF NOT EXISTS idx_inbox_updated
                 ON inbox_items(updated_at, id);
+            CREATE INDEX IF NOT EXISTS idx_sessions_status
+                ON sessions(status);
+            CREATE INDEX IF NOT EXISTS idx_sessions_last_event
+                ON sessions(last_event_at);
             """)
+        self.telemetry.init_schema()
         if token_usage_column_is_new:
             self._mark_sessions_pretracked()
         self.connection.commit()
@@ -572,6 +579,7 @@ class Storage:
             "DELETE FROM session_token_usage_records WHERE session_id = ?",
             (session_id,),
         )
+        self.telemetry.delete_session(session_id)
         cursor = self.connection.execute(
             "DELETE FROM sessions WHERE id = ?",
             (session_id,),
@@ -629,6 +637,8 @@ class Storage:
                     {
                         "totals": record.totals,
                         "display_total_tokens": record.display_total_tokens,
+                        "model": record.model,
+                        "effort": record.effort,
                     }
                 ),
             ),
@@ -759,6 +769,8 @@ class Storage:
                 observed_at=observed,
                 totals=usage.get("totals", {}) or {},
                 display_total_tokens=usage.get("display_total_tokens"),
+                model=usage.get("model"),
+                effort=usage.get("effort"),
             )
             if blob is None:
                 blob = {

--- a/backend/src/waypoint/telemetry/__init__.py
+++ b/backend/src/waypoint/telemetry/__init__.py
@@ -1,0 +1,41 @@
+"""Backend-neutral usage telemetry subsystem.
+
+Turns Waypoint's already-normalized session/event/usage signals into a durable,
+queryable history that powers the Telemetry dashboard. The fact contract in
+``facts.py`` is the seam every other module (storage, ingestion, aggregation,
+API, frontend) consumes; generic code never branches on backend id.
+"""
+
+from waypoint.telemetry.facts import (
+    ApprovalDecision,
+    ContextSnapshotFact,
+    FactSource,
+    LifecycleTransition,
+    LimitSnapshotFact,
+    SessionLifecycleFact,
+    TelemetryFact,
+    TelemetryFactKind,
+    TelemetryFilter,
+    TelemetryRange,
+    ToolCallFact,
+    ToolOutcome,
+    TurnFact,
+    TurnKind,
+)
+
+__all__ = [
+    "ApprovalDecision",
+    "ContextSnapshotFact",
+    "FactSource",
+    "LifecycleTransition",
+    "LimitSnapshotFact",
+    "SessionLifecycleFact",
+    "TelemetryFact",
+    "TelemetryFactKind",
+    "TelemetryFilter",
+    "TelemetryRange",
+    "ToolCallFact",
+    "ToolOutcome",
+    "TurnFact",
+    "TurnKind",
+]

--- a/backend/src/waypoint/telemetry/__init__.py
+++ b/backend/src/waypoint/telemetry/__init__.py
@@ -22,6 +22,7 @@ from waypoint.telemetry.facts import (
     TurnFact,
     TurnKind,
 )
+from waypoint.telemetry.store import TelemetryStore
 
 __all__ = [
     "ApprovalDecision",
@@ -34,6 +35,7 @@ __all__ = [
     "TelemetryFactKind",
     "TelemetryFilter",
     "TelemetryRange",
+    "TelemetryStore",
     "ToolCallFact",
     "ToolOutcome",
     "TurnFact",

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -870,7 +870,12 @@ def build_drilldown(
     page_size: int,
 ) -> TelemetryDrilldown:
     offset = (page - 1) * page_size
-    rows = storage.telemetry.query_facts(kind, rng, flt, limit=page_size, offset=offset)
+    # Newest-first: the first page should surface the most recent facts (with
+    # their resolved outcomes) rather than the oldest, which skew toward
+    # unpaired/unknown early history.
+    rows = storage.telemetry.query_facts(
+        kind, rng, flt, limit=page_size, offset=offset, descending=True
+    )
     total = storage.telemetry.count_facts(kind, rng, flt)
     return TelemetryDrilldown(
         range=rng,

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -55,6 +55,8 @@ from waypoint.telemetry.api_models import (
     TurnCounts,
 )
 from waypoint.telemetry.facts import (
+    ACTIVE_TRANSITIONS,
+    LifecycleTransition,
     TelemetryFactKind,
     TelemetryFilter,
     TelemetryRange,
@@ -357,7 +359,9 @@ def _session_matches_filter(
         if flt.include_descendants:
             if session.id != flt.parent_session_id and session.id not in descendant_ids:
                 return False
-        elif session.spawner_session_id != flt.parent_session_id:
+        # Excluding descendants means the parent's OWN session only — not
+        # "only its direct children" (that would be backwards).
+        elif session.id != flt.parent_session_id:
             return False
     for term in flt.tags:
         parsed = _parse_tag_term(term)
@@ -369,12 +373,25 @@ def _session_matches_filter(
     return True
 
 
-def count_active_sessions(storage: Storage, flt: TelemetryFilter) -> int:
-    """Point-in-time count of sessions in a live state matching ``flt`` (FR-3).
+def count_active_sessions(
+    storage: Storage, flt: TelemetryFilter, rng: TelemetryRange
+) -> int:
+    """Point-in-time count of sessions active at ``rng.end`` matching ``flt`` (FR-3).
 
-    Unlike every other overview metric this ignores the time range — "active
-    now" is evaluated against live ``SessionRecord.status``, not a fact window.
+    "Active now" means the state at the range's end instant, not something
+    summed over the range. When ``rng.end`` covers the live present, the
+    cheap live-``SessionRecord.status`` shortcut is exact and avoids a fact
+    scan. For a wholly historical range (``rng.end`` in the past) live status
+    reflects the session's state *now*, not at ``rng.end``, so it must instead
+    be reconstructed from the latest ``SessionLifecycleFact.transition``
+    recorded before that instant.
     """
+    if rng.end >= datetime.now(UTC):
+        return _count_active_sessions_live(storage, flt)
+    return _count_active_sessions_historical(storage, flt, rng.end)
+
+
+def _count_active_sessions_live(storage: Storage, flt: TelemetryFilter) -> int:
     sessions = storage.list_sessions()
     descendant_ids = (
         _descendant_session_ids(sessions, flt.parent_session_id)
@@ -389,21 +406,106 @@ def count_active_sessions(storage: Storage, flt: TelemetryFilter) -> int:
     )
 
 
+def _count_active_sessions_historical(
+    storage: Storage, flt: TelemetryFilter, at: datetime
+) -> int:
+    as_of_range = TelemetryRange(
+        start=ALL_TIME_RANGE.start, end=at, tz=ALL_TIME_RANGE.tz
+    )
+    rows = storage.telemetry.query_facts(
+        TelemetryFactKind.SESSION_LIFECYCLE, as_of_range, flt
+    )
+    latest: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        existing = latest.get(row["session_id"])
+        if existing is None or row["occurred_at"] > existing["occurred_at"]:
+            latest[row["session_id"]] = row
+    return sum(1 for row in latest.values() if row["transition"] in ACTIVE_TRANSITIONS)
+
+
 # ── /overview ─────────────────────────────────────────────────────────────
+
+
+def _needs_fact_scan_for_session_counts(flt: TelemetryFilter) -> bool:
+    """Whether lifecycle/turn/tool counts must come from a fact scan, not the rollup.
+
+    ``query_rollup`` is keyed on ``(day, backend, model, repo, source,
+    transport, is_child)`` — it has no tag or parent-session dimension. Under
+    a ``flt.tags`` or ``flt.parent_session_id`` filter, using it anyway would
+    silently mix UNFILTERED session/turn/tool counts with the (correctly)
+    FILTERED fact-derived token totals in the same response. Fact scans
+    respect every ``TelemetryFilter`` dimension via ``_filter_clause``, so
+    fall back to them whenever the rollup can't represent the active filter.
+    """
+    return bool(flt.tags) or flt.parent_session_id is not None
+
+
+def _lifecycle_turn_tool_totals_from_rollup(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> tuple[dict[str, int], int, int, int]:
+    lifecycle: dict[str, int] = {}
+    turns_user = turns_agent = tool_calls = 0
+    for row in storage.telemetry.query_rollup(rng, flt):
+        metrics = json.loads(row["metrics_json"])
+        for transition, count in (metrics.get("lifecycle") or {}).items():
+            lifecycle[transition] = lifecycle.get(transition, 0) + count
+        turns_user += metrics.get("turns_user", 0)
+        turns_agent += metrics.get("turns_agent", 0)
+        tool_calls += metrics.get("tool_calls", 0)
+    return lifecycle, turns_user, turns_agent, tool_calls
+
+
+def _lifecycle_turn_tool_totals_from_facts(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> tuple[dict[str, int], int, int, int]:
+    lifecycle: dict[str, int] = {}
+    for row in storage.telemetry.query_facts(
+        TelemetryFactKind.SESSION_LIFECYCLE, rng, flt
+    ):
+        lifecycle[row["transition"]] = lifecycle.get(row["transition"], 0) + 1
+    turns_user = turns_agent = 0
+    for row in storage.telemetry.query_facts(TelemetryFactKind.TURN, rng, flt):
+        if row["turn_kind"] == TurnKind.USER:
+            turns_user += 1
+        elif row["turn_kind"] == TurnKind.AGENT:
+            turns_agent += 1
+    tool_calls = storage.telemetry.count_facts(TelemetryFactKind.TOOL_CALL, rng, flt)
+    return lifecycle, turns_user, turns_agent, tool_calls
+
+
+def session_counts_totals(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> tuple[dict[str, int], int, int, int]:
+    """Lifecycle/turn/tool totals for ``rng``/``flt`` (``lifecycle, user, agent, tool_calls``).
+
+    Uses the daily rollup when it can represent every active filter
+    dimension; falls back to a direct fact scan under a tag or
+    parent-session filter, since the rollup has neither dimension (see
+    ``_needs_fact_scan_for_session_counts``). Note: a ``model=`` filter
+    always zeroes the lifecycle bucket either way — lifecycle facts carry no
+    ``model_at_turn`` (lifecycle isn't model-attributable), so they never
+    match a concrete model value in either the rollup or a fact scan.
+    """
+    if _needs_fact_scan_for_session_counts(flt):
+        return _lifecycle_turn_tool_totals_from_facts(storage, rng, flt)
+    return _lifecycle_turn_tool_totals_from_rollup(storage, rng, flt)
 
 
 def build_overview(
     storage: Storage, settings: Settings, rng: TelemetryRange, flt: TelemetryFilter
 ) -> TelemetryOverview:
-    lifecycle_totals: dict[str, int] = {}
-    turns_user = turns_agent = tool_calls = 0
-    for row in storage.telemetry.query_rollup(rng, flt):
-        metrics = json.loads(row["metrics_json"])
-        for transition, count in (metrics.get("lifecycle") or {}).items():
-            lifecycle_totals[transition] = lifecycle_totals.get(transition, 0) + count
-        turns_user += metrics.get("turns_user", 0)
-        turns_agent += metrics.get("turns_agent", 0)
-        tool_calls += metrics.get("tool_calls", 0)
+    """Shape the ``/api/telemetry/overview`` response.
+
+    Note: for a sub-day custom range, session/turn/tool counts sourced from
+    the daily rollup cover the WHOLE calendar day(s) touching ``rng`` (the
+    rollup's own granularity — see ``query_rollup``), while the token totals
+    below are always fact-derived and reflect the exact sub-range instant
+    window. The two can diverge for hour-granularity queries; this is
+    expected, not a bug (the fact-scan fallback above doesn't have this gap).
+    """
+    lifecycle_totals, turns_user, turns_agent, tool_calls = session_counts_totals(
+        storage, rng, flt
+    )
 
     rows = agent_turn_rows(storage, rng, flt)
     ledger = ledger_rows_for_sessions(storage, {row["session_id"] for row in rows})
@@ -426,7 +528,7 @@ def build_overview(
             exited=lifecycle_totals.get("exited", 0),
             interrupted=lifecycle_totals.get("interrupted", 0),
             error=lifecycle_totals.get("error", 0),
-            active_now=count_active_sessions(storage, flt),
+            active_now=count_active_sessions(storage, flt, rng),
         ),
         turns=TurnCounts(user=turns_user, agent=turns_agent),
         tool_calls=tool_calls,
@@ -519,20 +621,57 @@ def build_tokens(
 # ── /activity ─────────────────────────────────────────────────────────────
 
 
-def build_activity(
+def _empty_activity_bucket() -> dict[str, int]:
+    return {"user_turns": 0, "agent_turns": 0, "tool_calls": 0, "sessions_created": 0}
+
+
+def _activity_daily_from_rollup(
     storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
-) -> TelemetryActivity:
+) -> dict[str, dict[str, int]]:
     by_day: dict[str, dict[str, int]] = {}
     for row in storage.telemetry.query_rollup(rng, flt):
         metrics = json.loads(row["metrics_json"])
-        bucket = by_day.setdefault(
-            row["day"],
-            {"user_turns": 0, "agent_turns": 0, "tool_calls": 0, "sessions_created": 0},
-        )
+        bucket = by_day.setdefault(row["day"], _empty_activity_bucket())
         bucket["user_turns"] += metrics.get("turns_user", 0)
         bucket["agent_turns"] += metrics.get("turns_agent", 0)
         bucket["tool_calls"] += metrics.get("tool_calls", 0)
         bucket["sessions_created"] += (metrics.get("lifecycle") or {}).get("created", 0)
+    return by_day
+
+
+def _activity_daily_from_facts(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> dict[str, dict[str, int]]:
+    by_day: dict[str, dict[str, int]] = {}
+
+    def bucket_for(occurred_at: str) -> dict[str, int]:
+        day = _day_key(datetime.fromisoformat(occurred_at))
+        return by_day.setdefault(day, _empty_activity_bucket())
+
+    for row in storage.telemetry.query_facts(
+        TelemetryFactKind.SESSION_LIFECYCLE, rng, flt
+    ):
+        if row["transition"] == LifecycleTransition.CREATED:
+            bucket_for(row["occurred_at"])["sessions_created"] += 1
+    for row in storage.telemetry.query_facts(TelemetryFactKind.TURN, rng, flt):
+        bucket = bucket_for(row["occurred_at"])
+        if row["turn_kind"] == TurnKind.USER:
+            bucket["user_turns"] += 1
+        elif row["turn_kind"] == TurnKind.AGENT:
+            bucket["agent_turns"] += 1
+    for row in storage.telemetry.query_facts(TelemetryFactKind.TOOL_CALL, rng, flt):
+        bucket_for(row["occurred_at"])["tool_calls"] += 1
+    return by_day
+
+
+def build_activity(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> TelemetryActivity:
+    by_day = (
+        _activity_daily_from_facts(storage, rng, flt)
+        if _needs_fact_scan_for_session_counts(flt)
+        else _activity_daily_from_rollup(storage, rng, flt)
+    )
 
     daily = [ActivityDaily(day=day, **by_day.get(day, {})) for day in day_range(rng)]
 

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -1,0 +1,755 @@
+"""Shaper: turns ``TelemetryStore`` queries into the PR1 API DTOs.
+
+Analogous to ``usage_dashboard.py`` but reading the telemetry fact/rollup
+tables instead of live session snapshots. Token totals are computed by
+walking ``AGENT`` ``TurnFact`` rows and joining back to the per-turn ledger
+(``session_token_usage_records``) exactly like ``TelemetryStore``'s own
+rollup recompute does (``_agent_turn_tokens``) — the rollup itself doesn't
+persist enough detail (which individual turns lacked a ledger match) to
+derive meter coverage, so the fact-level walk is authoritative here and also
+naturally supports the arbitrary (non-day-aligned) windows insights compare.
+
+Coverage vocabulary (``entire``/``tracked_since``/``partial``): ``entire``
+when every matching agent turn has a ledger record (or there are none to
+miss); ``tracked_since`` when the one-time history backfill hasn't completed
+yet (older gaps are a backfill boundary, not a real loss); ``partial``
+otherwise (backfill is done and turns are still missing ledger rows — a
+genuine data gap).
+"""
+
+import json
+from collections.abc import Callable
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from waypoint.schemas import SessionRecord, SessionStatus
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+from waypoint.telemetry.api_models import (
+    ActivityDaily,
+    ActivityHeatmapCell,
+    ContextSeriesPoint,
+    ContextSnapshotView,
+    DrilldownItem,
+    LimitSeries,
+    LimitSeriesPoint,
+    LimitSnapshotView,
+    SessionCounts,
+    TelemetryActivity,
+    TelemetryAlerts,
+    TelemetryCoverageInfo,
+    TelemetryDeleteCounts,
+    TelemetryDeleteResponse,
+    TelemetryDrilldown,
+    TelemetryHealth,
+    TelemetryHealthContext,
+    TelemetryHealthLimits,
+    TelemetryOverview,
+    TelemetrySettingsResponse,
+    TelemetryTokens,
+    TokenCoverage,
+    TokenGroup,
+    TokenGroupBy,
+    TokenSeriesPoint,
+    TokenTotals,
+    TurnCounts,
+)
+from waypoint.telemetry.facts import (
+    TelemetryFactKind,
+    TelemetryFilter,
+    TelemetryRange,
+    TurnKind,
+)
+from waypoint.telemetry.store import _day_bounds_utc, _day_key, _parse_tag_term
+
+# A snapshot is "current" (CONTRACT.md §4) for 15 minutes or until its
+# provider-declared reset, whichever is sooner.
+_SNAPSHOT_FRESH_WINDOW = timedelta(minutes=15)
+
+_ACTIVE_STATUSES = frozenset(
+    {
+        SessionStatus.STARTING,
+        SessionStatus.RUNNING,
+        SessionStatus.IDLE,
+        SessionStatus.WAITING_INPUT,
+    }
+)
+
+_LIMIT_CARD_HIDDEN_REASON = (
+    "provider rate limits are account-wide, not session-attributable; clear "
+    "the model/repo/tag/source/transport/parent filter to view them"
+)
+
+ALL_TIME_RANGE = TelemetryRange(
+    start=datetime(1970, 1, 1, tzinfo=UTC),
+    end=datetime(2100, 1, 1, tzinfo=UTC),
+    tz="UTC",
+)
+
+
+# ── shared range/day/hour helpers ─────────────────────────────────────────
+
+
+def day_range(rng: TelemetryRange) -> list[str]:
+    """Every host-tz calendar day with at least one instant inside ``[start, end)``."""
+    days: list[str] = []
+    current = date.fromisoformat(_day_key(rng.start))
+    while True:
+        day_str = current.isoformat()
+        start_iso, _ = _day_bounds_utc(day_str)
+        if datetime.fromisoformat(start_iso) >= rng.end:
+            break
+        days.append(day_str)
+        current += timedelta(days=1)
+    return days
+
+
+def hour_range(rng: TelemetryRange) -> list[datetime]:
+    """Hourly bucket starts (UTC) covering ``[start, end)`` — gaps stay explicit nulls."""
+    start = rng.start.replace(minute=0, second=0, microsecond=0)
+    buckets: list[datetime] = []
+    cursor = start
+    while cursor < rng.end:
+        buckets.append(cursor)
+        cursor += timedelta(hours=1)
+    return buckets
+
+
+def range_key(rng: TelemetryRange) -> str:
+    """A stable key for insight dismissal — identical resolved ranges collapse together."""
+    return f"{rng.start.isoformat()}|{rng.end.isoformat()}"
+
+
+# ── token totals (facts + ledger join) ────────────────────────────────────
+
+
+def agent_turn_rows(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> list[dict[str, Any]]:
+    return [
+        row
+        for row in storage.telemetry.query_facts(TelemetryFactKind.TURN, rng, flt)
+        if row["turn_kind"] == TurnKind.AGENT
+    ]
+
+
+def ledger_rows_for_sessions(
+    storage: Storage, session_ids: set[str]
+) -> dict[tuple[str, str, str], dict[str, Any]]:
+    if not session_ids:
+        return {}
+    placeholders = ", ".join("?" for _ in session_ids)
+    rows = storage.connection.execute(
+        "SELECT session_id, source, record_id, usage_json "
+        f"FROM session_token_usage_records WHERE session_id IN ({placeholders})",
+        list(session_ids),
+    ).fetchall()
+    ledger: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        try:
+            usage = json.loads(row["usage_json"])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(usage, dict):
+            ledger[(row["session_id"], row["source"], row["record_id"])] = usage
+    return ledger
+
+
+def fold_tokens(
+    rows: list[dict[str, Any]], ledger: dict[tuple[str, str, str], dict[str, Any]]
+) -> tuple[dict[str, int], int | None, int, int]:
+    """Fold a set of AGENT ``TurnFact`` rows into ``(totals, display_total, tracked, total)``.
+
+    ``tracked`` is the number of turns with a resolvable ledger record;
+    ``total`` is ``len(rows)``. ``display_total`` is the safe grand total only
+    when every tracked turn supplied one (never a partial sum passed off as
+    complete).
+    """
+    totals: dict[str, int] = {}
+    display_totals: list[int | None] = []
+    tracked = 0
+    for row in rows:
+        usage = ledger.get((row["session_id"], row["source"], row["fact_id"]))
+        if usage is None:
+            display_totals.append(None)
+            continue
+        tracked += 1
+        for category, amount in (usage.get("totals") or {}).items():
+            if isinstance(amount, int | float):
+                totals[category] = totals.get(category, 0) + int(amount)
+        display_total = usage.get("display_total_tokens")
+        display_totals.append(display_total if isinstance(display_total, int) else None)
+    display_total = (
+        sum(d for d in display_totals if d is not None)
+        if display_totals and all(d is not None for d in display_totals)
+        else None
+    )
+    return totals, display_total, tracked, len(rows)
+
+
+def grand_total(totals: dict[str, int], display_total: int | None) -> int:
+    """A single comparable token quantity for insight gating (CONTRACT.md §4/§7).
+
+    Prefers the safe backend-declared ``display_total``; falls back to the sum
+    of tracked categories when no backend supplied one (best-effort, never
+    shown as the safe grand total in the UI).
+    """
+    return display_total if display_total is not None else sum(totals.values())
+
+
+def coverage_label(
+    storage: Storage, meter_coverage_percent: float | None
+) -> TokenCoverage:
+    if meter_coverage_percent is None or meter_coverage_percent >= 100.0:
+        return "entire"
+    if storage.telemetry.get_meta("backfill_done") != "true":
+        return "tracked_since"
+    return "partial"
+
+
+# ── current + series snapshots (context/limit health) ────────────────────
+
+
+def _is_stale(
+    occurred_at: datetime, now: datetime, resets_at: datetime | None = None
+) -> bool:
+    if now - occurred_at > _SNAPSHOT_FRESH_WINDOW:
+        return True
+    return resets_at is not None and now >= resets_at
+
+
+def current_context_snapshots(
+    storage: Storage, flt: TelemetryFilter, now: datetime
+) -> list[ContextSnapshotView]:
+    rows = storage.telemetry.query_facts(
+        TelemetryFactKind.CONTEXT_SNAPSHOT, ALL_TIME_RANGE, flt
+    )
+    latest: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        existing = latest.get(row["session_id"])
+        if existing is None or row["occurred_at"] > existing["occurred_at"]:
+            latest[row["session_id"]] = row
+    views = []
+    for session_id, row in latest.items():
+        occurred_at = datetime.fromisoformat(row["occurred_at"])
+        views.append(
+            ContextSnapshotView(
+                session_id=session_id,
+                used=row["used_tokens"],
+                window=row["window_tokens"],
+                percent=row["occupancy_percent"],
+                stale=_is_stale(occurred_at, now),
+                updated_at=occurred_at,
+            )
+        )
+    return sorted(views, key=lambda v: v.session_id)
+
+
+def current_limit_snapshots(
+    storage: Storage, flt: TelemetryFilter, now: datetime
+) -> list[LimitSnapshotView]:
+    rows = storage.telemetry.query_facts(
+        TelemetryFactKind.LIMIT_SNAPSHOT, ALL_TIME_RANGE, flt
+    )
+    latest: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for row in rows:
+        key = (row["backend"], row["account_key"], row["window_id"])
+        existing = latest.get(key)
+        if existing is None or row["occurred_at"] > existing["occurred_at"]:
+            latest[key] = row
+    views = []
+    for (backend, account_key, window_id), row in latest.items():
+        occurred_at = datetime.fromisoformat(row["occurred_at"])
+        resets_at = (
+            datetime.fromisoformat(row["resets_at"]) if row["resets_at"] else None
+        )
+        views.append(
+            LimitSnapshotView(
+                backend=backend,
+                account_key=account_key,
+                window_id=window_id,
+                label=row["window_label"],
+                used_percent=row["used_percent"],
+                resets_at=resets_at,
+                stale=_is_stale(occurred_at, now, resets_at),
+                updated_at=occurred_at,
+            )
+        )
+    return sorted(views, key=lambda v: (v.backend, v.account_key, v.window_id))
+
+
+def severity_for_percent(
+    percent: float, thresholds: tuple[int, int, int]
+) -> str | None:
+    low, high, critical = thresholds
+    if percent >= critical:
+        return "critical"
+    if percent >= high:
+        return "warning"
+    if percent >= low:
+        return "info"
+    return None
+
+
+def alerting_context(
+    storage: Storage, settings: Settings, flt: TelemetryFilter
+) -> list[ContextSnapshotView]:
+    low = settings.telemetry_context_thresholds[0]
+    now = datetime.now(UTC)
+    return [
+        snapshot
+        for snapshot in current_context_snapshots(storage, flt, now)
+        if not snapshot.stale
+        and snapshot.percent is not None
+        and snapshot.percent >= low
+    ]
+
+
+def alerting_limits(
+    storage: Storage, settings: Settings, flt: TelemetryFilter
+) -> list[LimitSnapshotView]:
+    if flt.has_session_scoping():
+        return []
+    low = settings.telemetry_context_thresholds[0]
+    now = datetime.now(UTC)
+    return [
+        snapshot
+        for snapshot in current_limit_snapshots(storage, flt, now)
+        if not snapshot.stale and snapshot.used_percent >= low
+    ]
+
+
+# ── live session filtering (point-in-time counts) ─────────────────────────
+
+
+def _descendant_session_ids(sessions: list[SessionRecord], root_id: str) -> set[str]:
+    children: dict[str, list[str]] = {}
+    for session in sessions:
+        if session.spawner_session_id is not None:
+            children.setdefault(session.spawner_session_id, []).append(session.id)
+    found: set[str] = set()
+    queue = list(children.get(root_id, []))
+    while queue:
+        current = queue.pop()
+        if current in found or current == root_id:
+            continue
+        found.add(current)
+        queue.extend(children.get(current, []))
+    return found
+
+
+def _session_matches_filter(
+    session: SessionRecord, flt: TelemetryFilter, descendant_ids: set[str]
+) -> bool:
+    if flt.backends and session.backend not in flt.backends:
+        return False
+    if flt.repos and (session.repo_name or "") not in flt.repos:
+        return False
+    if flt.sources and session.source not in flt.sources:
+        return False
+    if flt.transports and session.transport not in flt.transports:
+        return False
+    if flt.parent_scope == "top_level" and session.spawner_session_id is not None:
+        return False
+    if flt.parent_scope == "children" and session.spawner_session_id is None:
+        return False
+    if flt.parent_session_id:
+        if flt.include_descendants:
+            if session.id != flt.parent_session_id and session.id not in descendant_ids:
+                return False
+        elif session.spawner_session_id != flt.parent_session_id:
+            return False
+    for term in flt.tags:
+        parsed = _parse_tag_term(term)
+        if parsed is None:
+            continue
+        key, value = parsed
+        if session.tags.get(key) != value:
+            return False
+    return True
+
+
+def count_active_sessions(storage: Storage, flt: TelemetryFilter) -> int:
+    """Point-in-time count of sessions in a live state matching ``flt`` (FR-3).
+
+    Unlike every other overview metric this ignores the time range — "active
+    now" is evaluated against live ``SessionRecord.status``, not a fact window.
+    """
+    sessions = storage.list_sessions()
+    descendant_ids = (
+        _descendant_session_ids(sessions, flt.parent_session_id)
+        if flt.parent_session_id
+        else set()
+    )
+    return sum(
+        1
+        for session in sessions
+        if session.status in _ACTIVE_STATUSES
+        and _session_matches_filter(session, flt, descendant_ids)
+    )
+
+
+# ── /overview ─────────────────────────────────────────────────────────────
+
+
+def build_overview(
+    storage: Storage, settings: Settings, rng: TelemetryRange, flt: TelemetryFilter
+) -> TelemetryOverview:
+    lifecycle_totals: dict[str, int] = {}
+    turns_user = turns_agent = tool_calls = 0
+    for row in storage.telemetry.query_rollup(rng, flt):
+        metrics = json.loads(row["metrics_json"])
+        for transition, count in (metrics.get("lifecycle") or {}).items():
+            lifecycle_totals[transition] = lifecycle_totals.get(transition, 0) + count
+        turns_user += metrics.get("turns_user", 0)
+        turns_agent += metrics.get("turns_agent", 0)
+        tool_calls += metrics.get("tool_calls", 0)
+
+    rows = agent_turn_rows(storage, rng, flt)
+    ledger = ledger_rows_for_sessions(storage, {row["session_id"] for row in rows})
+    totals, display_total, tracked, total = fold_tokens(rows, ledger)
+    meter_pct = (100.0 * tracked / total) if total else None
+
+    hidden = flt.has_session_scoping()
+    return TelemetryOverview(
+        range=rng,
+        filters_echo=flt,
+        tokens=TokenTotals(
+            totals=totals,
+            display_total=display_total,
+            safe_total=display_total is not None,
+            coverage=coverage_label(storage, meter_pct),
+            meter_coverage_percent=meter_pct,
+        ),
+        sessions=SessionCounts(
+            created=lifecycle_totals.get("created", 0),
+            exited=lifecycle_totals.get("exited", 0),
+            interrupted=lifecycle_totals.get("interrupted", 0),
+            error=lifecycle_totals.get("error", 0),
+            active_now=count_active_sessions(storage, flt),
+        ),
+        turns=TurnCounts(user=turns_user, agent=turns_agent),
+        tool_calls=tool_calls,
+        alerts=TelemetryAlerts(
+            context=alerting_context(storage, settings, flt),
+            limits=alerting_limits(storage, settings, flt),
+        ),
+        limit_card_hidden=hidden,
+        limit_card_hidden_reason=_LIMIT_CARD_HIDDEN_REASON if hidden else None,
+    )
+
+
+# ── /tokens ───────────────────────────────────────────────────────────────
+
+
+def _group_key_and_label(
+    storage: Storage, group_by: TokenGroupBy
+) -> tuple[Callable[[dict[str, Any]], str], Callable[[str], str]]:
+    if group_by == "time":
+        return (lambda row: _day_key(datetime.fromisoformat(row["occurred_at"]))), (
+            lambda key: key
+        )
+    if group_by == "backend":
+        return (lambda row: row["backend"]), (lambda key: key)
+    if group_by == "model":
+        return (lambda row: row["model_at_turn"] or ""), (
+            lambda key: key or "(no model)"
+        )
+    if group_by == "repo":
+        return (lambda row: row["repo_name"] or ""), (lambda key: key or "(no repo)")
+
+    def _session_label(session_id: str) -> str:
+        session = storage.get_session(session_id)
+        return session.title if session is not None else session_id
+
+    return (lambda row: row["session_id"]), _session_label
+
+
+def build_tokens(
+    storage: Storage,
+    rng: TelemetryRange,
+    flt: TelemetryFilter,
+    group_by: TokenGroupBy = "time",
+) -> TelemetryTokens:
+    rows = agent_turn_rows(storage, rng, flt)
+    ledger = ledger_rows_for_sessions(storage, {row["session_id"] for row in rows})
+
+    by_day: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_day.setdefault(
+            _day_key(datetime.fromisoformat(row["occurred_at"])), []
+        ).append(row)
+    series = []
+    for day in day_range(rng):
+        totals, display_total, _tracked, _total = fold_tokens(
+            by_day.get(day, []), ledger
+        )
+        start_iso, _ = _day_bounds_utc(day)
+        series.append(
+            TokenSeriesPoint(
+                bucket_start=datetime.fromisoformat(start_iso),
+                totals=totals,
+                display_total=display_total,
+            )
+        )
+
+    key_fn, label_fn = _group_key_and_label(storage, group_by)
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(key_fn(row), []).append(row)
+    groups = []
+    for key in sorted(grouped):
+        totals, display_total, tracked, total = fold_tokens(grouped[key], ledger)
+        meter_pct = (100.0 * tracked / total) if total else None
+        groups.append(
+            TokenGroup(
+                key=key,
+                label=label_fn(key),
+                totals=totals,
+                display_total=display_total,
+                coverage=coverage_label(storage, meter_pct),
+            )
+        )
+
+    return TelemetryTokens(
+        range=rng, filters_echo=flt, series=series, group_by=group_by, groups=groups
+    )
+
+
+# ── /activity ─────────────────────────────────────────────────────────────
+
+
+def build_activity(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> TelemetryActivity:
+    by_day: dict[str, dict[str, int]] = {}
+    for row in storage.telemetry.query_rollup(rng, flt):
+        metrics = json.loads(row["metrics_json"])
+        bucket = by_day.setdefault(
+            row["day"],
+            {"user_turns": 0, "agent_turns": 0, "tool_calls": 0, "sessions_created": 0},
+        )
+        bucket["user_turns"] += metrics.get("turns_user", 0)
+        bucket["agent_turns"] += metrics.get("turns_agent", 0)
+        bucket["tool_calls"] += metrics.get("tool_calls", 0)
+        bucket["sessions_created"] += (metrics.get("lifecycle") or {}).get("created", 0)
+
+    daily = [ActivityDaily(day=day, **by_day.get(day, {})) for day in day_range(rng)]
+
+    heatmap_counts: dict[tuple[int, int], int] = {}
+    for kind in (TelemetryFactKind.TURN, TelemetryFactKind.TOOL_CALL):
+        for row in storage.telemetry.query_facts(kind, rng, flt):
+            occurred = datetime.fromisoformat(row["occurred_at"]).astimezone()
+            key = (occurred.weekday(), occurred.hour)
+            heatmap_counts[key] = heatmap_counts.get(key, 0) + 1
+    heatmap = [
+        ActivityHeatmapCell(dow=dow, hour=hour, count=count)
+        for (dow, hour), count in sorted(heatmap_counts.items())
+    ]
+
+    return TelemetryActivity(range=rng, filters_echo=flt, daily=daily, heatmap=heatmap)
+
+
+# ── /health ───────────────────────────────────────────────────────────────
+
+
+def _context_series(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> list[ContextSeriesPoint]:
+    peaks: dict[datetime, float] = {}
+    for row in storage.telemetry.query_facts(
+        TelemetryFactKind.CONTEXT_SNAPSHOT, rng, flt
+    ):
+        percent = row["occupancy_percent"]
+        if percent is None:
+            continue
+        bucket = datetime.fromisoformat(row["occurred_at"]).replace(
+            minute=0, second=0, microsecond=0
+        )
+        peaks[bucket] = max(peaks.get(bucket, percent), percent)
+    return [
+        ContextSeriesPoint(bucket_start=bucket, peak_percent=peaks.get(bucket))
+        for bucket in hour_range(rng)
+    ]
+
+
+def _limits_series(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> list[LimitSeries]:
+    groups: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+    for row in storage.telemetry.query_facts(
+        TelemetryFactKind.LIMIT_SNAPSHOT, rng, flt
+    ):
+        key = (row["backend"], row["account_key"], row["window_id"])
+        groups.setdefault(key, []).append(row)
+
+    buckets = hour_range(rng)
+    result = []
+    for (backend, account_key, window_id), group_rows in groups.items():
+        label = None
+        best_per_bucket: dict[datetime, tuple[datetime, float]] = {}
+        for row in group_rows:
+            occurred = datetime.fromisoformat(row["occurred_at"])
+            bucket = occurred.replace(minute=0, second=0, microsecond=0)
+            existing = best_per_bucket.get(bucket)
+            if existing is None or occurred > existing[0]:
+                best_per_bucket[bucket] = (occurred, row["used_percent"])
+            if row["window_label"]:
+                label = row["window_label"]
+        points = [
+            LimitSeriesPoint(
+                bucket_start=bucket,
+                used_percent=(
+                    best_per_bucket[bucket][1] if bucket in best_per_bucket else None
+                ),
+            )
+            for bucket in buckets
+        ]
+        result.append(
+            LimitSeries(
+                backend=backend,
+                account_key=account_key,
+                window_id=window_id,
+                label=label,
+                points=points,
+            )
+        )
+    return sorted(
+        result,
+        key=lambda series: (series.backend, series.account_key, series.window_id),
+    )
+
+
+def build_health(
+    storage: Storage, settings: Settings, rng: TelemetryRange, flt: TelemetryFilter
+) -> TelemetryHealth:
+    now = datetime.now(UTC)
+    hidden = flt.has_session_scoping()
+    limits_current = [] if hidden else current_limit_snapshots(storage, flt, now)
+    limits_series = [] if hidden else _limits_series(storage, rng, flt)
+    return TelemetryHealth(
+        range=rng,
+        filters_echo=flt,
+        context=TelemetryHealthContext(
+            current=current_context_snapshots(storage, flt, now),
+            series=_context_series(storage, rng, flt),
+        ),
+        limits=TelemetryHealthLimits(
+            current=limits_current,
+            series=limits_series,
+            hidden=hidden,
+            hidden_reason=_LIMIT_CARD_HIDDEN_REASON if hidden else None,
+        ),
+    )
+
+
+# ── /drilldown ────────────────────────────────────────────────────────────
+
+
+def _drilldown_label(row: dict[str, Any]) -> str:
+    kind = row["kind"]
+    if kind == TelemetryFactKind.SESSION_LIFECYCLE:
+        return f"session {row['transition']}"
+    if kind == TelemetryFactKind.TURN:
+        return f"{row['turn_kind']} turn"
+    if kind == TelemetryFactKind.TOOL_CALL:
+        return f"{row['tool_name']} ({row['outcome']})"
+    if kind == TelemetryFactKind.CONTEXT_SNAPSHOT:
+        percent = row["occupancy_percent"]
+        return f"context {percent:.0f}%" if percent is not None else "context snapshot"
+    if kind == TelemetryFactKind.LIMIT_SNAPSHOT:
+        label = row["window_label"] or row["window_id"]
+        return f"{label} {row['used_percent']:.0f}%"
+    return str(kind)
+
+
+def _drilldown_item(row: dict[str, Any]) -> DrilldownItem:
+    return DrilldownItem(
+        session_id=row["session_id"],
+        kind=row["kind"],
+        fact_id=row["fact_id"],
+        occurred_at=datetime.fromisoformat(row["occurred_at"]),
+        label=_drilldown_label(row),
+        backend=row["backend"],
+        model=row["model_at_turn"],
+        repo_name=row["repo_name"],
+        transition=row["transition"],
+        turn_kind=row["turn_kind"],
+        tool_name=row["tool_name"],
+        tool_category=row["tool_category"],
+        outcome=row["outcome"],
+        duration_ms=row["duration_ms"],
+        used_tokens=row["used_tokens"],
+        window_tokens=row["window_tokens"],
+        occupancy_percent=row["occupancy_percent"],
+        account_key=row["account_key"],
+        window_id=row["window_id"],
+        used_percent=row["used_percent"],
+    )
+
+
+def build_drilldown(
+    storage: Storage,
+    rng: TelemetryRange,
+    flt: TelemetryFilter,
+    kind: TelemetryFactKind,
+    page: int,
+    page_size: int,
+) -> TelemetryDrilldown:
+    offset = (page - 1) * page_size
+    rows = storage.telemetry.query_facts(kind, rng, flt, limit=page_size, offset=offset)
+    total = storage.telemetry.count_facts(kind, rng, flt)
+    return TelemetryDrilldown(
+        range=rng,
+        filters_echo=flt,
+        items=[_drilldown_item(row) for row in rows],
+        page=page,
+        page_size=page_size,
+        total=total,
+    )
+
+
+# ── /settings + DELETE /api/telemetry ─────────────────────────────────────
+
+PRIVACY_STATEMENT = (
+    "Telemetry stores only counts, timestamps, model ids, normalized tool names, "
+    "and occupancy/limit percentages — never raw prompts, tool inputs/outputs, "
+    "filenames, or paths. Repo names are basenames; tool names are bare "
+    "identifiers. Nothing leaves this Waypoint instance."
+)
+
+
+def build_settings(storage: Storage, settings: Settings) -> TelemetrySettingsResponse:
+    backfill_through_raw = storage.telemetry.get_meta("backfill_through")
+    return TelemetrySettingsResponse(
+        retention_days_facts=settings.telemetry_retention_days,
+        retention_months_rollups=settings.telemetry_rollup_retention_months,
+        coverage=TelemetryCoverageInfo(
+            backfill_done=storage.telemetry.get_meta("backfill_done") == "true",
+            backfill_through=(
+                datetime.fromisoformat(backfill_through_raw)
+                if backfill_through_raw
+                else None
+            ),
+        ),
+        privacy_statement=PRIVACY_STATEMENT,
+        external_export=False,
+        content_capture=False,
+        nl_enabled=False,
+    )
+
+
+def delete_all(storage: Storage) -> TelemetryDeleteResponse:
+    """Delete every retained telemetry fact/rollup/dismissal. Transcripts untouched."""
+    far_future = datetime.now(UTC) + timedelta(days=1)
+    removed = storage.telemetry.prune(
+        facts_before=far_future, rollups_before=far_future
+    )
+    storage.connection.execute("DELETE FROM telemetry_insight_dismissal")
+    storage.connection.commit()
+    return TelemetryDeleteResponse(
+        removed=TelemetryDeleteCounts(
+            facts=removed["facts"], rollups=removed["rollups"]
+        ),
+        transcripts_unaffected=True,
+    )

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -223,11 +223,24 @@ def _is_stale(
 def current_context_snapshots(
     storage: Storage, flt: TelemetryFilter, now: datetime
 ) -> list[ContextSnapshotView]:
+    # "Current" context occupancy is a property of sessions that are still
+    # live: an exited/errored session holds no context window (FR-6). Restrict
+    # to sessions whose latest status is active so the panel shows the handful
+    # of running sessions, not every session that ever recorded a snapshot.
+    active_ids = {
+        session.id
+        for session in storage.list_sessions()
+        if session.status in _ACTIVE_STATUSES
+    }
+    if not active_ids:
+        return []
     rows = storage.telemetry.query_facts(
         TelemetryFactKind.CONTEXT_SNAPSHOT, ALL_TIME_RANGE, flt
     )
     latest: dict[str, dict[str, Any]] = {}
     for row in rows:
+        if row["session_id"] not in active_ids:
+            continue
         existing = latest.get(row["session_id"])
         if existing is None or row["occurred_at"] > existing["occurred_at"]:
             latest[row["session_id"]] = row
@@ -247,6 +260,16 @@ def current_context_snapshots(
     return sorted(views, key=lambda v: v.session_id)
 
 
+def _is_real_account(account_key: str) -> bool:
+    """A verified account, not the per-session pseudonym fallback.
+
+    Provider limits are account-scoped (FR-6); a session with no verified
+    account gets a ``session:<id>`` placeholder key at ingest, which must not
+    surface as its own account row and fragment the limit view.
+    """
+    return not account_key.startswith("session:")
+
+
 def current_limit_snapshots(
     storage: Storage, flt: TelemetryFilter, now: datetime
 ) -> list[LimitSnapshotView]:
@@ -255,6 +278,8 @@ def current_limit_snapshots(
     )
     latest: dict[tuple[str, str, str], dict[str, Any]] = {}
     for row in rows:
+        if not _is_real_account(row["account_key"]):
+            continue
         key = (row["backend"], row["account_key"], row["window_id"])
         existing = latest.get(key)
         if existing is None or row["occurred_at"] > existing["occurred_at"]:
@@ -719,6 +744,8 @@ def _limits_series(
     for row in storage.telemetry.query_facts(
         TelemetryFactKind.LIMIT_SNAPSHOT, rng, flt
     ):
+        if not _is_real_account(row["account_key"]):
+            continue
         key = (row["backend"], row["account_key"], row["window_id"])
         groups.setdefault(key, []).append(row)
 

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -63,6 +63,7 @@ from waypoint.telemetry.facts import (
     TurnKind,
 )
 from waypoint.telemetry.store import _day_bounds_utc, _day_key, _parse_tag_term
+from waypoint.telemetry.tokens import unify_tokens
 
 # A snapshot is "current" (CONTRACT.md §4) for 15 minutes or until its
 # provider-declared reset, whichever is sooner.
@@ -162,39 +163,34 @@ def fold_tokens(
 ) -> tuple[dict[str, int], int | None, int, int]:
     """Fold a set of AGENT ``TurnFact`` rows into ``(totals, display_total, tracked, total)``.
 
+    Each tracked row's raw ledger totals are mapped through
+    ``unify_tokens(row.source, ...)`` before folding, onto the 5 disjoint
+    buckets (``waypoint.schemas.TOKEN_USAGE_CATEGORIES``); because those
+    buckets never overlap for any backend, ``display_total`` is simply their
+    sum and is always safe — no backend-declared total to trust or gate on.
     ``tracked`` is the number of turns with a resolvable ledger record;
-    ``total`` is ``len(rows)``. ``display_total`` is the safe grand total only
-    when every tracked turn supplied one (never a partial sum passed off as
-    complete).
+    ``total`` is ``len(rows)``.
     """
     totals: dict[str, int] = {}
-    display_totals: list[int | None] = []
     tracked = 0
     for row in rows:
         usage = ledger.get((row["session_id"], row["source"], row["fact_id"]))
         if usage is None:
-            display_totals.append(None)
             continue
         tracked += 1
-        for category, amount in (usage.get("totals") or {}).items():
-            if isinstance(amount, int | float):
-                totals[category] = totals.get(category, 0) + int(amount)
-        display_total = usage.get("display_total_tokens")
-        display_totals.append(display_total if isinstance(display_total, int) else None)
-    display_total = (
-        sum(d for d in display_totals if d is not None)
-        if display_totals and all(d is not None for d in display_totals)
-        else None
-    )
+        unified = unify_tokens(row["source"], usage.get("totals") or {})
+        for category, amount in unified.items():
+            totals[category] = totals.get(category, 0) + amount
+    display_total = sum(totals.values())
     return totals, display_total, tracked, len(rows)
 
 
 def grand_total(totals: dict[str, int], display_total: int | None) -> int:
     """A single comparable token quantity for insight gating (CONTRACT.md §4/§7).
 
-    Prefers the safe backend-declared ``display_total``; falls back to the sum
-    of tracked categories when no backend supplied one (best-effort, never
-    shown as the safe grand total in the UI).
+    ``display_total`` (``fold_tokens``'s unconditional sum of the unified
+    buckets) is always the safe grand total now; the ``None`` branch is dead
+    but kept so ``TokenTotals.display_total``'s optional type still type-checks.
     """
     return display_total if display_total is not None else sum(totals.values())
 
@@ -271,7 +267,7 @@ def _is_real_account(account_key: str) -> bool:
 
 
 def current_limit_snapshots(
-    storage: Storage, flt: TelemetryFilter, now: datetime
+    storage: Storage, flt: TelemetryFilter, now: datetime, settings: Settings
 ) -> list[LimitSnapshotView]:
     rows = storage.telemetry.query_facts(
         TelemetryFactKind.LIMIT_SNAPSHOT, ALL_TIME_RANGE, flt
@@ -294,6 +290,9 @@ def current_limit_snapshots(
             LimitSnapshotView(
                 backend=backend,
                 account_key=account_key,
+                account_label=(
+                    row["account_label"] if settings.telemetry_local_labels else None
+                ),
                 window_id=window_id,
                 label=row["window_label"],
                 used_percent=row["used_percent"],
@@ -341,7 +340,7 @@ def alerting_limits(
     now = datetime.now(UTC)
     return [
         snapshot
-        for snapshot in current_limit_snapshots(storage, flt, now)
+        for snapshot in current_limit_snapshots(storage, flt, now, settings)
         if not snapshot.stale and snapshot.used_percent >= low
     ]
 
@@ -738,7 +737,7 @@ def _context_series(
 
 
 def _limits_series(
-    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter, settings: Settings
 ) -> list[LimitSeries]:
     groups: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
     for row in storage.telemetry.query_facts(
@@ -753,6 +752,7 @@ def _limits_series(
     result = []
     for (backend, account_key, window_id), group_rows in groups.items():
         label = None
+        account_label = None
         best_per_bucket: dict[datetime, tuple[datetime, float]] = {}
         for row in group_rows:
             occurred = datetime.fromisoformat(row["occurred_at"])
@@ -762,6 +762,8 @@ def _limits_series(
                 best_per_bucket[bucket] = (occurred, row["used_percent"])
             if row["window_label"]:
                 label = row["window_label"]
+            if row["account_label"]:
+                account_label = row["account_label"]
         points = [
             LimitSeriesPoint(
                 bucket_start=bucket,
@@ -775,6 +777,9 @@ def _limits_series(
             LimitSeries(
                 backend=backend,
                 account_key=account_key,
+                account_label=(
+                    account_label if settings.telemetry_local_labels else None
+                ),
                 window_id=window_id,
                 label=label,
                 points=points,
@@ -791,8 +796,10 @@ def build_health(
 ) -> TelemetryHealth:
     now = datetime.now(UTC)
     hidden = flt.has_session_scoping()
-    limits_current = [] if hidden else current_limit_snapshots(storage, flt, now)
-    limits_series = [] if hidden else _limits_series(storage, rng, flt)
+    limits_current = (
+        [] if hidden else current_limit_snapshots(storage, flt, now, settings)
+    )
+    limits_series = [] if hidden else _limits_series(storage, rng, flt, settings)
     return TelemetryHealth(
         range=rng,
         filters_echo=flt,

--- a/backend/src/waypoint/telemetry/api_models.py
+++ b/backend/src/waypoint/telemetry/api_models.py
@@ -1,0 +1,268 @@
+"""Response DTOs for the PR1 ``/api/telemetry/*`` endpoints (CONTRACT.md §4).
+
+Every response echoes the resolved ``TelemetryRange``/``TelemetryFilter`` it
+was computed against (``range``/``filters_echo``) so the frontend always
+renders against the server's actual interpretation of the query, never its
+own guess.
+"""
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from waypoint.telemetry.facts import TelemetryFactKind, TelemetryFilter, TelemetryRange
+
+TokenCoverage = Literal["entire", "tracked_since", "partial"]
+TokenGroupBy = Literal["time", "backend", "model", "repo", "session"]
+InsightType = Literal["near_limit", "context_pressure", "token_volume_change"]
+InsightSeverity = Literal["info", "warning", "critical"]
+
+
+# ── shared sub-shapes ─────────────────────────────────────────────────────
+
+
+class TokenTotals(BaseModel):
+    totals: dict[str, int] = Field(default_factory=dict)
+    # Only present when every contributing row supplied a safe, backend-declared
+    # display total (CONTRACT.md §4: categories must not otherwise be summed).
+    display_total: int | None = None
+    safe_total: bool = False
+    coverage: TokenCoverage = "entire"
+    meter_coverage_percent: float | None = None
+
+
+class SessionCounts(BaseModel):
+    created: int = 0
+    exited: int = 0
+    interrupted: int = 0
+    error: int = 0
+    active_now: int = 0
+
+
+class TurnCounts(BaseModel):
+    user: int = 0
+    agent: int = 0
+
+
+class ContextSnapshotView(BaseModel):
+    session_id: str
+    used: int
+    window: int | None = None
+    percent: float | None = None
+    stale: bool = False
+    updated_at: datetime
+
+
+class LimitSnapshotView(BaseModel):
+    backend: str
+    account_key: str
+    window_id: str
+    label: str | None = None
+    used_percent: float
+    resets_at: datetime | None = None
+    stale: bool = False
+    updated_at: datetime
+
+
+class TelemetryAlerts(BaseModel):
+    context: list[ContextSnapshotView] = Field(default_factory=list)
+    limits: list[LimitSnapshotView] = Field(default_factory=list)
+
+
+# ── /overview ─────────────────────────────────────────────────────────────
+
+
+class TelemetryOverview(BaseModel):
+    range: TelemetryRange
+    filters_echo: TelemetryFilter
+    tokens: TokenTotals
+    sessions: SessionCounts
+    turns: TurnCounts
+    tool_calls: int = 0
+    alerts: TelemetryAlerts
+    limit_card_hidden: bool = False
+    limit_card_hidden_reason: str | None = None
+
+
+# ── /tokens ───────────────────────────────────────────────────────────────
+
+
+class TokenSeriesPoint(BaseModel):
+    bucket_start: datetime
+    totals: dict[str, int] = Field(default_factory=dict)
+    display_total: int | None = None
+
+
+class TokenGroup(BaseModel):
+    key: str
+    label: str
+    totals: dict[str, int] = Field(default_factory=dict)
+    display_total: int | None = None
+    coverage: TokenCoverage = "entire"
+
+
+class TelemetryTokens(BaseModel):
+    range: TelemetryRange
+    filters_echo: TelemetryFilter
+    series: list[TokenSeriesPoint] = Field(default_factory=list)
+    group_by: TokenGroupBy = "time"
+    groups: list[TokenGroup] = Field(default_factory=list)
+
+
+# ── /activity ─────────────────────────────────────────────────────────────
+
+
+class ActivityDaily(BaseModel):
+    day: str
+    user_turns: int = 0
+    agent_turns: int = 0
+    tool_calls: int = 0
+    sessions_created: int = 0
+
+
+class ActivityHeatmapCell(BaseModel):
+    dow: int
+    hour: int
+    count: int
+
+
+class TelemetryActivity(BaseModel):
+    range: TelemetryRange
+    filters_echo: TelemetryFilter
+    daily: list[ActivityDaily] = Field(default_factory=list)
+    heatmap: list[ActivityHeatmapCell] = Field(default_factory=list)
+
+
+# ── /health ───────────────────────────────────────────────────────────────
+
+
+class ContextSeriesPoint(BaseModel):
+    bucket_start: datetime
+    peak_percent: float | None = None
+
+
+class TelemetryHealthContext(BaseModel):
+    current: list[ContextSnapshotView] = Field(default_factory=list)
+    series: list[ContextSeriesPoint] = Field(default_factory=list)
+
+
+class LimitSeriesPoint(BaseModel):
+    bucket_start: datetime
+    used_percent: float | None = None
+
+
+class LimitSeries(BaseModel):
+    backend: str
+    account_key: str
+    window_id: str
+    label: str | None = None
+    points: list[LimitSeriesPoint] = Field(default_factory=list)
+
+
+class TelemetryHealthLimits(BaseModel):
+    current: list[LimitSnapshotView] = Field(default_factory=list)
+    series: list[LimitSeries] = Field(default_factory=list)
+    hidden: bool = False
+    hidden_reason: str | None = None
+
+
+class TelemetryHealth(BaseModel):
+    range: TelemetryRange
+    filters_echo: TelemetryFilter
+    context: TelemetryHealthContext
+    limits: TelemetryHealthLimits
+
+
+# ── /drilldown ────────────────────────────────────────────────────────────
+
+
+class DrilldownItem(BaseModel):
+    session_id: str
+    kind: TelemetryFactKind
+    fact_id: str
+    occurred_at: datetime
+    label: str
+    backend: str | None = None
+    model: str | None = None
+    repo_name: str | None = None
+    transition: str | None = None
+    turn_kind: str | None = None
+    tool_name: str | None = None
+    tool_category: str | None = None
+    outcome: str | None = None
+    duration_ms: int | None = None
+    used_tokens: int | None = None
+    window_tokens: int | None = None
+    occupancy_percent: float | None = None
+    account_key: str | None = None
+    window_id: str | None = None
+    used_percent: float | None = None
+
+
+class TelemetryDrilldown(BaseModel):
+    range: TelemetryRange
+    filters_echo: TelemetryFilter
+    items: list[DrilldownItem] = Field(default_factory=list)
+    page: int
+    page_size: int
+    total: int
+
+
+# ── /insights ─────────────────────────────────────────────────────────────
+
+
+class InsightClickThrough(BaseModel):
+    endpoint: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class Insight(BaseModel):
+    signature: str
+    type: InsightType
+    statement: str
+    metrics: dict[str, Any] = Field(default_factory=dict)
+    range: TelemetryRange
+    filters: TelemetryFilter
+    click_through: InsightClickThrough
+    severity: InsightSeverity
+
+
+class TelemetryInsightsResponse(BaseModel):
+    insights: list[Insight] = Field(default_factory=list)
+
+
+class InsightDismissResponse(BaseModel):
+    signature: str
+    dismissed: bool = True
+
+
+# ── /settings ─────────────────────────────────────────────────────────────
+
+
+class TelemetryCoverageInfo(BaseModel):
+    backfill_done: bool = False
+    backfill_through: datetime | None = None
+
+
+class TelemetrySettingsResponse(BaseModel):
+    retention_days_facts: int
+    retention_months_rollups: int
+    coverage: TelemetryCoverageInfo
+    privacy_statement: str
+    external_export: bool = False
+    content_capture: bool = False
+    nl_enabled: bool = False
+
+
+# ── DELETE /api/telemetry ─────────────────────────────────────────────────
+
+
+class TelemetryDeleteCounts(BaseModel):
+    facts: int
+    rollups: int
+
+
+class TelemetryDeleteResponse(BaseModel):
+    removed: TelemetryDeleteCounts
+    transcripts_unaffected: bool = True

--- a/backend/src/waypoint/telemetry/api_models.py
+++ b/backend/src/waypoint/telemetry/api_models.py
@@ -57,6 +57,10 @@ class ContextSnapshotView(BaseModel):
 class LimitSnapshotView(BaseModel):
     backend: str
     account_key: str
+    # Only populated when the ``telemetry_local_labels`` setting is on
+    # (default off); ``None`` otherwise (FR-9 — ``account_key`` is always the
+    # pseudonym, never a raw email/org).
+    account_label: str | None = None
     window_id: str
     label: str | None = None
     used_percent: float
@@ -155,6 +159,8 @@ class LimitSeriesPoint(BaseModel):
 class LimitSeries(BaseModel):
     backend: str
     account_key: str
+    # See ``LimitSnapshotView.account_label`` — same local-labels gate.
+    account_label: str | None = None
     window_id: str
     label: str | None = None
     points: list[LimitSeriesPoint] = Field(default_factory=list)

--- a/backend/src/waypoint/telemetry/facts.py
+++ b/backend/src/waypoint/telemetry/facts.py
@@ -1,0 +1,274 @@
+"""The backend-neutral telemetry fact contract.
+
+Every fact is derived from an already-normalized signal (an ``EventRecord``, a
+``SessionRecord`` field update, or a ``TokenUsageRecord``) and carries a stable,
+source-owned identity so ingestion is idempotent under retransmission/replay and
+a later revision replaces an earlier one. Generic code (ingest, store, aggregate,
+API) consumes these types and never branches on backend id; the only
+backend-specific work is at each agent's normalization boundary (model-at-turn on
+the token ledger; typed tool outcome).
+
+Field names are chosen to be OpenTelemetry-GenAI alignable where a stable
+attribute exists (FR-10), but this internal contract is authoritative and no
+third-party exporter is wired in the MVP.
+"""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+# ── Vocabularies ─────────────────────────────────────────────────────────────
+
+
+class TelemetryFactKind(StrEnum):
+    """The fact table a fact belongs to."""
+
+    SESSION_LIFECYCLE = "session_lifecycle"
+    TURN = "turn"
+    TOOL_CALL = "tool_call"
+    CONTEXT_SNAPSHOT = "context_snapshot"
+    LIMIT_SNAPSHOT = "limit_snapshot"
+
+
+class LifecycleTransition(StrEnum):
+    """An explicit session state transition that occurred at a point in time.
+
+    Lifecycle *counts* use these transitions, never merely the latest status
+    (Appendix: Session). A point-in-time "active" count is derived separately as
+    the set of sessions whose latest transition at the range end is one of
+    STARTING/RUNNING/IDLE/WAITING.
+    """
+
+    CREATED = "created"
+    STARTING = "starting"
+    RUNNING = "running"
+    IDLE = "idle"
+    WAITING = "waiting"
+    INTERRUPTED = "interrupted"
+    EXITED = "exited"
+    ERROR = "error"
+
+
+# The transitions that make a session "active" at a point in time (FR-3).
+ACTIVE_TRANSITIONS: frozenset[LifecycleTransition] = frozenset(
+    {
+        LifecycleTransition.STARTING,
+        LifecycleTransition.RUNNING,
+        LifecycleTransition.IDLE,
+        LifecycleTransition.WAITING,
+    }
+)
+
+
+class TurnKind(StrEnum):
+    USER = "user"  # a submitted user input (draft/non-submitted excluded)
+    AGENT = "agent"  # a backend-native turn/message with a stable identity
+
+
+class ToolOutcome(StrEnum):
+    """Terminal classification of a tool call.
+
+    ``UNKNOWN`` means the backend could not establish an outcome; it is never
+    shown as success and is excluded from failure-rate denominators (Appendix:
+    Tool-outcome coverage). Absent data must map to ``UNKNOWN``, not ``SUCCEEDED``.
+    """
+
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    TIMED_OUT = "timed_out"
+    UNKNOWN = "unknown"
+
+
+# The outcomes that count as terminally classified for coverage/failure-rate.
+TERMINAL_OUTCOMES: frozenset[ToolOutcome] = frozenset(
+    {
+        ToolOutcome.SUCCEEDED,
+        ToolOutcome.FAILED,
+        ToolOutcome.CANCELLED,
+        ToolOutcome.TIMED_OUT,
+    }
+)
+
+
+class ApprovalDecision(StrEnum):
+    REQUESTED = "requested"
+    APPROVED = "approved"
+    DECLINED = "declined"
+
+
+class FactSource(StrEnum):
+    """What produced a fact (part of its stable identity + provenance).
+
+    Backend-derived facts use the backend id as the source string; ``RUNTIME`` is
+    used for facts a generic runtime seam derives directly (e.g. session-created).
+    """
+
+    RUNTIME = "runtime"
+
+
+# ── Shared denormalized dimensions ───────────────────────────────────────────
+
+
+class FactDimensions(BaseModel):
+    """Session-level filter dimensions stamped onto every fact at ingest.
+
+    These are immutable-per-session (FR-1 filters that are session attributes),
+    so stamping them inline lets filtered range queries and daily rollups avoid a
+    join to ``sessions``. Tags are the one exception — they live in a normalized
+    ``telemetry_fact_tag`` side table because ``sessions.tags`` is a JSON blob
+    (see CONTRACT.md).
+    """
+
+    backend: str
+    # Basename only, never a full path (FR-9 excludes paths). ``None`` = no repo.
+    repo_name: str | None = None
+    source: str  # SessionSource value (managed/attached_tmux/assistant/…)
+    transport: str
+    spawner_session_id: str | None = None
+    is_child: bool = False
+
+
+# ── The fact envelope + typed facts ──────────────────────────────────────────
+
+_SCHEMA_VERSION: Literal[1] = 1
+
+
+class TelemetryFactBase(BaseModel):
+    """Common identity/provenance every fact carries.
+
+    ``fact_id`` is the stable, source-owned identity; the store's unique key is
+    ``(kind, source, fact_id)``. ``revision`` orders replacements: a fact replaces
+    the canonical value of a known ``(kind, source, fact_id)`` only when its
+    revision is strictly greater. A fact whose source cannot supply a stable id is
+    marked ``partial=True`` and excluded from totals that require deduplication.
+    """
+
+    fact_id: str
+    source: str
+    kind: TelemetryFactKind
+    revision: int = 0
+    partial: bool = False
+    session_id: str
+    occurred_at: datetime
+    schema_version: Literal[1] = _SCHEMA_VERSION
+    dims: FactDimensions
+
+
+class SessionLifecycleFact(TelemetryFactBase):
+    kind: Literal[TelemetryFactKind.SESSION_LIFECYCLE] = (
+        TelemetryFactKind.SESSION_LIFECYCLE
+    )
+    transition: LifecycleTransition
+
+
+class TurnFact(TelemetryFactBase):
+    kind: Literal[TelemetryFactKind.TURN] = TelemetryFactKind.TURN
+    turn_kind: TurnKind
+    # Concrete model at the observed turn (FR-4 "actual model at turn time").
+    # Exact for agent turns (from the token record); best-effort for user turns
+    # (session resolved_model as-of the event). ``None`` when unknown.
+    model_at_turn: str | None = None
+    effort_at_turn: str | None = None
+
+
+class ToolCallFact(TelemetryFactBase):
+    kind: Literal[TelemetryFactKind.TOOL_CALL] = TelemetryFactKind.TOOL_CALL
+    # Bare normalized tool name (``Read``/``Bash``) — never the invocation/args.
+    tool_name: str
+    tool_category: str | None = None
+    outcome: ToolOutcome = ToolOutcome.UNKNOWN
+    duration_ms: int | None = None
+    model_at_turn: str | None = None
+    # Present only for approval-bearing tool events; drives FR-5 approval counts.
+    approval_decision: ApprovalDecision | None = None
+
+
+class ContextSnapshotFact(TelemetryFactBase):
+    kind: Literal[TelemetryFactKind.CONTEXT_SNAPSHOT] = (
+        TelemetryFactKind.CONTEXT_SNAPSHOT
+    )
+    used_tokens: int
+    window_tokens: int | None = None
+    # 0–100; ``None`` when the window is unknown (unavailable, not zero).
+    occupancy_percent: float | None = None
+
+
+class LimitSnapshotFact(TelemetryFactBase):
+    """A provider rate-limit snapshot — account-scoped, NOT session-attributable.
+
+    ``session_id`` carries the session the snapshot was observed through (for
+    provenance) but limit aggregates group by ``(backend, account_key, window_id)``
+    and the dashboard hides the limit card when any session-scoping filter is
+    active (FR-1). ``account_key`` is the pseudonymous verified-account key.
+    """
+
+    kind: Literal[TelemetryFactKind.LIMIT_SNAPSHOT] = TelemetryFactKind.LIMIT_SNAPSHOT
+    account_key: str
+    window_id: str
+    window_label: str | None = None
+    used_percent: float
+    resets_at: datetime | None = None
+
+
+TelemetryFact = Annotated[
+    SessionLifecycleFact
+    | TurnFact
+    | ToolCallFact
+    | ContextSnapshotFact
+    | LimitSnapshotFact,
+    Field(discriminator="kind"),
+]
+
+
+# ── Query inputs (shared by every /api/telemetry endpoint) ───────────────────
+
+
+class TelemetryRange(BaseModel):
+    """A resolved query window.
+
+    Interpreted in the displayed Waypoint-host timezone with an inclusive
+    ``start`` and exclusive ``end`` instant (Appendix: Date range). ``tz`` is the
+    IANA name the host is configured with and is echoed back so the UI can show it.
+    """
+
+    start: datetime
+    end: datetime
+    tz: str
+
+
+class TelemetryFilter(BaseModel):
+    """The filter set every attributable summary/chart responds to (FR-1).
+
+    ``None``/empty means unconstrained on that dimension. ``parent_scope`` selects
+    top-level vs. child sessions; when filtering to a specific parent the
+    include/exclude-descendants choice rides ``include_descendants`` (FR-7).
+    """
+
+    backends: list[str] = Field(default_factory=list)
+    models: list[str] = Field(default_factory=list)
+    repos: list[str] = Field(default_factory=list)
+    tags: list[str] = Field(default_factory=list)
+    sources: list[str] = Field(default_factory=list)
+    transports: list[str] = Field(default_factory=list)
+    parent_scope: Literal["all", "top_level", "children"] = "all"
+    parent_session_id: str | None = None
+    include_descendants: bool = True
+
+    def has_session_scoping(self) -> bool:
+        """True when a non-time/non-backend filter is active.
+
+        The provider-limit card/chart is hidden in this case because limit data
+        is account-wide, not session-attributable (FR-1, FR-6).
+        """
+        return bool(
+            self.models
+            or self.repos
+            or self.tags
+            or self.sources
+            or self.transports
+            or self.parent_scope != "all"
+            or self.parent_session_id
+        )

--- a/backend/src/waypoint/telemetry/facts.py
+++ b/backend/src/waypoint/telemetry/facts.py
@@ -202,11 +202,15 @@ class LimitSnapshotFact(TelemetryFactBase):
     ``session_id`` carries the session the snapshot was observed through (for
     provenance) but limit aggregates group by ``(backend, account_key, window_id)``
     and the dashboard hides the limit card when any session-scoping filter is
-    active (FR-1). ``account_key`` is the pseudonymous verified-account key.
+    active (FR-1). ``account_key`` is a stable pseudonymous digest of the
+    resolved account identity (never a raw email/org, FR-9); ``account_label``
+    carries the human-readable name and is only ever surfaced by the API when
+    the ``telemetry_local_labels`` setting opts into local labels.
     """
 
     kind: Literal[TelemetryFactKind.LIMIT_SNAPSHOT] = TelemetryFactKind.LIMIT_SNAPSHOT
     account_key: str
+    account_label: str | None = None
     window_id: str
     window_label: str | None = None
     used_percent: float

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -13,6 +13,7 @@ alongside its own lifecycle, and invoking ``backfill()`` once at boot.
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -46,6 +47,7 @@ from waypoint.telemetry.facts import (
     TurnFact,
     TurnKind,
 )
+from waypoint.usage_dashboard import _PluginRegistry, resolve_account
 
 log = logging.getLogger("waypoint.telemetry.ingest")
 
@@ -121,18 +123,43 @@ def _epoch_ms(value: datetime) -> int:
     return int(aware.timestamp() * 1000)
 
 
+# Length of the pseudonymous digest suffix on a telemetry ``account_key``
+# (e.g. ``acct_1a2b3c4d``) — short enough to stay a label, long enough that
+# collisions across the handful of accounts one Waypoint instance sees are
+# not a practical concern.
+_ACCOUNT_KEY_DIGEST_LENGTH = 8
+
+
+def _pseudonymize_account_key(raw_account_key: str) -> str:
+    """A stable, non-reversible grouping key for a raw account identity (FR-9).
+
+    ``raw_account_key`` (e.g. ``codex:noppanat@u.nus.edu``, ``claude_code:lumid``)
+    must never reach the store or the API verbatim; only this digest does.
+    Stable across process restarts (plain SHA-256, no per-process salt) so the
+    same account always groups under the same ``account_key``.
+    """
+    digest = hashlib.sha256(raw_account_key.encode("utf-8")).hexdigest()
+    return f"acct_{digest[:_ACCOUNT_KEY_DIGEST_LENGTH]}"
+
+
 class TelemetryIngester:
     """Enqueue-and-drain seam between normalized signals and ``TelemetryStore``."""
 
     def __init__(
         self,
         storage: Storage,
+        registry: _PluginRegistry | None = None,
         *,
         batch_size: int = 200,
         drain_debounce_seconds: float = 1.0,
     ) -> None:
         self._storage = storage
         self._store = storage.telemetry
+        # Backend-plugin lookup for resolving a rate-limit snapshot's account
+        # when the session has no verified probe (``resolve_account``). Only
+        # ``None`` in tests that don't exercise that fallback; the runtime
+        # always supplies its real registry.
+        self._registry = registry
         self._batch_size = batch_size
         self._drain_debounce_seconds = drain_debounce_seconds
         self._queue: list[tuple[TelemetryFact, dict[str, str]]] = []
@@ -402,13 +429,26 @@ class TelemetryIngester:
 
         rate_limit_usage = updates.get("rate_limit_usage")
         if isinstance(rate_limit_usage, SessionRateLimitUsage):
-            # Provider limits are account-scoped (FR-6). Without a verified
-            # account the snapshot can't be attributed to an account, so skip
-            # it rather than mint a per-session pseudo-account that fragments
-            # the account-scoped limit view into one row per session.
-            account_key = session.verified_account_key
-            if not account_key:
+            # Provider limits are account-scoped (FR-6). Without a resolvable
+            # account the snapshot can't be attributed to one, so skip it
+            # rather than mint a per-session pseudo-account that fragments
+            # the account-scoped limit view into one row per session. Prefers
+            # the session's verified probe, falling back to the plugin's own
+            # ``rate_limit_account`` (e.g. CC/profile-less-Codex org/email
+            # notes) so sessions that never ran a verified-account probe
+            # still surface (root cause of the "only Codex shows" bug).
+            resolved = resolve_account(
+                rate_limit_usage,
+                registry=self._registry,
+                verified_account_key=session.verified_account_key,
+                verified_account_label=session.verified_account_label,
+            )
+            if resolved is None:
                 return
+            raw_account_key, account_label = resolved
+            # FR-9: only the pseudonymous digest is persisted as account_key;
+            # the raw identity never reaches the store or the API.
+            account_key = _pseudonymize_account_key(raw_account_key)
             for window in rate_limit_usage.windows:
                 self._enqueue(
                     LimitSnapshotFact(
@@ -421,6 +461,7 @@ class TelemetryIngester:
                         occurred_at=rate_limit_usage.updated_at,
                         dims=dims,
                         account_key=account_key,
+                        account_label=account_label,
                         window_id=window.id,
                         window_label=window.label,
                         used_percent=window.used_percent,

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -389,10 +389,13 @@ class TelemetryIngester:
 
         rate_limit_usage = updates.get("rate_limit_usage")
         if isinstance(rate_limit_usage, SessionRateLimitUsage):
-            # Account-scoped, not session-attributable (CONTRACT.md §1f
-            # docstring on LimitSnapshotFact) — falls back to a per-session
-            # pseudonym only when the account hasn't been verified yet.
-            account_key = session.verified_account_key or f"session:{session.id}"
+            # Provider limits are account-scoped (FR-6). Without a verified
+            # account the snapshot can't be attributed to an account, so skip
+            # it rather than mint a per-session pseudo-account that fragments
+            # the account-scoped limit view into one row per session.
+            account_key = session.verified_account_key
+            if not account_key:
+                return
             for window in rate_limit_usage.windows:
                 self._enqueue(
                     LimitSnapshotFact(

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -1,0 +1,512 @@
+"""Generic derivation from normalized signals into telemetry facts (CONTRACT.md §3).
+
+``TelemetryIngester`` consumes already-normalized ``EventRecord``s, session-field
+updates, and per-turn token-ledger records — it never branches on backend id.
+Each ``derive_from_*`` call is a fast, synchronous, error-swallowing enqueue
+(never raises into a turn); a runtime-owned background task drains the queue
+in small batches so a burst of events never holds the sqlite writer for long.
+
+The runtime (not this module) is responsible for constructing one
+``TelemetryIngester`` per process, calling the ``derive_from_*`` methods from
+its event/session-update/token-ledger seams, starting/stopping the drain task
+alongside its own lifecycle, and invoking ``backfill()`` once at boot.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from collections.abc import Mapping
+from contextlib import suppress
+from datetime import UTC, datetime
+from typing import Any
+
+from waypoint.schemas import (
+    EventKind,
+    EventRecord,
+    SessionContextUsage,
+    SessionRateLimitUsage,
+    SessionRecord,
+    SessionStatus,
+    TokenUsageRecord,
+)
+from waypoint.storage import Storage
+from waypoint.telemetry.facts import (
+    ApprovalDecision,
+    ContextSnapshotFact,
+    FactDimensions,
+    FactSource,
+    LifecycleTransition,
+    LimitSnapshotFact,
+    SessionLifecycleFact,
+    TelemetryFact,
+    ToolCallFact,
+    ToolOutcome,
+    TurnFact,
+    TurnKind,
+)
+
+log = logging.getLogger("waypoint.telemetry.ingest")
+
+_STATUS_TO_TRANSITION: dict[str, LifecycleTransition] = {
+    SessionStatus.STARTING: LifecycleTransition.STARTING,
+    SessionStatus.RUNNING: LifecycleTransition.RUNNING,
+    SessionStatus.IDLE: LifecycleTransition.IDLE,
+    SessionStatus.WAITING_INPUT: LifecycleTransition.WAITING,
+    SessionStatus.INTERRUPTED: LifecycleTransition.INTERRUPTED,
+    SessionStatus.EXITED: LifecycleTransition.EXITED,
+    SessionStatus.ERROR: LifecycleTransition.ERROR,
+}
+
+# The exact text ``SessionRuntime.approve()`` records via ``_record_system_event``
+# (a generic, backend-neutral runtime path, not a per-plugin one) — the only
+# place a decision on an ``APPROVAL_REQUEST`` currently surfaces at all.
+_APPROVAL_DECISION_PREFIX = "Approval response sent: "
+_APPROVE_WORDS = {"accept", "acceptforsession", "approve", "approved"}
+_DECLINE_WORDS = {"decline", "declined", "cancel", "cancelled", "deny", "denied"}
+
+# ``ContextSnapshotFact`` is rate-limited to one per session per minute bucket
+# (CONTRACT.md §3); this is the strftime pattern for that bucket.
+_MINUTE_BUCKET_FORMAT = "%Y%m%dT%H%M"
+
+
+def _dims_for_session(session: SessionRecord) -> FactDimensions:
+    repo_name = os.path.basename(session.repo_name) if session.repo_name else None
+    return FactDimensions(
+        backend=session.backend,
+        repo_name=repo_name or None,
+        source=session.source,
+        transport=session.transport,
+        spawner_session_id=session.spawner_session_id,
+        is_child=session.spawner_session_id is not None,
+    )
+
+
+def _tool_use_id(metadata: Mapping[str, Any]) -> str | None:
+    value = metadata.get("tool_use_id") or metadata.get("item_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _tool_name(metadata: Mapping[str, Any]) -> str | None:
+    value = metadata.get("tool_name")
+    return value if isinstance(value, str) and value else None
+
+
+def _approval_id(metadata: Mapping[str, Any]) -> str | None:
+    value = metadata.get("approval_id")
+    return value if isinstance(value, str) and value else None
+
+
+def _approval_decision_from_event(
+    event: EventRecord,
+) -> tuple[str, ApprovalDecision] | None:
+    approval_id = _approval_id(event.metadata)
+    if approval_id is None or not event.text.startswith(_APPROVAL_DECISION_PREFIX):
+        return None
+    word = event.text[len(_APPROVAL_DECISION_PREFIX) :].strip().lower()
+    if word in _APPROVE_WORDS:
+        return approval_id, ApprovalDecision.APPROVED
+    if word in _DECLINE_WORDS:
+        return approval_id, ApprovalDecision.DECLINED
+    return None
+
+
+def _epoch_ms(value: datetime) -> int:
+    aware = value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    return int(aware.timestamp() * 1000)
+
+
+class TelemetryIngester:
+    """Enqueue-and-drain seam between normalized signals and ``TelemetryStore``."""
+
+    def __init__(
+        self,
+        storage: Storage,
+        *,
+        batch_size: int = 200,
+        drain_debounce_seconds: float = 1.0,
+    ) -> None:
+        self._storage = storage
+        self._store = storage.telemetry
+        self._batch_size = batch_size
+        self._drain_debounce_seconds = drain_debounce_seconds
+        self._queue: list[tuple[TelemetryFact, dict[str, str]]] = []
+        self._wake = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        # Transient cross-event correlation, keyed by (session_id, id). Small
+        # and self-cleaning (each entry is popped once its counterpart event
+        # arrives); never persisted.
+        self._pending_tool_calls: dict[tuple[str, str], datetime] = {}
+        self._pending_approvals: dict[tuple[str, str], str | None] = {}
+
+    # ── enqueue (fast path; called inline from runtime signal points) ──────
+
+    def derive_from_session_created(self, session: SessionRecord) -> None:
+        try:
+            self._enqueue(
+                SessionLifecycleFact(
+                    fact_id=f"{session.id}:created",
+                    source=FactSource.RUNTIME,
+                    session_id=session.id,
+                    occurred_at=session.created_at,
+                    dims=_dims_for_session(session),
+                    transition=LifecycleTransition.CREATED,
+                ),
+                session.tags,
+            )
+        except Exception:
+            log.debug(
+                "telemetry derivation failed for session-created",
+                extra={"session_id": session.id},
+                exc_info=True,
+            )
+
+    def derive_from_event(self, session: SessionRecord, event: EventRecord) -> None:
+        try:
+            self._derive_from_event(session, event)
+        except Exception:
+            log.debug(
+                "telemetry derivation failed for event",
+                extra={"session_id": session.id, "kind": event.kind},
+                exc_info=True,
+            )
+
+    def derive_from_token_record(
+        self, session: SessionRecord, record: TokenUsageRecord
+    ) -> None:
+        try:
+            self._derive_from_token_record(session, record)
+        except Exception:
+            log.debug(
+                "telemetry derivation failed for token record",
+                extra={"session_id": session.id},
+                exc_info=True,
+            )
+
+    def derive_from_session_update(
+        self, session: SessionRecord, updates: Mapping[str, Any]
+    ) -> None:
+        try:
+            self._derive_from_session_update(session, updates)
+        except Exception:
+            log.debug(
+                "telemetry derivation failed for session update",
+                extra={"session_id": session.id, "fields": sorted(updates)},
+                exc_info=True,
+            )
+
+    # ── derivation ──────────────────────────────────────────────────────────
+
+    def _derive_from_event(self, session: SessionRecord, event: EventRecord) -> None:
+        dims = _dims_for_session(session)
+        tags = session.tags
+
+        # ``status`` may be a ``SessionStatus`` member or its plain string
+        # value (both hash/compare equal since ``SessionStatus`` is a
+        # ``StrEnum``, so one lookup handles either).
+        status = event.metadata.get("status")
+        transition = (
+            _STATUS_TO_TRANSITION.get(status) if isinstance(status, str) else None
+        )
+        if transition is not None:
+            self._enqueue(
+                SessionLifecycleFact(
+                    fact_id=f"{session.id}:{event.sequence}",
+                    source=FactSource.RUNTIME,
+                    session_id=session.id,
+                    occurred_at=event.ts,
+                    dims=dims,
+                    transition=transition,
+                ),
+                tags,
+            )
+
+        if event.kind == EventKind.USER_INPUT:
+            self._enqueue(
+                TurnFact(
+                    fact_id=f"{session.id}:{event.sequence}",
+                    source=session.backend,
+                    session_id=session.id,
+                    occurred_at=event.ts,
+                    dims=dims,
+                    turn_kind=TurnKind.USER,
+                    model_at_turn=session.resolved_model,
+                ),
+                tags,
+            )
+        elif event.kind == EventKind.TOOL_CALL:
+            tool_use_id = _tool_use_id(event.metadata)
+            if tool_use_id is not None:
+                self._pending_tool_calls[(session.id, tool_use_id)] = event.ts
+                self._enqueue(
+                    ToolCallFact(
+                        fact_id=tool_use_id,
+                        source=session.backend,
+                        session_id=session.id,
+                        occurred_at=event.ts,
+                        dims=dims,
+                        tool_name=_tool_name(event.metadata) or "unknown",
+                        outcome=ToolOutcome.UNKNOWN,
+                    ),
+                    tags,
+                )
+        elif event.kind == EventKind.TOOL_RESULT:
+            tool_use_id = _tool_use_id(event.metadata)
+            if tool_use_id is not None:
+                call_ts = self._pending_tool_calls.pop((session.id, tool_use_id), None)
+                duration_ms = (
+                    max(0, int((event.ts - call_ts).total_seconds() * 1000))
+                    if call_ts is not None
+                    else None
+                )
+                is_error = event.metadata.get("is_error")
+                outcome = ToolOutcome.UNKNOWN
+                if isinstance(is_error, bool):
+                    outcome = ToolOutcome.FAILED if is_error else ToolOutcome.SUCCEEDED
+                self._enqueue(
+                    ToolCallFact(
+                        fact_id=tool_use_id,
+                        source=session.backend,
+                        session_id=session.id,
+                        occurred_at=event.ts,
+                        revision=1,
+                        dims=dims,
+                        tool_name=_tool_name(event.metadata) or "unknown",
+                        outcome=outcome,
+                        duration_ms=duration_ms,
+                    ),
+                    tags,
+                )
+        elif event.kind == EventKind.APPROVAL_REQUEST:
+            approval_id = _approval_id(event.metadata)
+            if approval_id is not None:
+                tool_name = _tool_name(event.metadata)
+                self._pending_approvals[(session.id, approval_id)] = tool_name
+                self._enqueue(
+                    ToolCallFact(
+                        fact_id=approval_id,
+                        source=session.backend,
+                        session_id=session.id,
+                        occurred_at=event.ts,
+                        dims=dims,
+                        tool_name=tool_name or "unknown",
+                        outcome=ToolOutcome.UNKNOWN,
+                        approval_decision=ApprovalDecision.REQUESTED,
+                    ),
+                    tags,
+                )
+
+        decision = _approval_decision_from_event(event)
+        if decision is not None:
+            approval_id, mapped = decision
+            tool_name = self._pending_approvals.pop((session.id, approval_id), None)
+            self._enqueue(
+                ToolCallFact(
+                    fact_id=approval_id,
+                    source=session.backend,
+                    session_id=session.id,
+                    occurred_at=event.ts,
+                    revision=1,
+                    dims=dims,
+                    tool_name=tool_name or "unknown",
+                    outcome=ToolOutcome.UNKNOWN,
+                    approval_decision=mapped,
+                ),
+                tags,
+            )
+
+    def _derive_from_token_record(
+        self, session: SessionRecord, record: TokenUsageRecord
+    ) -> None:
+        if not record.record_id:
+            return
+        # Best-effort fallback when the plugin can't resolve a precise
+        # per-turn model: the session's last-known resolved model, never a
+        # guess (CONTRACT.md §3 backfill note; applies live too).
+        model_at_turn = record.model or session.resolved_model
+        self._enqueue(
+            TurnFact(
+                fact_id=record.record_id,
+                source=record.source,
+                session_id=session.id,
+                occurred_at=record.observed_at,
+                # A corrected record keeps the same identity but should still
+                # win over the earlier sighting, so the rollup (which joins
+                # back to the live ledger row) gets recomputed for it.
+                revision=_epoch_ms(record.observed_at),
+                dims=_dims_for_session(session),
+                turn_kind=TurnKind.AGENT,
+                model_at_turn=model_at_turn,
+                effort_at_turn=record.effort,
+            ),
+            session.tags,
+        )
+
+    def _derive_from_session_update(
+        self, session: SessionRecord, updates: Mapping[str, Any]
+    ) -> None:
+        dims = _dims_for_session(session)
+        tags = session.tags
+
+        context_usage = updates.get("context_usage")
+        if isinstance(context_usage, SessionContextUsage):
+            occupancy = None
+            if context_usage.context_window_tokens:
+                occupancy = (
+                    context_usage.used_tokens
+                    / context_usage.context_window_tokens
+                    * 100
+                )
+            bucket = context_usage.updated_at.strftime(_MINUTE_BUCKET_FORMAT)
+            self._enqueue(
+                ContextSnapshotFact(
+                    fact_id=f"{session.id}:{bucket}",
+                    source=context_usage.source,
+                    session_id=session.id,
+                    occurred_at=context_usage.updated_at,
+                    revision=_epoch_ms(context_usage.updated_at),
+                    dims=dims,
+                    used_tokens=context_usage.used_tokens,
+                    window_tokens=context_usage.context_window_tokens,
+                    occupancy_percent=occupancy,
+                ),
+                tags,
+            )
+
+        rate_limit_usage = updates.get("rate_limit_usage")
+        if isinstance(rate_limit_usage, SessionRateLimitUsage):
+            # Account-scoped, not session-attributable (CONTRACT.md §1f
+            # docstring on LimitSnapshotFact) — falls back to a per-session
+            # pseudonym only when the account hasn't been verified yet.
+            account_key = session.verified_account_key or f"session:{session.id}"
+            for window in rate_limit_usage.windows:
+                self._enqueue(
+                    LimitSnapshotFact(
+                        fact_id=(
+                            f"{account_key}:{window.id}:"
+                            f"{rate_limit_usage.updated_at.isoformat()}"
+                        ),
+                        source=rate_limit_usage.source,
+                        session_id=session.id,
+                        occurred_at=rate_limit_usage.updated_at,
+                        dims=dims,
+                        account_key=account_key,
+                        window_id=window.id,
+                        window_label=window.label,
+                        used_percent=window.used_percent,
+                        resets_at=window.resets_at,
+                    ),
+                    tags,
+                )
+
+    def _enqueue(self, fact: TelemetryFact, tags: Mapping[str, str]) -> None:
+        self._queue.append((fact, dict(tags)))
+        self._wake.set()
+
+    # ── drain (runtime-owned background task) ──────────────────────────────
+
+    async def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(
+                self._drain_loop(), name="telemetry-ingest-drain"
+            )
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        # Best-effort final flush so nothing enqueued right before shutdown
+        # is silently dropped.
+        self._drain_available()
+
+    async def _drain_loop(self) -> None:
+        while True:
+            await self._wake.wait()
+            await asyncio.sleep(self._drain_debounce_seconds)
+            self._wake.clear()
+            await self._drain_available_yielding()
+
+    async def _drain_available_yielding(self) -> None:
+        while self._queue:
+            batch, self._queue = (
+                self._queue[: self._batch_size],
+                self._queue[self._batch_size :],
+            )
+            self._ingest_batch(batch)
+            await asyncio.sleep(0)
+
+    def _drain_available(self) -> None:
+        while self._queue:
+            batch, self._queue = (
+                self._queue[: self._batch_size],
+                self._queue[self._batch_size :],
+            )
+            self._ingest_batch(batch)
+
+    def _ingest_batch(self, batch: list[tuple[TelemetryFact, dict[str, str]]]) -> None:
+        try:
+            self._store.ingest_facts(batch)
+        except Exception:
+            log.debug("telemetry drain batch failed", exc_info=True)
+
+    # ── backfill (one-shot, off the hot path) ───────────────────────────────
+
+    async def backfill(self) -> None:
+        """One guarded pass deriving facts from existing data, then a rollup rebuild.
+
+        Guarded by ``telemetry_meta['backfill_done']`` so it runs at most once
+        ever per database; safe to call unconditionally at boot.
+        """
+        if self._store.get_meta("backfill_done") == "true":
+            return
+        for session in self._storage.list_sessions():
+            self.derive_from_session_created(session)
+            for event in self._storage.list_events(session.id):
+                self.derive_from_event(session, event)
+            for record in self._ledger_records(session.id):
+                self.derive_from_token_record(session, record)
+            if session.context_usage is not None:
+                self.derive_from_session_update(
+                    session, {"context_usage": session.context_usage}
+                )
+            if session.rate_limit_usage is not None:
+                self.derive_from_session_update(
+                    session, {"rate_limit_usage": session.rate_limit_usage}
+                )
+            await self._drain_available_yielding()
+        self._store.rebuild_rollups_from_facts()
+        now = datetime.now(UTC).isoformat()
+        self._store.set_meta("backfill_through", now)
+        self._store.set_meta("backfill_done", "true")
+
+    def _ledger_records(self, session_id: str) -> list[TokenUsageRecord]:
+        rows = self._storage.connection.execute(
+            """
+            SELECT source, record_id, observed_at, usage_json
+            FROM session_token_usage_records
+            WHERE session_id = ? ORDER BY observed_at ASC
+            """,
+            (session_id,),
+        ).fetchall()
+        records: list[TokenUsageRecord] = []
+        for row in rows:
+            try:
+                usage = json.loads(row["usage_json"])
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(usage, dict):
+                continue
+            records.append(
+                TokenUsageRecord(
+                    record_id=row["record_id"],
+                    source=row["source"],
+                    observed_at=datetime.fromisoformat(row["observed_at"]),
+                    totals=usage.get("totals") or {},
+                    display_total_tokens=usage.get("display_total_tokens"),
+                    model=usage.get("model"),
+                    effort=usage.get("effort"),
+                )
+            )
+        return records

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -141,7 +141,9 @@ class TelemetryIngester:
         # Transient cross-event correlation, keyed by (session_id, id). Small
         # and self-cleaning (each entry is popped once its counterpart event
         # arrives); never persisted.
-        self._pending_tool_calls: dict[tuple[str, str], datetime] = {}
+        self._pending_tool_calls: dict[tuple[str, str], tuple[datetime, str | None]] = (
+            {}
+        )
         self._pending_approvals: dict[tuple[str, str], str | None] = {}
         # Nearly every event stamps ``metadata["status"]`` (STATUS_UPDATE is
         # never actually emitted; see the note below), so without this a
@@ -251,7 +253,11 @@ class TelemetryIngester:
         elif event.kind == EventKind.TOOL_CALL:
             tool_use_id = _tool_use_id(event.metadata)
             if tool_use_id is not None:
-                self._pending_tool_calls[(session.id, tool_use_id)] = event.ts
+                tool_name = _tool_name(event.metadata)
+                self._pending_tool_calls[(session.id, tool_use_id)] = (
+                    event.ts,
+                    tool_name,
+                )
                 self._enqueue(
                     ToolCallFact(
                         fact_id=tool_use_id,
@@ -259,7 +265,7 @@ class TelemetryIngester:
                         session_id=session.id,
                         occurred_at=event.ts,
                         dims=dims,
-                        tool_name=_tool_name(event.metadata) or "unknown",
+                        tool_name=tool_name or "unknown",
                         outcome=ToolOutcome.UNKNOWN,
                     ),
                     tags,
@@ -267,7 +273,8 @@ class TelemetryIngester:
         elif event.kind == EventKind.TOOL_RESULT:
             tool_use_id = _tool_use_id(event.metadata)
             if tool_use_id is not None:
-                call_ts = self._pending_tool_calls.pop((session.id, tool_use_id), None)
+                pending = self._pending_tool_calls.pop((session.id, tool_use_id), None)
+                call_ts, call_tool_name = pending if pending else (None, None)
                 duration_ms = (
                     max(0, int((event.ts - call_ts).total_seconds() * 1000))
                     if call_ts is not None
@@ -277,6 +284,10 @@ class TelemetryIngester:
                 outcome = ToolOutcome.UNKNOWN
                 if isinstance(is_error, bool):
                     outcome = ToolOutcome.FAILED if is_error else ToolOutcome.SUCCEEDED
+                # The tool_result event carries no tool_name (only the paired
+                # tool_call does), and this revision-1 fact overwrites the
+                # revision-0 one, so carry the name forward from the pending
+                # call — otherwise every resolved tool collapses to "unknown".
                 self._enqueue(
                     ToolCallFact(
                         fact_id=tool_use_id,
@@ -285,7 +296,9 @@ class TelemetryIngester:
                         occurred_at=event.ts,
                         revision=1,
                         dims=dims,
-                        tool_name=_tool_name(event.metadata) or "unknown",
+                        tool_name=_tool_name(event.metadata)
+                        or call_tool_name
+                        or "unknown",
                         outcome=outcome,
                         duration_ms=duration_ms,
                     ),

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -21,6 +21,7 @@ from contextlib import suppress
 from datetime import UTC, datetime
 from typing import Any
 
+from waypoint.backends.approvals import is_approve_decision
 from waypoint.schemas import (
     EventKind,
     EventRecord,
@@ -62,8 +63,6 @@ _STATUS_TO_TRANSITION: dict[str, LifecycleTransition] = {
 # (a generic, backend-neutral runtime path, not a per-plugin one) — the only
 # place a decision on an ``APPROVAL_REQUEST`` currently surfaces at all.
 _APPROVAL_DECISION_PREFIX = "Approval response sent: "
-_APPROVE_WORDS = {"accept", "acceptforsession", "approve", "approved"}
-_DECLINE_WORDS = {"decline", "declined", "cancel", "cancelled", "deny", "denied"}
 
 # ``ContextSnapshotFact`` is rate-limited to one per session per minute bucket
 # (CONTRACT.md §3); this is the strftime pattern for that bucket.
@@ -71,7 +70,9 @@ _MINUTE_BUCKET_FORMAT = "%Y%m%dT%H%M"
 
 
 def _dims_for_session(session: SessionRecord) -> FactDimensions:
-    repo_name = os.path.basename(session.repo_name) if session.repo_name else None
+    repo_name = (
+        os.path.basename(session.repo_name.rstrip("/")) if session.repo_name else None
+    )
     return FactDimensions(
         backend=session.backend,
         repo_name=repo_name or None,
@@ -103,12 +104,16 @@ def _approval_decision_from_event(
     approval_id = _approval_id(event.metadata)
     if approval_id is None or not event.text.startswith(_APPROVAL_DECISION_PREFIX):
         return None
-    word = event.text[len(_APPROVAL_DECISION_PREFIX) :].strip().lower()
-    if word in _APPROVE_WORDS:
-        return approval_id, ApprovalDecision.APPROVED
-    if word in _DECLINE_WORDS:
-        return approval_id, ApprovalDecision.DECLINED
-    return None
+    word = event.text[len(_APPROVAL_DECISION_PREFIX) :].strip()
+    # An unrecognized word is treated as a decline, never skipped — skipping
+    # would strand the fact at REQUESTED forever even though a decision was
+    # actually made.
+    decision = (
+        ApprovalDecision.APPROVED
+        if is_approve_decision(word)
+        else ApprovalDecision.DECLINED
+    )
+    return approval_id, decision
 
 
 def _epoch_ms(value: datetime) -> int:
@@ -138,6 +143,11 @@ class TelemetryIngester:
         # arrives); never persisted.
         self._pending_tool_calls: dict[tuple[str, str], datetime] = {}
         self._pending_approvals: dict[tuple[str, str], str | None] = {}
+        # Nearly every event stamps ``metadata["status"]`` (STATUS_UPDATE is
+        # never actually emitted; see the note below), so without this a
+        # single turn's worth of same-status events would each mint their own
+        # lifecycle fact. Only a genuine transition is worth recording.
+        self._last_transition: dict[str, LifecycleTransition] = {}
 
     # ── enqueue (fast path; called inline from runtime signal points) ──────
 
@@ -208,7 +218,11 @@ class TelemetryIngester:
         transition = (
             _STATUS_TO_TRANSITION.get(status) if isinstance(status, str) else None
         )
-        if transition is not None:
+        if (
+            transition is not None
+            and self._last_transition.get(session.id) != transition
+        ):
+            self._last_transition[session.id] = transition
             self._enqueue(
                 SessionLifecycleFact(
                     fact_id=f"{session.id}:{event.sequence}",

--- a/backend/src/waypoint/telemetry/insights.py
+++ b/backend/src/waypoint/telemetry/insights.py
@@ -1,0 +1,190 @@
+"""Deterministic PR1 insights (CONTRACT.md §4/§7, plan §2.5).
+
+Two rule types ship in PR1 — the ones that need no tool-outcome data:
+
+- **near-limit / context pressure**: fires when a live provider-limit or
+  context-window snapshot crosses ``settings.telemetry_context_thresholds``
+  (70/90/100). Emitted as two independently dismissible ``type`` values —
+  ``context_pressure`` for context occupancy, ``near_limit`` for provider
+  limits — sharing the same threshold set and severity mapping.
+- **token volume change**: fires only when the selected range's token volume
+  moves >=25% AND >=10k tokens vs. the immediately preceding equal-length
+  range, with >=10 tracked (meter-covered) agent turns and >=80% meter
+  coverage in *both* ranges. Below any gate -> no insight (silence, never a
+  hedged or low-confidence one).
+
+A dismissed ``(signature, range_key)`` is omitted from the response entirely,
+never merely marked read (CONTRACT.md §4).
+"""
+
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+from waypoint.telemetry.aggregate import (
+    agent_turn_rows,
+    alerting_context,
+    alerting_limits,
+    fold_tokens,
+    grand_total,
+    ledger_rows_for_sessions,
+    range_key,
+    severity_for_percent,
+)
+from waypoint.telemetry.api_models import Insight, InsightClickThrough
+from waypoint.telemetry.facts import TelemetryFilter, TelemetryRange
+
+_VOLUME_CHANGE_MIN_PERCENT = 25.0
+_VOLUME_CHANGE_MIN_TOKENS = 10_000
+_VOLUME_CHANGE_MIN_TRACKED_TURNS = 10
+_VOLUME_CHANGE_MIN_METER_COVERAGE_PERCENT = 80.0
+
+
+def compute_insights(
+    storage: Storage, settings: Settings, rng: TelemetryRange, flt: TelemetryFilter
+) -> list[Insight]:
+    candidates = [
+        insight
+        for insight in (
+            _context_pressure_insight(storage, settings, rng, flt),
+            _near_limit_insight(storage, settings, rng, flt),
+            _token_volume_change_insight(storage, rng, flt),
+        )
+        if insight is not None
+    ]
+    dismissed = storage.telemetry.dismissed_insights(range_key(rng))
+    return [insight for insight in candidates if insight.signature not in dismissed]
+
+
+def _context_pressure_insight(
+    storage: Storage, settings: Settings, rng: TelemetryRange, flt: TelemetryFilter
+) -> Insight | None:
+    alerts = alerting_context(storage, settings, flt)
+    if not alerts:
+        return None
+    thresholds = settings.telemetry_context_thresholds
+    worst = max(alerts, key=lambda a: a.percent or 0.0)
+    assert worst.percent is not None  # alerting_context only keeps non-None percents
+    severity = severity_for_percent(worst.percent, thresholds)
+    if severity is None:
+        return None
+    return Insight(
+        signature="context_pressure",
+        type="context_pressure",
+        statement=(
+            f"Context usage is at {worst.percent:.0f}% for {len(alerts)} session(s), "
+            f"including {worst.session_id} — at or above the {thresholds[0]}% threshold."
+        ),
+        metrics={
+            "sessions_above_threshold": len(alerts),
+            "worst_percent": worst.percent,
+            "worst_session_id": worst.session_id,
+            "thresholds": list(thresholds),
+        },
+        range=rng,
+        filters=flt,
+        click_through=InsightClickThrough(endpoint="/api/telemetry/health", params={}),
+        severity=severity,
+    )
+
+
+def _near_limit_insight(
+    storage: Storage, settings: Settings, rng: TelemetryRange, flt: TelemetryFilter
+) -> Insight | None:
+    alerts = alerting_limits(storage, settings, flt)
+    if not alerts:
+        return None
+    thresholds = settings.telemetry_context_thresholds
+    worst = max(alerts, key=lambda a: a.used_percent)
+    severity = severity_for_percent(worst.used_percent, thresholds)
+    if severity is None:
+        return None
+    label = worst.label or worst.window_id
+    return Insight(
+        signature="near_limit",
+        type="near_limit",
+        statement=(
+            f"{worst.backend} {label} usage is at {worst.used_percent:.0f}% "
+            f"— at or above the {thresholds[0]}% threshold."
+        ),
+        metrics={
+            "limits_above_threshold": len(alerts),
+            "worst_percent": worst.used_percent,
+            "worst_backend": worst.backend,
+            "worst_window_id": worst.window_id,
+            "thresholds": list(thresholds),
+        },
+        range=rng,
+        filters=flt,
+        click_through=InsightClickThrough(endpoint="/api/telemetry/health", params={}),
+        severity=severity,
+    )
+
+
+def _token_volume_change_insight(
+    storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
+) -> Insight | None:
+    duration = rng.end - rng.start
+    previous_rng = TelemetryRange(start=rng.start - duration, end=rng.start, tz=rng.tz)
+
+    current_rows = agent_turn_rows(storage, rng, flt)
+    previous_rows = agent_turn_rows(storage, previous_rng, flt)
+    ledger = ledger_rows_for_sessions(
+        storage,
+        {row["session_id"] for row in current_rows}
+        | {row["session_id"] for row in previous_rows},
+    )
+
+    cur_totals, cur_display, cur_tracked, cur_total = fold_tokens(current_rows, ledger)
+    prev_totals, prev_display, prev_tracked, prev_total = fold_tokens(
+        previous_rows, ledger
+    )
+
+    cur_coverage = (100.0 * cur_tracked / cur_total) if cur_total else 0.0
+    prev_coverage = (100.0 * prev_tracked / prev_total) if prev_total else 0.0
+    if (
+        cur_tracked < _VOLUME_CHANGE_MIN_TRACKED_TURNS
+        or prev_tracked < _VOLUME_CHANGE_MIN_TRACKED_TURNS
+        or cur_coverage < _VOLUME_CHANGE_MIN_METER_COVERAGE_PERCENT
+        or prev_coverage < _VOLUME_CHANGE_MIN_METER_COVERAGE_PERCENT
+    ):
+        return None
+
+    current_total = grand_total(cur_totals, cur_display)
+    previous_total = grand_total(prev_totals, prev_display)
+    diff = current_total - previous_total
+    if abs(diff) < _VOLUME_CHANGE_MIN_TOKENS:
+        return None
+
+    percent_change: float | None
+    if previous_total == 0:
+        # An unambiguous jump off a zero baseline — nothing to divide by, but
+        # the absolute-tokens gate above already guards against noise.
+        percent_change = None
+    else:
+        percent_change = 100.0 * diff / previous_total
+        if abs(percent_change) < _VOLUME_CHANGE_MIN_PERCENT:
+            return None
+
+    direction = "increased" if diff > 0 else "decreased"
+    percent_text = f"{abs(percent_change):.0f}%" if percent_change is not None else "∞%"
+    return Insight(
+        signature="token_volume_change",
+        type="token_volume_change",
+        statement=(
+            f"Token volume {direction} {percent_text} ({abs(diff):,} tokens) vs. the "
+            "immediately preceding equal-length range."
+        ),
+        metrics={
+            "current_total": current_total,
+            "previous_total": previous_total,
+            "diff": diff,
+            "percent_change": percent_change,
+            "current_tracked_turns": cur_tracked,
+            "previous_tracked_turns": prev_tracked,
+            "current_meter_coverage_percent": cur_coverage,
+            "previous_meter_coverage_percent": prev_coverage,
+        },
+        range=rng,
+        filters=flt,
+        click_through=InsightClickThrough(endpoint="/api/telemetry/tokens", params={}),
+        severity="info",
+    )

--- a/backend/src/waypoint/telemetry/query.py
+++ b/backend/src/waypoint/telemetry/query.py
@@ -1,0 +1,144 @@
+"""Shared range/filter parsing for every ``/api/telemetry/*`` endpoint.
+
+A single parser (``parse_range_filter``) reads the query params directly off
+the request instead of each endpoint redeclaring the same dozen ``Query()``
+parameters (CONTRACT.md §4). Day/range boundaries reuse the store's host-tz
+day helpers so a "today" or "7d" preset lines up exactly with the daily
+rollup buckets ``TelemetryStore`` maintains (both derive the calendar day the
+same way), rather than drifting apart under two independent tz calculations.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import HTTPException, Request, status
+
+from waypoint.settings import Settings
+from waypoint.telemetry.facts import TelemetryFilter, TelemetryRange
+from waypoint.telemetry.store import _day_bounds_utc, _day_key
+
+_VALID_PRESETS = ("today", "7d", "30d", "custom")
+_VALID_SCOPES = ("all", "top_level", "children")
+
+
+def host_tz_name() -> str:
+    """The abbreviated name of the process's local timezone (e.g. ``UTC``, ``ICT``).
+
+    Waypoint has no separate configured display timezone (CONTRACT.md §1c);
+    this mirrors the store's ``_day_key`` which resolves calendar days
+    against the same local system tz via naive ``astimezone()``.
+    """
+    return datetime.now().astimezone().tzname() or "UTC"
+
+
+def _parse_bool(raw: str | None, *, default: bool) -> bool:
+    if raw is None:
+        return default
+    return raw.strip().lower() not in ("", "0", "false", "no")
+
+
+def _parse_instant(raw: str, *, end_of_day: bool) -> datetime:
+    """Parse a query-param date/datetime into a UTC instant.
+
+    A bare ``YYYY-MM-DD`` date is interpreted as a host-tz calendar day
+    boundary (its start, or its exclusive end-of-day when ``end_of_day``),
+    matching the store's day-bucket alignment. A full ISO 8601 datetime is
+    used as-is (naive values are assumed UTC).
+    """
+    try:
+        if len(raw) == 10:
+            day = raw
+            start_iso, end_iso = _day_bounds_utc(day)
+            return datetime.fromisoformat(end_iso if end_of_day else start_iso)
+        value = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"invalid date/time: {raw!r}",
+        ) from exc
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _resolve_preset_range(preset: str, tz: str) -> TelemetryRange:
+    now = datetime.now(UTC)
+    today = _day_key(now)
+    _, end = _day_bounds_utc(today)
+    if preset == "today":
+        start, _ = _day_bounds_utc(today)
+    elif preset == "7d":
+        start_day = _day_key(now - timedelta(days=6))
+        start, _ = _day_bounds_utc(start_day)
+    elif preset == "30d":
+        start_day = _day_key(now - timedelta(days=29))
+        start, _ = _day_bounds_utc(start_day)
+    else:  # pragma: no cover - guarded by the caller
+        raise ValueError(preset)
+    return TelemetryRange(
+        start=datetime.fromisoformat(start), end=datetime.fromisoformat(end), tz=tz
+    )
+
+
+def parse_range_filter(
+    request: Request, settings: Settings
+) -> tuple[TelemetryRange, TelemetryFilter]:
+    """Resolve the effective ``(TelemetryRange, TelemetryFilter)`` for a request.
+
+    ``settings`` is accepted (per CONTRACT.md §4's ``parse_range_filter(request,
+    settings)`` signature) for a future host-tz setting; today the host has no
+    configured display timezone so range boundaries derive from the local
+    system tz regardless.
+    """
+    del settings
+    params = request.query_params
+    tz = host_tz_name()
+
+    preset = params.get("preset")
+    start_raw = params.get("start")
+    end_raw = params.get("end")
+
+    if preset is not None and preset not in _VALID_PRESETS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"unknown preset: {preset!r}",
+        )
+
+    if preset in ("today", "7d", "30d"):
+        rng = _resolve_preset_range(preset, tz)
+    elif preset == "custom" or start_raw is not None or end_raw is not None:
+        if start_raw is None or end_raw is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="a custom range requires both 'start' and 'end'",
+            )
+        start = _parse_instant(start_raw, end_of_day=False)
+        end = _parse_instant(end_raw, end_of_day=True)
+        if end <= start:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="'end' must be after 'start'",
+            )
+        rng = TelemetryRange(start=start, end=end, tz=tz)
+    else:
+        rng = _resolve_preset_range("7d", tz)
+
+    scope = params.get("scope", "all")
+    if scope not in _VALID_SCOPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=f"unknown scope: {scope!r}"
+        )
+
+    flt = TelemetryFilter.model_validate(
+        {
+            "backends": params.getlist("backend"),
+            "models": params.getlist("model"),
+            "repos": params.getlist("repo"),
+            "tags": params.getlist("tag"),
+            "sources": params.getlist("source"),
+            "transports": params.getlist("transport"),
+            "parent_scope": scope,
+            "parent_session_id": params.get("parent"),
+            "include_descendants": _parse_bool(params.get("descendants"), default=True),
+        }
+    )
+    return rng, flt

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -558,6 +558,7 @@ class TelemetryStore:
         limit: int | None = None,
         offset: int | None = None,
         partial: bool = False,
+        descending: bool = False,
     ) -> list[dict[str, Any]]:
         with self._lock:
             where, params = self._filter_clause(
@@ -565,10 +566,14 @@ class TelemetryStore:
             )
             # Stable tiebreak (source, fact_id) after occurred_at so paginated
             # drilldown results (LIMIT/OFFSET) never reorder or repeat a row
-            # across pages when several facts share the same instant.
+            # across pages when several facts share the same instant. Drill-down
+            # defaults to newest-first (``descending``) so the first page shows
+            # the most recent, most relevant facts rather than the oldest.
+            direction = "DESC" if descending else "ASC"
             sql = (
                 f"SELECT * FROM telemetry_facts WHERE {where} "
-                "ORDER BY occurred_at ASC, source ASC, fact_id ASC"
+                f"ORDER BY occurred_at {direction}, source {direction}, "
+                f"fact_id {direction}"
             )
             if limit is not None:
                 sql += " LIMIT ?"

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -555,8 +555,12 @@ class TelemetryStore:
             where, params = self._filter_clause(
                 rng, flt, extra_kind=kind, partial=partial
             )
+            # Stable tiebreak (source, fact_id) after occurred_at so paginated
+            # drilldown results (LIMIT/OFFSET) never reorder or repeat a row
+            # across pages when several facts share the same instant.
             sql = (
-                f"SELECT * FROM telemetry_facts WHERE {where} ORDER BY occurred_at ASC"
+                f"SELECT * FROM telemetry_facts WHERE {where} "
+                "ORDER BY occurred_at ASC, source ASC, fact_id ASC"
             )
             if limit is not None:
                 sql += " LIMIT ?"
@@ -582,6 +586,17 @@ class TelemetryStore:
     def query_rollup(
         self, rng: TelemetryRange, flt: TelemetryFilter
     ) -> list[dict[str, Any]]:
+        """Daily rollup rows matching ``rng``/``flt``.
+
+        The rollup key is ``(day, backend, model, repo, source, transport,
+        is_child)`` — it has no tag or parent-session dimension, so it cannot
+        represent a ``flt.tags`` or ``flt.parent_session_id`` filter. Callers
+        that need those must fall back to a fact scan instead of this method
+        (``aggregate.session_counts_totals`` does); a ``model=`` filter also
+        always zeroes lifecycle-derived counts here since lifecycle facts
+        carry no ``model_at_turn`` and so always land in the ``""`` model
+        bucket (lifecycle isn't model-attributable).
+        """
         with self._lock:
             end_day = _day_key(rng.end)
             # ``end`` is an exclusive instant; only exclude its calendar day when
@@ -638,6 +653,31 @@ class TelemetryStore:
             ).fetchall()
             return {row["signature"] for row in rows}
 
+    def _descendant_session_ids(self, root_id: str) -> set[str]:
+        """Every transitive descendant of ``root_id`` (excluding ``root_id`` itself).
+
+        Walks the ``spawner_session_id`` edges telemetry facts carry — mirrors
+        ``aggregate._descendant_session_ids``'s BFS, fed from facts instead of
+        live ``SessionRecord``s (a session with zero facts contributes nothing
+        to a facts query anyway, so this is sufficient here).
+        """
+        rows = self._conn.execute(
+            "SELECT DISTINCT session_id, spawner_session_id FROM telemetry_facts "
+            "WHERE spawner_session_id IS NOT NULL"
+        ).fetchall()
+        children: dict[str, list[str]] = {}
+        for row in rows:
+            children.setdefault(row["spawner_session_id"], []).append(row["session_id"])
+        found: set[str] = set()
+        queue = list(children.get(root_id, []))
+        while queue:
+            current = queue.pop()
+            if current in found:
+                continue
+            found.add(current)
+            queue.extend(children.get(current, []))
+        return found
+
     def _filter_clause(
         self,
         rng: TelemetryRange,
@@ -671,10 +711,16 @@ class TelemetryStore:
             clauses.append("is_child = 1")
         if flt.parent_session_id:
             if flt.include_descendants:
-                clauses.append("(spawner_session_id = ? OR session_id = ?)")
-                params.extend([flt.parent_session_id, flt.parent_session_id])
+                # The parent's own facts plus every transitive descendant's —
+                # a direct-children-only join would silently drop grandchildren.
+                descendant_ids = self._descendant_session_ids(flt.parent_session_id)
+                ids = [flt.parent_session_id, *sorted(descendant_ids)]
+                clauses.append(f"session_id IN ({', '.join('?' for _ in ids)})")
+                params.extend(ids)
             else:
-                clauses.append("spawner_session_id = ?")
+                # Excluding descendants means the parent's OWN facts only —
+                # not "only its children" (that would be backwards).
+                clauses.append("session_id = ?")
                 params.append(flt.parent_session_id)
         if flt.tags:
             tag_terms = [

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -1,0 +1,753 @@
+"""SQLite-backed storage for the telemetry fact contract (CONTRACT.md §1).
+
+Shares the single connection + lock ``Storage`` owns (WAL is single-writer;
+this module never opens a second connection). Every public method acquires
+the shared lock, mirroring ``Storage``'s ``_synchronized`` decorator.
+
+Rollup maintenance is implemented as recompute-on-write rather than a hand
+-rolled incremental delta: ``_recompute_rollup_key`` recomputes one rollup
+row from scratch from ``telemetry_facts`` (a query bounded to one
+day/backend/model/repo/source/transport/is_child key, cheap at personal-
+instance scale) and both ``ingest_fact`` and ``rebuild_rollups_from_facts``
+call it. This makes delta-update and full-rebuild the same code path by
+construction, instead of two independently-maintained implementations that
+could drift apart.
+"""
+
+import json
+import sqlite3
+import threading
+from collections.abc import Iterable
+from datetime import UTC, date, datetime, timedelta
+from typing import Any
+
+from waypoint.telemetry.facts import (
+    ContextSnapshotFact,
+    LimitSnapshotFact,
+    SessionLifecycleFact,
+    TelemetryFact,
+    TelemetryFactKind,
+    TelemetryFilter,
+    TelemetryRange,
+    ToolCallFact,
+    TurnFact,
+    TurnKind,
+)
+
+# Filter terms for ``TelemetryFilter.tags`` are ``key:value`` strings joined
+# against the ``telemetry_fact_tag`` side table.
+_TAG_FILTER_SEPARATOR = ":"
+
+
+def _iso_utc(value: datetime) -> str:
+    """Normalize to a UTC ISO8601 string so lexical and chronological order agree."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()
+
+
+def _day_key(occurred_at: datetime) -> str:
+    """The host-tz calendar day an instant falls on (CONTRACT.md §1c: "day in host tz").
+
+    Uses the process's local system timezone via naive ``astimezone()`` — this
+    deployment has no separate configured display timezone yet.
+    """
+    aware = (
+        occurred_at
+        if occurred_at.tzinfo is not None
+        else occurred_at.replace(tzinfo=UTC)
+    )
+    return aware.astimezone().date().isoformat()
+
+
+def _day_bounds_utc(day: str) -> tuple[str, str]:
+    """The [start, end) UTC instants spanning a host-tz calendar day."""
+    day_date = date.fromisoformat(day)
+    start_local = datetime.combine(day_date, datetime.min.time())
+    start_utc = start_local.astimezone(UTC)
+    end_utc = (start_local + timedelta(days=1)).astimezone(UTC)
+    return start_utc.isoformat(), end_utc.isoformat()
+
+
+def _parse_tag_term(term: str) -> tuple[str, str] | None:
+    """Parse a ``key:value`` filter term; ``None`` when it doesn't fit that shape."""
+    if _TAG_FILTER_SEPARATOR not in term:
+        return None
+    key, _, value = term.partition(_TAG_FILTER_SEPARATOR)
+    if not key:
+        return None
+    return key, value
+
+
+class TelemetryStore:
+    """Owns the ``telemetry_*`` tables on the shared ``Storage`` connection."""
+
+    def __init__(self, conn: sqlite3.Connection, lock: threading.RLock) -> None:
+        self._conn = conn
+        self._lock = lock
+
+    def init_schema(self) -> None:
+        with self._lock:
+            self._conn.executescript("""
+                CREATE TABLE IF NOT EXISTS telemetry_facts (
+                  kind            TEXT NOT NULL,
+                  source          TEXT NOT NULL,
+                  fact_id         TEXT NOT NULL,
+                  revision        INTEGER NOT NULL DEFAULT 0,
+                  partial         INTEGER NOT NULL DEFAULT 0,
+                  session_id      TEXT NOT NULL,
+                  occurred_at     TEXT NOT NULL,
+                  recorded_at     TEXT NOT NULL,
+                  schema_version  INTEGER NOT NULL DEFAULT 1,
+                  backend         TEXT NOT NULL,
+                  repo_name       TEXT,
+                  src_source      TEXT NOT NULL,
+                  transport       TEXT NOT NULL,
+                  spawner_session_id TEXT,
+                  is_child        INTEGER NOT NULL DEFAULT 0,
+                  transition      TEXT,
+                  turn_kind       TEXT,
+                  model_at_turn   TEXT,
+                  effort_at_turn  TEXT,
+                  tool_name       TEXT,
+                  tool_category   TEXT,
+                  outcome         TEXT,
+                  duration_ms     INTEGER,
+                  approval_decision TEXT,
+                  used_tokens     INTEGER,
+                  window_tokens   INTEGER,
+                  occupancy_percent REAL,
+                  account_key     TEXT,
+                  window_id       TEXT,
+                  window_label    TEXT,
+                  used_percent    REAL,
+                  resets_at       TEXT,
+                  PRIMARY KEY (kind, source, fact_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_tf_kind_time      ON telemetry_facts(kind, occurred_at);
+                CREATE INDEX IF NOT EXISTS idx_tf_kind_backend_time ON telemetry_facts(kind, backend, occurred_at);
+                CREATE INDEX IF NOT EXISTS idx_tf_session        ON telemetry_facts(session_id);
+                CREATE INDEX IF NOT EXISTS idx_tf_time           ON telemetry_facts(occurred_at);
+
+                CREATE TABLE IF NOT EXISTS telemetry_fact_tag (
+                  kind TEXT NOT NULL, source TEXT NOT NULL, fact_id TEXT NOT NULL,
+                  key TEXT NOT NULL, value TEXT NOT NULL,
+                  PRIMARY KEY (kind, source, fact_id, key)
+                );
+                CREATE INDEX IF NOT EXISTS idx_tft_kv ON telemetry_fact_tag(key, value);
+
+                CREATE TABLE IF NOT EXISTS telemetry_daily_rollup (
+                  day TEXT NOT NULL,
+                  backend TEXT NOT NULL, model TEXT NOT NULL DEFAULT '',
+                  repo_name TEXT NOT NULL DEFAULT '', src_source TEXT NOT NULL DEFAULT '',
+                  transport TEXT NOT NULL DEFAULT '', is_child INTEGER NOT NULL DEFAULT 0,
+                  metrics_json TEXT NOT NULL,
+                  PRIMARY KEY (day, backend, model, repo_name, src_source, transport, is_child)
+                );
+
+                CREATE TABLE IF NOT EXISTS telemetry_insight_dismissal (
+                  signature TEXT NOT NULL, range_key TEXT NOT NULL, dismissed_at TEXT NOT NULL,
+                  PRIMARY KEY (signature, range_key)
+                );
+                CREATE TABLE IF NOT EXISTS telemetry_meta (k TEXT PRIMARY KEY, v TEXT NOT NULL);
+
+                -- Internal bookkeeping (not part of the frozen contract's public
+                -- tables): dedupes which sessions contributed to a rollup key so
+                -- ``active_denom`` is an exact distinct count rather than an
+                -- estimate, and survives partial recomputation.
+                CREATE TABLE IF NOT EXISTS telemetry_rollup_session (
+                  day TEXT NOT NULL, backend TEXT NOT NULL, model TEXT NOT NULL,
+                  repo_name TEXT NOT NULL, src_source TEXT NOT NULL,
+                  transport TEXT NOT NULL, is_child INTEGER NOT NULL,
+                  session_id TEXT NOT NULL,
+                  PRIMARY KEY (day, backend, model, repo_name, src_source, transport, is_child, session_id)
+                );
+                """)
+            self._conn.commit()
+
+    # ── ingest ────────────────────────────────────────────────────────────
+
+    def ingest_fact(
+        self, fact: TelemetryFact, *, tags: dict[str, str] | None = None
+    ) -> bool:
+        with self._lock:
+            wrote = self._ingest_fact_locked(fact, tags or {})
+            self._conn.commit()
+            return wrote
+
+    def ingest_facts(
+        self, facts: Iterable[tuple[TelemetryFact, dict[str, str]]]
+    ) -> int:
+        with self._lock:
+            written = sum(
+                1 for fact, tags in facts if self._ingest_fact_locked(fact, tags)
+            )
+            self._conn.commit()
+            return written
+
+    def _ingest_fact_locked(self, fact: TelemetryFact, tags: dict[str, str]) -> bool:
+        existing = self._conn.execute(
+            """
+            SELECT revision, occurred_at, backend, model_at_turn, repo_name,
+                   src_source, transport, is_child
+            FROM telemetry_facts WHERE kind = ? AND source = ? AND fact_id = ?
+            """,
+            (fact.kind, fact.source, fact.fact_id),
+        ).fetchone()
+        if existing is not None and existing["revision"] > fact.revision:
+            return False
+        if existing is not None and existing["revision"] == fact.revision:
+            return False
+
+        row = _row_from_fact(fact)
+        columns = list(row)
+        placeholders = ", ".join("?" for _ in columns)
+        assignments = ", ".join(
+            f"{c} = excluded.{c}"
+            for c in columns
+            if c not in ("kind", "source", "fact_id")
+        )
+        self._conn.execute(
+            f"""
+            INSERT INTO telemetry_facts ({", ".join(columns)})
+            VALUES ({placeholders})
+            ON CONFLICT(kind, source, fact_id) DO UPDATE SET {assignments}
+            """,
+            [row[c] for c in columns],
+        )
+
+        self._conn.execute(
+            "DELETE FROM telemetry_fact_tag WHERE kind = ? AND source = ? AND fact_id = ?",
+            (fact.kind, fact.source, fact.fact_id),
+        )
+        for key, value in tags.items():
+            self._conn.execute(
+                """
+                INSERT INTO telemetry_fact_tag (kind, source, fact_id, key, value)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (fact.kind, fact.source, fact.fact_id, key, value),
+            )
+
+        keys_to_recompute: set[tuple[str, str, str, str, str, str, int]] = set()
+        if existing is not None:
+            keys_to_recompute.add(
+                (
+                    _day_key(datetime.fromisoformat(existing["occurred_at"])),
+                    existing["backend"],
+                    existing["model_at_turn"] or "",
+                    existing["repo_name"] or "",
+                    existing["src_source"],
+                    existing["transport"],
+                    int(existing["is_child"]),
+                )
+            )
+        keys_to_recompute.add(
+            (
+                _day_key(fact.occurred_at),
+                fact.dims.backend,
+                row["model_at_turn"] or "",
+                fact.dims.repo_name or "",
+                fact.dims.source,
+                fact.dims.transport,
+                int(fact.dims.is_child),
+            )
+        )
+        for rollup_key in keys_to_recompute:
+            self._recompute_rollup_key(*rollup_key)
+        return True
+
+    # ── maintenance ───────────────────────────────────────────────────────
+
+    def prune(
+        self, *, facts_before: datetime, rollups_before: datetime
+    ) -> dict[str, int]:
+        with self._lock:
+            facts_cutoff = _iso_utc(facts_before)
+            fact_ids = self._conn.execute(
+                "SELECT kind, source, fact_id FROM telemetry_facts WHERE occurred_at < ?",
+                (facts_cutoff,),
+            ).fetchall()
+            for row in fact_ids:
+                self._conn.execute(
+                    "DELETE FROM telemetry_fact_tag WHERE kind = ? AND source = ? AND fact_id = ?",
+                    (row["kind"], row["source"], row["fact_id"]),
+                )
+            cursor = self._conn.execute(
+                "DELETE FROM telemetry_facts WHERE occurred_at < ?", (facts_cutoff,)
+            )
+            facts_removed = cursor.rowcount or 0
+
+            rollups_cutoff = _day_key(rollups_before)
+            cursor = self._conn.execute(
+                "DELETE FROM telemetry_daily_rollup WHERE day < ?", (rollups_cutoff,)
+            )
+            rollups_removed = cursor.rowcount or 0
+            self._conn.execute(
+                "DELETE FROM telemetry_rollup_session WHERE day < ?", (rollups_cutoff,)
+            )
+            self._conn.commit()
+            return {"facts": facts_removed, "rollups": rollups_removed}
+
+    def rebuild_rollups_from_facts(self) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM telemetry_daily_rollup")
+            self._conn.execute("DELETE FROM telemetry_rollup_session")
+            rows = self._conn.execute("""
+                SELECT DISTINCT backend, COALESCE(model_at_turn, '') AS model,
+                       COALESCE(repo_name, '') AS repo_name, src_source, transport, is_child,
+                       occurred_at
+                FROM telemetry_facts WHERE partial = 0
+                """).fetchall()
+            keys = {
+                (
+                    _day_key(datetime.fromisoformat(row["occurred_at"])),
+                    row["backend"],
+                    row["model"],
+                    row["repo_name"],
+                    row["src_source"],
+                    row["transport"],
+                    int(row["is_child"]),
+                )
+                for row in rows
+            }
+            for key in keys:
+                self._recompute_rollup_key(*key)
+            self._conn.commit()
+
+    def delete_session(self, session_id: str) -> None:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT kind, source, fact_id, occurred_at, backend,
+                       COALESCE(model_at_turn, '') AS model, COALESCE(repo_name, '') AS repo_name,
+                       src_source, transport, is_child
+                FROM telemetry_facts WHERE session_id = ?
+                """,
+                (session_id,),
+            ).fetchall()
+            affected_keys = {
+                (
+                    _day_key(datetime.fromisoformat(row["occurred_at"])),
+                    row["backend"],
+                    row["model"],
+                    row["repo_name"],
+                    row["src_source"],
+                    row["transport"],
+                    int(row["is_child"]),
+                )
+                for row in rows
+            }
+            for row in rows:
+                self._conn.execute(
+                    "DELETE FROM telemetry_fact_tag WHERE kind = ? AND source = ? AND fact_id = ?",
+                    (row["kind"], row["source"], row["fact_id"]),
+                )
+            self._conn.execute(
+                "DELETE FROM telemetry_facts WHERE session_id = ?", (session_id,)
+            )
+            for key in affected_keys:
+                self._recompute_rollup_key(*key)
+            self._conn.commit()
+
+    def get_meta(self, key: str) -> str | None:
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT v FROM telemetry_meta WHERE k = ?", (key,)
+            ).fetchone()
+            return row["v"] if row is not None else None
+
+    def set_meta(self, key: str, value: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO telemetry_meta (k, v) VALUES (?, ?)
+                ON CONFLICT(k) DO UPDATE SET v = excluded.v
+                """,
+                (key, value),
+            )
+            self._conn.commit()
+
+    # ── rollup recompute ──────────────────────────────────────────────────
+
+    def _recompute_rollup_key(
+        self,
+        day: str,
+        backend: str,
+        model: str,
+        repo_name: str,
+        src_source: str,
+        transport: str,
+        is_child: int,
+    ) -> None:
+        start_utc, end_utc = _day_bounds_utc(day)
+        rows = self._conn.execute(
+            """
+            SELECT kind, turn_kind, transition, tool_name, outcome, session_id, source, fact_id
+            FROM telemetry_facts
+            WHERE backend = ? AND COALESCE(model_at_turn, '') = ? AND COALESCE(repo_name, '') = ?
+              AND src_source = ? AND transport = ? AND is_child = ? AND partial = 0
+              AND occurred_at >= ? AND occurred_at < ?
+            """,
+            (
+                backend,
+                model,
+                repo_name,
+                src_source,
+                transport,
+                is_child,
+                start_utc,
+                end_utc,
+            ),
+        ).fetchall()
+
+        self._conn.execute(
+            """
+            DELETE FROM telemetry_rollup_session
+            WHERE day = ? AND backend = ? AND model = ? AND repo_name = ?
+              AND src_source = ? AND transport = ? AND is_child = ?
+            """,
+            (day, backend, model, repo_name, src_source, transport, is_child),
+        )
+        if not rows:
+            self._conn.execute(
+                """
+                DELETE FROM telemetry_daily_rollup
+                WHERE day = ? AND backend = ? AND model = ? AND repo_name = ?
+                  AND src_source = ? AND transport = ? AND is_child = ?
+                """,
+                (day, backend, model, repo_name, src_source, transport, is_child),
+            )
+            return
+
+        turns_user = 0
+        turns_agent = 0
+        tool_calls = 0
+        tool_outcomes: dict[str, int] = {}
+        lifecycle: dict[str, int] = {}
+        tokens: dict[str, int] = {}
+        display_totals: list[int | None] = []
+        session_ids: set[str] = set()
+
+        for row in rows:
+            session_ids.add(row["session_id"])
+            kind = row["kind"]
+            if kind == TelemetryFactKind.SESSION_LIFECYCLE:
+                lifecycle[row["transition"]] = lifecycle.get(row["transition"], 0) + 1
+            elif kind == TelemetryFactKind.TURN:
+                if row["turn_kind"] == TurnKind.USER:
+                    turns_user += 1
+                elif row["turn_kind"] == TurnKind.AGENT:
+                    turns_agent += 1
+                    ledger = self._agent_turn_tokens(
+                        row["session_id"], row["source"], row["fact_id"]
+                    )
+                    if ledger is None:
+                        display_totals.append(None)
+                    else:
+                        totals, display_total = ledger
+                        for category, amount in totals.items():
+                            tokens[category] = tokens.get(category, 0) + amount
+                        display_totals.append(display_total)
+            elif kind == TelemetryFactKind.TOOL_CALL:
+                tool_calls += 1
+                tool_outcomes[row["outcome"]] = tool_outcomes.get(row["outcome"], 0) + 1
+
+        for session_id in session_ids:
+            self._conn.execute(
+                """
+                INSERT OR IGNORE INTO telemetry_rollup_session
+                    (day, backend, model, repo_name, src_source, transport, is_child, session_id)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    day,
+                    backend,
+                    model,
+                    repo_name,
+                    src_source,
+                    transport,
+                    is_child,
+                    session_id,
+                ),
+            )
+
+        display_total = (
+            sum(d for d in display_totals if d is not None)
+            if display_totals and all(d is not None for d in display_totals)
+            else None
+        )
+        metrics = {
+            "tokens": tokens,
+            "display_total": display_total,
+            "turns_user": turns_user,
+            "turns_agent": turns_agent,
+            "tool_calls": tool_calls,
+            "tool_outcomes": tool_outcomes,
+            "lifecycle": lifecycle,
+            "active_denom": len(session_ids),
+        }
+        self._conn.execute(
+            """
+            INSERT INTO telemetry_daily_rollup
+                (day, backend, model, repo_name, src_source, transport, is_child, metrics_json)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(day, backend, model, repo_name, src_source, transport, is_child)
+            DO UPDATE SET metrics_json = excluded.metrics_json
+            """,
+            (
+                day,
+                backend,
+                model,
+                repo_name,
+                src_source,
+                transport,
+                is_child,
+                json.dumps(metrics),
+            ),
+        )
+
+    def _agent_turn_tokens(
+        self, session_id: str, source: str, fact_id: str
+    ) -> tuple[dict[str, int], int | None] | None:
+        """Look up the per-turn token ledger row an AGENT ``TurnFact`` derives from.
+
+        The ledger (``session_token_usage_records``) is the source of truth for
+        token amounts (plan §2.1: "reuse the existing ledger... do not
+        duplicate it"); facts carry no token columns of their own, so the
+        rollup's token bucket joins back to it by the shared ``record_id``.
+        """
+        row = self._conn.execute(
+            """
+            SELECT usage_json FROM session_token_usage_records
+            WHERE session_id = ? AND source = ? AND record_id = ?
+            """,
+            (session_id, source, fact_id),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            usage = json.loads(row["usage_json"])
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(usage, dict):
+            return None
+        raw_totals = usage.get("totals") or {}
+        totals = {
+            str(k): int(v) for k, v in raw_totals.items() if isinstance(v, int | float)
+        }
+        display_total = usage.get("display_total_tokens")
+        return totals, display_total if isinstance(display_total, int) else None
+
+    # ── queries ───────────────────────────────────────────────────────────
+
+    def query_facts(
+        self,
+        kind: TelemetryFactKind,
+        rng: TelemetryRange,
+        flt: TelemetryFilter,
+        *,
+        limit: int | None = None,
+        offset: int | None = None,
+        partial: bool = False,
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            where, params = self._filter_clause(
+                rng, flt, extra_kind=kind, partial=partial
+            )
+            sql = (
+                f"SELECT * FROM telemetry_facts WHERE {where} ORDER BY occurred_at ASC"
+            )
+            if limit is not None:
+                sql += " LIMIT ?"
+                params.append(limit)
+                if offset is not None:
+                    sql += " OFFSET ?"
+                    params.append(offset)
+            rows = self._conn.execute(sql, params).fetchall()
+            return [dict(row) for row in rows]
+
+    def count_facts(
+        self, kind: TelemetryFactKind, rng: TelemetryRange, flt: TelemetryFilter
+    ) -> int:
+        with self._lock:
+            where, params = self._filter_clause(
+                rng, flt, extra_kind=kind, partial=False
+            )
+            row = self._conn.execute(
+                f"SELECT COUNT(*) AS n FROM telemetry_facts WHERE {where}", params
+            ).fetchone()
+            return int(row["n"])
+
+    def query_rollup(
+        self, rng: TelemetryRange, flt: TelemetryFilter
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            end_day = _day_key(rng.end)
+            # ``end`` is an exclusive instant; only exclude its calendar day when
+            # it falls exactly on that day's local midnight (nothing from it is
+            # in range), otherwise the day is partially covered and stays in.
+            end_is_boundary = _day_bounds_utc(end_day)[0] == _iso_utc(rng.end)
+            clauses = ["day >= ?", "day < ?" if end_is_boundary else "day <= ?"]
+            params: list[Any] = [_day_key(rng.start), end_day]
+            if flt.backends:
+                clauses.append(f"backend IN ({', '.join('?' for _ in flt.backends)})")
+                params.extend(flt.backends)
+            if flt.models:
+                clauses.append(f"model IN ({', '.join('?' for _ in flt.models)})")
+                params.extend(flt.models)
+            if flt.repos:
+                clauses.append(f"repo_name IN ({', '.join('?' for _ in flt.repos)})")
+                params.extend(flt.repos)
+            if flt.sources:
+                clauses.append(f"src_source IN ({', '.join('?' for _ in flt.sources)})")
+                params.extend(flt.sources)
+            if flt.transports:
+                clauses.append(
+                    f"transport IN ({', '.join('?' for _ in flt.transports)})"
+                )
+                params.extend(flt.transports)
+            if flt.parent_scope == "top_level":
+                clauses.append("is_child = 0")
+            elif flt.parent_scope == "children":
+                clauses.append("is_child = 1")
+            where = " AND ".join(clauses)
+            rows = self._conn.execute(
+                f"SELECT * FROM telemetry_daily_rollup WHERE {where} ORDER BY day ASC",
+                params,
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    def dismiss_insight(self, signature: str, range_key: str) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO telemetry_insight_dismissal (signature, range_key, dismissed_at)
+                VALUES (?, ?, ?)
+                ON CONFLICT(signature, range_key) DO UPDATE SET dismissed_at = excluded.dismissed_at
+                """,
+                (signature, range_key, _iso_utc(datetime.now(UTC))),
+            )
+            self._conn.commit()
+
+    def dismissed_insights(self, range_key: str) -> set[str]:
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT signature FROM telemetry_insight_dismissal WHERE range_key = ?",
+                (range_key,),
+            ).fetchall()
+            return {row["signature"] for row in rows}
+
+    def _filter_clause(
+        self,
+        rng: TelemetryRange,
+        flt: TelemetryFilter,
+        *,
+        extra_kind: TelemetryFactKind,
+        partial: bool,
+    ) -> tuple[str, list[Any]]:
+        clauses = ["kind = ?", "occurred_at >= ?", "occurred_at < ?"]
+        params: list[Any] = [extra_kind, _iso_utc(rng.start), _iso_utc(rng.end)]
+        if not partial:
+            clauses.append("partial = 0")
+        if flt.backends:
+            clauses.append(f"backend IN ({', '.join('?' for _ in flt.backends)})")
+            params.extend(flt.backends)
+        if flt.models:
+            clauses.append(f"model_at_turn IN ({', '.join('?' for _ in flt.models)})")
+            params.extend(flt.models)
+        if flt.repos:
+            clauses.append(f"repo_name IN ({', '.join('?' for _ in flt.repos)})")
+            params.extend(flt.repos)
+        if flt.sources:
+            clauses.append(f"src_source IN ({', '.join('?' for _ in flt.sources)})")
+            params.extend(flt.sources)
+        if flt.transports:
+            clauses.append(f"transport IN ({', '.join('?' for _ in flt.transports)})")
+            params.extend(flt.transports)
+        if flt.parent_scope == "top_level":
+            clauses.append("is_child = 0")
+        elif flt.parent_scope == "children":
+            clauses.append("is_child = 1")
+        if flt.parent_session_id:
+            if flt.include_descendants:
+                clauses.append("(spawner_session_id = ? OR session_id = ?)")
+                params.extend([flt.parent_session_id, flt.parent_session_id])
+            else:
+                clauses.append("spawner_session_id = ?")
+                params.append(flt.parent_session_id)
+        if flt.tags:
+            tag_terms = [
+                term for term in (_parse_tag_term(t) for t in flt.tags) if term
+            ]
+            for key, value in tag_terms:
+                clauses.append("""
+                    (kind, source, fact_id) IN (
+                        SELECT kind, source, fact_id FROM telemetry_fact_tag
+                        WHERE key = ? AND value = ?
+                    )
+                    """)
+                params.extend([key, value])
+        return " AND ".join(clauses), params
+
+
+def _row_from_fact(fact: TelemetryFact) -> dict[str, Any]:
+    """Project a typed ``TelemetryFact`` onto the flat ``telemetry_facts`` row."""
+    row: dict[str, Any] = {
+        "kind": fact.kind,
+        "source": fact.source,
+        "fact_id": fact.fact_id,
+        "revision": fact.revision,
+        "partial": int(fact.partial),
+        "session_id": fact.session_id,
+        "occurred_at": _iso_utc(fact.occurred_at),
+        "recorded_at": _iso_utc(datetime.now(UTC)),
+        "schema_version": fact.schema_version,
+        "backend": fact.dims.backend,
+        "repo_name": fact.dims.repo_name,
+        "src_source": fact.dims.source,
+        "transport": fact.dims.transport,
+        "spawner_session_id": fact.dims.spawner_session_id,
+        "is_child": int(fact.dims.is_child),
+        "transition": None,
+        "turn_kind": None,
+        "model_at_turn": None,
+        "effort_at_turn": None,
+        "tool_name": None,
+        "tool_category": None,
+        "outcome": None,
+        "duration_ms": None,
+        "approval_decision": None,
+        "used_tokens": None,
+        "window_tokens": None,
+        "occupancy_percent": None,
+        "account_key": None,
+        "window_id": None,
+        "window_label": None,
+        "used_percent": None,
+        "resets_at": None,
+    }
+    if isinstance(fact, SessionLifecycleFact):
+        row["transition"] = fact.transition
+    elif isinstance(fact, TurnFact):
+        row["turn_kind"] = fact.turn_kind
+        row["model_at_turn"] = fact.model_at_turn
+        row["effort_at_turn"] = fact.effort_at_turn
+    elif isinstance(fact, ToolCallFact):
+        row["tool_name"] = fact.tool_name
+        row["tool_category"] = fact.tool_category
+        row["outcome"] = fact.outcome
+        row["duration_ms"] = fact.duration_ms
+        row["model_at_turn"] = fact.model_at_turn
+        row["approval_decision"] = fact.approval_decision
+    elif isinstance(fact, ContextSnapshotFact):
+        row["used_tokens"] = fact.used_tokens
+        row["window_tokens"] = fact.window_tokens
+        row["occupancy_percent"] = fact.occupancy_percent
+    elif isinstance(fact, LimitSnapshotFact):
+        row["account_key"] = fact.account_key
+        row["window_id"] = fact.window_id
+        row["window_label"] = fact.window_label
+        row["used_percent"] = fact.used_percent
+        row["resets_at"] = _iso_utc(fact.resets_at) if fact.resets_at else None
+    return row

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -118,6 +118,7 @@ class TelemetryStore:
                   window_tokens   INTEGER,
                   occupancy_percent REAL,
                   account_key     TEXT,
+                  account_label   TEXT,
                   window_id       TEXT,
                   window_label    TEXT,
                   used_percent    REAL,
@@ -163,7 +164,14 @@ class TelemetryStore:
                   PRIMARY KEY (day, backend, model, repo_name, src_source, transport, is_child, session_id)
                 );
                 """)
+            self._ensure_column("account_label", "TEXT")
             self._conn.commit()
+
+    def _ensure_column(self, column: str, ddl: str) -> None:
+        rows = self._conn.execute("PRAGMA table_info(telemetry_facts)").fetchall()
+        if any(row["name"] == column for row in rows):
+            return
+        self._conn.execute(f"ALTER TABLE telemetry_facts ADD COLUMN {column} {ddl}")
 
     # ── ingest ────────────────────────────────────────────────────────────
 
@@ -768,6 +776,7 @@ def _row_from_fact(fact: TelemetryFact) -> dict[str, Any]:
         "window_tokens": None,
         "occupancy_percent": None,
         "account_key": None,
+        "account_label": None,
         "window_id": None,
         "window_label": None,
         "used_percent": None,
@@ -792,6 +801,7 @@ def _row_from_fact(fact: TelemetryFact) -> dict[str, Any]:
         row["occupancy_percent"] = fact.occupancy_percent
     elif isinstance(fact, LimitSnapshotFact):
         row["account_key"] = fact.account_key
+        row["account_label"] = fact.account_label
         row["window_id"] = fact.window_id
         row["window_label"] = fact.window_label
         row["used_percent"] = fact.used_percent

--- a/backend/src/waypoint/telemetry/tokens.py
+++ b/backend/src/waypoint/telemetry/tokens.py
@@ -1,0 +1,76 @@
+"""Read-layer token category unification (token-unify-spec).
+
+Every backend's ledger totals use a different, overlapping native vocabulary
+(see ``waypoint.schemas.TokenUsageRecord``): Claude's four categories are
+already disjoint; Codex's ``inputTokens``/``outputTokens`` are provider
+*totals* that already include ``cachedInputTokens``/``reasoningOutputTokens``;
+OpenCode's ``output`` likewise includes ``reasoning``. Summing the raw
+categories verbatim double-counts Codex/OpenCode and silently drops
+OpenCode's missing declared total.
+
+``unify_tokens`` is the one place generic aggregate code is allowed to
+normalize across backends (``waypoint.schemas.TOKEN_USAGE_CATEGORIES``'s
+doctrine comment) — a deterministic, source-keyed subset subtraction, never a
+guess. It never writes back to the ledger; the ledger keeps its raw native
+keys (they still feed the per-session context pill).
+"""
+
+from waypoint.schemas import TOKEN_USAGE_CATEGORIES
+
+UNIFIED_TOKEN_CATEGORIES = TOKEN_USAGE_CATEGORIES
+
+UNIFIED_TOKEN_LABELS: dict[str, str] = {
+    "fresh_input": "Fresh input",
+    "cache_read": "Cached input (read)",
+    "cache_write": "Cache write",
+    "output": "Output",
+    "reasoning": "Reasoning",
+}
+
+
+def _amount(raw_totals: dict[str, int], key: str) -> int:
+    value = raw_totals.get(key)
+    return int(value) if isinstance(value, int | float) else 0
+
+
+def unify_tokens(source: str, raw_totals: dict[str, int]) -> dict[str, int]:
+    """Fold one backend's raw ledger ``totals`` onto the 5 disjoint buckets.
+
+    The result always sums to the provider's true total for ``source`` and
+    always carries all 5 keys (0 where the backend has no such category), so
+    callers can fold/sum results across mixed-backend rows without an
+    ``all(... is not None)`` gate.
+    """
+    if source == "codex":
+        input_total = _amount(raw_totals, "input_tokens")
+        cached_input = _amount(raw_totals, "cached_input_tokens")
+        output_total = _amount(raw_totals, "output_tokens")
+        reasoning_output = _amount(raw_totals, "reasoning_output_tokens")
+        return {
+            "fresh_input": input_total - cached_input,
+            "cache_read": cached_input,
+            "cache_write": 0,
+            "output": output_total - reasoning_output,
+            "reasoning": reasoning_output,
+        }
+    if source == "opencode":
+        output_total = _amount(raw_totals, "output_tokens")
+        reasoning = _amount(raw_totals, "reasoning_tokens")
+        return {
+            "fresh_input": _amount(raw_totals, "input_tokens"),
+            "cache_read": _amount(raw_totals, "cache_read_tokens"),
+            "cache_write": _amount(raw_totals, "cache_write_tokens"),
+            "output": output_total - reasoning,
+            "reasoning": reasoning,
+        }
+    # claude_code, and any future/unrecognized source: treated as already
+    # disjoint native categories (the conservative default — never a guess
+    # at overlap, so it can only under-populate a not-yet-mapped backend's
+    # totals, never double-count one).
+    return {
+        "fresh_input": _amount(raw_totals, "input_tokens"),
+        "cache_read": _amount(raw_totals, "cache_read_tokens"),
+        "cache_write": _amount(raw_totals, "cache_creation_tokens"),
+        "output": _amount(raw_totals, "output_tokens"),
+        "reasoning": 0,
+    }

--- a/backend/src/waypoint/usage_dashboard.py
+++ b/backend/src/waypoint/usage_dashboard.py
@@ -30,28 +30,28 @@ class _PluginRegistry(Protocol):
     def get(self, backend_id: str) -> object: ...
 
 
-def account_bucket_for(
+def resolve_account(
     snapshot: SessionRateLimitUsage,
     *,
-    session_id: str,
-    registry: _PluginRegistry,
+    registry: _PluginRegistry | None,
     verified_account_key: str | None = None,
     verified_account_label: str | None = None,
-) -> tuple[str, str]:
-    """Return ``(account_key, account_label)`` for a snapshot.
+) -> tuple[str, str] | None:
+    """Return the raw ``(account_key, account_label)`` for a snapshot, or ``None``.
 
-    Prefers the session's persisted ``verified_account_key``/``label`` (last
-    probed at launch/switch/reattach) when present — it's already in the same
-    ``{backend}:{identity}`` shape ``rate_limit_account`` produces, since both
-    derive from the same probe. Otherwise dispatches the account-scoping
-    decision to the snapshot's agent plugin (``rate_limit_account``), falling
-    back to a session-scoped key labelled with the plugin's human name when
-    the plugin declines (no account info) or is unknown, so probes without
-    org/email metadata still surface as their own bucket instead of
-    collapsing together.
+    Resolution order: the session's persisted ``verified_account_key``/``label``
+    (last probed at launch/switch/reattach) when present — it's already in the
+    same ``{backend}:{identity}`` shape ``rate_limit_account`` produces, since
+    both derive from the same probe — else the snapshot's agent plugin's own
+    ``rate_limit_account``. ``None`` means neither source could attribute the
+    snapshot to an account; callers decide what that means for them (the
+    dashboard buckets it per-session below, telemetry ingest skips it instead
+    of minting a per-session pseudo-account).
     """
     if verified_account_key is not None:
         return verified_account_key, verified_account_label or verified_account_key
+    if registry is None:
+        return None
     plugin = (
         registry.get(snapshot.source) if registry.has_backend(snapshot.source) else None
     )
@@ -61,6 +61,32 @@ def account_bucket_for(
             account = resolver(snapshot)
             if account is not None:
                 return account
+    return None
+
+
+def account_bucket_for(
+    snapshot: SessionRateLimitUsage,
+    *,
+    session_id: str,
+    registry: _PluginRegistry,
+    verified_account_key: str | None = None,
+    verified_account_label: str | None = None,
+) -> tuple[str, str]:
+    """Return ``(account_key, account_label)`` for a snapshot, raw identity.
+
+    Falls back to a session-scoped key labelled with the plugin's human name
+    when ``resolve_account`` declines (no account info) or the plugin is
+    unknown, so probes without org/email metadata still surface as their own
+    bucket instead of collapsing together.
+    """
+    resolved = resolve_account(
+        snapshot,
+        registry=registry,
+        verified_account_key=verified_account_key,
+        verified_account_label=verified_account_label,
+    )
+    if resolved is not None:
+        return resolved
     return (
         f"{snapshot.source}:session:{session_id}",
         _humanise_backend(snapshot.source, registry),

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -11,13 +12,36 @@ from waypoint.backends.claude_code.adapter import (
     _is_plan_file_path,
     _read_stream_line,
     claude_cli_mode_for,
+    claude_token_usage_record,
 )
 from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
 )
 from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
-from waypoint.schemas import EventKind, SessionStatus
+from waypoint.schemas import EventKind, SessionContextUsage, SessionStatus
+
+
+def test_claude_token_usage_record_threads_model_and_effort() -> None:
+    snapshot = SessionContextUsage(
+        used_tokens=15,
+        context_window_tokens=200_000,
+        updated_at=datetime.now(UTC),
+        source="claude_code",
+        breakdown={"input_tokens": 10, "output_tokens": 5},
+    )
+    record = claude_token_usage_record(
+        "msg_1", snapshot, model="claude-sonnet-4-5", effort="high"
+    )
+    assert record is not None
+    assert record.model == "claude-sonnet-4-5"
+    assert record.effort == "high"
+
+    # Absent values are never guessed.
+    bare = claude_token_usage_record("msg_1", snapshot)
+    assert bare is not None
+    assert bare.model is None
+    assert bare.effort is None
 
 
 def test_is_plan_file_path_honors_config_dir() -> None:
@@ -86,6 +110,7 @@ class FakeProcess:
 def _make_adapter(
     emitted: list[tuple[str, EventKind, str, dict[str, Any], SessionStatus]],
     session_updates: list[tuple[str, dict[str, Any], bool]] | None = None,
+    token_usage_records: list[tuple[str, Any, bool]] | None = None,
 ) -> ClaudeCliAdapter:
     async def emit(session_id, kind, text, metadata, status):
         emitted.append((session_id, kind, text, metadata, status))
@@ -95,9 +120,15 @@ def _make_adapter(
             session_updates.append((session_id, updates, publish))
         return updates
 
+    async def on_token_usage(session_id: str, record: Any, publish: bool) -> Any:
+        if token_usage_records is not None:
+            token_usage_records.append((session_id, record, publish))
+        return None
+
     return ClaudeCliAdapter(
         emit,
         on_session_update=update if session_updates is not None else None,
+        on_token_usage=on_token_usage if token_usage_records is not None else None,
     )
 
 
@@ -186,6 +217,40 @@ async def test_dispatch_assistant_emits_text_and_tool_use_events() -> None:
     # text block carries assistant message id; tool_use carries its own tool_use_id as item_id
     assert emitted[0][3]["item_id"] == "msg_1"
     assert emitted[1][3]["tool_use_id"] == "toolu_xyz"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_assistant_threads_resolved_model_and_effort_into_ledger() -> (
+    None
+):
+    emitted: list = []
+    token_usage_records: list[tuple[str, Any, bool]] = []
+    adapter = _make_adapter(emitted, token_usage_records=token_usage_records)
+    state, _ = _attach_state(adapter)
+    # ``state.model`` (family-normalized) drives the context-window lookup
+    # that gates publishing at all; ``state.resolved_model`` (the concrete id)
+    # is the value threaded into the ledger record.
+    state.model = "sonnet"
+    state.resolved_model = "claude-sonnet-4-5"
+    state.effort = "high"
+    event = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Working on it"}],
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        },
+    }
+
+    await adapter._dispatch(state, event)
+
+    assert len(token_usage_records) == 1
+    session_id, record, _ = token_usage_records[0]
+    assert session_id == "sess"
+    assert record.record_id == "msg_1"
+    assert record.model == "claude-sonnet-4-5"
+    assert record.effort == "high"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_claude_code_usage_source.py
+++ b/backend/tests/test_claude_code_usage_source.py
@@ -104,6 +104,28 @@ async def test_drain_publishes_context_usage_on_assistant_record(
 
 
 @pytest.mark.asyncio
+async def test_token_record_prefers_message_model_over_stale_session_model(
+    tmp_path: Path,
+) -> None:
+    # The session's resolved_model reflects the *latest* turn, not necessarily
+    # this one — a transcript replayed from offset 0 after a resume must not
+    # have every earlier turn rewritten onto the current model.
+    runtime = _make_runtime(resolved_model="claude-opus-4-8", effort="high")
+    source = _make_source(runtime, tmp_path)
+
+    record = _assistant_record(
+        model="claude-sonnet-4-5", usage={"input_tokens": 10, "output_tokens": 5}
+    )
+    data = _jsonl(record)
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    published = runtime.publish_token_usage_record.call_args.args[1]
+    assert published.model == "claude-sonnet-4-5"
+
+
+@pytest.mark.asyncio
 async def test_token_record_falls_back_to_transcript_model_without_session(
     tmp_path: Path,
 ) -> None:

--- a/backend/tests/test_claude_code_usage_source.py
+++ b/backend/tests/test_claude_code_usage_source.py
@@ -10,7 +10,11 @@ import pytest
 from waypoint.backends.claude_code.usage_source import TranscriptContextUsageSource
 
 
-def _make_runtime(session_model: str | None = None) -> MagicMock:
+def _make_runtime(
+    session_model: str | None = None,
+    resolved_model: str | None = None,
+    effort: str | None = None,
+) -> MagicMock:
     runtime = MagicMock()
     runtime.update_session_fields = AsyncMock()
     runtime.publish_token_usage_record = AsyncMock()
@@ -18,7 +22,9 @@ def _make_runtime(session_model: str | None = None) -> MagicMock:
     # resolve the context window (the transcript only carries the resolved API
     # id, which loses the ``[1m]`` marker). Tests reassign
     # ``get_session.return_value`` to simulate a dynamic model change mid-run.
-    runtime.storage.get_session.return_value = SimpleNamespace(model=session_model)
+    runtime.storage.get_session.return_value = SimpleNamespace(
+        model=session_model, resolved_model=resolved_model, effort=effort
+    )
     return runtime
 
 
@@ -62,7 +68,7 @@ def _assistant_record(
 async def test_drain_publishes_context_usage_on_assistant_record(
     tmp_path: Path,
 ) -> None:
-    runtime = _make_runtime()
+    runtime = _make_runtime(resolved_model="claude-sonnet-4-5", effort="high")
     source = _make_source(runtime, tmp_path)
 
     record = _assistant_record(
@@ -93,6 +99,31 @@ async def test_drain_publishes_context_usage_on_assistant_record(
         "output_tokens": 6,
     }
     assert record.display_total_tokens == 25
+    assert record.model == "claude-sonnet-4-5"
+    assert record.effort == "high"
+
+
+@pytest.mark.asyncio
+async def test_token_record_falls_back_to_transcript_model_without_session(
+    tmp_path: Path,
+) -> None:
+    # No session (or a session with no resolved_model): the record's model
+    # falls back to the transcript's resolved API id rather than going unset.
+    runtime = _make_runtime()
+    runtime.storage.get_session.return_value = None
+    source = _make_source(runtime, tmp_path)
+
+    record = _assistant_record(
+        model="claude-opus-4-8", usage={"input_tokens": 10, "output_tokens": 5}
+    )
+    data = _jsonl(record)
+
+    with patch.object(source, "_read_new_bytes", return_value=data):
+        await source._drain()
+
+    published = runtime.publish_token_usage_record.call_args.args[1]
+    assert published.model == "claude-opus-4-8"
+    assert published.effort is None
 
 
 @pytest.mark.asyncio
@@ -236,7 +267,9 @@ async def test_dynamic_model_change_updates_window(tmp_path: Path) -> None:
         == 1_000_000
     )
     # Switch the configured model to the base alias; next publish uses 200k.
-    runtime.storage.get_session.return_value = SimpleNamespace(model="sonnet")
+    runtime.storage.get_session.return_value = SimpleNamespace(
+        model="sonnet", resolved_model=None, effort=None
+    )
     rec2 = _assistant_record(
         model="claude-sonnet-4-6", usage={"input_tokens": 99, "output_tokens": 1}
     )

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -8,6 +8,7 @@ effort return contract, custom-arg validation, thread-discovery dedup, and the
 resume-import path — all against fakes so no live TUI/tmux is needed.
 """
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
@@ -673,6 +674,71 @@ async def test_import_thread_resumes_and_starts_tailer(
     # Resumed thread import recorded with provenance metadata.
     meta = runtime._record_system_event.call_args.kwargs["metadata"]
     assert meta["imported_thread_id"] == "imp-1"
+
+
+async def test_import_thread_seeds_token_usage_ledger_from_transcript(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # The resumed pane's tailer starts at EOF (asserted above), so the
+    # on-disk transcript read here is the only source of per-turn model for
+    # the imported turns' ledger.
+    thread_id = "44444444-4444-4444-4444-444444444444"
+    claude_config_dir = tmp_path / "claude"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_config_dir))
+    project_dir = claude_config_dir / "projects" / "-work"
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / f"{thread_id}.jsonl"
+    transcript.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_1",
+                    "model": "claude-sonnet-4-5",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    info = _thread_info(thread_id)
+    info.cwd = str(tmp_path)
+    monkeypatch.setattr(
+        plugin_mod, "find_local_claude_thread", lambda tid, config_dir=None: info
+    )
+    plugin = ClaudeTtyPlugin()
+    _stub_lifecycle(plugin)
+
+    target = MagicMock(session="s", window="0", pane="%1", pane_pid=7)
+    runtime = MagicMock()
+    runtime._generate_session_id.return_value = "claude_tty-token"
+    runtime._session_dir.return_value = tmp_path
+    runtime._command_for_backend.return_value = ["claude", "--resume", thread_id]
+    runtime.tmux.start_managed_session = AsyncMock(return_value=target)
+    runtime.tmux.pipe_output = AsyncMock()
+    runtime.tmux.resize_window = AsyncMock()
+    runtime.storage.list_sessions.return_value = []
+    created_holder: dict[str, SessionRecord] = {}
+    runtime.storage.create_session.side_effect = lambda s: created_holder.update(
+        session=s
+    )
+    runtime.get_session.side_effect = lambda sid: created_holder["session"]
+    runtime._record_system_event = AsyncMock()
+    runtime.seed_thread_history = AsyncMock(return_value=0)
+    runtime.publish_token_usage_record = AsyncMock()
+
+    request = ClaudeThreadImportRequest(thread_id=thread_id)
+    await plugin.import_thread(runtime, request)
+
+    runtime.publish_token_usage_record.assert_called_once()
+    session_id, record = runtime.publish_token_usage_record.call_args.args
+    assert session_id == "claude_tty-token"
+    assert record.record_id == "msg_1"
+    assert record.model == "claude-sonnet-4-5"
+    assert runtime.publish_token_usage_record.call_args.kwargs == {"publish": False}
 
 
 async def test_import_thread_persists_resolving_agent_backend(

--- a/backend/tests/test_claude_tty_tailer.py
+++ b/backend/tests/test_claude_tty_tailer.py
@@ -163,6 +163,26 @@ async def test_drain_publishes_token_record_with_resolved_model_and_effort() -> 
 
 
 @pytest.mark.asyncio
+async def test_token_record_prefers_message_model_over_stale_session_model() -> None:
+    # The session's resolved_model reflects the *latest* turn, not necessarily
+    # this one — a transcript replayed from offset 0 after a resume must not
+    # have every earlier turn rewritten onto the current model.
+    session = _make_session(resolved_model="claude-opus-4-8", effort="high")
+    runtime = _make_runtime(session)
+    tailer, source = _make_tailer(runtime)
+
+    record = _assistant_record(
+        model="claude-sonnet-4-5",
+        usage={"input_tokens": 10, "output_tokens": 5},
+    )
+    source.feed(_jsonl(record))
+    await tailer._drain()
+
+    published = runtime.publish_token_usage_record.call_args.args[1]
+    assert published.model == "claude-sonnet-4-5"
+
+
+@pytest.mark.asyncio
 async def test_drain_dedupes_unchanged_context_usage() -> None:
     session = _make_session()
     runtime = _make_runtime(session)

--- a/backend/tests/test_claude_tty_tailer.py
+++ b/backend/tests/test_claude_tty_tailer.py
@@ -45,7 +45,11 @@ def test_transcript_path_honors_config_dir() -> None:
     assert scoped.name == f"{uuid}.jsonl"
 
 
-def _make_session(session_id: str = "sess-1") -> SessionRecord:
+def _make_session(
+    session_id: str = "sess-1",
+    resolved_model: str | None = None,
+    effort: str | None = None,
+) -> SessionRecord:
     now = datetime.now(UTC)
     return SessionRecord(
         id=session_id,
@@ -60,6 +64,8 @@ def _make_session(session_id: str = "sess-1") -> SessionRecord:
         last_event_at=now,
         raw_log_path="/tmp/raw.log",
         structured_log_path="/tmp/structured.log",
+        resolved_model=resolved_model,
+        effort=effort,
         transport_state={
             "tmux_session": session_id,
             "tmux_window": "0",
@@ -136,6 +142,24 @@ async def test_drain_publishes_context_usage_on_assistant_record() -> None:
     assert snapshot.used_tokens == 19
     assert snapshot.context_window_tokens == 200_000
     assert snapshot.source == "claude_code"
+
+
+@pytest.mark.asyncio
+async def test_drain_publishes_token_record_with_resolved_model_and_effort() -> None:
+    session = _make_session(resolved_model="claude-sonnet-4-5", effort="high")
+    runtime = _make_runtime(session)
+    tailer, source = _make_tailer(runtime)
+
+    record = _assistant_record(
+        usage={"input_tokens": 15, "cache_read_input_tokens": 4, "output_tokens": 6}
+    )
+    source.feed(_jsonl(record))
+    await tailer._drain()
+
+    runtime.publish_token_usage_record.assert_called_once()
+    published = runtime.publish_token_usage_record.call_args.args[1]
+    assert published.model == "claude-sonnet-4-5"
+    assert published.effort == "high"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_codex_app_server.py
+++ b/backend/tests/test_codex_app_server.py
@@ -1103,3 +1103,47 @@ async def test_token_usage_record_uses_turn_id_and_provider_total() -> None:
     records.clear()
     await adapter._publish_token_usage(state, "", snapshot)
     assert records == []
+
+
+@pytest.mark.asyncio
+async def test_token_usage_record_threads_sticky_model_and_effort() -> None:
+    records: list[tuple[str, Any, bool]] = []
+
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def on_token_usage(session_id: str, record: Any, publish: bool) -> Any:
+        records.append((session_id, record, publish))
+        return None
+
+    fake = FakeCodexClient()
+    adapter = CodexAppServerAdapter(
+        _emit,
+        on_token_usage=on_token_usage,
+        client_factory=lambda *_: cast(CodexClient, fake),
+    )
+    state = CodexSessionState(
+        session_id="sess",
+        cwd="/tmp",
+        client=cast(CodexClient, fake),
+        transport_lock=asyncio.Lock(),
+        thread_id="thread-1",
+        model="gpt-5-codex",
+        effort="high",
+    )
+    snapshot = _context_usage_snapshot_from_thread_token_usage(
+        {
+            "tokenUsage": {
+                "last": {"totalTokens": 100, "inputTokens": 80, "outputTokens": 20},
+                "modelContextWindow": 8192,
+            }
+        }
+    )
+    assert snapshot is not None
+
+    await adapter._publish_token_usage(state, "turn-1", snapshot)
+
+    assert len(records) == 1
+    record = records[0][1]
+    assert record.model == "gpt-5-codex"
+    assert record.effort == "high"

--- a/backend/tests/test_import_history_claude.py
+++ b/backend/tests/test_import_history_claude.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from waypoint.backends.claude_code.history import (
     convert_transcript_records,
     read_local_claude_history,
+    token_usage_records_from_history,
 )
 from waypoint.backends.claude_code.threads import read_local_claude_transcript
 from waypoint.schemas import EventKind
@@ -170,6 +171,82 @@ def test_read_local_claude_transcript_reads_entire_file(monkeypatch, tmp_path) -
     # Longer than the 200-line cap `_read_thread_info` uses for metadata
     # sniffing — history import must not inherit that cap.
     assert len(read_records) == 250
+
+
+def _assistant_with_usage(
+    msg_id: str,
+    model: str,
+    usage: dict,
+    text: str = "hi",
+    ts: str = "2026-04-29T15:47:09.826Z",
+) -> dict:
+    return {
+        "type": "assistant",
+        "timestamp": ts,
+        "message": {
+            "id": msg_id,
+            "model": model,
+            "content": [{"type": "text", "text": text}],
+            "stop_reason": "end_turn",
+            "usage": usage,
+        },
+    }
+
+
+def test_token_usage_records_from_history_threads_model_no_effort() -> None:
+    records = [
+        _assistant_with_usage(
+            "msg1",
+            "claude-sonnet-4-5",
+            {"input_tokens": 10, "output_tokens": 5},
+        )
+    ]
+
+    token_records = token_usage_records_from_history(records)
+
+    assert len(token_records) == 1
+    record = token_records[0]
+    assert record.record_id == "msg1"
+    assert record.model == "claude-sonnet-4-5"
+    # A transcript never records reasoning effort per message — a replayed
+    # turn always surfaces it as unknown rather than guessed.
+    assert record.effort is None
+    assert record.totals == {"input_tokens": 10, "output_tokens": 5}
+
+
+def test_token_usage_records_from_history_skips_unresolvable_model() -> None:
+    # Model not in the Claude catalogue — context window unknown, so the
+    # snapshot gate (shared with the live path) drops it rather than guess.
+    records = [
+        _assistant_with_usage("msg1", "gpt-4", {"input_tokens": 10, "output_tokens": 5})
+    ]
+
+    assert token_usage_records_from_history(records) == []
+
+
+def test_token_usage_records_from_history_skips_non_assistant_and_no_usage() -> None:
+    records = [
+        _user_text("hello"),
+        {"type": "assistant", "message": {"id": "msg1", "model": "claude-sonnet-4-5"}},
+    ]
+
+    assert token_usage_records_from_history(records) == []
+
+
+def test_token_usage_records_from_history_multiple_turns() -> None:
+    records = [
+        _assistant_with_usage(
+            "msg1", "claude-sonnet-4-5", {"input_tokens": 10, "output_tokens": 5}
+        ),
+        _assistant_with_usage(
+            "msg2", "claude-opus-4-8", {"input_tokens": 20, "output_tokens": 8}
+        ),
+    ]
+
+    token_records = token_usage_records_from_history(records)
+
+    assert [r.record_id for r in token_records] == ["msg1", "msg2"]
+    assert [r.model for r in token_records] == ["claude-sonnet-4-5", "claude-opus-4-8"]
 
 
 async def test_read_local_claude_history_converts_full_file(

--- a/backend/tests/test_import_history_claude.py
+++ b/backend/tests/test_import_history_claude.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from waypoint.backends.claude_code.history import (
     convert_transcript_records,
     read_local_claude_history,
+    read_local_claude_token_usage_history,
     token_usage_records_from_history,
 )
 from waypoint.backends.claude_code.threads import read_local_claude_transcript
@@ -266,3 +267,30 @@ async def test_read_local_claude_history_converts_full_file(
 
     assert len(events) == 210
     assert all(event.kind == EventKind.USER_INPUT for event in events)
+
+
+async def test_read_local_claude_token_usage_history_reads_full_file(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    thread_id = "33333333-3333-3333-3333-333333333333"
+    project_dir = tmp_path / "claude" / "projects" / "-home-user-project"
+    project_dir.mkdir(parents=True)
+    transcript = project_dir / f"{thread_id}.jsonl"
+    records = [
+        _assistant_with_usage(
+            "msg1", "claude-sonnet-4-5", {"input_tokens": 10, "output_tokens": 5}
+        ),
+        _assistant_with_usage(
+            "msg2", "claude-opus-4-8", {"input_tokens": 20, "output_tokens": 8}
+        ),
+    ]
+    transcript.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+    )
+
+    token_records = await read_local_claude_token_usage_history(thread_id)
+
+    assert [r.record_id for r in token_records] == ["msg1", "msg2"]
+    assert [r.model for r in token_records] == ["claude-sonnet-4-5", "claude-opus-4-8"]
+    assert all(r.effort is None for r in token_records)

--- a/backend/tests/test_opencode_adapter.py
+++ b/backend/tests/test_opencode_adapter.py
@@ -463,6 +463,46 @@ async def test_token_usage_record_keys_on_session_and_message_id() -> None:
 
 
 @pytest.mark.asyncio
+async def test_token_usage_record_threads_resolved_model_and_effort() -> None:
+    records: list[tuple[str, Any, bool]] = []
+
+    async def _emit(*args: object, **kwargs: object) -> None:
+        return None
+
+    async def on_token_usage(session_id: str, record: Any, publish: bool) -> object:
+        records.append((session_id, record, publish))
+        return None
+
+    adapter = OpenCodeAdapter(emit_event=_emit, on_token_usage=on_token_usage)
+    state = OpenCodeSessionState(
+        session_id="local-1",
+        cwd="/tmp",
+        opencode_session_id="ses_1",
+        effort="high",
+    )
+    properties = {
+        "sessionID": "ses_1",
+        "info": {
+            "id": "msg_9",
+            "role": "assistant",
+            "providerID": "opencode",
+            "modelID": "minimax-m2.5-free",
+            "tokens": {"input": 120, "output": 30},
+        },
+    }
+
+    await adapter._maybe_update_context_usage(state, properties)
+
+    assert len(records) == 1
+    record = records[0][1]
+    # The ledger's model is the exact per-message resolved value, not the
+    # session's sticky selection — assembled as "provider/model" to match the
+    # session-level ``state.model`` convention.
+    assert record.model == "opencode/minimax-m2.5-free"
+    assert record.effort == "high"
+
+
+@pytest.mark.asyncio
 async def test_context_usage_background_lookup_publishes_once_ready() -> None:
     calls: list[tuple[str, dict[str, object], bool]] = []
 

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -2959,6 +2960,64 @@ async def test_import_claude_thread_creates_session_and_resumes(
     events = storage.list_events(session.id)
     assert events[-1].kind == EventKind.SYSTEM_NOTE
     assert "Imported stored Claude thread" in events[-1].text
+
+
+@pytest.mark.asyncio
+async def test_import_claude_thread_seeds_token_usage_ledger_from_transcript(
+    monkeypatch, tmp_path
+) -> None:
+    # The direct-SDK ``--resume`` continues the session without re-emitting
+    # historical stream-json events, so this on-disk transcript read is the
+    # only source of per-turn model for the imported turns' ledger.
+    runtime, storage, settings = make_runtime(tmp_path)
+    fake = FakeClaudeAdapter()
+    _claude_plugin(runtime).adapter = cast(Any, fake)
+    thread_id = "55555555-5555-4555-8555-555555555555"
+    info = _make_claude_thread_info(
+        id=thread_id,
+        cwd=str(tmp_path),
+        title="Resumed thread",
+        branch="main",
+        repo_name=tmp_path.name,
+        preview="Pick up where we left off",
+    )
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.find_local_claude_thread",
+        lambda tid, config_dir=None: info if tid == thread_id else None,
+    )
+
+    claude_config_dir = tmp_path / "claude-config"
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_config_dir))
+    project_dir = claude_config_dir / "projects" / "-work"
+    project_dir.mkdir(parents=True)
+    (project_dir / f"{thread_id}.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "id": "msg_1",
+                    "model": "claude-sonnet-4-5",
+                    "content": [{"type": "text", "text": "hi"}],
+                    "usage": {"input_tokens": 10, "output_tokens": 5},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    session = await runtime.registry.get("claude_code").import_thread(
+        runtime, ClaudeThreadImportRequest(thread_id=thread_id)
+    )
+
+    row = storage.connection.execute(
+        "SELECT usage_json FROM session_token_usage_records WHERE session_id = ?",
+        (session.id,),
+    ).fetchone()
+    assert row is not None
+    usage = json.loads(row["usage_json"])
+    assert usage["model"] == "claude-sonnet-4-5"
+    assert usage["effort"] is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -326,6 +326,30 @@ def test_build_overview_empty_range_is_zero_not_error(tmp_path: Path) -> None:
     assert overview.tool_calls == 0
 
 
+def test_current_context_only_includes_active_sessions(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "live", status=SessionStatus.IDLE)
+    _make_session(storage, "gone", status=SessionStatus.EXITED)
+    for sid in ("live", "gone"):
+        storage.telemetry.ingest_fact(
+            ContextSnapshotFact(
+                fact_id=f"{sid}:bucket",
+                source="codex",
+                session_id=sid,
+                occurred_at=now - timedelta(minutes=1),
+                dims=_dims(),
+                used_tokens=1000,
+                window_tokens=10000,
+                occupancy_percent=10.0,
+            )
+        )
+    views = aggregate.current_context_snapshots(storage, TelemetryFilter(), now)
+    # The exited session holds no live context window and must not surface,
+    # even though it recorded a recent snapshot before exiting.
+    assert [v.session_id for v in views] == ["live"]
+
+
 # ── /health ───────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -622,10 +622,14 @@ def test_activity_daily_is_zero_not_missing_for_quiet_days(tmp_path: Path) -> No
         start=now - timedelta(days=2), end=now + timedelta(hours=1), tz="UTC"
     )
     activity = aggregate.build_activity(storage, rng, TelemetryFilter())
-    assert len(activity.daily) == 3  # today + 2 prior quiet days
+    # One row per host-tz calendar day the range touches (derived, not a fixed
+    # count — running near host-tz midnight makes ``now + 1h`` cross into an
+    # extra day, which is correct: that day is partially in range).
+    expected_days = aggregate.day_range(rng)
+    assert [d.day for d in activity.daily] == expected_days
     assert sum(d.sessions_created for d in activity.daily) == 1
     quiet_days = [d for d in activity.daily if d.sessions_created == 0]
-    assert len(quiet_days) == 2
+    assert len(quiet_days) == len(expected_days) - 1  # only the created day is busy
     for day in quiet_days:
         assert day.user_turns == 0
         assert day.tool_calls == 0

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -156,10 +156,87 @@ def test_fold_tokens_counts_tracked_vs_untracked_turns(tmp_path: Path) -> None:
     assert len(rows) == 2
     ledger = aggregate.ledger_rows_for_sessions(storage, {"s1"})
     totals, display_total, tracked, total = aggregate.fold_tokens(rows, ledger)
-    assert totals == {"input_tokens": 100}
-    assert display_total is None  # t1 has no display_total_tokens
+    assert totals == {
+        "fresh_input": 100,
+        "cache_read": 0,
+        "cache_write": 0,
+        "output": 0,
+        "reasoning": 0,
+    }
+    assert display_total == 100  # unify_tokens's sum is always safe now
     assert tracked == 1
     assert total == 2
+
+
+def test_fold_tokens_unifies_mixed_backends_without_double_counting(
+    tmp_path: Path,
+) -> None:
+    """Regression: OpenCode's ``display_total_tokens=None`` used to poison a
+    mixed-backend group's ``display_total`` to ``None``, and Codex's
+    overlapping ``inputTokens``/``cachedInputTokens`` would double-count if
+    ever summed verbatim. ``unify_tokens`` removes the dependency on the
+    (sometimes-absent) declared total entirely, so the fold is always a safe,
+    non-double-counted sum across every backend in the group."""
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    _seed_agent_turn(
+        storage,
+        "s1",
+        fact_id="claude-turn",
+        occurred_at=now,
+        source="claude_code",
+        totals={
+            "input_tokens": 50,
+            "cache_read_tokens": 10,
+            "cache_creation_tokens": 5,
+            "output_tokens": 20,
+        },
+    )
+    _seed_agent_turn(
+        storage,
+        "s1",
+        fact_id="codex-turn",
+        occurred_at=now,
+        source="codex",
+        totals={
+            "input_tokens": 100,  # TOTAL, includes cached_input_tokens
+            "cached_input_tokens": 30,
+            "output_tokens": 40,  # TOTAL, includes reasoning_output_tokens
+            "reasoning_output_tokens": 10,
+        },
+    )
+    _seed_agent_turn(
+        storage,
+        "s1",
+        fact_id="opencode-turn",
+        occurred_at=now,
+        source="opencode",
+        totals={
+            "input_tokens": 60,
+            "cache_read_tokens": 5,
+            "cache_write_tokens": 2,
+            "output_tokens": 25,  # TOTAL, includes reasoning_tokens
+            "reasoning_tokens": 8,
+        },
+        display_total=None,  # OpenCode never declares one
+    )
+
+    rows = aggregate.agent_turn_rows(storage, _full_range(), TelemetryFilter())
+    ledger = aggregate.ledger_rows_for_sessions(storage, {"s1"})
+    totals, display_total, tracked, total = aggregate.fold_tokens(rows, ledger)
+
+    assert totals == {
+        "fresh_input": 50 + 70 + 60,
+        "cache_read": 10 + 30 + 5,
+        "cache_write": 5 + 0 + 2,
+        "output": 20 + 30 + 17,
+        "reasoning": 0 + 10 + 8,
+    }
+    provider_totals = 85 + 140 + 92  # each backend's true (unified) grand total
+    assert display_total == provider_totals
+    assert display_total == sum(totals.values())
+    assert tracked == 3
+    assert total == 3
 
 
 def test_coverage_label_entire_when_all_turns_tracked(tmp_path: Path) -> None:
@@ -232,7 +309,13 @@ def test_build_overview_sums_tokens_turns_and_lifecycle(tmp_path: Path) -> None:
     assert overview.turns.user == 1
     assert overview.turns.agent == 1
     assert overview.tool_calls == 1
-    assert overview.tokens.totals == {"input_tokens": 100, "output_tokens": 20}
+    assert overview.tokens.totals == {
+        "fresh_input": 100,
+        "cache_read": 0,
+        "cache_write": 0,
+        "output": 20,
+        "reasoning": 0,
+    }
     assert overview.tokens.display_total == 120
     assert overview.tokens.safe_total is True
     assert overview.tokens.meter_coverage_percent == 100.0
@@ -321,7 +404,8 @@ def test_build_overview_empty_range_is_zero_not_error(tmp_path: Path) -> None:
         storage, _settings(), empty_rng, TelemetryFilter()
     )
     assert overview.tokens.totals == {}
-    assert overview.tokens.display_total is None
+    assert overview.tokens.display_total == 0
+    assert overview.tokens.safe_total is True
     assert overview.turns.user == 0
     assert overview.tool_calls == 0
 
@@ -431,11 +515,55 @@ def test_current_limit_snapshot_stale_after_15_minutes(tmp_path: Path) -> None:
             used_percent=95.0,
         )
     )
-    current = aggregate.current_limit_snapshots(storage, TelemetryFilter(), now)
+    current = aggregate.current_limit_snapshots(
+        storage, TelemetryFilter(), now, _settings()
+    )
     assert len(current) == 1
     assert current[0].stale is True
     # A stale snapshot never drives an alert/insight even above threshold.
     assert aggregate.alerting_limits(storage, _settings(), TelemetryFilter()) == []
+
+
+def test_account_label_hidden_unless_local_labels_setting_is_on(
+    tmp_path: Path,
+) -> None:
+    """FR-9: account_key is always the pseudonym; account_label is only ever
+    surfaced by the API when telemetry_local_labels opts in (default off)."""
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        LimitSnapshotFact(
+            fact_id="limit-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            account_key="acct_deadbeef",
+            account_label="noppanat@u.nus.edu · plan: pro",
+            window_id="5h",
+            used_percent=42.0,
+        )
+    )
+
+    default_settings = Settings(telemetry_context_thresholds=(70, 90, 100))
+    assert default_settings.telemetry_local_labels is False
+    hidden = aggregate.build_health(
+        storage, default_settings, _full_range(), TelemetryFilter()
+    )
+    assert len(hidden.limits.current) == 1
+    assert hidden.limits.current[0].account_key == "acct_deadbeef"
+    assert hidden.limits.current[0].account_label is None
+    assert hidden.limits.series[0].account_label is None
+
+    labels_on = Settings(
+        telemetry_context_thresholds=(70, 90, 100), telemetry_local_labels=True
+    )
+    visible = aggregate.build_health(
+        storage, labels_on, _full_range(), TelemetryFilter()
+    )
+    assert visible.limits.current[0].account_label == "noppanat@u.nus.edu · plan: pro"
+    assert visible.limits.series[0].account_label == "noppanat@u.nus.edu · plan: pro"
 
 
 # ── /drilldown ────────────────────────────────────────────────────────────
@@ -866,7 +994,13 @@ def test_overview_tag_filter_keeps_session_counts_consistent_with_tokens(
     # only the tagged one — an internally inconsistent response.
     assert overview.sessions.created == 1
     assert overview.turns.agent == 1
-    assert overview.tokens.totals == {"input_tokens": 500}
+    assert overview.tokens.totals == {
+        "fresh_input": 500,
+        "cache_read": 0,
+        "cache_write": 0,
+        "output": 0,
+        "reasoning": 0,
+    }
     assert overview.tokens.display_total == 500
 
 

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -1,0 +1,722 @@
+"""Unit tests for the ``telemetry/aggregate.py`` shaper (CONTRACT.md §4/§7).
+
+Exercises aggregation math (token folding, meter coverage, rollup sums),
+filter semantics including limit-card hiding, date/tz range boundaries,
+empty ranges, and drill-down count/page consistency — all against
+``TelemetryStore``/``Storage`` directly (no HTTP layer).
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from waypoint.schemas import (
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+    TokenUsageInit,
+    TokenUsageRecord,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+from waypoint.telemetry import aggregate
+from waypoint.telemetry import insights as telemetry_insights
+from waypoint.telemetry.facts import (
+    ContextSnapshotFact,
+    FactDimensions,
+    LifecycleTransition,
+    LimitSnapshotFact,
+    SessionLifecycleFact,
+    TelemetryFactKind,
+    TelemetryFilter,
+    TelemetryRange,
+    ToolCallFact,
+    ToolOutcome,
+    TurnFact,
+    TurnKind,
+)
+
+
+def _dims(**overrides: object) -> FactDimensions:
+    fields: dict[str, object] = {
+        "backend": "codex",
+        "repo_name": "waypoint",
+        "source": SessionSource.MANAGED,
+        "transport": "tmux",
+        "spawner_session_id": None,
+        "is_child": False,
+    }
+    fields.update(overrides)
+    return FactDimensions.model_validate(fields)
+
+
+def _make_session(
+    storage: Storage,
+    session_id: str,
+    *,
+    backend: str = "codex",
+    status: SessionStatus = SessionStatus.IDLE,
+    repo_name: str | None = "waypoint",
+    spawner_session_id: str | None = None,
+) -> datetime:
+    now = datetime.now(UTC)
+    storage.create_session(
+        SessionRecord(
+            id=session_id,
+            backend=backend,
+            source=SessionSource.MANAGED,
+            transport="tmux",
+            title=session_id,
+            cwd="/tmp",
+            repo_name=repo_name,
+            spawner_session_id=spawner_session_id,
+            status=status,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/tmp/raw.log",
+            structured_log_path="/tmp/events.jsonl",
+        )
+    )
+    return now
+
+
+def _seed_agent_turn(
+    storage: Storage,
+    session_id: str,
+    *,
+    fact_id: str,
+    occurred_at: datetime,
+    totals: dict[str, int] | None = None,
+    display_total: int | None = None,
+    model_at_turn: str | None = None,
+    source: str = "codex",
+) -> None:
+    """A ``TurnFact`` (AGENT) plus its ledger row (or none, to leave it untracked)."""
+    if totals is not None:
+        storage.record_token_usage(
+            session_id,
+            TokenUsageRecord(
+                record_id=fact_id,
+                source=source,
+                observed_at=occurred_at,
+                totals=totals,
+                display_total_tokens=display_total,
+                model=model_at_turn,
+            ),
+            init=TokenUsageInit(
+                coverage="entire_waypoint_session", observed_from=occurred_at
+            ),
+        )
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id=fact_id,
+            source=source,
+            session_id=session_id,
+            occurred_at=occurred_at,
+            dims=_dims(backend=source),
+            turn_kind=TurnKind.AGENT,
+            model_at_turn=model_at_turn,
+        )
+    )
+
+
+def _settings() -> Settings:
+    return Settings(telemetry_context_thresholds=(70, 90, 100))
+
+
+def _full_range(hours: int = 48) -> TelemetryRange:
+    now = datetime.now(UTC)
+    return TelemetryRange(
+        start=now - timedelta(hours=hours), end=now + timedelta(hours=1), tz="UTC"
+    )
+
+
+# ── token folding / meter coverage ────────────────────────────────────────
+
+
+def test_fold_tokens_counts_tracked_vs_untracked_turns(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    _seed_agent_turn(
+        storage, "s1", fact_id="t1", occurred_at=now, totals={"input_tokens": 100}
+    )
+    # No ledger row for t2 — an untracked agent turn (meter-coverage gap).
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="t2",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.AGENT,
+        )
+    )
+
+    rows = aggregate.agent_turn_rows(storage, _full_range(), TelemetryFilter())
+    assert len(rows) == 2
+    ledger = aggregate.ledger_rows_for_sessions(storage, {"s1"})
+    totals, display_total, tracked, total = aggregate.fold_tokens(rows, ledger)
+    assert totals == {"input_tokens": 100}
+    assert display_total is None  # t1 has no display_total_tokens
+    assert tracked == 1
+    assert total == 2
+
+
+def test_coverage_label_entire_when_all_turns_tracked(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    assert aggregate.coverage_label(storage, 100.0) == "entire"
+    assert aggregate.coverage_label(storage, None) == "entire"
+
+
+def test_coverage_label_tracked_since_before_backfill_done(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    assert aggregate.coverage_label(storage, 50.0) == "tracked_since"
+
+
+def test_coverage_label_partial_after_backfill_done(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    storage.telemetry.set_meta("backfill_done", "true")
+    assert aggregate.coverage_label(storage, 50.0) == "partial"
+
+
+# ── /overview ─────────────────────────────────────────────────────────────
+
+
+def test_build_overview_sums_tokens_turns_and_lifecycle(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:created",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.CREATED,
+        )
+    )
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="s1:user:1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.USER,
+        )
+    )
+    _seed_agent_turn(
+        storage,
+        "s1",
+        fact_id="turn-1",
+        occurred_at=now,
+        totals={"input_tokens": 100, "output_tokens": 20},
+        display_total=120,
+    )
+    storage.telemetry.ingest_fact(
+        ToolCallFact(
+            fact_id="tool-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            tool_name="Read",
+            outcome=ToolOutcome.SUCCEEDED,
+        )
+    )
+
+    overview = aggregate.build_overview(
+        storage, _settings(), _full_range(), TelemetryFilter()
+    )
+    assert overview.sessions.created == 1
+    assert overview.turns.user == 1
+    assert overview.turns.agent == 1
+    assert overview.tool_calls == 1
+    assert overview.tokens.totals == {"input_tokens": 100, "output_tokens": 20}
+    assert overview.tokens.display_total == 120
+    assert overview.tokens.safe_total is True
+    assert overview.tokens.meter_coverage_percent == 100.0
+
+
+def test_build_overview_hides_limit_card_when_session_scoped(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "s1")
+    # No session-scoping filter -> limit card visible.
+    unscoped = aggregate.build_overview(
+        storage, _settings(), _full_range(), TelemetryFilter()
+    )
+    assert unscoped.limit_card_hidden is False
+    assert unscoped.limit_card_hidden_reason is None
+
+    scoped = aggregate.build_overview(
+        storage, _settings(), _full_range(), TelemetryFilter(repos=["waypoint"])
+    )
+    assert scoped.limit_card_hidden is True
+    assert scoped.limit_card_hidden_reason is not None
+    assert scoped.alerts.limits == []
+
+
+def test_build_overview_active_now_ignores_time_range(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "running", status=SessionStatus.RUNNING)
+    _make_session(storage, "exited", status=SessionStatus.EXITED)
+
+    # A range that predates both sessions entirely — active_now must still
+    # reflect live status, not the (empty) fact window.
+    empty_rng = TelemetryRange(
+        start=datetime(2000, 1, 1, tzinfo=UTC),
+        end=datetime(2000, 1, 2, tzinfo=UTC),
+        tz="UTC",
+    )
+    overview = aggregate.build_overview(
+        storage, _settings(), empty_rng, TelemetryFilter()
+    )
+    assert overview.sessions.active_now == 1
+
+
+def test_build_overview_empty_range_is_zero_not_error(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "s1")
+    empty_rng = TelemetryRange(
+        start=datetime(2000, 1, 1, tzinfo=UTC),
+        end=datetime(2000, 1, 2, tzinfo=UTC),
+        tz="UTC",
+    )
+    overview = aggregate.build_overview(
+        storage, _settings(), empty_rng, TelemetryFilter()
+    )
+    assert overview.tokens.totals == {}
+    assert overview.tokens.display_total is None
+    assert overview.turns.user == 0
+    assert overview.tool_calls == 0
+
+
+# ── /health ───────────────────────────────────────────────────────────────
+
+
+def test_health_context_series_gap_is_null_not_zero(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC).replace(minute=30, second=0, microsecond=0)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        ContextSnapshotFact(
+            fact_id="ctx-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            used_tokens=1000,
+            window_tokens=10000,
+            occupancy_percent=10.0,
+        )
+    )
+    rng = TelemetryRange(
+        start=now - timedelta(hours=3), end=now + timedelta(hours=1), tz="UTC"
+    )
+    health = aggregate.build_health(storage, _settings(), rng, TelemetryFilter())
+    populated_bucket = now.replace(minute=0, second=0, microsecond=0)
+    by_bucket = {
+        point.bucket_start: point.peak_percent for point in health.context.series
+    }
+    assert by_bucket[populated_bucket] == 10.0
+    empty_buckets = [b for b in by_bucket if b != populated_bucket]
+    assert empty_buckets  # the 3-hour window has other hourly buckets
+    assert all(by_bucket[b] is None for b in empty_buckets)
+
+
+def test_health_limits_hidden_when_session_scoped(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        LimitSnapshotFact(
+            fact_id="limit-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            account_key="codex:acct",
+            window_id="5h",
+            used_percent=95.0,
+        )
+    )
+    hidden = aggregate.build_health(
+        storage, _settings(), _full_range(), TelemetryFilter(models=["gpt-5"])
+    )
+    assert hidden.limits.hidden is True
+    assert hidden.limits.current == []
+    assert hidden.limits.series == []
+
+    visible = aggregate.build_health(
+        storage, _settings(), _full_range(), TelemetryFilter()
+    )
+    assert visible.limits.hidden is False
+    assert len(visible.limits.current) == 1
+    assert visible.limits.current[0].used_percent == 95.0
+
+
+def test_current_limit_snapshot_stale_after_15_minutes(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    old = now - timedelta(minutes=20)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        LimitSnapshotFact(
+            fact_id="limit-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=old,
+            dims=_dims(),
+            account_key="codex:acct",
+            window_id="5h",
+            used_percent=95.0,
+        )
+    )
+    current = aggregate.current_limit_snapshots(storage, TelemetryFilter(), now)
+    assert len(current) == 1
+    assert current[0].stale is True
+    # A stale snapshot never drives an alert/insight even above threshold.
+    assert aggregate.alerting_limits(storage, _settings(), TelemetryFilter()) == []
+
+
+# ── /drilldown ────────────────────────────────────────────────────────────
+
+
+def test_drilldown_pagination_and_total_are_consistent(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    for i in range(5):
+        storage.telemetry.ingest_fact(
+            ToolCallFact(
+                fact_id=f"tool-{i}",
+                source="codex",
+                session_id="s1",
+                occurred_at=now + timedelta(seconds=i),
+                dims=_dims(),
+                tool_name="Read",
+                outcome=ToolOutcome.SUCCEEDED,
+            )
+        )
+    page1 = aggregate.build_drilldown(
+        storage, _full_range(), TelemetryFilter(), TelemetryFactKind.TOOL_CALL, 1, 2
+    )
+    page2 = aggregate.build_drilldown(
+        storage, _full_range(), TelemetryFilter(), TelemetryFactKind.TOOL_CALL, 2, 2
+    )
+    page3 = aggregate.build_drilldown(
+        storage, _full_range(), TelemetryFilter(), TelemetryFactKind.TOOL_CALL, 3, 2
+    )
+    assert page1.total == page2.total == page3.total == 5
+    assert len(page1.items) == 2
+    assert len(page2.items) == 2
+    assert len(page3.items) == 1
+    all_ids = {item.fact_id for item in page1.items + page2.items + page3.items}
+    assert all_ids == {f"tool-{i}" for i in range(5)}
+
+
+# ── /activity ─────────────────────────────────────────────────────────────
+
+
+def test_activity_daily_is_zero_not_missing_for_quiet_days(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:created",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.CREATED,
+        )
+    )
+    rng = TelemetryRange(
+        start=now - timedelta(days=2), end=now + timedelta(hours=1), tz="UTC"
+    )
+    activity = aggregate.build_activity(storage, rng, TelemetryFilter())
+    assert len(activity.daily) == 3  # today + 2 prior quiet days
+    assert sum(d.sessions_created for d in activity.daily) == 1
+    quiet_days = [d for d in activity.daily if d.sessions_created == 0]
+    assert len(quiet_days) == 2
+    for day in quiet_days:
+        assert day.user_turns == 0
+        assert day.tool_calls == 0
+
+
+# ── range/day helpers ──────────────────────────────────────────────────────
+
+
+def test_day_range_single_day_range_yields_one_day() -> None:
+    day_start = (
+        datetime(2026, 3, 5, tzinfo=UTC)
+        .astimezone()
+        .replace(hour=0, minute=0, second=0, microsecond=0)
+    )
+    rng = TelemetryRange(
+        start=day_start.astimezone(UTC),
+        end=day_start.astimezone(UTC) + timedelta(days=1),
+        tz="UTC",
+    )
+    days = aggregate.day_range(rng)
+    assert len(days) == 1
+
+
+def test_range_key_is_stable_for_identical_bounds() -> None:
+    rng_a = TelemetryRange(
+        start=datetime(2026, 1, 1, tzinfo=UTC),
+        end=datetime(2026, 1, 2, tzinfo=UTC),
+        tz="UTC",
+    )
+    rng_b = TelemetryRange(
+        start=datetime(2026, 1, 1, tzinfo=UTC),
+        end=datetime(2026, 1, 2, tzinfo=UTC),
+        tz="UTC",
+    )
+    assert aggregate.range_key(rng_a) == aggregate.range_key(rng_b)
+
+
+# ── settings / delete ──────────────────────────────────────────────────────
+
+
+def test_build_settings_reflects_configured_retention(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    settings = Settings(
+        telemetry_retention_days=42, telemetry_rollup_retention_months=6
+    )
+    view = aggregate.build_settings(storage, settings)
+    assert view.retention_days_facts == 42
+    assert view.retention_months_rollups == 6
+    assert view.external_export is False
+    assert view.content_capture is False
+
+
+def test_delete_all_clears_facts_rollups_and_dismissals(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:created",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.CREATED,
+        )
+    )
+    storage.telemetry.dismiss_insight("near_limit", "somerange")
+    result = aggregate.delete_all(storage)
+    assert result.removed.facts == 1
+    facts_left = storage.connection.execute(
+        "SELECT COUNT(*) AS n FROM telemetry_facts"
+    ).fetchone()
+    assert facts_left["n"] == 0
+    assert storage.telemetry.dismissed_insights("somerange") == set()
+    # Transcript/session record untouched by a telemetry-only delete.
+    assert storage.get_session("s1") is not None
+
+
+# ── insight gates (FR-8, plan §2.5) ────────────────────────────────────────
+
+
+def test_context_pressure_insight_fires_above_threshold(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        ContextSnapshotFact(
+            fact_id="ctx-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            used_tokens=8000,
+            window_tokens=10000,
+            occupancy_percent=80.0,
+        )
+    )
+    insights = telemetry_insights.compute_insights(
+        storage, _settings(), _full_range(), TelemetryFilter()
+    )
+    context_insights = [i for i in insights if i.type == "context_pressure"]
+    assert len(context_insights) == 1
+    assert context_insights[0].severity == "info"  # 80% is >= 70 but < 90
+    assert context_insights[0].signature == "context_pressure"
+
+
+def test_context_pressure_insight_omitted_below_threshold(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        ContextSnapshotFact(
+            fact_id="ctx-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            used_tokens=1000,
+            window_tokens=10000,
+            occupancy_percent=10.0,
+        )
+    )
+    insights = telemetry_insights.compute_insights(
+        storage, _settings(), _full_range(), TelemetryFilter()
+    )
+    assert [i for i in insights if i.type == "context_pressure"] == []
+
+
+def test_near_limit_insight_omitted_when_session_scoped(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        LimitSnapshotFact(
+            fact_id="limit-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            account_key="codex:acct",
+            window_id="5h",
+            used_percent=99.0,
+        )
+    )
+    unscoped = telemetry_insights.compute_insights(
+        storage, _settings(), _full_range(), TelemetryFilter()
+    )
+    assert any(i.type == "near_limit" for i in unscoped)
+
+    scoped = telemetry_insights.compute_insights(
+        storage, _settings(), _full_range(), TelemetryFilter(repos=["waypoint"])
+    )
+    assert not any(i.type == "near_limit" for i in scoped)
+
+
+def test_dismissed_insight_is_omitted(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        ContextSnapshotFact(
+            fact_id="ctx-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            used_tokens=9000,
+            window_tokens=10000,
+            occupancy_percent=90.0,
+        )
+    )
+    rng = _full_range()
+    before = telemetry_insights.compute_insights(
+        storage, _settings(), rng, TelemetryFilter()
+    )
+    assert any(i.type == "context_pressure" for i in before)
+
+    storage.telemetry.dismiss_insight("context_pressure", aggregate.range_key(rng))
+    after = telemetry_insights.compute_insights(
+        storage, _settings(), rng, TelemetryFilter()
+    )
+    assert not any(i.type == "context_pressure" for i in after)
+
+
+def _seed_tracked_turns(
+    storage: Storage,
+    session_id: str,
+    occurred_ats: list[datetime],
+    *,
+    per_turn_tokens: int,
+    prefix: str,
+) -> None:
+    for i, occurred_at in enumerate(occurred_ats):
+        _seed_agent_turn(
+            storage,
+            session_id,
+            fact_id=f"{prefix}:{i}",
+            occurred_at=occurred_at,
+            totals={"input_tokens": per_turn_tokens},
+            display_total=per_turn_tokens,
+        )
+
+
+def test_token_volume_change_fires_when_all_gates_met(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    rng = TelemetryRange(start=now - timedelta(hours=2), end=now, tz="UTC")
+    current_times = [now - timedelta(minutes=100 - 5 * i) for i in range(10)]
+    previous_times = [now - timedelta(minutes=220 - 5 * i) for i in range(10)]
+    _seed_tracked_turns(
+        storage, "s1", previous_times, per_turn_tokens=2000, prefix="prev"
+    )
+    _seed_tracked_turns(
+        storage, "s1", current_times, per_turn_tokens=3200, prefix="cur"
+    )
+
+    insights = telemetry_insights.compute_insights(
+        storage, _settings(), rng, TelemetryFilter()
+    )
+    volume_insights = [i for i in insights if i.type == "token_volume_change"]
+    assert len(volume_insights) == 1
+    metrics = volume_insights[0].metrics
+    assert metrics["current_total"] == 32000
+    assert metrics["previous_total"] == 20000
+    assert metrics["diff"] == 12000
+
+
+def test_token_volume_change_omitted_when_meter_coverage_too_low(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    rng = TelemetryRange(start=now - timedelta(hours=2), end=now, tz="UTC")
+    current_times = [now - timedelta(minutes=100 - 5 * i) for i in range(10)]
+    previous_times = [now - timedelta(minutes=220 - 5 * i) for i in range(10)]
+    _seed_tracked_turns(
+        storage, "s1", previous_times, per_turn_tokens=2000, prefix="prev"
+    )
+    _seed_tracked_turns(
+        storage, "s1", current_times[:2], per_turn_tokens=3200, prefix="cur"
+    )
+    # 8 more AGENT turns with no ledger row — meter coverage in the current
+    # range drops to 2/10 = 20%, well under the 80% gate.
+    for i in range(8):
+        storage.telemetry.ingest_fact(
+            TurnFact(
+                fact_id=f"untracked:{i}",
+                source="codex",
+                session_id="s1",
+                occurred_at=current_times[2 + i],
+                dims=_dims(),
+                turn_kind=TurnKind.AGENT,
+            )
+        )
+
+    insights = telemetry_insights.compute_insights(
+        storage, _settings(), rng, TelemetryFilter()
+    )
+    assert [i for i in insights if i.type == "token_volume_change"] == []
+
+
+def test_token_volume_change_omitted_below_percent_gate(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1")
+    rng = TelemetryRange(start=now - timedelta(hours=2), end=now, tz="UTC")
+    current_times = [now - timedelta(minutes=100 - 5 * i) for i in range(10)]
+    previous_times = [now - timedelta(minutes=220 - 5 * i) for i in range(10)]
+    # Absolute diff clears 10k (15000) but relative change is only 10%.
+    _seed_tracked_turns(
+        storage, "s1", previous_times, per_turn_tokens=15000, prefix="prev"
+    )
+    _seed_tracked_turns(
+        storage, "s1", current_times, per_turn_tokens=16500, prefix="cur"
+    )
+
+    insights = telemetry_insights.compute_insights(
+        storage, _settings(), rng, TelemetryFilter()
+    )
+    assert [i for i in insights if i.type == "token_volume_change"] == []

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -256,22 +256,57 @@ def test_build_overview_hides_limit_card_when_session_scoped(tmp_path: Path) -> 
     assert scoped.alerts.limits == []
 
 
-def test_build_overview_active_now_ignores_time_range(tmp_path: Path) -> None:
+def test_build_overview_active_now_uses_live_status_for_current_range(
+    tmp_path: Path,
+) -> None:
     storage = Storage(tmp_path / "db.sqlite")
     _make_session(storage, "running", status=SessionStatus.RUNNING)
     _make_session(storage, "exited", status=SessionStatus.EXITED)
 
-    # A range that predates both sessions entirely — active_now must still
-    # reflect live status, not the (empty) fact window.
-    empty_rng = TelemetryRange(
-        start=datetime(2000, 1, 1, tzinfo=UTC),
-        end=datetime(2000, 1, 2, tzinfo=UTC),
-        tz="UTC",
-    )
+    # rng.end covers the live present -> the cheap live-status shortcut applies,
+    # even though no lifecycle facts were seeded to back it.
     overview = aggregate.build_overview(
-        storage, _settings(), empty_rng, TelemetryFilter()
+        storage, _settings(), _full_range(), TelemetryFilter()
     )
     assert overview.sessions.active_now == 1
+
+
+def test_build_overview_active_now_reconstructs_from_facts_for_historical_range(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "s1", status=SessionStatus.EXITED)
+    # Live status says EXITED, but at the historical instant below the
+    # session's last known transition was RUNNING — active_now for a
+    # wholly-past range must reflect *that*, not today's live status.
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:running",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now - timedelta(days=10),
+            dims=_dims(),
+            transition=LifecycleTransition.RUNNING,
+        )
+    )
+    historical_rng = TelemetryRange(
+        start=now - timedelta(days=11), end=now - timedelta(days=9), tz="UTC"
+    )
+    overview = aggregate.build_overview(
+        storage, _settings(), historical_rng, TelemetryFilter()
+    )
+    assert overview.sessions.active_now == 1
+
+    # A range ending before the RUNNING transition was even recorded sees no
+    # active sessions yet (facts, not live status, govern the past).
+    earlier_rng = TelemetryRange(
+        start=now - timedelta(days=20), end=now - timedelta(days=15), tz="UTC"
+    )
+    earlier_overview = aggregate.build_overview(
+        storage, _settings(), earlier_rng, TelemetryFilter()
+    )
+    assert earlier_overview.sessions.active_now == 0
 
 
 def test_build_overview_empty_range_is_zero_not_error(tmp_path: Path) -> None:
@@ -720,3 +755,183 @@ def test_token_volume_change_omitted_below_percent_gate(tmp_path: Path) -> None:
         storage, _settings(), rng, TelemetryFilter()
     )
     assert [i for i in insights if i.type == "token_volume_change"] == []
+
+
+# ── fix-api regression tests (review findings 1-3) ────────────────────────
+
+
+def test_overview_tag_filter_keeps_session_counts_consistent_with_tokens(
+    tmp_path: Path,
+) -> None:
+    """Finding 1: query_rollup can't represent a tag filter, so the fact-scan
+    fallback must be used for lifecycle/turn counts too — not just tokens."""
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "tagged")
+    _make_session(storage, "untagged")
+
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="tagged:created",
+            source="runtime",
+            session_id="tagged",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.CREATED,
+        ),
+        tags={"role": "lead"},
+    )
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="untagged:created",
+            source="runtime",
+            session_id="untagged",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.CREATED,
+        )
+    )
+    storage.record_token_usage(
+        "tagged",
+        TokenUsageRecord(
+            record_id="tagged:turn",
+            source="codex",
+            observed_at=now,
+            totals={"input_tokens": 500},
+            display_total_tokens=500,
+        ),
+        init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
+    )
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="tagged:turn",
+            source="codex",
+            session_id="tagged",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.AGENT,
+        ),
+        tags={"role": "lead"},
+    )
+    storage.record_token_usage(
+        "untagged",
+        TokenUsageRecord(
+            record_id="untagged:turn",
+            source="codex",
+            observed_at=now,
+            totals={"input_tokens": 900},
+            display_total_tokens=900,
+        ),
+        init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
+    )
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="untagged:turn",
+            source="codex",
+            session_id="untagged",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.AGENT,
+        )
+    )
+
+    overview = aggregate.build_overview(
+        storage, _settings(), _full_range(), TelemetryFilter(tags=["role:lead"])
+    )
+    # Before the fix, sessions/turns came from the (tag-blind) rollup and
+    # would include BOTH sessions while tokens (always fact-derived) included
+    # only the tagged one — an internally inconsistent response.
+    assert overview.sessions.created == 1
+    assert overview.turns.agent == 1
+    assert overview.tokens.totals == {"input_tokens": 500}
+    assert overview.tokens.display_total == 500
+
+
+def test_transitive_descendants_scope_tokens_and_drilldown(tmp_path: Path) -> None:
+    """Finding 3: exclude-descendants means the parent's own facts only;
+    include-descendants must resolve the full transitive descendant set."""
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "parent")
+    _make_session(storage, "child", spawner_session_id="parent")
+    _make_session(storage, "grandchild", spawner_session_id="child")
+
+    spawner_by_session = {"parent": None, "child": "parent", "grandchild": "child"}
+    for session_id, tokens in (("parent", 100), ("child", 200), ("grandchild", 300)):
+        spawner = spawner_by_session[session_id]
+        dims = _dims(spawner_session_id=spawner, is_child=spawner is not None)
+        storage.record_token_usage(
+            session_id,
+            TokenUsageRecord(
+                record_id=f"{session_id}:turn",
+                source="codex",
+                observed_at=now,
+                totals={"input_tokens": tokens},
+                display_total_tokens=tokens,
+            ),
+            init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
+        )
+        storage.telemetry.ingest_fact(
+            TurnFact(
+                fact_id=f"{session_id}:turn",
+                source="codex",
+                session_id=session_id,
+                occurred_at=now,
+                dims=dims,
+                turn_kind=TurnKind.AGENT,
+            )
+        )
+        storage.telemetry.ingest_fact(
+            ToolCallFact(
+                fact_id=f"{session_id}:tool",
+                source="codex",
+                session_id=session_id,
+                occurred_at=now,
+                dims=dims,
+                tool_name="Read",
+                outcome=ToolOutcome.SUCCEEDED,
+            )
+        )
+
+    include_all = aggregate.build_tokens(
+        storage,
+        _full_range(),
+        TelemetryFilter(parent_session_id="parent", include_descendants=True),
+        "session",
+    )
+    assert {g.key for g in include_all.groups} == {"parent", "child", "grandchild"}
+
+    own_only = aggregate.build_tokens(
+        storage,
+        _full_range(),
+        TelemetryFilter(parent_session_id="parent", include_descendants=False),
+        "session",
+    )
+    assert {g.key for g in own_only.groups} == {"parent"}
+
+    include_from_child = aggregate.build_tokens(
+        storage,
+        _full_range(),
+        TelemetryFilter(parent_session_id="child", include_descendants=True),
+        "session",
+    )
+    assert {g.key for g in include_from_child.groups} == {"child", "grandchild"}
+
+    drilldown_all = aggregate.build_drilldown(
+        storage,
+        _full_range(),
+        TelemetryFilter(parent_session_id="parent", include_descendants=True),
+        TelemetryFactKind.TOOL_CALL,
+        1,
+        10,
+    )
+    assert drilldown_all.total == 3
+
+    drilldown_own = aggregate.build_drilldown(
+        storage,
+        _full_range(),
+        TelemetryFilter(parent_session_id="parent", include_descendants=False),
+        TelemetryFactKind.TOOL_CALL,
+        1,
+        10,
+    )
+    assert drilldown_own.total == 1
+    assert drilldown_own.items[0].session_id == "parent"

--- a/backend/tests/test_telemetry_api.py
+++ b/backend/tests/test_telemetry_api.py
@@ -1,0 +1,313 @@
+"""Route-level tests for ``/api/telemetry/*`` over the real FastAPI app.
+
+Covers the API contract pieces CONTRACT.md §4/§7 calls out explicitly: auth,
+date/tz range boundaries, empty range, filter semantics (including limit-card
+hiding), drill-down parameter validation, insight dismissal, and the
+debounced ``telemetry_update`` WS envelope.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+from starlette.testclient import TestClient
+
+from waypoint.api import create_app
+from waypoint.schemas import (
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+    TokenUsageInit,
+    TokenUsageRecord,
+)
+from waypoint.settings import Settings
+from waypoint.telemetry.facts import (
+    ContextSnapshotFact,
+    FactDimensions,
+    LifecycleTransition,
+    LimitSnapshotFact,
+    SessionLifecycleFact,
+    TurnFact,
+    TurnKind,
+)
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    context = app.state.context
+    token = context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _dims() -> FactDimensions:
+    return FactDimensions.model_validate(
+        {
+            "backend": "codex",
+            "repo_name": "waypoint",
+            "source": SessionSource.MANAGED,
+            "transport": "tmux",
+            "spawner_session_id": None,
+            "is_child": False,
+        }
+    )
+
+
+def _seed_session(context: Any, session_id: str) -> None:
+    now = datetime.now(UTC)
+    context.storage.create_session(
+        SessionRecord(
+            id=session_id,
+            backend="codex",
+            source=SessionSource.MANAGED,
+            transport="tmux",
+            title=session_id,
+            cwd="/tmp",
+            repo_name="waypoint",
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/tmp/raw.log",
+            structured_log_path="/tmp/events.jsonl",
+        )
+    )
+
+
+async def test_requires_auth(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/telemetry/overview")
+    assert resp.status_code == 401
+
+
+async def test_overview_empty_instance_returns_zeros_not_error(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/telemetry/overview", headers=_auth(token))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tokens"]["totals"] == {}
+    assert body["tokens"]["display_total"] is None
+    assert body["sessions"]["active_now"] == 0
+    assert body["tool_calls"] == 0
+    assert "start" in body["range"] and "end" in body["range"] and "tz" in body["range"]
+
+
+async def test_custom_range_requires_both_start_and_end(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/telemetry/overview",
+            params={"start": "2026-01-01"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 400
+
+
+async def test_unknown_preset_is_rejected(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/telemetry/overview",
+            params={"preset": "bogus"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 400
+
+
+async def test_preset_today_excludes_yesterdays_data(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    context = app.state.context
+    _seed_session(context, "s1")
+    now = datetime.now(UTC)
+    yesterday = now - timedelta(days=1)
+    context.storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:created:today",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.CREATED,
+        )
+    )
+    context.storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:created:yesterday",
+            source="runtime",
+            session_id="s1",
+            occurred_at=yesterday,
+            dims=_dims(),
+            transition=LifecycleTransition.STARTING,
+        )
+    )
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/telemetry/overview", params={"preset": "today"}, headers=_auth(token)
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["sessions"]["created"] == 1
+
+
+async def test_tokens_group_by_backend_splits_totals(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    context = app.state.context
+    _seed_session(context, "s1")
+    now = datetime.now(UTC)
+
+    for backend, tokens in (("codex", 100), ("claude_code", 250)):
+        context.storage.record_token_usage(
+            "s1",
+            TokenUsageRecord(
+                record_id=f"turn-{backend}",
+                source=backend,
+                observed_at=now,
+                totals={"input_tokens": tokens},
+                display_total_tokens=tokens,
+            ),
+            init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
+        )
+        context.storage.telemetry.ingest_fact(
+            TurnFact(
+                fact_id=f"turn-{backend}",
+                source=backend,
+                session_id="s1",
+                occurred_at=now,
+                dims=FactDimensions.model_validate(
+                    {
+                        "backend": backend,
+                        "repo_name": "waypoint",
+                        "source": SessionSource.MANAGED,
+                        "transport": "tmux",
+                        "spawner_session_id": None,
+                        "is_child": False,
+                    }
+                ),
+                turn_kind=TurnKind.AGENT,
+            )
+        )
+
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/telemetry/tokens",
+            params={"group_by": "backend"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["group_by"] == "backend"
+    by_key = {group["key"]: group for group in body["groups"]}
+    assert by_key["codex"]["totals"] == {"input_tokens": 100}
+    assert by_key["claude_code"]["totals"] == {"input_tokens": 250}
+
+
+async def test_drilldown_requires_kind_query_param(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/telemetry/drilldown", headers=_auth(token))
+    assert resp.status_code == 422
+
+
+async def test_settings_endpoint_shape(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/telemetry/settings", headers=_auth(token))
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["retention_days_facts"] == 90
+    assert body["retention_months_rollups"] == 13
+    assert body["external_export"] is False
+    assert body["content_capture"] is False
+    assert "privacy_statement" in body
+
+
+async def test_limit_card_hidden_via_session_scoped_filter(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    context = app.state.context
+    _seed_session(context, "s1")
+    now = datetime.now(UTC)
+    context.storage.telemetry.ingest_fact(
+        LimitSnapshotFact(
+            fact_id="limit-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            account_key="codex:acct",
+            window_id="5h",
+            used_percent=95.0,
+        )
+    )
+    async with _client(app) as client:
+        unscoped = await client.get("/api/telemetry/overview", headers=_auth(token))
+        scoped = await client.get(
+            "/api/telemetry/overview",
+            params={"repo": "waypoint"},
+            headers=_auth(token),
+        )
+    assert unscoped.json()["limit_card_hidden"] is False
+    assert scoped.json()["limit_card_hidden"] is True
+    assert scoped.json()["limit_card_hidden_reason"] is not None
+    assert scoped.json()["alerts"]["limits"] == []
+
+
+async def test_insight_dismiss_round_trip(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    context = app.state.context
+    _seed_session(context, "s1")
+    now = datetime.now(UTC)
+    context.storage.telemetry.ingest_fact(
+        ContextSnapshotFact(
+            fact_id="ctx-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            used_tokens=9500,
+            window_tokens=10000,
+            occupancy_percent=95.0,
+        )
+    )
+    async with _client(app) as client:
+        before = await client.get("/api/telemetry/insights", headers=_auth(token))
+        assert before.status_code == 200
+        types_before = {i["type"] for i in before.json()["insights"]}
+        assert "context_pressure" in types_before
+
+        dismiss = await client.post(
+            "/api/telemetry/insights/context_pressure/dismiss", headers=_auth(token)
+        )
+        assert dismiss.status_code == 200
+        assert dismiss.json()["signature"] == "context_pressure"
+
+        after = await client.get("/api/telemetry/insights", headers=_auth(token))
+        types_after = {i["type"] for i in after.json()["insights"]}
+        assert "context_pressure" not in types_after
+
+
+def test_delete_publishes_debounced_telemetry_update(tmp_path: Path) -> None:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    context = app.state.context
+    token = context.tokens.issue().token
+    with TestClient(app) as client:
+        with client.websocket_connect(f"/ws/sessions?token={token}") as ws:
+            ws.receive_json()  # initial session_list_update hydration frame
+            client.delete(
+                "/api/telemetry", headers={"Authorization": f"Bearer {token}"}
+            )
+            update = ws.receive_json()
+    assert update["type"] == "telemetry_update"

--- a/backend/tests/test_telemetry_api.py
+++ b/backend/tests/test_telemetry_api.py
@@ -99,7 +99,8 @@ async def test_overview_empty_instance_returns_zeros_not_error(tmp_path: Path) -
     assert resp.status_code == 200
     body = resp.json()
     assert body["tokens"]["totals"] == {}
-    assert body["tokens"]["display_total"] is None
+    assert body["tokens"]["display_total"] == 0
+    assert body["tokens"]["safe_total"] is True
     assert body["sessions"]["active_now"] == 0
     assert body["tool_calls"] == 0
     assert "start" in body["range"] and "end" in body["range"] and "tz" in body["range"]
@@ -210,8 +211,20 @@ async def test_tokens_group_by_backend_splits_totals(tmp_path: Path) -> None:
     body = resp.json()
     assert body["group_by"] == "backend"
     by_key = {group["key"]: group for group in body["groups"]}
-    assert by_key["codex"]["totals"] == {"input_tokens": 100}
-    assert by_key["claude_code"]["totals"] == {"input_tokens": 250}
+    assert by_key["codex"]["totals"] == {
+        "fresh_input": 100,
+        "cache_read": 0,
+        "cache_write": 0,
+        "output": 0,
+        "reasoning": 0,
+    }
+    assert by_key["claude_code"]["totals"] == {
+        "fresh_input": 250,
+        "cache_read": 0,
+        "cache_write": 0,
+        "output": 0,
+        "reasoning": 0,
+    }
 
 
 async def test_drilldown_requires_kind_query_param(tmp_path: Path) -> None:

--- a/backend/tests/test_telemetry_ingest.py
+++ b/backend/tests/test_telemetry_ingest.py
@@ -592,7 +592,9 @@ def test_context_usage_update_is_rate_limited_to_one_per_minute(tmp_path: Path) 
 
 def test_rate_limit_usage_derives_one_fact_per_window(tmp_path: Path) -> None:
     storage = Storage(tmp_path / "db.sqlite")
-    session = _make_session(storage, "s1")
+    session = _make_session(storage, "s1").model_copy(
+        update={"verified_account_key": "acct-abc"}
+    )
     ingester = TelemetryIngester(storage)
     now = datetime.now(UTC)
 
@@ -615,7 +617,30 @@ def test_rate_limit_usage_derives_one_fact_per_window(tmp_path: Path) -> None:
     assert len(rows) == 2
     window_ids = {r["window_id"] for r in rows}
     assert window_ids == {"5h", "7d"}
-    assert all(r["account_key"] == "session:s1" for r in rows)
+    # Keyed to the verified account, so windows aggregate across the account's
+    # sessions rather than fragmenting per session.
+    assert all(r["account_key"] == "acct-abc" for r in rows)
+
+
+def test_rate_limit_usage_without_verified_account_derives_nothing(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")  # no verified_account_key
+    ingester = TelemetryIngester(storage)
+    ingester.derive_from_session_update(
+        session,
+        {
+            "rate_limit_usage": SessionRateLimitUsage(
+                source="codex",
+                updated_at=datetime.now(UTC),
+                windows=[UsageWindow(id="5h", label="5 hour", used_percent=42.0)],
+            )
+        },
+    )
+    ingester._drain_available()
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "limit_snapshot"]
+    assert rows == []
 
 
 def test_backfill_derives_facts_and_is_idempotent(tmp_path: Path) -> None:

--- a/backend/tests/test_telemetry_ingest.py
+++ b/backend/tests/test_telemetry_ingest.py
@@ -1,0 +1,581 @@
+"""Tests for ``TelemetryIngester`` (CONTRACT.md §3/§7).
+
+Covers derivation correctness per signal (session-created, status-carrying
+events, user/agent turns, tool call+result pairing, approval request+decision,
+context/limit snapshots), dedup on event replay, ``backfill()`` idempotency,
+and privacy (no raw text/paths ever land in a fact/tag column).
+"""
+
+import asyncio
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from waypoint.schemas import (
+    EventKind,
+    EventRecord,
+    SessionContextUsage,
+    SessionRateLimitUsage,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+    TokenUsageInit,
+    TokenUsageRecord,
+    UsageWindow,
+)
+from waypoint.storage import Storage
+from waypoint.telemetry.ingest import TelemetryIngester
+
+
+def _make_session(
+    storage: Storage,
+    session_id: str,
+    *,
+    repo_path: str | None = "/home/user/projects/waypoint",
+    resolved_model: str | None = "gpt-5-codex",
+    spawner_session_id: str | None = None,
+    tags: dict[str, str] | None = None,
+) -> SessionRecord:
+    now = datetime.now(UTC)
+    session = SessionRecord(
+        id=session_id,
+        backend="codex",
+        source=SessionSource.MANAGED,
+        transport="tmux",
+        title="t",
+        cwd="/home/user/projects/waypoint",
+        repo_name=repo_path,
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path="/home/user/.waypoint/sessions/s1/raw.log",
+        structured_log_path="/home/user/.waypoint/sessions/s1/events.jsonl",
+        resolved_model=resolved_model,
+        spawner_session_id=spawner_session_id,
+        tags=tags or {},
+    )
+    storage.create_session(session)
+    return session
+
+
+def _facts(storage: Storage, session_id: str | None = None) -> list[dict]:
+    if session_id is None:
+        rows = storage.connection.execute("SELECT * FROM telemetry_facts").fetchall()
+    else:
+        rows = storage.connection.execute(
+            "SELECT * FROM telemetry_facts WHERE session_id = ?", (session_id,)
+        ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def test_session_created_derives_lifecycle_fact(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+
+    ingester.derive_from_session_created(session)
+    ingester._drain_available()
+
+    rows = _facts(storage, "s1")
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "session_lifecycle"
+    assert rows[0]["transition"] == "created"
+    assert rows[0]["backend"] == "codex"
+    assert rows[0]["repo_name"] == "waypoint"
+    assert rows[0]["is_child"] == 0
+
+
+def test_child_session_is_stamped_is_child(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "child", spawner_session_id="parent")
+    ingester = TelemetryIngester(storage)
+
+    ingester.derive_from_session_created(session)
+    ingester._drain_available()
+
+    row = _facts(storage, "child")[0]
+    assert row["is_child"] == 1
+    assert row["spawner_session_id"] == "parent"
+
+
+def test_status_metadata_on_event_derives_lifecycle_fact_and_dedups_replay(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    event = EventRecord(
+        session_id="s1",
+        ts=now,
+        kind=EventKind.SYSTEM_NOTE,
+        text="Turn ended",
+        metadata={"status": SessionStatus.IDLE},
+        sequence=7,
+    )
+    ingester.derive_from_event(session, event)
+    ingester.derive_from_event(session, event)  # replay of the exact same event
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "session_lifecycle"]
+    assert len(rows) == 1
+    assert rows[0]["transition"] == "idle"
+    assert rows[0]["fact_id"] == "s1:7"
+
+
+def test_user_input_event_derives_turn_fact_with_resolved_model(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1", resolved_model="claude-sonnet-5")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    event = EventRecord(
+        session_id="s1",
+        ts=now,
+        kind=EventKind.USER_INPUT,
+        text="do the thing",
+        metadata={},
+        sequence=1,
+    )
+    ingester.derive_from_event(session, event)
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "turn"]
+    assert len(rows) == 1
+    assert rows[0]["turn_kind"] == "user"
+    assert rows[0]["model_at_turn"] == "claude-sonnet-5"
+
+
+def test_tool_call_then_result_merges_into_one_fact_with_outcome_and_duration(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    call_ts = datetime.now(UTC)
+    result_ts = call_ts + timedelta(milliseconds=250)
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=call_ts,
+            kind=EventKind.TOOL_CALL,
+            text="Read\n{...}",
+            metadata={"tool_use_id": "tool-1", "tool_name": "Read"},
+            sequence=1,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=result_ts,
+            kind=EventKind.TOOL_RESULT,
+            text="<file contents>",
+            metadata={"tool_use_id": "tool-1", "tool_name": "Read", "is_error": False},
+            sequence=2,
+        ),
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "tool_call"]
+    assert len(rows) == 1
+    assert rows[0]["fact_id"] == "tool-1"
+    assert rows[0]["tool_name"] == "Read"
+    assert rows[0]["outcome"] == "succeeded"
+    assert rows[0]["duration_ms"] == 250
+    assert rows[0]["revision"] == 1
+
+
+def test_tool_result_is_error_maps_to_failed(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.TOOL_CALL,
+            text="Bash\n{...}",
+            metadata={"tool_use_id": "tool-2", "tool_name": "Bash"},
+            sequence=1,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.TOOL_RESULT,
+            text="error output",
+            metadata={"tool_use_id": "tool-2", "tool_name": "Bash", "is_error": True},
+            sequence=2,
+        ),
+    )
+    ingester._drain_available()
+
+    row = [r for r in _facts(storage, "s1") if r["kind"] == "tool_call"][0]
+    assert row["outcome"] == "failed"
+
+
+def test_duplicate_tool_result_event_is_deduped(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+    result_event = EventRecord(
+        session_id="s1",
+        ts=now,
+        kind=EventKind.TOOL_RESULT,
+        text="ok",
+        metadata={"tool_use_id": "tool-3", "tool_name": "Read", "is_error": False},
+        sequence=2,
+    )
+
+    ingester.derive_from_event(session, result_event)
+    ingester.derive_from_event(session, result_event)  # replay
+    ingester._drain_available()
+
+    rows = storage.connection.execute(
+        "SELECT COUNT(*) AS n FROM telemetry_facts WHERE kind = 'tool_call' AND fact_id = 'tool-3'"
+    ).fetchone()
+    assert rows["n"] == 1
+
+
+def test_approval_request_then_decision_updates_fact(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.APPROVAL_REQUEST,
+            text="Allow Bash to run `rm -rf /secret/path`?",
+            metadata={"approval_id": "appr-1", "tool_name": "Bash"},
+            sequence=1,
+        ),
+    )
+    ingester._drain_available()
+    requested = [r for r in _facts(storage, "s1") if r["kind"] == "tool_call"][0]
+    assert requested["approval_decision"] == "requested"
+    assert requested["tool_name"] == "Bash"
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now + timedelta(seconds=1),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Approval response sent: accept",
+            metadata={"approval_id": "appr-1", "status": SessionStatus.RUNNING},
+            sequence=2,
+        ),
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "tool_call"]
+    assert len(rows) == 1
+    assert rows[0]["approval_decision"] == "approved"
+    assert rows[0]["tool_name"] == "Bash"  # carried over from the request
+
+    # The same event also carried a status, so a lifecycle fact derives too.
+    lifecycle = [r for r in _facts(storage, "s1") if r["kind"] == "session_lifecycle"]
+    assert len(lifecycle) == 1
+    assert lifecycle[0]["transition"] == "running"
+
+
+def test_approval_decline_maps_to_declined(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.APPROVAL_REQUEST,
+            text="Allow?",
+            metadata={"approval_id": "appr-2", "tool_name": "Write"},
+            sequence=1,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now + timedelta(seconds=1),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Approval response sent: decline",
+            metadata={"approval_id": "appr-2"},
+            sequence=2,
+        ),
+    )
+    ingester._drain_available()
+
+    row = [r for r in _facts(storage, "s1") if r["kind"] == "tool_call"][0]
+    assert row["approval_decision"] == "declined"
+
+
+def test_token_record_derives_agent_turn_fact(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    storage.record_token_usage(
+        "s1",
+        TokenUsageRecord(
+            record_id="turn-1",
+            source="codex",
+            observed_at=now,
+            totals={"input_tokens": 10},
+            model="gpt-5-codex",
+            effort="high",
+        ),
+        init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
+    )
+    ingester.derive_from_token_record(
+        session,
+        TokenUsageRecord(
+            record_id="turn-1",
+            source="codex",
+            observed_at=now,
+            totals={"input_tokens": 10},
+            model="gpt-5-codex",
+            effort="high",
+        ),
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "turn"]
+    assert len(rows) == 1
+    assert rows[0]["fact_id"] == "turn-1"
+    assert rows[0]["turn_kind"] == "agent"
+    assert rows[0]["model_at_turn"] == "gpt-5-codex"
+    assert rows[0]["effort_at_turn"] == "high"
+    assert rows[0]["source"] == "codex"
+
+
+def test_token_record_without_model_falls_back_to_resolved_model(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1", resolved_model="gpt-5-codex")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_token_record(
+        session,
+        TokenUsageRecord(
+            record_id="turn-2", source="codex", observed_at=now, totals={}
+        ),
+    )
+    ingester._drain_available()
+
+    row = [r for r in _facts(storage, "s1") if r["kind"] == "turn"][0]
+    assert row["model_at_turn"] == "gpt-5-codex"
+
+
+def test_context_usage_update_is_rate_limited_to_one_per_minute(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    t0 = datetime.now(UTC).replace(second=1, microsecond=0)
+
+    ingester.derive_from_session_update(
+        session,
+        {
+            "context_usage": SessionContextUsage(
+                used_tokens=1000,
+                context_window_tokens=10000,
+                updated_at=t0,
+                source="codex",
+            )
+        },
+    )
+    ingester.derive_from_session_update(
+        session,
+        {
+            "context_usage": SessionContextUsage(
+                used_tokens=2000,
+                context_window_tokens=10000,
+                updated_at=t0 + timedelta(seconds=10),
+                source="codex",
+            )
+        },
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "context_snapshot"]
+    assert len(rows) == 1
+    assert rows[0]["used_tokens"] == 2000
+    assert rows[0]["occupancy_percent"] == 20.0
+
+
+def test_rate_limit_usage_derives_one_fact_per_window(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_session_update(
+        session,
+        {
+            "rate_limit_usage": SessionRateLimitUsage(
+                source="codex",
+                updated_at=now,
+                windows=[
+                    UsageWindow(id="5h", label="5 hour", used_percent=42.0),
+                    UsageWindow(id="7d", label="weekly", used_percent=10.0),
+                ],
+            )
+        },
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "limit_snapshot"]
+    assert len(rows) == 2
+    window_ids = {r["window_id"] for r in rows}
+    assert window_ids == {"5h", "7d"}
+    assert all(r["account_key"] == "session:s1" for r in rows)
+
+
+def test_backfill_derives_facts_and_is_idempotent(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    storage.append_event(
+        EventRecord(
+            session_id="s1",
+            ts=session.created_at,
+            kind=EventKind.USER_INPUT,
+            text="hello",
+            sequence=1,
+        )
+    )
+    storage.record_token_usage(
+        "s1",
+        TokenUsageRecord(
+            record_id="turn-1",
+            source="codex",
+            observed_at=session.created_at,
+            totals={"input_tokens": 5},
+            model="gpt-5-codex",
+        ),
+        init=TokenUsageInit(
+            coverage="entire_waypoint_session", observed_from=session.created_at
+        ),
+    )
+
+    ingester = TelemetryIngester(storage)
+    asyncio.run(ingester.backfill())
+
+    rows = _facts(storage, "s1")
+    kinds = {r["kind"] for r in rows}
+    assert "session_lifecycle" in kinds
+    assert "turn" in kinds
+    assert storage.telemetry.get_meta("backfill_done") == "true"
+
+    # A second call is a no-op guarded by telemetry_meta, not a re-derive.
+    count_before = storage.connection.execute(
+        "SELECT COUNT(*) AS n FROM telemetry_facts"
+    ).fetchone()["n"]
+    asyncio.run(ingester.backfill())
+    count_after = storage.connection.execute(
+        "SELECT COUNT(*) AS n FROM telemetry_facts"
+    ).fetchone()["n"]
+    assert count_after == count_before
+
+
+def test_privacy_no_raw_text_or_paths_persisted(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(
+        storage,
+        "s1",
+        repo_path="/home/user/projects/waypoint",
+    )
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+    secret_path = "/home/user/.ssh/id_rsa"
+    secret_text = f"cat {secret_path}\nSUPER_SECRET_TOKEN=abc123"
+
+    ingester.derive_from_session_created(session)
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.USER_INPUT,
+            text=secret_text,
+            metadata={},
+            sequence=1,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.TOOL_CALL,
+            text=f'Bash\n{{"command": "cat {secret_path}"}}',
+            metadata={
+                "tool_use_id": "tool-9",
+                "tool_name": "Bash",
+                "payload": {"input": {"command": f"cat {secret_path}"}},
+            },
+            sequence=2,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.TOOL_RESULT,
+            text=secret_text,
+            metadata={"tool_use_id": "tool-9", "tool_name": "Bash", "is_error": False},
+            sequence=3,
+        ),
+    )
+    ingester._drain_available()
+
+    fact_rows = storage.connection.execute("SELECT * FROM telemetry_facts").fetchall()
+    tag_rows = storage.connection.execute("SELECT * FROM telemetry_fact_tag").fetchall()
+    serialized = json.dumps(
+        [dict(r) for r in fact_rows] + [dict(r) for r in tag_rows], default=str
+    )
+    assert secret_path not in serialized
+    assert "SUPER_SECRET_TOKEN" not in serialized
+    assert session.cwd not in serialized
+    assert session.raw_log_path not in serialized
+
+    repo_row = next(r for r in fact_rows if r["kind"] == "session_lifecycle")
+    assert repo_row["repo_name"] == "waypoint"  # basename only, never the full path
+    tool_row = next(r for r in fact_rows if r["kind"] == "tool_call")
+    assert tool_row["tool_name"] == "Bash"  # bare name only
+
+
+def test_start_stop_drains_queued_facts(tmp_path: Path) -> None:
+    async def _run() -> None:
+        storage = Storage(tmp_path / "db.sqlite")
+        session = _make_session(storage, "s1")
+        ingester = TelemetryIngester(storage, drain_debounce_seconds=0.01)
+        await ingester.start()
+        ingester.derive_from_session_created(session)
+        await asyncio.sleep(0.2)
+        rows = _facts(storage, "s1")
+        assert len(rows) == 1
+        await ingester.stop()
+
+    asyncio.run(_run())

--- a/backend/tests/test_telemetry_ingest.py
+++ b/backend/tests/test_telemetry_ingest.py
@@ -11,6 +11,9 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import pytest
+
+from waypoint.backends import BackendRegistry, get_registry, reset_registry_for_tests
 from waypoint.schemas import (
     EventKind,
     EventRecord,
@@ -25,6 +28,12 @@ from waypoint.schemas import (
 )
 from waypoint.storage import Storage
 from waypoint.telemetry.ingest import TelemetryIngester
+
+
+@pytest.fixture
+def registry() -> BackendRegistry:
+    reset_registry_for_tests()
+    return get_registry()
 
 
 def _make_session(
@@ -618,8 +627,14 @@ def test_rate_limit_usage_derives_one_fact_per_window(tmp_path: Path) -> None:
     window_ids = {r["window_id"] for r in rows}
     assert window_ids == {"5h", "7d"}
     # Keyed to the verified account, so windows aggregate across the account's
-    # sessions rather than fragmenting per session.
-    assert all(r["account_key"] == "acct-abc" for r in rows)
+    # sessions rather than fragmenting per session — but the persisted key is
+    # a pseudonymous digest, never the raw verified account key (FR-9).
+    account_keys = {r["account_key"] for r in rows}
+    assert len(account_keys) == 1
+    account_key = next(iter(account_keys))
+    assert account_key != "acct-abc"
+    assert account_key.startswith("acct_")
+    assert all(r["account_label"] == "acct-abc" for r in rows)
 
 
 def test_rate_limit_usage_without_verified_account_derives_nothing(
@@ -641,6 +656,126 @@ def test_rate_limit_usage_without_verified_account_derives_nothing(
     ingester._drain_available()
     rows = [r for r in _facts(storage, "s1") if r["kind"] == "limit_snapshot"]
     assert rows == []
+
+
+def test_rate_limit_usage_flows_for_claude_code_without_verified_account(
+    tmp_path: Path, registry: BackendRegistry
+) -> None:
+    """Root-cause regression: a claude_code session carrying rate_limit_usage
+    plus org/tier notes but no verified_account_key (never ran a
+    verified-account probe) now yields limit facts, resolved via the plugin's
+    own ``rate_limit_account`` instead of being silently dropped."""
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1").model_copy(update={"backend": "claude_code"})
+    ingester = TelemetryIngester(storage, registry)
+
+    ingester.derive_from_session_update(
+        session,
+        {
+            "rate_limit_usage": SessionRateLimitUsage(
+                source="claude_code",
+                updated_at=datetime.now(UTC),
+                notes=["CLI OAuth", "org: Acme", "org tier: enterprise"],
+                windows=[UsageWindow(id="5h", label="5 hour", used_percent=42.0)],
+            )
+        },
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "limit_snapshot"]
+    assert len(rows) == 1
+    assert rows[0]["account_key"].startswith("acct_")
+    assert "Acme" not in rows[0]["account_key"]
+    assert rows[0]["account_label"] == "Acme · enterprise"
+
+
+def test_rate_limit_usage_flows_for_profile_less_codex(
+    tmp_path: Path, registry: BackendRegistry
+) -> None:
+    """A codex session with no launched account profile (and so no verified
+    probe) still surfaces its rate-limit windows, via the plugin's email/plan
+    notes fallback."""
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")  # backend="codex", no verified key
+    ingester = TelemetryIngester(storage, registry)
+
+    ingester.derive_from_session_update(
+        session,
+        {
+            "rate_limit_usage": SessionRateLimitUsage(
+                source="codex",
+                updated_at=datetime.now(UTC),
+                notes=["noppanat@u.nus.edu", "plan: pro"],
+                windows=[UsageWindow(id="5h", label="5 hour", used_percent=10.0)],
+            )
+        },
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "limit_snapshot"]
+    assert len(rows) == 1
+    assert rows[0]["account_key"].startswith("acct_")
+    assert "noppanat" not in rows[0]["account_key"]
+    assert rows[0]["account_label"] == "noppanat@u.nus.edu · plan: pro"
+
+
+def test_account_key_is_never_the_raw_email_or_org(
+    tmp_path: Path, registry: BackendRegistry
+) -> None:
+    """FR-9: whichever resolution path fires, the persisted ``account_key``
+    is always a digest — the raw identity never reaches the store."""
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage, registry)
+
+    ingester.derive_from_session_update(
+        session,
+        {
+            "rate_limit_usage": SessionRateLimitUsage(
+                source="codex",
+                updated_at=datetime.now(UTC),
+                notes=["secret.user@example.com"],
+                windows=[UsageWindow(id="5h", label="5 hour", used_percent=10.0)],
+            )
+        },
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "limit_snapshot"]
+    assert len(rows) == 1
+    assert "secret.user@example.com" not in rows[0]["account_key"]
+    assert rows[0]["account_key"].startswith("acct_")
+    # The label is still the human identity (gated behind the API's
+    # telemetry_local_labels setting, not at ingest/storage time).
+    assert rows[0]["account_label"] == "secret.user@example.com"
+
+
+def test_pseudonymized_account_key_is_stable_across_sessions(
+    tmp_path: Path, registry: BackendRegistry
+) -> None:
+    """The same raw account always digests to the same account_key, so two
+    sessions on the same account still group together."""
+    storage = Storage(tmp_path / "db.sqlite")
+    ingester = TelemetryIngester(storage, registry)
+    session_a = _make_session(storage, "s1")
+    session_b = _make_session(storage, "s2")
+
+    for session in (session_a, session_b):
+        ingester.derive_from_session_update(
+            session,
+            {
+                "rate_limit_usage": SessionRateLimitUsage(
+                    source="codex",
+                    updated_at=datetime.now(UTC),
+                    notes=["shared@example.com"],
+                    windows=[UsageWindow(id="5h", label="5 hour", used_percent=1.0)],
+                )
+            },
+        )
+    ingester._drain_available()
+
+    keys = {r["account_key"] for r in _facts(storage) if r["kind"] == "limit_snapshot"}
+    assert len(keys) == 1
 
 
 def test_backfill_derives_facts_and_is_idempotent(tmp_path: Path) -> None:

--- a/backend/tests/test_telemetry_ingest.py
+++ b/backend/tests/test_telemetry_ingest.py
@@ -99,6 +99,18 @@ def test_child_session_is_stamped_is_child(tmp_path: Path) -> None:
     assert row["spawner_session_id"] == "parent"
 
 
+def test_repo_name_basename_handles_trailing_slash(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1", repo_path="/home/user/projects/waypoint/")
+    ingester = TelemetryIngester(storage)
+
+    ingester.derive_from_session_created(session)
+    ingester._drain_available()
+
+    row = _facts(storage, "s1")[0]
+    assert row["repo_name"] == "waypoint"
+
+
 def test_status_metadata_on_event_derives_lifecycle_fact_and_dedups_replay(
     tmp_path: Path,
 ) -> None:
@@ -123,6 +135,87 @@ def test_status_metadata_on_event_derives_lifecycle_fact_and_dedups_replay(
     assert len(rows) == 1
     assert rows[0]["transition"] == "idle"
     assert rows[0]["fact_id"] == "s1:7"
+
+
+def test_many_same_status_events_in_one_turn_collapse_to_one_lifecycle_fact(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    # STATUS_UPDATE is never actually emitted; nearly every event of a turn
+    # (tool calls, agent output, ...) stamps metadata["status"] with the
+    # current status instead, so a single turn easily carries 30 RUNNING
+    # events. Only the first should mint a lifecycle fact.
+    for sequence in range(1, 31):
+        ingester.derive_from_event(
+            session,
+            EventRecord(
+                session_id="s1",
+                ts=now,
+                kind=EventKind.TOOL_CALL,
+                text="Read\n{...}",
+                metadata={
+                    "tool_use_id": f"tool-{sequence}",
+                    "tool_name": "Read",
+                    "status": SessionStatus.RUNNING,
+                },
+                sequence=sequence,
+            ),
+        )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "session_lifecycle"]
+    assert len(rows) == 1
+    assert rows[0]["transition"] == "running"
+
+
+def test_status_change_after_dedup_still_emits(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.SYSTEM_NOTE,
+            text="a",
+            metadata={"status": SessionStatus.RUNNING},
+            sequence=1,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.SYSTEM_NOTE,
+            text="b",
+            metadata={"status": SessionStatus.RUNNING},
+            sequence=2,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.SYSTEM_NOTE,
+            text="c",
+            metadata={"status": SessionStatus.IDLE},
+            sequence=3,
+        ),
+    )
+    ingester._drain_available()
+
+    rows = [r for r in _facts(storage, "s1") if r["kind"] == "session_lifecycle"]
+    transitions = sorted(r["transition"] for r in rows)
+    assert transitions == ["idle", "running"]
 
 
 def test_user_input_event_derives_turn_fact_with_resolved_model(tmp_path: Path) -> None:
@@ -319,6 +412,79 @@ def test_approval_decline_maps_to_declined(tmp_path: Path) -> None:
             kind=EventKind.SYSTEM_NOTE,
             text="Approval response sent: decline",
             metadata={"approval_id": "appr-2"},
+            sequence=2,
+        ),
+    )
+    ingester._drain_available()
+
+    row = [r for r in _facts(storage, "s1") if r["kind"] == "tool_call"][0]
+    assert row["approval_decision"] == "declined"
+
+
+def test_approval_shared_vocabulary_words_map_to_approved(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    for word in ["allow", "acceptalways", "yes"]:
+        session_id = f"s-{word}"
+        session = _make_session(storage, session_id)
+        approval_id = f"appr-{word}"
+        ingester.derive_from_event(
+            session,
+            EventRecord(
+                session_id=session_id,
+                ts=now,
+                kind=EventKind.APPROVAL_REQUEST,
+                text="Allow?",
+                metadata={"approval_id": approval_id, "tool_name": "Bash"},
+                sequence=1,
+            ),
+        )
+        ingester.derive_from_event(
+            session,
+            EventRecord(
+                session_id=session_id,
+                ts=now + timedelta(seconds=1),
+                kind=EventKind.SYSTEM_NOTE,
+                text=f"Approval response sent: {word}",
+                metadata={"approval_id": approval_id},
+                sequence=2,
+            ),
+        )
+        ingester._drain_available()
+
+        row = [r for r in _facts(storage, session_id) if r["kind"] == "tool_call"][0]
+        assert row["approval_decision"] == "approved", word
+
+
+def test_approval_unrecognized_word_maps_to_declined_not_stranded(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    ingester = TelemetryIngester(storage)
+    now = datetime.now(UTC)
+
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.APPROVAL_REQUEST,
+            text="Allow?",
+            metadata={"approval_id": "appr-3", "tool_name": "Write"},
+            sequence=1,
+        ),
+    )
+    ingester.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now + timedelta(seconds=1),
+            kind=EventKind.SYSTEM_NOTE,
+            text="Approval response sent: some-unrecognized-word",
+            metadata={"approval_id": "appr-3"},
             sequence=2,
         ),
     )

--- a/backend/tests/test_telemetry_store.py
+++ b/backend/tests/test_telemetry_store.py
@@ -1,0 +1,480 @@
+"""Tests for ``TelemetryStore`` (CONTRACT.md §1/§7).
+
+Covers dedup/revision-replace on ``ingest_fact``, that the recompute-on-write
+rollup path agrees with a full ``rebuild_rollups_from_facts``, that
+``Storage.delete_session`` cascades to telemetry facts/tags/rollups without
+touching another session's transcript, and that retention pruning drops old
+facts while the longer-lived daily rollup survives.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from waypoint.schemas import (
+    EventKind,
+    EventRecord,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+    TokenUsageInit,
+    TokenUsageRecord,
+)
+from waypoint.storage import Storage
+from waypoint.telemetry.facts import (
+    ContextSnapshotFact,
+    FactDimensions,
+    LifecycleTransition,
+    SessionLifecycleFact,
+    TelemetryFactKind,
+    TelemetryFilter,
+    TelemetryRange,
+    ToolCallFact,
+    ToolOutcome,
+    TurnFact,
+    TurnKind,
+)
+
+
+def _dims(**overrides: object) -> FactDimensions:
+    fields: dict[str, object] = {
+        "backend": "codex",
+        "repo_name": "waypoint",
+        "source": SessionSource.MANAGED,
+        "transport": "tmux",
+        "spawner_session_id": None,
+        "is_child": False,
+    }
+    fields.update(overrides)
+    return FactDimensions.model_validate(fields)
+
+
+def _make_session(storage: Storage, session_id: str) -> datetime:
+    now = datetime.now(UTC)
+    storage.create_session(
+        SessionRecord(
+            id=session_id,
+            backend="codex",
+            source=SessionSource.MANAGED,
+            transport="tmux",
+            title="t",
+            cwd="/tmp",
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path="/tmp/raw.log",
+            structured_log_path="/tmp/events.jsonl",
+        )
+    )
+    return now
+
+
+def _lifecycle_fact(
+    session_id: str,
+    transition: LifecycleTransition,
+    *,
+    occurred_at: datetime,
+    revision: int = 0,
+) -> SessionLifecycleFact:
+    return SessionLifecycleFact(
+        fact_id=f"{session_id}:{transition}",
+        source="runtime",
+        session_id=session_id,
+        occurred_at=occurred_at,
+        revision=revision,
+        dims=_dims(),
+        transition=transition,
+    )
+
+
+def _rollup_row(
+    storage: Storage, day: str, backend: str = "codex", model: str = ""
+) -> dict[str, Any] | None:
+    row = storage.connection.execute(
+        """
+        SELECT metrics_json FROM telemetry_daily_rollup
+        WHERE day = ? AND backend = ? AND model = ?
+        """,
+        (day, backend, model),
+    ).fetchone()
+    return json.loads(row["metrics_json"]) if row is not None else None
+
+
+def _require_rollup(
+    storage: Storage, day: str, backend: str = "codex", model: str = ""
+) -> dict[str, Any]:
+    metrics = _rollup_row(storage, day, backend, model)
+    assert metrics is not None
+    return metrics
+
+
+def test_new_fact_writes_and_replay_is_ignored(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    fact = _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+
+    assert storage.telemetry.ingest_fact(fact) is True
+    # Same revision replayed (retransmission) is a no-op, not a duplicate count.
+    assert storage.telemetry.ingest_fact(fact) is False
+
+    rows = storage.connection.execute(
+        "SELECT COUNT(*) AS n FROM telemetry_facts WHERE session_id = ?", ("s1",)
+    ).fetchone()
+    assert rows["n"] == 1
+
+
+def test_lower_or_equal_revision_is_ignored_higher_replaces(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    v0 = _lifecycle_fact(
+        "s1", LifecycleTransition.STARTING, occurred_at=now, revision=0
+    )
+    assert storage.telemetry.ingest_fact(v0) is True
+
+    # Same identity, same revision replayed (retransmission) — ignored.
+    replay = SessionLifecycleFact(
+        fact_id=v0.fact_id,
+        source="runtime",
+        session_id="s1",
+        occurred_at=now,
+        revision=0,
+        dims=_dims(),
+        transition=LifecycleTransition.STARTING,
+    )
+    assert storage.telemetry.ingest_fact(replay) is False
+
+    revised = SessionLifecycleFact(
+        fact_id=v0.fact_id,
+        source="runtime",
+        session_id="s1",
+        occurred_at=now,
+        revision=1,
+        dims=_dims(),
+        transition=LifecycleTransition.RUNNING,
+    )
+    assert storage.telemetry.ingest_fact(revised) is True
+
+    row = storage.connection.execute(
+        "SELECT transition, revision FROM telemetry_facts WHERE fact_id = ?",
+        (v0.fact_id,),
+    ).fetchone()
+    assert row["transition"] == LifecycleTransition.RUNNING
+    assert row["revision"] == 1
+
+
+def test_tags_are_rewritten_on_revision_replace(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    fact = _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+    storage.telemetry.ingest_fact(fact, tags={"role": "lead"})
+
+    revised = SessionLifecycleFact(
+        fact_id=fact.fact_id,
+        source="runtime",
+        session_id="s1",
+        occurred_at=now,
+        revision=1,
+        dims=_dims(),
+        transition=LifecycleTransition.CREATED,
+    )
+    storage.telemetry.ingest_fact(revised, tags={"role": "worker"})
+
+    rows = storage.connection.execute(
+        "SELECT key, value FROM telemetry_fact_tag WHERE fact_id = ?", (fact.fact_id,)
+    ).fetchall()
+    assert [(r["key"], r["value"]) for r in rows] == [("role", "worker")]
+
+
+def test_rollup_delta_matches_rebuild(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    day = now.astimezone().date().isoformat()
+
+    storage.telemetry.ingest_fact(
+        _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+    )
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:running",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.RUNNING,
+        )
+    )
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="s1:user:1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.USER,
+        )
+    )
+
+    # Agent turn backed by a ledger record — the rollup's token bucket joins
+    # back to session_token_usage_records, so seed the ledger first.
+    storage.record_token_usage(
+        "s1",
+        TokenUsageRecord(
+            record_id="turn-1",
+            source="codex",
+            observed_at=now,
+            totals={"input_tokens": 100, "output_tokens": 20},
+            display_total_tokens=120,
+            model="gpt-5-codex",
+        ),
+        init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
+    )
+    # ``model_at_turn`` left unset so this fact stays in the same (model="")
+    # rollup bucket as the other facts above — model-dimension splitting is
+    # covered separately in test_rollup_splits_by_model.
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="turn-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.AGENT,
+        )
+    )
+    storage.telemetry.ingest_fact(
+        ToolCallFact(
+            fact_id="tool-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            tool_name="Read",
+            outcome=ToolOutcome.SUCCEEDED,
+        )
+    )
+
+    delta_metrics = _rollup_row(storage, day)
+    assert delta_metrics is not None
+    assert delta_metrics["turns_user"] == 1
+    assert delta_metrics["turns_agent"] == 1
+    assert delta_metrics["tool_calls"] == 1
+    assert delta_metrics["tool_outcomes"] == {"succeeded": 1}
+    assert delta_metrics["lifecycle"] == {"created": 1, "running": 1}
+    assert delta_metrics["tokens"] == {"input_tokens": 100, "output_tokens": 20}
+    assert delta_metrics["display_total"] == 120
+    assert delta_metrics["active_denom"] == 1
+
+    storage.telemetry.rebuild_rollups_from_facts()
+    rebuilt_metrics = _rollup_row(storage, day)
+    assert rebuilt_metrics == delta_metrics
+
+
+def test_rollup_splits_by_model(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    day = now.astimezone().date().isoformat()
+
+    # No model — lands in the default ("") bucket.
+    storage.telemetry.ingest_fact(
+        _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+    )
+    # A turn with a concrete model_at_turn is a distinct rollup key (FR-2
+    # token-by-model), not folded into the model-less bucket.
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="s1:agent:1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            turn_kind=TurnKind.AGENT,
+            model_at_turn="gpt-5-codex",
+        )
+    )
+
+    assert _require_rollup(storage, day, model="")["lifecycle"] == {"created": 1}
+    assert _require_rollup(storage, day, model="")["turns_agent"] == 0
+    by_model = _require_rollup(storage, day, model="gpt-5-codex")
+    assert by_model["turns_agent"] == 1
+    assert by_model["lifecycle"] == {}
+
+
+def test_rollup_revision_replace_moves_lifecycle_count(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    day = now.astimezone().date().isoformat()
+
+    fact = _lifecycle_fact(
+        "s1", LifecycleTransition.STARTING, occurred_at=now, revision=0
+    )
+    storage.telemetry.ingest_fact(fact)
+    assert _require_rollup(storage, day)["lifecycle"] == {"starting": 1}
+
+    revised = SessionLifecycleFact(
+        fact_id=fact.fact_id,
+        source="runtime",
+        session_id="s1",
+        occurred_at=now,
+        revision=1,
+        dims=_dims(),
+        transition=LifecycleTransition.RUNNING,
+    )
+    storage.telemetry.ingest_fact(revised)
+
+    metrics = _require_rollup(storage, day)
+    # The old transition's count is gone, not double-counted alongside the new one.
+    assert metrics["lifecycle"] == {"running": 1}
+
+
+def test_partial_facts_excluded_from_rollup(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    day = now.astimezone().date().isoformat()
+
+    storage.telemetry.ingest_fact(
+        ContextSnapshotFact(
+            fact_id="ctx-1",
+            source="codex",
+            session_id="s1",
+            occurred_at=now,
+            partial=True,
+            dims=_dims(),
+            used_tokens=100,
+            window_tokens=1000,
+            occupancy_percent=10.0,
+        )
+    )
+    assert _rollup_row(storage, day) is None
+
+
+def test_delete_session_cascades_without_touching_other_sessions(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now_a = _make_session(storage, "a")
+    now_b = _make_session(storage, "b")
+    day = now_a.astimezone().date().isoformat()
+
+    storage.telemetry.ingest_fact(
+        _lifecycle_fact("a", LifecycleTransition.CREATED, occurred_at=now_a),
+        tags={"k": "v"},
+    )
+    storage.telemetry.ingest_fact(
+        _lifecycle_fact("b", LifecycleTransition.CREATED, occurred_at=now_b)
+    )
+    storage.append_event(
+        EventRecord(
+            session_id="b",
+            ts=now_b,
+            kind=EventKind.USER_INPUT,
+            text="hello",
+            sequence=1,
+        )
+    )
+
+    storage.delete_session("a")
+
+    remaining = storage.connection.execute(
+        "SELECT session_id FROM telemetry_facts"
+    ).fetchall()
+    assert [r["session_id"] for r in remaining] == ["b"]
+    tags = storage.connection.execute("SELECT * FROM telemetry_fact_tag").fetchall()
+    assert tags == []
+
+    metrics = _require_rollup(storage, day)
+    assert metrics["lifecycle"] == {"created": 1}
+    assert metrics["active_denom"] == 1
+
+    # Session "b"'s transcript is untouched by "a"'s deletion.
+    b_events = storage.list_events("b")
+    assert len(b_events) == 1
+    assert b_events[0].text == "hello"
+    assert storage.get_session("b") is not None
+
+
+def test_prune_drops_old_facts_but_rollup_outlives_them(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    old = now - timedelta(days=200)
+    _make_session(storage, "s1")
+    day = old.astimezone().date().isoformat()
+
+    storage.telemetry.ingest_fact(
+        _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=old)
+    )
+    assert _rollup_row(storage, day) is not None
+
+    removed = storage.telemetry.prune(
+        facts_before=now - timedelta(days=90),
+        rollups_before=now - timedelta(days=400 * 13 // 12),
+    )
+    assert removed["facts"] == 1
+    assert removed["rollups"] == 0
+
+    facts_left = storage.connection.execute(
+        "SELECT COUNT(*) AS n FROM telemetry_facts"
+    ).fetchone()
+    assert facts_left["n"] == 0
+    # The daily rollup (13-month retention) survives the 90-day fact prune.
+    assert _rollup_row(storage, day) is not None
+
+    removed_again = storage.telemetry.prune(
+        facts_before=now, rollups_before=now + timedelta(days=1)
+    )
+    assert removed_again["rollups"] == 1
+    assert _rollup_row(storage, day) is None
+
+
+def test_get_set_meta_round_trip(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    assert storage.telemetry.get_meta("backfill_done") is None
+    storage.telemetry.set_meta("backfill_done", "true")
+    assert storage.telemetry.get_meta("backfill_done") == "true"
+    storage.telemetry.set_meta("backfill_done", "false")
+    assert storage.telemetry.get_meta("backfill_done") == "false"
+
+
+def test_ingest_facts_batches_and_returns_written_count(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    fact_a = _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+    fact_b = _lifecycle_fact("s1", LifecycleTransition.STARTING, occurred_at=now)
+    written = storage.telemetry.ingest_facts([(fact_a, {}), (fact_b, {}), (fact_a, {})])
+    assert written == 2
+
+
+def test_query_facts_and_count_facts(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    storage.telemetry.ingest_fact(
+        _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+    )
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:running",
+            source="runtime",
+            session_id="s1",
+            occurred_at=now,
+            dims=_dims(),
+            transition=LifecycleTransition.RUNNING,
+        )
+    )
+    rng = TelemetryRange(
+        start=now - timedelta(hours=1), end=now + timedelta(hours=1), tz="UTC"
+    )
+    flt = TelemetryFilter()
+    facts = storage.telemetry.query_facts(TelemetryFactKind.SESSION_LIFECYCLE, rng, flt)
+    assert len(facts) == 2
+    assert (
+        storage.telemetry.count_facts(TelemetryFactKind.SESSION_LIFECYCLE, rng, flt)
+        == 2
+    )
+
+
+def test_dismiss_insight_round_trip(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    assert storage.telemetry.dismissed_insights("2026-07") == set()
+    storage.telemetry.dismiss_insight("near_limit:codex", "2026-07")
+    assert storage.telemetry.dismissed_insights("2026-07") == {"near_limit:codex"}

--- a/backend/tests/test_telemetry_tokens.py
+++ b/backend/tests/test_telemetry_tokens.py
@@ -1,0 +1,89 @@
+"""Unit tests for ``telemetry/tokens.py::unify_tokens`` (token-unify-spec).
+
+Each backend's ledger totals use a different, overlapping native vocabulary;
+``unify_tokens`` folds them onto 5 disjoint buckets via a deterministic,
+source-keyed subset subtraction so the result always sums to the backend's
+true provider total.
+"""
+
+from waypoint.telemetry.tokens import UNIFIED_TOKEN_CATEGORIES, unify_tokens
+
+
+def test_unify_tokens_claude_code_categories_are_already_disjoint() -> None:
+    raw = {
+        "input_tokens": 50,
+        "cache_read_tokens": 10,
+        "cache_creation_tokens": 5,
+        "output_tokens": 20,
+    }
+    unified = unify_tokens("claude_code", raw)
+    assert unified == {
+        "fresh_input": 50,
+        "cache_read": 10,
+        "cache_write": 5,
+        "output": 20,
+        "reasoning": 0,
+    }
+    assert set(unified) == set(UNIFIED_TOKEN_CATEGORIES)
+    # Claude's native categories are already disjoint, so the sum is
+    # unchanged by unification.
+    assert sum(unified.values()) == sum(raw.values())
+
+
+def test_unify_tokens_codex_subtracts_overlapping_totals() -> None:
+    raw = {
+        "input_tokens": 100,  # TOTAL, includes cached_input_tokens
+        "cached_input_tokens": 30,
+        "output_tokens": 40,  # TOTAL, includes reasoning_output_tokens
+        "reasoning_output_tokens": 10,
+    }
+    unified = unify_tokens("codex", raw)
+    assert unified == {
+        "fresh_input": 70,
+        "cache_read": 30,
+        "cache_write": 0,
+        "output": 30,
+        "reasoning": 10,
+    }
+    # Codex's own totalTokens = inputTokens + outputTokens.
+    assert sum(unified.values()) == raw["input_tokens"] + raw["output_tokens"]
+
+
+def test_unify_tokens_opencode_subtracts_reasoning_from_output() -> None:
+    raw = {
+        "input_tokens": 60,
+        "cache_read_tokens": 5,
+        "cache_write_tokens": 2,
+        "output_tokens": 25,  # TOTAL, includes reasoning_tokens
+        "reasoning_tokens": 8,
+    }
+    unified = unify_tokens("opencode", raw)
+    assert unified == {
+        "fresh_input": 60,
+        "cache_read": 5,
+        "cache_write": 2,
+        "output": 17,
+        "reasoning": 8,
+    }
+    provider_total = (
+        raw["input_tokens"]
+        + raw["cache_read_tokens"]
+        + raw["cache_write_tokens"]
+        + raw["output_tokens"]
+    )
+    assert sum(unified.values()) == provider_total
+
+
+def test_unify_tokens_missing_fields_default_to_zero() -> None:
+    assert unify_tokens("codex", {}) == {
+        "fresh_input": 0,
+        "cache_read": 0,
+        "cache_write": 0,
+        "output": 0,
+        "reasoning": 0,
+    }
+
+
+def test_unify_tokens_unknown_source_falls_back_to_disjoint_native() -> None:
+    raw = {"input_tokens": 5, "output_tokens": 7}
+    assert unify_tokens("some_future_backend", raw) == unify_tokens("claude_code", raw)

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -30,6 +30,10 @@
   --tm-series-6: #e66767;
   --tm-series-7: #d55181;
   --tm-series-8: #d95926;
+  /* Re-read context (cache_read) is cheap re-sent prior context and routinely
+   * dwarfs every other bucket — it carries a muted slate rather than a vivid
+   * categorical hue so it reads as background bulk, not headline work. */
+  --tm-token-reread: #47566b;
   /* Thick glass is fully opaque: text-dense sheets sit over bright
    * transcript text, where even a few percent of bleed-through reads as
    * ghost text on a dark ground — and popovers nested inside the composer
@@ -86,6 +90,7 @@ html[data-theme="light"] {
   --tm-series-6: #e34948;
   --tm-series-7: #e87ba4;
   --tm-series-8: #eb6834;
+  --tm-token-reread: #9a9382;
   --glass-bg: rgba(250, 246, 238, 0.8);
   --glass-bg-thick: rgb(250, 247, 240);
   --glass-line: rgba(90, 78, 58, 0.18);
@@ -16259,22 +16264,52 @@ html[data-theme="light"] .wp-hl {
   border: 1px solid var(--line);
 }
 
+.tm-overview-hero-block {
+  display: grid;
+  gap: 0;
+}
+
 .tm-overview-hero {
   margin: 0;
   font-family: var(--font-display);
-  font-size: 2rem;
+  font-size: 2.15rem;
+  line-height: 1.05;
+  letter-spacing: -0.01em;
   color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.tm-overview-hero.is-clear {
+  color: var(--success);
 }
 
 .tm-overview-hero-caption {
-  margin: -6px 0 0;
+  margin: 3px 0 0;
   color: var(--muted-soft);
-  font-size: 0.78rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .tm-overview-hero-note {
   margin: 0;
   color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.4;
+}
+
+/* Hairline shelf under the hero: separates headline from breakdown so the
+   card reads as instrument (numeral + supporting detail), not a flat list. */
+.tm-overview-body {
+  display: grid;
+  gap: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+
+.tm-overview-empty {
+  margin: 0;
   font-size: 0.82rem;
 }
 
@@ -16282,12 +16317,13 @@ html[data-theme="light"] .wp-hl {
   margin: 0;
   color: var(--muted-soft);
   font-size: 0.76rem;
+  line-height: 1.4;
 }
 
 .tm-stat-list {
   margin: 0;
   display: grid;
-  gap: 4px;
+  gap: 5px;
 }
 
 .tm-stat-row {
@@ -16295,16 +16331,122 @@ html[data-theme="light"] .wp-hl {
   align-items: baseline;
   justify-content: space-between;
   gap: 10px;
-  font-size: 0.84rem;
+  font-size: 0.82rem;
 }
 
 .tm-stat-row-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
   color: var(--muted);
 }
 
 .tm-stat-row-value {
   font-family: var(--font-mono);
   color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+.tm-stat-row.tone-danger .tm-stat-row-value {
+  color: var(--danger);
+}
+
+.tm-stat-row.tone-warn .tm-stat-row-value {
+  color: var(--warn);
+}
+
+.tm-stat-swatch {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.tm-stat-swatch.is-newwork {
+  background: var(--tm-series-1);
+}
+
+.tm-stat-swatch.is-reread {
+  background: var(--tm-token-reread);
+}
+
+/* Token tiers (Tokens card) — new work vs re-read context */
+.tm-tier-bar {
+  display: flex;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--bg-input);
+  border: 1px solid var(--line);
+}
+
+.tm-tier-bar-seg {
+  min-width: 2px;
+}
+
+.tm-tier-bar-seg.is-newwork {
+  background: var(--tm-series-1);
+}
+
+.tm-tier-bar-seg.is-reread {
+  background: var(--tm-token-reread);
+}
+
+.tm-tier-list {
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.tm-tier {
+  display: grid;
+  gap: 4px;
+}
+
+.tm-tier-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.tm-tier-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text);
+}
+
+.tm-tier-value {
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Sub-rows sit inset under their tier head, one hairline column rule tying
+   the four new-work buckets to the tier they roll up into. */
+.tm-tier-sub {
+  display: grid;
+  gap: 3px;
+  margin-left: 3px;
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+}
+
+.tm-tier-sub .tm-stat-row {
+  font-size: 0.78rem;
+}
+
+.tm-tier-note {
+  margin: 0 0 0 3px;
+  padding-left: 10px;
+  color: var(--muted-soft);
+  font-size: 0.74rem;
 }
 
 .tm-alerts-card.has-alerts {
@@ -16496,6 +16638,37 @@ html[data-theme="light"] .wp-hl {
   flex-shrink: 0;
 }
 
+/* Token legend: the five buckets split into their two named tiers so the
+   chart's colour groups read as new-work vs re-read at a glance. */
+.tm-token-legend {
+  gap: 8px 22px;
+}
+
+.tm-legend-tier {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 14px;
+}
+
+.tm-legend-tier-name {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-legend-tier-name::after {
+  content: "";
+  display: inline-block;
+  width: 1px;
+  height: 11px;
+  margin-left: 12px;
+  vertical-align: -2px;
+  background: var(--line-strong);
+}
+
 /* Hover/focus readout — floating chrome, so it takes the glass recipe. */
 .tm-chart-tooltip {
   position: fixed;
@@ -16594,14 +16767,106 @@ html[data-theme="light"] .wp-hl {
   letter-spacing: 0.04em;
 }
 
+/* Small-multiples session-activity trend */
+.tm-smallmult-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.tm-smallmult {
+  display: grid;
+  gap: 5px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card-soft);
+}
+
+.tm-smallmult-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tm-smallmult-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+
+.tm-smallmult-total {
+  font-family: var(--font-mono);
+  font-size: 0.92rem;
+  color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.tm-smallmult-svg {
+  width: 100%;
+  height: 60px;
+  display: block;
+}
+
+.tm-smallmult-area {
+  opacity: 0.14;
+}
+
+.tm-smallmult-foot {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  color: var(--muted-soft);
+}
+
+.tm-chart-footnote {
+  margin: 0;
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+
 /* Activity heatmap */
+.tm-heatmap-scale {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-heatmap-scale-ramp {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.tm-heatmap-scale-ramp span {
+  width: 12px;
+  height: 10px;
+  border-radius: 2px;
+  border: 1px solid var(--line);
+}
+
 .tm-heatmap-scroll {
   overflow-x: auto;
 }
 
 .tm-heatmap {
   border-collapse: collapse;
-  min-width: 720px;
+  min-width: 760px;
+}
+
+.tm-heatmap-corner {
+  width: 92px;
 }
 
 .tm-heatmap-hour {
@@ -16610,16 +16875,30 @@ html[data-theme="light"] .wp-hl {
   color: var(--muted-soft);
   font-weight: 400;
   padding-bottom: 4px;
+  text-align: center;
 }
 
 .tm-heatmap-dow {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--muted);
   text-align: right;
-  padding-right: 8px;
+  padding-right: 10px;
   font-weight: 400;
   white-space: nowrap;
+  vertical-align: middle;
+  line-height: 1.15;
+}
+
+.tm-heatmap-dow-name {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--text);
+}
+
+.tm-heatmap-dow-date {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--muted-soft);
 }
 
 .tm-heatmap-cell-wrap {
@@ -16631,6 +16910,19 @@ html[data-theme="light"] .wp-hl {
   height: 20px;
   border-radius: var(--radius-sm);
   border: 1px solid var(--line);
+}
+
+/* Empty cells carry a faint hollow fill so the grid still reads as a grid
+   and a genuinely-empty slot is unmistakably distinct from a low-count one. */
+.tm-heatmap-cell.is-empty {
+  background: color-mix(in srgb, var(--muted-soft) 8%, transparent);
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--line) 70%, transparent);
+}
+
+.tm-heatmap-cell.is-peak {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
 }
 
 .tm-heatmap-cell:hover,
@@ -16707,79 +16999,315 @@ html[data-theme="light"] .wp-hl {
   white-space: nowrap;
 }
 
-.tm-dial-grid {
+/* Provider-limit account groups */
+.tm-account-groups {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 12px;
-  margin-bottom: 4px;
 }
 
-.tm-dial-cell {
+.tm-account-group {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card-soft);
+}
+
+.tm-account-head {
   display: flex;
-  justify-content: center;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--line);
+}
+
+.tm-account-name {
+  font-family: var(--font-mono);
+  font-size: 0.86rem;
+  color: var(--text-strong);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tm-account-backend {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.tm-window-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 12px;
+}
+
+.tm-window-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 6px;
+}
+
+.tm-window-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.tm-window-label {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text);
+}
+
+.tm-window-glyph {
+  font-size: 0.62rem;
+  color: var(--muted-soft);
+}
+
+.tm-window-row.tone-warn .tm-window-glyph {
+  color: var(--warn);
+}
+
+.tm-window-row.tone-danger .tm-window-glyph {
+  color: var(--danger);
+}
+
+.tm-window-value {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.tm-window-trend {
+  margin-top: 2px;
 }
 
 .tm-sparkline-wrap {
   display: grid;
-  gap: 2px;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: 8px;
 }
 
 .tm-sparkline-scale {
-  justify-self: end;
+  order: 2;
   font-family: var(--font-mono);
-  font-size: 0.68rem;
+  font-size: 0.66rem;
+  white-space: nowrap;
 }
 
 .tm-sparkline {
+  order: 1;
   width: 100%;
-  height: auto;
-  overflow: visible;
+  height: 30px;
+  display: block;
 }
 
-.tm-sparkline-empty {
+.tm-sparkline-area {
+  fill: var(--tm-series-1);
+  opacity: 0.12;
+}
+
+.tm-sparkline-empty,
+.tm-sparkline-single {
   margin: 0;
+  font-size: 0.74rem;
+  font-family: var(--font-mono);
 }
 
 /* Drilldown */
+/* Aggregate header — gives the list meaning instead of a raw dump. The
+   headline count is the authoritative full-set total; the chips summarise the
+   loaded page (labelled as such below when the set is larger). */
+.tm-drill-summary {
+  display: grid;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card-soft);
+}
+
+.tm-drill-summary-hero {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.tm-drill-summary-count {
+  font-family: var(--font-display);
+  font-size: 1.6rem;
+  line-height: 1;
+  color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
+}
+
+.tm-drill-summary-caption {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-drill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tm-drill-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--text);
+  padding: 3px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+}
+
+.tm-drill-chip.is-rest {
+  color: var(--muted);
+}
+
+.tm-drill-chip-glyph {
+  font-size: 0.66rem;
+  color: var(--muted-soft);
+}
+
+.tm-drill-chip.tone-good .tm-drill-chip-glyph {
+  color: var(--success);
+}
+
+.tm-drill-chip.tone-warn .tm-drill-chip-glyph {
+  color: var(--warn);
+}
+
+.tm-drill-chip.tone-danger .tm-drill-chip-glyph {
+  color: var(--danger);
+}
+
+.tm-drill-chip-count {
+  font-variant-numeric: tabular-nums;
+  color: var(--muted-soft);
+}
+
+.tm-drill-tools {
+  display: grid;
+  gap: 6px;
+}
+
+.tm-drill-tools-label {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-drill-scope {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
 .tm-drilldown-list {
   margin: 0;
   padding: 0;
   list-style: none;
   display: grid;
-  gap: 2px;
+  gap: 0;
 }
 
 .tm-drilldown-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 8px 4px;
+  gap: 10px;
+  padding: 7px 4px;
   border-bottom: 1px solid var(--line);
-  flex-wrap: wrap;
 }
 
-.tm-drilldown-row.tone-danger .tm-drilldown-label {
+/* Single status indicator — glyph carries colour, text carries the same
+   meaning for the colour-blind (sr-only in the pip, visible inline in the
+   label), so the outcome is stated once and remains non-colour-safe. */
+.tm-drill-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+}
+
+.tm-drill-status.tone-good {
+  color: var(--success);
+}
+
+.tm-drill-status.tone-warn {
+  color: var(--warn);
+}
+
+.tm-drill-status.tone-danger {
   color: var(--danger);
 }
 
-.tm-drilldown-row.tone-warn .tm-drilldown-label {
+.tm-drill-status-text {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+
+.tm-drilldown-row .tm-drill-status.tone-danger ~ .tm-drilldown-main .tm-drill-status-text {
+  color: var(--danger);
+}
+
+.tm-drilldown-row .tm-drill-status.tone-warn ~ .tm-drilldown-main .tm-drill-status-text {
   color: var(--warn);
+}
+
+.tm-drill-duration {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
 }
 
 .tm-drilldown-main {
   display: grid;
-  gap: 2px;
+  gap: 1px;
   min-width: 0;
 }
 
 .tm-drilldown-label {
-  font-size: 0.86rem;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
   color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .tm-drilldown-secondary {
-  font-size: 0.74rem;
+  font-size: 0.72rem;
 }
 
 .tm-drilldown-meta {
@@ -16791,13 +17319,13 @@ html[data-theme="light"] .wp-hl {
 
 .tm-drilldown-session {
   font-family: var(--font-mono);
-  font-size: 0.74rem;
+  font-size: 0.72rem;
   color: var(--accent-cool);
 }
 
 .tm-drilldown-time {
   font-family: var(--font-mono);
-  font-size: 0.72rem;
+  font-size: 0.7rem;
   color: var(--muted-soft);
   white-space: nowrap;
 }
@@ -16986,12 +17514,27 @@ html[data-theme="light"] .wp-hl {
     align-self: center;
   }
 
+  /* Restack the row: status + primary on top, session/time meta on its own
+     full-width line underneath (see the .tm-health-row note above on why the
+     grid-area assignments must stay scoped to this query). */
   .tm-drilldown-row {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 16px minmax(0, 1fr);
+    grid-template-areas:
+      "status main"
+      "meta meta";
+    row-gap: 4px;
+  }
+
+  .tm-drill-status {
+    grid-area: status;
+  }
+
+  .tm-drilldown-main {
+    grid-area: main;
   }
 
   .tm-drilldown-meta {
+    grid-area: meta;
     width: 100%;
     justify-content: space-between;
   }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16042,6 +16042,8 @@ html[data-theme="light"] .wp-hl {
 }
 
 .tm-chip {
+  display: inline-flex;
+  align-items: center;
   font-family: var(--font-mono);
   font-size: 0.76rem;
   padding: 6px 12px;
@@ -16717,6 +16719,17 @@ html[data-theme="light"] .wp-hl {
   justify-content: center;
 }
 
+.tm-sparkline-wrap {
+  display: grid;
+  gap: 2px;
+}
+
+.tm-sparkline-scale {
+  justify-self: end;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
 .tm-sparkline {
   width: 100%;
   height: auto;
@@ -16931,12 +16944,42 @@ html[data-theme="light"] .wp-hl {
     margin-left: 0;
   }
 
+  /* The bar's 80px-min column doesn't fit a phone width; give it a
+     dedicated full-width row underneath instead of dropping it (the glyph,
+     numeric %, and tone word alone don't convey the occupancy shape). The
+     `grid-area` assignments live only in this scoped block — declaring them
+     unconditionally on the elements (so they'd also cover the desktop rule,
+     which has no `grid-template-areas`) does NOT safely no-op: an unmatched
+     named `grid-area` still claims its own implicit line/track per element,
+     which silently collapses the desktop 4-column row (verified empirically,
+     not just per spec-reading — every child ends up stacked in one track). */
   .tm-health-row {
-    grid-template-columns: 16px minmax(0, 1fr) auto;
+    grid-template-columns: 16px minmax(0, 1fr) 60px auto;
+    grid-template-areas:
+      "glyph label value time"
+      "bar bar bar bar";
+    row-gap: 6px;
+  }
+
+  .tm-health-glyph {
+    grid-area: glyph;
+  }
+
+  .tm-health-label {
+    grid-area: label;
+  }
+
+  .tm-health-value {
+    grid-area: value;
+  }
+
+  .tm-health-time {
+    grid-area: time;
   }
 
   .tm-health-row .usage-bar {
-    display: none;
+    grid-area: bar;
+    align-self: center;
   }
 
   .tm-drilldown-row {
@@ -16947,5 +16990,39 @@ html[data-theme="light"] .wp-hl {
   .tm-drilldown-meta {
     width: 100%;
     justify-content: space-between;
+  }
+
+  /* ~40px tap targets on touch — desktop keeps the denser flat-instrument
+     sizing; only the box grows (via min-height / padding), not the type
+     scale, so these still read as text links and thin instruments, not
+     inflated buttons. `.back-link`, `.theme-toggle`, and `.pager-btn` are
+     shared beyond this page, so the reach benefits every mobile view. */
+  .tm-filters-toggle,
+  .tm-table-toggle,
+  .back-link {
+    min-height: 40px;
+  }
+
+  .tm-table-toggle {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .tm-chip {
+    min-height: 40px;
+    padding: 0 14px;
+  }
+
+  .tm-chart-select {
+    min-height: 40px;
+  }
+
+  .theme-toggle {
+    width: 40px;
+    height: 40px;
+  }
+
+  .pager-btn {
+    min-height: 40px;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16896,6 +16896,10 @@ html[data-theme="light"] .wp-hl {
 
 .tm-insight-evidence {
   justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  min-height: 40px;
+  padding-block: 8px;
   font-family: var(--font-mono);
   font-size: 0.76rem;
   color: var(--accent-cool);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -17,6 +17,19 @@
   --warn: #d99a4a;
   --success: #6cc99a;
   --todo-glyph: #c8a3eb;
+  /* Telemetry categorical series (token categories, backend/model/repo/session
+   * groups). Values are the dataviz skill's validated 8-hue reference set,
+   * fixed order — never cycled or reassigned by value. Status meaning
+   * (good/warn/danger) stays on --success/--warn/--danger; these are pure
+   * identity and always ship with a legend/direct label, never color alone. */
+  --tm-series-1: #3987e5;
+  --tm-series-2: #199e70;
+  --tm-series-3: #c98500;
+  --tm-series-4: #008300;
+  --tm-series-5: #9085e9;
+  --tm-series-6: #e66767;
+  --tm-series-7: #d55181;
+  --tm-series-8: #d95926;
   /* Thick glass is fully opaque: text-dense sheets sit over bright
    * transcript text, where even a few percent of bleed-through reads as
    * ghost text on a dark ground — and popovers nested inside the composer
@@ -65,6 +78,14 @@ html[data-theme="light"] {
   --warn: #aa6618;
   --success: #257a50;
   --todo-glyph: #7040b0;
+  --tm-series-1: #2a78d6;
+  --tm-series-2: #1baf7a;
+  --tm-series-3: #eda100;
+  --tm-series-4: #008300;
+  --tm-series-5: #4a3aa7;
+  --tm-series-6: #e34948;
+  --tm-series-7: #e87ba4;
+  --tm-series-8: #eb6834;
   --glass-bg: rgba(250, 246, 238, 0.8);
   --glass-bg-thick: rgb(250, 247, 240);
   --glass-line: rgba(90, 78, 58, 0.18);
@@ -15925,5 +15946,1006 @@ html[data-theme="light"] .wp-hl {
     right: -4px;
     background: var(--accent);
     color: var(--bg-base);
+  }
+}
+
+/* ─── Telemetry dashboard ─── */
+
+/* Home entry: bottom-center glass floater (mirrors .inbox-dock/.assistant-fab,
+   centered so it never collides with either corner dock) + a link out of the
+   existing rate-limit "Telemetry" deck. */
+.telemetry-dock {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: max(20px, env(safe-area-inset-bottom));
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  padding: 12px 18px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--glass-line);
+  background: var(--glass-bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  box-shadow:
+    inset 0 1px 0 var(--glass-hi),
+    var(--shadow);
+  backdrop-filter: var(--glass-blur);
+  transition:
+    border-color 0.16s ease,
+    background 0.16s ease;
+}
+
+.telemetry-dock:hover {
+  border-color: var(--accent-cool);
+}
+
+.telemetry-dock-glyph {
+  display: inline-flex;
+  color: var(--accent-cool);
+}
+
+@media (max-width: 640px) {
+  .telemetry-dock {
+    padding: 0;
+    width: 52px;
+    height: 52px;
+    justify-content: center;
+  }
+
+  .telemetry-dock-label {
+    display: none;
+  }
+}
+
+.usage-deck-full-link {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-cool);
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.usage-deck-full-link:hover {
+  text-decoration: underline;
+}
+
+/* Page-level grid: every telemetry section is a direct child of .page-shell's
+   grid, spaced by its existing `gap`, so no extra top-level wrapper needed. */
+
+/* Filters */
+.tm-filters {
+  display: grid;
+  gap: 12px;
+}
+
+.tm-filters-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.tm-range-presets,
+.tm-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.tm-chip {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--muted);
+  transition:
+    border-color 0.14s ease,
+    color 0.14s ease,
+    background 0.14s ease;
+}
+
+.tm-chip:hover {
+  border-color: var(--line-strong);
+  color: var(--text);
+}
+
+.tm-chip.is-active {
+  border-color: var(--accent-cool);
+  background: color-mix(in srgb, var(--accent-cool) 14%, var(--bg-input));
+  color: var(--text-strong);
+}
+
+.tm-custom-range {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.tm-date-input,
+.tm-text-input {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+}
+
+.tm-effective-range {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+  white-space: nowrap;
+}
+
+.tm-filters-toggle {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--accent-cool);
+}
+
+.tm-filters-toggle-chevron {
+  font-size: 0.7rem;
+}
+
+.tm-filters-body {
+  display: grid;
+  gap: 14px;
+  padding-top: 4px;
+  border-top: 1px solid var(--line);
+}
+
+.tm-filter-field {
+  display: grid;
+  gap: 6px;
+}
+
+.tm-filter-label {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-filter-sublabel {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
+.tm-tag-field {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 6px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+}
+
+.tm-tag-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 6px;
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--accent-cool) 16%, var(--bg-card-soft));
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+}
+
+.tm-tag-chip-remove {
+  color: var(--muted);
+  line-height: 1;
+  font-size: 0.9rem;
+}
+
+.tm-tag-chip-remove:hover {
+  color: var(--danger);
+}
+
+.tm-tag-input {
+  flex: 1;
+  min-width: 120px;
+  border: 0;
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text);
+  padding: 4px;
+}
+
+.tm-tag-input:focus {
+  outline: none;
+}
+
+.tm-parent-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.tm-checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+/* Overview cards */
+.tm-overview-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.tm-overview-card {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.tm-overview-card.is-loading {
+  min-height: 180px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 25%,
+    var(--bg-card-soft) 37%,
+    var(--bg-card) 63%
+  );
+  background-size: 400% 100%;
+  animation: tm-shimmer 1.6s ease infinite;
+}
+
+@keyframes tm-shimmer {
+  0% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0 50%;
+  }
+}
+
+.tm-overview-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.tm-overview-card-head h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  color: var(--text-strong);
+}
+
+.tm-overview-card-badge {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+}
+
+.tm-overview-hero {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 2rem;
+  color: var(--text-strong);
+}
+
+.tm-overview-hero-caption {
+  margin: -6px 0 0;
+  color: var(--muted-soft);
+  font-size: 0.78rem;
+}
+
+.tm-overview-hero-note {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.tm-overview-footnote {
+  margin: 0;
+  color: var(--muted-soft);
+  font-size: 0.76rem;
+}
+
+.tm-stat-list {
+  margin: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.tm-stat-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  font-size: 0.84rem;
+}
+
+.tm-stat-row-label {
+  color: var(--muted);
+}
+
+.tm-stat-row-value {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.tm-alerts-card.has-alerts {
+  border-color: var(--line-strong);
+}
+
+.tm-alert-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 6px;
+}
+
+.tm-alert-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+}
+
+.tm-alert-glyph {
+  font-size: 0.7rem;
+  color: var(--muted-soft);
+}
+
+.tm-alert-row.tone-warn .tm-alert-glyph {
+  color: var(--warn);
+}
+
+.tm-alert-row.tone-danger .tm-alert-glyph {
+  color: var(--danger);
+}
+
+.tm-alert-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.tm-alert-row.tone-warn .tm-alert-text {
+  color: var(--warn);
+}
+
+.tm-alert-row.tone-danger .tm-alert-text {
+  color: var(--danger);
+}
+
+.tm-alert-time {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted-soft);
+  white-space: nowrap;
+}
+
+/* Chart cards (shared chrome for TokenChart / ActivityChart / HealthPanel) */
+.tm-chart-card {
+  display: grid;
+  gap: 10px;
+  position: relative;
+}
+
+.tm-chart-card.is-loading {
+  min-height: 220px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 25%,
+    var(--bg-card-soft) 37%,
+    var(--bg-card) 63%
+  );
+  background-size: 400% 100%;
+  animation: tm-shimmer 1.6s ease infinite;
+}
+
+.tm-chart-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.tm-chart-head h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1rem;
+  color: var(--text-strong);
+}
+
+.tm-chart-subhead {
+  margin: 4px 0 -2px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-chart-summary {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+}
+
+.tm-chart-select-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-chart-select {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+}
+
+.tm-chart-empty {
+  margin: 0;
+  padding: 24px 0;
+  text-align: center;
+}
+
+.tm-chart-svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.tm-chart-gridline {
+  stroke: var(--line);
+  stroke-width: 1;
+}
+
+.tm-chart-axis {
+  stroke: var(--line-strong);
+  stroke-width: 1;
+}
+
+.tm-chart-axis-label {
+  font-family: var(--font-mono);
+  font-size: 8px;
+  fill: var(--muted-soft);
+}
+
+.tm-rowlabel {
+  font-size: 9px;
+}
+
+.tm-bar-group,
+.tm-hover-column,
+.tm-hover-point {
+  cursor: pointer;
+}
+
+.tm-bar-group:focus,
+.tm-hover-column:focus,
+.tm-hover-point:focus {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 1px;
+}
+
+.tm-chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+}
+
+.tm-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--muted);
+}
+
+.tm-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+/* Hover/focus readout — floating chrome, so it takes the glass recipe. */
+.tm-chart-tooltip {
+  position: fixed;
+  transform: translate(-50%, calc(-100% - 12px));
+  z-index: 60;
+  pointer-events: none;
+  min-width: 140px;
+  max-width: 240px;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--glass-line);
+  background: var(--glass-bg-thick);
+  box-shadow:
+    inset 0 1px 0 var(--glass-hi),
+    var(--shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+.tm-chart-tooltip-title {
+  margin: 0 0 4px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.03em;
+  color: var(--muted-soft);
+}
+
+.tm-chart-tooltip-rows {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 3px;
+}
+
+.tm-chart-tooltip-row {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 0.8rem;
+}
+
+.tm-chart-tooltip-row strong {
+  color: var(--text-strong);
+}
+
+.tm-chart-tooltip-row .muted {
+  font-size: 0.74rem;
+}
+
+.tm-chart-tooltip-key {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+
+.tm-table-toggle {
+  justify-self: start;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent-cool);
+}
+
+.tm-table-wrap {
+  overflow-x: auto;
+}
+
+.tm-data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.tm-data-table th,
+.tm-data-table td {
+  padding: 6px 10px;
+  text-align: right;
+  border-bottom: 1px solid var(--line);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+
+.tm-data-table th[scope="row"] {
+  text-align: left;
+  color: var(--muted);
+  font-variant-numeric: normal;
+}
+
+.tm-data-table thead th {
+  color: var(--muted-soft);
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Activity heatmap */
+.tm-heatmap-scroll {
+  overflow-x: auto;
+}
+
+.tm-heatmap {
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.tm-heatmap-hour {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--muted-soft);
+  font-weight: 400;
+  padding-bottom: 4px;
+}
+
+.tm-heatmap-dow {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted);
+  text-align: right;
+  padding-right: 8px;
+  font-weight: 400;
+  white-space: nowrap;
+}
+
+.tm-heatmap-cell-wrap {
+  padding: 1px;
+}
+
+.tm-heatmap-cell {
+  width: 26px;
+  height: 20px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+}
+
+.tm-heatmap-cell:hover,
+.tm-heatmap-cell:focus {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 1px;
+}
+
+/* Health panel */
+.tm-health-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 8px;
+}
+
+.tm-health-row {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr) minmax(80px, 2fr) 72px auto;
+  align-items: center;
+  gap: 10px;
+  font-size: 0.82rem;
+}
+
+.tm-health-glyph {
+  color: var(--muted-soft);
+  font-size: 0.7rem;
+}
+
+.tm-health-row.tone-warn .tm-health-glyph {
+  color: var(--warn);
+}
+
+.tm-health-row.tone-danger .tm-health-glyph {
+  color: var(--danger);
+}
+
+.tm-health-label {
+  font-family: var(--font-mono);
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tm-health-stale {
+  color: var(--muted-soft);
+}
+
+.tm-health-value {
+  font-family: var(--font-mono);
+  text-align: right;
+  color: var(--text);
+}
+
+.tm-health-tone-word {
+  color: var(--muted-soft);
+  font-size: 0.72rem;
+}
+
+.tm-health-row.tone-warn .tm-health-tone-word {
+  color: var(--warn);
+}
+
+.tm-health-row.tone-danger .tm-health-tone-word {
+  color: var(--danger);
+}
+
+.tm-health-time {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+  white-space: nowrap;
+}
+
+.tm-dial-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 4px;
+}
+
+.tm-dial-cell {
+  display: flex;
+  justify-content: center;
+}
+
+.tm-sparkline {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.tm-sparkline-empty {
+  margin: 0;
+}
+
+/* Drilldown */
+.tm-drilldown-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 2px;
+}
+
+.tm-drilldown-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--line);
+  flex-wrap: wrap;
+}
+
+.tm-drilldown-row.tone-danger .tm-drilldown-label {
+  color: var(--danger);
+}
+
+.tm-drilldown-row.tone-warn .tm-drilldown-label {
+  color: var(--warn);
+}
+
+.tm-drilldown-main {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.tm-drilldown-label {
+  font-size: 0.86rem;
+  color: var(--text);
+}
+
+.tm-drilldown-secondary {
+  font-size: 0.74rem;
+}
+
+.tm-drilldown-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.tm-drilldown-session {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--accent-cool);
+}
+
+.tm-drilldown-time {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+  white-space: nowrap;
+}
+
+/* Insight cards */
+.tm-insight-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.tm-insight-card {
+  display: grid;
+  gap: 8px;
+  align-content: start;
+}
+
+.tm-insight-card.tone-warn {
+  border-color: color-mix(in srgb, var(--warn) 45%, var(--line));
+}
+
+.tm-insight-card.tone-danger {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--line));
+}
+
+.tm-insight-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tm-insight-glyph {
+  font-size: 0.7rem;
+  color: var(--muted-soft);
+}
+
+.tm-insight-card.tone-warn .tm-insight-glyph {
+  color: var(--warn);
+}
+
+.tm-insight-card.tone-danger .tm-insight-glyph {
+  color: var(--danger);
+}
+
+.tm-insight-severity {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.tm-insight-dismiss {
+  margin-left: auto;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--muted-soft);
+  padding: 2px 6px;
+}
+
+.tm-insight-dismiss:hover:not(:disabled) {
+  color: var(--danger);
+}
+
+.tm-insight-statement {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.tm-insight-metrics {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 14px;
+}
+
+.tm-insight-metric {
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  font-size: 0.76rem;
+}
+
+.tm-insight-metric dt {
+  color: var(--muted-soft);
+  text-transform: capitalize;
+}
+
+.tm-insight-metric dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+
+.tm-insight-evidence {
+  justify-self: start;
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  color: var(--accent-cool);
+}
+
+/* Settings panel */
+.tm-settings-panel {
+  display: grid;
+  gap: 10px;
+}
+
+.tm-settings-toggle {
+  margin-left: 0;
+  justify-content: space-between;
+}
+
+.tm-settings-body {
+  display: grid;
+  gap: 14px;
+  padding-top: 4px;
+  border-top: 1px solid var(--line);
+}
+
+.tm-settings-statement {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+  line-height: 1.5;
+}
+
+.tm-settings-danger {
+  display: grid;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px solid var(--line);
+}
+
+.tm-settings-delete-result {
+  margin: 0;
+  color: var(--success);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 640px) {
+  .tm-filters-toggle {
+    margin-left: 0;
+  }
+
+  .tm-health-row {
+    grid-template-columns: 16px minmax(0, 1fr) auto;
+  }
+
+  .tm-health-row .usage-bar {
+    display: none;
+  }
+
+  .tm-drilldown-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .tm-drilldown-meta {
+    width: 100%;
+    justify-content: space-between;
   }
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import { AssistantMark } from "@/components/AssistantMark";
 import { BackendSwitcher } from "@/components/BackendSwitcher";
 import { BoardPanel } from "@/components/BoardPanel";
 import { InboxDock } from "@/components/InboxDock";
+import { TelemetryDock } from "@/components/TelemetryDock";
 import { LaunchPanel } from "@/components/LaunchPanel";
 import { LoginForm } from "@/components/LoginForm";
 import { SchedulePanel } from "@/components/SchedulePanel";
@@ -1210,6 +1211,7 @@ export default function HomePage() {
         </Link>
       ) : null}
       {token ? <InboxDock host={host} token={token} /> : null}
+      {token ? <TelemetryDock /> : null}
       {connectPrompt ? (
         <SshConnectModal
           targetName={connectPrompt.target.name}

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -85,6 +85,11 @@ export default function TelemetryPage() {
 
   const catalog = useBackendCatalog(host || null, token || null, null);
 
+  // A custom range with only one bound picked is a normal mid-edit state, not
+  // an error — the backend 400s on it ("custom range requires both start and
+  // end"), so every fetch below no-ops instead of firing while it's incomplete.
+  const customRangeIncomplete = range.preset === "custom" && (!range.start || !range.end);
+
   const handleAuthFailure = useCallback(() => {
     clearToken();
     setToken("");
@@ -114,6 +119,13 @@ export default function TelemetryPage() {
 
   const refreshOverviewGroup = useCallback(async () => {
     if (!host || !token) return;
+    if (customRangeIncomplete) {
+      setOverviewLoading(false);
+      setActivityLoading(false);
+      setHealthLoading(false);
+      setInsightsLoading(false);
+      return;
+    }
     setOverviewLoading(true);
     setActivityLoading(true);
     setHealthLoading(true);
@@ -144,10 +156,14 @@ export default function TelemetryPage() {
       setHealthLoading(false);
       setInsightsLoading(false);
     }
-  }, [host, token, range, filters, handleAuthFailure]);
+  }, [host, token, range, filters, customRangeIncomplete, handleAuthFailure]);
 
   const refreshTokens = useCallback(async () => {
     if (!host || !token) return;
+    if (customRangeIncomplete) {
+      setTokensLoading(false);
+      return;
+    }
     setTokensLoading(true);
     try {
       const res = await fetchTelemetryTokens(host, token, range, filters, tokenGroupBy);
@@ -161,10 +177,14 @@ export default function TelemetryPage() {
     } finally {
       setTokensLoading(false);
     }
-  }, [host, token, range, filters, tokenGroupBy, handleAuthFailure]);
+  }, [host, token, range, filters, tokenGroupBy, customRangeIncomplete, handleAuthFailure]);
 
   const refreshDrilldown = useCallback(async () => {
     if (!host || !token) return;
+    if (customRangeIncomplete) {
+      setDrilldownLoading(false);
+      return;
+    }
     setDrilldownLoading(true);
     try {
       const res = await fetchTelemetryDrilldown(
@@ -186,7 +206,16 @@ export default function TelemetryPage() {
     } finally {
       setDrilldownLoading(false);
     }
-  }, [host, token, range, filters, drilldownKind, drilldownPage, handleAuthFailure]);
+  }, [
+    host,
+    token,
+    range,
+    filters,
+    drilldownKind,
+    drilldownPage,
+    customRangeIncomplete,
+    handleAuthFailure,
+  ]);
 
   const refreshSettings = useCallback(async () => {
     if (!host || !token) return;

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { ThemeToggle } from "@/components/ThemeToggle";
+import { ActivityChart } from "@/components/telemetry/ActivityChart";
+import { DrilldownPanel } from "@/components/telemetry/DrilldownPanel";
+import { HealthPanel } from "@/components/telemetry/HealthPanel";
+import { InsightCards } from "@/components/telemetry/InsightCards";
+import { OverviewCards } from "@/components/telemetry/OverviewCards";
+import { SettingsPanel } from "@/components/telemetry/SettingsPanel";
+import { TelemetryFilters } from "@/components/telemetry/TelemetryFilters";
+import { TokenChart } from "@/components/telemetry/TokenChart";
+import {
+  connectSessionsSocket,
+  deleteTelemetry,
+  dismissTelemetryInsight,
+  fetchTelemetryActivity,
+  fetchTelemetryDrilldown,
+  fetchTelemetryHealth,
+  fetchTelemetryInsights,
+  fetchTelemetryOverview,
+  fetchTelemetrySettings,
+  fetchTelemetryTokens,
+  isAuthError,
+} from "@/lib/api";
+import { agentTransports, useBackendCatalog } from "@/lib/backends";
+import { clearToken, readHost, readToken } from "@/lib/store";
+import { formatRangeLabel, readTelemetryQuery, writeTelemetryQuery } from "@/lib/telemetry";
+import { useTheme } from "@/lib/theme";
+import {
+  Insight,
+  SessionEnvelope,
+  TelemetryActivity,
+  TelemetryDeleteResponse,
+  TelemetryDrilldown,
+  TelemetryFactKind,
+  TelemetryHealth,
+  TelemetryOverview,
+  TelemetrySettingsResponse,
+  TelemetryTokens,
+  TokenGroupBy,
+} from "@/lib/types";
+
+const DRILLDOWN_PAGE_SIZE = 25;
+const REFRESH_DEBOUNCE_MS = 400;
+
+type LoadState = "loading" | "ready" | "error";
+
+export default function TelemetryPage() {
+  const router = useRouter();
+  const { theme } = useTheme();
+  const [host, setHost] = useState("");
+  const [token, setToken] = useState("");
+  const [state, setState] = useState<LoadState>("loading");
+  const [error, setError] = useState("");
+
+  const [range, setRange] = useState(() => readTelemetryQuery().range);
+  const [filters, setFilters] = useState(() => readTelemetryQuery().filters);
+
+  const [overview, setOverview] = useState<TelemetryOverview | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(true);
+  const [tokens, setTokens] = useState<TelemetryTokens | null>(null);
+  const [tokensLoading, setTokensLoading] = useState(true);
+  const [tokenGroupBy, setTokenGroupBy] = useState<TokenGroupBy>("time");
+  const [activity, setActivity] = useState<TelemetryActivity | null>(null);
+  const [activityLoading, setActivityLoading] = useState(true);
+  const [health, setHealth] = useState<TelemetryHealth | null>(null);
+  const [healthLoading, setHealthLoading] = useState(true);
+  const [insights, setInsights] = useState<Insight[]>([]);
+  const [insightsLoading, setInsightsLoading] = useState(true);
+  const [dismissingSignature, setDismissingSignature] = useState<string | null>(null);
+  const [settings, setSettings] = useState<TelemetrySettingsResponse | null>(null);
+  const [settingsLoading, setSettingsLoading] = useState(true);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteResult, setDeleteResult] = useState<TelemetryDeleteResponse | null>(null);
+
+  const [drilldownKind, setDrilldownKind] = useState<TelemetryFactKind>("tool_call");
+  const [drilldownPage, setDrilldownPage] = useState(1);
+  const [drilldown, setDrilldown] = useState<TelemetryDrilldown | null>(null);
+  const [drilldownLoading, setDrilldownLoading] = useState(true);
+
+  const catalog = useBackendCatalog(host || null, token || null, null);
+
+  const handleAuthFailure = useCallback(() => {
+    clearToken();
+    setToken("");
+    router.replace("/");
+  }, [router]);
+
+  useEffect(() => {
+    const currentHost = readHost();
+    const currentToken = readToken();
+    setHost(currentHost);
+    setToken(currentToken);
+    if (!currentHost || !currentToken) {
+      router.replace("/");
+    }
+  }, [router]);
+
+  // Persist range/filters (skip the very first render, which is what we just read).
+  const skipPersist = useRef(true);
+  useEffect(() => {
+    if (skipPersist.current) {
+      skipPersist.current = false;
+      return;
+    }
+    writeTelemetryQuery(range, filters);
+    setDrilldownPage(1);
+  }, [range, filters]);
+
+  const refreshOverviewGroup = useCallback(async () => {
+    if (!host || !token) return;
+    setOverviewLoading(true);
+    setActivityLoading(true);
+    setHealthLoading(true);
+    setInsightsLoading(true);
+    try {
+      const [overviewRes, activityRes, healthRes, insightsRes] = await Promise.all([
+        fetchTelemetryOverview(host, token, range, filters),
+        fetchTelemetryActivity(host, token, range, filters),
+        fetchTelemetryHealth(host, token, range, filters),
+        fetchTelemetryInsights(host, token, range, filters),
+      ]);
+      setOverview(overviewRes);
+      setActivity(activityRes);
+      setHealth(healthRes);
+      setInsights(insightsRes);
+      setState("ready");
+      setError("");
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      setState((current) => (current === "ready" ? current : "error"));
+      setError(err instanceof Error ? err.message : "failed to load telemetry");
+    } finally {
+      setOverviewLoading(false);
+      setActivityLoading(false);
+      setHealthLoading(false);
+      setInsightsLoading(false);
+    }
+  }, [host, token, range, filters, handleAuthFailure]);
+
+  const refreshTokens = useCallback(async () => {
+    if (!host || !token) return;
+    setTokensLoading(true);
+    try {
+      const res = await fetchTelemetryTokens(host, token, range, filters, tokenGroupBy);
+      setTokens(res);
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(err instanceof Error ? err.message : "failed to load token usage");
+    } finally {
+      setTokensLoading(false);
+    }
+  }, [host, token, range, filters, tokenGroupBy, handleAuthFailure]);
+
+  const refreshDrilldown = useCallback(async () => {
+    if (!host || !token) return;
+    setDrilldownLoading(true);
+    try {
+      const res = await fetchTelemetryDrilldown(
+        host,
+        token,
+        range,
+        filters,
+        drilldownKind,
+        drilldownPage,
+        DRILLDOWN_PAGE_SIZE,
+      );
+      setDrilldown(res);
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(err instanceof Error ? err.message : "failed to load drilldown");
+    } finally {
+      setDrilldownLoading(false);
+    }
+  }, [host, token, range, filters, drilldownKind, drilldownPage, handleAuthFailure]);
+
+  const refreshSettings = useCallback(async () => {
+    if (!host || !token) return;
+    setSettingsLoading(true);
+    try {
+      const res = await fetchTelemetrySettings(host, token);
+      setSettings(res);
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(err instanceof Error ? err.message : "failed to load telemetry settings");
+    } finally {
+      setSettingsLoading(false);
+    }
+  }, [host, token, handleAuthFailure]);
+
+  useEffect(() => {
+    void refreshOverviewGroup();
+  }, [refreshOverviewGroup]);
+
+  useEffect(() => {
+    void refreshTokens();
+  }, [refreshTokens]);
+
+  useEffect(() => {
+    void refreshDrilldown();
+  }, [refreshDrilldown]);
+
+  useEffect(() => {
+    void refreshSettings();
+  }, [refreshSettings]);
+
+  // Live refresh: re-fetch whenever the runtime reports telemetry facts
+  // changed, debounced so a burst of ingested facts triggers one refetch.
+  const latestRefreshersRef = useRef({
+    overview: refreshOverviewGroup,
+    tokens: refreshTokens,
+    drilldown: refreshDrilldown,
+  });
+  useEffect(() => {
+    latestRefreshersRef.current = {
+      overview: refreshOverviewGroup,
+      tokens: refreshTokens,
+      drilldown: refreshDrilldown,
+    };
+  }, [refreshOverviewGroup, refreshTokens, refreshDrilldown]);
+
+  useEffect(() => {
+    if (!host || !token) return;
+    let active = true;
+    let socket: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+
+    function scheduleRefresh() {
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        if (!active) return;
+        void latestRefreshersRef.current.overview();
+        void latestRefreshersRef.current.tokens();
+        void latestRefreshersRef.current.drilldown();
+      }, REFRESH_DEBOUNCE_MS);
+    }
+
+    function connect() {
+      socket = connectSessionsSocket(
+        host,
+        token,
+        (message: SessionEnvelope) => {
+          if (message.type === "telemetry_update") scheduleRefresh();
+          if (message.type === "auth_revoked") handleAuthFailure();
+        },
+        () => {
+          if (active) handleAuthFailure();
+        },
+        {
+          onOpen: () => {
+            attempt = 0;
+          },
+          onClose: () => {
+            if (!active) return;
+            const delay = Math.min(15000, 500 * 2 ** attempt);
+            attempt += 1;
+            reconnectTimer = setTimeout(connect, delay);
+          },
+        },
+      );
+    }
+    connect();
+
+    return () => {
+      active = false;
+      if (reconnectTimer !== null) clearTimeout(reconnectTimer);
+      if (debounceTimer !== null) clearTimeout(debounceTimer);
+      socket?.close();
+    };
+  }, [host, token, handleAuthFailure]);
+
+  const handleDismissInsight = useCallback(
+    async (insight: Insight) => {
+      if (!host || !token) return;
+      setDismissingSignature(insight.signature);
+      try {
+        await dismissTelemetryInsight(host, token, range, filters, insight.signature);
+        setInsights((prev) => prev.filter((item) => item.signature !== insight.signature));
+      } catch (err) {
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return;
+        }
+        setError(err instanceof Error ? err.message : "failed to dismiss insight");
+      } finally {
+        setDismissingSignature(null);
+      }
+    },
+    [host, token, range, filters, handleAuthFailure],
+  );
+
+  const handleInsightClickThrough = useCallback((insight: Insight) => {
+    const kindParam = insight.click_through.params?.kind;
+    if (typeof kindParam === "string") {
+      setDrilldownKind(kindParam as TelemetryFactKind);
+      setDrilldownPage(1);
+    }
+    document.getElementById("tm-drilldown-anchor")?.scrollIntoView({ behavior: "smooth" });
+  }, []);
+
+  const handleDeleteTelemetry = useCallback(async () => {
+    if (!host || !token) return;
+    setDeleting(true);
+    setError("");
+    try {
+      const result = await deleteTelemetry(host, token);
+      setDeleteResult(result);
+      await Promise.all([refreshOverviewGroup(), refreshTokens(), refreshDrilldown(), refreshSettings()]);
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(err instanceof Error ? err.message : "failed to delete telemetry");
+    } finally {
+      setDeleting(false);
+    }
+  }, [host, token, refreshOverviewGroup, refreshTokens, refreshDrilldown, refreshSettings, handleAuthFailure]);
+
+  const backendOptions = catalog.ids().map((id) => ({ id, label: catalog.labelFor(id) }));
+  const transportOptions = Array.from(
+    new Set(catalog.ids().flatMap((id) => agentTransports(id, catalog))),
+  );
+  const effectiveRangeLabel = overview ? formatRangeLabel(overview.range) : null;
+
+  return (
+    <main className="page-shell">
+      <header className="app-bar">
+        <div className="app-bar-brand">
+          <Link className="app-bar-mark" href="/" aria-label="Waypoint home">
+            <Image
+              src={theme === "light" ? "/waypoint-light.svg" : "/waypoint.svg"}
+              alt=""
+              width={38}
+              height={38}
+              priority
+            />
+          </Link>
+          <div className="app-bar-titles">
+            <p className="app-bar-eyebrow">Waypoint · telemetry</p>
+            <h1 className="app-bar-title">Telemetry</h1>
+          </div>
+        </div>
+        <div className="app-bar-meta">
+          <Link className="back-link" href="/">
+            ← all sessions
+          </Link>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      {error ? (
+        <div className="error-banner" role="alert">
+          <span>{error}</span>
+          <button className="error-banner-dismiss" onClick={() => setError("")} aria-label="Dismiss">
+            ×
+          </button>
+        </div>
+      ) : null}
+
+      {state === "error" && !overview ? (
+        <section className="panel bordered board-empty">
+          <h2>Couldn’t load telemetry</h2>
+          <p className="muted">The backend didn’t respond. Check that Waypoint is running, then retry.</p>
+          <button type="button" className="primary" onClick={() => void refreshOverviewGroup()}>
+            Retry
+          </button>
+        </section>
+      ) : (
+        <>
+          <TelemetryFilters
+            range={range}
+            filters={filters}
+            onRangeChange={setRange}
+            onFiltersChange={setFilters}
+            backendOptions={backendOptions}
+            transportOptions={transportOptions}
+            effectiveRangeLabel={effectiveRangeLabel}
+          />
+
+          <OverviewCards overview={overview} loading={overviewLoading} />
+
+          <InsightCards
+            insights={insights}
+            loading={insightsLoading}
+            dismissingSignature={dismissingSignature}
+            onDismiss={(insight) => void handleDismissInsight(insight)}
+            onClickThrough={handleInsightClickThrough}
+          />
+
+          <TokenChart
+            tokens={tokens}
+            loading={tokensLoading}
+            groupBy={tokenGroupBy}
+            onGroupByChange={setTokenGroupBy}
+          />
+
+          <ActivityChart activity={activity} loading={activityLoading} />
+
+          <HealthPanel health={health} loading={healthLoading} />
+
+          <div id="tm-drilldown-anchor" />
+          <DrilldownPanel
+            drilldown={drilldown}
+            loading={drilldownLoading}
+            kind={drilldownKind}
+            onKindChange={(kind) => {
+              setDrilldownKind(kind);
+              setDrilldownPage(1);
+            }}
+            page={drilldownPage}
+            onPageChange={setDrilldownPage}
+            pageSize={DRILLDOWN_PAGE_SIZE}
+          />
+
+          <SettingsPanel
+            settings={settings}
+            loading={settingsLoading}
+            deleting={deleting}
+            deleteResult={deleteResult}
+            onDelete={() => void handleDeleteTelemetry()}
+          />
+        </>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -45,7 +45,7 @@ import {
   TokenGroupBy,
 } from "@/lib/types";
 
-const DRILLDOWN_PAGE_SIZE = 25;
+const DRILLDOWN_PAGE_SIZE = 50;
 const REFRESH_DEBOUNCE_MS = 400;
 
 type LoadState = "loading" | "ready" | "error";

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom";
 
 import { UsageBar, UsageReadout } from "@/components/UsageReadout";
 import { humaniseBackend, type BackendCatalog } from "@/lib/backends";
+import { UNIFIED_TOKEN_LABELS, unifyTokens } from "@/lib/tokens";
 import type {
   SessionContextUsage,
   SessionRecord,
@@ -103,8 +104,13 @@ export function SessionUsagePill({
       : formatTokens(contextUsage.used_tokens)
     : null;
 
+  // Raw per-backend ledger totals overlap (Codex/OpenCode totals already
+  // include cached/reasoning tokens); unify onto the 5 disjoint buckets
+  // before display so the chip list never double-counts.
+  const hasTokenTotals =
+    tokenUsage !== null && Object.keys(tokenUsage.totals ?? {}).length > 0;
   const tokenUsageTotals = tokenUsage
-    ? Object.entries(tokenUsage.totals ?? {})
+    ? Object.entries(unifyTokens(tokenUsage.source, tokenUsage.totals ?? {}))
     : [];
   // A partial disclosure with nothing tracked (e.g. Codex tmux) carries only a
   // coverage note; the per-turn totals are genuinely unavailable there.
@@ -341,11 +347,11 @@ export function SessionUsagePill({
                       </span>
                     ) : null}
                   </div>
-                  {tokenUsageTotals.length > 0 ? (
+                  {hasTokenTotals ? (
                     <ul className="usage-chips">
                       {tokenUsageTotals.map(([key, value]) => (
                         <li key={key}>
-                          <em>{tokenCategoryLabel(key)}</em>
+                          <em>{UNIFIED_TOKEN_LABELS[key as keyof typeof UNIFIED_TOKEN_LABELS] ?? key}</em>
                           <strong>{formatTokens(value)}</strong>
                         </li>
                       ))}

--- a/frontend/src/components/TelemetryDock.tsx
+++ b/frontend/src/components/TelemetryDock.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Link from "next/link";
+
+// Bottom-center glass floater linking to the full /telemetry dashboard —
+// mirrors InboxDock/assistant-fab's treatment but sits center so it never
+// collides with either corner dock.
+export function TelemetryDock() {
+  return (
+    <Link className="telemetry-dock" href="/telemetry" aria-label="Open telemetry">
+      <span className="telemetry-dock-glyph" aria-hidden="true">
+        <GaugeIcon />
+      </span>
+      <span className="telemetry-dock-label">Telemetry</span>
+    </Link>
+  );
+}
+
+function GaugeIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="18"
+      height="18"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 15a8 8 0 1 1 16 0" />
+      <path d="M12 15V9" />
+      <path d="M12 15 16 11" />
+    </svg>
+  );
+}

--- a/frontend/src/components/UsageDashboardSection.tsx
+++ b/frontend/src/components/UsageDashboardSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { UsageInstrumentPanel } from "@/components/UsageInstrumentPanel";
@@ -333,6 +334,9 @@ export function UsageDashboardSection({
               <span className="usage-deck-status-detail">{status.detail}</span>
             </div>
             <div className="usage-deck-status-actions">
+              <Link className="usage-deck-full-link" href="/telemetry">
+                View full telemetry →
+              </Link>
               {status.freshest ? (
                 <span
                   className="usage-deck-status-sweep"

--- a/frontend/src/components/telemetry/ActivityChart.tsx
+++ b/frontend/src/components/telemetry/ActivityChart.tsx
@@ -4,25 +4,22 @@ import { useId, useMemo, useState } from "react";
 
 import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
 import { DOW_LABELS, formatDayLabel, formatHourLabel } from "@/lib/telemetry";
-import { TelemetryActivity } from "@/lib/types";
+import { ActivityDaily, TelemetryActivity } from "@/lib/types";
 
 interface ActivityChartProps {
   activity: TelemetryActivity | null;
   loading: boolean;
 }
 
-const CHART_W = 640;
-const CHART_H = 200;
-const PAD_LEFT = 40;
-const PAD_RIGHT = 12;
-const PAD_TOP = 12;
-const PAD_BOTTOM = 26;
+const MINI_W = 240;
+const MINI_H = 60;
+const MINI_PAD = 4;
 
-const DAILY_SERIES: { key: keyof TelemetryActivity["daily"][number]; label: string; slot: number }[] = [
-  { key: "user_turns", label: "User turns", slot: 1 },
-  { key: "agent_turns", label: "Agent turns", slot: 2 },
+const DAILY_SERIES: { key: keyof ActivityDaily; label: string; slot: number }[] = [
   { key: "tool_calls", label: "Tool calls", slot: 3 },
-  { key: "sessions_created", label: "Sessions created", slot: 4 },
+  { key: "agent_turns", label: "Agent turns", slot: 2 },
+  { key: "user_turns", label: "User turns", slot: 1 },
+  { key: "sessions_created", label: "Sessions created", slot: 5 },
 ];
 
 function seriesColor(slot: number): string {
@@ -37,6 +34,147 @@ function niceMax(value: number): number {
   return niceResidual * magnitude;
 }
 
+// Python weekday (Mon=0…Sun=6) from a host-tz calendar day string, matching
+// the backend heatmap bucketing so the derived date labels line up with the rows.
+function pythonDow(day: string): number {
+  const parsed = new Date(`${day}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return -1;
+  return (parsed.getDay() + 6) % 7;
+}
+
+// Each heatmap row is an aggregate over every day in the range that fell on
+// that weekday — not a single date. Surfacing the actual dates each row covers
+// is what makes "where did Sunday come from" self-evidently correct.
+function formatDowDates(days: string[]): string {
+  if (days.length === 0) return "no days";
+  if (days.length === 1) return formatDayLabel(days[0]);
+  const sorted = [...days].sort();
+  return `${formatDayLabel(sorted[0])} – ${formatDayLabel(sorted[sorted.length - 1])} · ${days.length}×`;
+}
+
+function MiniTrend({
+  daily,
+  seriesKey,
+  label,
+  color,
+  onHover,
+}: {
+  daily: ActivityDaily[];
+  seriesKey: keyof ActivityDaily;
+  label: string;
+  color: string;
+  onHover: (state: ChartTooltipState | null) => void;
+}) {
+  const values = daily.map((day) => Number(day[seriesKey]));
+  const total = values.reduce((sum, v) => sum + v, 0);
+  const peak = Math.max(0, ...values);
+  const max = niceMax(peak);
+  const plotW = MINI_W - MINI_PAD * 2;
+  const plotH = MINI_H - MINI_PAD * 2;
+  const stepX = daily.length > 1 ? plotW / (daily.length - 1) : 0;
+
+  const coords = daily.map((_, i) => {
+    const x = MINI_PAD + i * stepX;
+    const y = MINI_PAD + plotH - (max > 0 ? (values[i] / max) * plotH : 0);
+    return { x, y };
+  });
+  const line = coords.map((c) => `${c.x},${c.y}`).join(" ");
+  const area =
+    coords.length > 0
+      ? `M ${coords[0].x},${MINI_PAD + plotH} ${coords.map((c) => `L ${c.x},${c.y}`).join(" ")} L ${
+          coords[coords.length - 1].x
+        },${MINI_PAD + plotH} Z`
+      : "";
+
+  return (
+    <div className="tm-smallmult">
+      <div className="tm-smallmult-head">
+        <span className="tm-smallmult-name">
+          <span className="tm-stat-swatch" aria-hidden="true" style={{ background: color }} />
+          {label}
+        </span>
+        <span className="tm-smallmult-total">{total.toLocaleString()}</span>
+      </div>
+      <svg
+        viewBox={`0 0 ${MINI_W} ${MINI_H}`}
+        className="tm-smallmult-svg"
+        preserveAspectRatio="none"
+        role="img"
+        aria-label={`${label}: ${total.toLocaleString()} total across ${daily.length} day${
+          daily.length === 1 ? "" : "s"
+        }, peaking at ${peak.toLocaleString()} per day`}
+      >
+        <line
+          x1={MINI_PAD}
+          y1={MINI_H - MINI_PAD}
+          x2={MINI_W - MINI_PAD}
+          y2={MINI_H - MINI_PAD}
+          className="tm-chart-gridline"
+        />
+        {area ? <path d={area} fill={color} className="tm-smallmult-area" /> : null}
+        {coords.length > 1 ? (
+          <polyline
+            points={line}
+            fill="none"
+            stroke={color}
+            strokeWidth={1.75}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            vectorEffect="non-scaling-stroke"
+          />
+        ) : coords.length === 1 ? (
+          <circle cx={coords[0].x} cy={coords[0].y} r={2.5} fill={color} />
+        ) : null}
+        {daily.map((day, i) => (
+          <rect
+            key={day.day}
+            x={coords[i].x - (stepX || plotW) / 2}
+            y={0}
+            width={Math.max(stepX || plotW, 1)}
+            height={MINI_H}
+            fill="transparent"
+            tabIndex={0}
+            role="img"
+            aria-label={`${formatDayLabel(day.day)}: ${values[i].toLocaleString()} ${label.toLowerCase()}`}
+            className="tm-hover-column"
+            onMouseEnter={(event) =>
+              onHover({
+                left: event.clientX,
+                top: event.clientY,
+                title: formatDayLabel(day.day),
+                rows: [{ key: label, label, value: values[i].toLocaleString(), color }],
+              })
+            }
+            onMouseMove={(event) =>
+              onHover({
+                left: event.clientX,
+                top: event.clientY,
+                title: formatDayLabel(day.day),
+                rows: [{ key: label, label, value: values[i].toLocaleString(), color }],
+              })
+            }
+            onFocus={() =>
+              onHover({
+                left: 0,
+                top: 0,
+                title: formatDayLabel(day.day),
+                rows: [{ key: label, label, value: values[i].toLocaleString(), color }],
+              })
+            }
+            onMouseLeave={() => onHover(null)}
+            onBlur={() => onHover(null)}
+          />
+        ))}
+      </svg>
+      <div className="tm-smallmult-foot">
+        <span>{daily.length > 0 ? formatDayLabel(daily[0].day) : ""}</span>
+        <span className="muted">peak {peak.toLocaleString()}/day</span>
+        <span>{daily.length > 0 ? formatDayLabel(daily[daily.length - 1].day) : ""}</span>
+      </div>
+    </div>
+  );
+}
+
 export function ActivityChart({ activity, loading }: ActivityChartProps) {
   const [tooltip, setTooltip] = useState<ChartTooltipState | null>(null);
   const [tableOpen, setTableOpen] = useState(false);
@@ -46,7 +184,20 @@ export function ActivityChart({ activity, loading }: ActivityChartProps) {
   const heatmapSummary = useMemo(() => {
     if (!activity || activity.heatmap.length === 0) return null;
     const peak = activity.heatmap.reduce((best, cell) => (cell.count > best.count ? cell : best));
-    return `Busiest: ${DOW_LABELS[peak.dow] ?? peak.dow} at ${formatHourLabel(peak.hour)} (${peak.count} events)`;
+    return { dow: peak.dow, hour: peak.hour, count: peak.count };
+  }, [activity]);
+
+  // Which real calendar dates from the range land on each weekday row.
+  const dowDates = useMemo(() => {
+    const map = new Map<number, string[]>();
+    for (const day of activity?.daily ?? []) {
+      const dow = pythonDow(day.day);
+      if (dow < 0) continue;
+      const list = map.get(dow) ?? [];
+      list.push(day.day);
+      map.set(dow, list);
+    }
+    return map;
   }, [activity]);
 
   if (loading && !activity) {
@@ -55,12 +206,12 @@ export function ActivityChart({ activity, loading }: ActivityChartProps) {
   if (!activity) return null;
 
   const daily = activity.daily;
-  const plotW = CHART_W - PAD_LEFT - PAD_RIGHT;
-  const plotH = CHART_H - PAD_TOP - PAD_BOTTOM;
-  const max = niceMax(
-    Math.max(0, ...daily.flatMap((d) => DAILY_SERIES.map((s) => Number(d[s.key])))),
-  );
-  const stepX = daily.length > 1 ? plotW / (daily.length - 1) : 0;
+  const trendSummary =
+    daily.length > 0
+      ? DAILY_SERIES.map(
+          (s) => `${daily.reduce((sum, d) => sum + Number(d[s.key]), 0).toLocaleString()} ${s.label.toLowerCase()}`,
+        ).join(", ")
+      : "";
 
   const heatmapByCell = new Map<string, number>();
   let heatmapMax = 0;
@@ -78,176 +229,108 @@ export function ActivityChart({ activity, loading }: ActivityChartProps) {
         {daily.length === 0 ? (
           <p className="muted tm-chart-empty">No activity in this range.</p>
         ) : (
-          <svg
-            viewBox={`0 0 ${CHART_W} ${CHART_H}`}
-            className="tm-chart-svg"
-            role="img"
-            aria-label={`Daily user turns, agent turns, tool calls, and sessions created across ${daily.length} days, peaking at ${max}`}
-          >
-            <g transform={`translate(${PAD_LEFT},${PAD_TOP})`}>
-              {[0, 0.5, 1].map((fraction) => {
-                const y = plotH - plotH * fraction;
-                return (
-                  <g key={fraction}>
-                    <line x1={0} y1={y} x2={plotW} y2={y} className="tm-chart-gridline" />
-                    <text x={-8} y={y} className="tm-chart-axis-label" textAnchor="end" dy="0.32em">
-                      {Math.round(max * fraction)}
-                    </text>
-                  </g>
-                );
-              })}
-
-              {DAILY_SERIES.map((series) => {
-                const points = daily
-                  .map((day, i) => {
-                    const value = Number(day[series.key]);
-                    const x = i * stepX;
-                    const y = plotH - (max > 0 ? (value / max) * plotH : 0);
-                    return `${x},${y}`;
-                  })
-                  .join(" ");
-                return (
-                  <polyline
-                    key={series.key}
-                    points={points}
-                    fill="none"
-                    stroke={seriesColor(series.slot)}
-                    strokeWidth={2}
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                );
-              })}
-
-              {daily.map((day, i) => {
-                const x = i * stepX;
-                return (
-                  <rect
-                    key={day.day}
-                    x={x - stepX / 2}
-                    y={0}
-                    width={Math.max(stepX, 1)}
-                    height={plotH}
-                    fill="transparent"
-                    tabIndex={0}
-                    role="img"
-                    aria-label={`${formatDayLabel(day.day)}: ${day.user_turns} user turns, ${day.agent_turns} agent turns, ${day.tool_calls} tool calls, ${day.sessions_created} sessions created`}
-                    className="tm-hover-column"
-                    onMouseEnter={(event) =>
-                      setTooltip({
-                        left: event.clientX,
-                        top: event.clientY,
-                        title: formatDayLabel(day.day),
-                        rows: DAILY_SERIES.map((series) => ({
-                          key: series.key,
-                          label: series.label,
-                          value: String(day[series.key]),
-                          color: seriesColor(series.slot),
-                        })),
-                      })
-                    }
-                    onMouseMove={(event) =>
-                      setTooltip({
-                        left: event.clientX,
-                        top: event.clientY,
-                        title: formatDayLabel(day.day),
-                        rows: DAILY_SERIES.map((series) => ({
-                          key: series.key,
-                          label: series.label,
-                          value: String(day[series.key]),
-                          color: seriesColor(series.slot),
-                        })),
-                      })
-                    }
-                    onFocus={() =>
-                      setTooltip({
-                        left: 0,
-                        top: 0,
-                        title: formatDayLabel(day.day),
-                        rows: DAILY_SERIES.map((series) => ({
-                          key: series.key,
-                          label: series.label,
-                          value: String(day[series.key]),
-                          color: seriesColor(series.slot),
-                        })),
-                      })
-                    }
-                    onMouseLeave={() => setTooltip(null)}
-                    onBlur={() => setTooltip(null)}
-                  />
-                );
-              })}
-              <line x1={0} y1={plotH} x2={plotW} y2={plotH} className="tm-chart-axis" />
-            </g>
-          </svg>
+          <>
+            <p className="sr-only">
+              Daily activity across {daily.length} days: {trendSummary}. Each panel is scaled to its
+              own peak so every series stays legible.
+            </p>
+            <div className="tm-smallmult-grid">
+              {DAILY_SERIES.map((series) => (
+                <MiniTrend
+                  key={series.key}
+                  daily={daily}
+                  seriesKey={series.key}
+                  label={series.label}
+                  color={seriesColor(series.slot)}
+                  onHover={setTooltip}
+                />
+              ))}
+            </div>
+            <p className="tm-chart-footnote muted">
+              Each panel scales to its own peak — compare shape and rhythm, not height across panels.
+            </p>
+          </>
         )}
         <ChartTooltip state={tooltip} />
-        {daily.length > 0 ? (
-          <div className="tm-chart-legend" role="list" aria-label="Series">
-            {DAILY_SERIES.map((series) => (
-              <span key={series.key} className="tm-legend-item" role="listitem">
-                <span
-                  className="tm-legend-swatch"
-                  aria-hidden="true"
-                  style={{ background: seriesColor(series.slot) }}
-                />
-                {series.label}
-              </span>
-            ))}
-          </div>
-        ) : null}
 
-        <button
-          type="button"
-          className="tm-table-toggle"
-          onClick={() => setTableOpen((v) => !v)}
-          aria-expanded={tableOpen}
-        >
-          {tableOpen ? "Hide data table" : "View as table"}
-        </button>
-        {tableOpen ? (
-          <div className="tm-table-wrap">
-            <table className="tm-data-table">
-              <caption className="sr-only">Daily session activity</caption>
-              <thead>
-                <tr>
-                  <th scope="col">Day</th>
-                  {DAILY_SERIES.map((series) => (
-                    <th scope="col" key={series.key}>
-                      {series.label}
-                    </th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {daily.map((day) => (
-                  <tr key={day.day}>
-                    <th scope="row">{day.day}</th>
-                    {DAILY_SERIES.map((series) => (
-                      <td key={series.key}>{day[series.key]}</td>
+        {daily.length > 0 ? (
+          <>
+            <button
+              type="button"
+              className="tm-table-toggle"
+              onClick={() => setTableOpen((v) => !v)}
+              aria-expanded={tableOpen}
+            >
+              {tableOpen ? "Hide data table" : "View as table"}
+            </button>
+            {tableOpen ? (
+              <div className="tm-table-wrap">
+                <table className="tm-data-table">
+                  <caption className="sr-only">Daily session activity</caption>
+                  <thead>
+                    <tr>
+                      <th scope="col">Day</th>
+                      {DAILY_SERIES.map((series) => (
+                        <th scope="col" key={series.key}>
+                          {series.label}
+                        </th>
+                      ))}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {daily.map((day) => (
+                      <tr key={day.day}>
+                        <th scope="row">{day.day}</th>
+                        {DAILY_SERIES.map((series) => (
+                          <td key={series.key}>{day[series.key]}</td>
+                        ))}
+                      </tr>
                     ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+          </>
         ) : null}
       </section>
 
       <section className="panel tm-chart-card" aria-labelledby={heatmapTitleId}>
         <header className="tm-chart-head">
           <h3 id={heatmapTitleId}>Activity heatmap</h3>
+          <span className="tm-heatmap-scale" aria-hidden="true">
+            less
+            <span className="tm-heatmap-scale-ramp">
+              {[0.12, 0.36, 0.6, 0.84, 1].map((step) => (
+                <span
+                  key={step}
+                  style={{
+                    background: `color-mix(in srgb, var(--tm-series-1) ${Math.round(
+                      step * 100,
+                    )}%, var(--bg-input))`,
+                  }}
+                />
+              ))}
+            </span>
+            more
+          </span>
         </header>
         {activity.heatmap.length === 0 ? (
           <p className="muted tm-chart-empty">No activity in this range.</p>
         ) : (
           <>
-            <p className="tm-chart-summary">{heatmapSummary}</p>
+            <p className="tm-chart-summary">
+              Events by weekday × hour of day, aggregated across the range.
+              {heatmapSummary
+                ? ` Busiest: ${DOW_LABELS[heatmapSummary.dow] ?? heatmapSummary.dow} at ${formatHourLabel(
+                    heatmapSummary.hour,
+                  )} (${heatmapSummary.count} event${heatmapSummary.count === 1 ? "" : "s"}).`
+                : ""}
+            </p>
             <div className="tm-heatmap-scroll">
               <table className="tm-heatmap" role="table" aria-label="Activity by day of week and hour">
                 <thead>
                   <tr>
-                    <th scope="col" />
+                    <th scope="col" className="tm-heatmap-corner" />
                     {Array.from({ length: 24 }, (_, hour) => (
                       <th key={hour} scope="col" className="tm-heatmap-hour">
                         {hour % 3 === 0 ? formatHourLabel(hour) : ""}
@@ -256,50 +339,73 @@ export function ActivityChart({ activity, loading }: ActivityChartProps) {
                   </tr>
                 </thead>
                 <tbody>
-                  {DOW_LABELS.map((label, dow) => (
-                    <tr key={label}>
-                      <th scope="row" className="tm-heatmap-dow">
-                        {label}
-                      </th>
-                      {Array.from({ length: 24 }, (_, hour) => {
-                        const count = heatmapByCell.get(`${dow}:${hour}`) ?? 0;
-                        const intensity = heatmapMax > 0 ? count / heatmapMax : 0;
-                        return (
-                          <td key={hour} className="tm-heatmap-cell-wrap">
-                            <button
-                              type="button"
-                              className="tm-heatmap-cell"
-                              style={{
-                                background:
+                  {DOW_LABELS.map((label, dow) => {
+                    const dates = dowDates.get(dow) ?? [];
+                    return (
+                      <tr key={label}>
+                        <th scope="row" className="tm-heatmap-dow">
+                          <span className="tm-heatmap-dow-name">{label}</span>
+                          <span className="tm-heatmap-dow-date">{formatDowDates(dates)}</span>
+                        </th>
+                        {Array.from({ length: 24 }, (_, hour) => {
+                          const count = heatmapByCell.get(`${dow}:${hour}`) ?? 0;
+                          const intensity = heatmapMax > 0 ? count / heatmapMax : 0;
+                          const isPeak =
+                            heatmapSummary?.dow === dow &&
+                            heatmapSummary?.hour === hour &&
+                            count > 0;
+                          return (
+                            <td key={hour} className="tm-heatmap-cell-wrap">
+                              <button
+                                type="button"
+                                className={`tm-heatmap-cell${count === 0 ? " is-empty" : ""}${
+                                  isPeak ? " is-peak" : ""
+                                }`}
+                                style={
                                   count === 0
-                                    ? "transparent"
-                                    : `color-mix(in srgb, var(--tm-series-1) ${Math.round(18 + intensity * 82)}%, var(--bg-card))`,
-                              }}
-                              aria-label={`${label} ${formatHourLabel(hour)}: ${count} event${count === 1 ? "" : "s"}`}
-                              onMouseEnter={(event) =>
-                                setTooltip({
-                                  left: event.clientX,
-                                  top: event.clientY,
-                                  title: `${label} · ${formatHourLabel(hour)}`,
-                                  rows: [{ key: "count", label: "events", value: String(count) }],
-                                })
-                              }
-                              onFocus={() =>
-                                setTooltip({
-                                  left: 0,
-                                  top: 0,
-                                  title: `${label} · ${formatHourLabel(hour)}`,
-                                  rows: [{ key: "count", label: "events", value: String(count) }],
-                                })
-                              }
-                              onMouseLeave={() => setTooltip(null)}
-                              onBlur={() => setTooltip(null)}
-                            />
-                          </td>
-                        );
-                      })}
-                    </tr>
-                  ))}
+                                    ? undefined
+                                    : {
+                                        // Floor at 22% so the faintest real cell is still
+                                        // clearly distinct from an empty one in both themes.
+                                        background: `color-mix(in srgb, var(--tm-series-1) ${Math.round(
+                                          22 + intensity * 78,
+                                        )}%, var(--bg-input))`,
+                                      }
+                                }
+                                aria-label={`${label} ${formatDowDates(dates)}, ${formatHourLabel(
+                                  hour,
+                                )}: ${count} event${count === 1 ? "" : "s"}`}
+                                onMouseEnter={(event) =>
+                                  setTooltip({
+                                    left: event.clientX,
+                                    top: event.clientY,
+                                    title: `${label} · ${formatHourLabel(hour)}`,
+                                    rows: [
+                                      { key: "count", label: "events", value: String(count) },
+                                      { key: "dates", label: "covers", value: formatDowDates(dates) },
+                                    ],
+                                  })
+                                }
+                                onFocus={() =>
+                                  setTooltip({
+                                    left: 0,
+                                    top: 0,
+                                    title: `${label} · ${formatHourLabel(hour)}`,
+                                    rows: [
+                                      { key: "count", label: "events", value: String(count) },
+                                      { key: "dates", label: "covers", value: formatDowDates(dates) },
+                                    ],
+                                  })
+                                }
+                                onMouseLeave={() => setTooltip(null)}
+                                onBlur={() => setTooltip(null)}
+                              />
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/frontend/src/components/telemetry/ActivityChart.tsx
+++ b/frontend/src/components/telemetry/ActivityChart.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+
+import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
+import { DOW_LABELS, formatDayLabel, formatHourLabel } from "@/lib/telemetry";
+import { TelemetryActivity } from "@/lib/types";
+
+interface ActivityChartProps {
+  activity: TelemetryActivity | null;
+  loading: boolean;
+}
+
+const CHART_W = 640;
+const CHART_H = 200;
+const PAD_LEFT = 40;
+const PAD_RIGHT = 12;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 26;
+
+const DAILY_SERIES: { key: keyof TelemetryActivity["daily"][number]; label: string; slot: number }[] = [
+  { key: "user_turns", label: "User turns", slot: 1 },
+  { key: "agent_turns", label: "Agent turns", slot: 2 },
+  { key: "tool_calls", label: "Tool calls", slot: 3 },
+  { key: "sessions_created", label: "Sessions created", slot: 4 },
+];
+
+function seriesColor(slot: number): string {
+  return `var(--tm-series-${slot})`;
+}
+
+function niceMax(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const residual = value / magnitude;
+  const niceResidual = residual <= 1 ? 1 : residual <= 2 ? 2 : residual <= 5 ? 5 : 10;
+  return niceResidual * magnitude;
+}
+
+export function ActivityChart({ activity, loading }: ActivityChartProps) {
+  const [tooltip, setTooltip] = useState<ChartTooltipState | null>(null);
+  const [tableOpen, setTableOpen] = useState(false);
+  const trendTitleId = useId();
+  const heatmapTitleId = useId();
+
+  const heatmapSummary = useMemo(() => {
+    if (!activity || activity.heatmap.length === 0) return null;
+    const peak = activity.heatmap.reduce((best, cell) => (cell.count > best.count ? cell : best));
+    return `Busiest: ${DOW_LABELS[peak.dow] ?? peak.dow} at ${formatHourLabel(peak.hour)} (${peak.count} events)`;
+  }, [activity]);
+
+  if (loading && !activity) {
+    return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
+  }
+  if (!activity) return null;
+
+  const daily = activity.daily;
+  const plotW = CHART_W - PAD_LEFT - PAD_RIGHT;
+  const plotH = CHART_H - PAD_TOP - PAD_BOTTOM;
+  const max = niceMax(
+    Math.max(0, ...daily.flatMap((d) => DAILY_SERIES.map((s) => Number(d[s.key])))),
+  );
+  const stepX = daily.length > 1 ? plotW / (daily.length - 1) : 0;
+
+  const heatmapByCell = new Map<string, number>();
+  let heatmapMax = 0;
+  for (const cell of activity.heatmap) {
+    heatmapByCell.set(`${cell.dow}:${cell.hour}`, cell.count);
+    if (cell.count > heatmapMax) heatmapMax = cell.count;
+  }
+
+  return (
+    <>
+      <section className="panel tm-chart-card" aria-labelledby={trendTitleId}>
+        <header className="tm-chart-head">
+          <h3 id={trendTitleId}>Session activity</h3>
+        </header>
+        {daily.length === 0 ? (
+          <p className="muted tm-chart-empty">No activity in this range.</p>
+        ) : (
+          <svg
+            viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+            className="tm-chart-svg"
+            role="img"
+            aria-label={`Daily user turns, agent turns, tool calls, and sessions created across ${daily.length} days, peaking at ${max}`}
+          >
+            <g transform={`translate(${PAD_LEFT},${PAD_TOP})`}>
+              {[0, 0.5, 1].map((fraction) => {
+                const y = plotH - plotH * fraction;
+                return (
+                  <g key={fraction}>
+                    <line x1={0} y1={y} x2={plotW} y2={y} className="tm-chart-gridline" />
+                    <text x={-8} y={y} className="tm-chart-axis-label" textAnchor="end" dy="0.32em">
+                      {Math.round(max * fraction)}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {DAILY_SERIES.map((series) => {
+                const points = daily
+                  .map((day, i) => {
+                    const value = Number(day[series.key]);
+                    const x = i * stepX;
+                    const y = plotH - (max > 0 ? (value / max) * plotH : 0);
+                    return `${x},${y}`;
+                  })
+                  .join(" ");
+                return (
+                  <polyline
+                    key={series.key}
+                    points={points}
+                    fill="none"
+                    stroke={seriesColor(series.slot)}
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                );
+              })}
+
+              {daily.map((day, i) => {
+                const x = i * stepX;
+                return (
+                  <rect
+                    key={day.day}
+                    x={x - stepX / 2}
+                    y={0}
+                    width={Math.max(stepX, 1)}
+                    height={plotH}
+                    fill="transparent"
+                    tabIndex={0}
+                    role="img"
+                    aria-label={`${formatDayLabel(day.day)}: ${day.user_turns} user turns, ${day.agent_turns} agent turns, ${day.tool_calls} tool calls, ${day.sessions_created} sessions created`}
+                    className="tm-hover-column"
+                    onMouseEnter={(event) =>
+                      setTooltip({
+                        left: event.clientX,
+                        top: event.clientY,
+                        title: formatDayLabel(day.day),
+                        rows: DAILY_SERIES.map((series) => ({
+                          key: series.key,
+                          label: series.label,
+                          value: String(day[series.key]),
+                          color: seriesColor(series.slot),
+                        })),
+                      })
+                    }
+                    onMouseMove={(event) =>
+                      setTooltip({
+                        left: event.clientX,
+                        top: event.clientY,
+                        title: formatDayLabel(day.day),
+                        rows: DAILY_SERIES.map((series) => ({
+                          key: series.key,
+                          label: series.label,
+                          value: String(day[series.key]),
+                          color: seriesColor(series.slot),
+                        })),
+                      })
+                    }
+                    onFocus={() =>
+                      setTooltip({
+                        left: 0,
+                        top: 0,
+                        title: formatDayLabel(day.day),
+                        rows: DAILY_SERIES.map((series) => ({
+                          key: series.key,
+                          label: series.label,
+                          value: String(day[series.key]),
+                          color: seriesColor(series.slot),
+                        })),
+                      })
+                    }
+                    onMouseLeave={() => setTooltip(null)}
+                    onBlur={() => setTooltip(null)}
+                  />
+                );
+              })}
+              <line x1={0} y1={plotH} x2={plotW} y2={plotH} className="tm-chart-axis" />
+            </g>
+          </svg>
+        )}
+        <ChartTooltip state={tooltip} />
+        {daily.length > 0 ? (
+          <div className="tm-chart-legend" role="list" aria-label="Series">
+            {DAILY_SERIES.map((series) => (
+              <span key={series.key} className="tm-legend-item" role="listitem">
+                <span
+                  className="tm-legend-swatch"
+                  aria-hidden="true"
+                  style={{ background: seriesColor(series.slot) }}
+                />
+                {series.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        <button
+          type="button"
+          className="tm-table-toggle"
+          onClick={() => setTableOpen((v) => !v)}
+          aria-expanded={tableOpen}
+        >
+          {tableOpen ? "Hide data table" : "View as table"}
+        </button>
+        {tableOpen ? (
+          <div className="tm-table-wrap">
+            <table className="tm-data-table">
+              <caption className="sr-only">Daily session activity</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Day</th>
+                  {DAILY_SERIES.map((series) => (
+                    <th scope="col" key={series.key}>
+                      {series.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {daily.map((day) => (
+                  <tr key={day.day}>
+                    <th scope="row">{day.day}</th>
+                    {DAILY_SERIES.map((series) => (
+                      <td key={series.key}>{day[series.key]}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="panel tm-chart-card" aria-labelledby={heatmapTitleId}>
+        <header className="tm-chart-head">
+          <h3 id={heatmapTitleId}>Activity heatmap</h3>
+        </header>
+        {activity.heatmap.length === 0 ? (
+          <p className="muted tm-chart-empty">No activity in this range.</p>
+        ) : (
+          <>
+            <p className="tm-chart-summary">{heatmapSummary}</p>
+            <div className="tm-heatmap-scroll">
+              <table className="tm-heatmap" role="table" aria-label="Activity by day of week and hour">
+                <thead>
+                  <tr>
+                    <th scope="col" />
+                    {Array.from({ length: 24 }, (_, hour) => (
+                      <th key={hour} scope="col" className="tm-heatmap-hour">
+                        {hour % 3 === 0 ? formatHourLabel(hour) : ""}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {DOW_LABELS.map((label, dow) => (
+                    <tr key={label}>
+                      <th scope="row" className="tm-heatmap-dow">
+                        {label}
+                      </th>
+                      {Array.from({ length: 24 }, (_, hour) => {
+                        const count = heatmapByCell.get(`${dow}:${hour}`) ?? 0;
+                        const intensity = heatmapMax > 0 ? count / heatmapMax : 0;
+                        return (
+                          <td key={hour} className="tm-heatmap-cell-wrap">
+                            <button
+                              type="button"
+                              className="tm-heatmap-cell"
+                              style={{
+                                background:
+                                  count === 0
+                                    ? "transparent"
+                                    : `color-mix(in srgb, var(--tm-series-1) ${Math.round(18 + intensity * 82)}%, var(--bg-card))`,
+                              }}
+                              aria-label={`${label} ${formatHourLabel(hour)}: ${count} event${count === 1 ? "" : "s"}`}
+                              onMouseEnter={(event) =>
+                                setTooltip({
+                                  left: event.clientX,
+                                  top: event.clientY,
+                                  title: `${label} · ${formatHourLabel(hour)}`,
+                                  rows: [{ key: "count", label: "events", value: String(count) }],
+                                })
+                              }
+                              onFocus={() =>
+                                setTooltip({
+                                  left: 0,
+                                  top: 0,
+                                  title: `${label} · ${formatHourLabel(hour)}`,
+                                  rows: [{ key: "count", label: "events", value: String(count) }],
+                                })
+                              }
+                              onMouseLeave={() => setTooltip(null)}
+                              onBlur={() => setTooltip(null)}
+                            />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <ChartTooltip state={tooltip} />
+          </>
+        )}
+      </section>
+    </>
+  );
+}

--- a/frontend/src/components/telemetry/ChartTooltip.tsx
+++ b/frontend/src/components/telemetry/ChartTooltip.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+export interface ChartTooltipRow {
+  key: string;
+  label: string;
+  value: string;
+  color?: string;
+}
+
+export interface ChartTooltipState {
+  left: number;
+  top: number;
+  title: string;
+  rows: ChartTooltipRow[];
+}
+
+// Shared hover/focus readout for the hand-built SVG charts. Values lead,
+// labels follow (dataviz skill's interaction convention); every value here is
+// also reachable without hovering via the chart's text summary / table view.
+export function ChartTooltip({ state }: { state: ChartTooltipState | null }) {
+  if (!state) return null;
+  return (
+    <div
+      className="tm-chart-tooltip"
+      style={{ left: state.left, top: state.top }}
+      role="status"
+    >
+      <p className="tm-chart-tooltip-title">{state.title}</p>
+      <ul className="tm-chart-tooltip-rows">
+        {state.rows.map((row) => (
+          <li key={row.key} className="tm-chart-tooltip-row">
+            {row.color ? (
+              <span
+                className="tm-chart-tooltip-key"
+                aria-hidden="true"
+                style={{ background: row.color }}
+              />
+            ) : null}
+            <strong>{row.value}</strong>
+            <span className="muted">{row.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/telemetry/DrilldownPanel.tsx
+++ b/frontend/src/components/telemetry/DrilldownPanel.tsx
@@ -6,6 +6,7 @@ import { useId } from "react";
 import { Pager } from "@/components/Pager";
 import {
   DRILLDOWN_KIND_OPTIONS,
+  shortId,
   toolOutcomeLabel,
   toolOutcomeTone,
   transitionLabel,
@@ -105,7 +106,7 @@ export function DrilldownPanel({
                   </div>
                   <div className="tm-drilldown-meta">
                     <Link className="tm-drilldown-session" href={`/session/${item.session_id}`}>
-                      {item.session_id.slice(0, 10)}
+                      {shortId(item.session_id)}
                     </Link>
                     <span className="tm-drilldown-time">
                       {new Date(item.occurred_at).toLocaleString()}

--- a/frontend/src/components/telemetry/DrilldownPanel.tsx
+++ b/frontend/src/components/telemetry/DrilldownPanel.tsx
@@ -1,16 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import { useId } from "react";
+import { useId, useMemo } from "react";
 
 import { Pager } from "@/components/Pager";
 import {
   DRILLDOWN_KIND_OPTIONS,
+  factKindLabel,
+  formatCompactNumber,
   shortId,
   toolOutcomeLabel,
   toolOutcomeTone,
   transitionLabel,
   turnKindLabel,
+  ToneWithNeutral,
 } from "@/lib/telemetry";
 import { DrilldownItem, TelemetryDrilldown, TelemetryFactKind } from "@/lib/types";
 
@@ -24,28 +27,188 @@ interface DrilldownPanelProps {
   pageSize: number;
 }
 
-function secondaryLine(item: DrilldownItem): string {
+const OUTCOME_GLYPH: Record<ToneWithNeutral, string> = {
+  good: "●",
+  danger: "▲",
+  warn: "■",
+  neutral: "○",
+};
+
+// Durations are captured but many calls are 0ms (fast or backfilled), so a
+// uniform "· 0ms" is pure noise. Render only meaningful (>0) durations, subtly.
+function formatDuration(ms: number): string {
+  if (ms >= 60000) {
+    const minutes = Math.floor(ms / 60000);
+    const seconds = Math.round((ms % 60000) / 1000);
+    return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+  }
+  if (ms >= 1000) return `${(ms / 1000).toFixed(ms < 10000 ? 1 : 0)}s`;
+  return `${ms}ms`;
+}
+
+function countBy(items: DrilldownItem[], key: (item: DrilldownItem) => string): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const bucket = key(item);
+    counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+  }
+  return counts;
+}
+
+// The primary line + status glyph for a row, split so the outcome is stated
+// exactly once (as the status indicator) rather than baked into the label too.
+function rowStatus(item: DrilldownItem): { tone: ToneWithNeutral; text: string } | null {
   switch (item.kind) {
-    case "session_lifecycle":
-      return transitionLabel(item.transition ?? "");
-    case "turn":
-      return [turnKindLabel(item.turn_kind ?? ""), item.model].filter(Boolean).join(" · ");
-    case "tool_call": {
-      const parts = [item.tool_category, toolOutcomeLabel(item.outcome)];
-      if (item.duration_ms !== null && item.duration_ms !== undefined) {
-        parts.push(`${item.duration_ms}ms`);
-      }
-      return parts.filter(Boolean).join(" · ");
+    case "tool_call":
+      return { tone: toolOutcomeTone(item.outcome), text: toolOutcomeLabel(item.outcome) };
+    case "session_lifecycle": {
+      const tone: ToneWithNeutral = item.transition === "error" ? "danger" : "neutral";
+      return { tone, text: transitionLabel(item.transition ?? "") };
     }
+    default:
+      return null;
+  }
+}
+
+function primaryLabel(item: DrilldownItem): string {
+  if (item.kind === "tool_call") return item.tool_name ?? item.label;
+  if (item.kind === "turn") return turnKindLabel(item.turn_kind ?? "");
+  return item.label;
+}
+
+// Secondary detail that is genuinely per-row (not the outcome, not the session
+// id / time which live in the meta column).
+function rowDetail(item: DrilldownItem): string | null {
+  switch (item.kind) {
+    case "tool_call":
+      return item.tool_category ?? null;
+    case "turn":
+      return item.model ?? null;
     case "context_snapshot":
       return item.occupancy_percent !== null && item.occupancy_percent !== undefined
         ? `${Math.round(item.occupancy_percent)}% of ${item.window_tokens ?? "?"}`
-        : `${item.used_tokens ?? "?"} tokens`;
+        : item.used_tokens !== null && item.used_tokens !== undefined
+          ? `${formatCompactNumber(item.used_tokens)} tokens`
+          : null;
     case "limit_snapshot":
-      return `${item.used_percent !== null && item.used_percent !== undefined ? Math.round(item.used_percent) : "?"}% · ${item.account_key ?? ""}`;
+      return [
+        item.used_percent !== null && item.used_percent !== undefined
+          ? `${Math.round(item.used_percent)}%`
+          : null,
+        item.account_key,
+      ]
+        .filter(Boolean)
+        .join(" · ") || null;
     default:
-      return "";
+      return null;
   }
+}
+
+function SummaryHeader({
+  kind,
+  items,
+  total,
+  shown,
+}: {
+  kind: TelemetryFactKind;
+  items: DrilldownItem[];
+  total: number;
+  shown: number;
+}) {
+  const statusChips = useMemo(() => {
+    if (kind === "tool_call") {
+      const byOutcome = countBy(items, (i) => i.outcome ?? "unknown");
+      return [...byOutcome.entries()]
+        .map(([outcome, count]) => ({
+          label: toolOutcomeLabel(outcome),
+          tone: toolOutcomeTone(outcome),
+          count,
+        }))
+        .sort((a, b) => b.count - a.count);
+    }
+    if (kind === "turn") {
+      const byTurn = countBy(items, (i) => i.turn_kind ?? "unknown");
+      return [...byTurn.entries()]
+        .map(([turnKind, count]) => ({
+          label: turnKindLabel(turnKind),
+          tone: "neutral" as ToneWithNeutral,
+          count,
+        }))
+        .sort((a, b) => b.count - a.count);
+    }
+    if (kind === "session_lifecycle") {
+      const byTransition = countBy(items, (i) => i.transition ?? "unknown");
+      return [...byTransition.entries()]
+        .map(([transition, count]) => ({
+          label: transitionLabel(transition),
+          tone: (transition === "error" ? "danger" : "neutral") as ToneWithNeutral,
+          count,
+        }))
+        .sort((a, b) => b.count - a.count);
+    }
+    return [];
+  }, [kind, items]);
+
+  const topTools = useMemo(() => {
+    if (kind !== "tool_call") return [];
+    const byTool = countBy(items, (i) => i.tool_name ?? i.label);
+    const sorted = [...byTool.entries()].sort((a, b) => b[1] - a[1]);
+    const head = sorted.slice(0, 5);
+    const rest = sorted.slice(5);
+    const restTotal = rest.reduce((sum, [, count]) => sum + count, 0);
+    return { head, restCount: rest.length, restTotal };
+  }, [kind, items]);
+
+  const scoped = shown < total;
+
+  return (
+    <div className="tm-drill-summary">
+      <div className="tm-drill-summary-hero">
+        <span className="tm-drill-summary-count">{formatCompactNumber(total)}</span>
+        <span className="tm-drill-summary-caption">{factKindLabel(kind).toLowerCase()} in range</span>
+      </div>
+
+      {statusChips.length > 0 ? (
+        <div className="tm-drill-chips" role="list" aria-label="Outcome breakdown (shown page)">
+          {statusChips.map((chip) => (
+            <span key={chip.label} className={`tm-drill-chip tone-${chip.tone}`} role="listitem">
+              <span className="tm-drill-chip-glyph" aria-hidden="true">
+                {OUTCOME_GLYPH[chip.tone]}
+              </span>
+              {chip.label}
+              <span className="tm-drill-chip-count">{chip.count}</span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {kind === "tool_call" && "head" in topTools && topTools.head.length > 0 ? (
+        <div className="tm-drill-tools">
+          <span className="tm-drill-tools-label">Top tools</span>
+          <div className="tm-drill-chips" role="list" aria-label="Top tools (shown page)">
+            {topTools.head.map(([tool, count]) => (
+              <span key={tool} className="tm-drill-chip" role="listitem">
+                {tool}
+                <span className="tm-drill-chip-count">{count}</span>
+              </span>
+            ))}
+            {topTools.restCount > 0 ? (
+              <span className="tm-drill-chip is-rest">
+                +{topTools.restCount} more
+                <span className="tm-drill-chip-count">{topTools.restTotal}</span>
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {statusChips.length > 0 && scoped ? (
+        <p className="tm-drill-scope muted">
+          Breakdown reflects the {shown} facts on this page, of {formatCompactNumber(total)} total.
+        </p>
+      ) : null}
+    </div>
+  );
 }
 
 export function DrilldownPanel({
@@ -92,18 +255,44 @@ export function DrilldownPanel({
         <p className="muted tm-chart-empty">No facts match this filter and range.</p>
       ) : (
         <>
+          <SummaryHeader kind={kind} items={items} total={total} shown={items.length} />
+
           <ul className="tm-drilldown-list">
             {items.map((item) => {
-              const tone = item.kind === "tool_call" ? toolOutcomeTone(item.outcome) : null;
+              const status = rowStatus(item);
+              const detail = rowDetail(item);
+              const duration =
+                item.kind === "tool_call" &&
+                item.duration_ms !== null &&
+                item.duration_ms !== undefined &&
+                item.duration_ms > 0
+                  ? formatDuration(item.duration_ms)
+                  : null;
               return (
-                <li
-                  key={`${item.kind}:${item.fact_id}`}
-                  className={`tm-drilldown-row${tone ? ` tone-${tone}` : ""}`}
-                >
+                <li key={`${item.kind}:${item.fact_id}`} className="tm-drilldown-row">
+                  {status ? (
+                    <span
+                      className={`tm-drill-status tone-${status.tone}`}
+                      title={status.text}
+                    >
+                      <span className="tm-drill-status-glyph" aria-hidden="true">
+                        {OUTCOME_GLYPH[status.tone]}
+                      </span>
+                      <span className="sr-only">{status.text}</span>
+                    </span>
+                  ) : (
+                    <span className="tm-drill-status is-none" aria-hidden="true" />
+                  )}
+
                   <div className="tm-drilldown-main">
-                    <span className="tm-drilldown-label">{item.label}</span>
-                    <span className="tm-drilldown-secondary muted">{secondaryLine(item)}</span>
+                    <span className="tm-drilldown-label">
+                      {primaryLabel(item)}
+                      {status ? <span className="tm-drill-status-text"> {status.text}</span> : null}
+                      {duration ? <span className="tm-drill-duration"> · {duration}</span> : null}
+                    </span>
+                    {detail ? <span className="tm-drilldown-secondary muted">{detail}</span> : null}
                   </div>
+
                   <div className="tm-drilldown-meta">
                     <Link className="tm-drilldown-session" href={`/session/${item.session_id}`}>
                       {shortId(item.session_id)}

--- a/frontend/src/components/telemetry/DrilldownPanel.tsx
+++ b/frontend/src/components/telemetry/DrilldownPanel.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import { useId } from "react";
+
+import { Pager } from "@/components/Pager";
+import {
+  DRILLDOWN_KIND_OPTIONS,
+  toolOutcomeLabel,
+  toolOutcomeTone,
+  transitionLabel,
+  turnKindLabel,
+} from "@/lib/telemetry";
+import { DrilldownItem, TelemetryDrilldown, TelemetryFactKind } from "@/lib/types";
+
+interface DrilldownPanelProps {
+  drilldown: TelemetryDrilldown | null;
+  loading: boolean;
+  kind: TelemetryFactKind;
+  onKindChange: (kind: TelemetryFactKind) => void;
+  page: number;
+  onPageChange: (page: number) => void;
+  pageSize: number;
+}
+
+function secondaryLine(item: DrilldownItem): string {
+  switch (item.kind) {
+    case "session_lifecycle":
+      return transitionLabel(item.transition ?? "");
+    case "turn":
+      return [turnKindLabel(item.turn_kind ?? ""), item.model].filter(Boolean).join(" · ");
+    case "tool_call": {
+      const parts = [item.tool_category, toolOutcomeLabel(item.outcome)];
+      if (item.duration_ms !== null && item.duration_ms !== undefined) {
+        parts.push(`${item.duration_ms}ms`);
+      }
+      return parts.filter(Boolean).join(" · ");
+    }
+    case "context_snapshot":
+      return item.occupancy_percent !== null && item.occupancy_percent !== undefined
+        ? `${Math.round(item.occupancy_percent)}% of ${item.window_tokens ?? "?"}`
+        : `${item.used_tokens ?? "?"} tokens`;
+    case "limit_snapshot":
+      return `${item.used_percent !== null && item.used_percent !== undefined ? Math.round(item.used_percent) : "?"}% · ${item.account_key ?? ""}`;
+    default:
+      return "";
+  }
+}
+
+export function DrilldownPanel({
+  drilldown,
+  loading,
+  kind,
+  onKindChange,
+  page,
+  onPageChange,
+  pageSize,
+}: DrilldownPanelProps) {
+  const titleId = useId();
+  const items = drilldown?.items ?? [];
+  const total = drilldown?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const pageStart = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const pageEnd = Math.min(total, page * pageSize);
+
+  return (
+    <section className="panel tm-chart-card" aria-labelledby={titleId}>
+      <header className="tm-chart-head">
+        <h3 id={titleId}>Drilldown</h3>
+        <label className="tm-chart-select-label">
+          Kind
+          <select
+            className="tm-chart-select"
+            value={kind}
+            onChange={(event) => onKindChange(event.target.value as TelemetryFactKind)}
+          >
+            {DRILLDOWN_KIND_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {loading && !drilldown ? (
+        <p className="muted tm-chart-empty" aria-busy="true">
+          Loading…
+        </p>
+      ) : items.length === 0 ? (
+        <p className="muted tm-chart-empty">No facts match this filter and range.</p>
+      ) : (
+        <>
+          <ul className="tm-drilldown-list">
+            {items.map((item) => {
+              const tone = item.kind === "tool_call" ? toolOutcomeTone(item.outcome) : null;
+              return (
+                <li
+                  key={`${item.kind}:${item.fact_id}`}
+                  className={`tm-drilldown-row${tone ? ` tone-${tone}` : ""}`}
+                >
+                  <div className="tm-drilldown-main">
+                    <span className="tm-drilldown-label">{item.label}</span>
+                    <span className="tm-drilldown-secondary muted">{secondaryLine(item)}</span>
+                  </div>
+                  <div className="tm-drilldown-meta">
+                    <Link className="tm-drilldown-session" href={`/session/${item.session_id}`}>
+                      {item.session_id.slice(0, 10)}
+                    </Link>
+                    <span className="tm-drilldown-time">
+                      {new Date(item.occurred_at).toLocaleString()}
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+          <Pager
+            page={page}
+            totalPages={totalPages}
+            total={total}
+            pageStart={pageStart}
+            pageEnd={pageEnd}
+            onPage={onPageChange}
+            label="facts"
+          />
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/telemetry/HealthPanel.tsx
+++ b/frontend/src/components/telemetry/HealthPanel.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useId, useState } from "react";
+import { useId, useMemo, useState } from "react";
 
 import { UsageBar } from "@/components/UsageReadout";
-import { UsageDial } from "@/components/UsageDial";
 import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
 import { shortId } from "@/lib/telemetry";
-import { TelemetryHealth } from "@/lib/types";
+import { LimitSeries, LimitSnapshotView, TelemetryHealth } from "@/lib/types";
 import { formatRelativeTime, usageTone, UsageTone } from "@/lib/usage";
 
 interface HealthPanelProps {
@@ -14,15 +13,12 @@ interface HealthPanelProps {
   loading: boolean;
 }
 
-const SPARK_W = 320;
-const SPARK_H = 56;
-// A sparkline's job is local trend shape, not absolute magnitude (the exact
-// number already reads via the paired dial/numeral) — so it autoscales to
-// its own observed range rather than a fixed 0-100 domain. A mostly-null
-// low-usage series (a 5h/weekly limit window sitting at a few percent) would
-// otherwise flatline against the bottom edge with the rest of the box empty.
-// A floor keeps genuinely flat/near-flat data from collapsing to a hairline.
-const SPARK_MIN_SPAN = 20;
+const SPARK_W = 200;
+const SPARK_H = 30;
+// A mini-trend shows local shape, not magnitude (the paired bar/numeral already
+// carries the exact value), so it autoscales to its own observed range. A floor
+// keeps a near-flat low-usage window from collapsing to a hairline.
+const SPARK_MIN_SPAN = 15;
 
 function toneGlyph(tone: UsageTone): string {
   if (tone === "danger") return "▲";
@@ -51,115 +47,144 @@ function sparklineDomain(values: number[]): [number, number] {
   return [Math.max(0, min - pad), Math.min(100, max + pad)];
 }
 
-function Sparkline({
+// One compact trend line through every non-null sample in time order. Bridging
+// short null gaps keeps the line connected and readable, rather than scattering
+// a lightly-sampled window into disconnected dots with dead vertical space.
+function MiniTrend({
   points,
   onHover,
 }: {
   points: { label: string; percent: number | null }[];
   onHover: (state: ChartTooltipState | null) => void;
 }) {
-  if (points.length === 0) {
-    return <p className="muted tm-sparkline-empty">No samples in range.</p>;
+  const real = points
+    .map((point, index) => ({ ...point, index }))
+    .filter((point): point is { label: string; percent: number; index: number } => point.percent !== null);
+
+  if (real.length === 0) {
+    return <p className="muted tm-sparkline-empty">No recent samples in range.</p>;
   }
-  const [domainMin, domainMax] = sparklineDomain(
-    points.filter((p): p is { label: string; percent: number } => p.percent !== null).map((p) => p.percent),
-  );
+
+  const latest = real[real.length - 1];
+  if (real.length === 1) {
+    return (
+      <p className="tm-sparkline-single muted">
+        <span aria-hidden="true">◦</span> Single sample · {latest.label} at{" "}
+        {Math.round(latest.percent)}%
+      </p>
+    );
+  }
+
+  const [domainMin, domainMax] = sparklineDomain(real.map((p) => p.percent));
   const domainSpan = domainMax - domainMin || 1;
-  const toY = (percent: number) =>
-    SPARK_H - ((Math.min(100, Math.max(0, percent)) - domainMin) / domainSpan) * SPARK_H;
   const stepX = points.length > 1 ? SPARK_W / (points.length - 1) : 0;
-  const segments: string[] = [];
-  // A sample with no adjacent non-null neighbor never joins a 2+ point
-  // polyline segment, so it needs its own visible mark — otherwise a sparse,
-  // mostly-null series (a lightly-used 5h/weekly limit window) renders as
-  // nothing at all rather than as real, if sparse, data.
-  const isolated = new Set<number>();
-  let current: { i: number; xy: string }[] = [];
-  const flush = () => {
-    if (current.length > 1) {
-      segments.push(current.map((p) => p.xy).join(" "));
-    } else if (current.length === 1) {
-      isolated.add(current[0].i);
-    }
-    current = [];
-  };
-  points.forEach((point, i) => {
-    if (point.percent === null) {
-      flush();
-      return;
-    }
-    const x = i * stepX;
-    current.push({ i, xy: `${x},${toY(point.percent)}` });
-  });
-  flush();
+  const toY = (percent: number) =>
+    SPARK_H - 1 - ((Math.min(100, Math.max(0, percent)) - domainMin) / domainSpan) * (SPARK_H - 2);
+  const coords = real.map((point) => ({ ...point, x: point.index * stepX, y: toY(point.percent) }));
+  const line = coords.map((c) => `${c.x},${c.y}`).join(" ");
+  const area = `M ${coords[0].x},${SPARK_H} ${coords.map((c) => `L ${c.x},${c.y}`).join(" ")} L ${
+    coords[coords.length - 1].x
+  },${SPARK_H} Z`;
 
   return (
     <div className="tm-sparkline-wrap">
       <span className="tm-sparkline-scale muted">
-        {Math.round(domainMin)}–{Math.round(domainMax)}% shown
+        {Math.round(domainMin)}–{Math.round(domainMax)}%
       </span>
       <svg
         viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
         className="tm-sparkline"
+        preserveAspectRatio="none"
         role="img"
-        aria-label={`Occupancy over time, from ${points[0].label} to ${points[points.length - 1].label}, ranging ${Math.round(domainMin)}% to ${Math.round(domainMax)}%`}
+        aria-label={`Trend from ${real[0].label} to ${latest.label}, ranging ${Math.round(
+          domainMin,
+        )}% to ${Math.round(domainMax)}%, latest ${Math.round(latest.percent)}%`}
       >
-        <line x1={0} y1={1} x2={SPARK_W} y2={1} className="tm-chart-gridline" />
-        <line x1={0} y1={SPARK_H - 1} x2={SPARK_W} y2={SPARK_H - 1} className="tm-chart-gridline" />
-        {segments.map((segment, i) => (
-          <polyline
-            key={i}
-            points={segment}
-            fill="none"
-            stroke="var(--tm-series-1)"
-            strokeWidth={2}
-            strokeLinecap="round"
-            strokeLinejoin="round"
+        <path d={area} className="tm-sparkline-area" />
+        <polyline
+          points={line}
+          fill="none"
+          stroke="var(--tm-series-1)"
+          strokeWidth={1.75}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+        {coords.map((c) => (
+          <circle
+            key={c.index}
+            cx={c.x}
+            cy={c.y}
+            r={5}
+            fill="transparent"
+            tabIndex={0}
+            role="img"
+            aria-label={`${c.label}: ${Math.round(c.percent)}%`}
+            className="tm-hover-point"
+            onMouseEnter={(event) =>
+              onHover({
+                left: event.clientX,
+                top: event.clientY,
+                title: c.label,
+                rows: [{ key: "pct", label: "occupancy", value: `${Math.round(c.percent)}%` }],
+              })
+            }
+            onFocus={() =>
+              onHover({
+                left: 0,
+                top: 0,
+                title: c.label,
+                rows: [{ key: "pct", label: "occupancy", value: `${Math.round(c.percent)}%` }],
+              })
+            }
+            onMouseLeave={() => onHover(null)}
+            onBlur={() => onHover(null)}
           />
         ))}
-        {points.map((point, i) => {
-          if (point.percent === null) return null;
-          const x = i * stepX;
-          const y = toY(point.percent);
-          return (
-            <g key={i}>
-              {isolated.has(i) ? (
-                <circle cx={x} cy={y} r={3} fill="var(--tm-series-1)" stroke="var(--bg-card)" strokeWidth={2} />
-              ) : null}
-              <circle
-                cx={x}
-                cy={y}
-                r={7}
-                fill="transparent"
-                tabIndex={0}
-                role="img"
-                aria-label={`${point.label}: ${Math.round(point.percent)}%`}
-                className="tm-hover-point"
-                onMouseEnter={(event) =>
-                  onHover({
-                    left: event.clientX,
-                    top: event.clientY,
-                    title: point.label,
-                    rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
-                  })
-                }
-                onFocus={() =>
-                  onHover({
-                    left: 0,
-                    top: 0,
-                    title: point.label,
-                    rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
-                  })
-                }
-                onMouseLeave={() => onHover(null)}
-                onBlur={() => onHover(null)}
-              />
-            </g>
-          );
-        })}
       </svg>
     </div>
   );
+}
+
+function seriesLabel(point: { bucket_start: string }): string {
+  return new Date(point.bucket_start).toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+  });
+}
+
+interface AccountGroup {
+  backend: string;
+  accountKey: string;
+  accountLabel: string | null;
+  windows: { snapshot: LimitSnapshotView; series: LimitSeries | undefined }[];
+}
+
+function groupLimitsByAccount(limits: TelemetryHealth["limits"]): AccountGroup[] {
+  const seriesByWindow = new Map<string, LimitSeries>();
+  for (const series of limits.series) {
+    seriesByWindow.set(`${series.backend}:${series.account_key}:${series.window_id}`, series);
+  }
+  const groups = new Map<string, AccountGroup>();
+  for (const snapshot of limits.current) {
+    const groupKey = `${snapshot.backend}:${snapshot.account_key}`;
+    let group = groups.get(groupKey);
+    if (!group) {
+      group = {
+        backend: snapshot.backend,
+        accountKey: snapshot.account_key,
+        accountLabel: snapshot.account_label,
+        windows: [],
+      };
+      groups.set(groupKey, group);
+    }
+    group.windows.push({
+      snapshot,
+      series: seriesByWindow.get(`${snapshot.backend}:${snapshot.account_key}:${snapshot.window_id}`),
+    });
+  }
+  return [...groups.values()];
 }
 
 export function HealthPanel({ health, loading }: HealthPanelProps) {
@@ -167,17 +192,18 @@ export function HealthPanel({ health, loading }: HealthPanelProps) {
   const contextTitleId = useId();
   const limitsTitleId = useId();
 
+  const accountGroups = useMemo(
+    () => (health ? groupLimitsByAccount(health.limits) : []),
+    [health],
+  );
+
   if (loading && !health) {
     return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
   }
   if (!health) return null;
 
   const contextSeriesPoints = health.context.series.map((point) => ({
-    label: new Date(point.bucket_start).toLocaleString([], {
-      month: "short",
-      day: "numeric",
-      hour: "numeric",
-    }),
+    label: seriesLabel(point),
     percent: point.peak_percent,
   }));
 
@@ -214,7 +240,7 @@ export function HealthPanel({ health, loading }: HealthPanelProps) {
           </ul>
         )}
         <p className="tm-chart-subhead">Peak occupancy over time</p>
-        <Sparkline points={contextSeriesPoints} onHover={setTooltip} />
+        <MiniTrend points={contextSeriesPoints} onHover={setTooltip} />
         <ChartTooltip state={tooltip} />
       </section>
 
@@ -226,45 +252,54 @@ export function HealthPanel({ health, loading }: HealthPanelProps) {
           <p className="muted tm-chart-empty">
             {health.limits.hidden_reason ?? "Hidden while a session filter is active."}
           </p>
-        ) : health.limits.current.length === 0 ? (
+        ) : accountGroups.length === 0 ? (
           <p className="muted tm-chart-empty">No live limit snapshots.</p>
         ) : (
-          <>
-            <div className="tm-dial-grid">
-              {health.limits.current.map((snapshot) => (
-                <div
-                  key={`${snapshot.backend}:${snapshot.account_key}:${snapshot.window_id}`}
-                  className="tm-dial-cell"
-                >
-                  <UsageDial
-                    percent={snapshot.used_percent}
-                    tone={usageTone(snapshot.used_percent)}
-                    label={snapshot.label ?? snapshot.window_id}
-                    caption={`${snapshot.backend}${snapshot.stale ? " · stale" : ""}`}
-                    size="md"
-                  />
-                </div>
-              ))}
-            </div>
-            {health.limits.series.map((series) => (
-              <div key={`${series.backend}:${series.account_key}:${series.window_id}`}>
-                <p className="tm-chart-subhead">
-                  {series.label ?? series.window_id} · {series.backend}
-                </p>
-                <Sparkline
-                  points={series.points.map((point) => ({
-                    label: new Date(point.bucket_start).toLocaleString([], {
-                      month: "short",
-                      day: "numeric",
-                      hour: "numeric",
-                    }),
-                    percent: point.used_percent,
-                  }))}
-                  onHover={setTooltip}
-                />
-              </div>
+          <div className="tm-account-groups">
+            {accountGroups.map((group) => (
+              <article key={`${group.backend}:${group.accountKey}`} className="tm-account-group">
+                <header className="tm-account-head">
+                  <span className="tm-account-name">{group.accountLabel ?? group.accountKey}</span>
+                  <span className="tm-account-backend">{group.backend}</span>
+                </header>
+                <ul className="tm-window-list">
+                  {group.windows.map(({ snapshot, series }) => {
+                    const tone = usageTone(snapshot.used_percent);
+                    const points = (series?.points ?? []).map((point) => ({
+                      label: seriesLabel(point),
+                      percent: point.used_percent,
+                    }));
+                    return (
+                      <li
+                        key={snapshot.window_id}
+                        className={`tm-window-row tone-${tone}`}
+                      >
+                        <div className="tm-window-head">
+                          <span className="tm-window-label">
+                            <span className="tm-window-glyph" aria-hidden="true">
+                              {toneGlyph(tone)}
+                            </span>
+                            {snapshot.label ?? snapshot.window_id}
+                            {snapshot.stale ? (
+                              <span className="tm-health-stale"> · stale</span>
+                            ) : null}
+                          </span>
+                          <span className="tm-window-value">
+                            {Math.round(snapshot.used_percent)}%
+                            <span className="tm-health-tone-word"> {toneWord(tone)}</span>
+                          </span>
+                        </div>
+                        <UsageBar percent={snapshot.used_percent} tone={tone} />
+                        <div className="tm-window-trend">
+                          <MiniTrend points={points} onHover={setTooltip} />
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </article>
             ))}
-          </>
+          </div>
         )}
         <ChartTooltip state={tooltip} />
       </section>

--- a/frontend/src/components/telemetry/HealthPanel.tsx
+++ b/frontend/src/components/telemetry/HealthPanel.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useId, useState } from "react";
+
+import { UsageBar } from "@/components/UsageReadout";
+import { UsageDial } from "@/components/UsageDial";
+import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
+import { TelemetryHealth } from "@/lib/types";
+import { formatRelativeTime, usageTone, UsageTone } from "@/lib/usage";
+
+interface HealthPanelProps {
+  health: TelemetryHealth | null;
+  loading: boolean;
+}
+
+const SPARK_W = 320;
+const SPARK_H = 56;
+
+function toneGlyph(tone: UsageTone): string {
+  if (tone === "danger") return "▲";
+  if (tone === "warn") return "■";
+  return "●";
+}
+
+function toneWord(tone: UsageTone): string {
+  if (tone === "danger") return "critical";
+  if (tone === "warn") return "warning";
+  return "nominal";
+}
+
+function Sparkline({
+  points,
+  onHover,
+}: {
+  points: { label: string; percent: number | null }[];
+  onHover: (state: ChartTooltipState | null) => void;
+}) {
+  if (points.length === 0) {
+    return <p className="muted tm-sparkline-empty">No samples in range.</p>;
+  }
+  const stepX = points.length > 1 ? SPARK_W / (points.length - 1) : 0;
+  const segments: string[] = [];
+  let current: string[] = [];
+  points.forEach((point, i) => {
+    if (point.percent === null) {
+      if (current.length > 1) segments.push(current.join(" "));
+      current = [];
+      return;
+    }
+    const x = i * stepX;
+    const y = SPARK_H - (Math.min(100, Math.max(0, point.percent)) / 100) * SPARK_H;
+    current.push(`${x},${y}`);
+  });
+  if (current.length > 1) segments.push(current.join(" "));
+
+  return (
+    <svg
+      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+      className="tm-sparkline"
+      role="img"
+      aria-label={`Occupancy over time, from ${points[0].label} to ${points[points.length - 1].label}`}
+    >
+      <line x1={0} y1={SPARK_H * 0.3} x2={SPARK_W} y2={SPARK_H * 0.3} className="tm-chart-gridline" />
+      {segments.map((segment, i) => (
+        <polyline
+          key={i}
+          points={segment}
+          fill="none"
+          stroke="var(--tm-series-1)"
+          strokeWidth={2}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ))}
+      {points.map((point, i) => {
+        if (point.percent === null) return null;
+        const x = i * stepX;
+        const y = SPARK_H - (Math.min(100, Math.max(0, point.percent)) / 100) * SPARK_H;
+        return (
+          <circle
+            key={i}
+            cx={x}
+            cy={y}
+            r={7}
+            fill="transparent"
+            tabIndex={0}
+            role="img"
+            aria-label={`${point.label}: ${Math.round(point.percent)}%`}
+            className="tm-hover-point"
+            onMouseEnter={(event) =>
+              onHover({
+                left: event.clientX,
+                top: event.clientY,
+                title: point.label,
+                rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
+              })
+            }
+            onFocus={() =>
+              onHover({
+                left: 0,
+                top: 0,
+                title: point.label,
+                rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
+              })
+            }
+            onMouseLeave={() => onHover(null)}
+            onBlur={() => onHover(null)}
+          />
+        );
+      })}
+    </svg>
+  );
+}
+
+export function HealthPanel({ health, loading }: HealthPanelProps) {
+  const [tooltip, setTooltip] = useState<ChartTooltipState | null>(null);
+  const contextTitleId = useId();
+  const limitsTitleId = useId();
+
+  if (loading && !health) {
+    return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
+  }
+  if (!health) return null;
+
+  const contextSeriesPoints = health.context.series.map((point) => ({
+    label: new Date(point.bucket_start).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+    }),
+    percent: point.peak_percent,
+  }));
+
+  return (
+    <>
+      <section className="panel tm-chart-card" aria-labelledby={contextTitleId}>
+        <header className="tm-chart-head">
+          <h3 id={contextTitleId}>Context health</h3>
+        </header>
+        {health.context.current.length === 0 ? (
+          <p className="muted tm-chart-empty">No live context snapshots.</p>
+        ) : (
+          <ul className="tm-health-list">
+            {health.context.current.map((snapshot) => {
+              const tone = usageTone(snapshot.percent);
+              return (
+                <li key={snapshot.session_id} className={`tm-health-row tone-${tone}`}>
+                  <span className="tm-health-glyph" aria-hidden="true">
+                    {toneGlyph(tone)}
+                  </span>
+                  <span className="tm-health-label">
+                    {snapshot.session_id.slice(0, 12)}
+                    {snapshot.stale ? <span className="tm-health-stale"> · stale</span> : null}
+                  </span>
+                  <UsageBar percent={snapshot.percent} tone={tone} disabled={snapshot.percent === null} />
+                  <span className="tm-health-value">
+                    {snapshot.percent !== null ? `${Math.round(snapshot.percent)}%` : "—"}
+                    <span className="tm-health-tone-word"> {toneWord(tone)}</span>
+                  </span>
+                  <span className="tm-health-time">{formatRelativeTime(snapshot.updated_at)}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <p className="tm-chart-subhead">Peak occupancy over time</p>
+        <Sparkline points={contextSeriesPoints} onHover={setTooltip} />
+        <ChartTooltip state={tooltip} />
+      </section>
+
+      <section className="panel tm-chart-card" aria-labelledby={limitsTitleId}>
+        <header className="tm-chart-head">
+          <h3 id={limitsTitleId}>Provider limits</h3>
+        </header>
+        {health.limits.hidden ? (
+          <p className="muted tm-chart-empty">
+            {health.limits.hidden_reason ?? "Hidden while a session filter is active."}
+          </p>
+        ) : health.limits.current.length === 0 ? (
+          <p className="muted tm-chart-empty">No live limit snapshots.</p>
+        ) : (
+          <>
+            <div className="tm-dial-grid">
+              {health.limits.current.map((snapshot) => (
+                <div
+                  key={`${snapshot.backend}:${snapshot.account_key}:${snapshot.window_id}`}
+                  className="tm-dial-cell"
+                >
+                  <UsageDial
+                    percent={snapshot.used_percent}
+                    tone={usageTone(snapshot.used_percent)}
+                    label={snapshot.label ?? snapshot.window_id}
+                    caption={`${snapshot.backend}${snapshot.stale ? " · stale" : ""}`}
+                    size="md"
+                  />
+                </div>
+              ))}
+            </div>
+            {health.limits.series.map((series) => (
+              <div key={`${series.backend}:${series.account_key}:${series.window_id}`}>
+                <p className="tm-chart-subhead">
+                  {series.label ?? series.window_id} · {series.backend}
+                </p>
+                <Sparkline
+                  points={series.points.map((point) => ({
+                    label: new Date(point.bucket_start).toLocaleString([], {
+                      month: "short",
+                      day: "numeric",
+                      hour: "numeric",
+                    }),
+                    percent: point.used_percent,
+                  }))}
+                  onHover={setTooltip}
+                />
+              </div>
+            ))}
+          </>
+        )}
+        <ChartTooltip state={tooltip} />
+      </section>
+    </>
+  );
+}

--- a/frontend/src/components/telemetry/HealthPanel.tsx
+++ b/frontend/src/components/telemetry/HealthPanel.tsx
@@ -5,6 +5,7 @@ import { useId, useState } from "react";
 import { UsageBar } from "@/components/UsageReadout";
 import { UsageDial } from "@/components/UsageDial";
 import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
+import { shortId } from "@/lib/telemetry";
 import { TelemetryHealth } from "@/lib/types";
 import { formatRelativeTime, usageTone, UsageTone } from "@/lib/usage";
 
@@ -15,6 +16,13 @@ interface HealthPanelProps {
 
 const SPARK_W = 320;
 const SPARK_H = 56;
+// A sparkline's job is local trend shape, not absolute magnitude (the exact
+// number already reads via the paired dial/numeral) — so it autoscales to
+// its own observed range rather than a fixed 0-100 domain. A mostly-null
+// low-usage series (a 5h/weekly limit window sitting at a few percent) would
+// otherwise flatline against the bottom edge with the rest of the box empty.
+// A floor keeps genuinely flat/near-flat data from collapsing to a hairline.
+const SPARK_MIN_SPAN = 20;
 
 function toneGlyph(tone: UsageTone): string {
   if (tone === "danger") return "▲";
@@ -28,6 +36,21 @@ function toneWord(tone: UsageTone): string {
   return "nominal";
 }
 
+function sparklineDomain(values: number[]): [number, number] {
+  if (values.length === 0) return [0, 100];
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min;
+  if (span < SPARK_MIN_SPAN) {
+    const mid = (min + max) / 2;
+    const half = SPARK_MIN_SPAN / 2;
+    const lo = Math.max(0, mid - half);
+    return [lo, Math.min(100, lo + SPARK_MIN_SPAN)];
+  }
+  const pad = span * 0.1;
+  return [Math.max(0, min - pad), Math.min(100, max + pad)];
+}
+
 function Sparkline({
   points,
   onHover,
@@ -38,77 +61,104 @@ function Sparkline({
   if (points.length === 0) {
     return <p className="muted tm-sparkline-empty">No samples in range.</p>;
   }
+  const [domainMin, domainMax] = sparklineDomain(
+    points.filter((p): p is { label: string; percent: number } => p.percent !== null).map((p) => p.percent),
+  );
+  const domainSpan = domainMax - domainMin || 1;
+  const toY = (percent: number) =>
+    SPARK_H - ((Math.min(100, Math.max(0, percent)) - domainMin) / domainSpan) * SPARK_H;
   const stepX = points.length > 1 ? SPARK_W / (points.length - 1) : 0;
   const segments: string[] = [];
-  let current: string[] = [];
+  // A sample with no adjacent non-null neighbor never joins a 2+ point
+  // polyline segment, so it needs its own visible mark — otherwise a sparse,
+  // mostly-null series (a lightly-used 5h/weekly limit window) renders as
+  // nothing at all rather than as real, if sparse, data.
+  const isolated = new Set<number>();
+  let current: { i: number; xy: string }[] = [];
+  const flush = () => {
+    if (current.length > 1) {
+      segments.push(current.map((p) => p.xy).join(" "));
+    } else if (current.length === 1) {
+      isolated.add(current[0].i);
+    }
+    current = [];
+  };
   points.forEach((point, i) => {
     if (point.percent === null) {
-      if (current.length > 1) segments.push(current.join(" "));
-      current = [];
+      flush();
       return;
     }
     const x = i * stepX;
-    const y = SPARK_H - (Math.min(100, Math.max(0, point.percent)) / 100) * SPARK_H;
-    current.push(`${x},${y}`);
+    current.push({ i, xy: `${x},${toY(point.percent)}` });
   });
-  if (current.length > 1) segments.push(current.join(" "));
+  flush();
 
   return (
-    <svg
-      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
-      className="tm-sparkline"
-      role="img"
-      aria-label={`Occupancy over time, from ${points[0].label} to ${points[points.length - 1].label}`}
-    >
-      <line x1={0} y1={SPARK_H * 0.3} x2={SPARK_W} y2={SPARK_H * 0.3} className="tm-chart-gridline" />
-      {segments.map((segment, i) => (
-        <polyline
-          key={i}
-          points={segment}
-          fill="none"
-          stroke="var(--tm-series-1)"
-          strokeWidth={2}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      ))}
-      {points.map((point, i) => {
-        if (point.percent === null) return null;
-        const x = i * stepX;
-        const y = SPARK_H - (Math.min(100, Math.max(0, point.percent)) / 100) * SPARK_H;
-        return (
-          <circle
+    <div className="tm-sparkline-wrap">
+      <span className="tm-sparkline-scale muted">
+        {Math.round(domainMin)}–{Math.round(domainMax)}% shown
+      </span>
+      <svg
+        viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+        className="tm-sparkline"
+        role="img"
+        aria-label={`Occupancy over time, from ${points[0].label} to ${points[points.length - 1].label}, ranging ${Math.round(domainMin)}% to ${Math.round(domainMax)}%`}
+      >
+        <line x1={0} y1={1} x2={SPARK_W} y2={1} className="tm-chart-gridline" />
+        <line x1={0} y1={SPARK_H - 1} x2={SPARK_W} y2={SPARK_H - 1} className="tm-chart-gridline" />
+        {segments.map((segment, i) => (
+          <polyline
             key={i}
-            cx={x}
-            cy={y}
-            r={7}
-            fill="transparent"
-            tabIndex={0}
-            role="img"
-            aria-label={`${point.label}: ${Math.round(point.percent)}%`}
-            className="tm-hover-point"
-            onMouseEnter={(event) =>
-              onHover({
-                left: event.clientX,
-                top: event.clientY,
-                title: point.label,
-                rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
-              })
-            }
-            onFocus={() =>
-              onHover({
-                left: 0,
-                top: 0,
-                title: point.label,
-                rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
-              })
-            }
-            onMouseLeave={() => onHover(null)}
-            onBlur={() => onHover(null)}
+            points={segment}
+            fill="none"
+            stroke="var(--tm-series-1)"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
           />
-        );
-      })}
-    </svg>
+        ))}
+        {points.map((point, i) => {
+          if (point.percent === null) return null;
+          const x = i * stepX;
+          const y = toY(point.percent);
+          return (
+            <g key={i}>
+              {isolated.has(i) ? (
+                <circle cx={x} cy={y} r={3} fill="var(--tm-series-1)" stroke="var(--bg-card)" strokeWidth={2} />
+              ) : null}
+              <circle
+                cx={x}
+                cy={y}
+                r={7}
+                fill="transparent"
+                tabIndex={0}
+                role="img"
+                aria-label={`${point.label}: ${Math.round(point.percent)}%`}
+                className="tm-hover-point"
+                onMouseEnter={(event) =>
+                  onHover({
+                    left: event.clientX,
+                    top: event.clientY,
+                    title: point.label,
+                    rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
+                  })
+                }
+                onFocus={() =>
+                  onHover({
+                    left: 0,
+                    top: 0,
+                    title: point.label,
+                    rows: [{ key: "pct", label: "occupancy", value: `${Math.round(point.percent!)}%` }],
+                  })
+                }
+                onMouseLeave={() => onHover(null)}
+                onBlur={() => onHover(null)}
+              />
+            </g>
+          );
+        })}
+      </svg>
+    </div>
   );
 }
 
@@ -149,7 +199,7 @@ export function HealthPanel({ health, loading }: HealthPanelProps) {
                     {toneGlyph(tone)}
                   </span>
                   <span className="tm-health-label">
-                    {snapshot.session_id.slice(0, 12)}
+                    {shortId(snapshot.session_id)}
                     {snapshot.stale ? <span className="tm-health-stale"> · stale</span> : null}
                   </span>
                   <UsageBar percent={snapshot.percent} tone={tone} disabled={snapshot.percent === null} />

--- a/frontend/src/components/telemetry/InsightCards.tsx
+++ b/frontend/src/components/telemetry/InsightCards.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { insightSeverityTone } from "@/lib/telemetry";
+import { Insight } from "@/lib/types";
+
+interface InsightCardsProps {
+  insights: Insight[];
+  loading: boolean;
+  dismissingSignature: string | null;
+  onDismiss: (insight: Insight) => void;
+  onClickThrough: (insight: Insight) => void;
+}
+
+function severityGlyph(severity: Insight["severity"]): string {
+  if (severity === "critical") return "▲";
+  if (severity === "warning") return "■";
+  return "●";
+}
+
+export function InsightCards({
+  insights,
+  loading,
+  dismissingSignature,
+  onDismiss,
+  onClickThrough,
+}: InsightCardsProps) {
+  if (loading && insights.length === 0) {
+    return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
+  }
+  if (insights.length === 0) {
+    return (
+      <section className="panel tm-chart-card" aria-label="Insights">
+        <header className="tm-chart-head">
+          <h3>Insights</h3>
+        </header>
+        <p className="muted tm-chart-empty">
+          No insights for this range — deterministic checks fire only once their evidence gates are met.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="tm-insight-grid" aria-label="Insights">
+      {insights.map((insight) => {
+        const tone = insightSeverityTone(insight.severity);
+        return (
+          <article key={insight.signature} className={`panel tm-insight-card tone-${tone}`}>
+            <header className="tm-insight-head">
+              <span className="tm-insight-glyph" aria-hidden="true">
+                {severityGlyph(insight.severity)}
+              </span>
+              <span className="tm-insight-severity">{insight.severity}</span>
+              <button
+                type="button"
+                className="tm-insight-dismiss"
+                onClick={() => onDismiss(insight)}
+                disabled={dismissingSignature === insight.signature}
+                aria-label="Dismiss insight"
+              >
+                {dismissingSignature === insight.signature ? "…" : "×"}
+              </button>
+            </header>
+            <p className="tm-insight-statement">{insight.statement}</p>
+            {Object.keys(insight.metrics).length > 0 ? (
+              <dl className="tm-insight-metrics">
+                {Object.entries(insight.metrics).map(([key, value]) => (
+                  <div key={key} className="tm-insight-metric">
+                    <dt>{key.replace(/_/g, " ")}</dt>
+                    <dd>{String(value)}</dd>
+                  </div>
+                ))}
+              </dl>
+            ) : null}
+            <button type="button" className="tm-insight-evidence" onClick={() => onClickThrough(insight)}>
+              View evidence →
+            </button>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/frontend/src/components/telemetry/OverviewCards.tsx
+++ b/frontend/src/components/telemetry/OverviewCards.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { coverageLabel, formatCompactNumber, orderedTokenCategories, tokenCategoryLabel } from "@/lib/telemetry";
+import { TelemetryOverview } from "@/lib/types";
+import { formatRelativeTime, usageTone } from "@/lib/usage";
+
+interface OverviewCardsProps {
+  overview: TelemetryOverview | null;
+  loading: boolean;
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="tm-stat-row">
+      <span className="tm-stat-row-label">{label}</span>
+      <span className="tm-stat-row-value">{value}</span>
+    </div>
+  );
+}
+
+export function OverviewCards({ overview, loading }: OverviewCardsProps) {
+  if (loading && !overview) {
+    return (
+      <section className="tm-overview-grid" aria-busy="true">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="panel tm-overview-card is-loading" />
+        ))}
+      </section>
+    );
+  }
+
+  if (!overview) {
+    return null;
+  }
+
+  const { tokens, sessions, turns, tool_calls: toolCalls, alerts } = overview;
+  const categories = orderedTokenCategories(tokens.totals);
+  const alertCount = alerts.context.length + alerts.limits.length;
+
+  return (
+    <section className="tm-overview-grid" aria-label="Overview">
+      <article className="panel tm-overview-card" aria-label="Token usage">
+        <header className="tm-overview-card-head">
+          <h3>Tokens</h3>
+          <span className="tm-overview-card-badge">{coverageLabel(tokens.coverage)}</span>
+        </header>
+        {tokens.safe_total && tokens.display_total !== null ? (
+          <p className="tm-overview-hero">{formatCompactNumber(tokens.display_total)}</p>
+        ) : (
+          <p className="tm-overview-hero-note">No safe grand total — categories below don’t sum</p>
+        )}
+        <dl className="tm-stat-list">
+          {categories.length === 0 ? (
+            <p className="muted">No token activity in range.</p>
+          ) : (
+            categories.map((category) => (
+              <StatRow
+                key={category}
+                label={tokenCategoryLabel(category)}
+                value={formatCompactNumber(tokens.totals[category] ?? 0)}
+              />
+            ))
+          )}
+        </dl>
+        {tokens.meter_coverage_percent !== null ? (
+          <p className="tm-overview-footnote">
+            Metered on {Math.round(tokens.meter_coverage_percent)}% of tracked turns
+          </p>
+        ) : null}
+      </article>
+
+      <article className="panel tm-overview-card" aria-label="Sessions">
+        <header className="tm-overview-card-head">
+          <h3>Sessions</h3>
+        </header>
+        <p className="tm-overview-hero">{sessions.active_now}</p>
+        <p className="tm-overview-hero-caption">active now</p>
+        <dl className="tm-stat-list">
+          <StatRow label="Created" value={sessions.created} />
+          <StatRow label="Exited" value={sessions.exited} />
+          <StatRow label="Interrupted" value={sessions.interrupted} />
+          <StatRow label="Errored" value={sessions.error} />
+        </dl>
+      </article>
+
+      <article className="panel tm-overview-card" aria-label="Turns and tool calls">
+        <header className="tm-overview-card-head">
+          <h3>Activity</h3>
+        </header>
+        <p className="tm-overview-hero">{formatCompactNumber(turns.user + turns.agent)}</p>
+        <p className="tm-overview-hero-caption">turns</p>
+        <dl className="tm-stat-list">
+          <StatRow label="User turns" value={turns.user} />
+          <StatRow label="Agent turns" value={turns.agent} />
+          <StatRow label="Tool calls" value={toolCalls} />
+        </dl>
+      </article>
+
+      <article
+        className={`panel tm-overview-card tm-alerts-card${alertCount > 0 ? " has-alerts" : ""}`}
+        aria-label="Alerts"
+      >
+        <header className="tm-overview-card-head">
+          <h3>Alerts</h3>
+          <span className="tm-overview-card-badge">{alertCount}</span>
+        </header>
+        {overview.limit_card_hidden ? (
+          <p className="muted tm-overview-footnote">
+            {overview.limit_card_hidden_reason ??
+              "Provider limits hidden while a session filter is active."}
+          </p>
+        ) : null}
+        {alertCount === 0 ? (
+          <p className="muted">Nothing above threshold.</p>
+        ) : (
+          <ul className="tm-alert-list">
+            {alerts.context.map((snapshot) => {
+              const tone = usageTone(snapshot.percent);
+              return (
+                <li key={snapshot.session_id} className={`tm-alert-row tone-${tone}`}>
+                  <span className="tm-alert-glyph" aria-hidden="true">
+                    {tone === "danger" ? "▲" : "●"}
+                  </span>
+                  <span className="tm-alert-text">
+                    Context {snapshot.percent !== null ? Math.round(snapshot.percent) : "—"}%
+                    <span className="muted"> · {snapshot.session_id.slice(0, 12)}</span>
+                  </span>
+                  <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
+                </li>
+              );
+            })}
+            {alerts.limits.map((snapshot) => {
+              const tone = usageTone(snapshot.used_percent);
+              return (
+                <li
+                  key={`${snapshot.backend}:${snapshot.account_key}:${snapshot.window_id}`}
+                  className={`tm-alert-row tone-${tone}`}
+                >
+                  <span className="tm-alert-glyph" aria-hidden="true">
+                    {tone === "danger" ? "▲" : "●"}
+                  </span>
+                  <span className="tm-alert-text">
+                    {snapshot.label ?? snapshot.window_id} {Math.round(snapshot.used_percent)}%
+                    <span className="muted"> · {snapshot.backend}</span>
+                  </span>
+                  <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </article>
+    </section>
+  );
+}

--- a/frontend/src/components/telemetry/OverviewCards.tsx
+++ b/frontend/src/components/telemetry/OverviewCards.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { coverageLabel, formatCompactNumber, orderedTokenCategories, tokenCategoryLabel } from "@/lib/telemetry";
+import {
+  coverageLabel,
+  formatCompactNumber,
+  orderedTokenCategories,
+  shortId,
+  tokenCategoryLabel,
+} from "@/lib/telemetry";
 import { TelemetryOverview } from "@/lib/types";
 import { formatRelativeTime, usageTone } from "@/lib/usage";
 
@@ -123,7 +129,7 @@ export function OverviewCards({ overview, loading }: OverviewCardsProps) {
                   </span>
                   <span className="tm-alert-text">
                     Context {snapshot.percent !== null ? Math.round(snapshot.percent) : "—"}%
-                    <span className="muted"> · {snapshot.session_id.slice(0, 12)}</span>
+                    <span className="muted"> · {shortId(snapshot.session_id)}</span>
                   </span>
                   <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
                 </li>

--- a/frontend/src/components/telemetry/OverviewCards.tsx
+++ b/frontend/src/components/telemetry/OverviewCards.tsx
@@ -3,9 +3,11 @@
 import {
   coverageLabel,
   formatCompactNumber,
-  orderedTokenCategories,
-  shortId,
+  splitTokenTiers,
+  tokenCategoryColor,
   tokenCategoryLabel,
+  TOKEN_TIER_NEW_WORK,
+  shortId,
 } from "@/lib/telemetry";
 import { TelemetryOverview } from "@/lib/types";
 import { formatRelativeTime, usageTone } from "@/lib/usage";
@@ -15,12 +17,115 @@ interface OverviewCardsProps {
   loading: boolean;
 }
 
-function StatRow({ label, value }: { label: string; value: string | number }) {
+function StatRow({
+  label,
+  value,
+  tone,
+  swatch,
+}: {
+  label: string;
+  value: string | number;
+  tone?: "danger" | "warn";
+  swatch?: string;
+}) {
   return (
-    <div className="tm-stat-row">
-      <span className="tm-stat-row-label">{label}</span>
+    <div className={`tm-stat-row${tone ? ` tone-${tone}` : ""}`}>
+      <span className="tm-stat-row-label">
+        {swatch ? (
+          <span className="tm-stat-swatch" aria-hidden="true" style={{ background: swatch }} />
+        ) : null}
+        {label}
+      </span>
       <span className="tm-stat-row-value">{value}</span>
     </div>
+  );
+}
+
+function percentOf(part: number, whole: number): number {
+  return whole > 0 ? Math.round((part / whole) * 100) : 0;
+}
+
+function TokensCard({ tokens }: { tokens: TelemetryOverview["tokens"] }) {
+  const tiers = splitTokenTiers(tokens.totals);
+  const hasData = tiers.total > 0;
+
+  return (
+    <article className="panel tm-overview-card" aria-label="Token usage">
+      <header className="tm-overview-card-head">
+        <h3>Tokens</h3>
+        <span className="tm-overview-card-badge">{coverageLabel(tokens.coverage)}</span>
+      </header>
+
+      {tokens.safe_total && tokens.display_total !== null ? (
+        <div className="tm-overview-hero-block">
+          <p className="tm-overview-hero">{formatCompactNumber(tokens.display_total)}</p>
+          <p className="tm-overview-hero-caption">total tokens</p>
+        </div>
+      ) : (
+        <p className="tm-overview-hero-note">No safe grand total — the tiers below don’t sum.</p>
+      )}
+
+      {hasData ? (
+        <div className="tm-overview-body">
+          <div
+            className="tm-tier-bar"
+            role="img"
+            aria-label={`${percentOf(tiers.newWork, tiers.total)}% new work, ${percentOf(
+              tiers.reread,
+              tiers.total,
+            )}% re-read context`}
+          >
+            <span
+              className="tm-tier-bar-seg is-newwork"
+              style={{ flexGrow: Math.max(tiers.newWork, 0) }}
+            />
+            <span
+              className="tm-tier-bar-seg is-reread"
+              style={{ flexGrow: Math.max(tiers.reread, 0) }}
+            />
+          </div>
+          <dl className="tm-tier-list">
+            <div className="tm-tier">
+              <div className="tm-tier-head">
+                <span className="tm-tier-name">
+                  <span className="tm-stat-swatch is-newwork" aria-hidden="true" />
+                  New work
+                </span>
+                <span className="tm-tier-value">{formatCompactNumber(tiers.newWork)}</span>
+              </div>
+              <div className="tm-tier-sub">
+                {TOKEN_TIER_NEW_WORK.filter((c) => (tokens.totals[c] ?? 0) > 0).map((category) => (
+                  <StatRow
+                    key={category}
+                    label={tokenCategoryLabel(category)}
+                    value={formatCompactNumber(tokens.totals[category] ?? 0)}
+                    swatch={tokenCategoryColor(category)}
+                  />
+                ))}
+              </div>
+            </div>
+            <div className="tm-tier">
+              <div className="tm-tier-head">
+                <span className="tm-tier-name">
+                  <span className="tm-stat-swatch is-reread" aria-hidden="true" />
+                  Re-read context
+                </span>
+                <span className="tm-tier-value">{formatCompactNumber(tiers.reread)}</span>
+              </div>
+              <p className="tm-tier-note">cheap re-sent prior context</p>
+            </div>
+          </dl>
+        </div>
+      ) : (
+        <p className="muted tm-overview-empty">No token activity in range.</p>
+      )}
+
+      {tokens.meter_coverage_percent !== null ? (
+        <p className="tm-overview-footnote">
+          Metered on {Math.round(tokens.meter_coverage_percent)}% of tracked turns
+        </p>
+      ) : null}
+    </article>
   );
 }
 
@@ -40,66 +145,53 @@ export function OverviewCards({ overview, loading }: OverviewCardsProps) {
   }
 
   const { tokens, sessions, turns, tool_calls: toolCalls, alerts } = overview;
-  const categories = orderedTokenCategories(tokens.totals);
   const alertCount = alerts.context.length + alerts.limits.length;
 
   return (
     <section className="tm-overview-grid" aria-label="Overview">
-      <article className="panel tm-overview-card" aria-label="Token usage">
-        <header className="tm-overview-card-head">
-          <h3>Tokens</h3>
-          <span className="tm-overview-card-badge">{coverageLabel(tokens.coverage)}</span>
-        </header>
-        {tokens.safe_total && tokens.display_total !== null ? (
-          <p className="tm-overview-hero">{formatCompactNumber(tokens.display_total)}</p>
-        ) : (
-          <p className="tm-overview-hero-note">No safe grand total — categories below don’t sum</p>
-        )}
-        <dl className="tm-stat-list">
-          {categories.length === 0 ? (
-            <p className="muted">No token activity in range.</p>
-          ) : (
-            categories.map((category) => (
-              <StatRow
-                key={category}
-                label={tokenCategoryLabel(category)}
-                value={formatCompactNumber(tokens.totals[category] ?? 0)}
-              />
-            ))
-          )}
-        </dl>
-        {tokens.meter_coverage_percent !== null ? (
-          <p className="tm-overview-footnote">
-            Metered on {Math.round(tokens.meter_coverage_percent)}% of tracked turns
-          </p>
-        ) : null}
-      </article>
+      <TokensCard tokens={tokens} />
 
       <article className="panel tm-overview-card" aria-label="Sessions">
         <header className="tm-overview-card-head">
           <h3>Sessions</h3>
         </header>
-        <p className="tm-overview-hero">{sessions.active_now}</p>
-        <p className="tm-overview-hero-caption">active now</p>
-        <dl className="tm-stat-list">
-          <StatRow label="Created" value={sessions.created} />
-          <StatRow label="Exited" value={sessions.exited} />
-          <StatRow label="Interrupted" value={sessions.interrupted} />
-          <StatRow label="Errored" value={sessions.error} />
-        </dl>
+        <div className="tm-overview-hero-block">
+          <p className="tm-overview-hero">{formatCompactNumber(sessions.active_now)}</p>
+          <p className="tm-overview-hero-caption">active now</p>
+        </div>
+        <div className="tm-overview-body">
+          <dl className="tm-stat-list">
+            <StatRow label="Created" value={formatCompactNumber(sessions.created)} />
+            <StatRow label="Exited" value={formatCompactNumber(sessions.exited)} />
+            <StatRow
+              label="Interrupted"
+              value={formatCompactNumber(sessions.interrupted)}
+              tone={sessions.interrupted > 0 ? "warn" : undefined}
+            />
+            <StatRow
+              label="Errored"
+              value={formatCompactNumber(sessions.error)}
+              tone={sessions.error > 0 ? "danger" : undefined}
+            />
+          </dl>
+        </div>
       </article>
 
       <article className="panel tm-overview-card" aria-label="Turns and tool calls">
         <header className="tm-overview-card-head">
           <h3>Activity</h3>
         </header>
-        <p className="tm-overview-hero">{formatCompactNumber(turns.user + turns.agent)}</p>
-        <p className="tm-overview-hero-caption">turns</p>
-        <dl className="tm-stat-list">
-          <StatRow label="User turns" value={turns.user} />
-          <StatRow label="Agent turns" value={turns.agent} />
-          <StatRow label="Tool calls" value={toolCalls} />
-        </dl>
+        <div className="tm-overview-hero-block">
+          <p className="tm-overview-hero">{formatCompactNumber(turns.user + turns.agent)}</p>
+          <p className="tm-overview-hero-caption">turns</p>
+        </div>
+        <div className="tm-overview-body">
+          <dl className="tm-stat-list">
+            <StatRow label="User turns" value={formatCompactNumber(turns.user)} />
+            <StatRow label="Agent turns" value={formatCompactNumber(turns.agent)} />
+            <StatRow label="Tool calls" value={formatCompactNumber(toolCalls)} />
+          </dl>
+        </div>
       </article>
 
       <article
@@ -110,51 +202,64 @@ export function OverviewCards({ overview, loading }: OverviewCardsProps) {
           <h3>Alerts</h3>
           <span className="tm-overview-card-badge">{alertCount}</span>
         </header>
-        {overview.limit_card_hidden ? (
-          <p className="muted tm-overview-footnote">
-            {overview.limit_card_hidden_reason ??
-              "Provider limits hidden while a session filter is active."}
+        <div className="tm-overview-hero-block">
+          <p className={`tm-overview-hero${alertCount === 0 ? " is-clear" : ""}`}>
+            {alertCount === 0 ? "0" : formatCompactNumber(alertCount)}
           </p>
-        ) : null}
-        {alertCount === 0 ? (
-          <p className="muted">Nothing above threshold.</p>
-        ) : (
-          <ul className="tm-alert-list">
-            {alerts.context.map((snapshot) => {
-              const tone = usageTone(snapshot.percent);
-              return (
-                <li key={snapshot.session_id} className={`tm-alert-row tone-${tone}`}>
-                  <span className="tm-alert-glyph" aria-hidden="true">
-                    {tone === "danger" ? "▲" : "●"}
-                  </span>
-                  <span className="tm-alert-text">
-                    Context {snapshot.percent !== null ? Math.round(snapshot.percent) : "—"}%
-                    <span className="muted"> · {shortId(snapshot.session_id)}</span>
-                  </span>
-                  <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
-                </li>
-              );
-            })}
-            {alerts.limits.map((snapshot) => {
-              const tone = usageTone(snapshot.used_percent);
-              return (
-                <li
-                  key={`${snapshot.backend}:${snapshot.account_key}:${snapshot.window_id}`}
-                  className={`tm-alert-row tone-${tone}`}
-                >
-                  <span className="tm-alert-glyph" aria-hidden="true">
-                    {tone === "danger" ? "▲" : "●"}
-                  </span>
-                  <span className="tm-alert-text">
-                    {snapshot.label ?? snapshot.window_id} {Math.round(snapshot.used_percent)}%
-                    <span className="muted"> · {snapshot.backend}</span>
-                  </span>
-                  <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
-                </li>
-              );
-            })}
-          </ul>
-        )}
+          <p className="tm-overview-hero-caption">
+            {alertCount === 0 ? "all clear" : "need attention"}
+          </p>
+        </div>
+        <div className="tm-overview-body">
+          {overview.limit_card_hidden ? (
+            <p className="muted tm-overview-footnote">
+              {overview.limit_card_hidden_reason ??
+                "Provider limits hidden while a session filter is active."}
+            </p>
+          ) : null}
+          {alertCount === 0 ? (
+            <p className="muted tm-overview-empty">Nothing above threshold.</p>
+          ) : (
+            <ul className="tm-alert-list">
+              {alerts.context.map((snapshot) => {
+                const tone = usageTone(snapshot.percent);
+                return (
+                  <li key={snapshot.session_id} className={`tm-alert-row tone-${tone}`}>
+                    <span className="tm-alert-glyph" aria-hidden="true">
+                      {tone === "danger" ? "▲" : "●"}
+                    </span>
+                    <span className="tm-alert-text">
+                      Context {snapshot.percent !== null ? Math.round(snapshot.percent) : "—"}%
+                      <span className="muted"> · {shortId(snapshot.session_id)}</span>
+                    </span>
+                    <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
+                  </li>
+                );
+              })}
+              {alerts.limits.map((snapshot) => {
+                const tone = usageTone(snapshot.used_percent);
+                return (
+                  <li
+                    key={`${snapshot.backend}:${snapshot.account_key}:${snapshot.window_id}`}
+                    className={`tm-alert-row tone-${tone}`}
+                  >
+                    <span className="tm-alert-glyph" aria-hidden="true">
+                      {tone === "danger" ? "▲" : "●"}
+                    </span>
+                    <span className="tm-alert-text">
+                      {snapshot.label ?? snapshot.window_id} {Math.round(snapshot.used_percent)}%
+                      <span className="muted">
+                        {" · "}
+                        {snapshot.account_label ?? snapshot.account_key} · {snapshot.backend}
+                      </span>
+                    </span>
+                    <span className="tm-alert-time">{formatRelativeTime(snapshot.updated_at)}</span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
       </article>
     </section>
   );

--- a/frontend/src/components/telemetry/SettingsPanel.tsx
+++ b/frontend/src/components/telemetry/SettingsPanel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+
+import { TelemetryDeleteResponse, TelemetrySettingsResponse } from "@/lib/types";
+
+interface SettingsPanelProps {
+  settings: TelemetrySettingsResponse | null;
+  loading: boolean;
+  deleting: boolean;
+  deleteResult: TelemetryDeleteResponse | null;
+  onDelete: () => void;
+}
+
+export function SettingsPanel({
+  settings,
+  loading,
+  deleting,
+  deleteResult,
+  onDelete,
+}: SettingsPanelProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <section className="panel tm-settings-panel">
+      <button
+        type="button"
+        className="tm-filters-toggle tm-settings-toggle"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+      >
+        Privacy, coverage &amp; retention
+        <span aria-hidden="true" className="tm-filters-toggle-chevron">
+          {expanded ? "▴" : "▾"}
+        </span>
+      </button>
+
+      {expanded ? (
+        loading && !settings ? (
+          <p className="muted">Loading settings…</p>
+        ) : settings ? (
+          <div className="tm-settings-body">
+            <p className="tm-settings-statement">{settings.privacy_statement}</p>
+            <dl className="tm-stat-list">
+              <div className="tm-stat-row">
+                <span className="tm-stat-row-label">Fact retention</span>
+                <span className="tm-stat-row-value">{settings.retention_days_facts} days</span>
+              </div>
+              <div className="tm-stat-row">
+                <span className="tm-stat-row-label">Rollup retention</span>
+                <span className="tm-stat-row-value">
+                  {settings.retention_months_rollups} months
+                </span>
+              </div>
+              <div className="tm-stat-row">
+                <span className="tm-stat-row-label">Backfill</span>
+                <span className="tm-stat-row-value">
+                  {settings.coverage.backfill_done ? "Complete" : "In progress"}
+                  {settings.coverage.backfill_through
+                    ? ` · through ${new Date(settings.coverage.backfill_through).toLocaleDateString()}`
+                    : ""}
+                </span>
+              </div>
+              <div className="tm-stat-row">
+                <span className="tm-stat-row-label">External export</span>
+                <span className="tm-stat-row-value">
+                  {settings.external_export ? "Enabled" : "Disabled"}
+                </span>
+              </div>
+              <div className="tm-stat-row">
+                <span className="tm-stat-row-label">Content capture</span>
+                <span className="tm-stat-row-value">
+                  {settings.content_capture ? "Enabled" : "Disabled"}
+                </span>
+              </div>
+            </dl>
+
+            <div className="tm-settings-danger">
+              <p className="muted">
+                Deleting telemetry removes every stored fact and rollup. Session
+                transcripts are never affected.
+              </p>
+              <button
+                type="button"
+                className="board-action board-action-danger"
+                disabled={deleting}
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      "Delete all retained telemetry (facts + rollups)? Session transcripts are not affected. This cannot be undone.",
+                    )
+                  ) {
+                    onDelete();
+                  }
+                }}
+              >
+                {deleting ? "Deleting…" : "Delete all telemetry"}
+              </button>
+              {deleteResult ? (
+                <p className="tm-settings-delete-result" role="status">
+                  Removed {deleteResult.removed.facts} facts and {deleteResult.removed.rollups}{" "}
+                  rollup rows. Transcripts unaffected.
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <p className="muted">Settings unavailable.</p>
+        )
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/telemetry/TelemetryFilters.tsx
+++ b/frontend/src/components/telemetry/TelemetryFilters.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useId, useState, type KeyboardEvent } from "react";
+
+import {
+  RANGE_PRESET_OPTIONS,
+  SESSION_SOURCE_OPTIONS,
+  TelemetryFiltersState,
+  TelemetryRangeState,
+} from "@/lib/telemetry";
+import { TelemetryParentScope } from "@/lib/types";
+
+interface TelemetryFiltersProps {
+  range: TelemetryRangeState;
+  filters: TelemetryFiltersState;
+  onRangeChange: (range: TelemetryRangeState) => void;
+  onFiltersChange: (filters: TelemetryFiltersState) => void;
+  backendOptions: { id: string; label: string }[];
+  transportOptions: string[];
+  effectiveRangeLabel: string | null;
+}
+
+function ChipToggle({
+  label,
+  active,
+  onToggle,
+}: {
+  label: string;
+  active: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={`tm-chip${active ? " is-active" : ""}`}
+      aria-pressed={active}
+      onClick={onToggle}
+    >
+      {label}
+    </button>
+  );
+}
+
+function toggleInList(list: string[], value: string): string[] {
+  return list.includes(value) ? list.filter((item) => item !== value) : [...list, value];
+}
+
+function TagField({
+  label,
+  hint,
+  values,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  values: string[];
+  onChange: (values: string[]) => void;
+}) {
+  const [draft, setDraft] = useState("");
+  const inputId = useId();
+
+  const commit = () => {
+    const value = draft.trim();
+    if (!value || values.includes(value)) {
+      setDraft("");
+      return;
+    }
+    onChange([...values, value]);
+    setDraft("");
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commit();
+    } else if (event.key === "Backspace" && !draft && values.length > 0) {
+      onChange(values.slice(0, -1));
+    }
+  };
+
+  return (
+    <div className="tm-filter-field">
+      <label className="tm-filter-label" htmlFor={inputId}>
+        {label}
+      </label>
+      <div className="tm-tag-field">
+        {values.map((value) => (
+          <span key={value} className="tm-tag-chip">
+            {value}
+            <button
+              type="button"
+              className="tm-tag-chip-remove"
+              onClick={() => onChange(values.filter((item) => item !== value))}
+              aria-label={`Remove ${label.toLowerCase()} filter ${value}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          id={inputId}
+          className="tm-tag-input"
+          type="text"
+          placeholder={hint}
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onKeyDown}
+          onBlur={commit}
+        />
+      </div>
+    </div>
+  );
+}
+
+const PARENT_SCOPE_OPTIONS: { value: TelemetryParentScope; label: string }[] = [
+  { value: "all", label: "All sessions" },
+  { value: "top_level", label: "Top-level only" },
+  { value: "children", label: "Children only" },
+];
+
+export function TelemetryFilters({
+  range,
+  filters,
+  onRangeChange,
+  onFiltersChange,
+  backendOptions,
+  transportOptions,
+  effectiveRangeLabel,
+}: TelemetryFiltersProps) {
+  const [expanded, setExpanded] = useState(false);
+  const parentFieldId = useId();
+
+  return (
+    <section className="panel tm-filters" aria-label="Telemetry filters">
+      <div className="tm-filters-row">
+        <div className="tm-range-presets" role="group" aria-label="Date range">
+          {RANGE_PRESET_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              className={`tm-chip${range.preset === option.value ? " is-active" : ""}`}
+              aria-pressed={range.preset === option.value}
+              onClick={() => onRangeChange({ ...range, preset: option.value })}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {range.preset === "custom" ? (
+          <div className="tm-custom-range">
+            <label className="tm-filter-label" htmlFor="tm-range-start">
+              From
+            </label>
+            <input
+              id="tm-range-start"
+              type="date"
+              className="tm-date-input"
+              value={range.start}
+              max={range.end || undefined}
+              onChange={(event) => onRangeChange({ ...range, start: event.target.value })}
+            />
+            <label className="tm-filter-label" htmlFor="tm-range-end">
+              To
+            </label>
+            <input
+              id="tm-range-end"
+              type="date"
+              className="tm-date-input"
+              value={range.end}
+              min={range.start || undefined}
+              onChange={(event) => onRangeChange({ ...range, end: event.target.value })}
+            />
+          </div>
+        ) : null}
+
+        {effectiveRangeLabel ? (
+          <span className="tm-effective-range">{effectiveRangeLabel}</span>
+        ) : null}
+
+        <button
+          type="button"
+          className="tm-filters-toggle"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+        >
+          {expanded ? "Hide filters" : "More filters"}
+          <span aria-hidden="true" className="tm-filters-toggle-chevron">
+            {expanded ? "▴" : "▾"}
+          </span>
+        </button>
+      </div>
+
+      {expanded ? (
+        <div className="tm-filters-body">
+          {backendOptions.length > 0 ? (
+            <div className="tm-filter-field">
+              <span className="tm-filter-label">Backend</span>
+              <div className="tm-chip-row" role="group" aria-label="Filter by backend">
+                {backendOptions.map((option) => (
+                  <ChipToggle
+                    key={option.id}
+                    label={option.label}
+                    active={filters.backends.includes(option.id)}
+                    onToggle={() =>
+                      onFiltersChange({
+                        ...filters,
+                        backends: toggleInList(filters.backends, option.id),
+                      })
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="tm-filter-field">
+            <span className="tm-filter-label">Source</span>
+            <div className="tm-chip-row" role="group" aria-label="Filter by session source">
+              {SESSION_SOURCE_OPTIONS.map((option) => (
+                <ChipToggle
+                  key={option.value}
+                  label={option.label}
+                  active={filters.sources.includes(option.value)}
+                  onToggle={() =>
+                    onFiltersChange({
+                      ...filters,
+                      sources: toggleInList(filters.sources, option.value),
+                    })
+                  }
+                />
+              ))}
+            </div>
+          </div>
+
+          {transportOptions.length > 0 ? (
+            <div className="tm-filter-field">
+              <span className="tm-filter-label">Transport</span>
+              <div className="tm-chip-row" role="group" aria-label="Filter by transport">
+                {transportOptions.map((transport) => (
+                  <ChipToggle
+                    key={transport}
+                    label={transport}
+                    active={filters.transports.includes(transport)}
+                    onToggle={() =>
+                      onFiltersChange({
+                        ...filters,
+                        transports: toggleInList(filters.transports, transport),
+                      })
+                    }
+                  />
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <TagField
+            label="Model"
+            hint="type a model id, ↵ to add"
+            values={filters.models}
+            onChange={(models) => onFiltersChange({ ...filters, models })}
+          />
+          <TagField
+            label="Repo"
+            hint="type a repo name, ↵ to add"
+            values={filters.repos}
+            onChange={(repos) => onFiltersChange({ ...filters, repos })}
+          />
+          <TagField
+            label="Tag"
+            hint="key:value, ↵ to add"
+            values={filters.tags}
+            onChange={(tags) => onFiltersChange({ ...filters, tags })}
+          />
+
+          <div className="tm-filter-field">
+            <span className="tm-filter-label">Parent / child</span>
+            <div className="tm-chip-row" role="group" aria-label="Filter by parent scope">
+              {PARENT_SCOPE_OPTIONS.map((option) => (
+                <ChipToggle
+                  key={option.value}
+                  label={option.label}
+                  active={filters.parentScope === option.value}
+                  onToggle={() =>
+                    onFiltersChange({ ...filters, parentScope: option.value })
+                  }
+                />
+              ))}
+            </div>
+            <div className="tm-parent-row">
+              <label className="tm-filter-sublabel" htmlFor={parentFieldId}>
+                Parent session id
+              </label>
+              <input
+                id={parentFieldId}
+                type="text"
+                className="tm-text-input"
+                placeholder="session id (optional)"
+                value={filters.parentSessionId}
+                onChange={(event) =>
+                  onFiltersChange({ ...filters, parentSessionId: event.target.value })
+                }
+              />
+              <label className="tm-checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={filters.includeDescendants}
+                  onChange={(event) =>
+                    onFiltersChange({
+                      ...filters,
+                      includeDescendants: event.target.checked,
+                    })
+                  }
+                />
+                Include descendants
+              </label>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/telemetry/TokenChart.tsx
+++ b/frontend/src/components/telemetry/TokenChart.tsx
@@ -1,0 +1,465 @@
+"use client";
+
+import { useId, useMemo, useState } from "react";
+
+import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
+import {
+  TOKEN_GROUP_BY_OPTIONS,
+  coverageLabel,
+  formatCompactNumber,
+  orderedTokenCategories,
+  tokenCategoryLabel,
+} from "@/lib/telemetry";
+import { TelemetryTokens, TokenGroupBy } from "@/lib/types";
+
+interface TokenChartProps {
+  tokens: TelemetryTokens | null;
+  loading: boolean;
+  groupBy: TokenGroupBy;
+  onGroupByChange: (groupBy: TokenGroupBy) => void;
+}
+
+const CHART_W = 640;
+const CHART_H = 220;
+const PAD_LEFT = 40;
+const PAD_RIGHT = 12;
+const PAD_TOP = 12;
+const PAD_BOTTOM = 26;
+const SEGMENT_GAP = 2;
+const BAR_GAP_RATIO = 0.28;
+const MAX_RANKED_GROUPS = 7;
+
+function seriesColor(index: number): string {
+  return `var(--tm-series-${(index % 8) + 1})`;
+}
+
+function niceMax(value: number): number {
+  if (value <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(value));
+  const residual = value / magnitude;
+  const niceResidual = residual <= 1 ? 1 : residual <= 2 ? 2 : residual <= 5 ? 5 : 10;
+  return niceResidual * magnitude;
+}
+
+function roundedTopRectPath(x: number, y: number, w: number, h: number, r: number): string {
+  const radius = Math.max(0, Math.min(r, w / 2, h));
+  if (radius <= 0) {
+    return `M ${x} ${y} h ${w} v ${h} h ${-w} Z`;
+  }
+  return [
+    `M ${x} ${y + radius}`,
+    `a ${radius} ${radius} 0 0 1 ${radius} ${-radius}`,
+    `h ${w - 2 * radius}`,
+    `a ${radius} ${radius} 0 0 1 ${radius} ${radius}`,
+    `v ${h - radius}`,
+    `h ${-w}`,
+    `Z`,
+  ].join(" ");
+}
+
+// Horizontal bar rounded only at its free (right) end; square at the axis.
+function roundedRightRectPath(x: number, y: number, w: number, h: number, r: number): string {
+  const radius = Math.max(0, Math.min(r, w, h / 2));
+  if (radius <= 0 || w <= 0) {
+    return `M ${x} ${y} h ${Math.max(w, 0)} v ${h} h ${-Math.max(w, 0)} Z`;
+  }
+  return [
+    `M ${x} ${y}`,
+    `h ${w - radius}`,
+    `a ${radius} ${radius} 0 0 1 ${radius} ${radius}`,
+    `v ${h - 2 * radius}`,
+    `a ${radius} ${radius} 0 0 1 ${-radius} ${radius}`,
+    `h ${-(w - radius)}`,
+    `Z`,
+  ].join(" ");
+}
+
+export function TokenChart({ tokens, loading, groupBy, onGroupByChange }: TokenChartProps) {
+  const [tooltip, setTooltip] = useState<ChartTooltipState | null>(null);
+  const [tableOpen, setTableOpen] = useState(false);
+  const titleId = useId();
+
+  const timeSeries = groupBy === "time" ? tokens?.series ?? [] : [];
+
+  const categories = useMemo(() => {
+    const points = groupBy === "time" ? tokens?.series ?? [] : [];
+    const merged: Record<string, number> = {};
+    for (const point of points) {
+      for (const [key, value] of Object.entries(point.totals)) {
+        merged[key] = (merged[key] ?? 0) + value;
+      }
+    }
+    return orderedTokenCategories(merged);
+  }, [groupBy, tokens]);
+
+  const rankedGroups = useMemo(() => {
+    const rawGroups = groupBy !== "time" ? tokens?.groups ?? [] : [];
+    const withValues = rawGroups.map((group) => ({
+      group,
+      value: group.display_total ?? Object.values(group.totals).reduce((a, b) => a + b, 0),
+    }));
+    withValues.sort((a, b) => b.value - a.value);
+    if (withValues.length <= MAX_RANKED_GROUPS + 1) return withValues;
+    const head = withValues.slice(0, MAX_RANKED_GROUPS);
+    const tail = withValues.slice(MAX_RANKED_GROUPS);
+    const otherValue = tail.reduce((sum, item) => sum + item.value, 0);
+    return [
+      ...head,
+      {
+        group: {
+          key: "__other__",
+          label: `Other (${tail.length})`,
+          totals: {},
+          display_total: otherValue,
+          coverage: "partial" as const,
+        },
+        value: otherValue,
+      },
+    ];
+  }, [groupBy, tokens]);
+
+  if (loading && !tokens) {
+    return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
+  }
+  if (!tokens) return null;
+
+  const hasData =
+    groupBy === "time" ? timeSeries.some((p) => Object.keys(p.totals).length > 0) : rankedGroups.length > 0;
+
+  const plotW = CHART_W - PAD_LEFT - PAD_RIGHT;
+  const plotH = CHART_H - PAD_TOP - PAD_BOTTOM;
+
+  return (
+    <section className="panel tm-chart-card" aria-labelledby={titleId}>
+      <header className="tm-chart-head">
+        <h3 id={titleId}>Token usage</h3>
+        <label className="tm-chart-select-label">
+          Group by
+          <select
+            className="tm-chart-select"
+            value={groupBy}
+            onChange={(event) => onGroupByChange(event.target.value as TokenGroupBy)}
+          >
+            {TOKEN_GROUP_BY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {!hasData ? (
+        <p className="muted tm-chart-empty">No token activity in this range.</p>
+      ) : groupBy === "time" ? (
+        <TimeSeriesBars
+          series={timeSeries}
+          categories={categories}
+          plotW={plotW}
+          plotH={plotH}
+          onHover={setTooltip}
+        />
+      ) : (
+        <RankedBars items={rankedGroups} plotW={plotW} plotH={plotH} onHover={setTooltip} />
+      )}
+      <ChartTooltip state={tooltip} />
+
+      {hasData ? (
+        <div className="tm-chart-legend" role="list" aria-label="Series">
+          {(groupBy === "time" ? categories : rankedGroups.map((g) => g.group.label)).map(
+            (label, index) => (
+              <span key={typeof label === "string" ? label : index} className="tm-legend-item" role="listitem">
+                <span
+                  className="tm-legend-swatch"
+                  aria-hidden="true"
+                  style={{ background: seriesColor(index) }}
+                />
+                {groupBy === "time" ? tokenCategoryLabel(label as string) : label}
+              </span>
+            ),
+          )}
+        </div>
+      ) : null}
+
+      <button
+        type="button"
+        className="tm-table-toggle"
+        onClick={() => setTableOpen((v) => !v)}
+        aria-expanded={tableOpen}
+      >
+        {tableOpen ? "Hide data table" : "View as table"}
+      </button>
+      {tableOpen ? (
+        groupBy === "time" ? (
+          <div className="tm-table-wrap">
+            <table className="tm-data-table">
+              <caption className="sr-only">Token usage over time by category</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Bucket</th>
+                  {categories.map((category) => (
+                    <th scope="col" key={category}>
+                      {tokenCategoryLabel(category)}
+                    </th>
+                  ))}
+                  <th scope="col">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {timeSeries.map((point) => (
+                  <tr key={point.bucket_start}>
+                    <th scope="row">{new Date(point.bucket_start).toLocaleString()}</th>
+                    {categories.map((category) => (
+                      <td key={category}>{formatCompactNumber(point.totals[category] ?? 0)}</td>
+                    ))}
+                    <td>
+                      {point.display_total !== null ? formatCompactNumber(point.display_total) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="tm-table-wrap">
+            <table className="tm-data-table">
+              <caption className="sr-only">Token usage grouped by {groupBy}</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Group</th>
+                  <th scope="col">Tokens</th>
+                  <th scope="col">Coverage</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rankedGroups.map(({ group, value }) => (
+                  <tr key={group.key}>
+                    <th scope="row">{group.label}</th>
+                    <td>{formatCompactNumber(value)}</td>
+                    <td>{coverageLabel(group.coverage)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )
+      ) : null}
+    </section>
+  );
+}
+
+function TimeSeriesBars({
+  series,
+  categories,
+  plotW,
+  plotH,
+  onHover,
+}: {
+  series: TelemetryTokens["series"];
+  categories: string[];
+  plotW: number;
+  plotH: number;
+  onHover: (state: ChartTooltipState | null) => void;
+}) {
+  const totals = series.map((point) =>
+    categories.reduce((sum, category) => sum + (point.totals[category] ?? 0), 0),
+  );
+  const max = niceMax(Math.max(...totals, 0));
+  const barSlot = plotW / Math.max(series.length, 1);
+  const barW = barSlot * (1 - BAR_GAP_RATIO);
+
+  return (
+    <svg
+      viewBox={`0 0 ${CHART_W} ${CHART_H}`}
+      className="tm-chart-svg"
+      role="img"
+      aria-label={`Token usage across ${series.length} time buckets, up to ${formatCompactNumber(max)} tokens`}
+    >
+      <g transform={`translate(${PAD_LEFT},${PAD_TOP})`}>
+        {[0, 0.5, 1].map((fraction) => {
+          const y = plotH - plotH * fraction;
+          return (
+            <g key={fraction}>
+              <line x1={0} y1={y} x2={plotW} y2={y} className="tm-chart-gridline" />
+              <text x={-8} y={y} className="tm-chart-axis-label" textAnchor="end" dy="0.32em">
+                {formatCompactNumber(max * fraction)}
+              </text>
+            </g>
+          );
+        })}
+        {series.map((point, i) => {
+          const x = i * barSlot + (barSlot - barW) / 2;
+          const usableH = plotH - (categories.length - 1) * SEGMENT_GAP;
+          let cursorY = plotH;
+          const segments = categories
+            .map((category, ci) => {
+              const value = point.totals[category] ?? 0;
+              const h = max > 0 ? (value / max) * usableH : 0;
+              cursorY -= h;
+              const segY = cursorY;
+              cursorY -= SEGMENT_GAP;
+              return { category, ci, value, y: segY, h };
+            })
+            .filter((segment) => segment.h > 0);
+          const topIndex = segments.length - 1;
+          const total = totals[i];
+          return (
+            <g
+              key={point.bucket_start}
+              tabIndex={0}
+              role="img"
+              aria-label={`${new Date(point.bucket_start).toLocaleString()}: ${formatCompactNumber(total)} tokens`}
+              className="tm-bar-group"
+              onMouseEnter={(event) =>
+                onHover({
+                  left: event.clientX,
+                  top: event.clientY,
+                  title: new Date(point.bucket_start).toLocaleString(),
+                  rows: categories
+                    .filter((c) => (point.totals[c] ?? 0) > 0)
+                    .map((c, idx) => ({
+                      key: c,
+                      label: tokenCategoryLabel(c),
+                      value: formatCompactNumber(point.totals[c] ?? 0),
+                      color: seriesColor(idx),
+                    })),
+                })
+              }
+              onMouseMove={(event) =>
+                onHover({
+                  left: event.clientX,
+                  top: event.clientY,
+                  title: new Date(point.bucket_start).toLocaleString(),
+                  rows: categories
+                    .filter((c) => (point.totals[c] ?? 0) > 0)
+                    .map((c, idx) => ({
+                      key: c,
+                      label: tokenCategoryLabel(c),
+                      value: formatCompactNumber(point.totals[c] ?? 0),
+                      color: seriesColor(idx),
+                    })),
+                })
+              }
+              onFocus={() =>
+                onHover({
+                  left: 0,
+                  top: 0,
+                  title: new Date(point.bucket_start).toLocaleString(),
+                  rows: categories
+                    .filter((c) => (point.totals[c] ?? 0) > 0)
+                    .map((c, idx) => ({
+                      key: c,
+                      label: tokenCategoryLabel(c),
+                      value: formatCompactNumber(point.totals[c] ?? 0),
+                      color: seriesColor(idx),
+                    })),
+                })
+              }
+              onMouseLeave={() => onHover(null)}
+              onBlur={() => onHover(null)}
+            >
+              {segments.map((segment, idx) =>
+                idx === topIndex ? (
+                  <path
+                    key={segment.category}
+                    d={roundedTopRectPath(x, segment.y, barW, segment.h, 3)}
+                    fill={seriesColor(segment.ci)}
+                  />
+                ) : (
+                  <rect
+                    key={segment.category}
+                    x={x}
+                    y={segment.y}
+                    width={barW}
+                    height={segment.h}
+                    fill={seriesColor(segment.ci)}
+                  />
+                ),
+              )}
+            </g>
+          );
+        })}
+        <line x1={0} y1={plotH} x2={plotW} y2={plotH} className="tm-chart-axis" />
+      </g>
+    </svg>
+  );
+}
+
+function RankedBars({
+  items,
+  plotW,
+  plotH,
+  onHover,
+}: {
+  items: { group: TelemetryTokens["groups"][number]; value: number }[];
+  plotW: number;
+  plotH: number;
+  onHover: (state: ChartTooltipState | null) => void;
+}) {
+  const max = niceMax(Math.max(...items.map((item) => item.value), 0));
+  const rowSlot = plotH / Math.max(items.length, 1);
+  const barH = Math.min(24, rowSlot * (1 - BAR_GAP_RATIO));
+  const labelW = 96;
+
+  return (
+    <svg
+      viewBox={`0 0 ${CHART_W} ${Math.max(plotH, items.length * rowSlot) + PAD_TOP + PAD_BOTTOM}`}
+      className="tm-chart-svg"
+      role="img"
+      aria-label={`Token usage ranked across ${items.length} groups, up to ${formatCompactNumber(max)} tokens`}
+    >
+      <g transform={`translate(${PAD_LEFT + labelW},${PAD_TOP})`}>
+        {items.map(({ group, value }, i) => {
+          const y = i * rowSlot + (rowSlot - barH) / 2;
+          const w = max > 0 ? (value / max) * (plotW - labelW) : 0;
+          return (
+            <g
+              key={group.key}
+              tabIndex={0}
+              role="img"
+              aria-label={`${group.label}: ${formatCompactNumber(value)} tokens`}
+              className="tm-bar-group"
+              onMouseEnter={(event) =>
+                onHover({
+                  left: event.clientX,
+                  top: event.clientY,
+                  title: group.label,
+                  rows: [{ key: group.key, label: "tokens", value: formatCompactNumber(value) }],
+                })
+              }
+              onMouseMove={(event) =>
+                onHover({
+                  left: event.clientX,
+                  top: event.clientY,
+                  title: group.label,
+                  rows: [{ key: group.key, label: "tokens", value: formatCompactNumber(value) }],
+                })
+              }
+              onMouseLeave={() => onHover(null)}
+              onFocus={() =>
+                onHover({
+                  left: 0,
+                  top: 0,
+                  title: group.label,
+                  rows: [{ key: group.key, label: "tokens", value: formatCompactNumber(value) }],
+                })
+              }
+              onBlur={() => onHover(null)}
+            >
+              <text
+                x={-8}
+                y={y + barH / 2}
+                textAnchor="end"
+                dy="0.32em"
+                className="tm-chart-axis-label tm-rowlabel"
+              >
+                {group.label}
+              </text>
+              <path d={roundedRightRectPath(0, y, w, barH, 4)} fill={seriesColor(i)} />
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/components/telemetry/TokenChart.tsx
+++ b/frontend/src/components/telemetry/TokenChart.tsx
@@ -94,9 +94,11 @@ export function TokenChart({ tokens, loading, groupBy, onGroupByChange }: TokenC
 
   const rankedGroups = useMemo(() => {
     const rawGroups = groupBy !== "time" ? tokens?.groups ?? [] : [];
+    // `display_total` is always the safe sum of the 5 unified categories now
+    // (backend `fold_tokens`); the `?? 0` only guards the TS type, not a real gap.
     const withValues = rawGroups.map((group) => ({
       group,
-      value: group.display_total ?? Object.values(group.totals).reduce((a, b) => a + b, 0),
+      value: group.display_total ?? 0,
     }));
     withValues.sort((a, b) => b.value - a.value);
     if (withValues.length <= MAX_RANKED_GROUPS + 1) return withValues;

--- a/frontend/src/components/telemetry/TokenChart.tsx
+++ b/frontend/src/components/telemetry/TokenChart.tsx
@@ -4,10 +4,13 @@ import { useId, useMemo, useState } from "react";
 
 import { ChartTooltip, ChartTooltipState } from "@/components/telemetry/ChartTooltip";
 import {
+  TOKEN_DISPLAY_ORDER,
   TOKEN_GROUP_BY_OPTIONS,
+  TOKEN_TIER_NEW_WORK,
+  TOKEN_TIER_REREAD,
   coverageLabel,
   formatCompactNumber,
-  orderedTokenCategories,
+  tokenCategoryColor,
   tokenCategoryLabel,
 } from "@/lib/telemetry";
 import { TelemetryTokens, TokenGroupBy } from "@/lib/types";
@@ -83,13 +86,17 @@ export function TokenChart({ tokens, loading, groupBy, onGroupByChange }: TokenC
 
   const categories = useMemo(() => {
     const points = groupBy === "time" ? tokens?.series ?? [] : [];
-    const merged: Record<string, number> = {};
+    const present = new Set<string>();
     for (const point of points) {
       for (const [key, value] of Object.entries(point.totals)) {
-        merged[key] = (merged[key] ?? 0) + value;
+        if (value > 0) present.add(key);
       }
     }
-    return orderedTokenCategories(merged);
+    // Fixed two-tier stacking order (new work first, muted re-read band last),
+    // then any unrecognized key trailing so nothing silently drops.
+    const known = TOKEN_DISPLAY_ORDER.filter((key) => present.has(key));
+    const rest = [...present].filter((key) => !TOKEN_DISPLAY_ORDER.includes(key as never)).sort();
+    return [...known, ...rest];
   }, [groupBy, tokens]);
 
   const rankedGroups = useMemo(() => {
@@ -166,20 +173,45 @@ export function TokenChart({ tokens, loading, groupBy, onGroupByChange }: TokenC
       )}
       <ChartTooltip state={tooltip} />
 
-      {hasData ? (
+      {hasData && groupBy === "time" ? (
+        <div className="tm-chart-legend tm-token-legend" role="list" aria-label="Token categories">
+          {(
+            [
+              ["New work", TOKEN_TIER_NEW_WORK],
+              ["Re-read context", TOKEN_TIER_REREAD],
+            ] as const
+          ).map(([tierName, tierCats]) => {
+            const present = tierCats.filter((c) => categories.includes(c));
+            if (present.length === 0) return null;
+            return (
+              <div key={tierName} className="tm-legend-tier">
+                <span className="tm-legend-tier-name">{tierName}</span>
+                {present.map((category) => (
+                  <span key={category} className="tm-legend-item" role="listitem">
+                    <span
+                      className="tm-legend-swatch"
+                      aria-hidden="true"
+                      style={{ background: tokenCategoryColor(category) }}
+                    />
+                    {tokenCategoryLabel(category)}
+                  </span>
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      ) : hasData ? (
         <div className="tm-chart-legend" role="list" aria-label="Series">
-          {(groupBy === "time" ? categories : rankedGroups.map((g) => g.group.label)).map(
-            (label, index) => (
-              <span key={typeof label === "string" ? label : index} className="tm-legend-item" role="listitem">
-                <span
-                  className="tm-legend-swatch"
-                  aria-hidden="true"
-                  style={{ background: seriesColor(index) }}
-                />
-                {groupBy === "time" ? tokenCategoryLabel(label as string) : label}
-              </span>
-            ),
-          )}
+          {rankedGroups.map(({ group }, index) => (
+            <span key={group.key} className="tm-legend-item" role="listitem">
+              <span
+                className="tm-legend-swatch"
+                aria-hidden="true"
+                style={{ background: seriesColor(index) }}
+              />
+              {group.label}
+            </span>
+          ))}
         </div>
       ) : null}
 
@@ -319,11 +351,11 @@ function TimeSeriesBars({
                   title: new Date(point.bucket_start).toLocaleString(),
                   rows: categories
                     .filter((c) => (point.totals[c] ?? 0) > 0)
-                    .map((c, idx) => ({
+                    .map((c) => ({
                       key: c,
                       label: tokenCategoryLabel(c),
                       value: formatCompactNumber(point.totals[c] ?? 0),
-                      color: seriesColor(idx),
+                      color: tokenCategoryColor(c),
                     })),
                 })
               }
@@ -334,11 +366,11 @@ function TimeSeriesBars({
                   title: new Date(point.bucket_start).toLocaleString(),
                   rows: categories
                     .filter((c) => (point.totals[c] ?? 0) > 0)
-                    .map((c, idx) => ({
+                    .map((c) => ({
                       key: c,
                       label: tokenCategoryLabel(c),
                       value: formatCompactNumber(point.totals[c] ?? 0),
-                      color: seriesColor(idx),
+                      color: tokenCategoryColor(c),
                     })),
                 })
               }
@@ -349,11 +381,11 @@ function TimeSeriesBars({
                   title: new Date(point.bucket_start).toLocaleString(),
                   rows: categories
                     .filter((c) => (point.totals[c] ?? 0) > 0)
-                    .map((c, idx) => ({
+                    .map((c) => ({
                       key: c,
                       label: tokenCategoryLabel(c),
                       value: formatCompactNumber(point.totals[c] ?? 0),
-                      color: seriesColor(idx),
+                      color: tokenCategoryColor(c),
                     })),
                 })
               }
@@ -365,7 +397,7 @@ function TimeSeriesBars({
                   <path
                     key={segment.category}
                     d={roundedTopRectPath(x, segment.y, barW, segment.h, 3)}
-                    fill={seriesColor(segment.ci)}
+                    fill={tokenCategoryColor(segment.category)}
                   />
                 ) : (
                   <rect
@@ -374,7 +406,7 @@ function TimeSeriesBars({
                     y={segment.y}
                     width={barW}
                     height={segment.h}
-                    fill={seriesColor(segment.ci)}
+                    fill={tokenCategoryColor(segment.category)}
                   />
                 ),
               )}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,9 +31,21 @@ import {
   SessionPresetSummary,
   SessionPresetWriteRequest,
   SessionRecord,
+  TelemetryActivity,
+  TelemetryDeleteResponse,
+  TelemetryDrilldown,
+  TelemetryFactKind,
+  TelemetryHealth,
+  TelemetryOverview,
+  TelemetrySettingsResponse,
+  TelemetryTokens,
+  TokenGroupBy,
+  Insight,
   UsageDashboardResponse,
 } from "@/lib/types";
 import { parseDiffPreviewPayload, type EventDiffPreview } from "@/lib/events";
+import type { TelemetryFiltersState, TelemetryRangeState } from "@/lib/telemetry";
+import { telemetryParams } from "@/lib/telemetry";
 
 export class AuthError extends Error {
   constructor(message = "session expired") {
@@ -470,6 +482,142 @@ export async function refreshUsageDashboard(
   });
   await ensureOk(response, "failed to refresh usage dashboard");
   return (await response.json()) as UsageDashboardResponse;
+}
+
+// ── Telemetry (CONTRACT.md §4 — /api/telemetry/*) ────────────────────────
+
+export async function fetchTelemetryOverview(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+): Promise<TelemetryOverview> {
+  const response = await fetch(
+    `${host}/api/telemetry/overview?${telemetryParams(range, filters).toString()}`,
+    { headers: { Authorization: `Bearer ${token}` }, cache: "no-store" },
+  );
+  await ensureOk(response, "failed to fetch telemetry overview");
+  return (await response.json()) as TelemetryOverview;
+}
+
+export async function fetchTelemetryTokens(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+  groupBy: TokenGroupBy,
+): Promise<TelemetryTokens> {
+  const params = telemetryParams(range, filters, { group_by: groupBy });
+  const response = await fetch(`${host}/api/telemetry/tokens?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  await ensureOk(response, "failed to fetch telemetry tokens");
+  return (await response.json()) as TelemetryTokens;
+}
+
+export async function fetchTelemetryActivity(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+): Promise<TelemetryActivity> {
+  const response = await fetch(
+    `${host}/api/telemetry/activity?${telemetryParams(range, filters).toString()}`,
+    { headers: { Authorization: `Bearer ${token}` }, cache: "no-store" },
+  );
+  await ensureOk(response, "failed to fetch telemetry activity");
+  return (await response.json()) as TelemetryActivity;
+}
+
+export async function fetchTelemetryHealth(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+): Promise<TelemetryHealth> {
+  const response = await fetch(
+    `${host}/api/telemetry/health?${telemetryParams(range, filters).toString()}`,
+    { headers: { Authorization: `Bearer ${token}` }, cache: "no-store" },
+  );
+  await ensureOk(response, "failed to fetch telemetry health");
+  return (await response.json()) as TelemetryHealth;
+}
+
+export async function fetchTelemetryDrilldown(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+  kind: TelemetryFactKind,
+  page: number,
+  pageSize: number,
+): Promise<TelemetryDrilldown> {
+  const params = telemetryParams(range, filters, {
+    kind,
+    page,
+    page_size: pageSize,
+  });
+  const response = await fetch(`${host}/api/telemetry/drilldown?${params.toString()}`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  await ensureOk(response, "failed to fetch telemetry drilldown");
+  return (await response.json()) as TelemetryDrilldown;
+}
+
+export async function fetchTelemetryInsights(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+): Promise<Insight[]> {
+  const response = await fetch(
+    `${host}/api/telemetry/insights?${telemetryParams(range, filters).toString()}`,
+    { headers: { Authorization: `Bearer ${token}` }, cache: "no-store" },
+  );
+  await ensureOk(response, "failed to fetch telemetry insights");
+  const payload = await response.json();
+  return (payload.insights ?? []) as Insight[];
+}
+
+export async function dismissTelemetryInsight(
+  host: string,
+  token: string,
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+  signature: string,
+): Promise<void> {
+  const params = telemetryParams(range, filters);
+  const response = await fetch(
+    `${host}/api/telemetry/insights/${encodeURIComponent(signature)}/dismiss?${params.toString()}`,
+    { method: "POST", headers: { Authorization: `Bearer ${token}` } },
+  );
+  await ensureOk(response, "failed to dismiss insight");
+}
+
+export async function fetchTelemetrySettings(
+  host: string,
+  token: string,
+): Promise<TelemetrySettingsResponse> {
+  const response = await fetch(`${host}/api/telemetry/settings`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  await ensureOk(response, "failed to fetch telemetry settings");
+  return (await response.json()) as TelemetrySettingsResponse;
+}
+
+export async function deleteTelemetry(
+  host: string,
+  token: string,
+): Promise<TelemetryDeleteResponse> {
+  const response = await fetch(`${host}/api/telemetry`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  await ensureOk(response, "failed to delete telemetry");
+  return (await response.json()) as TelemetryDeleteResponse;
 }
 
 export async function setSessionPermissionMode(

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -304,3 +304,17 @@ export function formatRangeLabel(range: TelemetryRange): string {
     : inclusiveEnd.toLocaleDateString(undefined, fmt);
   return `${startLabel} – ${endLabel} (${range.tz})`;
 }
+
+// A session id is `<backend>-<8 hex>` (e.g. `claude_code-196bdf37`) — the
+// distinguishing part is the *suffix*, so a plain `.slice(0, N)` truncation
+// collapses every row from the same backend to an identical prefix. Show the
+// full id when it already fits; otherwise keep both ends so the id stays
+// distinguishable at a glance.
+const SHORT_ID_MAX = 24;
+const SHORT_ID_HEAD = 12;
+const SHORT_ID_TAIL = 8;
+
+export function shortId(id: string): string {
+  if (id.length <= SHORT_ID_MAX) return id;
+  return `${id.slice(0, SHORT_ID_HEAD)}…${id.slice(-SHORT_ID_TAIL)}`;
+}

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -268,6 +268,53 @@ export function orderedTokenCategories(totals: Record<string, number>): string[]
   return [...known, ...rest];
 }
 
+// The two spend tiers the Tokens card and legend group by: fresh work the
+// model actually did this range vs. cheap prior context re-sent to it. Keeping
+// `cache_read` in its own tier is what stops it visually drowning the rest.
+export const TOKEN_TIER_NEW_WORK: readonly UnifiedTokenCategory[] = [
+  "fresh_input",
+  "output",
+  "reasoning",
+  "cache_write",
+];
+export const TOKEN_TIER_REREAD: readonly UnifiedTokenCategory[] = ["cache_read"];
+
+// Stacking/legend order: the four new-work buckets first (most→least
+// characteristic), then the muted re-read band last so it reads as the
+// backdrop the vivid work sits against.
+export const TOKEN_DISPLAY_ORDER: readonly UnifiedTokenCategory[] = [
+  ...TOKEN_TIER_NEW_WORK,
+  ...TOKEN_TIER_REREAD,
+];
+
+const TOKEN_CATEGORY_COLORS: Record<UnifiedTokenCategory, string> = {
+  fresh_input: "var(--tm-series-1)",
+  output: "var(--tm-series-2)",
+  reasoning: "var(--tm-series-3)",
+  cache_write: "var(--tm-series-5)",
+  cache_read: "var(--tm-token-reread)",
+};
+
+export function tokenCategoryColor(category: string): string {
+  return TOKEN_CATEGORY_COLORS[category as UnifiedTokenCategory] ?? "var(--tm-series-6)";
+}
+
+export interface TokenTierSplit {
+  newWork: number;
+  reread: number;
+  total: number;
+}
+
+function tierSum(totals: Record<string, number>, keys: readonly string[]): number {
+  return keys.reduce((sum, key) => sum + (totals[key] ?? 0), 0);
+}
+
+export function splitTokenTiers(totals: Record<string, number>): TokenTierSplit {
+  const newWork = tierSum(totals, TOKEN_TIER_NEW_WORK);
+  const reread = tierSum(totals, TOKEN_TIER_REREAD);
+  return { newWork, reread, total: newWork + reread };
+}
+
 // Python's `datetime.weekday()` (Monday=0…Sunday=6) — matches
 // `telemetry/aggregate.py`'s heatmap bucketing exactly.
 export const DOW_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,6 +1,11 @@
 "use client";
 
 import {
+  UNIFIED_TOKEN_CATEGORIES,
+  UNIFIED_TOKEN_LABELS,
+  UnifiedTokenCategory,
+} from "@/lib/tokens";
+import {
   InsightSeverity,
   LifecycleTransition,
   TelemetryFactKind,
@@ -241,16 +246,14 @@ export function coverageLabel(coverage: TokenCoverage): string {
 
 // Category keys a token totals map may carry — order here is the fixed
 // stacking/legend order (never resorted by value; see the telemetry CSS
-// section's `--tm-series-*` categorical slots).
-export const TOKEN_CATEGORY_ORDER = [
-  "input",
-  "output",
-  "cache_read",
-  "cache_write",
-  "reasoning",
-] as const;
+// section's `--tm-series-*` categorical slots). Mirrors the backend's 5
+// unified buckets (`telemetry/tokens.py`) that every aggregate response's
+// `totals` now carries.
+export const TOKEN_CATEGORY_ORDER = UNIFIED_TOKEN_CATEGORIES;
 
 export function tokenCategoryLabel(category: string): string {
+  const known = UNIFIED_TOKEN_LABELS[category as UnifiedTokenCategory];
+  if (known) return known;
   return category
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,0 +1,306 @@
+"use client";
+
+import {
+  InsightSeverity,
+  LifecycleTransition,
+  TelemetryFactKind,
+  TelemetryParentScope,
+  TelemetryRange,
+  TokenCoverage,
+  TokenGroupBy,
+  TurnKind,
+} from "@/lib/types";
+import { UsageTone } from "@/lib/usage";
+
+// ── Range + filter state ─────────────────────────────────────────────────
+//
+// Mirrors the shared query params every `/api/telemetry/*` endpoint reads
+// (CONTRACT.md §4 / backend/src/waypoint/telemetry/query.py). The frontend
+// never resolves the range itself — it sends a preset (or a custom
+// start/end) and always renders the `range`/`filters_echo` a response
+// echoes back, never its own guess.
+
+export type TelemetryRangePreset = "today" | "7d" | "30d" | "custom";
+
+export interface TelemetryRangeState {
+  preset: TelemetryRangePreset;
+  // Bare YYYY-MM-DD strings (host-tz calendar days per query.py's
+  // `_parse_instant`); only read when preset === "custom".
+  start: string;
+  end: string;
+}
+
+export interface TelemetryFiltersState {
+  backends: string[];
+  models: string[];
+  repos: string[];
+  // `key:value` terms (backend/src/waypoint/telemetry/store.py `_parse_tag_term`).
+  tags: string[];
+  sources: string[];
+  transports: string[];
+  parentScope: TelemetryParentScope;
+  parentSessionId: string;
+  includeDescendants: boolean;
+}
+
+export const RANGE_PRESET_OPTIONS: { value: TelemetryRangePreset; label: string }[] = [
+  { value: "today", label: "Today" },
+  { value: "7d", label: "7 days" },
+  { value: "30d", label: "30 days" },
+  { value: "custom", label: "Custom" },
+];
+
+export const DEFAULT_RANGE: TelemetryRangeState = { preset: "7d", start: "", end: "" };
+
+export const DEFAULT_FILTERS: TelemetryFiltersState = {
+  backends: [],
+  models: [],
+  repos: [],
+  tags: [],
+  sources: [],
+  transports: [],
+  parentScope: "all",
+  parentSessionId: "",
+  includeDescendants: true,
+};
+
+export function hasActiveFilters(filters: TelemetryFiltersState): boolean {
+  return (
+    filters.backends.length > 0 ||
+    filters.models.length > 0 ||
+    filters.repos.length > 0 ||
+    filters.tags.length > 0 ||
+    filters.sources.length > 0 ||
+    filters.transports.length > 0 ||
+    filters.parentScope !== "all" ||
+    Boolean(filters.parentSessionId.trim())
+  );
+}
+
+// Builds the shared range+filter query params every endpoint reads. `extra`
+// layers endpoint-specific params (group_by, kind, page, ...) on the same base.
+export function telemetryParams(
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+  extra?: Record<string, string | number | boolean | undefined | null>,
+): URLSearchParams {
+  const params = new URLSearchParams();
+  if (range.preset === "custom") {
+    params.set("preset", "custom");
+    if (range.start) params.set("start", range.start);
+    if (range.end) params.set("end", range.end);
+  } else {
+    params.set("preset", range.preset);
+  }
+  for (const backend of filters.backends) params.append("backend", backend);
+  for (const model of filters.models) params.append("model", model);
+  for (const repo of filters.repos) params.append("repo", repo);
+  for (const tag of filters.tags) params.append("tag", tag);
+  for (const source of filters.sources) params.append("source", source);
+  for (const transport of filters.transports) params.append("transport", transport);
+  if (filters.parentScope !== "all") params.set("scope", filters.parentScope);
+  const parentSessionId = filters.parentSessionId.trim();
+  if (parentSessionId) params.set("parent", parentSessionId);
+  if (!filters.includeDescendants) params.set("descendants", "false");
+  if (extra) {
+    for (const [key, value] of Object.entries(extra)) {
+      if (value === undefined || value === null) continue;
+      params.set(key, String(value));
+    }
+  }
+  return params;
+}
+
+// ── Persistence (mirrors lib/store.ts conventions) ───────────────────────
+
+const QUERY_KEY = "waypoint.telemetry-query";
+
+interface StoredTelemetryQuery {
+  range: TelemetryRangeState;
+  filters: TelemetryFiltersState;
+}
+
+export function readTelemetryQuery(): { range: TelemetryRangeState; filters: TelemetryFiltersState } {
+  if (typeof window === "undefined") {
+    return { range: DEFAULT_RANGE, filters: DEFAULT_FILTERS };
+  }
+  const raw = window.localStorage.getItem(QUERY_KEY);
+  if (!raw) {
+    return { range: DEFAULT_RANGE, filters: DEFAULT_FILTERS };
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredTelemetryQuery>;
+    return {
+      range: { ...DEFAULT_RANGE, ...parsed.range },
+      filters: { ...DEFAULT_FILTERS, ...parsed.filters },
+    };
+  } catch {
+    return { range: DEFAULT_RANGE, filters: DEFAULT_FILTERS };
+  }
+}
+
+export function writeTelemetryQuery(
+  range: TelemetryRangeState,
+  filters: TelemetryFiltersState,
+): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(QUERY_KEY, JSON.stringify({ range, filters }));
+}
+
+// ── Labels & tones ────────────────────────────────────────────────────────
+
+export const SESSION_SOURCE_OPTIONS: { value: string; label: string }[] = [
+  { value: "managed", label: "Managed" },
+  { value: "attached_tmux", label: "Attached tmux" },
+  { value: "assistant", label: "Assistant" },
+];
+
+export const DRILLDOWN_KIND_OPTIONS: { value: TelemetryFactKind; label: string }[] = [
+  { value: "session_lifecycle", label: "Session lifecycle" },
+  { value: "turn", label: "Turns" },
+  { value: "tool_call", label: "Tool calls" },
+  { value: "context_snapshot", label: "Context snapshots" },
+  { value: "limit_snapshot", label: "Limit snapshots" },
+];
+
+export const TOKEN_GROUP_BY_OPTIONS: { value: TokenGroupBy; label: string }[] = [
+  { value: "time", label: "Over time" },
+  { value: "backend", label: "By backend" },
+  { value: "model", label: "By model" },
+  { value: "repo", label: "By repo" },
+  { value: "session", label: "By session" },
+];
+
+const TRANSITION_LABELS: Record<string, string> = {
+  created: "Created",
+  starting: "Starting",
+  running: "Running",
+  idle: "Idle",
+  waiting: "Waiting on input",
+  interrupted: "Interrupted",
+  exited: "Exited",
+  error: "Errored",
+};
+
+export function transitionLabel(transition: LifecycleTransition | string): string {
+  return TRANSITION_LABELS[transition] ?? transition;
+}
+
+export function turnKindLabel(kind: TurnKind | string): string {
+  return kind === "agent" ? "Agent turn" : kind === "user" ? "User turn" : kind;
+}
+
+export function factKindLabel(kind: TelemetryFactKind | string): string {
+  return DRILLDOWN_KIND_OPTIONS.find((option) => option.value === kind)?.label ?? kind;
+}
+
+export type ToneWithNeutral = UsageTone | "neutral";
+
+const TOOL_OUTCOME_LABELS: Record<string, string> = {
+  succeeded: "Succeeded",
+  failed: "Failed",
+  cancelled: "Cancelled",
+  timed_out: "Timed out",
+  unknown: "Unknown",
+};
+
+export function toolOutcomeLabel(outcome: string | null | undefined): string {
+  if (!outcome) return "Unknown";
+  return TOOL_OUTCOME_LABELS[outcome] ?? outcome;
+}
+
+export function toolOutcomeTone(outcome: string | null | undefined): ToneWithNeutral {
+  switch (outcome) {
+    case "succeeded":
+      return "good";
+    case "failed":
+    case "timed_out":
+      return "danger";
+    case "cancelled":
+      return "warn";
+    default:
+      return "neutral";
+  }
+}
+
+export function insightSeverityTone(severity: InsightSeverity): UsageTone {
+  if (severity === "critical") return "danger";
+  if (severity === "warning") return "warn";
+  return "good";
+}
+
+const COVERAGE_LABELS: Record<TokenCoverage, string> = {
+  entire: "Full history",
+  tracked_since: "Tracked since backfill",
+  partial: "Partial — some sessions untracked",
+};
+
+export function coverageLabel(coverage: TokenCoverage): string {
+  return COVERAGE_LABELS[coverage] ?? coverage;
+}
+
+// Category keys a token totals map may carry — order here is the fixed
+// stacking/legend order (never resorted by value; see the telemetry CSS
+// section's `--tm-series-*` categorical slots).
+export const TOKEN_CATEGORY_ORDER = [
+  "input",
+  "output",
+  "cache_read",
+  "cache_write",
+  "reasoning",
+] as const;
+
+export function tokenCategoryLabel(category: string): string {
+  return category
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function orderedTokenCategories(totals: Record<string, number>): string[] {
+  const known = TOKEN_CATEGORY_ORDER.filter((key) => key in totals);
+  const rest = Object.keys(totals)
+    .filter((key) => !TOKEN_CATEGORY_ORDER.includes(key as (typeof TOKEN_CATEGORY_ORDER)[number]))
+    .sort();
+  return [...known, ...rest];
+}
+
+// Python's `datetime.weekday()` (Monday=0…Sunday=6) — matches
+// `telemetry/aggregate.py`'s heatmap bucketing exactly.
+export const DOW_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export function formatDayLabel(day: string): string {
+  const parsed = new Date(`${day}T00:00:00`);
+  if (Number.isNaN(parsed.getTime())) return day;
+  return parsed.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+export function formatHourLabel(hour: number): string {
+  if (hour === 0) return "12a";
+  if (hour === 12) return "12p";
+  return hour < 12 ? `${hour}a` : `${hour - 12}p`;
+}
+
+const COMPACT_NUMBER_FORMATTER = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+export function formatCompactNumber(value: number): string {
+  return COMPACT_NUMBER_FORMATTER.format(value);
+}
+
+// The effective range a response echoed back (CONTRACT.md §4) — always
+// rendered instead of the client's own guess at what it asked for.
+export function formatRangeLabel(range: TelemetryRange): string {
+  const start = new Date(range.start);
+  const end = new Date(range.end);
+  const fmt: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
+  const startLabel = Number.isNaN(start.getTime()) ? range.start : start.toLocaleDateString(undefined, fmt);
+  // `end` is exclusive; show the inclusive last day for a human-readable range.
+  const inclusiveEnd = Number.isNaN(end.getTime()) ? end : new Date(end.getTime() - 1000);
+  const endLabel = Number.isNaN(end.getTime())
+    ? range.end
+    : inclusiveEnd.toLocaleDateString(undefined, fmt);
+  return `${startLabel} – ${endLabel} (${range.tz})`;
+}

--- a/frontend/src/lib/tokens.ts
+++ b/frontend/src/lib/tokens.ts
@@ -1,0 +1,69 @@
+// Mirrors backend/src/waypoint/telemetry/tokens.py — keep in sync.
+//
+// Every backend's ledger totals use a different, overlapping native
+// vocabulary; summing them verbatim double-counts Codex/OpenCode (their
+// input/output totals already include cached/reasoning tokens). `unifyTokens`
+// folds a backend's raw totals onto 5 disjoint buckets via a deterministic,
+// source-keyed subset subtraction so they can always be summed safely.
+
+export const UNIFIED_TOKEN_CATEGORIES = [
+  "fresh_input",
+  "cache_read",
+  "cache_write",
+  "output",
+  "reasoning",
+] as const;
+
+export type UnifiedTokenCategory = (typeof UNIFIED_TOKEN_CATEGORIES)[number];
+
+export const UNIFIED_TOKEN_LABELS: Record<UnifiedTokenCategory, string> = {
+  fresh_input: "Fresh input",
+  cache_read: "Cached input (read)",
+  cache_write: "Cache write",
+  output: "Output",
+  reasoning: "Reasoning",
+};
+
+function amount(totals: Record<string, number>, key: string): number {
+  const value = totals[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+export function unifyTokens(
+  source: string,
+  rawTotals: Record<string, number>,
+): Record<UnifiedTokenCategory, number> {
+  if (source === "codex") {
+    const input = amount(rawTotals, "input_tokens");
+    const cachedInput = amount(rawTotals, "cached_input_tokens");
+    const output = amount(rawTotals, "output_tokens");
+    const reasoningOutput = amount(rawTotals, "reasoning_output_tokens");
+    return {
+      fresh_input: input - cachedInput,
+      cache_read: cachedInput,
+      cache_write: 0,
+      output: output - reasoningOutput,
+      reasoning: reasoningOutput,
+    };
+  }
+  if (source === "opencode") {
+    const output = amount(rawTotals, "output_tokens");
+    const reasoning = amount(rawTotals, "reasoning_tokens");
+    return {
+      fresh_input: amount(rawTotals, "input_tokens"),
+      cache_read: amount(rawTotals, "cache_read_tokens"),
+      cache_write: amount(rawTotals, "cache_write_tokens"),
+      output: output - reasoning,
+      reasoning,
+    };
+  }
+  // claude_code, and any unrecognized source: treated as already-disjoint
+  // native categories (the conservative default — never a guess at overlap).
+  return {
+    fresh_input: amount(rawTotals, "input_tokens"),
+    cache_read: amount(rawTotals, "cache_read_tokens"),
+    cache_write: amount(rawTotals, "cache_creation_tokens"),
+    output: amount(rawTotals, "output_tokens"),
+    reasoning: 0,
+  };
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -808,6 +808,9 @@ export interface ContextSnapshotView {
 export interface LimitSnapshotView {
   backend: string;
   account_key: string;
+  // Only populated when the server's `telemetry_local_labels` setting is on
+  // (default off); `account_key` is always a pseudonym, never a raw email/org.
+  account_label: string | null;
   window_id: string;
   label: string | null;
   used_percent: number;
@@ -894,6 +897,8 @@ export interface LimitSeriesPoint {
 export interface LimitSeries {
   backend: string;
   account_key: string;
+  // See `LimitSnapshotView.account_label` — same local-labels gate.
+  account_label: string | null;
   window_id: string;
   label: string | null;
   points: LimitSeriesPoint[];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -610,7 +610,8 @@ export interface SessionEnvelope {
     | "board_update"
     | "clipboard_copy"
     | "side_question"
-    | "inbox_update";
+    | "inbox_update"
+    | "telemetry_update";
   payload: Record<string, unknown>;
 }
 
@@ -717,4 +718,279 @@ export interface InboxItem {
   created_at: string;
   updated_at: string;
   blocks: InboxBlock[];
+}
+
+// ── Telemetry (mirrors backend/src/waypoint/telemetry/{facts,api_models}.py —
+// CONTRACT.md §4). Every response echoes the range/filters it was resolved
+// against, so the client renders the server's interpretation, never its own.
+
+export type TelemetryFactKind =
+  | "session_lifecycle"
+  | "turn"
+  | "tool_call"
+  | "context_snapshot"
+  | "limit_snapshot";
+
+export type LifecycleTransition =
+  | "created"
+  | "starting"
+  | "running"
+  | "idle"
+  | "waiting"
+  | "interrupted"
+  | "exited"
+  | "error";
+
+export type TurnKind = "user" | "agent";
+
+export type ToolOutcome =
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "unknown";
+
+export type TelemetryParentScope = "all" | "top_level" | "children";
+
+export interface TelemetryRange {
+  start: string;
+  end: string;
+  tz: string;
+}
+
+export interface TelemetryFilter {
+  backends: string[];
+  models: string[];
+  repos: string[];
+  tags: string[];
+  sources: string[];
+  transports: string[];
+  parent_scope: TelemetryParentScope;
+  parent_session_id: string | null;
+  include_descendants: boolean;
+}
+
+export type TokenCoverage = "entire" | "tracked_since" | "partial";
+export type TokenGroupBy = "time" | "backend" | "model" | "repo" | "session";
+export type InsightType = "near_limit" | "context_pressure" | "token_volume_change";
+export type InsightSeverity = "info" | "warning" | "critical";
+
+export interface TokenTotals {
+  totals: Record<string, number>;
+  display_total: number | null;
+  safe_total: boolean;
+  coverage: TokenCoverage;
+  meter_coverage_percent: number | null;
+}
+
+export interface SessionCounts {
+  created: number;
+  exited: number;
+  interrupted: number;
+  error: number;
+  active_now: number;
+}
+
+export interface TurnCounts {
+  user: number;
+  agent: number;
+}
+
+export interface ContextSnapshotView {
+  session_id: string;
+  used: number;
+  window: number | null;
+  percent: number | null;
+  stale: boolean;
+  updated_at: string;
+}
+
+export interface LimitSnapshotView {
+  backend: string;
+  account_key: string;
+  window_id: string;
+  label: string | null;
+  used_percent: number;
+  resets_at: string | null;
+  stale: boolean;
+  updated_at: string;
+}
+
+export interface TelemetryAlerts {
+  context: ContextSnapshotView[];
+  limits: LimitSnapshotView[];
+}
+
+export interface TelemetryOverview {
+  range: TelemetryRange;
+  filters_echo: TelemetryFilter;
+  tokens: TokenTotals;
+  sessions: SessionCounts;
+  turns: TurnCounts;
+  tool_calls: number;
+  alerts: TelemetryAlerts;
+  limit_card_hidden: boolean;
+  limit_card_hidden_reason: string | null;
+}
+
+export interface TokenSeriesPoint {
+  bucket_start: string;
+  totals: Record<string, number>;
+  display_total: number | null;
+}
+
+export interface TokenGroup {
+  key: string;
+  label: string;
+  totals: Record<string, number>;
+  display_total: number | null;
+  coverage: TokenCoverage;
+}
+
+export interface TelemetryTokens {
+  range: TelemetryRange;
+  filters_echo: TelemetryFilter;
+  series: TokenSeriesPoint[];
+  group_by: TokenGroupBy;
+  groups: TokenGroup[];
+}
+
+export interface ActivityDaily {
+  day: string;
+  user_turns: number;
+  agent_turns: number;
+  tool_calls: number;
+  sessions_created: number;
+}
+
+export interface ActivityHeatmapCell {
+  dow: number;
+  hour: number;
+  count: number;
+}
+
+export interface TelemetryActivity {
+  range: TelemetryRange;
+  filters_echo: TelemetryFilter;
+  daily: ActivityDaily[];
+  heatmap: ActivityHeatmapCell[];
+}
+
+export interface ContextSeriesPoint {
+  bucket_start: string;
+  peak_percent: number | null;
+}
+
+export interface TelemetryHealthContext {
+  current: ContextSnapshotView[];
+  series: ContextSeriesPoint[];
+}
+
+export interface LimitSeriesPoint {
+  bucket_start: string;
+  used_percent: number | null;
+}
+
+export interface LimitSeries {
+  backend: string;
+  account_key: string;
+  window_id: string;
+  label: string | null;
+  points: LimitSeriesPoint[];
+}
+
+export interface TelemetryHealthLimits {
+  current: LimitSnapshotView[];
+  series: LimitSeries[];
+  hidden: boolean;
+  hidden_reason: string | null;
+}
+
+export interface TelemetryHealth {
+  range: TelemetryRange;
+  filters_echo: TelemetryFilter;
+  context: TelemetryHealthContext;
+  limits: TelemetryHealthLimits;
+}
+
+export interface DrilldownItem {
+  session_id: string;
+  kind: TelemetryFactKind;
+  fact_id: string;
+  occurred_at: string;
+  label: string;
+  backend?: string | null;
+  model?: string | null;
+  repo_name?: string | null;
+  transition?: string | null;
+  turn_kind?: string | null;
+  tool_name?: string | null;
+  tool_category?: string | null;
+  outcome?: string | null;
+  duration_ms?: number | null;
+  used_tokens?: number | null;
+  window_tokens?: number | null;
+  occupancy_percent?: number | null;
+  account_key?: string | null;
+  window_id?: string | null;
+  used_percent?: number | null;
+}
+
+export interface TelemetryDrilldown {
+  range: TelemetryRange;
+  filters_echo: TelemetryFilter;
+  items: DrilldownItem[];
+  page: number;
+  page_size: number;
+  total: number;
+}
+
+export interface InsightClickThrough {
+  endpoint: string;
+  params: Record<string, unknown>;
+}
+
+export interface Insight {
+  signature: string;
+  type: InsightType;
+  statement: string;
+  metrics: Record<string, unknown>;
+  range: TelemetryRange;
+  filters: TelemetryFilter;
+  click_through: InsightClickThrough;
+  severity: InsightSeverity;
+}
+
+export interface TelemetryInsightsResponse {
+  insights: Insight[];
+}
+
+export interface InsightDismissResponse {
+  signature: string;
+  dismissed: boolean;
+}
+
+export interface TelemetryCoverageInfo {
+  backfill_done: boolean;
+  backfill_through: string | null;
+}
+
+export interface TelemetrySettingsResponse {
+  retention_days_facts: number;
+  retention_months_rollups: number;
+  coverage: TelemetryCoverageInfo;
+  privacy_statement: string;
+  external_export: boolean;
+  content_capture: boolean;
+  nl_enabled: boolean;
+}
+
+export interface TelemetryDeleteCounts {
+  facts: number;
+  rollups: number;
+}
+
+export interface TelemetryDeleteResponse {
+  removed: TelemetryDeleteCounts;
+  transcripts_unaffected: boolean;
 }


### PR DESCRIPTION
## Purpose

Add a first-party, local-first Telemetry page that turns Waypoint's existing session/event/usage signals into a queryable history of AI coding usage and operational risk. A user can pick a time range and filters (backend, resolved model, repository, tag, source, transport, top-level vs. child) and read token consumption, session lifecycle, user/agent turns and tool calls, context pressure, and provider limits — then drill from any aggregate into the source facts. Everything is aggregate-only and stays on the host; no raw prompts, outputs, tool arguments, or paths are captured.

This is the deterministic-dashboard slice (PR1). The optional natural-language insight summarizer is a separate stacked PR, and the model/backend comparison (FR-4), tool/approval health (FR-5), and multi-agent hierarchy (FR-7) views are tracked as a follow-up. Relates to the AI Usage Telemetry Dashboard PRD.

## Changes

### Backend
- `telemetry/facts.py`, `telemetry/store.py` — a versioned, backend-neutral telemetry fact contract (lifecycle, turn, tool-call, context-snapshot, limit-snapshot) with denormalized session dimensions, plus a SQLite store: one indexed `telemetry_facts` table, a normalized tag side-table, recompute-on-write daily rollups (so delta and full-rebuild are one code path), 90-day fact / 13-month rollup retention, an idempotent revision-aware upsert, and a session delete-cascade. Adds the missing `sessions(status)`/`sessions(last_event_at)` indexes.
- `telemetry/ingest.py` — a generic `TelemetryIngester` that derives facts from already-normalized `EventRecord`s, session-field updates, and per-turn token records with no backend branch; enqueue-and-drain keeps derivation off the turn hot path, and a one-shot, guarded backfill seeds facts from existing history so the dashboard is populated immediately.
- `runtime.py` — construct and wire the ingester into the event, session-update, and token-ledger seams; own its drain, boot backfill, periodic retention prune, and a debounced `telemetry_update` WebSocket broadcast as runtime background tasks (gated on `telemetry_enabled`).
- `telemetry/aggregate.py`, `telemetry/query.py`, `telemetry/api_models.py`, `telemetry/insights.py`, `api.py` — the range/filter parser, response DTOs, the read-side shaper, and the `/api/telemetry/*` endpoints (overview, tokens, activity, health, drilldown, insights + dismiss, settings, delete). Two deterministic, evidence-linked insights (near-limit/context pressure, token-volume change) with the PRD's exact evidence gates. Token totals honor the provider-safe-total rule; lifecycle counts are transitions in range while "active now" is the latest status at the range end; provider limits stay account-scoped and hide under session-scoping filters.
- token ledger — thread the concrete resolved model/effort at each turn into the Claude/Codex/OpenCode record builders (and Claude transcript replay) so model comparison uses the actual model at turn time, not the session's latest setting.
- `settings.py`, `cli.py`, `client.py` — telemetry settings + env overrides, and a `waypoint telemetry` CLI command.

### Frontend
- `app/telemetry/page.tsx`, `components/telemetry/*`, `lib/telemetry.ts` — the Telemetry page: range presets + custom range, the full filter set, overview cards, hand-built inline-SVG charts (token time-series, session-activity trend, day/hour heatmap, context/limit health), paginated drilldown, insight cards, and a privacy/coverage/retention/delete settings panel, reusing the existing flat-instrument design tokens and `UsageDial`/`UsageBar` primitives. Adds a home-page entry link.
- `lib/api.ts`, `lib/types.ts` — telemetry fetch helpers and DTO types mirroring the backend contract.

## Design

The dashboard reads a common, versioned fact contract; generic runtime/storage/API/frontend code never branches on backend id, and the only backend-specific work is at each agent's normalization boundary (model-at-turn on the token ledger; reusing Claude's `is_error` for tool outcome). Ingestion enqueues on the turn path and drains in yielding batches so it never holds the single SQLite writer long, and telemetry failures are swallowed so they can never block a session. Rollups are recomputed per affected key on write, which makes the incremental and full-rebuild paths identical by construction. "Current" context occupancy is scoped to sessions that are still active (an exited session holds no live window), and provider limits require a verified account rather than minting a per-session pseudo-account, so the health surface stays bounded and honest. Facts carry only counts, ids, normalized tool names, model ids, timestamps, and occupancy/limit percentages — never raw text or paths.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- E2E: deployed the branch with `waypointctl restart` (which ran the additive migration + backfill over the live instance's history), verified `/api/telemetry/overview` and `/drilldown` return correctly-shaped, populated data, and drove the deployed `/telemetry` page with Playwright at mobile (390px) and desktop widths in both light and dark themes.

## Test Result

- Pre-commit: clean (isort, black, ruff, codespell, mypy).
- Backend suite: 1974 passed, 3 pre-existing/unrelated warnings.
- Frontend lint and production build: passed.
- E2E: the page rendered with real backfilled data (608.8M tracked tokens with a safe grand total and 100% meter coverage; 7 active sessions; lifecycle, turn, and tool-call counts; a firing critical near-limit insight linking to its evidence; correctly-named tool calls in the drilldown), with zero console errors; the context-health and provider-limit panels were bounded to active sessions / verified accounts; both themes and both viewport widths were usable.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title and described migration steps above.
- [x] I have updated documentation or config examples if user-facing behavior changed.

</details>