### PR TITLE
fix: eliminate empty-insights refresh flash on the telemetry page

### DIFF
--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -105,6 +105,12 @@ export default function TelemetryPage() {
   const [healthLoading, setHealthLoading] = useState(true);
   const [insights, setInsights] = useState<Insight[]>([]);
   const [insightsLoading, setInsightsLoading] = useState(true);
+  // Whether the deterministic-insights query has settled at least once for this
+  // mount. Distinguishes initial discovery (show the skeleton) from background
+  // revalidation of a known-empty region (render nothing). Never reset for
+  // range/filter changes: an optional, conditionally-present region revalidates
+  // stale-while-revalidate, and the settled response stays authoritative.
+  const [insightsHasSettled, setInsightsHasSettled] = useState(false);
   const [dismissingSignature, setDismissingSignature] = useState<string | null>(null);
   const [settings, setSettings] = useState<TelemetrySettingsResponse | null>(null);
   const [settingsLoading, setSettingsLoading] = useState(true);
@@ -202,6 +208,9 @@ export default function TelemetryPage() {
       setActivityLoading(false);
       setHealthLoading(false);
       setInsightsLoading(false);
+      // No request fires for an incomplete range; treat the region as settled
+      // so a mid-edit custom range never shows a phantom insight skeleton.
+      setInsightsHasSettled(true);
       return;
     }
     setOverviewLoading(true);
@@ -220,6 +229,7 @@ export default function TelemetryPage() {
       setActivity(activityRes);
       setHealth(healthRes);
       setInsights(insightsRes);
+      setInsightsHasSettled(true);
       setState("ready");
       setError("");
     } catch (err) {
@@ -772,6 +782,7 @@ export default function TelemetryPage() {
           <InsightCards
             insights={insights}
             loading={insightsLoading}
+            hasSettled={insightsHasSettled}
             dismissingSignature={dismissingSignature}
             onDismiss={(insight) => void handleDismissInsight(insight)}
             onClickThrough={handleInsightClickThrough}

--- a/frontend/src/app/telemetry/page.tsx
+++ b/frontend/src/app/telemetry/page.tsx
@@ -105,11 +105,8 @@ export default function TelemetryPage() {
   const [healthLoading, setHealthLoading] = useState(true);
   const [insights, setInsights] = useState<Insight[]>([]);
   const [insightsLoading, setInsightsLoading] = useState(true);
-  // Whether the deterministic-insights query has settled at least once for this
-  // mount. Distinguishes initial discovery (show the skeleton) from background
-  // revalidation of a known-empty region (render nothing). Never reset for
-  // range/filter changes: an optional, conditionally-present region revalidates
-  // stale-while-revalidate, and the settled response stays authoritative.
+  // Never reset across range/filter changes: a known-empty insights region
+  // revalidates stale-while-revalidate instead of flashing the first-load skeleton.
   const [insightsHasSettled, setInsightsHasSettled] = useState(false);
   const [dismissingSignature, setDismissingSignature] = useState<string | null>(null);
   const [settings, setSettings] = useState<TelemetrySettingsResponse | null>(null);
@@ -208,8 +205,7 @@ export default function TelemetryPage() {
       setActivityLoading(false);
       setHealthLoading(false);
       setInsightsLoading(false);
-      // No request fires for an incomplete range; treat the region as settled
-      // so a mid-edit custom range never shows a phantom insight skeleton.
+      // No request fires here, so mark settled to avoid a phantom skeleton.
       setInsightsHasSettled(true);
       return;
     }

--- a/frontend/src/components/telemetry/InsightCards.tsx
+++ b/frontend/src/components/telemetry/InsightCards.tsx
@@ -6,6 +6,7 @@ import { Insight } from "@/lib/types";
 interface InsightCardsProps {
   insights: Insight[];
   loading: boolean;
+  hasSettled: boolean;
   dismissingSignature: string | null;
   onDismiss: (insight: Insight) => void;
   onClickThrough: (insight: Insight) => void;
@@ -20,11 +21,15 @@ function severityGlyph(severity: Insight["severity"]): string {
 export function InsightCards({
   insights,
   loading,
+  hasSettled,
   dismissingSignature,
   onDismiss,
   onClickThrough,
 }: InsightCardsProps) {
-  if (loading && insights.length === 0) {
+  // The skeleton is only for the true first load: once a request has settled,
+  // a known-empty region renders nothing even while a later refresh is in
+  // flight, so a background revalidation never flashes a placeholder panel.
+  if (loading && !hasSettled && insights.length === 0) {
     return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
   }
   if (insights.length === 0) {

--- a/frontend/src/components/telemetry/InsightCards.tsx
+++ b/frontend/src/components/telemetry/InsightCards.tsx
@@ -26,9 +26,8 @@ export function InsightCards({
   onDismiss,
   onClickThrough,
 }: InsightCardsProps) {
-  // The skeleton is only for the true first load: once a request has settled,
-  // a known-empty region renders nothing even while a later refresh is in
-  // flight, so a background revalidation never flashes a placeholder panel.
+  // First load only: a settled-empty region stays absent through later
+  // refreshes instead of flashing the skeleton.
   if (loading && !hasSettled && insights.length === 0) {
     return <div className="panel tm-chart-card is-loading" aria-busy="true" />;
   }


### PR DESCRIPTION
## Summary

Eliminates the transient dark shimmer panel that flashed between the AI insight card and the Token usage chart on the telemetry page during background refreshes when the deterministic-insights endpoint returns no cards. Implements the RFC at `.waypoint/specs/rfc-telemetry-empty-insights-refresh.md` (Option 1, frontend-only). Closes ticket 595.

## Changes

Adds a parent-owned `insightsHasSettled` flag to `telemetry/page.tsx` and threads it into `InsightCards`. The skeleton renders only on the true first load — loading, empty, and not yet settled. Once the deterministic-insights query has settled with zero cards, later live refreshes render nothing instead of re-mounting the 220px `is-loading` panel.

The flag is set on the latest successful overview-group response and on an incomplete custom range (no request fires), and never on a stale, auth-redirect, disabled-feature, or failed response. It is never reset across range or filter changes, so a known-empty region revalidates stale-while-revalidate without flashing a placeholder. No CSS, API, WebSocket, or backend change — `globals.css` is untouched, as the RFC specifies.

## Verification

- `npm run lint` — clean.
- `npm run build` — compiles, TypeScript passes.
- Deployed the frontend and loaded `/telemetry` at mobile width: page renders end to end, deterministic insight cards display between the NL digest and Token usage with no broken skeleton, layout intact.
- Traced the render condition against the RFC's 6-row rendering matrix; all states match, including the fixed case (later refresh in flight, empty, settled → no element).