### PR TITLE
fix: harden the AI usage telemetry dashboard against review findings

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -385,6 +385,7 @@ class SessionRuntime:
         # re-enqueueing on every subsequent event).
         self._telemetry_created_seen: set[str] = set()
         self._telemetry_maintenance_task: asyncio.Task[None] | None = None
+        self._telemetry_backfill_task: asyncio.Task[None] | None = None
         # Id of the personal-assistant singleton, populated by
         # ``_ensure_assistant_session`` during ``start``. ``None`` when the
         # assistant is disabled or its bootstrap failed.
@@ -424,7 +425,7 @@ class SessionRuntime:
             await self.telemetry_ingester.start()
             # Backfill and pruning run off the boot path so a large history
             # never delays startup or blocks a turn.
-            asyncio.create_task(
+            self._telemetry_backfill_task = asyncio.create_task(
                 self._run_telemetry_backfill(), name="telemetry-backfill"
             )
             self._telemetry_maintenance_task = asyncio.create_task(
@@ -478,6 +479,11 @@ class SessionRuntime:
 
     async def stop(self) -> None:
         await self.scheduler.stop()
+        if self._telemetry_backfill_task is not None:
+            self._telemetry_backfill_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._telemetry_backfill_task
+            self._telemetry_backfill_task = None
         if self._telemetry_maintenance_task is not None:
             self._telemetry_maintenance_task.cancel()
             with suppress(asyncio.CancelledError):

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -160,7 +160,7 @@ def ledger_rows_for_sessions(
 
 def fold_tokens(
     rows: list[dict[str, Any]], ledger: dict[tuple[str, str, str], dict[str, Any]]
-) -> tuple[dict[str, int], int | None, int, int]:
+) -> tuple[dict[str, int], int, int, int]:
     """Fold a set of AGENT ``TurnFact`` rows into ``(totals, display_total, tracked, total)``.
 
     Each tracked row's raw ledger totals are mapped through
@@ -191,14 +191,15 @@ def fold_tokens(
     return totals, display_total, tracked, len(rows)
 
 
-def grand_total(totals: dict[str, int], display_total: int | None) -> int:
+def grand_total(display_total: int) -> int:
     """A single comparable token quantity for insight gating (CONTRACT.md §4/§7).
 
-    ``display_total`` (``fold_tokens``'s new-work-only sum, ``cache_read``
-    excluded) is always the safe grand total now; the ``None`` branch is dead
-    but kept so ``TokenTotals.display_total``'s optional type still type-checks.
+    Identity today: ``display_total`` (``fold_tokens``'s new-work-only sum,
+    ``cache_read`` excluded) is always the safe grand total. Kept as a named
+    seam so insight gating has one place to change if the definition ever
+    diverges from ``display_total``.
     """
-    return display_total if display_total is not None else sum(totals.values())
+    return display_total
 
 
 def coverage_label(
@@ -469,8 +470,13 @@ def _count_active_sessions_historical(
     as_of_range = TelemetryRange(
         start=ALL_TIME_RANGE.start, end=at, tz=ALL_TIME_RANGE.tz
     )
+    # Lifecycle facts carry no ``model_at_turn`` (liveness isn't per-turn
+    # model-attributable), so active-now is deliberately model-filter-
+    # independent in both paths — the live path already ignores model. Keeping
+    # the model clause here would exclude every lifecycle row and always yield 0.
+    lifecycle_flt = flt.model_copy(update={"models": []})
     rows = storage.telemetry.query_facts(
-        TelemetryFactKind.SESSION_LIFECYCLE, as_of_range, flt
+        TelemetryFactKind.SESSION_LIFECYCLE, as_of_range, lifecycle_flt
     )
     latest: dict[str, dict[str, Any]] = {}
     for row in rows:

--- a/backend/src/waypoint/telemetry/api_models.py
+++ b/backend/src/waypoint/telemetry/api_models.py
@@ -24,11 +24,12 @@ InsightSeverity = Literal["info", "warning", "critical"]
 
 class TokenTotals(BaseModel):
     totals: dict[str, int] = Field(default_factory=dict)
-    # Only present when every contributing row supplied a safe, backend-declared
-    # display total (CONTRACT.md §4: categories must not otherwise be summed).
-    # New-work total only (fresh input + cache write + output + reasoning) —
-    # cache reads are excluded (same prior context re-sent every turn, not new
-    # work) and reported standalone via ``cached_read_tokens`` instead.
+    # New-work total (fresh input + cache write + output + reasoning) — cache
+    # reads are excluded (same prior context re-sent every turn, not new work)
+    # and reported standalone via ``cached_read_tokens`` instead. Always safe to
+    # sum: ``unify_tokens`` folds every backend onto disjoint buckets, so this
+    # is always populated (the ``int | None`` type is retained only for wire
+    # stability, never null in practice).
     display_total: int | None = None
     # Standalone cache-read total, already folded into ``totals["cache_read"]``
     # but broken out here so the UI can show it distinct from — never added to

--- a/backend/src/waypoint/telemetry/insights.py
+++ b/backend/src/waypoint/telemetry/insights.py
@@ -134,8 +134,8 @@ def _token_volume_change_insight(
         | {row["session_id"] for row in previous_rows},
     )
 
-    cur_totals, cur_display, cur_tracked, cur_total = fold_tokens(current_rows, ledger)
-    prev_totals, prev_display, prev_tracked, prev_total = fold_tokens(
+    _cur_totals, cur_display, cur_tracked, cur_total = fold_tokens(current_rows, ledger)
+    _prev_totals, prev_display, prev_tracked, prev_total = fold_tokens(
         previous_rows, ledger
     )
 
@@ -149,8 +149,8 @@ def _token_volume_change_insight(
     ):
         return None
 
-    current_total = grand_total(cur_totals, cur_display)
-    previous_total = grand_total(prev_totals, prev_display)
+    current_total = grand_total(cur_display)
+    previous_total = grand_total(prev_display)
     diff = current_total - previous_total
     if abs(diff) < _VOLUME_CHANGE_MIN_TOKENS:
         return None

--- a/backend/src/waypoint/telemetry/tokens.py
+++ b/backend/src/waypoint/telemetry/tokens.py
@@ -47,10 +47,10 @@ def unify_tokens(source: str, raw_totals: dict[str, int]) -> dict[str, int]:
         output_total = _amount(raw_totals, "output_tokens")
         reasoning_output = _amount(raw_totals, "reasoning_output_tokens")
         return {
-            "fresh_input": input_total - cached_input,
+            "fresh_input": max(0, input_total - cached_input),
             "cache_read": cached_input,
             "cache_write": 0,
-            "output": output_total - reasoning_output,
+            "output": max(0, output_total - reasoning_output),
             "reasoning": reasoning_output,
         }
     if source == "opencode":
@@ -60,7 +60,7 @@ def unify_tokens(source: str, raw_totals: dict[str, int]) -> dict[str, int]:
             "fresh_input": _amount(raw_totals, "input_tokens"),
             "cache_read": _amount(raw_totals, "cache_read_tokens"),
             "cache_write": _amount(raw_totals, "cache_write_tokens"),
-            "output": output_total - reasoning,
+            "output": max(0, output_total - reasoning),
             "reasoning": reasoning,
         }
     # claude_code, and any future/unrecognized source: treated as already

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -452,6 +452,43 @@ def test_build_overview_active_now_reconstructs_from_facts_for_historical_range(
     assert earlier_overview.sessions.active_now == 0
 
 
+def test_active_now_is_model_filter_independent_in_both_paths(
+    tmp_path: Path,
+) -> None:
+    # active-now is a liveness count; lifecycle facts carry no model, so a
+    # model filter must not change it — historically it used to zero the count
+    # (lifecycle rows never match a concrete model) while the live path ignored
+    # the filter, flipping the same query between a real count and 0.
+    storage = Storage(tmp_path / "db.sqlite")
+    now = datetime.now(UTC)
+    _make_session(storage, "live", status=SessionStatus.RUNNING)
+    _make_session(storage, "past", status=SessionStatus.EXITED)
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="past:running",
+            source="runtime",
+            session_id="past",
+            occurred_at=now - timedelta(days=10),
+            dims=_dims(),
+            transition=LifecycleTransition.RUNNING,
+        )
+    )
+
+    live_rng = _full_range()
+    historical_rng = TelemetryRange(
+        start=now - timedelta(days=11), end=now - timedelta(days=9), tz="UTC"
+    )
+    model_flt = TelemetryFilter(models=["claude-opus-4"])
+
+    assert aggregate.count_active_sessions(
+        storage, TelemetryFilter(), live_rng
+    ) == aggregate.count_active_sessions(storage, model_flt, live_rng)
+    assert aggregate.count_active_sessions(
+        storage, TelemetryFilter(), historical_rng
+    ) == aggregate.count_active_sessions(storage, model_flt, historical_rng)
+    assert aggregate.count_active_sessions(storage, model_flt, historical_rng) == 1
+
+
 def test_build_overview_empty_range_is_zero_not_error(tmp_path: Path) -> None:
     storage = Storage(tmp_path / "db.sqlite")
     _make_session(storage, "s1")

--- a/backend/tests/test_telemetry_tokens.py
+++ b/backend/tests/test_telemetry_tokens.py
@@ -87,3 +87,26 @@ def test_unify_tokens_missing_fields_default_to_zero() -> None:
 def test_unify_tokens_unknown_source_falls_back_to_disjoint_native() -> None:
     raw = {"input_tokens": 5, "output_tokens": 7}
     assert unify_tokens("some_future_backend", raw) == unify_tokens("claude_code", raw)
+
+
+def test_unify_tokens_clamps_negative_codex_subtractions() -> None:
+    # A malformed provider payload where the "cached"/"reasoning" subsets exceed
+    # their declared totals must never push a bucket negative and silently
+    # reduce every downstream sum.
+    raw = {
+        "input_tokens": 20,
+        "cached_input_tokens": 50,
+        "output_tokens": 10,
+        "reasoning_output_tokens": 40,
+    }
+    unified = unify_tokens("codex", raw)
+    assert unified["fresh_input"] == 0
+    assert unified["output"] == 0
+    assert all(amount >= 0 for amount in unified.values())
+
+
+def test_unify_tokens_clamps_negative_opencode_reasoning() -> None:
+    raw = {"input_tokens": 15, "output_tokens": 5, "reasoning_tokens": 30}
+    unified = unify_tokens("opencode", raw)
+    assert unified["output"] == 0
+    assert all(amount >= 0 for amount in unified.values())

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -126,8 +126,17 @@ export default function TelemetryPage() {
     setDrilldownPage(1);
   }, [range, filters]);
 
+  // Monotonic request ids guard each refresher against stale responses: a
+  // slower earlier fetch must not overwrite state from a newer one (a preset /
+  // filter change, or a telemetry_update firing mid-edit). Each call captures
+  // its id and only applies state + clears loading while it is still the latest.
+  const overviewReqRef = useRef(0);
+  const tokensReqRef = useRef(0);
+  const drilldownReqRef = useRef(0);
+
   const refreshOverviewGroup = useCallback(async () => {
     if (!host || !token) return;
+    const requestId = ++overviewReqRef.current;
     if (customRangeIncomplete) {
       setOverviewLoading(false);
       setActivityLoading(false);
@@ -146,6 +155,7 @@ export default function TelemetryPage() {
         fetchTelemetryHealth(host, token, range, filters),
         fetchTelemetryInsights(host, token, range, filters),
       ]);
+      if (requestId !== overviewReqRef.current) return;
       setOverview(overviewRes);
       setActivity(activityRes);
       setHealth(healthRes);
@@ -157,18 +167,22 @@ export default function TelemetryPage() {
         handleAuthFailure();
         return;
       }
+      if (requestId !== overviewReqRef.current) return;
       setState((current) => (current === "ready" ? current : "error"));
       setError(err instanceof Error ? err.message : "failed to load telemetry");
     } finally {
-      setOverviewLoading(false);
-      setActivityLoading(false);
-      setHealthLoading(false);
-      setInsightsLoading(false);
+      if (requestId === overviewReqRef.current) {
+        setOverviewLoading(false);
+        setActivityLoading(false);
+        setHealthLoading(false);
+        setInsightsLoading(false);
+      }
     }
   }, [host, token, range, filters, customRangeIncomplete, handleAuthFailure]);
 
   const refreshTokens = useCallback(async () => {
     if (!host || !token) return;
+    const requestId = ++tokensReqRef.current;
     if (customRangeIncomplete) {
       setTokensLoading(false);
       return;
@@ -176,20 +190,25 @@ export default function TelemetryPage() {
     setTokensLoading(true);
     try {
       const res = await fetchTelemetryTokens(host, token, range, filters, tokenGroupBy);
+      if (requestId !== tokensReqRef.current) return;
       setTokens(res);
     } catch (err) {
       if (isAuthError(err)) {
         handleAuthFailure();
         return;
       }
+      if (requestId !== tokensReqRef.current) return;
       setError(err instanceof Error ? err.message : "failed to load token usage");
     } finally {
-      setTokensLoading(false);
+      if (requestId === tokensReqRef.current) {
+        setTokensLoading(false);
+      }
     }
   }, [host, token, range, filters, tokenGroupBy, customRangeIncomplete, handleAuthFailure]);
 
   const refreshDrilldown = useCallback(async () => {
     if (!host || !token) return;
+    const requestId = ++drilldownReqRef.current;
     if (customRangeIncomplete) {
       setDrilldownLoading(false);
       return;
@@ -205,15 +224,19 @@ export default function TelemetryPage() {
         drilldownPage,
         DRILLDOWN_PAGE_SIZE,
       );
+      if (requestId !== drilldownReqRef.current) return;
       setDrilldown(res);
     } catch (err) {
       if (isAuthError(err)) {
         handleAuthFailure();
         return;
       }
+      if (requestId !== drilldownReqRef.current) return;
       setError(err instanceof Error ? err.message : "failed to load drilldown");
     } finally {
-      setDrilldownLoading(false);
+      if (requestId === drilldownReqRef.current) {
+        setDrilldownLoading(false);
+      }
     }
   }, [
     host,

--- a/frontend/src/components/telemetry/TokenChart.tsx
+++ b/frontend/src/components/telemetry/TokenChart.tsx
@@ -147,8 +147,10 @@ export function TokenChart({ tokens, loading, groupBy, onGroupByChange }: TokenC
   }
   if (!tokens) return null;
 
-  const hasData =
-    groupBy === "time" ? timeSeries.some((p) => Object.keys(p.totals).length > 0) : rankedGroups.length > 0;
+  // `categories` already keeps only keys with a positive amount, so an all-zero
+  // range (unify_tokens always emits all 5 keys, 0 where absent) yields an empty
+  // list and falls through to the empty state instead of a blank SVG.
+  const hasData = groupBy === "time" ? categories.length > 0 : rankedGroups.length > 0;
 
   const plotW = CHART_W - PAD_LEFT - PAD_RIGHT;
   const plotH = CHART_H - PAD_TOP - PAD_BOTTOM;


### PR DESCRIPTION
## Purpose

A fresh-eyes review of the merged AI usage telemetry dashboard (#288, evaluated against current `main` after #289) surfaced six real issues — three correctness bugs, two robustness/edge-case gaps, and one piece of dead code with a misleading contract comment. None corrupt stored data, but all are user-visible or latent hazards, so this PR fixes them. The review's headline-total finding was already resolved by #289's cache-read demotion and is left untouched; three lower-severity items (dropping the unused per-session rollup table, offloading wide aggregations off the event loop, and assorted minor edges) are deferred to a follow-up issue to keep this PR focused. Follows up on #288.

## Changes

### Backend
- `runtime.py` — retain the one-shot telemetry backfill task on the runtime (and cancel/await it in `stop()`) so it can no longer be garbage-collected before it sets `backfill_done` and rebuilds the rollups.
- `telemetry/tokens.py` — clamp the `unify_tokens` subtractions with `max(0, …)` so a malformed provider payload (`cached > input`, `reasoning > output`) can't drive a bucket negative and silently deflate every downstream total.
- `telemetry/aggregate.py` — make the active-now count model-filter-independent: lifecycle facts carry no `model_at_turn`, so a model filter previously zeroed the historical count while the live path ignored it entirely. Also drop the dead `grand_total` `None` branch, since `fold_tokens` always returns a real `display_total` now.
- `telemetry/api_models.py`, `telemetry/insights.py` — correct the now-inaccurate `TokenTotals.display_total` contract comment and simplify the `grand_total` signature/call sites.

### Frontend
- `app/telemetry/page.tsx` — add a monotonic request-id guard to the overview, tokens, and drilldown refreshers so a slower earlier fetch can no longer overwrite newer state when the preset/filters change (or a WS refresh fires mid-edit); a superseded response is discarded, so the range badge can't contradict the active filters.
- `components/telemetry/TokenChart.tsx` — tie the has-data check to the same positive amounts that populate the chart categories, so an all-zero range shows the empty state instead of a blank SVG.

## Test Plan

- `cd backend && uv run pytest`
- `cd backend && uv run pre-commit run` (isort, black, ruff, codespell, mypy) on the changed files
- `cd frontend && npm run lint && npm run build`
- E2E: redeployed the branch with `waypointctl restart`, drove the deployed `/telemetry` page with Playwright across mobile (390px) and desktop (1280px) in both themes, and cross-checked the backend fixes against the live API.

## Test Result

- Backend suite: 2037 passed (3 new tests), only pre-existing/unrelated warnings.
- Pre-commit: clean (isort, black, ruff, codespell, mypy).
- Frontend lint and production build: clean.
- E2E: `/telemetry` rendered on all viewport/theme combinations with zero console errors; the overview `display_total` reported new-work only (7.7M) with cached reads (697M) reported standalone, and `active_now` was identical with and without a model filter for both a live range (4 = 4) and a historical range (2 = 2) — confirming the consistency fix.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title and described migration steps above.
- [ ] If this is a user-facing change, I updated documentation or config examples.

</details>