### PR TITLE
feat: add maintenance rebuild-telemetry command to re-run backfill

### DIFF
--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -3880,7 +3880,7 @@ def maintenance_rebuild_telemetry(
                 abort=True,
             )
 
-        asyncio.run(TelemetryIngester(storage, get_registry()).backfill(force=already))
+        asyncio.run(TelemetryIngester(storage, get_registry()).backfill(force=force))
 
         stats = storage.db_stats()
         typer.echo(

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -3,6 +3,7 @@ import importlib.metadata
 import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import sys
 from collections.abc import AsyncIterator, Callable
@@ -12,6 +13,7 @@ from pathlib import Path
 from typing import Annotated, Any, NamedTuple, Protocol, cast
 
 import click
+import httpx
 import typer
 import uvicorn
 from fastapi import HTTPException
@@ -27,6 +29,7 @@ from waypoint.backends.registry import get_registry
 from waypoint.client import (
     WaypointClient,
     WaypointError,
+    base_url,
     is_event_envelope,
     session_status_from_envelope,
     write_cli_token,
@@ -41,6 +44,7 @@ from waypoint.schemas import (
 )
 from waypoint.settings import Settings, load_settings
 from waypoint.storage import Storage
+from waypoint.telemetry.ingest import TelemetryIngester
 
 # Statuses that, by default, end a `sessions wait`: the session is idle,
 # blocked on the user, or finished. `starting`/`running`/`interrupted` are
@@ -3633,6 +3637,10 @@ def maintenance_stats(ctx: typer.Context) -> None:
         stats = storage.db_stats()
         orphans = storage.scan_orphan_session_dirs(settings.sessions_dir)
         stats["orphan_session_dirs"] = len(orphans)
+        stats["telemetry_backfill"] = {
+            "done": storage.telemetry.get_meta("backfill_done") == "true",
+            "through": storage.telemetry.get_meta("backfill_through"),
+        }
         typer.echo(json.dumps(stats, indent=2))
     finally:
         storage.close()
@@ -3784,6 +3792,115 @@ def maintenance_clear_structured_logs(
             except OSError as exc:
                 typer.echo(f"skipped {log_path}: {exc}")
         typer.echo(f"Deleted {removed} events.jsonl files ({total / 1e6:.1f} MB).")
+    finally:
+        storage.close()
+
+
+def _backend_reachable(settings: Settings) -> bool:
+    """Best-effort probe of the configured host/port for a live backend.
+
+    Keys on the configured host/port, so it cannot prove no server exists (a
+    server on a different port/config is invisible here) — the write-lock probe
+    is the correctness backstop for that case.
+    """
+    try:
+        response = httpx.get(f"{base_url(settings)}/health", timeout=1.0)
+    except httpx.HTTPError:
+        return False
+    return response.is_success
+
+
+def _database_write_locked(settings: Settings) -> bool:
+    """Detect a concurrent writer holding the database, regardless of port.
+
+    Probes on a throwaway connection (never the writable ``Storage`` this
+    command later opens, which would self-lock). ``BEGIN IMMEDIATE`` acquires
+    the WAL write lock; if another writer holds it the attempt raises. In WAL
+    the lock is held only during an actual write, so an idle backend passes —
+    best-effort per the RFC, backing the "stop the server first" instruction.
+    """
+    db_path = settings.database_path
+    if not db_path.exists():
+        return False
+    conn = sqlite3.connect(str(db_path), timeout=0.5)
+    try:
+        conn.execute("PRAGMA busy_timeout = 500")
+        conn.execute("BEGIN IMMEDIATE")
+        conn.rollback()
+        return False
+    except sqlite3.OperationalError:
+        return True
+    finally:
+        conn.close()
+
+
+@maintenance_app.command("rebuild-telemetry")
+def maintenance_rebuild_telemetry(
+    ctx: typer.Context,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            help="Re-run even if a backfill already completed for this database.",
+        ),
+    ] = False,
+    yes: Annotated[
+        bool,
+        typer.Option("--yes", help="Skip the confirmation prompt (scripting/CI)."),
+    ] = False,
+) -> None:
+    """Re-derive telemetry facts from existing sessions/events/ledger, rebuild rollups.
+
+    Reuses the boot-time backfill code path. Run with the backend stopped.
+    """
+    settings = _settings_from_ctx(ctx)
+    if _backend_reachable(settings) or _database_write_locked(settings):
+        typer.echo(
+            "A Waypoint backend appears to be using this database. Stop it first "
+            "(waypointctl stop) before rebuilding telemetry.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    storage = Storage(settings.database_path)
+    try:
+        already = storage.telemetry.get_meta("backfill_done") == "true"
+        if already and not force:
+            typer.echo(
+                "A telemetry backfill already completed for this database. "
+                "Re-running re-derives history, including any previously deleted "
+                "or pre-enablement activity. Pass --force to proceed.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+        if already and not yes:
+            typer.confirm(
+                "Re-derive telemetry history now? This re-derives history, "
+                "including any previously deleted or pre-enablement activity.",
+                abort=True,
+            )
+
+        asyncio.run(TelemetryIngester(storage, get_registry()).backfill(force=already))
+
+        stats = storage.db_stats()
+        typer.echo(
+            json.dumps(
+                {
+                    "telemetry_facts": stats.get("telemetry_facts", {}).get(
+                        "row_count"
+                    ),
+                    "telemetry_daily_rollup": stats.get(
+                        "telemetry_daily_rollup", {}
+                    ).get("row_count"),
+                    "backfill_through": storage.telemetry.get_meta("backfill_through"),
+                    "note": (
+                        "Activity is recovered as far back as the events table; "
+                        "token totals only as far back as the token ledger."
+                    ),
+                },
+                indent=2,
+            )
+        )
     finally:
         storage.close()
 

--- a/backend/src/waypoint/telemetry/ingest.py
+++ b/backend/src/waypoint/telemetry/ingest.py
@@ -553,13 +553,16 @@ class TelemetryIngester:
 
     # ── backfill (one-shot, off the hot path) ───────────────────────────────
 
-    async def backfill(self) -> None:
+    async def backfill(self, *, force: bool = False) -> None:
         """One guarded pass deriving facts from existing data, then a rollup rebuild.
 
         Guarded by ``telemetry_meta['backfill_done']`` so it runs at most once
-        ever per database; safe to call unconditionally at boot.
+        ever per database; safe to call unconditionally at boot. Pass
+        ``force=True`` to re-derive past a completed marker (the supported
+        ``waypoint maintenance rebuild-telemetry`` override); boot callers keep
+        the default so their one-shot behavior is unchanged.
         """
-        if self._store.get_meta("backfill_done") == "true":
+        if not force and self._store.get_meta("backfill_done") == "true":
             return
         for session in self._storage.list_sessions():
             self.derive_from_session_created(session)

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -3748,3 +3748,68 @@ def test_maintenance_stats_reports_backfill_state(tmp_path: Path) -> None:
     )
     assert after["telemetry_backfill"]["done"] is True
     assert after["telemetry_backfill"]["through"] is not None
+
+
+def test_rebuild_telemetry_real_lock_probe_passes_when_unlocked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    # Exercise the real _database_write_locked against an unlocked DB; keep the
+    # network probe stubbed so the test never depends on a live host backend.
+    monkeypatch.undo()
+    monkeypatch.setattr("waypoint.cli._backend_reachable", lambda _s: False)
+
+    result = runner.invoke(
+        app, ["--config", str(cfg), "maintenance", "rebuild-telemetry"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _fact_count(db_path) > 0
+
+
+def test_rebuild_telemetry_confirm_prompt_proceeds_on_yes(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    _mark_backfilled(db_path)
+
+    storage = Storage(db_path)
+    try:
+        storage.connection.execute("DELETE FROM telemetry_facts")
+        storage.connection.commit()
+    finally:
+        storage.close()
+
+    result = runner.invoke(
+        app,
+        ["--config", str(cfg), "maintenance", "rebuild-telemetry", "--force"],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _fact_count(db_path) > 0
+
+
+def test_rebuild_telemetry_confirm_prompt_aborts_on_no(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    _mark_backfilled(db_path)
+
+    storage = Storage(db_path)
+    try:
+        storage.connection.execute("DELETE FROM telemetry_facts")
+        storage.connection.commit()
+    finally:
+        storage.close()
+
+    result = runner.invoke(
+        app,
+        ["--config", str(cfg), "maintenance", "rebuild-telemetry", "--force"],
+        input="n\n",
+    )
+
+    assert result.exit_code != 0
+    assert _fact_count(db_path) == 0

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,4 +1,6 @@
+import asyncio
 import json
+import sqlite3
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -13,12 +15,22 @@ from typer.testing import CliRunner
 from waypoint.cli import (
     _backend_choices,
     _json_safe,
+    _settings_from_arg,
     app,
     exit_code_for_wait,
     parse_wait_until,
 )
 from waypoint.client import WaypointClient
+from waypoint.schemas import (
+    EventKind,
+    EventRecord,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
 from waypoint.settings import Settings
+from waypoint.storage import Storage
+from waypoint.telemetry.ingest import TelemetryIngester
 
 runner = CliRunner()
 
@@ -3548,3 +3560,191 @@ def test_accounts_list_unknown_launch_target_errors(
     )
     assert result.exit_code != 0
     assert "unknown launch target" in result.output
+
+
+# ── maintenance rebuild-telemetry ────────────────────────────────────────────
+
+
+def _seed_telemetry_source(db_path: Path) -> None:
+    """Seed one session + a user-input event so a backfill derives real facts."""
+    storage = Storage(db_path)
+    try:
+        now = datetime.now(UTC)
+        storage.create_session(
+            SessionRecord(
+                id="s1",
+                backend="codex",
+                source=SessionSource.MANAGED,
+                transport="tmux",
+                title="t",
+                cwd="/home/user/projects/waypoint",
+                repo_name="/home/user/projects/waypoint",
+                status=SessionStatus.IDLE,
+                created_at=now,
+                updated_at=now,
+                last_event_at=now,
+                raw_log_path="/tmp/raw.log",
+                structured_log_path="/tmp/events.jsonl",
+                resolved_model="gpt-5-codex",
+                spawner_session_id=None,
+                tags={},
+            )
+        )
+        storage.append_event(
+            EventRecord(
+                session_id="s1",
+                ts=now,
+                kind=EventKind.USER_INPUT,
+                text="hello",
+                sequence=1,
+            )
+        )
+    finally:
+        storage.close()
+
+
+def _mark_backfilled(db_path: Path) -> None:
+    storage = Storage(db_path)
+    try:
+        asyncio.run(TelemetryIngester(storage).backfill())
+    finally:
+        storage.close()
+
+
+def _fact_count(db_path: Path) -> int:
+    storage = Storage(db_path)
+    try:
+        return storage.connection.execute(
+            "SELECT COUNT(*) AS n FROM telemetry_facts"
+        ).fetchone()["n"]
+    finally:
+        storage.close()
+
+
+@pytest.fixture(autouse=True)
+def _stub_probes(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Default to "no live backend" so tests exercise the command body; the two
+    # refusal tests override these explicitly.
+    monkeypatch.setattr("waypoint.cli._backend_reachable", lambda _s: False)
+    monkeypatch.setattr("waypoint.cli._database_write_locked", lambda _s: False)
+
+
+def test_rebuild_telemetry_initial_import_needs_no_force(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+
+    result = runner.invoke(
+        app, ["--config", str(cfg), "maintenance", "rebuild-telemetry"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _fact_count(db_path) > 0
+    summary = json.loads(result.output)
+    assert summary["telemetry_facts"] > 0
+    assert summary["backfill_through"] is not None
+
+
+def test_rebuild_telemetry_refuses_when_done_without_force(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    _mark_backfilled(db_path)
+
+    result = runner.invoke(
+        app, ["--config", str(cfg), "maintenance", "rebuild-telemetry"]
+    )
+
+    assert result.exit_code == 1
+    assert "--force" in result.output
+
+
+def test_rebuild_telemetry_force_yes_re_derives(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    _mark_backfilled(db_path)
+
+    storage = Storage(db_path)
+    try:
+        storage.connection.execute("DELETE FROM telemetry_facts")
+        storage.connection.commit()
+    finally:
+        storage.close()
+    assert _fact_count(db_path) == 0
+
+    result = runner.invoke(
+        app,
+        ["--config", str(cfg), "maintenance", "rebuild-telemetry", "--force", "--yes"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _fact_count(db_path) > 0
+
+
+def test_rebuild_telemetry_refuses_when_backend_reachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    monkeypatch.setattr("waypoint.cli._backend_reachable", lambda _s: True)
+
+    result = runner.invoke(
+        app,
+        ["--config", str(cfg), "maintenance", "rebuild-telemetry", "--force", "--yes"],
+    )
+
+    assert result.exit_code == 1
+    assert "Stop it first" in result.output
+
+
+def test_rebuild_telemetry_refuses_when_database_write_locked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+    # Real lock probe against a sibling connection holding an open write txn.
+    monkeypatch.undo()
+    monkeypatch.setattr("waypoint.cli._backend_reachable", lambda _s: False)
+
+    holder = sqlite3.connect(str(db_path))
+    try:
+        holder.execute("BEGIN IMMEDIATE")
+        result = runner.invoke(
+            app,
+            [
+                "--config",
+                str(cfg),
+                "maintenance",
+                "rebuild-telemetry",
+                "--force",
+                "--yes",
+            ],
+        )
+    finally:
+        holder.rollback()
+        holder.close()
+
+    assert result.exit_code == 1
+    assert "Stop it first" in result.output
+
+
+def test_maintenance_stats_reports_backfill_state(tmp_path: Path) -> None:
+    cfg = _config(tmp_path)
+    db_path = _settings_from_arg(str(cfg)).database_path
+    _seed_telemetry_source(db_path)
+
+    before = json.loads(
+        runner.invoke(app, ["--config", str(cfg), "maintenance", "stats"]).output
+    )
+    assert before["telemetry_backfill"] == {"done": False, "through": None}
+
+    _mark_backfilled(db_path)
+
+    after = json.loads(
+        runner.invoke(app, ["--config", str(cfg), "maintenance", "stats"]).output
+    )
+    assert after["telemetry_backfill"]["done"] is True
+    assert after["telemetry_backfill"]["through"] is not None

--- a/backend/tests/test_telemetry_ingest.py
+++ b/backend/tests/test_telemetry_ingest.py
@@ -884,6 +884,44 @@ def test_backfill_derives_facts_and_is_idempotent(tmp_path: Path) -> None:
     assert count_after == count_before
 
 
+def test_backfill_force_re_derives_past_completed_marker(tmp_path: Path) -> None:
+    storage = Storage(tmp_path / "db.sqlite")
+    session = _make_session(storage, "s1")
+    storage.append_event(
+        EventRecord(
+            session_id="s1",
+            ts=session.created_at,
+            kind=EventKind.USER_INPUT,
+            text="hello",
+            sequence=1,
+        )
+    )
+
+    ingester = TelemetryIngester(storage)
+    asyncio.run(ingester.backfill())
+    assert storage.telemetry.get_meta("backfill_done") == "true"
+
+    # Wipe facts but leave the marker: the default no-ops, force re-derives.
+    storage.connection.execute("DELETE FROM telemetry_facts")
+    storage.connection.commit()
+
+    asyncio.run(ingester.backfill())
+    assert (
+        storage.connection.execute(
+            "SELECT COUNT(*) AS n FROM telemetry_facts"
+        ).fetchone()["n"]
+        == 0
+    )
+
+    asyncio.run(ingester.backfill(force=True))
+    assert (
+        storage.connection.execute(
+            "SELECT COUNT(*) AS n FROM telemetry_facts"
+        ).fetchone()["n"]
+        > 0
+    )
+
+
 def test_privacy_no_raw_text_or_paths_persisted(tmp_path: Path) -> None:
     storage = Storage(tmp_path / "db.sqlite")
     session = _make_session(

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -225,6 +225,25 @@ migration flag — the import is guarded by a persistent `backfill_done` marker,
 leaving it `true` is harmless (subsequent restarts are no-ops), but it is
 clearest to remove it after the first enabled boot.
 
+To re-run the import on demand — after enabling telemetry without
+`telemetry_backfill`, or to recover history you deleted and later decided you
+want — use `waypoint maintenance rebuild-telemetry`. It re-derives facts from
+the existing `sessions`/`events`/token-ledger rows and rebuilds the rollups via
+the same code path as the boot backfill. Run it **with the backend stopped**
+(`waypointctl stop`); the command refuses when it detects a live backend on the
+configured host/port or a concurrent writer holding the database. Because the
+`backfill_done` marker is one-shot and preserved across deletion, a database
+that already backfilled requires `--force` plus a confirmation that names the
+effect — re-deriving history includes any previously deleted or pre-enablement
+activity. Add `--yes` to skip the prompt for scripting. Re-running is safe to
+repeat: facts upsert on their primary key and rollups are fully rebuilt, so
+totals never double-count. One recovery-depth caveat: activity is recovered as
+far back as the `events` table reaches, but token totals only as far back as the
+token ledger, so token charts may start later than activity charts.
+`waypoint maintenance stats` reports the current `telemetry_backfill` state
+(`done`, `through`) so you can see whether a re-run is warranted and confirm the
+result afterward.
+
 Two upgrade notes for deployments that ran telemetry before it became opt-in:
 existing collectors must add `telemetry_enabled: true` before restarting or
 collection and the dashboard silently go away (existing facts stay on disk but
@@ -238,7 +257,9 @@ become inaccessible until re-enabled). And a config that sets
 Disabling telemetry later stops new collection but never deletes existing facts;
 use the explicit delete control (or `DELETE /api/telemetry`, which stays
 available while disabled) to erase them. Deletion preserves the `backfill_done`
-marker, so a later re-enable does not re-derive erased pre-enable history.
+marker, so a later re-enable does not re-derive erased pre-enable history; the
+only way back is the deliberate, confirmed `waypoint maintenance
+rebuild-telemetry --force` (see above).
 
 The opt-in summarizer is configured under a `telemetry_nl` block (or the matching
 `WAYPOINT_TELEMETRY_NL_*` env vars): `enabled` (default `false`), `backend`,


### PR DESCRIPTION
## Purpose

Add a supported `waypoint maintenance rebuild-telemetry` CLI command to re-run the usage-telemetry historical import on demand. Today the backfill is a one-time boot pass guarded by a persistent `backfill_done` marker (deliberately preserved across `DELETE /api/telemetry`), so the only way to force a re-run is to stop the backend and hand-delete the marker row from SQLite — undocumented and fragile. This replaces that procedure with a guarded, discoverable command, and turns the marker override into a first-class code path via a `force` parameter on `TelemetryIngester.backfill()`. Implements the RFC "A supported CLI to re-run the usage-telemetry backfill".

The override bends a privacy safeguard (the preserved marker keeps deleted/pre-enablement history from returning), so it is deliberately loud: refused by default once a backfill has completed, requiring `--force` plus a confirmation prompt that names the effect. The boot-path backfill and its `telemetry_backfill` gate are untouched.

## Changes

### Backend
- `telemetry/ingest.py` — `TelemetryIngester.backfill()` gains a keyword-only `force: bool = False` that skips the `backfill_done` guard. Boot callers keep the default, so their one-shot behavior is unchanged.
- `cli.py` — add `maintenance rebuild-telemetry [--force] [--yes]`: it re-derives facts + rebuilds rollups through the same code path as boot backfill, refuses when `backfill_done` is set unless `--force` is given (with an interactive confirmation, skippable via `--yes`), and refuses to run against a live database. Also surface backfill state (`done`, `through`) in `maintenance stats`.

### Docs
- `docs/telemetry.md` — document the command alongside the backfill/opt-in section: the stop-the-backend requirement, the `--force`/confirmation safeguard, re-run idempotency, and the activity-vs-token recovery-depth caveat, plus the new `maintenance stats` readout.

## Design

The command follows the existing `maintenance` convention exactly — a synchronous Typer command that opens a standalone read-write `Storage`, wraps the async backfill in a single `asyncio.run`, and closes in a `finally`. Reusing `backfill(force=...)` keeps the marker override auditable and testable inside the ingester rather than a raw `DELETE` from the CLI; re-running is safe because facts upsert on their primary key and rollups are fully rebuilt, so totals never double-count.

Live-database detection uses two probes because neither alone suffices: an HTTP `/health` probe on the configured host/port (a precise "stop the server first" message, but blind to a server on a different port/config), plus a SQLite write-lock backstop that briefly attempts `BEGIN IMMEDIATE` on a throwaway connection (catches a concurrent writer regardless of port). Both are best-effort — under WAL an idle backend holds no write lock — so the operating instruction stays "stop the backend first"; the probes exist to make the common mistakes fail loudly rather than corrupt the single-serialized-connection invariant.

The recovery-depth nuance is stated in the command output and docs: activity facts derive from `events` (deep history) but token totals derive from the token ledger (only as far back as per-record tracking began), so token charts may start later than activity charts.

## Test Plan

- `cd backend && uv run pre-commit run --all-files`
- `cd backend && uv run pytest`

## Test Result

- Pre-commit: clean (isort, black, ruff, codespell, mypy).
- Backend suite: 2125 passed, 3 pre-existing/unrelated warnings. New coverage: `test_telemetry_ingest.py` asserts `backfill(force=True)` re-derives past a set marker while the default still no-ops; `test_cli.py` covers the command end-to-end against a real on-disk SQLite DB — initial import needs no flags, refusal when `backfill_done` is set without `--force`, `--force --yes` re-derives, refusal when the backend health probe reports reachable, refusal when a concurrent writer holds the DB (real `BEGIN IMMEDIATE` on a sibling connection), and the `maintenance stats` backfill-state readout before/after a rebuild.
- These CliRunner tests are the end-to-end path for this command; a live-stack e2e is not meaningful since the command refuses to run against a live backend by design.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`, and `cd waypointctl && uv run pytest` if I touched `waypointctl`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional).
- [x] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [x] I have updated documentation or config examples (`.env.example`, `backend/waypoint.example.yaml`, `docs/`) if user-facing behavior changed.

</details>