### PR TITLE
fix: isolate /btw side-questions from built-in and MCP tools

### DIFF
--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -77,13 +77,33 @@ _ONE_SHOT_TIMEOUT = 120.0
 # process from loading any ambient MCP server, so no MCP tool ever exists in the
 # forked conversation. ``--disallowedTools "*"`` is belt-and-suspenders denial
 # on top. A ``/btw`` worker has no stream/approval channel to mediate a tool
-# call, so it must expose none. Never relax this to an advisory prompt.
+# call, so it must expose none. This boundary is the enforcement mechanism and
+# must never be relaxed to rely on the advisory prompt below instead.
 _TOOL_ISOLATION_ARGS: tuple[str, ...] = (
     "--tools",
     "",
     "--disallowedTools",
     "*",
     "--strict-mcp-config",
+)
+
+# Answer-quality shaping, NOT an enforcement mechanism — the flags above are the
+# capability boundary. With every tool stripped from its context, an aside asked
+# to do something tool-requiring otherwise emits a pseudo tool-call as prose
+# (and can leak an internal system-reminder) into the answer card instead of
+# declining. This short reminder makes it answer from the conversation or refuse
+# in one plain sentence. Kept minimal; never relied on for safety.
+_SIDE_QUESTION_SYSTEM_PROMPT = (
+    "You are answering a brief, read-only side-question from an existing "
+    "conversation. You have no tools available and cannot read files, run "
+    "commands, browse, or call any tool or MCP server. Answer only from the "
+    "conversation context and your own knowledge. If the question genuinely "
+    "requires a tool or information not in the conversation, say so in one "
+    "sentence."
+)
+_ANSWER_STYLE_ARGS: tuple[str, ...] = (
+    "--append-system-prompt",
+    _SIDE_QUESTION_SYSTEM_PROMPT,
 )
 
 # Per-session asyncio locks for transport_state["pending_side_questions"] mutations.
@@ -252,6 +272,7 @@ async def _run_one_shot_local(
         "--output-format",
         "json",
         *_TOOL_ISOLATION_ARGS,
+        *_ANSWER_STYLE_ARGS,
     ]
     cwd_path = Path(cwd).expanduser()
     proc = await asyncio.create_subprocess_exec(
@@ -295,6 +316,7 @@ async def _run_one_shot_remote(
         "--output-format",
         "json",
         *_TOOL_ISOLATION_ARGS,
+        *_ANSWER_STYLE_ARGS,
     ]
     remote_parts = [
         f"cd {quote_remote_path(cwd)}",

--- a/backend/src/waypoint/backends/claude_code/side_question.py
+++ b/backend/src/waypoint/backends/claude_code/side_question.py
@@ -70,6 +70,22 @@ log = logging.getLogger("waypoint.backends.claude_code.side_question")
 MAX_ATTEMPTS = 3
 _ONE_SHOT_TIMEOUT = 120.0
 
+# Capability boundary for the ``/btw`` one-shot, applied identically on the
+# local and remote paths. Enforcement lives here in the CLI flags, not in a
+# prompt reminder: ``--tools ""`` disables every built-in tool, and
+# ``--strict-mcp-config`` with no accompanying ``--mcp-config`` stops the aside
+# process from loading any ambient MCP server, so no MCP tool ever exists in the
+# forked conversation. ``--disallowedTools "*"`` is belt-and-suspenders denial
+# on top. A ``/btw`` worker has no stream/approval channel to mediate a tool
+# call, so it must expose none. Never relax this to an advisory prompt.
+_TOOL_ISOLATION_ARGS: tuple[str, ...] = (
+    "--tools",
+    "",
+    "--disallowedTools",
+    "*",
+    "--strict-mcp-config",
+)
+
 # Per-session asyncio locks for transport_state["pending_side_questions"] mutations.
 _session_locks: dict[str, asyncio.Lock] = {}
 
@@ -235,8 +251,7 @@ async def _run_one_shot_local(
         fork_id,
         "--output-format",
         "json",
-        "--tools",
-        "",
+        *_TOOL_ISOLATION_ARGS,
     ]
     cwd_path = Path(cwd).expanduser()
     proc = await asyncio.create_subprocess_exec(
@@ -279,8 +294,7 @@ async def _run_one_shot_remote(
         fork_id,
         "--output-format",
         "json",
-        "--tools",
-        "",
+        *_TOOL_ISOLATION_ARGS,
     ]
     remote_parts = [
         f"cd {quote_remote_path(cwd)}",

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -1026,7 +1026,7 @@ async def test_recover_covers_extra_backend_ids(
 
 
 # ---------------------------------------------------------------------------
-# Fix 1: --tools "" disables tools in one-shot argv
+# Fix 1: built-in and MCP tools are disabled in the one-shot argv
 # ---------------------------------------------------------------------------
 
 
@@ -1034,7 +1034,11 @@ async def test_one_shot_local_argv_disables_tools(
     runtime: Any,
     plugin: Any,
 ) -> None:
-    """The local one-shot must pass --tools "" so Claude cannot call any tool."""
+    """The local one-shot must isolate the aside from every built-in and MCP tool.
+
+    ``--tools ""`` denies built-ins, ``--disallowedTools "*"`` denies every
+    surfaced tool, and ``--strict-mcp-config`` (with no ``--mcp-config``) stops
+    any ambient MCP server from loading. All three must be present."""
     session = _make_session(runtime.storage, thread_id="thread-abc")
     _write_side_questions(
         runtime,
@@ -1086,10 +1090,17 @@ async def test_one_shot_local_argv_disables_tools(
     assert (
         argv[tools_idx + 1] == ""
     ), f"--tools value is not empty: {argv[tools_idx + 1]!r}"
+    # MCP isolation: deny every surfaced tool and refuse ambient MCP config.
+    assert "--disallowedTools" in argv, f"--disallowedTools not in argv: {argv}"
+    disallowed_idx = argv.index("--disallowedTools")
+    assert (
+        argv[disallowed_idx + 1] == "*"
+    ), f"--disallowedTools value is not '*': {argv[disallowed_idx + 1]!r}"
+    assert "--strict-mcp-config" in argv, f"--strict-mcp-config not in argv: {argv}"
 
 
 async def test_one_shot_remote_argv_disables_tools() -> None:
-    """The remote one-shot command string must include --tools ''."""
+    """The remote one-shot command must isolate tools with quoting preserved."""
     from waypoint.launch_targets import SshLaunchTargetConfig
 
     target = SshLaunchTargetConfig(id="box", name="Box", ssh_destination="user@host")
@@ -1113,16 +1124,35 @@ async def test_one_shot_remote_argv_disables_tools() -> None:
 
         return _FakeProc()
 
-    with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+    # Neutralize the launch target's shell wrapping so the assertions inspect
+    # the remote command this module builds — the ``cd ... && exec
+    # shlex.join(claude_args)`` string whose quoting side_question.py owns —
+    # rather than the second bash-wrapping layer that belongs to launch_targets.
+    with (
+        patch.object(
+            SshLaunchTargetConfig, "wrap_remote_command", lambda self, cmd: cmd
+        ),
+        patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+    ):
         await sq_module._run_one_shot_remote(
             "What branch?", "thread-1", "fork-1", "~/project", target, "claude"
         )
 
     assert captured_args, "subprocess was never called"
     # The remote command is the last arg passed to ssh; the claude args are
-    # embedded in it.  Check the full command string contains --tools.
-    full_cmd = " ".join(captured_args[0])
-    assert "--tools" in full_cmd, f"--tools not in remote command: {full_cmd!r}"
+    # embedded in it via shlex.join. Assert all three isolation flags survive,
+    # with the empty value and literal asterisk shell-quoted rather than
+    # expanded by the remote shell.
+    remote_cmd = captured_args[0][-1]
+    assert (
+        "--tools ''" in remote_cmd
+    ), f"--tools '' not in remote command: {remote_cmd!r}"
+    assert (
+        "--disallowedTools '*'" in remote_cmd
+    ), f"--disallowedTools '*' not in remote command: {remote_cmd!r}"
+    assert (
+        "--strict-mcp-config" in remote_cmd
+    ), f"--strict-mcp-config not in remote command: {remote_cmd!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -1097,6 +1097,15 @@ async def test_one_shot_local_argv_disables_tools(
         argv[disallowed_idx + 1] == "*"
     ), f"--disallowedTools value is not '*': {argv[disallowed_idx + 1]!r}"
     assert "--strict-mcp-config" in argv, f"--strict-mcp-config not in argv: {argv}"
+    # Answer-quality prompt: makes a tool-requiring aside decline cleanly rather
+    # than emit a pseudo tool-call. Not the enforcement boundary, but must ship.
+    assert (
+        "--append-system-prompt" in argv
+    ), f"--append-system-prompt not in argv: {argv}"
+    prompt_idx = argv.index("--append-system-prompt")
+    assert (
+        "no tools available" in argv[prompt_idx + 1]
+    ), f"side-question system prompt missing/unexpected: {argv[prompt_idx + 1]!r}"
 
 
 async def test_one_shot_remote_argv_disables_tools() -> None:
@@ -1153,6 +1162,13 @@ async def test_one_shot_remote_argv_disables_tools() -> None:
     assert (
         "--strict-mcp-config" in remote_cmd
     ), f"--strict-mcp-config not in remote command: {remote_cmd!r}"
+    # The answer-quality prompt survives shlex.join as a single quoted argument.
+    assert (
+        "--append-system-prompt" in remote_cmd
+    ), f"--append-system-prompt not in remote command: {remote_cmd!r}"
+    assert (
+        "'You are answering a brief, read-only side-question" in remote_cmd
+    ), f"side-question system prompt not quoted intact: {remote_cmd!r}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

A `/btw` side-question is defined as an ephemeral, read-only question answered from the current conversation with **no tools**. The one-shot already passed `--tools ""`, but Claude Code documents that this disables only built-in tools — MCP tools stay reachable. A session with configured MCP servers therefore surfaced MCP tools to the `/btw` worker, which has no stream/approval channel to mediate a tool call: the attempt either stalls until the 120s timeout or actually executes. In practice a `/btw` was observed making Claude attempt a file read and disrupt the turn. This PR closes that gap by hardening the one-shot at the capability boundary, and additionally makes a tool-requiring aside decline cleanly. Implements `tmp/rfcs/rfc-harden-claude-btw-tool-isolation.md` (Option 3), with one deliberate deviation noted below.

## Changes

### Backend
- `backends/claude_code/side_question.py` — introduce a shared `_TOOL_ISOLATION_ARGS` constant (`--tools ""`, `--disallowedTools "*"`, `--strict-mcp-config`) and append it to both `_run_one_shot_local` and `_run_one_shot_remote`, replacing the lone `--tools ""` tail so the two paths cannot drift. `--tools ""` denies built-ins, `--strict-mcp-config` (with no accompanying `--mcp-config`) stops the aside process from loading any ambient MCP server, and `--disallowedTools "*"` is belt-and-suspenders denial on top.
- `backends/claude_code/side_question.py` — add a separate `_ANSWER_STYLE_ARGS` (`--append-system-prompt <read-only reminder>`) applied on both paths. This is an answer-quality measure, explicitly **not** an enforcement mechanism (see Design); the isolation flags remain the capability boundary.
- `backends/claude_code/tests` — assert all four flags on the local argv and the remote command, including that the empty value and literal asterisk are shell-quoted (not expanded) and the system prompt survives `shlex.join` intact on the remote path.

## Design

Enforcement lives in the CLI flags, not in a prompt. The RFC rejected `--append-system-prompt` — correctly, **as an enforcement mechanism**: it is advisory and adds no capability boundary. This PR deviates by adding it for a different reason the RFC did not weigh: **answer quality**. With every tool stripped from its context, an aside asked to do something tool-requiring otherwise emits a pseudo tool-call as prose — and can leak an internal `<system-reminder>` — into the user-facing answer card. The short read-only prompt makes it answer from the conversation or refuse in one plain sentence instead. The code keeps the two concerns visibly separate (`_TOOL_ISOLATION_ARGS` vs `_ANSWER_STYLE_ARGS`) with comments stating the flags are the boundary and the prompt is never relied on for safety. Cost is ~60 tokens per aside and, per the RFC's own cache analysis, no new cache-miss class.

The remote path's quoting is unit-tested at the boundary this module owns (the inner `cd ... && exec shlex.join(...)` command), with the launch target's own shell wrapping neutralized so the assertions test what `side_question.py` constructs.

## Test Plan

- `cd backend && uv run pytest tests/test_side_question.py`
- `cd backend && uv run pytest`
- `cd backend && uv run pre-commit run --all-files`
- E2E against the real Claude CLI (2.1.207), driving the exact argv the one-shot builds:
  - Flag acceptance: `claude -p "..." --output-format json --tools "" --disallowedTools "*" --strict-mcp-config` returns valid JSON (`is_error: false`), confirming the flags parse together and `/btw` does not break.
  - MCP isolation: with an ambient MCP server configured, the same argv (no `--mcp-config`) reports zero `mcp__*` tools, vs. a baseline run where `mcp__everything__*` and ambient `mcp__lumid__*` tools are visible.
  - File-read reproduction: a "read this file" prompt runs the baseline as a real 2-turn tool execution, but under the isolation argv completes in a single turn with no tool call and no permission denial.
  - Answer quality: the same file-read prompt under the isolation argv + `--append-system-prompt` returns a clean one-sentence decline instead of a pseudo tool-call blob.

## Test Result

- `tests/test_side_question.py`: 38 passed.
- Backend suite: 2078 passed, 3 pre-existing/unrelated warnings.
- Pre-commit: clean (isort, black, ruff, codespell, mypy).
- E2E: all controls confirmed. Isolated file-read run returned `num_turns=1`, `permission_denials=[]` with no tool executed; without the prompt the answer was a pseudo `Tool use: Read {...}` blob plus a leaked system-reminder, and with the prompt it was: "I can't do that — I have no tools available in this side-question mode, so I can't read the file. You'll need to ask this in the main conversation where file access is available."