### PR TITLE
feat: add a resizable desktop context-usage popover

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4344,9 +4344,11 @@ html[data-theme="light"] .composer-context-trigger.tone-danger {
 }
 
 /* Owns vertical scrolling so the seams and reset affordance stay fixed outside
-   it when a chosen or viewport-clamped height is shorter than the content. */
+   it when a chosen or viewport-clamped height is shorter than the content. It
+   shrinks-and-scrolls but never grows past its content (``flex-grow: 0``), so
+   ``scrollHeight`` always reports the true content height for the snap detent. */
 .usage-panel-body {
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-height: 0;
   overflow-y: auto;
   display: grid;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4335,11 +4335,185 @@ html[data-theme="light"] .composer-context-trigger.tone-danger {
     inset 0 1px 0 var(--glass-hi),
     var(--shadow);
   backdrop-filter: var(--glass-blur);
-  display: grid;
-  gap: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
   z-index: 30;
   overflow: hidden;
   animation: usage-panel-enter 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+}
+
+/* Composer placement is anchored bottom/right and grows up/left, so its
+   control row sits at the bottom (near the anchor) and its free-edge seams
+   sit on the top and left; reversing the flow puts the controls below the
+   scroll body without reordering the DOM. Terminal placement keeps controls
+   on top. */
+.usage-panel--composer {
+  flex-direction: column-reverse;
+}
+
+/* Owns vertical scrolling so the seams and control row stay fixed outside it
+   when a chosen or viewport-clamped height is shorter than the content. */
+.usage-panel-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  display: grid;
+  gap: 18px;
+}
+
+.usage-panel-controls {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.usage-panel-reset {
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--muted);
+  border-radius: var(--radius-sm);
+  padding: 3px 9px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.04em;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+
+.usage-panel-reset:hover {
+  color: var(--fg);
+  border-color: var(--line-strong);
+}
+
+.usage-panel-reset:focus-visible {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 2px;
+}
+
+.usage-panel-close {
+  appearance: none;
+  cursor: pointer;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 2px 5px;
+  border-radius: var(--radius-sm);
+  transition: color 120ms ease;
+}
+
+.usage-panel-close:hover {
+  color: var(--fg);
+}
+
+.usage-panel-close:focus-visible {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 2px;
+}
+
+/* Thin, subtle resize seams on the two free edges opposite the trigger-facing
+   anchor. Each seam changes exactly one dimension; the ::after bar is the only
+   visible mark and lights up on hover, keyboard focus, and active drag. */
+.usage-resize {
+  position: absolute;
+  z-index: 3;
+  border: none;
+  background: transparent;
+  padding: 0;
+  touch-action: none;
+}
+
+.usage-resize::after {
+  content: "";
+  position: absolute;
+  background: transparent;
+  border-radius: var(--radius-pill);
+  transition: background-color 120ms ease;
+}
+
+.usage-resize:hover::after,
+.usage-resize:focus-visible::after,
+body.usage-resizing-x .usage-resize-width::after,
+body.usage-resizing-y .usage-resize-height::after {
+  background: var(--accent-cool);
+}
+
+.usage-resize:focus-visible {
+  outline: none;
+}
+
+.usage-resize-width {
+  width: 10px;
+  top: 16px;
+  bottom: 16px;
+  cursor: ew-resize;
+}
+
+.usage-resize-width::after {
+  top: 0;
+  bottom: 0;
+  width: 2px;
+}
+
+.usage-resize-height {
+  height: 10px;
+  left: 16px;
+  right: 16px;
+  cursor: ns-resize;
+}
+
+.usage-resize-height::after {
+  left: 0;
+  right: 0;
+  height: 2px;
+}
+
+.usage-panel--composer .usage-resize-width {
+  left: 0;
+}
+
+.usage-panel--composer .usage-resize-width::after {
+  left: 4px;
+}
+
+.usage-panel--composer .usage-resize-height {
+  top: 0;
+}
+
+.usage-panel--composer .usage-resize-height::after {
+  top: 4px;
+}
+
+.usage-panel--terminal .usage-resize-width {
+  right: 0;
+  top: 44px;
+}
+
+.usage-panel--terminal .usage-resize-width::after {
+  right: 4px;
+}
+
+.usage-panel--terminal .usage-resize-height {
+  bottom: 0;
+}
+
+.usage-panel--terminal .usage-resize-height::after {
+  bottom: 4px;
+}
+
+body.usage-resizing-x {
+  cursor: ew-resize;
+  user-select: none;
+}
+
+body.usage-resizing-y {
+  cursor: ns-resize;
+  user-select: none;
 }
 
 @keyframes usage-panel-enter {
@@ -5962,7 +6136,8 @@ html[data-theme="light"] .usage-dial-hub-cap {
 /* ── Mobile: bottom-anchored sheet for the popover; dashboard cards
        fold to a single column with smaller dials. ── */
 @media (max-width: 540px) {
-  .usage-panel {
+  .usage-panel,
+  .usage-panel--composer {
     position: fixed;
     left: 12px;
     right: 12px;
@@ -5972,6 +6147,13 @@ html[data-theme="light"] .usage-dial-hub-cap {
     overflow-y: auto;
     padding: 16px 16px 14px;
     border-radius: var(--radius-glass);
+    flex-direction: column;
+  }
+
+  /* The bottom sheet is not resizable; the component also skips these, this is
+     a defensive belt so a saved desktop size never leaks into the sheet. */
+  .usage-resize {
+    display: none;
   }
 
   .usage-numeral strong {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4343,17 +4343,8 @@ html[data-theme="light"] .composer-context-trigger.tone-danger {
   animation: usage-panel-enter 220ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
 
-/* Composer placement is anchored bottom/right and grows up/left, so its
-   control row sits at the bottom (near the anchor) and its free-edge seams
-   sit on the top and left; reversing the flow puts the controls below the
-   scroll body without reordering the DOM. Terminal placement keeps controls
-   on top. */
-.usage-panel--composer {
-  flex-direction: column-reverse;
-}
-
-/* Owns vertical scrolling so the seams and control row stay fixed outside it
-   when a chosen or viewport-clamped height is shorter than the content. */
+/* Owns vertical scrolling so the seams and reset affordance stay fixed outside
+   it when a chosen or viewport-clamped height is shorter than the content. */
 .usage-panel-body {
   flex: 1 1 auto;
   min-height: 0;
@@ -4362,58 +4353,46 @@ html[data-theme="light"] .composer-context-trigger.tone-danger {
   gap: 18px;
 }
 
-.usage-panel-controls {
-  flex: 0 0 auto;
+/* Bare glyph pinned in the free corner where the two seams meet (top-left for
+   composer, bottom-right for terminal); shown only once a custom size exists
+   and consuming no layout height. */
+.usage-resize-reset {
+  position: absolute;
+  z-index: 4;
+  width: 18px;
+  height: 18px;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
-  gap: 10px;
-}
-
-.usage-panel-reset {
-  appearance: none;
-  cursor: pointer;
-  border: 1px solid var(--line);
-  background: transparent;
-  color: var(--muted);
-  border-radius: var(--radius-sm);
-  padding: 3px 9px;
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  letter-spacing: 0.04em;
-  transition: color 120ms ease, border-color 120ms ease;
-}
-
-.usage-panel-reset:hover {
-  color: var(--fg);
-  border-color: var(--line-strong);
-}
-
-.usage-panel-reset:focus-visible {
-  outline: 2px solid var(--accent-cool);
-  outline-offset: 2px;
-}
-
-.usage-panel-close {
-  appearance: none;
-  cursor: pointer;
+  justify-content: center;
+  padding: 0;
   border: none;
   background: transparent;
-  color: var(--muted);
-  font-size: 1.1rem;
+  color: var(--muted-soft);
+  font-size: 0.8rem;
   line-height: 1;
-  padding: 2px 5px;
+  cursor: pointer;
   border-radius: var(--radius-sm);
   transition: color 120ms ease;
 }
 
-.usage-panel-close:hover {
-  color: var(--fg);
+.usage-resize-reset:hover {
+  color: var(--accent-strong);
 }
 
-.usage-panel-close:focus-visible {
+.usage-resize-reset:focus-visible {
   outline: 2px solid var(--accent-cool);
-  outline-offset: 2px;
+  outline-offset: 1px;
+  color: var(--accent-strong);
+}
+
+.usage-panel--composer .usage-resize-reset {
+  top: 5px;
+  left: 5px;
+}
+
+.usage-panel--terminal .usage-resize-reset {
+  bottom: 5px;
+  right: 5px;
 }
 
 /* Thin, subtle resize seams on the two free edges opposite the trigger-facing

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Dispatch, MutableRefObject, SetStateAction, useCallback, useState } from "react";
+import {
+  CSSProperties,
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useCallback,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 
 import { SessionUsagePill } from "@/components/SessionUsagePill";
@@ -151,7 +158,16 @@ export function SessionTerminalView({
   // usage panel — it drops out of the term-bar, and ``.session-terminal``'s
   // ``overflow: hidden`` would clip an in-pane absolute menu. Right-anchored
   // to match the trigger's top-right home.
-  const overflowMenuStyle = usePopoverAnchor(termMenuWrapRef, termMenuOpen, "right");
+  const { style: overflowMenuAnchor, bounds: overflowMenuBounds } = usePopoverAnchor(
+    termMenuWrapRef,
+    termMenuOpen,
+    "right",
+  );
+  // The hook now returns positioning and bounds separately; keep the menu's
+  // prior tall-menu scrolling by capping height to the available space.
+  const overflowMenuStyle: CSSProperties | undefined = overflowMenuAnchor
+    ? { ...overflowMenuAnchor, maxHeight: overflowMenuBounds?.maxHeight, overflowY: "auto" }
+    : undefined;
 
   return (
     <section

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { useEffect, useId, useRef, useState } from "react";
+import {
+  CSSProperties,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 
 import { UsageBar, UsageReadout } from "@/components/UsageReadout";
@@ -20,6 +29,67 @@ import {
 import { usePopoverAnchor } from "@/lib/use-popover-anchor";
 
 type Connection = "idle" | "connecting" | "open" | "reconnecting";
+
+// Versioned so a future shape change can coexist with an old saved value.
+const SIZE_STORAGE_KEY = "waypoint.usage-popover-size.v1";
+// Below this viewport width the mobile bottom sheet takes over; resize controls
+// and saved desktop dimensions are suppressed. Matches the ``.usage-panel``
+// media query and the hook's ``deferBelow``.
+const DESKTOP_MIN_WIDTH = 541;
+// Pixel steps for keyboard resize; Shift takes the larger stride.
+const KEY_STEP = 24;
+const KEY_STEP_LARGE = 72;
+
+interface UsagePopoverSize {
+  width?: number;
+  height?: number;
+}
+
+function readStoredSize(): UsagePopoverSize {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(SIZE_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed === null || typeof parsed !== "object") return {};
+    const record = parsed as Record<string, unknown>;
+    const size: UsagePopoverSize = {};
+    if (
+      typeof record.width === "number" &&
+      Number.isFinite(record.width) &&
+      record.width > 0
+    ) {
+      size.width = record.width;
+    }
+    if (
+      typeof record.height === "number" &&
+      Number.isFinite(record.height) &&
+      record.height > 0
+    ) {
+      size.height = record.height;
+    }
+    return size;
+  } catch {
+    return {};
+  }
+}
+
+function writeStoredSize(size: UsagePopoverSize): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (size.width === undefined && size.height === undefined) {
+      window.localStorage.removeItem(SIZE_STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(SIZE_STORAGE_KEY, JSON.stringify(size));
+    }
+  } catch {
+    // Storage disabled or over quota: the preference is best-effort only.
+  }
+}
+
+function clampSize(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max));
+}
 
 interface SessionUsagePillProps {
   session: SessionRecord | null;
@@ -50,11 +120,89 @@ export function SessionUsagePill({
   const totalTipId = useId();
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const closeRef = useRef<HTMLButtonElement | null>(null);
+  const resetRef = useRef<HTMLButtonElement | null>(null);
+  // Whether the most recent open was keyboard-activated, so focus moves into
+  // the panel only then (a pointer open leaves focus on the trigger).
+  const openedViaKeyboardRef = useRef(false);
+
+  // Desktop drives resize controls and saved dimensions; the mobile sheet is
+  // left untouched. Tracked reactively so a viewport crossing 540px re-renders.
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window === "undefined"
+      ? true
+      : window.matchMedia(`(min-width: ${DESKTOP_MIN_WIDTH}px)`).matches,
+  );
+  useEffect(() => {
+    const mq = window.matchMedia(`(min-width: ${DESKTOP_MIN_WIDTH}px)`);
+    const onChange = () => setIsDesktop(mq.matches);
+    onChange();
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
   // Below 540px the generic ``.usage-panel`` mobile bottom-sheet rule takes
-  // over (deferBelow), so the inline fixed anchor only drives wider viewports.
-  const anchorStyle = usePopoverAnchor(wrapRef, anchored && open, "left", {
-    deferBelow: 540,
-  });
+  // over (deferBelow), so the fixed anchor and bounds only drive wider
+  // viewports. The composer placement leaves positioning to CSS but still uses
+  // the bounds; the terminal placement is portaled and fixed-positioned.
+  const { style: anchorStyle, bounds } = usePopoverAnchor(
+    wrapRef,
+    open,
+    "left",
+    { deferBelow: 540 },
+    anchored ? "dropdown" : "composer",
+  );
+
+  // The saved preference is the source of truth; the rendered size is this
+  // clamped against the current placement bounds on every measurement, so an
+  // oversized preference is retained but shown clamped and expands when space
+  // permits.
+  const [pref, setPref] = useState<UsagePopoverSize>(() => readStoredSize());
+  // Mirrors ``pref`` for the pointer/keyboard handlers, which merge into the
+  // latest committed value; updated eagerly in those handlers and reconciled
+  // here for any other path.
+  const prefRef = useRef(pref);
+  useEffect(() => {
+    prefRef.current = pref;
+  }, [pref]);
+  // Actual rendered dimensions, measured after layout, for accurate seam
+  // ``aria-valuenow`` (the natural default height is not known until measured).
+  const [rendered, setRendered] = useState<{
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const closePopover = useCallback(() => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  }, []);
+
+  const applyResize = useCallback((patch: UsagePopoverSize) => {
+    const next = { ...prefRef.current, ...patch };
+    prefRef.current = next;
+    setPref(next);
+    writeStoredSize(next);
+  }, []);
+
+  const resetSize = useCallback(() => {
+    prefRef.current = {};
+    setPref({});
+    writeStoredSize({});
+    // Reset auto-hides once no preference remains; keep focus in the panel by
+    // moving it to Close rather than dropping it to the body.
+    closeRef.current?.focus();
+  }, []);
+
+  // Re-read storage on open so a resize made in the other placement is picked
+  // up, then apply within current bounds.
+  useEffect(() => {
+    if (open) {
+      const stored = readStoredSize();
+      prefRef.current = stored;
+      setPref(stored);
+    }
+  }, [open]);
 
   useEffect(() => {
     if (!open) return;
@@ -66,15 +214,155 @@ export function SessionUsagePill({
       // wrapper — check it separately so clicks inside the panel
       // don't dismiss it.
       if (panelRef.current?.contains(target)) return;
+      // Only pull focus back to the trigger when it was inside the panel, so a
+      // click that lands on another control keeps its own focus.
+      const restoreFocus = panelRef.current?.contains(document.activeElement);
       setOpen(false);
+      if (restoreFocus) triggerRef.current?.focus();
+    }
+    function onKey(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+        triggerRef.current?.focus();
+      }
     }
     document.addEventListener("mousedown", onDocClick);
-    return () => document.removeEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
   }, [open]);
+
+  // A keyboard open moves focus to the in-panel Close button.
+  useEffect(() => {
+    if (open && isDesktop && openedViaKeyboardRef.current) {
+      closeRef.current?.focus();
+    }
+    if (!open) openedViaKeyboardRef.current = false;
+  }, [open, isDesktop]);
 
   useEffect(() => {
     if (!open) setTotalTipOpen(false);
   }, [open]);
+
+  const startResize = useCallback(
+    (axis: "width" | "height") => (event: React.PointerEvent) => {
+      if (!bounds) return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      event.preventDefault();
+      const startX = event.clientX;
+      const startY = event.clientY;
+      const startWidth = panel.offsetWidth;
+      const startHeight = panel.offsetHeight;
+      // Composer free edges are top/left (a negative pointer delta grows the
+      // panel); terminal free edges are bottom/right (a positive delta grows it).
+      const sign = anchored ? 1 : -1;
+      const bodyClass =
+        axis === "width" ? "usage-resizing-x" : "usage-resizing-y";
+      document.body.classList.add(bodyClass);
+      const onMove = (ev: PointerEvent) => {
+        if (axis === "width") {
+          applyResize({
+            width: clampSize(
+              startWidth + sign * (ev.clientX - startX),
+              bounds.minWidth,
+              bounds.maxWidth,
+            ),
+          });
+        } else {
+          applyResize({
+            height: clampSize(
+              startHeight + sign * (ev.clientY - startY),
+              bounds.minHeight,
+              bounds.maxHeight,
+            ),
+          });
+        }
+      };
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        document.body.classList.remove(bodyClass);
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [bounds, anchored, applyResize],
+  );
+
+  const onResizeKey = useCallback(
+    (axis: "width" | "height") => (event: React.KeyboardEvent) => {
+      if (!bounds) return;
+      const step = event.shiftKey ? KEY_STEP_LARGE : KEY_STEP;
+      const panel = panelRef.current;
+      // The arrow toward the placement's free edge grows the panel, matching
+      // the pointer drag on the same seam: composer grows up/left, terminal
+      // grows down/right. ``sign`` mirrors ``startResize``.
+      const sign = anchored ? 1 : -1;
+      if (axis === "width") {
+        let dir = 0;
+        if (event.key === "ArrowRight") dir = 1;
+        else if (event.key === "ArrowLeft") dir = -1;
+        else return;
+        event.preventDefault();
+        const current =
+          prefRef.current.width ?? panel?.offsetWidth ?? bounds.minWidth;
+        applyResize({
+          width: clampSize(
+            current + dir * sign * step,
+            bounds.minWidth,
+            bounds.maxWidth,
+          ),
+        });
+      } else {
+        let dir = 0;
+        if (event.key === "ArrowDown") dir = 1;
+        else if (event.key === "ArrowUp") dir = -1;
+        else return;
+        event.preventDefault();
+        const current =
+          prefRef.current.height ?? panel?.offsetHeight ?? bounds.minHeight;
+        applyResize({
+          height: clampSize(
+            current + dir * sign * step,
+            bounds.minHeight,
+            bounds.maxHeight,
+          ),
+        });
+      }
+    },
+    [bounds, anchored, applyResize],
+  );
+
+  const showResizeControls = isDesktop && bounds !== null;
+  const hasCustomSize = pref.width !== undefined || pref.height !== undefined;
+
+  const panelStyle = useMemo<CSSProperties | undefined>(() => {
+    const base = anchored ? (anchorStyle ?? undefined) : undefined;
+    if (!isDesktop || !bounds) return base;
+    const style: CSSProperties = { ...(base ?? {}) };
+    style.maxWidth = bounds.maxWidth;
+    style.maxHeight = bounds.maxHeight;
+    if (pref.width !== undefined) {
+      style.width = clampSize(pref.width, bounds.minWidth, bounds.maxWidth);
+    }
+    if (pref.height !== undefined) {
+      style.height = clampSize(pref.height, bounds.minHeight, bounds.maxHeight);
+    }
+    return style;
+  }, [anchored, anchorStyle, isDesktop, bounds, pref]);
+
+  useLayoutEffect(() => {
+    if (!open || !showResizeControls) {
+      setRendered(null);
+      return;
+    }
+    const panel = panelRef.current;
+    if (panel)
+      setRendered({ width: panel.offsetWidth, height: panel.offsetHeight });
+  }, [open, showResizeControls, panelStyle]);
 
   const contextUsage = session?.context_usage ?? null;
   const tokenUsage = session?.session_token_usage ?? null;
@@ -120,7 +408,9 @@ export function SessionUsagePill({
   const rateLimitUsageSummary = rateLimitUsage
     ? rateLimitUsage.windows.length > 0
       ? rateLimitUsage.windows
-          .map((window) => `${window.label} ${Math.round(window.used_percent)}%`)
+          .map(
+            (window) => `${window.label} ${Math.round(window.used_percent)}%`,
+          )
           .join(" · ")
       : rateLimitUsage.notes?.length
         ? rateLimitUsage.notes.join(" · ")
@@ -142,7 +432,10 @@ export function SessionUsagePill({
     ) {
       return "danger";
     }
-    if (contextUsageToneValue === "warn" || rateLimitUsageToneValue === "warn") {
+    if (
+      contextUsageToneValue === "warn" ||
+      rateLimitUsageToneValue === "warn"
+    ) {
       return "warn";
     }
     return "good";
@@ -181,6 +474,7 @@ export function SessionUsagePill({
   return (
     <div className="composer-context" ref={wrapRef}>
       <button
+        ref={triggerRef}
         type="button"
         className={`composer-connection composer-context-trigger tone-${usageToneValue} ${connection} ${open ? "open" : ""}`}
         title={
@@ -192,7 +486,12 @@ export function SessionUsagePill({
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-label={`Backend socket ${connection}. Usage details`}
-        onClick={() => setOpen((value) => !value)}
+        onClick={(event) => {
+          // A keyboard-activated click reports detail 0; use it to route focus
+          // into the panel only when opening by keyboard.
+          openedViaKeyboardRef.current = !open && event.detail === 0;
+          setOpen((value) => !value);
+        }}
       >
         {connection === "open"
           ? "live"
@@ -200,179 +499,253 @@ export function SessionUsagePill({
             ? "reconnecting"
             : "connecting"}
       </button>
-      {open ? renderPanel(
-        <div
-          ref={panelRef}
-          className={`usage-panel tone-${usageToneValue}`}
-          style={anchored ? anchorStyle ?? undefined : undefined}
-          role="dialog"
-          aria-label="Usage details"
-        >
-
-          {rateLimitUsage ? (
-            <UsageReadout
-              usage={rateLimitUsage}
-              sourceLabel={rateLimitSourceLabel}
-              onRefresh={onRateLimitRefresh}
-              refreshing={rateLimitRefreshBusy}
-            />
-          ) : null}
-
-          {rateLimitUsage && (contextUsage || tokenUsage) ? (
-            <hr className="usage-divider" aria-hidden="true" />
-          ) : null}
-
-          {contextUsage ? (
-            <section className="usage-block">
-              <header className="usage-block-head">
-                <h3 className="usage-block-eyebrow">
-                  <span aria-hidden className="usage-block-mark">
-                    ◆
-                  </span>
-                  Current context window
-                </h3>
-                <span className="usage-block-tag">
-                  {humaniseBackend(contextUsage.source, catalog)}
-                </span>
-              </header>
-              <div className="usage-block-body">
-                <div className={`usage-numeral tone-${contextUsageToneValue}`}>
-                  <strong>
-                    {contextUsagePercentDisplay !== null
-                      ? contextUsagePercentDisplay
-                      : "—"}
-                  </strong>
-                  <em>%</em>
-                </div>
-                <div className="usage-block-stack">
-                  <p className="usage-line">
-                    <span>{formatTokens(contextUsage.used_tokens)}</span>
-                    <em>of</em>
-                    <span>
-                      {contextUsageWindowTokens !== null
-                        ? formatTokens(contextUsageWindowDisplay)
-                        : "—"}
-                    </span>
-                    <em>tokens</em>
-                  </p>
-                  <UsageBar
-                    percent={contextUsagePercentDisplay}
-                    tone={contextUsageToneValue}
-                    disabled={
-                      !contextUsageHasWindow ||
-                      contextUsagePercentDisplay === null
-                    }
-                  />
-                  <p className="usage-line-meta">
-                    <em>updated</em>
-                    <span title={new Date(contextUsage.updated_at).toLocaleString()}>
-                      {formatRelativeTime(contextUsage.updated_at)}
-                    </span>
-                  </p>
-                </div>
-              </div>
-              {contextUsageBreakdown.length > 0 ? (
-                <div className="usage-chip-group">
-                  <p className="usage-chips-caption">Last turn</p>
-                  <ul className="usage-chips">
-                    {contextUsageBreakdown.map(([key, value]) => (
-                      <li key={key}>
-                        <em>{tokenCategoryLabel(key)}</em>
-                        <strong>{formatTokens(value)}</strong>
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
-            </section>
-          ) : null}
-
-          {contextUsage && tokenUsage ? (
-            <hr className="usage-divider" aria-hidden="true" />
-          ) : null}
-
-          {tokenUsage ? (
-            <section className="usage-block">
-              <header className="usage-block-head">
-                <h3 className="usage-block-eyebrow">
-                  <span aria-hidden className="usage-block-mark">
-                    ◆
-                  </span>
-                  Tracked session total
-                </h3>
-                <span className="usage-block-tag">
-                  {humaniseBackend(tokenUsage.source, catalog)}
-                </span>
-              </header>
-              {tokenUsageHasTotals ? (
+      {open
+        ? renderPanel(
+            <div
+              ref={panelRef}
+              className={`usage-panel usage-panel--${anchored ? "terminal" : "composer"} tone-${usageToneValue}`}
+              style={panelStyle}
+              role="dialog"
+              aria-label="Usage details"
+            >
+              {showResizeControls && bounds ? (
                 <>
-                  <div className="usage-total-explain">
-                    <p className="usage-total-line">
-                      <span className="usage-total-count">
-                        {tokenUsage.tracked_turns}
-                      </span>
-                      <em>
-                        {tokenUsage.tracked_turns === 1 ? "turn" : "turns"}
-                      </em>
-                      {typeof tokenUsage.display_total_tokens === "number" ? (
-                        <span className="usage-total-work">
-                          <span aria-hidden>·</span>
-                          <strong>
-                            {formatTokens(tokenUsage.display_total_tokens)}
-                          </strong>
-                          cumulative tokens
-                          <button
-                            type="button"
-                            className="usage-info"
-                            aria-label="About cumulative tokens"
-                            aria-describedby={totalTipId}
-                            aria-expanded={totalTipOpen}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              setTotalTipOpen((value) => !value);
-                            }}
-                          >
-                            ⓘ
-                          </button>
-                        </span>
-                      ) : null}
-                    </p>
-                    {typeof tokenUsage.display_total_tokens === "number" ? (
-                      <span
-                        id={totalTipId}
-                        role="tooltip"
-                        className={`usage-tip${totalTipOpen ? " usage-tip--open" : ""}`}
-                      >
-                        Counts the whole conversation, re-read every turn.
-                      </span>
-                    ) : null}
-                  </div>
-                  {hasTokenTotals ? (
-                    <ul className="usage-chips">
-                      {tokenUsageTotals.map(([key, value]) => (
-                        <li key={key}>
-                          <em>{UNIFIED_TOKEN_LABELS[key as keyof typeof UNIFIED_TOKEN_LABELS] ?? key}</em>
-                          <strong>{formatTokens(value)}</strong>
-                        </li>
-                      ))}
-                    </ul>
-                  ) : null}
+                  <div
+                    className="usage-resize usage-resize-width"
+                    role="separator"
+                    aria-orientation="vertical"
+                    aria-label="Resize width"
+                    aria-valuenow={Math.round(
+                      rendered?.width ?? bounds.minWidth,
+                    )}
+                    aria-valuemin={bounds.minWidth}
+                    aria-valuemax={bounds.maxWidth}
+                    tabIndex={0}
+                    onPointerDown={startResize("width")}
+                    onKeyDown={onResizeKey("width")}
+                  />
+                  <div
+                    className="usage-resize usage-resize-height"
+                    role="separator"
+                    aria-orientation="horizontal"
+                    aria-label="Resize height"
+                    aria-valuenow={Math.round(
+                      rendered?.height ?? bounds.minHeight,
+                    )}
+                    aria-valuemin={bounds.minHeight}
+                    aria-valuemax={bounds.maxHeight}
+                    tabIndex={0}
+                    onPointerDown={startResize("height")}
+                    onKeyDown={onResizeKey("height")}
+                  />
                 </>
               ) : null}
-              <p
-                className={`usage-coverage${
-                  tokenUsage.coverage === "entire_waypoint_session"
-                    ? ""
-                    : " usage-coverage--partial"
-                }`}
-              >
-                <span aria-hidden className="usage-coverage-dot" />
-                {coverageLabel(tokenUsage)}
-              </p>
-            </section>
-          ) : null}
-        </div>
-      ) : null}
+              {showResizeControls ? (
+                <div className="usage-panel-controls">
+                  {hasCustomSize ? (
+                    <button
+                      ref={resetRef}
+                      type="button"
+                      className="usage-panel-reset"
+                      onClick={resetSize}
+                    >
+                      Reset size
+                    </button>
+                  ) : null}
+                  <button
+                    ref={closeRef}
+                    type="button"
+                    className="usage-panel-close"
+                    aria-label="Close usage details"
+                    onClick={closePopover}
+                  >
+                    ×
+                  </button>
+                </div>
+              ) : null}
+              <div className="usage-panel-body">
+                {rateLimitUsage ? (
+                  <UsageReadout
+                    usage={rateLimitUsage}
+                    sourceLabel={rateLimitSourceLabel}
+                    onRefresh={onRateLimitRefresh}
+                    refreshing={rateLimitRefreshBusy}
+                  />
+                ) : null}
+
+                {rateLimitUsage && (contextUsage || tokenUsage) ? (
+                  <hr className="usage-divider" aria-hidden="true" />
+                ) : null}
+
+                {contextUsage ? (
+                  <section className="usage-block">
+                    <header className="usage-block-head">
+                      <h3 className="usage-block-eyebrow">
+                        <span aria-hidden className="usage-block-mark">
+                          ◆
+                        </span>
+                        Current context window
+                      </h3>
+                      <span className="usage-block-tag">
+                        {humaniseBackend(contextUsage.source, catalog)}
+                      </span>
+                    </header>
+                    <div className="usage-block-body">
+                      <div
+                        className={`usage-numeral tone-${contextUsageToneValue}`}
+                      >
+                        <strong>
+                          {contextUsagePercentDisplay !== null
+                            ? contextUsagePercentDisplay
+                            : "—"}
+                        </strong>
+                        <em>%</em>
+                      </div>
+                      <div className="usage-block-stack">
+                        <p className="usage-line">
+                          <span>{formatTokens(contextUsage.used_tokens)}</span>
+                          <em>of</em>
+                          <span>
+                            {contextUsageWindowTokens !== null
+                              ? formatTokens(contextUsageWindowDisplay)
+                              : "—"}
+                          </span>
+                          <em>tokens</em>
+                        </p>
+                        <UsageBar
+                          percent={contextUsagePercentDisplay}
+                          tone={contextUsageToneValue}
+                          disabled={
+                            !contextUsageHasWindow ||
+                            contextUsagePercentDisplay === null
+                          }
+                        />
+                        <p className="usage-line-meta">
+                          <em>updated</em>
+                          <span
+                            title={new Date(
+                              contextUsage.updated_at,
+                            ).toLocaleString()}
+                          >
+                            {formatRelativeTime(contextUsage.updated_at)}
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    {contextUsageBreakdown.length > 0 ? (
+                      <div className="usage-chip-group">
+                        <p className="usage-chips-caption">Last turn</p>
+                        <ul className="usage-chips">
+                          {contextUsageBreakdown.map(([key, value]) => (
+                            <li key={key}>
+                              <em>{tokenCategoryLabel(key)}</em>
+                              <strong>{formatTokens(value)}</strong>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                  </section>
+                ) : null}
+
+                {contextUsage && tokenUsage ? (
+                  <hr className="usage-divider" aria-hidden="true" />
+                ) : null}
+
+                {tokenUsage ? (
+                  <section className="usage-block">
+                    <header className="usage-block-head">
+                      <h3 className="usage-block-eyebrow">
+                        <span aria-hidden className="usage-block-mark">
+                          ◆
+                        </span>
+                        Tracked session total
+                      </h3>
+                      <span className="usage-block-tag">
+                        {humaniseBackend(tokenUsage.source, catalog)}
+                      </span>
+                    </header>
+                    {tokenUsageHasTotals ? (
+                      <>
+                        <div className="usage-total-explain">
+                          <p className="usage-total-line">
+                            <span className="usage-total-count">
+                              {tokenUsage.tracked_turns}
+                            </span>
+                            <em>
+                              {tokenUsage.tracked_turns === 1
+                                ? "turn"
+                                : "turns"}
+                            </em>
+                            {typeof tokenUsage.display_total_tokens ===
+                            "number" ? (
+                              <span className="usage-total-work">
+                                <span aria-hidden>·</span>
+                                <strong>
+                                  {formatTokens(
+                                    tokenUsage.display_total_tokens,
+                                  )}
+                                </strong>
+                                cumulative tokens
+                                <button
+                                  type="button"
+                                  className="usage-info"
+                                  aria-label="About cumulative tokens"
+                                  aria-describedby={totalTipId}
+                                  aria-expanded={totalTipOpen}
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setTotalTipOpen((value) => !value);
+                                  }}
+                                >
+                                  ⓘ
+                                </button>
+                              </span>
+                            ) : null}
+                          </p>
+                          {typeof tokenUsage.display_total_tokens ===
+                          "number" ? (
+                            <span
+                              id={totalTipId}
+                              role="tooltip"
+                              className={`usage-tip${totalTipOpen ? " usage-tip--open" : ""}`}
+                            >
+                              Counts the whole conversation, re-read every turn.
+                            </span>
+                          ) : null}
+                        </div>
+                        {hasTokenTotals ? (
+                          <ul className="usage-chips">
+                            {tokenUsageTotals.map(([key, value]) => (
+                              <li key={key}>
+                                <em>
+                                  {UNIFIED_TOKEN_LABELS[
+                                    key as keyof typeof UNIFIED_TOKEN_LABELS
+                                  ] ?? key}
+                                </em>
+                                <strong>{formatTokens(value)}</strong>
+                              </li>
+                            ))}
+                          </ul>
+                        ) : null}
+                      </>
+                    ) : null}
+                    <p
+                      className={`usage-coverage${
+                        tokenUsage.coverage === "entire_waypoint_session"
+                          ? ""
+                          : " usage-coverage--partial"
+                      }`}
+                    >
+                      <span aria-hidden className="usage-coverage-dot" />
+                      {coverageLabel(tokenUsage)}
+                    </p>
+                  </section>
+                ) : null}
+              </div>
+            </div>,
+          )
+        : null}
     </div>
   );
 }

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -39,6 +39,11 @@ const DESKTOP_MIN_WIDTH = 541;
 // Pixel steps for keyboard resize; Shift takes the larger stride.
 const KEY_STEP = 24;
 const KEY_STEP_LARGE = 72;
+// The 440px CSS default width and the content-driven natural height act as snap
+// detents: a resize landing within this many pixels returns that axis to its
+// default (clearing the stored dimension).
+const DEFAULT_PANEL_WIDTH = 440;
+const SNAP_THRESHOLD = 14;
 
 interface UsagePopoverSize {
   width?: number;
@@ -121,11 +126,7 @@ export function SessionUsagePill({
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const closeRef = useRef<HTMLButtonElement | null>(null);
-  const resetRef = useRef<HTMLButtonElement | null>(null);
-  // Whether the most recent open was keyboard-activated, so focus moves into
-  // the panel only then (a pointer open leaves focus on the trigger).
-  const openedViaKeyboardRef = useRef(false);
+  const widthSeamRef = useRef<HTMLDivElement | null>(null);
 
   // Desktop drives resize controls and saved dimensions; the mobile sheet is
   // left untouched. Tracked reactively so a viewport crossing 540px re-renders.
@@ -173,11 +174,6 @@ export function SessionUsagePill({
     height: number;
   } | null>(null);
 
-  const closePopover = useCallback(() => {
-    setOpen(false);
-    triggerRef.current?.focus();
-  }, []);
-
   const applyResize = useCallback((patch: UsagePopoverSize) => {
     const next = { ...prefRef.current, ...patch };
     prefRef.current = next;
@@ -190,9 +186,44 @@ export function SessionUsagePill({
     setPref({});
     writeStoredSize({});
     // Reset auto-hides once no preference remains; keep focus in the panel by
-    // moving it to Close rather than dropping it to the body.
-    closeRef.current?.focus();
+    // moving it to a resize seam rather than dropping it to the body.
+    widthSeamRef.current?.focus();
   }, []);
+
+  // Snap a resized dimension to its default detent: 440px for width, the
+  // content-driven natural height for height. Returns whether to clear the axis
+  // (restoring the default) or store the explicit value.
+  const snapValue = useCallback(
+    (
+      axis: "width" | "height",
+      value: number,
+    ): { value: number; clear: boolean } => {
+      if (!bounds) return { value, clear: false };
+      if (axis === "width") {
+        const def = clampSize(
+          Math.min(DEFAULT_PANEL_WIDTH, bounds.maxWidth),
+          bounds.minWidth,
+          bounds.maxWidth,
+        );
+        if (Math.abs(value - def) <= SNAP_THRESHOLD)
+          return { value: def, clear: true };
+        return { value, clear: false };
+      }
+      const panel = panelRef.current;
+      const body = panel?.querySelector<HTMLElement>(".usage-panel-body");
+      if (panel && body) {
+        const natural = clampSize(
+          panel.offsetHeight - body.clientHeight + body.scrollHeight,
+          bounds.minHeight,
+          bounds.maxHeight,
+        );
+        if (Math.abs(value - natural) <= SNAP_THRESHOLD)
+          return { value: natural, clear: true };
+      }
+      return { value, clear: false };
+    },
+    [bounds],
+  );
 
   // Re-read storage on open so a resize made in the other placement is picked
   // up, then apply within current bounds.
@@ -234,14 +265,6 @@ export function SessionUsagePill({
     };
   }, [open]);
 
-  // A keyboard open moves focus to the in-panel Close button.
-  useEffect(() => {
-    if (open && isDesktop && openedViaKeyboardRef.current) {
-      closeRef.current?.focus();
-    }
-    if (!open) openedViaKeyboardRef.current = false;
-  }, [open, isDesktop]);
-
   useEffect(() => {
     if (!open) setTotalTipOpen(false);
   }, [open]);
@@ -264,21 +287,21 @@ export function SessionUsagePill({
       document.body.classList.add(bodyClass);
       const onMove = (ev: PointerEvent) => {
         if (axis === "width") {
-          applyResize({
-            width: clampSize(
-              startWidth + sign * (ev.clientX - startX),
-              bounds.minWidth,
-              bounds.maxWidth,
-            ),
-          });
+          const raw = clampSize(
+            startWidth + sign * (ev.clientX - startX),
+            bounds.minWidth,
+            bounds.maxWidth,
+          );
+          const snap = snapValue("width", raw);
+          applyResize({ width: snap.clear ? undefined : snap.value });
         } else {
-          applyResize({
-            height: clampSize(
-              startHeight + sign * (ev.clientY - startY),
-              bounds.minHeight,
-              bounds.maxHeight,
-            ),
-          });
+          const raw = clampSize(
+            startHeight + sign * (ev.clientY - startY),
+            bounds.minHeight,
+            bounds.maxHeight,
+          );
+          const snap = snapValue("height", raw);
+          applyResize({ height: snap.clear ? undefined : snap.value });
         }
       };
       const onUp = () => {
@@ -289,7 +312,7 @@ export function SessionUsagePill({
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
-    [bounds, anchored, applyResize],
+    [bounds, anchored, applyResize, snapValue],
   );
 
   const onResizeKey = useCallback(
@@ -309,13 +332,13 @@ export function SessionUsagePill({
         event.preventDefault();
         const current =
           prefRef.current.width ?? panel?.offsetWidth ?? bounds.minWidth;
-        applyResize({
-          width: clampSize(
-            current + dir * sign * step,
-            bounds.minWidth,
-            bounds.maxWidth,
-          ),
-        });
+        const raw = clampSize(
+          current + dir * sign * step,
+          bounds.minWidth,
+          bounds.maxWidth,
+        );
+        const snap = snapValue("width", raw);
+        applyResize({ width: snap.clear ? undefined : snap.value });
       } else {
         let dir = 0;
         if (event.key === "ArrowDown") dir = 1;
@@ -324,16 +347,16 @@ export function SessionUsagePill({
         event.preventDefault();
         const current =
           prefRef.current.height ?? panel?.offsetHeight ?? bounds.minHeight;
-        applyResize({
-          height: clampSize(
-            current + dir * sign * step,
-            bounds.minHeight,
-            bounds.maxHeight,
-          ),
-        });
+        const raw = clampSize(
+          current + dir * sign * step,
+          bounds.minHeight,
+          bounds.maxHeight,
+        );
+        const snap = snapValue("height", raw);
+        applyResize({ height: snap.clear ? undefined : snap.value });
       }
     },
-    [bounds, anchored, applyResize],
+    [bounds, anchored, applyResize, snapValue],
   );
 
   const showResizeControls = isDesktop && bounds !== null;
@@ -486,12 +509,7 @@ export function SessionUsagePill({
         aria-haspopup="dialog"
         aria-expanded={open}
         aria-label={`Backend socket ${connection}. Usage details`}
-        onClick={(event) => {
-          // A keyboard-activated click reports detail 0; use it to route focus
-          // into the panel only when opening by keyboard.
-          openedViaKeyboardRef.current = !open && event.detail === 0;
-          setOpen((value) => !value);
-        }}
+        onClick={() => setOpen((value) => !value)}
       >
         {connection === "open"
           ? "live"
@@ -511,6 +529,7 @@ export function SessionUsagePill({
               {showResizeControls && bounds ? (
                 <>
                   <div
+                    ref={widthSeamRef}
                     className="usage-resize usage-resize-width"
                     role="separator"
                     aria-orientation="vertical"
@@ -538,30 +557,18 @@ export function SessionUsagePill({
                     onPointerDown={startResize("height")}
                     onKeyDown={onResizeKey("height")}
                   />
-                </>
-              ) : null}
-              {showResizeControls ? (
-                <div className="usage-panel-controls">
                   {hasCustomSize ? (
                     <button
-                      ref={resetRef}
                       type="button"
-                      className="usage-panel-reset"
+                      className="usage-resize-reset"
+                      aria-label="Reset popover size"
+                      title="Reset size"
                       onClick={resetSize}
                     >
-                      Reset size
+                      ↺
                     </button>
                   ) : null}
-                  <button
-                    ref={closeRef}
-                    type="button"
-                    className="usage-panel-close"
-                    aria-label="Close usage details"
-                    onClick={closePopover}
-                  >
-                    ×
-                  </button>
-                </div>
+                </>
               ) : null}
               <div className="usage-panel-body">
                 {rateLimitUsage ? (

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -190,37 +190,36 @@ export function SessionUsagePill({
     widthSeamRef.current?.focus();
   }, []);
 
-  // Snap a resized dimension to its default detent: 440px for width, the
-  // content-driven natural height for height. Returns whether to clear the axis
-  // (restoring the default) or store the explicit value.
-  const snapValue = useCallback(
-    (
-      axis: "width" | "height",
-      value: number,
-    ): { value: number; clear: boolean } => {
-      if (!bounds) return { value, clear: false };
+  // The default detent a resize snaps to: 440px for width, the content-driven
+  // natural height for height. The height is derived from the content plus the
+  // panel's vertical chrome, independent of the panel's current height, so the
+  // target never chases a panel that has grown past its content (which would
+  // otherwise oscillate the snap and flicker). Computed once per gesture.
+  const snapTarget = useCallback(
+    (axis: "width" | "height"): number | null => {
+      if (!bounds) return null;
       if (axis === "width") {
-        const def = clampSize(
+        return clampSize(
           Math.min(DEFAULT_PANEL_WIDTH, bounds.maxWidth),
           bounds.minWidth,
           bounds.maxWidth,
         );
-        if (Math.abs(value - def) <= SNAP_THRESHOLD)
-          return { value: def, clear: true };
-        return { value, clear: false };
       }
       const panel = panelRef.current;
       const body = panel?.querySelector<HTMLElement>(".usage-panel-body");
-      if (panel && body) {
-        const natural = clampSize(
-          panel.offsetHeight - body.clientHeight + body.scrollHeight,
-          bounds.minHeight,
-          bounds.maxHeight,
-        );
-        if (Math.abs(value - natural) <= SNAP_THRESHOLD)
-          return { value: natural, clear: true };
-      }
-      return { value, clear: false };
+      if (!panel || !body) return null;
+      const cs = window.getComputedStyle(panel);
+      // ``offsetTop`` covers the top border + padding above the body (the sole
+      // flow child); the bottom chrome is read from the computed style.
+      const chrome =
+        body.offsetTop +
+        parseFloat(cs.paddingBottom) +
+        parseFloat(cs.borderBottomWidth);
+      return clampSize(
+        chrome + body.scrollHeight,
+        bounds.minHeight,
+        bounds.maxHeight,
+      );
     },
     [bounds],
   );
@@ -285,6 +284,8 @@ export function SessionUsagePill({
       const bodyClass =
         axis === "width" ? "usage-resizing-x" : "usage-resizing-y";
       document.body.classList.add(bodyClass);
+      // Captured once so the snap detent is a fixed target for the whole drag.
+      const target = snapTarget(axis);
       const onMove = (ev: PointerEvent) => {
         if (axis === "width") {
           const raw = clampSize(
@@ -292,16 +293,18 @@ export function SessionUsagePill({
             bounds.minWidth,
             bounds.maxWidth,
           );
-          const snap = snapValue("width", raw);
-          applyResize({ width: snap.clear ? undefined : snap.value });
+          const snap =
+            target !== null && Math.abs(raw - target) <= SNAP_THRESHOLD;
+          applyResize({ width: snap ? undefined : raw });
         } else {
           const raw = clampSize(
             startHeight + sign * (ev.clientY - startY),
             bounds.minHeight,
             bounds.maxHeight,
           );
-          const snap = snapValue("height", raw);
-          applyResize({ height: snap.clear ? undefined : snap.value });
+          const snap =
+            target !== null && Math.abs(raw - target) <= SNAP_THRESHOLD;
+          applyResize({ height: snap ? undefined : raw });
         }
       };
       const onUp = () => {
@@ -312,7 +315,7 @@ export function SessionUsagePill({
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
     },
-    [bounds, anchored, applyResize, snapValue],
+    [bounds, anchored, applyResize, snapTarget],
   );
 
   const onResizeKey = useCallback(
@@ -337,8 +340,10 @@ export function SessionUsagePill({
           bounds.minWidth,
           bounds.maxWidth,
         );
-        const snap = snapValue("width", raw);
-        applyResize({ width: snap.clear ? undefined : snap.value });
+        const target = snapTarget("width");
+        const snap =
+          target !== null && Math.abs(raw - target) <= SNAP_THRESHOLD;
+        applyResize({ width: snap ? undefined : raw });
       } else {
         let dir = 0;
         if (event.key === "ArrowDown") dir = 1;
@@ -352,11 +357,13 @@ export function SessionUsagePill({
           bounds.minHeight,
           bounds.maxHeight,
         );
-        const snap = snapValue("height", raw);
-        applyResize({ height: snap.clear ? undefined : snap.value });
+        const target = snapTarget("height");
+        const snap =
+          target !== null && Math.abs(raw - target) <= SNAP_THRESHOLD;
+        applyResize({ height: snap ? undefined : raw });
       }
     },
-    [bounds, anchored, applyResize, snapValue],
+    [bounds, anchored, applyResize, snapTarget],
   );
 
   const showResizeControls = isDesktop && bounds !== null;

--- a/frontend/src/lib/use-popover-anchor.ts
+++ b/frontend/src/lib/use-popover-anchor.ts
@@ -1,68 +1,158 @@
 "use client";
 
-import { CSSProperties, RefObject, useCallback, useLayoutEffect, useState } from "react";
+import {
+  CSSProperties,
+  RefObject,
+  useCallback,
+  useLayoutEffect,
+  useState,
+} from "react";
+
+// Where the popover is pinned relative to its trigger. ``dropdown`` drops the
+// panel just below the trigger and is portaled to ``document.body`` with
+// ``position: fixed`` (the term-bar case, whose trigger lives inside
+// ``.session-terminal``'s ``overflow: hidden`` box). ``composer`` renders the
+// panel in-tree above the trigger; CSS owns its ``position: absolute``
+// bottom/right anchor, so the hook emits no position, only bounds.
+export type PopoverPlacement = "dropdown" | "composer";
 
 interface PopoverAnchorOptions {
   gap?: number;
-  // Below this viewport width, return null so a CSS bottom-sheet media query
-  // (e.g. the generic ``.usage-panel`` mobile rule) takes over instead of the
-  // fixed drop-down. Omit for popovers whose mobile styling is specific to a
-  // different anchor and must not apply once portaled to the body.
+  // Below this viewport width, return null style/bounds so a CSS bottom-sheet
+  // media query (e.g. the generic ``.usage-panel`` mobile rule) takes over
+  // instead of the fixed drop-down. Omit for popovers whose mobile styling is
+  // specific to a different anchor and must not apply once portaled.
   deferBelow?: number;
+  // Minimum inset kept between the panel and every visual-viewport edge.
+  margin?: number;
 }
 
-// Fixed-viewport coordinates for a popover dropped just below a trigger.
-// Popovers that open from the term-bar live inside ``.session-terminal``'s
-// ``overflow: hidden`` box, which clips an absolutely-positioned panel to the
-// pane. Portaling the panel to ``document.body`` and positioning it ``fixed``
-// against the trigger's rect escapes the clip entirely. ``align`` pins the
-// panel to the trigger's left or right edge; ``max-height``/``overflow-y`` keep
-// a tall panel scrollable rather than running off the viewport bottom. The
-// coordinates are re-measured while open so the panel tracks scroll and resize.
+// The space available for the panel to grow into, measured from its fixed
+// anchor toward the free edges, in layout-viewport CSS pixels. ``SessionUsagePill``
+// clamps a user's saved size against these bounds on every remeasurement.
+export interface PopoverBounds {
+  minWidth: number;
+  maxWidth: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+export interface PopoverAnchor {
+  // Fixed-position style for a ``dropdown`` placement; null for ``composer``
+  // (CSS owns its anchor) and whenever the popover is closed or deferred to a
+  // mobile media query.
+  style: CSSProperties | null;
+  // Placement-aware growth bounds; null when closed or deferred.
+  bounds: PopoverBounds | null;
+}
+
+const CLOSED: PopoverAnchor = { style: null, bounds: null };
+
+// Usable minimums the panel may shrink to before the available viewport is the
+// tighter constraint; kept in sync with the RFC's proposed initial bounds.
+const MIN_WIDTH = 320;
+const MIN_HEIGHT = 240;
+
+// Fixed-viewport coordinates and growth bounds for a popover anchored to a
+// trigger. The dropdown placement positions the panel ``fixed`` just below the
+// trigger and pins it to the trigger's left or right edge; the composer
+// placement leaves positioning to CSS and only reports bounds. Both compute
+// available space from the visual viewport so the panel never runs past a
+// screen edge, and both re-measure while open so the panel tracks scroll,
+// resize, and visual-viewport pan/zoom.
 export function usePopoverAnchor(
   triggerRef: RefObject<HTMLElement | null>,
   open: boolean,
   align: "left" | "right",
-  { gap = 10, deferBelow }: PopoverAnchorOptions = {},
-): CSSProperties | null {
-  const [style, setStyle] = useState<CSSProperties | null>(null);
+  { gap = 10, deferBelow, margin = 8 }: PopoverAnchorOptions = {},
+  placement: PopoverPlacement = "dropdown",
+): PopoverAnchor {
+  const [anchor, setAnchor] = useState<PopoverAnchor>(CLOSED);
 
   const measure = useCallback(() => {
     const el = triggerRef.current;
     if (!el) return;
     if (deferBelow !== undefined && window.innerWidth <= deferBelow) {
-      setStyle(null);
+      setAnchor(CLOSED);
       return;
     }
+
+    const vv = window.visualViewport;
+    const visualLeft = vv?.offsetLeft ?? 0;
+    const visualTop = vv?.offsetTop ?? 0;
+    const visualWidth = vv?.width ?? window.innerWidth;
+    const visualHeight = vv?.height ?? window.innerHeight;
+    const visualRight = visualLeft + visualWidth;
+    const visualBottom = visualTop + visualHeight;
+
     const rect = el.getBoundingClientRect();
-    const top = rect.bottom + gap;
-    const common: CSSProperties = {
-      position: "fixed",
-      top,
-      bottom: "auto",
-      maxHeight: `calc(100vh - ${Math.round(top)}px - 8px)`,
-      overflowY: "auto",
-    };
-    setStyle(
-      align === "right"
-        ? { ...common, right: Math.max(8, window.innerWidth - rect.right), left: "auto" }
-        : { ...common, left: Math.max(8, rect.left), right: "auto" },
-    );
-  }, [triggerRef, align, gap, deferBelow]);
+    const triggerLeft = visualLeft + rect.left;
+    const triggerTop = visualTop + rect.top;
+    const triggerRight = visualLeft + rect.right;
+    const triggerBottom = visualTop + rect.bottom;
+
+    let availableWidth: number;
+    let availableHeight: number;
+    let style: CSSProperties | null;
+
+    if (placement === "composer") {
+      // Anchor bottom/right; grow toward the top/left viewport margins. The
+      // panel's right edge tracks the trigger's right edge, its bottom edge
+      // sits ``gap`` above the trigger's top edge.
+      availableWidth = triggerRight - visualLeft - margin;
+      availableHeight = triggerTop - gap - visualTop - margin;
+      style = null;
+    } else {
+      // Anchor top/left; drop below the trigger and grow toward the
+      // bottom/right viewport margins.
+      const top = rect.bottom + gap;
+      const common: CSSProperties = { position: "fixed", top, bottom: "auto" };
+      style =
+        align === "right"
+          ? {
+              ...common,
+              right: Math.max(margin, window.innerWidth - rect.right),
+              left: "auto",
+            }
+          : { ...common, left: Math.max(margin, rect.left), right: "auto" };
+      availableWidth =
+        align === "right"
+          ? triggerRight - visualLeft - margin
+          : visualRight - triggerLeft - margin;
+      availableHeight = visualBottom - (triggerBottom + gap) - margin;
+    }
+
+    const maxWidth = Math.max(0, Math.round(availableWidth));
+    const maxHeight = Math.max(0, Math.round(availableHeight));
+    setAnchor({
+      style,
+      bounds: {
+        maxWidth,
+        maxHeight,
+        minWidth: Math.min(MIN_WIDTH, maxWidth),
+        minHeight: Math.min(MIN_HEIGHT, maxHeight),
+      },
+    });
+  }, [triggerRef, align, gap, deferBelow, margin, placement]);
 
   useLayoutEffect(() => {
     if (!open) {
-      setStyle(null);
+      setAnchor(CLOSED);
       return;
     }
     measure();
     window.addEventListener("scroll", measure, true);
     window.addEventListener("resize", measure);
+    const vv = window.visualViewport;
+    vv?.addEventListener("resize", measure);
+    vv?.addEventListener("scroll", measure);
     return () => {
       window.removeEventListener("scroll", measure, true);
       window.removeEventListener("resize", measure);
+      vv?.removeEventListener("resize", measure);
+      vv?.removeEventListener("scroll", measure);
     };
   }, [open, measure]);
 
-  return style;
+  return anchor;
 }


### PR DESCRIPTION
## Purpose

Let desktop users reshape the session context-usage popover (`SessionUsagePill`), which is cramped at its fixed 440px width in both the transcript composer and the Terminal bar. The popover keeps its 440px natural-size default until a user resizes it, gains accessible width and height controls, remembers the chosen dimensions locally, and always stays within the visible viewport — scrolling internally only when the constrained or user-selected height cannot fit its content. The mobile bottom sheet is unchanged. Implements `.waypoint/specs/rfc-resizable-context-usage-popover.md`.

## Changes

- `frontend/src/lib/use-popover-anchor.ts` — return `{ style, bounds }` instead of a bare style: placement-aware growth bounds (min/max width and height with an 8px viewport margin) computed from the trigger rect and the visual viewport, for both the `composer` (bottom/right anchor, CSS-positioned) and `dropdown` (top/left anchor, fixed-positioned) placements, and subscribe to `visualViewport` resize/scroll alongside the existing window listeners.
- `frontend/src/components/SessionUsagePill.tsx` — desktop-only resize seams (`role="separator"` with live `aria-valuenow/min/max`) on the two free edges opposite the anchor, pointer drag and arrow-key resize (24px step, 72px with Shift) whose direction matches the free edge per placement, a versioned `localStorage` preference (`waypoint.usage-popover-size.v1`, independently optional width/height, malformed values ignored) clamped against the current bounds on every measurement, a `.usage-panel-body` scroll region with the seams and a Close/Reset control row outside it, and non-modal dialog behavior (keyboard-open focuses Close; Escape/close/outside-click dismiss and restore focus to the trigger; Reset clears the preference without closing).
- `frontend/src/app/globals.css` — seam styling with hover/focus/drag highlight, the `.usage-panel-body` scroll region, the Close/Reset control row, `.usage-panel` as a flex column with per-placement modifiers, and defensive suppression of the seams and inline dimensions below 540px.
- `frontend/src/components/SessionTerminalView.tsx` — adapt the term-bar overflow menu to the hook's new return shape, preserving its prior tall-menu height cap via the returned bounds.

## Verification

- `npm run lint` and `npm run build` green.
- Live Playwright (desktop 1280×900 and mobile 500px) in both the composer and Terminal placements: pointer and keyboard resize, anchor preservation on both axes, 320px/240px minimums and viewport-max clamping, internal body scrolling at the minimum height, Reset (clears storage, hides its button, moves focus to Close), persistence across reload, dialog focus and Escape/close restoration, and the unchanged mobile bottom sheet with no seams or inline dimensions.