### PR TITLE
feat: make the usage telemetry dashboard opt-in

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1098,6 +1098,9 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         # does not advertise the telemetry surface. DELETE stays ungated as a
         # narrow privacy-cleanup path.
         if not context.settings.telemetry_enabled:
+            # The "telemetry is disabled" prefix is matched by the frontend's
+            # isTelemetryDisabledError (lib/api.ts) for its mid-restart-race
+            # fallback; keep them in sync (pinned by test_telemetry_opt_in).
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=(

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -267,6 +267,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 redact_preset(preset) for preset in context.runtime.presets.list()
             ],
             default_preset_id=_default_preset_id(context),
+            telemetry_enabled=context.settings.telemetry_enabled,
         )
 
     @app.post(
@@ -1091,11 +1092,27 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         return refreshed.model_dump(mode="json")
 
+    def require_telemetry_enabled() -> None:
+        # Master opt-in gate. Runs after token auth (the token dependency
+        # resolves before the handler body) and 404s so a disabled deployment
+        # does not advertise the telemetry surface. DELETE stays ungated as a
+        # narrow privacy-cleanup path.
+        if not context.settings.telemetry_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    "telemetry is disabled; enable it in your Waypoint config "
+                    "or set WAYPOINT_TELEMETRY_ENABLED=true, then restart the "
+                    "backend"
+                ),
+            )
+
     @app.get("/api/telemetry/overview")
     async def telemetry_overview(
         request: Request,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         overview = await asyncio.to_thread(
             telemetry_aggregate.build_overview,
@@ -1112,6 +1129,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
         group_by: Annotated[TokenGroupBy, Query()] = "time",
     ) -> Any:
+        require_telemetry_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         tokens = await asyncio.to_thread(
             telemetry_aggregate.build_tokens, context.storage, rng, flt, group_by
@@ -1123,6 +1141,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         activity = await asyncio.to_thread(
             telemetry_aggregate.build_activity, context.storage, rng, flt
@@ -1134,6 +1153,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         health = await asyncio.to_thread(
             telemetry_aggregate.build_health,
@@ -1152,6 +1172,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         page: Annotated[int, Query(ge=1)] = 1,
         page_size: Annotated[int, Query(ge=1, le=200)] = 20,
     ) -> Any:
+        require_telemetry_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         drilldown = await asyncio.to_thread(
             telemetry_aggregate.build_drilldown,
@@ -1169,6 +1190,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         insights = await asyncio.to_thread(
             telemetry_insights.compute_insights,
@@ -1185,6 +1207,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         rng, _flt = parse_range_filter(request, context.settings)
         context.storage.telemetry.dismiss_insight(
             signature, telemetry_aggregate.range_key(rng)
@@ -1195,6 +1218,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def telemetry_settings_view(
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         return telemetry_aggregate.build_settings(
             context.storage, context.settings
         ).model_dump(mode="json")
@@ -1220,6 +1244,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def telemetry_nl_insight_get(
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         _require_nl_enabled()
         stored_json = context.storage.telemetry.get_nl_insight()
         if stored_json is None:
@@ -1238,6 +1263,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: Request,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
+        require_telemetry_enabled()
         _require_nl_enabled()
         rng, flt = parse_range_filter(request, context.settings)
         insight = await context.runtime.generate_nl_digest(rng, flt)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -424,16 +424,20 @@ class SessionRuntime:
         self._broadcast_flusher = asyncio.create_task(
             self._session_broadcast_loop(), name="session-broadcast-flusher"
         )
-        self._telemetry_broadcast_task = asyncio.create_task(
-            self._telemetry_broadcast_loop(), name="telemetry-broadcast-flusher"
-        )
         if self.telemetry_ingester is not None:
             await self.telemetry_ingester.start()
-            # Backfill and pruning run off the boot path so a large history
-            # never delays startup or blocks a turn.
-            self._telemetry_backfill_task = asyncio.create_task(
-                self._run_telemetry_backfill(), name="telemetry-backfill"
+            # The broadcast flusher only has a purpose while collection is on;
+            # keeping it off when disabled makes the disabled state complete.
+            self._telemetry_broadcast_task = asyncio.create_task(
+                self._telemetry_broadcast_loop(), name="telemetry-broadcast-flusher"
             )
+            # Backfill and pruning run off the boot path so a large history
+            # never delays startup or blocks a turn. Historical import is a
+            # separate opt-in from live collection.
+            if self.settings.telemetry_backfill:
+                self._telemetry_backfill_task = asyncio.create_task(
+                    self._run_telemetry_backfill(), name="telemetry-backfill"
+                )
             self._telemetry_maintenance_task = asyncio.create_task(
                 self._telemetry_maintenance_loop(), name="telemetry-maintenance"
             )

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -641,6 +641,10 @@ class MeResponse(BaseModel):
     # populate its selector without a second round-trip. Env values are omitted.
     session_presets: list[SessionPresetSummary] = Field(default_factory=list)
     default_preset_id: str | None = None
+    # Whether usage telemetry is enabled. The frontend uses this capability to
+    # decide whether to offer the dashboard entry point and to short-circuit
+    # the `/telemetry` page to its disabled state before any telemetry fetch.
+    telemetry_enabled: bool = False
 
 
 class EventsPageResponse(BaseModel):

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from waypoint.backends.plugin_config import PluginConfig
 from waypoint.backends.registry import get_registry
@@ -195,8 +195,14 @@ class Settings(BaseModel):
     # ``enabled: false``.
     assistant: AssistantConfig | None = None
     # Usage telemetry (session lifecycle/turn/tool/context/limit facts +
-    # daily rollups) backing the Telemetry dashboard.
-    telemetry_enabled: bool = True
+    # daily rollups) backing the Telemetry dashboard. Opt-in: off unless the
+    # operator sets it (master switch for collection and dashboard access).
+    telemetry_enabled: bool = False
+    # One-time historical import of pre-enable session/ledger history. Separate
+    # opt-in so enabling live collection does not retroactively derive facts
+    # from activity that predates the decision. Only runs when the master
+    # switch is also on; the ``backfill_done`` marker keeps it one-shot.
+    telemetry_backfill: bool = False
     telemetry_retention_days: int = 90
     telemetry_rollup_retention_months: int = 13
     # Context-window occupancy percent thresholds (low, elevated, critical)
@@ -224,6 +230,12 @@ class Settings(BaseModel):
                 raw if isinstance(raw, schema) else schema.model_validate(raw or {})
             )
         return dispatched
+
+    @model_validator(mode="after")
+    def _require_master_switch_for_nl(self) -> "Settings":
+        if self.telemetry_nl.enabled and not self.telemetry_enabled:
+            raise ValueError("telemetry_nl.enabled requires telemetry_enabled: true")
+        return self
 
     @property
     def database_path(self) -> Path:
@@ -356,6 +368,10 @@ def _env_overrides(payload: dict[str, Any]) -> dict[str, Any]:
     if "WAYPOINT_TELEMETRY_ENABLED" in os.environ:
         overrides["telemetry_enabled"] = os.environ[
             "WAYPOINT_TELEMETRY_ENABLED"
+        ].lower() not in {"0", "false", "no", ""}
+    if "WAYPOINT_TELEMETRY_BACKFILL" in os.environ:
+        overrides["telemetry_backfill"] = os.environ[
+            "WAYPOINT_TELEMETRY_BACKFILL"
         ].lower() not in {"0", "false", "no", ""}
     if "WAYPOINT_TELEMETRY_RETENTION_DAYS" in os.environ:
         overrides["telemetry_retention_days"] = int(

--- a/backend/tests/test_telemetry_api.py
+++ b/backend/tests/test_telemetry_api.py
@@ -36,7 +36,7 @@ from waypoint.telemetry.query import host_utc_offset_minutes
 
 
 def _build(tmp_path: Path) -> tuple[Any, str]:
-    settings = Settings(data_dir=tmp_path / "data")
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=True)
     app = create_app(settings)
     context = app.state.context
     token = context.tokens.issue().token
@@ -407,7 +407,7 @@ async def test_nl_insight_endpoints_404_when_disabled(tmp_path: Path) -> None:
 
 
 async def test_nl_insight_post_generates_and_get_returns_it(tmp_path: Path) -> None:
-    settings = Settings(data_dir=tmp_path / "data")
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=True)
     settings.telemetry_nl.enabled = True
     app = create_app(settings)
     context = app.state.context
@@ -433,7 +433,7 @@ async def test_nl_insight_post_generates_and_get_returns_it(tmp_path: Path) -> N
 async def test_nl_insight_get_reports_unavailable_before_first_generation(
     tmp_path: Path,
 ) -> None:
-    settings = Settings(data_dir=tmp_path / "data")
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=True)
     settings.telemetry_nl.enabled = True
     app = create_app(settings)
     context = app.state.context
@@ -450,7 +450,7 @@ async def test_nl_insight_get_reports_unavailable_before_first_generation(
 async def test_nl_insight_post_returns_409_on_generation_failure(
     tmp_path: Path,
 ) -> None:
-    settings = Settings(data_dir=tmp_path / "data")
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=True)
     settings.telemetry_nl.enabled = True
     app = create_app(settings)
     context = app.state.context
@@ -467,7 +467,7 @@ async def test_nl_insight_post_returns_409_on_generation_failure(
 
 
 def test_delete_publishes_debounced_telemetry_update(tmp_path: Path) -> None:
-    settings = Settings(data_dir=tmp_path / "data")
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=True)
     app = create_app(settings)
     context = app.state.context
     token = context.tokens.issue().token

--- a/backend/tests/test_telemetry_opt_in.py
+++ b/backend/tests/test_telemetry_opt_in.py
@@ -1,0 +1,266 @@
+"""Tests for the opt-in telemetry gate (RFC: opt-in usage telemetry dashboard).
+
+Covers the master switch defaulting off, the separate historical-import
+switch, the NL cross-field requirement, runtime task gating, the endpoint
+guard (404 while disabled, DELETE still available), backfill-marker
+preservation through deletion, and the `/api/me` capability field.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import ValidationError
+from starlette.testclient import TestClient
+
+from waypoint.api import create_app
+from waypoint.runtime import SessionRuntime
+from waypoint.settings import Settings, TelemetryNLConfig, load_settings
+from waypoint.storage import Storage
+from waypoint.telemetry import aggregate
+from waypoint.telemetry.facts import (
+    FactDimensions,
+    LifecycleTransition,
+    SessionLifecycleFact,
+)
+
+GUARDED_GET_ENDPOINTS = [
+    "/api/telemetry/overview",
+    "/api/telemetry/tokens",
+    "/api/telemetry/activity",
+    "/api/telemetry/health",
+    "/api/telemetry/insights",
+    "/api/telemetry/settings",
+    "/api/telemetry/nl-insight",
+]
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _build(tmp_path: Path, *, enabled: bool, backfill: bool = False) -> tuple[Any, str]:
+    settings = Settings(
+        data_dir=tmp_path / "data",
+        telemetry_enabled=enabled,
+        telemetry_backfill=backfill,
+    )
+    app = create_app(settings)
+    token = app.state.context.tokens.issue().token
+    return app, token
+
+
+# ── settings defaults / overrides / validation ──────────────────────────────
+
+
+def test_defaults_disable_telemetry_and_backfill() -> None:
+    settings = Settings()
+    assert settings.telemetry_enabled is False
+    assert settings.telemetry_backfill is False
+
+
+def test_yaml_enables_both_switches(tmp_path: Path) -> None:
+    config = tmp_path / "waypoint.yaml"
+    config.write_text("telemetry_enabled: true\ntelemetry_backfill: true\n")
+    settings = load_settings(config)
+    assert settings.telemetry_enabled is True
+    assert settings.telemetry_backfill is True
+
+
+def test_env_overrides_take_precedence_over_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / "waypoint.yaml"
+    config.write_text("telemetry_enabled: true\ntelemetry_backfill: true\n")
+    monkeypatch.setenv("WAYPOINT_TELEMETRY_ENABLED", "false")
+    monkeypatch.setenv("WAYPOINT_TELEMETRY_BACKFILL", "0")
+    settings = load_settings(config)
+    assert settings.telemetry_enabled is False
+    assert settings.telemetry_backfill is False
+
+
+def test_env_enables_backfill_without_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config = tmp_path / "waypoint.yaml"
+    config.write_text("telemetry_enabled: true\n")
+    monkeypatch.setenv("WAYPOINT_TELEMETRY_BACKFILL", "yes")
+    settings = load_settings(config)
+    assert settings.telemetry_backfill is True
+
+
+def test_nl_enabled_requires_master_switch() -> None:
+    with pytest.raises(ValidationError):
+        Settings(telemetry_nl=TelemetryNLConfig(enabled=True))
+
+
+def test_nl_enabled_ok_with_master_switch() -> None:
+    settings = Settings(
+        telemetry_enabled=True, telemetry_nl=TelemetryNLConfig(enabled=True)
+    )
+    assert settings.telemetry_nl.enabled is True
+
+
+# ── runtime construction / task gating ───────────────────────────────────────
+
+
+def test_disabled_runtime_has_no_ingester(tmp_path: Path) -> None:
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=False)
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+    assert runtime.telemetry_ingester is None
+
+
+def test_enabled_runtime_has_ingester(tmp_path: Path) -> None:
+    settings = Settings(data_dir=tmp_path / "data", telemetry_enabled=True)
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+    assert runtime.telemetry_ingester is not None
+
+
+def test_disabled_runtime_starts_no_telemetry_tasks(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path, enabled=False)
+    with TestClient(app):
+        runtime = app.state.context.runtime
+        assert runtime._telemetry_backfill_task is None
+        assert runtime._telemetry_maintenance_task is None
+        assert runtime._telemetry_broadcast_task is None
+
+
+def test_enabled_without_backfill_runs_maintenance_and_broadcast_only(
+    tmp_path: Path,
+) -> None:
+    app, _ = _build(tmp_path, enabled=True, backfill=False)
+    with TestClient(app):
+        runtime = app.state.context.runtime
+        assert runtime._telemetry_backfill_task is None
+        assert runtime._telemetry_maintenance_task is not None
+        assert runtime._telemetry_broadcast_task is not None
+
+
+def test_enabled_with_backfill_starts_backfill_task(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path, enabled=True, backfill=True)
+    with TestClient(app):
+        runtime = app.state.context.runtime
+        assert runtime._telemetry_backfill_task is not None
+
+
+# ── deletion preserves the one-shot backfill marker ──────────────────────────
+
+
+def test_delete_preserves_backfill_marker(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    storage.telemetry.set_meta("backfill_done", "true")
+    storage.telemetry.ingest_fact(
+        SessionLifecycleFact(
+            fact_id="s1:created",
+            source="runtime",
+            session_id="s1",
+            occurred_at=datetime.now(UTC),
+            dims=FactDimensions.model_validate(
+                {
+                    "backend": "codex",
+                    "repo_name": "waypoint",
+                    "source": "managed",
+                    "transport": "tmux",
+                    "spawner_session_id": None,
+                    "is_child": False,
+                }
+            ),
+            transition=LifecycleTransition.CREATED,
+        )
+    )
+
+    result = aggregate.delete_all(storage)
+
+    assert result.removed.facts >= 1
+    assert result.transcripts_unaffected is True
+    # The one-shot marker survives so a later enabled restart does not
+    # re-derive the erased pre-enable history.
+    assert storage.telemetry.get_meta("backfill_done") == "true"
+
+
+# ── endpoint guard ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("path", GUARDED_GET_ENDPOINTS)
+async def test_guarded_get_endpoints_404_when_disabled(
+    tmp_path: Path, path: str
+) -> None:
+    app, token = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.get(path, headers=_auth(token))
+    assert resp.status_code == 404
+    assert "telemetry is disabled" in resp.json()["detail"]
+
+
+async def test_guarded_drilldown_404_when_disabled(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.get(
+            "/api/telemetry/drilldown",
+            params={"kind": "turn"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 404
+
+
+async def test_insight_dismiss_404_when_disabled(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/telemetry/insights/context_pressure/dismiss", headers=_auth(token)
+        )
+    assert resp.status_code == 404
+
+
+async def test_nl_insight_generate_404_when_disabled(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.post("/api/telemetry/nl-insight", headers=_auth(token))
+    assert resp.status_code == 404
+
+
+async def test_guarded_endpoint_requires_auth_before_gate(tmp_path: Path) -> None:
+    # The gate runs after auth: an unauthenticated request 401s, not 404s.
+    app, _ = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.get("/api/telemetry/overview")
+    assert resp.status_code == 401
+
+
+async def test_delete_available_while_disabled(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.delete("/api/telemetry", headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["transcripts_unaffected"] is True
+
+
+# ── /api/me capability ───────────────────────────────────────────────────────
+
+
+async def test_me_advertises_disabled_capability(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, enabled=False)
+    async with _client(app) as client:
+        resp = await client.get("/api/me", headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["telemetry_enabled"] is False
+
+
+async def test_me_advertises_enabled_capability(tmp_path: Path) -> None:
+    app, token = _build(tmp_path, enabled=True)
+    async with _client(app) as client:
+        resp = await client.get("/api/me", headers=_auth(token))
+    assert resp.status_code == 200
+    assert resp.json()["telemetry_enabled"] is True

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -109,8 +109,16 @@ plugin_configs:
 #   transport: claude_cli         # agent default (Emulated for Claude Code) if unset
 
 # Usage telemetry backing the Telemetry dashboard (aggregate-only, local, no
-# content capture). All values shown at their defaults; see docs/telemetry.md.
-# telemetry_enabled: true
+# content capture). Opt-in and OFF by default: while disabled, nothing is
+# collected, the dashboard link is hidden, and telemetry read APIs 404.
+# Set telemetry_enabled: true and restart the backend to turn it on. See
+# docs/telemetry.md. All other values shown at their defaults.
+# telemetry_enabled: false
+# telemetry_backfill: false                 # one-time import of history from
+#                                           # sessions that predate activation.
+#                                           # Separate opt-in: enabling live
+#                                           # collection does not import history
+#                                           # unless this is also true.
 # telemetry_retention_days: 90              # fact-level retention
 # telemetry_rollup_retention_months: 13     # daily-rollup retention
 # telemetry_context_thresholds: [70, 90, 100]  # context/limit warning thresholds

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -156,7 +156,10 @@ existing collectors must add `telemetry_enabled: true` before restarting or
 collection and the dashboard silently go away (existing facts stay on disk but
 become inaccessible until re-enabled). And a config that sets
 `telemetry_nl.enabled: true` without `telemetry_enabled: true` now fails to boot
-— the NL summarizer requires the master switch.
+— the NL summarizer requires the master switch. Because of that fail-fast, a
+`WAYPOINT_TELEMETRY_ENABLED=false` env kill-switch over a YAML config that leaves
+`telemetry_nl.enabled: true` must also disable the summarizer
+(`WAYPOINT_TELEMETRY_NL_ENABLED=false`) so the resolved config stays valid.
 
 Disabling telemetry later stops new collection but never deletes existing facts;
 use the explicit delete control (or `DELETE /api/telemetry`, which stays

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -50,8 +50,9 @@ generic runtime, storage, API, and frontend code never branch on backend id.
   the already-normalized event stream and session-field updates at the runtime's
   existing publish seams. Derivation only enqueues (bounded, error-swallowing —
   telemetry never blocks a turn); a runtime-owned background task drains the queue
-  in yielding batches. A one-time, guarded backfill seeds facts from existing
-  history so the dashboard is populated immediately.
+  in yielding batches. A one-time, guarded backfill can seed facts from existing
+  history so the dashboard is populated immediately — it is off by default and
+  runs only when `telemetry_backfill` is enabled alongside the master switch.
 - **Aggregation + API** (`aggregate.py`, endpoints in `api.py`) — range/rollup
   queries shape the `/api/telemetry/*` responses (`overview`, `tokens`,
   `activity`, `health`, `drilldown`, `insights`, `settings`, and `DELETE`). A
@@ -63,8 +64,11 @@ generic runtime, storage, API, and frontend code never branch on backend id.
 Fact-level telemetry is retained for **90 days**, daily aggregates for **13
 months** (both configurable). Pruning runs on a slow runtime-owned task.
 Deleting a session immediately drops its facts and recomputes affected rollups;
-deleting all telemetry from Settings removes facts, rollups, and dismissals.
-Neither touches the session's separately managed transcript.
+deleting all telemetry from Settings removes facts, rollups, dismissals, and the
+stored NL digest. Neither touches the session's separately managed transcript.
+The all-telemetry delete deliberately keeps the one-time `backfill_done` marker,
+so a later restart with `telemetry_backfill` on cannot recreate the erased
+pre-enable history.
 
 ## Token accounting
 
@@ -123,15 +127,41 @@ maintenance task; a digest can also be regenerated on demand from the card.
 
 ## Configuration
 
+Telemetry is **opt-in and off by default**. With no `telemetry_enabled` setting,
+a fresh install collects nothing, hides the dashboard entry point, and returns
+`404` from every telemetry read/insight endpoint. To turn it on, set
+`telemetry_enabled: true` in `backend/waypoint.yaml` (or
+`WAYPOINT_TELEMETRY_ENABLED=true`) and **restart the backend** — settings load at
+startup. Live collection begins at that point; it does not import earlier
+history unless you also opt in to `telemetry_backfill` (see below).
+
 Backend settings (defaults shown; override in `backend/waypoint.yaml` or via env):
 
 | Setting | Env var | Default | Purpose |
 |---|---|---|---|
-| `telemetry_enabled` | `WAYPOINT_TELEMETRY_ENABLED` | `true` | Master switch for collection. |
+| `telemetry_enabled` | `WAYPOINT_TELEMETRY_ENABLED` | `false` | Master switch: enables live collection and dashboard/API availability. |
+| `telemetry_backfill` | `WAYPOINT_TELEMETRY_BACKFILL` | `false` | One-time import of history from sessions/ledger rows that predate activation. Only runs when the master switch is also on. |
 | `telemetry_retention_days` | `WAYPOINT_TELEMETRY_RETENTION_DAYS` | `90` | Fact-level retention. |
 | `telemetry_rollup_retention_months` | `WAYPOINT_TELEMETRY_ROLLUP_RETENTION_MONTHS` | `13` | Daily-rollup retention. |
 | `telemetry_context_thresholds` | `WAYPOINT_TELEMETRY_CONTEXT_THRESHOLDS` | `70,90,100` | Context/limit warning thresholds. |
 | `telemetry_local_labels` | `WAYPOINT_TELEMETRY_LOCAL_LABELS` | `false` | Show provider-derived account labels instead of the pseudonym. |
+
+Environment variables override YAML. `telemetry_backfill` is a one-time
+migration flag — the import is guarded by a persistent `backfill_done` marker, so
+leaving it `true` is harmless (subsequent restarts are no-ops), but it is
+clearest to remove it after the first enabled boot.
+
+Two upgrade notes for deployments that ran telemetry before it became opt-in:
+existing collectors must add `telemetry_enabled: true` before restarting or
+collection and the dashboard silently go away (existing facts stay on disk but
+become inaccessible until re-enabled). And a config that sets
+`telemetry_nl.enabled: true` without `telemetry_enabled: true` now fails to boot
+— the NL summarizer requires the master switch.
+
+Disabling telemetry later stops new collection but never deletes existing facts;
+use the explicit delete control (or `DELETE /api/telemetry`, which stays
+available while disabled) to erase them. Deletion preserves the `backfill_done`
+marker, so a later re-enable does not re-derive erased pre-enable history.
 
 The opt-in summarizer is configured under a `telemetry_nl` block (or the matching
 `WAYPOINT_TELEMETRY_NL_*` env vars): `enabled` (default `false`), `backend`,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -15972,6 +15972,30 @@ html[data-theme="light"] .wp-hl {
   text-decoration: underline;
 }
 
+/* Disabled state shown on /telemetry when the master switch is off. Flat,
+   opaque, in-flow content — reuses the .board-empty layout inside .panel. */
+.telemetry-disabled code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  color: var(--text-strong);
+}
+
+.telemetry-disabled-snippet {
+  margin: 4px 0;
+  padding: 12px 14px;
+  background: var(--bg-card-soft);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text-strong);
+  overflow-x: auto;
+}
+
+.telemetry-disabled-actions {
+  margin-top: 8px;
+}
+
 /* Page-level grid: every telemetry section is a direct child of .page-shell's
    grid, spaced by its existing `gap`, so no extra top-level wrapper needed. */
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -150,6 +150,7 @@ export default function HomePage() {
   const [launchTargets, setLaunchTargets] = useState<LaunchTargetSummary[]>([]);
   const [sessionPresets, setSessionPresets] = useState<SessionPresetSummary[]>([]);
   const [defaultPresetId, setDefaultPresetId] = useState<string | null>(null);
+  const [telemetryEnabled, setTelemetryEnabled] = useState(false);
   const [activeLaunchTargetId, setActiveLaunchTargetId] = useState("");
   // Password-auth SSH connect prompt. ``retry`` re-runs the launch that hit a
   // 409 once the ControlMaster is up; ``null`` when the prompt was opened
@@ -328,6 +329,7 @@ export default function HomePage() {
         }
         setSessionPresets(me.session_presets ?? []);
         setDefaultPresetId(me.default_preset_id ?? null);
+        setTelemetryEnabled(me.telemetry_enabled ?? false);
         setSchedules(scheduleItems);
         setMessageSchedules(messageItems);
         const storedTargetId = readLaunchTarget(host);
@@ -1167,6 +1169,7 @@ export default function HomePage() {
           host={host}
           token={token}
           sessions={sessions}
+          telemetryEnabled={telemetryEnabled}
           onAuthFailure={handleAuthFailure}
         />
       ) : null}

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -571,7 +571,11 @@ export default function TelemetryPage() {
         </div>
       ) : null}
 
-      {telemetryCap === "disabled" ? (
+      {telemetryCap === "unknown" ? (
+        <section className="panel bordered board-empty">
+          <h2>Loading telemetry…</h2>
+        </section>
+      ) : telemetryCap === "disabled" ? (
         <section className="panel bordered board-empty telemetry-disabled">
           <h2>Telemetry is disabled</h2>
           <p className="muted">

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -27,8 +27,10 @@ import {
   fetchTelemetrySettings,
   fetchTelemetryTokens,
   fetchNLInsight,
+  fetchMe,
   generateNLInsight,
   isAuthError,
+  isTelemetryDisabledError,
 } from "@/lib/api";
 import { agentTransports, useBackendCatalog } from "@/lib/backends";
 import { clearToken, readHost, readToken } from "@/lib/store";
@@ -54,6 +56,11 @@ const DRILLDOWN_PAGE_SIZE = 20;
 const REFRESH_DEBOUNCE_MS = 400;
 
 type LoadState = "loading" | "ready" | "error";
+// Master telemetry opt-in, resolved from `/api/me` before any telemetry fetch.
+// It starts "unknown" so the refreshers and the WS subscription stay dormant
+// until the capability is known — a fresh mount must never touch a telemetry
+// endpoint while the feature might be disabled.
+type TelemetryCapability = "unknown" | "enabled" | "disabled";
 
 // Insight click-throughs carry the aggregate endpoint they were derived from;
 // route "View evidence" to the matching section so it lands on the data behind
@@ -75,6 +82,7 @@ export default function TelemetryPage() {
   const [token, setToken] = useState("");
   const [state, setState] = useState<LoadState>("loading");
   const [error, setError] = useState("");
+  const [telemetryCap, setTelemetryCap] = useState<TelemetryCapability>("unknown");
 
   const [range, setRange] = useState(() => readTelemetryQuery().range);
   const [filters, setFilters] = useState(() => readTelemetryQuery().filters);
@@ -128,6 +136,31 @@ export default function TelemetryPage() {
     }
   }, [router]);
 
+  // Resolve the telemetry capability before any telemetry fetch fires. Until
+  // this settles, `telemetryCap` stays "unknown" and every refresher + the WS
+  // subscription short-circuit, so a disabled backend is never probed.
+  useEffect(() => {
+    if (!host || !token) return;
+    let active = true;
+    fetchMe(host, token)
+      .then((me) => {
+        if (!active) return;
+        setTelemetryCap(me.telemetry_enabled ? "enabled" : "disabled");
+      })
+      .catch((err) => {
+        if (!active) return;
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return;
+        }
+        setState("error");
+        setError(err instanceof Error ? err.message : "failed to load telemetry");
+      });
+    return () => {
+      active = false;
+    };
+  }, [host, token, handleAuthFailure]);
+
   // Persist range/filters (skip the very first render, which is what we just read).
   const skipPersist = useRef(true);
   useEffect(() => {
@@ -148,7 +181,7 @@ export default function TelemetryPage() {
   const drilldownReqRef = useRef(0);
 
   const refreshOverviewGroup = useCallback(async () => {
-    if (!host || !token) return;
+    if (!host || !token || telemetryCap !== "enabled") return;
     const requestId = ++overviewReqRef.current;
     if (customRangeIncomplete) {
       setOverviewLoading(false);
@@ -180,6 +213,10 @@ export default function TelemetryPage() {
         handleAuthFailure();
         return;
       }
+      if (isTelemetryDisabledError(err)) {
+        setTelemetryCap("disabled");
+        return;
+      }
       if (requestId !== overviewReqRef.current) return;
       setState((current) => (current === "ready" ? current : "error"));
       setError(err instanceof Error ? err.message : "failed to load telemetry");
@@ -191,10 +228,10 @@ export default function TelemetryPage() {
         setInsightsLoading(false);
       }
     }
-  }, [host, token, range, filters, customRangeIncomplete, handleAuthFailure]);
+  }, [host, token, range, filters, customRangeIncomplete, telemetryCap, handleAuthFailure]);
 
   const refreshTokens = useCallback(async () => {
-    if (!host || !token) return;
+    if (!host || !token || telemetryCap !== "enabled") return;
     const requestId = ++tokensReqRef.current;
     if (customRangeIncomplete) {
       setTokensLoading(false);
@@ -210,6 +247,10 @@ export default function TelemetryPage() {
         handleAuthFailure();
         return;
       }
+      if (isTelemetryDisabledError(err)) {
+        setTelemetryCap("disabled");
+        return;
+      }
       if (requestId !== tokensReqRef.current) return;
       setError(err instanceof Error ? err.message : "failed to load token usage");
     } finally {
@@ -217,10 +258,10 @@ export default function TelemetryPage() {
         setTokensLoading(false);
       }
     }
-  }, [host, token, range, filters, tokenGroupBy, customRangeIncomplete, handleAuthFailure]);
+  }, [host, token, range, filters, tokenGroupBy, customRangeIncomplete, telemetryCap, handleAuthFailure]);
 
   const refreshDrilldown = useCallback(async () => {
-    if (!host || !token) return;
+    if (!host || !token || telemetryCap !== "enabled") return;
     const requestId = ++drilldownReqRef.current;
     if (customRangeIncomplete) {
       setDrilldownLoading(false);
@@ -244,6 +285,10 @@ export default function TelemetryPage() {
         handleAuthFailure();
         return;
       }
+      if (isTelemetryDisabledError(err)) {
+        setTelemetryCap("disabled");
+        return;
+      }
       if (requestId !== drilldownReqRef.current) return;
       setError(err instanceof Error ? err.message : "failed to load drilldown");
     } finally {
@@ -259,11 +304,12 @@ export default function TelemetryPage() {
     drilldownKind,
     drilldownPage,
     customRangeIncomplete,
+    telemetryCap,
     handleAuthFailure,
   ]);
 
   const refreshSettings = useCallback(async () => {
-    if (!host || !token) return;
+    if (!host || !token || telemetryCap !== "enabled") return;
     setSettingsLoading(true);
     try {
       const res = await fetchTelemetrySettings(host, token);
@@ -273,11 +319,15 @@ export default function TelemetryPage() {
         handleAuthFailure();
         return;
       }
+      if (isTelemetryDisabledError(err)) {
+        setTelemetryCap("disabled");
+        return;
+      }
       setError(err instanceof Error ? err.message : "failed to load telemetry settings");
     } finally {
       setSettingsLoading(false);
     }
-  }, [host, token, handleAuthFailure]);
+  }, [host, token, telemetryCap, handleAuthFailure]);
 
   useEffect(() => {
     void refreshOverviewGroup();
@@ -300,7 +350,7 @@ export default function TelemetryPage() {
   // doesn't depend on [range, filters]. A 404/409 (feature off or not yet
   // deployed) resolves to `null`, not an error (CONTRACT-NL.md §4).
   const refreshNLInsight = useCallback(async () => {
-    if (!host || !token) return;
+    if (!host || !token || telemetryCap !== "enabled") return;
     setNlLoading(true);
     try {
       const res = await fetchNLInsight(host, token);
@@ -310,11 +360,15 @@ export default function TelemetryPage() {
         handleAuthFailure();
         return;
       }
+      if (isTelemetryDisabledError(err)) {
+        setTelemetryCap("disabled");
+        return;
+      }
       // Non-blocking: the NL card degrades to its empty state on failure.
     } finally {
       setNlLoading(false);
     }
-  }, [host, token, handleAuthFailure]);
+  }, [host, token, telemetryCap, handleAuthFailure]);
 
   useEffect(() => {
     void refreshNLInsight();
@@ -336,7 +390,7 @@ export default function TelemetryPage() {
   }, [refreshOverviewGroup, refreshTokens, refreshDrilldown]);
 
   useEffect(() => {
-    if (!host || !token) return;
+    if (!host || !token || telemetryCap !== "enabled") return;
     let active = true;
     let socket: WebSocket | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -386,7 +440,7 @@ export default function TelemetryPage() {
       if (debounceTimer !== null) clearTimeout(debounceTimer);
       socket?.close();
     };
-  }, [host, token, handleAuthFailure]);
+  }, [host, token, telemetryCap, handleAuthFailure]);
 
   const handleDismissInsight = useCallback(
     async (insight: Insight) => {
@@ -517,7 +571,42 @@ export default function TelemetryPage() {
         </div>
       ) : null}
 
-      {state === "error" && !overview ? (
+      {telemetryCap === "disabled" ? (
+        <section className="panel bordered board-empty telemetry-disabled">
+          <h2>Telemetry is disabled</h2>
+          <p className="muted">
+            The usage telemetry dashboard is opt-in. No usage facts are collected while it is off.
+          </p>
+          <p className="muted">
+            To turn it on, add this to <code>backend/waypoint.yaml</code> and restart the backend:
+          </p>
+          <pre className="telemetry-disabled-snippet">
+            <code>telemetry_enabled: true</code>
+          </pre>
+          <p className="muted">
+            Live collection starts after the restart. It does not import earlier history by default —
+            add <code>telemetry_backfill: true</code> for a one-time import of sessions that predate
+            activation.
+          </p>
+          <div className="telemetry-disabled-actions">
+            {deleteResult ? (
+              <p className="muted" role="status">
+                Removed {deleteResult.removed.facts} facts and {deleteResult.removed.rollups} rollups.
+                Transcripts were not affected.
+              </p>
+            ) : (
+              <button
+                type="button"
+                className="danger"
+                disabled={deleting}
+                onClick={() => void handleDeleteTelemetry()}
+              >
+                {deleting ? "Deleting…" : "Delete retained telemetry"}
+              </button>
+            )}
+          </div>
+        </section>
+      ) : state === "error" && !overview ? (
         <section className="panel bordered board-empty">
           <h2>Couldn’t load telemetry</h2>
           <p className="muted">The backend didn’t respond. Check that Waypoint is running, then retry.</p>

--- a/frontend/src/components/UsageDashboardSection.tsx
+++ b/frontend/src/components/UsageDashboardSection.tsx
@@ -27,6 +27,9 @@ interface UsageDashboardSectionProps {
   host: string;
   token: string;
   sessions: SessionRecord[];
+  // Master telemetry opt-in. The rate-limit deck always renders; only the
+  // full-telemetry dashboard link is gated on this.
+  telemetryEnabled: boolean;
   onAuthFailure?: () => void;
 }
 
@@ -184,6 +187,7 @@ export function UsageDashboardSection({
   host,
   token,
   sessions,
+  telemetryEnabled,
   onAuthFailure,
 }: UsageDashboardSectionProps) {
   const [open, setOpen] = useState(false);
@@ -334,9 +338,11 @@ export function UsageDashboardSection({
               <span className="usage-deck-status-detail">{status.detail}</span>
             </div>
             <div className="usage-deck-status-actions">
-              <Link className="usage-deck-full-link" href="/telemetry">
-                View full telemetry →
-              </Link>
+              {telemetryEnabled ? (
+                <Link className="usage-deck-full-link" href="/telemetry">
+                  View full telemetry →
+                </Link>
+              ) : null}
               {status.freshest ? (
                 <span
                   className="usage-deck-status-sweep"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1896,6 +1896,8 @@ export function isAuthError(error: unknown): error is AuthError {
 // `/telemetry` page can recognize a disabled-state 404 (e.g. a setting that
 // changed between the `/api/me` capability fetch and a telemetry request during
 // a backend restart) and fall back to its disabled view rather than an outage.
+// The prefix is set by `require_telemetry_enabled()` in backend/.../api.py and
+// pinned by test_telemetry_opt_in's 404-detail assertions — keep them in sync.
 export function isTelemetryDisabledError(error: unknown): boolean {
   return (
     error instanceof Error &&

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1891,6 +1891,19 @@ export function isAuthError(error: unknown): error is AuthError {
   return error instanceof AuthError;
 }
 
+// A telemetry endpoint returns 404 with this detail while the feature is
+// disabled. `ensureOk` surfaces the detail as the Error message, so the
+// `/telemetry` page can recognize a disabled-state 404 (e.g. a setting that
+// changed between the `/api/me` capability fetch and a telemetry request during
+// a backend restart) and fall back to its disabled view rather than an outage.
+export function isTelemetryDisabledError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    !(error instanceof AuthError) &&
+    error.message.toLowerCase().startsWith("telemetry is disabled")
+  );
+}
+
 export async function forkSideQuestion(
   host: string,
   token: string,

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -357,6 +357,9 @@ export interface MeResponse {
   assistant?: AssistantSummary | null;
   session_presets?: SessionPresetSummary[];
   default_preset_id?: string | null;
+  // Master telemetry opt-in. When false (or absent), the dashboard entry point
+  // is hidden and the /telemetry page renders its disabled state.
+  telemetry_enabled?: boolean;
 }
 
 // Full preset spec (with launch_env values); returned only from the


### PR DESCRIPTION
## Purpose

Make Waypoint's usage Telemetry dashboard opt-in. A fresh install now collects no telemetry facts and does not expose the dashboard unless the operator turns it on in `backend/waypoint.yaml`. `telemetry_enabled` becomes the master availability + collection switch and its default flips from `true` to `false`; while disabled, the dashboard entry point is hidden, telemetry read/insight endpoints return `404`, and the CLI is transitively covered. Historical import is split into a separate `telemetry_backfill` opt-in so enabling live collection never retroactively derives facts from sessions that predate consent. Implements `docs/rfc` "Opt-in Usage Telemetry Dashboard" (Option 2).

Two upgrade notes for deployments that ran telemetry before this change: an existing collector must add `telemetry_enabled: true` before restarting or collection and the dashboard silently go away (existing facts stay on disk, just inaccessible until re-enabled); and a config with `telemetry_nl.enabled: true` but no `telemetry_enabled: true` now fails fast at boot, since the NL summarizer requires the master switch. Settings load at startup, so a backend restart is required either way.

## Changes

### Backend
- `settings.py` — default `telemetry_enabled` to `false`; add `telemetry_backfill: bool = False` with a `WAYPOINT_TELEMETRY_BACKFILL` env override; add a model validator that rejects `telemetry_nl.enabled` without the master switch.
- `runtime.py` — construct the ingester only when enabled (unchanged); gate the historical backfill task on `telemetry_backfill`; start the telemetry broadcast flusher only when collection is on, so the disabled state is operationally complete.
- `api.py`, `schemas.py` — add a shared `require_telemetry_enabled()` guard (runs after token auth, returns `404` with an actionable detail) on every telemetry read/insight/generate endpoint; `DELETE /api/telemetry` stays authenticated but ungated as a privacy-cleanup path; expose `telemetry_enabled` on `/api/me`.
- Backfill stays one-shot via the existing `backfill_done` marker, which deletion deliberately preserves so a later enabled restart cannot re-derive erased pre-enable history.

### Frontend
- `lib/types.ts`, `lib/api.ts` — add the `telemetry_enabled` capability to `MeResponse` and an `isTelemetryDisabledError` helper (matches the guard's 404 detail without touching the shared `ensureOk`).
- `app/page.tsx`, `components/UsageDashboardSection.tsx` — thread the capability through so the "View full telemetry" link only renders when enabled; the rate-limit usage deck stays visible regardless.
- `app/telemetry/page.tsx` — resolve the capability from `/api/me` before any telemetry fetch; until it settles, all refreshers and the WebSocket subscription stay dormant, so a disabled backend is never probed. When disabled, render an explicit opt-in state (YAML snippet, restart note, live-vs-historical distinction, delete-retained-telemetry control). A telemetry 404 from a setting that flips mid-restart converts to the same disabled state rather than a generic outage.
- `app/globals.css` — disabled-state styles resolving from tokens in both themes.

### Docs
- `backend/waypoint.example.yaml`, `docs/telemetry.md` — document the default-off activation boundary, the separate `telemetry_backfill` one-time import, the restart requirement, the NL cross-field requirement, deletion semantics (marker preserved), and the two upgrade breaks.

## Design

`telemetry_enabled` is the single master gate; `telemetry_backfill` is an independent one-time-import flag because the pre-existing backfill otherwise turns a live-collection choice into a retrospective history-processing choice. The endpoint guard is an in-body call mirroring the existing `_require_nl_enabled()` precedent, which guarantees it runs after authentication. The SQLite schema stays eagerly initialized — empty local tables hold no collected telemetry, and moving schema setup behind the setting would add migration and delete-path complexity for no privacy gain. On the frontend, the capability starts "unknown" and blocks every fetch, so the opt-in guarantee ("no telemetry request while disabled") holds through the mount race, not just steady state.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`
- `cd frontend && npm run lint && npm run build`
- E2E on the deployed stack across a backend restart, both config states and both themes: with telemetry disabled, confirmed `/api/me` reports `false`, all guarded endpoints return `404` with the enablement detail, `DELETE /api/telemetry` still returns `200`, the home dashboard link is absent (with the usage deck forced open) while the rate-limit deck stays, and `/telemetry` renders the disabled state without issuing telemetry fetches; with telemetry enabled, confirmed `/api/me` reports `true`, all endpoints return `200`, the link reappears, and the full dashboard renders. Verified the validator boots cleanly for both the disabled (`telemetry_nl` off) and enabled (`telemetry_nl` on) configs.

## Test Result

- Pre-commit: clean (isort, black, ruff, codespell, mypy).
- Backend suite: 2078 passed, 3 pre-existing/unrelated warnings (includes a new `test_telemetry_opt_in.py` covering defaults, env precedence, the validator, runtime task gating, the 404 guards, DELETE-while-disabled, backfill-marker preservation, and the `/api/me` capability).
- Frontend lint and production build: passed.
- E2E: disabled and enabled states both verified live via API checks and Playwright screenshots (mobile width, dark + light); disabled state renders on-brand in both themes and probes no telemetry endpoint; enabled dashboard populates tokens/sessions/activity/health/drilldown.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [x] I have updated documentation or config examples (`backend/waypoint.example.yaml`, `docs/`) if user-facing behavior changed.

</details>