### PR TITLE
fix: resolve deferred telemetry review items (dead rollups, loop offload, edges)

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1097,9 +1097,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         rng, flt = parse_range_filter(request, context.settings)
-        return telemetry_aggregate.build_overview(
-            context.storage, context.settings, rng, flt
-        ).model_dump(mode="json")
+        overview = await asyncio.to_thread(
+            telemetry_aggregate.build_overview,
+            context.storage,
+            context.settings,
+            rng,
+            flt,
+        )
+        return overview.model_dump(mode="json")
 
     @app.get("/api/telemetry/tokens")
     async def telemetry_tokens(
@@ -1108,9 +1113,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         group_by: Annotated[TokenGroupBy, Query()] = "time",
     ) -> Any:
         rng, flt = parse_range_filter(request, context.settings)
-        return telemetry_aggregate.build_tokens(
-            context.storage, rng, flt, group_by
-        ).model_dump(mode="json")
+        tokens = await asyncio.to_thread(
+            telemetry_aggregate.build_tokens, context.storage, rng, flt, group_by
+        )
+        return tokens.model_dump(mode="json")
 
     @app.get("/api/telemetry/activity")
     async def telemetry_activity(
@@ -1118,9 +1124,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         rng, flt = parse_range_filter(request, context.settings)
-        return telemetry_aggregate.build_activity(context.storage, rng, flt).model_dump(
-            mode="json"
+        activity = await asyncio.to_thread(
+            telemetry_aggregate.build_activity, context.storage, rng, flt
         )
+        return activity.model_dump(mode="json")
 
     @app.get("/api/telemetry/health")
     async def telemetry_health(
@@ -1128,9 +1135,14 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         rng, flt = parse_range_filter(request, context.settings)
-        return telemetry_aggregate.build_health(
-            context.storage, context.settings, rng, flt
-        ).model_dump(mode="json")
+        health = await asyncio.to_thread(
+            telemetry_aggregate.build_health,
+            context.storage,
+            context.settings,
+            rng,
+            flt,
+        )
+        return health.model_dump(mode="json")
 
     @app.get("/api/telemetry/drilldown")
     async def telemetry_drilldown(
@@ -1141,9 +1153,16 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         page_size: Annotated[int, Query(ge=1, le=200)] = 20,
     ) -> Any:
         rng, flt = parse_range_filter(request, context.settings)
-        return telemetry_aggregate.build_drilldown(
-            context.storage, rng, flt, kind, page, page_size
-        ).model_dump(mode="json")
+        drilldown = await asyncio.to_thread(
+            telemetry_aggregate.build_drilldown,
+            context.storage,
+            rng,
+            flt,
+            kind,
+            page,
+            page_size,
+        )
+        return drilldown.model_dump(mode="json")
 
     @app.get("/api/telemetry/insights")
     async def telemetry_insights_list(
@@ -1151,8 +1170,12 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
         rng, flt = parse_range_filter(request, context.settings)
-        insights = telemetry_insights.compute_insights(
-            context.storage, context.settings, rng, flt
+        insights = await asyncio.to_thread(
+            telemetry_insights.compute_insights,
+            context.storage,
+            context.settings,
+            rng,
+            flt,
         )
         return TelemetryInsightsResponse(insights=insights).model_dump(mode="json")
 
@@ -1180,7 +1203,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def telemetry_delete(
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        result = telemetry_aggregate.delete_all(context.storage)
+        result = await asyncio.to_thread(
+            telemetry_aggregate.delete_all, context.storage
+        )
         context.runtime.mark_telemetry_dirty()
         return result.model_dump(mode="json")
 

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -108,7 +108,11 @@ from waypoint.storage import Storage
 from waypoint.telemetry.facts import TelemetryFilter, TelemetryRange
 from waypoint.telemetry.ingest import TelemetryIngester
 from waypoint.telemetry.nl import NLInsight
-from waypoint.telemetry.query import host_tz_name, resolve_preset_range
+from waypoint.telemetry.query import (
+    host_tz_name,
+    resolve_preset_range,
+    subtract_calendar_months,
+)
 from waypoint.telemetry.summarizer import CodingAgentSummarizer, build_nl_request
 from waypoint.transports import TransportAdapter
 
@@ -398,7 +402,9 @@ class SessionRuntime:
         # snapshot's account via a plugin's ``rate_limit_account`` for
         # sessions with no verified-account probe (CC, profile-less Codex).
         self.telemetry_ingester: TelemetryIngester | None = (
-            TelemetryIngester(storage, self.registry)
+            TelemetryIngester(
+                storage, self.registry, on_persisted=self.mark_telemetry_dirty
+            )
             if settings.telemetry_enabled
             else None
         )
@@ -4038,7 +4044,6 @@ class SessionRuntime:
             "context_usage" in updates or "rate_limit_usage" in updates
         ):
             self.telemetry_ingester.derive_from_session_update(session, updates)
-            self.mark_telemetry_dirty()
         if publish:
             self._publish_session_state(session_id)
         return session
@@ -4111,7 +4116,6 @@ class SessionRuntime:
             return
         if self.telemetry_ingester is not None:
             self.telemetry_ingester.derive_from_token_record(session, record)
-            self.mark_telemetry_dirty()
         if publish:
             self._publish_session_state(session_id)
 
@@ -4178,7 +4182,6 @@ class SessionRuntime:
             self._telemetry_created_seen.add(session.id)
             ingester.derive_from_session_created(session)
         ingester.derive_from_event(session, event)
-        self.mark_telemetry_dirty()
 
     def _publish_session_state(self, session_id: str) -> None:
         # Streaming hot path: mark the session dirty and let the debounced
@@ -4259,8 +4262,8 @@ class SessionRuntime:
                 facts_before = now - timedelta(
                     days=self.settings.telemetry_retention_days
                 )
-                rollups_before = now - timedelta(
-                    days=self.settings.telemetry_rollup_retention_months * 31
+                rollups_before = subtract_calendar_months(
+                    now, self.settings.telemetry_rollup_retention_months
                 )
                 self.storage.telemetry.prune(
                     facts_before=facts_before, rollups_before=rollups_before

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -4,7 +4,7 @@ import logging
 import sqlite3
 import threading
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -731,6 +731,27 @@ class Storage:
             "UPDATE sessions SET session_token_usage = ? WHERE id = ?",
             (json.dumps(blob), session_id),
         )
+
+    @_synchronized
+    def token_usage_records_for_sessions(
+        self, session_ids: Iterable[str]
+    ) -> list[dict[str, Any]]:
+        """Raw per-turn ledger rows for a set of sessions (telemetry token join).
+
+        Holds the shared connection lock so telemetry shapers can run under
+        ``asyncio.to_thread`` without the cross-thread ``sqlite3`` misuse a bare
+        ``connection.execute`` from the worker thread would risk.
+        """
+        ids = list(session_ids)
+        if not ids:
+            return []
+        placeholders = ", ".join("?" for _ in ids)
+        rows = self.connection.execute(
+            "SELECT session_id, source, record_id, usage_json "
+            f"FROM session_token_usage_records WHERE session_id IN ({placeholders})",
+            ids,
+        ).fetchall()
+        return [dict(row) for row in rows]
 
     @_synchronized
     def rebuild_aggregate_from_ledger(

--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -3,11 +3,10 @@
 Analogous to ``usage_dashboard.py`` but reading the telemetry fact/rollup
 tables instead of live session snapshots. Token totals are computed by
 walking ``AGENT`` ``TurnFact`` rows and joining back to the per-turn ledger
-(``session_token_usage_records``) exactly like ``TelemetryStore``'s own
-rollup recompute does (``_agent_turn_tokens``) — the rollup itself doesn't
-persist enough detail (which individual turns lacked a ledger match) to
-derive meter coverage, so the fact-level walk is authoritative here and also
-naturally supports the arbitrary (non-day-aligned) windows insights compare.
+(``session_token_usage_records``); the daily rollup deliberately carries no
+token detail, so this fact-level walk is the authoritative token source and
+also naturally supports the arbitrary (non-day-aligned) windows insights
+compare.
 
 Coverage vocabulary (``entire``/``tracked_since``/``partial``): ``entire``
 when every matching agent turn has a ledger record (or there are none to
@@ -141,12 +140,7 @@ def ledger_rows_for_sessions(
 ) -> dict[tuple[str, str, str], dict[str, Any]]:
     if not session_ids:
         return {}
-    placeholders = ", ".join("?" for _ in session_ids)
-    rows = storage.connection.execute(
-        "SELECT session_id, source, record_id, usage_json "
-        f"FROM session_token_usage_records WHERE session_id IN ({placeholders})",
-        list(session_ids),
-    ).fetchall()
+    rows = storage.token_usage_records_for_sessions(session_ids)
     ledger: dict[tuple[str, str, str], dict[str, Any]] = {}
     for row in rows:
         try:
@@ -972,8 +966,7 @@ def delete_all(storage: Storage) -> TelemetryDeleteResponse:
     removed = storage.telemetry.prune(
         facts_before=far_future, rollups_before=far_future
     )
-    storage.connection.execute("DELETE FROM telemetry_insight_dismissal")
-    storage.connection.commit()
+    storage.telemetry.clear_insight_dismissals()
     storage.telemetry.clear_nl_insight()
     return TelemetryDeleteResponse(
         removed=TelemetryDeleteCounts(

--- a/backend/src/waypoint/telemetry/facts.py
+++ b/backend/src/waypoint/telemetry/facts.py
@@ -242,12 +242,17 @@ class TelemetryRange(BaseModel):
 
     Interpreted in the displayed Waypoint-host timezone with an inclusive
     ``start`` and exclusive ``end`` instant (Appendix: Date range). ``tz`` is the
-    IANA name the host is configured with and is echoed back so the UI can show it.
+    host tz's abbreviated name (``tzname()``) echoed back as a human label;
+    ``utc_offset_minutes`` is the deterministic numeric offset (minutes east of
+    UTC) the UI uses to render the correct host-tz calendar day, since ``tz`` is
+    not a valid JS ``timeZone``. Defaults to ``0`` (UTC) for ranges constructed
+    outside the request path.
     """
 
     start: datetime
     end: datetime
     tz: str
+    utc_offset_minutes: int = 0
 
 
 class TelemetryFilter(BaseModel):

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -17,7 +17,7 @@ import hashlib
 import json
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from datetime import UTC, datetime
 from typing import Any
@@ -152,9 +152,14 @@ class TelemetryIngester:
         *,
         batch_size: int = 200,
         drain_debounce_seconds: float = 1.0,
+        on_persisted: Callable[[], None] | None = None,
     ) -> None:
         self._storage = storage
         self._store = storage.telemetry
+        # Fired after a batch is actually persisted, so the runtime's
+        # telemetry_update broadcast can only announce facts already stored —
+        # never a burst that a slow drain hasn't written yet.
+        self._on_persisted = on_persisted
         # Backend-plugin lookup for resolving a rate-limit snapshot's account
         # when the session has no verified probe (``resolve_account``). Only
         # ``None`` in tests that don't exercise that fallback; the runtime
@@ -486,9 +491,21 @@ class TelemetryIngester:
 
     async def start(self) -> None:
         if self._task is None:
+            self._seed_last_transitions()
             self._task = asyncio.create_task(
                 self._drain_loop(), name="telemetry-ingest-drain"
             )
+
+    def _seed_last_transitions(self) -> None:
+        """Rehydrate the in-memory transition dedup from persisted facts (#10b)."""
+        try:
+            persisted = self._store.latest_lifecycle_transitions()
+        except Exception:
+            log.debug("telemetry last-transition seed failed", exc_info=True)
+            return
+        for session_id, transition in persisted.items():
+            with suppress(ValueError):
+                self._last_transition[session_id] = LifecycleTransition(transition)
 
     async def stop(self) -> None:
         if self._task is not None:
@@ -529,6 +546,9 @@ class TelemetryIngester:
             self._store.ingest_facts(batch)
         except Exception:
             log.debug("telemetry drain batch failed", exc_info=True)
+            return
+        if self._on_persisted is not None:
+            self._on_persisted()
 
     # ── backfill (one-shot, off the hot path) ───────────────────────────────
 

--- a/backend/src/waypoint/telemetry/insights.py
+++ b/backend/src/waypoint/telemetry/insights.py
@@ -124,7 +124,12 @@ def _token_volume_change_insight(
     storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
 ) -> Insight | None:
     duration = rng.end - rng.start
-    previous_rng = TelemetryRange(start=rng.start - duration, end=rng.start, tz=rng.tz)
+    previous_rng = TelemetryRange(
+        start=rng.start - duration,
+        end=rng.start,
+        tz=rng.tz,
+        utc_offset_minutes=rng.utc_offset_minutes,
+    )
 
     current_rows = agent_turn_rows(storage, rng, flt)
     previous_rows = agent_turn_rows(storage, previous_rng, flt)

--- a/backend/src/waypoint/telemetry/query.py
+++ b/backend/src/waypoint/telemetry/query.py
@@ -8,6 +8,7 @@ rollup buckets ``TelemetryStore`` maintains (both derive the calendar day the
 same way), rather than drifting apart under two independent tz calculations.
 """
 
+import calendar
 from datetime import UTC, datetime, timedelta
 
 from fastapi import HTTPException, Request, status
@@ -28,6 +29,33 @@ def host_tz_name() -> str:
     against the same local system tz via naive ``astimezone()``.
     """
     return datetime.now().astimezone().tzname() or "UTC"
+
+
+def host_utc_offset_minutes() -> int:
+    """The host's current UTC offset in minutes east of UTC (e.g. Singapore = 480).
+
+    A deterministic numeric companion to ``host_tz_name()`` (a ``tzname()``
+    abbreviation that isn't a valid JS ``timeZone``): the frontend shifts each
+    range instant by this offset and formats in UTC so the rendered calendar
+    day matches the host-tz day the range actually covers.
+    """
+    offset = datetime.now().astimezone().utcoffset()
+    return round(offset.total_seconds() / 60) if offset is not None else 0
+
+
+def subtract_calendar_months(moment: datetime, months: int) -> datetime:
+    """``moment`` shifted back ``months`` calendar months, clamping the day.
+
+    Calendar-correct rollup retention: a naive ``months * 31`` days
+    over-retains (it treats every month as its longest). Clamps the
+    day-of-month so e.g. Mar 31 minus one month is Feb 28/29, never an invalid
+    date.
+    """
+    month_index = moment.year * 12 + (moment.month - 1) - months
+    year, month_zero = divmod(month_index, 12)
+    month = month_zero + 1
+    last_day = calendar.monthrange(year, month)[1]
+    return moment.replace(year=year, month=month, day=min(moment.day, last_day))
 
 
 def _parse_bool(raw: str | None, *, default: bool) -> bool:
@@ -75,7 +103,10 @@ def resolve_preset_range(preset: str, tz: str) -> TelemetryRange:
     else:  # pragma: no cover - guarded by the caller
         raise ValueError(preset)
     return TelemetryRange(
-        start=datetime.fromisoformat(start), end=datetime.fromisoformat(end), tz=tz
+        start=datetime.fromisoformat(start),
+        end=datetime.fromisoformat(end),
+        tz=tz,
+        utc_offset_minutes=host_utc_offset_minutes(),
     )
 
 
@@ -118,7 +149,9 @@ def parse_range_filter(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="'end' must be after 'start'",
             )
-        rng = TelemetryRange(start=start, end=end, tz=tz)
+        rng = TelemetryRange(
+            start=start, end=end, tz=tz, utc_offset_minutes=host_utc_offset_minutes()
+        )
     else:
         rng = resolve_preset_range("7d", tz)
 

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -156,17 +156,11 @@ class TelemetryStore:
                 );
                 CREATE TABLE IF NOT EXISTS telemetry_meta (k TEXT PRIMARY KEY, v TEXT NOT NULL);
 
-                -- Internal bookkeeping (not part of the frozen contract's public
-                -- tables): dedupes which sessions contributed to a rollup key so
-                -- ``active_denom`` is an exact distinct count rather than an
-                -- estimate, and survives partial recomputation.
-                CREATE TABLE IF NOT EXISTS telemetry_rollup_session (
-                  day TEXT NOT NULL, backend TEXT NOT NULL, model TEXT NOT NULL,
-                  repo_name TEXT NOT NULL, src_source TEXT NOT NULL,
-                  transport TEXT NOT NULL, is_child INTEGER NOT NULL,
-                  session_id TEXT NOT NULL,
-                  PRIMARY KEY (day, backend, model, repo_name, src_source, transport, is_child, session_id)
-                );
+                -- ``telemetry_rollup_session`` backed a since-removed
+                -- ``active_denom`` metric that no reader consumed; drop it on
+                -- every boot so existing on-disk databases shed it (no
+                -- migration framework — this idempotent DROP is the shedder).
+                DROP TABLE IF EXISTS telemetry_rollup_session;
                 """)
             self._ensure_column("account_label", "TEXT")
             self._ensure_column("profile_label", "TEXT")
@@ -296,16 +290,12 @@ class TelemetryStore:
                 "DELETE FROM telemetry_daily_rollup WHERE day < ?", (rollups_cutoff,)
             )
             rollups_removed = cursor.rowcount or 0
-            self._conn.execute(
-                "DELETE FROM telemetry_rollup_session WHERE day < ?", (rollups_cutoff,)
-            )
             self._conn.commit()
             return {"facts": facts_removed, "rollups": rollups_removed}
 
     def rebuild_rollups_from_facts(self) -> None:
         with self._lock:
             self._conn.execute("DELETE FROM telemetry_daily_rollup")
-            self._conn.execute("DELETE FROM telemetry_rollup_session")
             rows = self._conn.execute("""
                 SELECT DISTINCT backend, COALESCE(model_at_turn, '') AS model,
                        COALESCE(repo_name, '') AS repo_name, src_source, transport, is_child,
@@ -418,7 +408,7 @@ class TelemetryStore:
         start_utc, end_utc = _day_bounds_utc(day)
         rows = self._conn.execute(
             """
-            SELECT kind, turn_kind, transition, tool_name, outcome, session_id, source, fact_id
+            SELECT kind, turn_kind, transition
             FROM telemetry_facts
             WHERE backend = ? AND COALESCE(model_at_turn, '') = ? AND COALESCE(repo_name, '') = ?
               AND src_source = ? AND transport = ? AND is_child = ? AND partial = 0
@@ -436,14 +426,6 @@ class TelemetryStore:
             ),
         ).fetchall()
 
-        self._conn.execute(
-            """
-            DELETE FROM telemetry_rollup_session
-            WHERE day = ? AND backend = ? AND model = ? AND repo_name = ?
-              AND src_source = ? AND transport = ? AND is_child = ?
-            """,
-            (day, backend, model, repo_name, src_source, transport, is_child),
-        )
         if not rows:
             self._conn.execute(
                 """
@@ -458,14 +440,9 @@ class TelemetryStore:
         turns_user = 0
         turns_agent = 0
         tool_calls = 0
-        tool_outcomes: dict[str, int] = {}
         lifecycle: dict[str, int] = {}
-        tokens: dict[str, int] = {}
-        display_totals: list[int | None] = []
-        session_ids: set[str] = set()
 
         for row in rows:
-            session_ids.add(row["session_id"])
             kind = row["kind"]
             if kind == TelemetryFactKind.SESSION_LIFECYCLE:
                 lifecycle[row["transition"]] = lifecycle.get(row["transition"], 0) + 1
@@ -474,53 +451,14 @@ class TelemetryStore:
                     turns_user += 1
                 elif row["turn_kind"] == TurnKind.AGENT:
                     turns_agent += 1
-                    ledger = self._agent_turn_tokens(
-                        row["session_id"], row["source"], row["fact_id"]
-                    )
-                    if ledger is None:
-                        display_totals.append(None)
-                    else:
-                        totals, display_total = ledger
-                        for category, amount in totals.items():
-                            tokens[category] = tokens.get(category, 0) + amount
-                        display_totals.append(display_total)
             elif kind == TelemetryFactKind.TOOL_CALL:
                 tool_calls += 1
-                tool_outcomes[row["outcome"]] = tool_outcomes.get(row["outcome"], 0) + 1
 
-        for session_id in session_ids:
-            self._conn.execute(
-                """
-                INSERT OR IGNORE INTO telemetry_rollup_session
-                    (day, backend, model, repo_name, src_source, transport, is_child, session_id)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    day,
-                    backend,
-                    model,
-                    repo_name,
-                    src_source,
-                    transport,
-                    is_child,
-                    session_id,
-                ),
-            )
-
-        display_total = (
-            sum(d for d in display_totals if d is not None)
-            if display_totals and all(d is not None for d in display_totals)
-            else None
-        )
         metrics = {
-            "tokens": tokens,
-            "display_total": display_total,
             "turns_user": turns_user,
             "turns_agent": turns_agent,
             "tool_calls": tool_calls,
-            "tool_outcomes": tool_outcomes,
             "lifecycle": lifecycle,
-            "active_denom": len(session_ids),
         }
         self._conn.execute(
             """
@@ -541,38 +479,6 @@ class TelemetryStore:
                 json.dumps(metrics),
             ),
         )
-
-    def _agent_turn_tokens(
-        self, session_id: str, source: str, fact_id: str
-    ) -> tuple[dict[str, int], int | None] | None:
-        """Look up the per-turn token ledger row an AGENT ``TurnFact`` derives from.
-
-        The ledger (``session_token_usage_records``) is the source of truth for
-        token amounts (plan §2.1: "reuse the existing ledger... do not
-        duplicate it"); facts carry no token columns of their own, so the
-        rollup's token bucket joins back to it by the shared ``record_id``.
-        """
-        row = self._conn.execute(
-            """
-            SELECT usage_json FROM session_token_usage_records
-            WHERE session_id = ? AND source = ? AND record_id = ?
-            """,
-            (session_id, source, fact_id),
-        ).fetchone()
-        if row is None:
-            return None
-        try:
-            usage = json.loads(row["usage_json"])
-        except json.JSONDecodeError:
-            return None
-        if not isinstance(usage, dict):
-            return None
-        raw_totals = usage.get("totals") or {}
-        totals = {
-            str(k): int(v) for k, v in raw_totals.items() if isinstance(v, int | float)
-        }
-        display_total = usage.get("display_total_tokens")
-        return totals, display_total if isinstance(display_total, int) else None
 
     # ── queries ───────────────────────────────────────────────────────────
 
@@ -692,6 +598,31 @@ class TelemetryStore:
                 (range_key,),
             ).fetchall()
             return {row["signature"] for row in rows}
+
+    def clear_insight_dismissals(self) -> None:
+        with self._lock:
+            self._conn.execute("DELETE FROM telemetry_insight_dismissal")
+            self._conn.commit()
+
+    def latest_lifecycle_transitions(self) -> dict[str, str]:
+        """The most recent lifecycle transition per session (by ``occurred_at``).
+
+        Seeds the ingester's in-memory transition dedup at startup so the first
+        status event for a known session after a restart doesn't re-mint a
+        transition fact already persisted (a fresh event sequence yields a new
+        ``fact_id`` that dodges the store's PK dedup).
+        """
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT session_id, transition FROM telemetry_facts
+                WHERE kind = ? AND transition IS NOT NULL
+                ORDER BY occurred_at ASC
+                """,
+                (TelemetryFactKind.SESSION_LIFECYCLE,),
+            ).fetchall()
+            # Ascending scan, last write wins → the newest transition per session.
+            return {row["session_id"]: row["transition"] for row in rows}
 
     def _descendant_session_ids(self, root_id: str) -> set[str]:
         """Every transitive descendant of ``root_id`` (excluding ``root_id`` itself).

--- a/backend/tests/test_telemetry_api.py
+++ b/backend/tests/test_telemetry_api.py
@@ -32,6 +32,7 @@ from waypoint.telemetry.facts import (
     TurnFact,
     TurnKind,
 )
+from waypoint.telemetry.query import host_utc_offset_minutes
 
 
 def _build(tmp_path: Path) -> tuple[Any, str]:
@@ -105,6 +106,20 @@ async def test_overview_empty_instance_returns_zeros_not_error(tmp_path: Path) -
     assert body["sessions"]["active_now"] == 0
     assert body["tool_calls"] == 0
     assert "start" in body["range"] and "end" in body["range"] and "tz" in body["range"]
+
+
+async def test_range_echo_carries_numeric_utc_offset(tmp_path: Path) -> None:
+    # The frontend can't use ``tz`` (a tzname() abbreviation) as a JS timeZone,
+    # so the echo also carries a deterministic numeric offset (#10d).
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/telemetry/overview", params={"preset": "7d"}, headers=_auth(token)
+        )
+    assert resp.status_code == 200
+    rng = resp.json()["range"]
+    assert isinstance(rng["utc_offset_minutes"], int)
+    assert rng["utc_offset_minutes"] == host_utc_offset_minutes()
 
 
 async def test_custom_range_requires_both_start_and_end(tmp_path: Path) -> None:

--- a/backend/tests/test_telemetry_ingest.py
+++ b/backend/tests/test_telemetry_ingest.py
@@ -965,3 +965,67 @@ def test_start_stop_drains_queued_facts(tmp_path: Path) -> None:
         await ingester.stop()
 
     asyncio.run(_run())
+
+
+def test_on_persisted_fires_only_after_the_batch_is_drained(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    # Record the persisted fact count at the moment the callback fires, to
+    # prove the dirty signal (broadcast trigger, #10a) can only reflect
+    # already-stored facts — never a still-queued enqueue.
+    persisted_counts: list[int] = []
+    ingester = TelemetryIngester(
+        storage,
+        on_persisted=lambda: persisted_counts.append(len(_facts(storage, "s1"))),
+    )
+
+    ingester.derive_from_session_created(session)
+    assert persisted_counts == []  # enqueue alone must not signal
+    assert _facts(storage, "s1") == []
+
+    ingester._drain_available()
+    assert persisted_counts == [1]  # signalled once, after the fact was stored
+
+
+def test_seed_last_transitions_dedups_across_restart(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    now = datetime.now(UTC)
+
+    first = TelemetryIngester(storage)
+    first.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.SYSTEM_NOTE,
+            text="a",
+            metadata={"status": SessionStatus.IDLE},
+            sequence=5,
+        ),
+    )
+    first._drain_available()
+    before = [r for r in _facts(storage, "s1") if r["kind"] == "session_lifecycle"]
+    assert len(before) == 1
+
+    # A fresh ingester models a process restart: without seeding, the next
+    # IDLE event (new sequence → new fact_id) would dodge the store's PK dedup
+    # and re-mint a duplicate transition (#10b).
+    second = TelemetryIngester(storage)
+    second._seed_last_transitions()
+    second.derive_from_event(
+        session,
+        EventRecord(
+            session_id="s1",
+            ts=now,
+            kind=EventKind.SYSTEM_NOTE,
+            text="b",
+            metadata={"status": SessionStatus.IDLE},
+            sequence=9,
+        ),
+    )
+    second._drain_available()
+
+    after = [r for r in _facts(storage, "s1") if r["kind"] == "session_lifecycle"]
+    assert len(after) == 1
+    assert after[0]["fact_id"] == "s1:5"

--- a/backend/tests/test_telemetry_query.py
+++ b/backend/tests/test_telemetry_query.py
@@ -1,0 +1,37 @@
+"""Tests for the pure date helpers in ``telemetry.query`` (#10c)."""
+
+from datetime import UTC, datetime
+
+from waypoint.telemetry.query import subtract_calendar_months
+
+
+def test_subtract_calendar_months_basic() -> None:
+    assert subtract_calendar_months(datetime(2026, 7, 12, tzinfo=UTC), 1) == datetime(
+        2026, 6, 12, tzinfo=UTC
+    )
+
+
+def test_subtract_calendar_months_crosses_year() -> None:
+    assert subtract_calendar_months(datetime(2026, 2, 15, tzinfo=UTC), 13) == datetime(
+        2025, 1, 15, tzinfo=UTC
+    )
+
+
+def test_subtract_calendar_months_clamps_day_of_month() -> None:
+    # Mar 31 minus one month is Feb 28 (2026 is common), never invalid Feb 31.
+    assert subtract_calendar_months(datetime(2026, 3, 31, tzinfo=UTC), 1) == datetime(
+        2026, 2, 28, tzinfo=UTC
+    )
+    # Leap year clamps to Feb 29 instead.
+    assert subtract_calendar_months(datetime(2024, 3, 31, tzinfo=UTC), 1) == datetime(
+        2024, 2, 29, tzinfo=UTC
+    )
+
+
+def test_subtract_calendar_months_retains_less_than_naive_days() -> None:
+    # The old formula was months * 31 days; the default 13-month retention
+    # over-retained by treating every month as its longest.
+    moment = datetime(2026, 7, 12, tzinfo=UTC)
+    result = subtract_calendar_months(moment, 13)
+    assert result == datetime(2025, 6, 12, tzinfo=UTC)
+    assert (moment - result).days < 13 * 31

--- a/backend/tests/test_telemetry_store.py
+++ b/backend/tests/test_telemetry_store.py
@@ -18,8 +18,6 @@ from waypoint.schemas import (
     SessionRecord,
     SessionSource,
     SessionStatus,
-    TokenUsageInit,
-    TokenUsageRecord,
 )
 from waypoint.storage import Storage
 from waypoint.telemetry.facts import (
@@ -216,20 +214,6 @@ def test_rollup_delta_matches_rebuild(tmp_path: Path) -> None:
         )
     )
 
-    # Agent turn backed by a ledger record — the rollup's token bucket joins
-    # back to session_token_usage_records, so seed the ledger first.
-    storage.record_token_usage(
-        "s1",
-        TokenUsageRecord(
-            record_id="turn-1",
-            source="codex",
-            observed_at=now,
-            totals={"input_tokens": 100, "output_tokens": 20},
-            display_total_tokens=120,
-            model="gpt-5-codex",
-        ),
-        init=TokenUsageInit(coverage="entire_waypoint_session", observed_from=now),
-    )
     # ``model_at_turn`` left unset so this fact stays in the same (model="")
     # rollup bucket as the other facts above — model-dimension splitting is
     # covered separately in test_rollup_splits_by_model.
@@ -260,15 +244,42 @@ def test_rollup_delta_matches_rebuild(tmp_path: Path) -> None:
     assert delta_metrics["turns_user"] == 1
     assert delta_metrics["turns_agent"] == 1
     assert delta_metrics["tool_calls"] == 1
-    assert delta_metrics["tool_outcomes"] == {"succeeded": 1}
     assert delta_metrics["lifecycle"] == {"created": 1, "running": 1}
-    assert delta_metrics["tokens"] == {"input_tokens": 100, "output_tokens": 20}
-    assert delta_metrics["display_total"] == 120
-    assert delta_metrics["active_denom"] == 1
+    # The rollup carries only these four read-by-production keys; the dead
+    # token/outcome/active_denom keys were dropped (#7).
+    assert set(delta_metrics) == {
+        "turns_user",
+        "turns_agent",
+        "tool_calls",
+        "lifecycle",
+    }
 
     storage.telemetry.rebuild_rollups_from_facts()
     rebuilt_metrics = _rollup_row(storage, day)
     assert rebuilt_metrics == delta_metrics
+
+
+def _table_exists(storage: Storage, name: str) -> bool:
+    row = storage.connection.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def test_init_schema_drops_dead_rollup_session_table(tmp_path: Path) -> None:
+    # A database that predates #7 may still carry telemetry_rollup_session;
+    # re-running init_schema (every boot) must shed it.
+    storage = Storage(tmp_path / "db.sqlite")
+    assert not _table_exists(storage, "telemetry_rollup_session")
+
+    storage.connection.execute(
+        "CREATE TABLE telemetry_rollup_session (day TEXT PRIMARY KEY)"
+    )
+    storage.connection.commit()
+    assert _table_exists(storage, "telemetry_rollup_session")
+
+    storage.telemetry.init_schema()
+    assert not _table_exists(storage, "telemetry_rollup_session")
 
 
 def test_rollup_splits_by_model(tmp_path: Path) -> None:
@@ -385,7 +396,6 @@ def test_delete_session_cascades_without_touching_other_sessions(
 
     metrics = _require_rollup(storage, day)
     assert metrics["lifecycle"] == {"created": 1}
-    assert metrics["active_denom"] == 1
 
     # Session "b"'s transcript is untouched by "a"'s deletion.
     b_events = storage.list_events("b")

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -55,6 +55,19 @@ const REFRESH_DEBOUNCE_MS = 400;
 
 type LoadState = "loading" | "ready" | "error";
 
+// Insight click-throughs carry the aggregate endpoint they were derived from;
+// route "View evidence" to the matching section so it lands on the data behind
+// the claim. Anything unrecognized (or absent) falls back to the drilldown.
+function scrollToEvidenceSection(endpoint: string | undefined): void {
+  const target =
+    typeof endpoint === "string" && endpoint.includes("/health")
+      ? "tm-health-anchor"
+      : typeof endpoint === "string" && endpoint.includes("/tokens")
+        ? "tm-tokens-anchor"
+        : "tm-drilldown-anchor";
+  document.getElementById(target)?.scrollIntoView({ behavior: "smooth" });
+}
+
 export default function TelemetryPage() {
   const router = useRouter();
   const { theme } = useTheme();
@@ -401,7 +414,7 @@ export default function TelemetryPage() {
       setDrilldownKind(kindParam as TelemetryFactKind);
       setDrilldownPage(1);
     }
-    document.getElementById("tm-drilldown-anchor")?.scrollIntoView({ behavior: "smooth" });
+    scrollToEvidenceSection(insight.click_through.endpoint);
   }, []);
 
   const handleGenerateNLInsight = useCallback(async () => {
@@ -440,7 +453,8 @@ export default function TelemetryPage() {
       setDrilldownKind(kindParam as TelemetryFactKind);
       setDrilldownPage(1);
     }
-    document.getElementById("tm-drilldown-anchor")?.scrollIntoView({ behavior: "smooth" });
+    const endpoint = typeof clickThrough.endpoint === "string" ? clickThrough.endpoint : undefined;
+    scrollToEvidenceSection(endpoint);
   }, []);
 
   const handleDeleteTelemetry = useCallback(async () => {

--- a/frontend/src/components/telemetry/HealthPanel.tsx
+++ b/frontend/src/components/telemetry/HealthPanel.tsx
@@ -221,7 +221,7 @@ export function HealthPanel({ health, loading }: HealthPanelProps) {
 
   return (
     <>
-      <section className="panel tm-chart-card" aria-labelledby={contextTitleId}>
+      <section id="tm-health-anchor" className="panel tm-chart-card" aria-labelledby={contextTitleId}>
         <header className="tm-chart-head">
           <h3 id={contextTitleId}>Context health</h3>
         </header>

--- a/frontend/src/components/telemetry/TokenChart.tsx
+++ b/frontend/src/components/telemetry/TokenChart.tsx
@@ -156,7 +156,7 @@ export function TokenChart({ tokens, loading, groupBy, onGroupByChange }: TokenC
   const plotH = CHART_H - PAD_TOP - PAD_BOTTOM;
 
   return (
-    <section className="panel tm-chart-card" aria-labelledby={titleId}>
+    <section id="tm-tokens-anchor" className="panel tm-chart-card" aria-labelledby={titleId}>
       <header className="tm-chart-head">
         <h3 id={titleId}>Token usage</h3>
         <label className="tm-chart-select-label">

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -350,12 +350,22 @@ export function formatRangeLabel(range: TelemetryRange): string {
   const start = new Date(range.start);
   const end = new Date(range.end);
   const fmt: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
-  const startLabel = Number.isNaN(start.getTime()) ? range.start : start.toLocaleDateString(undefined, fmt);
+  // With the host-tz offset from the range echo, shift each instant by it and
+  // render in UTC so the day matches the host-tz calendar day the range covers.
+  // Without a usable offset (older payload / NaN), fall back to the browser tz.
+  const offset = range.utc_offset_minutes;
+  const shiftMinutes = typeof offset === "number" && !Number.isNaN(offset) ? offset : null;
+  const fmtDay = (instant: Date): string =>
+    shiftMinutes !== null
+      ? new Date(instant.getTime() + shiftMinutes * 60_000).toLocaleDateString(undefined, {
+          ...fmt,
+          timeZone: "UTC",
+        })
+      : instant.toLocaleDateString(undefined, fmt);
+  const startLabel = Number.isNaN(start.getTime()) ? range.start : fmtDay(start);
   // `end` is exclusive; show the inclusive last day for a human-readable range.
   const inclusiveEnd = Number.isNaN(end.getTime()) ? end : new Date(end.getTime() - 1000);
-  const endLabel = Number.isNaN(end.getTime())
-    ? range.end
-    : inclusiveEnd.toLocaleDateString(undefined, fmt);
+  const endLabel = Number.isNaN(end.getTime()) ? range.end : fmtDay(inclusiveEnd);
   return `${startLabel} – ${endLabel} (${range.tz})`;
 }
 

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -760,6 +760,11 @@ export interface TelemetryRange {
   start: string;
   end: string;
   tz: string;
+  // Host-tz UTC offset (integer minutes east of UTC) at the range instant, so
+  // the client can render the host's calendar days without knowing its IANA
+  // zone. Optional: older payloads omit it and the client falls back to the
+  // browser tz.
+  utc_offset_minutes?: number;
 }
 
 export interface TelemetryFilter {


### PR DESCRIPTION
## Purpose

Resolve the items deferred from the AI usage telemetry review (#288/#292), in one focused PR. The headline is a real responsiveness bug: the `/api/telemetry/*` handlers ran their synchronous full-scan shapers directly on the event loop, so a wide range froze the loop and the WebSocket. This offloads that work, removes a chunk of dead rollup machinery, and clears five smaller correctness/UX edges. Follows up on #288.

## Changes

### Backend
- **Dead rollup machinery removed** — the `telemetry_rollup_session` side-table and the `metrics_json` keys `tokens` / `display_total` / `tool_outcomes` / `active_denom` had zero production readers (an exhaustive search confirmed the only daily-rollup consumers read lifecycle/turn/tool counts). `_recompute_rollup_key` no longer computes them, the dead token-ledger join is gone, and `init_schema` now issues `DROP TABLE IF EXISTS telemetry_rollup_session` so existing on-disk DBs shed the table (there is no migration framework). Stale JSON keys on old rollup rows are harmless (readers use `.get`) and get rewritten on the next recompute.
- **Event-loop offload** — the seven fact-scanning shapers (`build_overview` / `build_tokens` / `build_activity` / `build_health` / `build_drilldown`, `compute_insights`, `delete_all`) now run under `await asyncio.to_thread(...)` (the repo idiom). As a prerequisite, the two reads that touched the shared sqlite connection without the storage lock (`ledger_rows_for_sessions`, `delete_all`) now go through locked `Storage`/`TelemetryStore` accessors so they are safe under executor threads. This unblocks the loop; the residual per-query lock hold on DB-bound work (the single global `RLock` is still held across each scan) is intentionally left to the follow-up performance audit — this PR does not claim to make the scans themselves fast, only to stop them from freezing the loop.
- **Broadcast coupled to persistence** — the `telemetry_update` broadcast now fires after a batch is persisted (an `on_persisted` callback from the ingester drain) instead of at enqueue time, so a trailing burst can't be broadcast before its facts are stored.
- **Lifecycle dedup survives restart** — the in-memory `_last_transition` map is seeded from the latest persisted lifecycle fact per session at ingester startup, so the first status event after a restart no longer mints a duplicate transition fact.
- **Retention cutoff** — rollup retention uses a calendar-correct month subtraction instead of `months * 31` days.
- **Range echo** — carries a numeric `utc_offset_minutes` alongside the `tz` label so the frontend can render the host-tz day deterministically.

### Frontend
- **Range-label timezone** — `formatRangeLabel` shifts the range instants by `utc_offset_minutes` and formats in UTC so the displayed days match the host tz named in the label (previously it formatted in the browser's timezone, so the days could disagree with the `(tz)` suffix). Falls back to the browser-tz render when the field is absent.
- **Insight "View evidence" routing** — routes on `click_through.endpoint` to the health panel or token chart section (new anchors), instead of always scrolling to the fact drilldown.

## Test Plan

- `cd backend && uv run pytest`
- `cd backend && uv run pre-commit run` (isort, black, ruff, codespell, mypy) on the changed files
- `cd frontend && npm run lint && npm run build`
- E2E: redeployed the branch with `waypointctl restart`; drove `/telemetry` with Playwright across mobile (390px) and desktop (1280px) in both themes; measured loop responsiveness during a heavy scan; and cross-checked the fixes against the live API.

## Test Result

- Backend suite: 2045 passed (8 new tests), only pre-existing/unrelated warnings.
- Pre-commit: clean (isort, black, ruff, codespell, mypy).
- Frontend lint and production build: clean.
- E2E: `/telemetry` rendered on all viewport/theme combinations with zero console errors. #9 — during a ~0.58s wide activity scan, four of five concurrent DB-touching `settings` requests returned in 2–3 ms (the loop stayed responsive; the one outlier at ~570 ms is the documented single lock-hold window, exactly as designed). #7 — overview counts, daily rollup, and the heatmap remained correct after the dead-code removal. #10d — the range label rendered the correct host-tz days (`Jul 6 – Jul 12 (+08)`) from a UTC-behind browser. #10e — the health/token/drilldown anchors are present and wired.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title and described migration steps above.
- [ ] If this is a user-facing change, I updated documentation or config examples.

</details>