### PR TITLE
perf: speed up telemetry rollup recompute and dashboard aggregation

### DIFF
--- a/backend/src/waypoint/telemetry/aggregate.py
+++ b/backend/src/waypoint/telemetry/aggregate.py
@@ -125,12 +125,30 @@ def range_key(rng: TelemetryRange) -> str:
 # ── token totals (facts + ledger join) ────────────────────────────────────
 
 
+# Every column an ``agent_turn_rows`` consumer reads: the AGENT filter
+# (turn_kind), the ledger join key (session_id, source, fact_id), day/group
+# bucketing (occurred_at, backend, model_at_turn, repo_name). Narrowing the
+# projection to these avoids materializing all ~38 columns per turn row.
+_AGENT_TURN_COLUMNS = (
+    "turn_kind",
+    "session_id",
+    "source",
+    "fact_id",
+    "occurred_at",
+    "backend",
+    "model_at_turn",
+    "repo_name",
+)
+
+
 def agent_turn_rows(
     storage: Storage, rng: TelemetryRange, flt: TelemetryFilter
 ) -> list[dict[str, Any]]:
     return [
         row
-        for row in storage.telemetry.query_facts(TelemetryFactKind.TURN, rng, flt)
+        for row in storage.telemetry.query_facts(
+            TelemetryFactKind.TURN, rng, flt, columns=_AGENT_TURN_COLUMNS
+        )
         if row["turn_kind"] == TurnKind.AGENT
     ]
 
@@ -218,16 +236,20 @@ def _is_stale(
 
 
 def current_context_snapshots(
-    storage: Storage, flt: TelemetryFilter, now: datetime
+    storage: Storage,
+    flt: TelemetryFilter,
+    now: datetime,
+    sessions: list[SessionRecord] | None = None,
 ) -> list[ContextSnapshotView]:
     # "Current" context occupancy is a property of sessions that are still
     # live: an exited/errored session holds no context window (FR-6). Restrict
     # to sessions whose latest status is active so the panel shows the handful
     # of running sessions, not every session that ever recorded a snapshot.
+    # ``sessions`` lets a caller share one ``list_sessions()`` across shapers.
+    if sessions is None:
+        sessions = storage.list_sessions()
     active_ids = {
-        session.id
-        for session in storage.list_sessions()
-        if session.status in _ACTIVE_STATUSES
+        session.id for session in sessions if session.status in _ACTIVE_STATUSES
     }
     if not active_ids:
         return []
@@ -346,13 +368,16 @@ def severity_for_percent(
 
 
 def alerting_context(
-    storage: Storage, settings: Settings, flt: TelemetryFilter
+    storage: Storage,
+    settings: Settings,
+    flt: TelemetryFilter,
+    sessions: list[SessionRecord] | None = None,
 ) -> list[ContextSnapshotView]:
     low = settings.telemetry_context_thresholds[0]
     now = datetime.now(UTC)
     return [
         snapshot
-        for snapshot in current_context_snapshots(storage, flt, now)
+        for snapshot in current_context_snapshots(storage, flt, now, sessions)
         if not snapshot.stale
         and snapshot.percent is not None
         and snapshot.percent >= low
@@ -426,7 +451,10 @@ def _session_matches_filter(
 
 
 def count_active_sessions(
-    storage: Storage, flt: TelemetryFilter, rng: TelemetryRange
+    storage: Storage,
+    flt: TelemetryFilter,
+    rng: TelemetryRange,
+    sessions: list[SessionRecord] | None = None,
 ) -> int:
     """Point-in-time count of sessions active at ``rng.end`` matching ``flt`` (FR-3).
 
@@ -439,12 +467,17 @@ def count_active_sessions(
     recorded before that instant.
     """
     if rng.end >= datetime.now(UTC):
-        return _count_active_sessions_live(storage, flt)
+        return _count_active_sessions_live(storage, flt, sessions)
     return _count_active_sessions_historical(storage, flt, rng.end)
 
 
-def _count_active_sessions_live(storage: Storage, flt: TelemetryFilter) -> int:
-    sessions = storage.list_sessions()
+def _count_active_sessions_live(
+    storage: Storage,
+    flt: TelemetryFilter,
+    sessions: list[SessionRecord] | None = None,
+) -> int:
+    if sessions is None:
+        sessions = storage.list_sessions()
     descendant_ids = (
         _descendant_session_ids(sessions, flt.parent_session_id)
         if flt.parent_session_id
@@ -560,6 +593,10 @@ def build_overview(
     window. The two can diverge for hour-granularity queries; this is
     expected, not a bug (the fact-scan fallback above doesn't have this gap).
     """
+    # One ``list_sessions()`` shared by the active-now count and the context
+    # alert scan below, instead of each re-fetching the session table.
+    sessions = storage.list_sessions()
+
     lifecycle_totals, turns_user, turns_agent, tool_calls = session_counts_totals(
         storage, rng, flt
     )
@@ -586,12 +623,12 @@ def build_overview(
             exited=lifecycle_totals.get("exited", 0),
             interrupted=lifecycle_totals.get("interrupted", 0),
             error=lifecycle_totals.get("error", 0),
-            active_now=count_active_sessions(storage, flt, rng),
+            active_now=count_active_sessions(storage, flt, rng, sessions),
         ),
         turns=TurnCounts(user=turns_user, agent=turns_agent),
         tool_calls=tool_calls,
         alerts=TelemetryAlerts(
-            context=alerting_context(storage, settings, flt),
+            context=alerting_context(storage, settings, flt, sessions),
             limits=alerting_limits(storage, settings, flt),
         ),
         limit_card_hidden=hidden,
@@ -734,15 +771,9 @@ def build_activity(
 
     daily = [ActivityDaily(day=day, **by_day.get(day, {})) for day in day_range(rng)]
 
-    heatmap_counts: dict[tuple[int, int], int] = {}
-    for kind in (TelemetryFactKind.TURN, TelemetryFactKind.TOOL_CALL):
-        for row in storage.telemetry.query_facts(kind, rng, flt):
-            occurred = datetime.fromisoformat(row["occurred_at"]).astimezone()
-            key = (occurred.weekday(), occurred.hour)
-            heatmap_counts[key] = heatmap_counts.get(key, 0) + 1
     heatmap = [
         ActivityHeatmapCell(dow=dow, hour=hour, count=count)
-        for (dow, hour), count in sorted(heatmap_counts.items())
+        for dow, hour, count in storage.telemetry.heatmap_counts(rng, flt)
     ]
 
     return TelemetryActivity(range=rng, filters_echo=flt, daily=daily, heatmap=heatmap)

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -491,7 +491,8 @@ class TelemetryIngester:
 
     async def start(self) -> None:
         if self._task is None:
-            self._seed_last_transitions()
+            # Off the event loop: the seed hits SQLite under the shared lock.
+            await asyncio.to_thread(self._seed_last_transitions)
             self._task = asyncio.create_task(
                 self._drain_loop(), name="telemetry-ingest-drain"
             )

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -17,7 +17,7 @@ could drift apart.
 import json
 import sqlite3
 import threading
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
@@ -40,6 +40,12 @@ _TAG_FILTER_SEPARATOR = ":"
 
 # ``telemetry_meta`` key the latest NL-insight digest is stored under (CONTRACT-NL.md §4).
 _NL_INSIGHT_META_KEY = "nl_insight"
+
+# The daily-rollup primary key a fact contributes to: (day, backend, model,
+# repo, source, transport, is_child). Recomputing one key rescans that key's
+# day-bounded slice from scratch, so accumulating the affected keys across a
+# batch and recomputing each once is byte-identical to recomputing per fact.
+_RollupKey = tuple[str, str, str, str, str, str, int]
 
 
 def _iso_utc(value: datetime) -> str:
@@ -70,6 +76,29 @@ def _day_bounds_utc(day: str) -> tuple[str, str]:
     start_utc = start_local.astimezone(UTC)
     end_utc = (start_local + timedelta(days=1)).astimezone(UTC)
     return start_utc.isoformat(), end_utc.isoformat()
+
+
+def _offset_modifier(minutes: int) -> str:
+    """A SQLite date-modifier shifting a UTC instant to a host-tz wall clock.
+
+    ``date`` / ``strftime`` need an explicit sign on the minutes modifier, so a
+    negative (west-of-UTC) offset formats as ``-300 minutes``. A single fixed
+    offset across a range differs from a per-instant tz resolution at a DST
+    boundary — immaterial on this non-DST host.
+    """
+    return f"{minutes:+d} minutes"
+
+
+def _host_offset_modifier() -> str:
+    """``_offset_modifier`` for the host's current UTC offset.
+
+    Uses the same tz source as ``_day_key`` (naive ``astimezone()``), so
+    ``date(occurred_at, _host_offset_modifier())`` matches ``_day_key`` for a
+    fixed offset.
+    """
+    offset = datetime.now().astimezone().utcoffset()
+    minutes = round(offset.total_seconds() / 60) if offset is not None else 0
+    return _offset_modifier(minutes)
 
 
 def _parse_tag_term(term: str) -> tuple[str, str] | None:
@@ -130,9 +159,15 @@ class TelemetryStore:
                   PRIMARY KEY (kind, source, fact_id)
                 );
                 CREATE INDEX IF NOT EXISTS idx_tf_kind_time      ON telemetry_facts(kind, occurred_at);
-                CREATE INDEX IF NOT EXISTS idx_tf_kind_backend_time ON telemetry_facts(kind, backend, occurred_at);
                 CREATE INDEX IF NOT EXISTS idx_tf_session        ON telemetry_facts(session_id);
                 CREATE INDEX IF NOT EXISTS idx_tf_time           ON telemetry_facts(occurred_at);
+
+                -- ``idx_tf_kind_backend_time`` bought nothing measurable:
+                -- backend is ~3-cardinality and every backend-filtered read
+                -- also constrains kind+time, so the planner rides
+                -- ``idx_tf_kind_time`` and filters backend as a residual at the
+                -- same latency. Drop it (~4.5MB + a per-fact write) on boot.
+                DROP INDEX IF EXISTS idx_tf_kind_backend_time;
 
                 CREATE TABLE IF NOT EXISTS telemetry_fact_tag (
                   kind TEXT NOT NULL, source TEXT NOT NULL, fact_id TEXT NOT NULL,
@@ -178,21 +213,37 @@ class TelemetryStore:
         self, fact: TelemetryFact, *, tags: dict[str, str] | None = None
     ) -> bool:
         with self._lock:
-            wrote = self._ingest_fact_locked(fact, tags or {})
+            keys = self._ingest_fact_locked(fact, tags or {})
+            for key in keys or ():
+                self._recompute_rollup_key(*key)
             self._conn.commit()
-            return wrote
+            return keys is not None
 
     def ingest_facts(
         self, facts: Iterable[tuple[TelemetryFact, dict[str, str]]]
     ) -> int:
         with self._lock:
-            written = sum(
-                1 for fact, tags in facts if self._ingest_fact_locked(fact, tags)
-            )
+            written = 0
+            keys_to_recompute: set[_RollupKey] = set()
+            for fact, tags in facts:
+                keys = self._ingest_fact_locked(fact, tags)
+                if keys is not None:
+                    written += 1
+                    keys_to_recompute |= keys
+            # Coalesce: a same-day/same-dims batch collapses to one recompute per
+            # key instead of one per fact, and recompute-from-scratch depends
+            # only on the final table state, so the result is byte-identical.
+            for key in keys_to_recompute:
+                self._recompute_rollup_key(*key)
             self._conn.commit()
             return written
 
-    def _ingest_fact_locked(self, fact: TelemetryFact, tags: dict[str, str]) -> bool:
+    def _ingest_fact_locked(
+        self, fact: TelemetryFact, tags: dict[str, str]
+    ) -> set[_RollupKey] | None:
+        """Insert/replace one fact, returning the rollup keys the caller must
+        recompute (the fact's new key plus its pre-revision key), or ``None``
+        when the fact was a dedup/stale-revision no-op."""
         existing = self._conn.execute(
             """
             SELECT revision, occurred_at, backend, model_at_turn, repo_name,
@@ -202,9 +253,9 @@ class TelemetryStore:
             (fact.kind, fact.source, fact.fact_id),
         ).fetchone()
         if existing is not None and existing["revision"] > fact.revision:
-            return False
+            return None
         if existing is not None and existing["revision"] == fact.revision:
-            return False
+            return None
 
         row = _row_from_fact(fact)
         columns = list(row)
@@ -223,10 +274,13 @@ class TelemetryStore:
             [row[c] for c in columns],
         )
 
-        self._conn.execute(
-            "DELETE FROM telemetry_fact_tag WHERE kind = ? AND source = ? AND fact_id = ?",
-            (fact.kind, fact.source, fact.fact_id),
-        )
+        # A brand-new row has no prior tags to clear, so skip the DELETE unless
+        # this is a revision (existing row) or the fact actually carries tags.
+        if existing is not None or tags:
+            self._conn.execute(
+                "DELETE FROM telemetry_fact_tag WHERE kind = ? AND source = ? AND fact_id = ?",
+                (fact.kind, fact.source, fact.fact_id),
+            )
         for key, value in tags.items():
             self._conn.execute(
                 """
@@ -236,7 +290,7 @@ class TelemetryStore:
                 (fact.kind, fact.source, fact.fact_id, key, value),
             )
 
-        keys_to_recompute: set[tuple[str, str, str, str, str, str, int]] = set()
+        keys_to_recompute: set[_RollupKey] = set()
         if existing is not None:
             keys_to_recompute.add(
                 (
@@ -260,9 +314,7 @@ class TelemetryStore:
                 int(fact.dims.is_child),
             )
         )
-        for rollup_key in keys_to_recompute:
-            self._recompute_rollup_key(*rollup_key)
-        return True
+        return keys_to_recompute
 
     # ── maintenance ───────────────────────────────────────────────────────
 
@@ -296,15 +348,23 @@ class TelemetryStore:
     def rebuild_rollups_from_facts(self) -> None:
         with self._lock:
             self._conn.execute("DELETE FROM telemetry_daily_rollup")
-            rows = self._conn.execute("""
-                SELECT DISTINCT backend, COALESCE(model_at_turn, '') AS model,
-                       COALESCE(repo_name, '') AS repo_name, src_source, transport, is_child,
-                       occurred_at
+            # DISTINCT on the host-tz day directly (not raw ``occurred_at``,
+            # which is near-unique and defeats the DISTINCT — 54k rows for 155
+            # keys). ``date(occurred_at, <offset>)`` matches ``_day_key`` for a
+            # fixed offset (naive UTC substr would misbucket near midnight).
+            modifier = _host_offset_modifier()
+            rows = self._conn.execute(
+                """
+                SELECT DISTINCT date(occurred_at, ?) AS day, backend,
+                       COALESCE(model_at_turn, '') AS model,
+                       COALESCE(repo_name, '') AS repo_name, src_source, transport, is_child
                 FROM telemetry_facts WHERE partial = 0
-                """).fetchall()
+                """,
+                (modifier,),
+            ).fetchall()
             keys = {
                 (
-                    _day_key(datetime.fromisoformat(row["occurred_at"])),
+                    row["day"],
                     row["backend"],
                     row["model"],
                     row["repo_name"],
@@ -492,11 +552,20 @@ class TelemetryStore:
         offset: int | None = None,
         partial: bool = False,
         descending: bool = False,
+        columns: Sequence[str] | None = None,
     ) -> list[dict[str, Any]]:
+        """Fact rows for ``kind``/``rng``/``flt``.
+
+        ``columns`` narrows the projection for read-heavy callers (token fold,
+        heatmap) that touch only a handful of the ~38 columns; the returned
+        dicts then carry ONLY those keys, so a projection must list every
+        column its caller reads. Defaults to the full row.
+        """
         with self._lock:
             where, params = self._filter_clause(
                 rng, flt, extra_kind=kind, partial=partial
             )
+            projection = "*" if columns is None else ", ".join(columns)
             # Stable tiebreak (source, fact_id) after occurred_at so paginated
             # drilldown results (LIMIT/OFFSET) never reorder or repeat a row
             # across pages when several facts share the same instant. Drill-down
@@ -504,7 +573,7 @@ class TelemetryStore:
             # the most recent, most relevant facts rather than the oldest.
             direction = "DESC" if descending else "ASC"
             sql = (
-                f"SELECT * FROM telemetry_facts WHERE {where} "
+                f"SELECT {projection} FROM telemetry_facts WHERE {where} "
                 f"ORDER BY occurred_at {direction}, source {direction}, "
                 f"fact_id {direction}"
             )
@@ -528,6 +597,41 @@ class TelemetryStore:
                 f"SELECT COUNT(*) AS n FROM telemetry_facts WHERE {where}", params
             ).fetchone()
             return int(row["n"])
+
+    def heatmap_counts(
+        self, rng: TelemetryRange, flt: TelemetryFilter
+    ) -> list[tuple[int, int, int]]:
+        """``(dow, hour, count)`` buckets over TURN + TOOL_CALL facts in range.
+
+        Buckets in SQL (≤168 rows) instead of materializing every fact and
+        counting in Python. ``occurred_at`` is shifted by the range's host UTC
+        offset so cells land on the host-tz wall clock the dashboard renders.
+        SQLite ``strftime('%w')`` numbers Sunday=0..Saturday=6, but the
+        ``ActivityHeatmapCell.dow`` contract is Monday=0 (Python
+        ``datetime.weekday()``), hence the ``+ 6) % 7`` shift. A single offset
+        across the range differs from a per-instant tz resolution at a DST
+        boundary — immaterial on this non-DST host.
+        """
+        with self._lock:
+            where, params = self._filter_clause(
+                rng,
+                flt,
+                extra_kind=(TelemetryFactKind.TURN, TelemetryFactKind.TOOL_CALL),
+                partial=False,
+            )
+            modifier = _offset_modifier(rng.utc_offset_minutes)
+            rows = self._conn.execute(
+                f"""
+                SELECT (CAST(strftime('%w', occurred_at, ?) AS INTEGER) + 6) % 7 AS dow,
+                       CAST(strftime('%H', occurred_at, ?) AS INTEGER) AS hour,
+                       COUNT(*) AS n
+                FROM telemetry_facts WHERE {where}
+                GROUP BY dow, hour
+                ORDER BY dow, hour
+                """,
+                [modifier, modifier, *params],
+            ).fetchall()
+            return [(int(r["dow"]), int(r["hour"]), int(r["n"])) for r in rows]
 
     def query_rollup(
         self, rng: TelemetryRange, flt: TelemetryFilter
@@ -613,15 +717,26 @@ class TelemetryStore:
         ``fact_id`` that dodges the store's PK dedup).
         """
         with self._lock:
+            # One newest row per session via a window function (≤ session-count
+            # rows) instead of scanning every lifecycle fact. The tiebreak makes
+            # exact-timestamp ties resolve to a single deterministic row (a bare
+            # MAX(...) join could return several tied rows); which tied
+            # transition wins is immaterial to the dedup seed.
             rows = self._conn.execute(
                 """
-                SELECT session_id, transition FROM telemetry_facts
-                WHERE kind = ? AND transition IS NOT NULL
-                ORDER BY occurred_at ASC
+                SELECT session_id, transition FROM (
+                    SELECT session_id, transition,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY session_id
+                               ORDER BY occurred_at DESC, source DESC, fact_id DESC
+                           ) AS rn
+                    FROM telemetry_facts
+                    WHERE kind = ? AND transition IS NOT NULL
+                )
+                WHERE rn = 1
                 """,
                 (TelemetryFactKind.SESSION_LIFECYCLE,),
             ).fetchall()
-            # Ascending scan, last write wins → the newest transition per session.
             return {row["session_id"]: row["transition"] for row in rows}
 
     def _descendant_session_ids(self, root_id: str) -> set[str]:
@@ -654,11 +769,18 @@ class TelemetryStore:
         rng: TelemetryRange,
         flt: TelemetryFilter,
         *,
-        extra_kind: TelemetryFactKind,
+        extra_kind: TelemetryFactKind | Sequence[TelemetryFactKind],
         partial: bool,
     ) -> tuple[str, list[Any]]:
-        clauses = ["kind = ?", "occurred_at >= ?", "occurred_at < ?"]
-        params: list[Any] = [extra_kind, _iso_utc(rng.start), _iso_utc(rng.end)]
+        kinds: Sequence[TelemetryFactKind] = (
+            [extra_kind] if isinstance(extra_kind, TelemetryFactKind) else extra_kind
+        )
+        clauses = [
+            f"kind IN ({', '.join('?' for _ in kinds)})",
+            "occurred_at >= ?",
+            "occurred_at < ?",
+        ]
+        params: list[Any] = [*kinds, _iso_utc(rng.start), _iso_utc(rng.end)]
         if not partial:
             clauses.append("partial = 0")
         if flt.backends:

--- a/backend/src/waypoint/telemetry/store.py
+++ b/backend/src/waypoint/telemetry/store.py
@@ -565,6 +565,8 @@ class TelemetryStore:
             where, params = self._filter_clause(
                 rng, flt, extra_kind=kind, partial=partial
             )
+            # ``columns`` must stay developer-controlled (interpolated, not
+            # bound) — never forward untrusted input here.
             projection = "*" if columns is None else ", ".join(columns)
             # Stable tiebreak (source, fact_id) after occurred_at so paginated
             # drilldown results (LIMIT/OFFSET) never reorder or repeat a row

--- a/backend/tests/test_telemetry_aggregate.py
+++ b/backend/tests/test_telemetry_aggregate.py
@@ -1318,3 +1318,83 @@ def test_transitive_descendants_scope_tokens_and_drilldown(tmp_path: Path) -> No
     )
     assert drilldown_own.total == 1
     assert drilldown_own.items[0].session_id == "parent"
+
+
+# ── column projection + SQL heatmap (perf paths) ───────────────────────────
+
+
+def test_agent_turn_projection_covers_every_token_fold_path(tmp_path: Path) -> None:
+    # The narrowed projection on ``agent_turn_rows`` must carry every column any
+    # downstream consumer reads; a missing one would ``KeyError`` in a group_by
+    # or the ledger join. Exercise the REAL token-fold path for all group_by
+    # keys and the overview, plus lock the projected column set.
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    _make_session(storage, "s2")
+    _seed_agent_turn(
+        storage,
+        "s1",
+        fact_id="t1",
+        occurred_at=now,
+        totals={"input_tokens": 100},
+        model_at_turn="m1",
+    )
+    _seed_agent_turn(
+        storage,
+        "s2",
+        fact_id="t2",
+        occurred_at=now,
+        totals={"input_tokens": 50},
+        model_at_turn="m2",
+    )
+    rng = _full_range()
+
+    rows = aggregate.agent_turn_rows(storage, rng, TelemetryFilter())
+    assert rows
+    for row in rows:
+        assert set(row) == set(aggregate._AGENT_TURN_COLUMNS)
+
+    for group_by in ("time", "backend", "model", "repo", "session"):
+        tokens = aggregate.build_tokens(storage, rng, TelemetryFilter(), group_by)
+        assert tokens.groups  # no KeyError on any grouping column
+
+    by_model = aggregate.build_tokens(storage, rng, TelemetryFilter(), "model")
+    assert {g.key: g.display_total for g in by_model.groups} == {"m1": 100, "m2": 50}
+
+    overview = aggregate.build_overview(storage, _settings(), rng, TelemetryFilter())
+    assert overview.tokens.display_total == 150
+
+
+def test_build_activity_heatmap_buckets_host_weekday_hour(tmp_path: Path) -> None:
+    # End-to-end through ``build_activity``: a known Sunday and Monday pin the
+    # Monday=0 contract (SQLite ``%w`` is Sunday=0), and the heatmap total must
+    # equal the turn+tool_call fact count in range.
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "s1")
+    sunday = datetime(2026, 3, 15, 9, 0, tzinfo=UTC)  # weekday()==6
+    monday = datetime(2026, 3, 16, 13, 0, tzinfo=UTC)  # weekday()==0
+    for fid, at in (("t-sun", sunday), ("t-mon-a", monday), ("t-mon-b", monday)):
+        storage.telemetry.ingest_fact(
+            TurnFact(
+                fact_id=fid,
+                source="codex",
+                session_id="s1",
+                occurred_at=at,
+                dims=_dims(),
+                turn_kind=TurnKind.AGENT,
+            )
+        )
+
+    rng = TelemetryRange(
+        start=datetime(2026, 3, 14, tzinfo=UTC),
+        end=datetime(2026, 3, 18, tzinfo=UTC),
+        tz="UTC",
+        utc_offset_minutes=0,
+    )
+    activity = aggregate.build_activity(storage, rng, TelemetryFilter())
+    cells = {(c.dow, c.hour): c.count for c in activity.heatmap}
+
+    assert cells[(6, 9)] == 1  # Sunday
+    assert cells[(0, 13)] == 2  # Monday, two turns same hour
+    assert (2, 5) not in cells  # quiet cell omitted
+    assert sum(c.count for c in activity.heatmap) == 3

--- a/backend/tests/test_telemetry_store.py
+++ b/backend/tests/test_telemetry_store.py
@@ -11,6 +11,7 @@ import json
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 from waypoint.schemas import (
     EventKind,
@@ -453,6 +454,228 @@ def test_ingest_facts_batches_and_returns_written_count(tmp_path: Path) -> None:
     fact_b = _lifecycle_fact("s1", LifecycleTransition.STARTING, occurred_at=now)
     written = storage.telemetry.ingest_facts([(fact_a, {}), (fact_b, {}), (fact_a, {})])
     assert written == 2
+
+
+def _same_day_batch(now: datetime) -> list[tuple[Any, dict[str, str]]]:
+    """Five distinct facts sharing one (day, dims, model="") rollup key."""
+    return [
+        (_lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now), {}),
+        (_lifecycle_fact("s1", LifecycleTransition.RUNNING, occurred_at=now), {}),
+        (
+            TurnFact(
+                fact_id="u1",
+                source="codex",
+                session_id="s1",
+                occurred_at=now,
+                dims=_dims(),
+                turn_kind=TurnKind.USER,
+            ),
+            {},
+        ),
+        (
+            TurnFact(
+                fact_id="a1",
+                source="codex",
+                session_id="s1",
+                occurred_at=now,
+                dims=_dims(),
+                turn_kind=TurnKind.AGENT,
+            ),
+            {},
+        ),
+        (
+            ToolCallFact(
+                fact_id="tool1",
+                source="codex",
+                session_id="s1",
+                occurred_at=now,
+                dims=_dims(),
+                tool_name="Read",
+                outcome=ToolOutcome.SUCCEEDED,
+            ),
+            {},
+        ),
+    ]
+
+
+def test_ingest_facts_coalesces_recompute_and_matches_per_fact(tmp_path: Path) -> None:
+    # A same-day/same-dims batch must recompute the shared rollup key exactly
+    # ONCE (not once per fact), and yield a rollup byte-identical to feeding the
+    # same facts through the singular ``ingest_fact`` path.
+    batch = Storage(tmp_path / "batch.sqlite")
+    now = _make_session(batch, "s1")
+    day = now.astimezone().date().isoformat()
+    facts = _same_day_batch(now)
+
+    with patch.object(
+        batch.telemetry,
+        "_recompute_rollup_key",
+        wraps=batch.telemetry._recompute_rollup_key,
+    ) as spy:
+        written = batch.telemetry.ingest_facts(facts)
+    assert written == 5
+    assert spy.call_count == 1
+    batch_metrics = _require_rollup(batch, day)
+    assert batch_metrics == {
+        "turns_user": 1,
+        "turns_agent": 1,
+        "tool_calls": 1,
+        "lifecycle": {"created": 1, "running": 1},
+    }
+
+    per_fact = Storage(tmp_path / "per_fact.sqlite")
+    _make_session(per_fact, "s1")
+    for fact, tags in _same_day_batch(now):
+        per_fact.telemetry.ingest_fact(fact, tags=tags)
+    assert _require_rollup(per_fact, day) == batch_metrics
+
+
+def test_ingest_facts_in_batch_revision_moves_across_days_leaves_no_stale_row(
+    tmp_path: Path,
+) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "s1")
+    day1_at = datetime(2026, 3, 15, 12, tzinfo=UTC)
+    day2_at = datetime(2026, 3, 17, 12, tzinfo=UTC)
+    day1 = day1_at.astimezone().date().isoformat()
+    day2 = day2_at.astimezone().date().isoformat()
+
+    v0 = TurnFact(
+        fact_id="a1",
+        source="codex",
+        session_id="s1",
+        occurred_at=day1_at,
+        dims=_dims(),
+        turn_kind=TurnKind.AGENT,
+        revision=0,
+    )
+    v1 = TurnFact(
+        fact_id="a1",
+        source="codex",
+        session_id="s1",
+        occurred_at=day2_at,
+        dims=_dims(),
+        turn_kind=TurnKind.AGENT,
+        revision=1,
+    )
+    storage.telemetry.ingest_facts([(v0, {}), (v1, {})])
+
+    # The fact moved to day2 in the same batch; day1's rollup key must be
+    # recomputed too (from the batch union) so it is deleted, not left stale.
+    assert _rollup_row(storage, day1) is None
+    assert _require_rollup(storage, day2)["turns_agent"] == 1
+
+
+class _RecordingConnection:
+    """Proxy that records executed SQL; ``sqlite3.Connection.execute`` is a
+    read-only C method and can't be patched directly."""
+
+    def __init__(self, real: Any) -> None:
+        self._real = real
+        self.executed: list[str] = []
+
+    def execute(self, sql: str, *args: Any, **kwargs: Any) -> Any:
+        self.executed.append(sql)
+        return self._real.execute(sql, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._real, name)
+
+
+def _tag_deletes(recorder: _RecordingConnection) -> list[str]:
+    return [sql for sql in recorder.executed if "DELETE FROM telemetry_fact_tag" in sql]
+
+
+def test_new_fact_without_tags_skips_tag_delete(tmp_path: Path) -> None:
+    # A brand-new untagged fact should not issue a tag-table DELETE (#7).
+    storage = Storage(tmp_path / "db.sqlite")
+    now = _make_session(storage, "s1")
+    fact = _lifecycle_fact("s1", LifecycleTransition.CREATED, occurred_at=now)
+
+    recorder = _RecordingConnection(storage.telemetry._conn)
+    storage.telemetry._conn = recorder  # type: ignore[assignment]
+    storage.telemetry.ingest_fact(fact)
+    assert _tag_deletes(recorder) == []
+
+    # A tagged new fact still writes (and clears) its tags.
+    recorder.executed.clear()
+    tagged = _lifecycle_fact("s1", LifecycleTransition.STARTING, occurred_at=now)
+    storage.telemetry.ingest_fact(tagged, tags={"role": "lead"})
+    assert _tag_deletes(recorder)
+
+    # A revision still clears prior tags even when untagged.
+    recorder.executed.clear()
+    revised = SessionLifecycleFact(
+        fact_id=fact.fact_id,
+        source="runtime",
+        session_id="s1",
+        occurred_at=now,
+        revision=1,
+        dims=_dims(),
+        transition=LifecycleTransition.CREATED,
+    )
+    storage.telemetry.ingest_fact(revised)
+    assert _tag_deletes(recorder)
+
+
+def test_heatmap_counts_bucket_weekday_hour_and_total(tmp_path: Path) -> None:
+    # Pins a KNOWN Sunday and Monday to explicit Monday=0 ``dow`` values to
+    # catch the SQLite ``%w`` (Sunday=0) off-by-one, plus an hour bucket, a
+    # quiet cell (omitted), and total-count == fact-count invariants.
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "s1")
+    sunday = datetime(2026, 3, 15, 10, 0, tzinfo=UTC)  # weekday()==6
+    monday = datetime(2026, 3, 16, 14, 0, tzinfo=UTC)  # weekday()==0
+
+    def _turn(fact_id: str, at: datetime) -> None:
+        storage.telemetry.ingest_fact(
+            TurnFact(
+                fact_id=fact_id,
+                source="codex",
+                session_id="s1",
+                occurred_at=at,
+                dims=_dims(),
+                turn_kind=TurnKind.AGENT,
+            )
+        )
+
+    _turn("t-sun", sunday)
+    _turn("t-mon-1", monday)
+    _turn("t-mon-2", monday + timedelta(minutes=30))  # same host hour → count 2
+    storage.telemetry.ingest_fact(
+        ToolCallFact(
+            fact_id="tool-mon",
+            source="codex",
+            session_id="s1",
+            occurred_at=monday + timedelta(minutes=45),  # same cell → count 3
+            dims=_dims(),
+            tool_name="Read",
+            outcome=ToolOutcome.SUCCEEDED,
+        )
+    )
+
+    rng = TelemetryRange(
+        start=datetime(2026, 3, 14, tzinfo=UTC),
+        end=datetime(2026, 3, 18, tzinfo=UTC),
+        tz="UTC",
+        utc_offset_minutes=0,
+    )
+    cells = {
+        (dow, hour): count
+        for dow, hour, count in storage.telemetry.heatmap_counts(rng, TelemetryFilter())
+    }
+
+    assert cells[(6, 10)] == 1  # Sunday 10:00 → Monday=0 contract dow 6
+    assert cells[(0, 14)] == 3  # Monday 14:xx: two turns + one tool_call
+    assert (1, 0) not in cells  # a quiet cell is omitted, not zero-filled
+
+    turn_count = storage.telemetry.count_facts(
+        TelemetryFactKind.TURN, rng, TelemetryFilter()
+    )
+    tool_count = storage.telemetry.count_facts(
+        TelemetryFactKind.TOOL_CALL, rng, TelemetryFilter()
+    )
+    assert sum(cells.values()) == turn_count + tool_count == 4
 
 
 def test_query_facts_and_count_facts(tmp_path: Path) -> None:

--- a/backend/tests/test_telemetry_store.py
+++ b/backend/tests/test_telemetry_store.py
@@ -678,6 +678,45 @@ def test_heatmap_counts_bucket_weekday_hour_and_total(tmp_path: Path) -> None:
     assert sum(cells.values()) == turn_count + tool_count == 4
 
 
+def test_heatmap_counts_applies_signed_host_offset(tmp_path: Path) -> None:
+    # Exercises the signed offset shift (and cross-midnight) that the zero-offset
+    # test above cannot: one UTC instant buckets into different host-tz cells
+    # under a positive (east, day-crossing) vs a negative (west) offset.
+    storage = Storage(tmp_path / "db.sqlite")
+    _make_session(storage, "s1")
+    # Sunday 23:30 UTC (weekday()==6).
+    at = datetime(2026, 3, 15, 23, 30, tzinfo=UTC)
+    storage.telemetry.ingest_fact(
+        TurnFact(
+            fact_id="t1",
+            source="codex",
+            session_id="s1",
+            occurred_at=at,
+            dims=_dims(),
+            turn_kind=TurnKind.AGENT,
+        )
+    )
+    window = dict(
+        start=datetime(2026, 3, 14, tzinfo=UTC),
+        end=datetime(2026, 3, 18, tzinfo=UTC),
+        tz="x",
+    )
+
+    def _cells(offset: int) -> dict[tuple[int, int], int]:
+        rng = TelemetryRange(**window, utc_offset_minutes=offset)
+        return {
+            (dow, hour): count
+            for dow, hour, count in storage.telemetry.heatmap_counts(
+                rng, TelemetryFilter()
+            )
+        }
+
+    # +08:00 → local Mon 07:30 → Monday=0 dow 0, hour 7 (crossed midnight).
+    assert _cells(480) == {(0, 7): 1}
+    # -05:00 → local Sun 18:30 → dow 6, hour 18 (still Sunday).
+    assert _cells(-300) == {(6, 18): 1}
+
+
 def test_query_facts_and_count_facts(tmp_path: Path) -> None:
     storage = Storage(tmp_path / "db.sqlite")
     now = _make_session(storage, "s1")


### PR DESCRIPTION
## Purpose

Address the telemetry performance/efficiency audit so the hot paths do work proportional to the answer, not to total fact count. **Stacked on #294** (base branch `fix/telemetry-deferred-followups`) — it builds on that PR's offload work and should merge after it. #294 offloaded the shapers off the event loop but left the residual per-query lock hold and the structural scan cost to this pass; this PR shortens both.

## Changes (backend only; API response shapes unchanged)

- **Coalesce rollup recompute across a drain batch** — `_ingest_fact_locked` now returns the affected `(day, dims)` keys instead of recomputing inline; `ingest_facts` recomputes each unique key once after all inserts. A same-day burst previously re-scanned that day up to once per fact (≈O(facts_today) per fact, all under the write lock); now it's one recompute per key. Byte-identical to the per-fact path (recompute is a full from-scratch day scan), including in-batch revisions that move a fact across days/dims (old+new key are both captured).
- **SQL activity heatmap + column projection** — the heatmap is now a `GROUP BY weekday, hour` over `kind IN ('turn','tool_call')` on the host-tz-shifted `occurred_at` (≤168 rows) instead of materializing ~32k row dicts and bucketing in Python; `query_facts` gained an optional column projection used by the heatmap and token-fold paths. Note: SQLite `strftime('%w')` is Sunday=0, converted to the code's Monday=0 contract with `(… + 6) % 7`.
- **Bounded lifecycle seed** — the restart dedup seed uses a per-session `ROW_NUMBER()` window query (≤ session count) run under `asyncio.to_thread`, instead of a full ordered scan of all lifecycle facts on the event-loop thread at boot.
- **Within-call dedupe** — `build_overview` fetches `list_sessions()` once and threads it into the active-count and alerting helpers (was 2–3 fetches). No cross-request cache (the dirty signal is an unversioned set/cleared event and deletes don't fire it — unusable for invalidation).
- **Rebuild DISTINCT / tag DELETE / index** — `rebuild_rollups_from_facts` groups by host-tz day instead of the near-unique timestamp; the per-fact `telemetry_fact_tag` DELETE is skipped for a new untagged fact; the marginal `idx_tf_kind_backend_time` index is dropped (measured within noise on a backend-filtered query, saves ~4.5 MB and a per-fact index write).

Deferred (audit Path 2): a dedicated read-only WAL connection for aggregation reads — revisit only if read/write contention persists after these hold-shortening changes.

## Test Plan

- `cd backend && uv run pytest`
- `cd backend && uv run pre-commit run` (isort, black, ruff, codespell, mypy) on the changed files
- Live before/after measurement against the populated backend DB (56k facts) via `waypointctl restart` + curl, and a Playwright `/telemetry` smoke.

## Test Result

- Backend suite: 2051 passed (6 new tests, incl. batch-coalesce equivalence + single-recompute assertion, in-batch cross-day revision, heatmap Sunday/Monday weekday pinning + total invariant, and the token-fold projection path). `test_rollup_delta_matches_rebuild` and the restart-dedup test stay green.
- Pre-commit: clean.
- Before/after (live, 56k-fact DB): wide `/api/telemetry/activity` ~0.58s → ~0.12s (~4–5×); during a heavy scan, concurrent DB-touching requests returned in 2–4 ms (4 of 5), with the single lock-hold window shrinking from ~570 ms to ~130 ms; heatmap renders all seven weekdays with the Monday=0 contract and its total matches the raw turn+tool_call fact count. `/telemetry` rendered on mobile+desktop, both themes, zero console errors.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title and described migration steps above.
- [ ] If this is a user-facing change, I updated documentation or config examples.

</details>