### PR TITLE
fix: keep the light terminal white slot legible for ANSI themes

### DIFF
--- a/frontend/src/lib/terminalTheme.ts
+++ b/frontend/src/lib/terminalTheme.ts
@@ -62,10 +62,14 @@ export const DARK_TERMINAL_THEME: ITheme = {
 
 // The light surface — a warm off-white ground with dark default text, matching
 // a native light TUI theme. The 16 base slots are darkened/saturated for
-// contrast on the light ground; crucially the white/brightWhite slots resolve
-// to dark values so a TUI's white-on-default emphasis stays readable (light
-// text on a light ground would vanish). Truecolor cells the TUI emits are left
-// untouched — only the palette and surface change.
+// contrast on the light ground, but the grayscale slots keep their native
+// light-terminal luminance ordering: black darkest, white a light gray,
+// brightWhite the lightest. An ANSI-only TUI theme addresses these slots as
+// *surfaces* as well as text — e.g. Claude's light-ansi theme paints the
+// user-message bar with `ansi:white` behind `ansi:black` text — so white must
+// stay light for that bar to read as a light panel with legible dark text.
+// Truecolor cells the TUI emits are left untouched — only the palette and
+// surface change.
 export const LIGHT_TERMINAL_THEME: ITheme = {
   background: "#faf7f0",
   foreground: "#1c1914",
@@ -79,7 +83,7 @@ export const LIGHT_TERMINAL_THEME: ITheme = {
   blue: "#2d6bb8",
   magenta: "#9b4dca",
   cyan: "#1e8a9e",
-  white: "#4a453b",
+  white: "#d0cabb",
   brightBlack: "#6c665a",
   brightRed: "#d0503f",
   brightGreen: "#3aa860",
@@ -87,7 +91,7 @@ export const LIGHT_TERMINAL_THEME: ITheme = {
   brightBlue: "#3a87ba",
   brightMagenta: "#b56fd8",
   brightCyan: "#2aa5bb",
-  brightWhite: "#1c1914",
+  brightWhite: "#efe9dc",
   extendedAnsi: EXTENDED_ANSI,
 };
 


### PR DESCRIPTION
## Purpose

Follow-up to #281 (terminal surface theme sync). A user reported that in a light-theme terminal pane the user-message bar rendered with a dark background and was hard to read. Under Claude's ANSI-colors light theme (`light-ansi`) the user-message bar is painted with `ansi:white` as the background behind `ansi:black` text. PR #281's `LIGHT_TERMINAL_THEME` deliberately darkened the base-16 `white`/`brightWhite` slots (so white-as-foreground text stayed legible on the cream ground), which inverted that bar into a dark olive block with dark text — measured contrast 1.49:1, effectively illegible. This restores native light-terminal luminance for the grayscale slots so `ansi:white` used as a surface reads as a light panel with legible dark text.

## Changes

- `frontend/src/lib/terminalTheme.ts` — in `LIGHT_TERMINAL_THEME`, set `white` to a light warm gray (`#d0cabb`) and `brightWhite` to the lightest tone (`#efe9dc`), restoring the native black→white luminance ordering of the base-16 grayscale slots. Only ANSI-theme sessions on the light surface are affected: truecolor themes emit rgb cells that downsample to the 256-colour range and never address slots 0–15, so plain "Light mode" is unchanged. The rationale comment is updated to describe the surface-vs-foreground constraint that pins these values.

## Design

The base-16 slots carry theme-relative *luminance*, not absolute colours: an ANSI-only TUI theme addresses `white` both as emphasis text and as a surface, so on a light ground `white` must stay light for the `ansi:white`-behind-`ansi:black` user bar to read correctly. Darkening `white` optimized only the foreground case and broke the (more visible) surface case. Keeping the native ordering — black darkest, white a light gray, brightWhite lightest — satisfies the surface case and matches how the same theme looks in a real light terminal; the narrower "white-as-foreground on the default ground" case is the expected faint look of an ANSI light theme and does not affect primary text, which uses `ansi:black`.

## Test Plan

- `cd frontend && npm run lint && npm run build`
- E2E: launched a Claude session in the `light-ansi` theme over the Terminal (tmux) transport, redeployed the frontend with `waypointctl`, and screenshotted the deployed terminal pane at mobile width with Playwright; sampled the rendered bar pixels before and after the fix.

## Test Result

- Frontend lint and production build: passed.
- E2E: the deployed pane resolves `.term-stage--light` (`#faf7f0`). The user-message bar background changed from `#4a453b` (contrast 1.49:1 with the `#2b2b2b` text) to `#d0cabb` (contrast 8.66:1, WCAG AAA); the `ansi:black` text is unchanged. The dark-theme and plain truecolor light-theme surfaces are unaffected.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [ ] I have added or updated tests covering my changes (if applicable).
- [ ] I have verified the relevant suites pass locally (`cd backend && uv run pytest`, and `cd waypointctl && uv run pytest` if I touched `waypointctl`).
- [ ] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional).
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [ ] I have updated documentation or config examples (`.env.example`, `backend/waypoint.example.yaml`, `docs/`) if user-facing behavior changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)