### PR TITLE
fix: render the workspace dock as a full-screen sheet when it overflows the viewport

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13380,11 +13380,9 @@ html[data-theme="light"] .session-switcher-row.selected {
   display: none;
 }
 
-/* Full-screen sheet: the dock fills the viewport (no push, no side border or
-   shadow, no resize seam) and clears the notch/home indicator on all edges.
-   The single source of truth for both the phone regime and the overflow
-   fallback — SessionDetail applies this class whenever the viewport is ≤640px
-   or the saved dock width exceeds the current viewport. */
+/* Full-screen sheet shared by the phone regime and the overflow fallback;
+   SessionDetail adds this class when the viewport is ≤640px or the saved width
+   overflows it. */
 .wp-dock-sheet {
   width: 100%;
   border-right: none;
@@ -14962,8 +14960,8 @@ html[data-theme="light"] .wp-hl {
   }
 }
 
-/* On phones SessionDetail always renders the dock as a sheet (see
-   .wp-dock-sheet); this only bumps the close control to a touch-sized target. */
+/* Phones always get .wp-dock-sheet from SessionDetail; this only enlarges the
+   close control to a touch target. */
 @media (max-width: 640px) {
   .wp-panel-close {
     width: 38px;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13380,6 +13380,23 @@ html[data-theme="light"] .session-switcher-row.selected {
   display: none;
 }
 
+/* Full-screen sheet: the dock fills the viewport (no push, no side border or
+   shadow, no resize seam) and clears the notch/home indicator on all edges.
+   The single source of truth for both the phone regime and the overflow
+   fallback — SessionDetail applies this class whenever the viewport is ≤640px
+   or the saved dock width exceeds the current viewport. */
+.wp-dock-sheet {
+  width: 100%;
+  border-right: none;
+  box-shadow: none;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right)
+    env(safe-area-inset-bottom) env(safe-area-inset-left);
+}
+
+.wp-dock-sheet .wp-dock-resizer {
+  display: none;
+}
+
 @keyframes wp-dock-in {
   from {
     transform: translateX(-100%);
@@ -13400,7 +13417,7 @@ body {
 }
 
 @media (min-width: 1180px) {
-  html[data-wp-dock="open"] body {
+  html[data-wp-dock="open"]:not([data-wp-dock-mode="sheet"]) body {
     padding-left: var(--wp-dock-width, 400px);
   }
 }
@@ -14945,21 +14962,9 @@ html[data-theme="light"] .wp-hl {
   }
 }
 
-/* Full-screen sheet on phones: the dock fills the viewport (no push, no resize
-   seam) and clears the notch/home indicator. */
+/* On phones SessionDetail always renders the dock as a sheet (see
+   .wp-dock-sheet); this only bumps the close control to a touch-sized target. */
 @media (max-width: 640px) {
-  .wp-dock {
-    width: 100%;
-    border-right: none;
-    box-shadow: none;
-    padding: env(safe-area-inset-top) env(safe-area-inset-right)
-      env(safe-area-inset-bottom) env(safe-area-inset-left);
-  }
-
-  .wp-dock-resizer {
-    display: none;
-  }
-
   .wp-panel-close {
     width: 38px;
     height: 38px;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -360,10 +360,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     const stored = Number(window.localStorage.getItem("waypoint.workspaceDockWidth"));
     return Number.isFinite(stored) && stored >= 300 ? stored : 400;
   });
-  // Current layout-viewport width, tracked so the dock can fall back to a
-  // full-screen sheet whenever its persisted width no longer fits (a desktop
-  // window shrunk below the saved dock width, or a phone). window.innerWidth
-  // matches CSS width media-query behavior during a desktop resize.
+  // innerWidth matches the CSS width media queries during a desktop resize.
   const [viewportWidth, setViewportWidth] = useState<number>(() =>
     typeof window === "undefined" ? Infinity : window.innerWidth,
   );
@@ -373,9 +370,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
   }, []);
-  // Present the dock as a sheet on phones or whenever the saved width overflows
-  // the viewport. Equality stays side-dock above the phone breakpoint: a dock
-  // exactly as wide as the viewport still contains its right-inset close button.
+  // Equality stays side-dock: a dock exactly viewport-wide still contains its
+  // right-inset close button.
   const dockSheet = viewportWidth <= 640 || dockWidth > viewportWidth;
   // The todo-event sequence the user last dismissed from the progress dock.
   // `undefined` means we haven't read the persisted value yet — the dock stays
@@ -1793,10 +1789,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
 
   // Drive the layout from the document root: when the dock is open on a wide
   // viewport, `.page-shell` pads left by --wp-dock-width so the session column
-  // slides clear of the dock instead of sitting under it. In sheet mode the
-  // dock fills the viewport, so the body-padding selector must exclude it —
-  // flag the mode with data-wp-dock-mode. useLayoutEffect keeps the padding and
-  // dock class in sync before paint, so a resize doesn't flash a stale layout.
+  // slides clear of the dock instead of sitting under it. Sheet mode excludes
+  // that push via data-wp-dock-mode; useLayoutEffect applies it before paint.
   useLayoutEffect(() => {
     const root = document.documentElement;
     if (workspacePreviewEnabled && workspaceOpen) {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -11,6 +11,7 @@ import {
   useCallback,
   useDeferredValue,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -359,6 +360,23 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     const stored = Number(window.localStorage.getItem("waypoint.workspaceDockWidth"));
     return Number.isFinite(stored) && stored >= 300 ? stored : 400;
   });
+  // Current layout-viewport width, tracked so the dock can fall back to a
+  // full-screen sheet whenever its persisted width no longer fits (a desktop
+  // window shrunk below the saved dock width, or a phone). window.innerWidth
+  // matches CSS width media-query behavior during a desktop resize.
+  const [viewportWidth, setViewportWidth] = useState<number>(() =>
+    typeof window === "undefined" ? Infinity : window.innerWidth,
+  );
+  useEffect(() => {
+    const onResize = () => setViewportWidth(window.innerWidth);
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  // Present the dock as a sheet on phones or whenever the saved width overflows
+  // the viewport. Equality stays side-dock above the phone breakpoint: a dock
+  // exactly as wide as the viewport still contains its right-inset close button.
+  const dockSheet = viewportWidth <= 640 || dockWidth > viewportWidth;
   // The todo-event sequence the user last dismissed from the progress dock.
   // `undefined` means we haven't read the persisted value yet — the dock stays
   // hidden until then so a dismissed dock doesn't flash on load (and to avoid
@@ -1775,19 +1793,29 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
 
   // Drive the layout from the document root: when the dock is open on a wide
   // viewport, `.page-shell` pads left by --wp-dock-width so the session column
-  // slides clear of the dock instead of sitting under it.
-  useEffect(() => {
+  // slides clear of the dock instead of sitting under it. In sheet mode the
+  // dock fills the viewport, so the body-padding selector must exclude it —
+  // flag the mode with data-wp-dock-mode. useLayoutEffect keeps the padding and
+  // dock class in sync before paint, so a resize doesn't flash a stale layout.
+  useLayoutEffect(() => {
     const root = document.documentElement;
     if (workspacePreviewEnabled && workspaceOpen) {
       root.style.setProperty("--wp-dock-width", `${dockWidth}px`);
       root.setAttribute("data-wp-dock", "open");
+      if (dockSheet) {
+        root.setAttribute("data-wp-dock-mode", "sheet");
+      } else {
+        root.removeAttribute("data-wp-dock-mode");
+      }
     } else {
       root.removeAttribute("data-wp-dock");
+      root.removeAttribute("data-wp-dock-mode");
     }
     return () => {
       root.removeAttribute("data-wp-dock");
+      root.removeAttribute("data-wp-dock-mode");
     };
-  }, [workspacePreviewEnabled, workspaceOpen, dockWidth]);
+  }, [workspacePreviewEnabled, workspaceOpen, dockWidth, dockSheet]);
 
   return (
     <WorkspaceFileLinkProvider value={workspaceLink}>
@@ -2352,6 +2380,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           initialDir={workspaceInitialDir}
           revealSeq={workspaceRevealSeq}
           width={dockWidth}
+          sheet={dockSheet}
           onResize={setDockWidth}
           onClose={() => setWorkspaceOpen(false)}
         />

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -74,11 +74,9 @@ export function WorkspaceFilesPanel({
     if (open) setHasOpened(true);
   }, [open]);
 
-  // In sheet mode the dock covers the viewport but focus may still sit outside
-  // its portal (on the opener or an underlying control), so a dock-local
-  // keydown never fires. Bridge Escape with a bubbling window handler installed
-  // only while the sheet is open. Honor defaultPrevented so a higher-priority
-  // modal or the explorer filter can consume Escape first.
+  // In sheet mode focus may sit outside the portal, where the dock-local keydown
+  // never fires; a window handler makes Escape reach it. defaultPrevented yields
+  // to a higher-priority modal or the explorer filter.
   useEffect(() => {
     if (!open || !sheet) return;
     const onKeyDown = (e: KeyboardEvent) => {
@@ -100,9 +98,8 @@ export function WorkspaceFilesPanel({
       aria-label="Workspace files"
       aria-hidden={!open}
       onKeyDown={(e) => {
-        // Only close when nothing inside the explorer already handled Escape
-        // (e.g. the filter clears itself first). preventDefault stops the
-        // window-level sheet handler from closing a second time.
+        // defaultPrevented lets the explorer consume Escape first; preventDefault
+        // keeps the window-level sheet handler from closing a second time.
         if (e.key === "Escape" && !e.defaultPrevented) {
           e.preventDefault();
           onClose();

--- a/frontend/src/components/WorkspaceFilesPanel.tsx
+++ b/frontend/src/components/WorkspaceFilesPanel.tsx
@@ -14,6 +14,7 @@ interface WorkspaceFilesPanelProps {
   initialDir?: string;
   revealSeq?: number;
   width: number;
+  sheet?: boolean;
   onResize: (width: number) => void;
   onClose: () => void;
 }
@@ -27,6 +28,7 @@ export function WorkspaceFilesPanel({
   initialDir,
   revealSeq,
   width,
+  sheet = false,
   onResize,
   onClose,
 }: WorkspaceFilesPanelProps) {
@@ -72,16 +74,39 @@ export function WorkspaceFilesPanel({
     if (open) setHasOpened(true);
   }, [open]);
 
+  // In sheet mode the dock covers the viewport but focus may still sit outside
+  // its portal (on the opener or an underlying control), so a dock-local
+  // keydown never fires. Bridge Escape with a bubbling window handler installed
+  // only while the sheet is open. Honor defaultPrevented so a higher-priority
+  // modal or the explorer filter can consume Escape first.
+  useEffect(() => {
+    if (!open || !sheet) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !e.defaultPrevented) {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, sheet, onClose]);
+
   if (typeof document === "undefined" || !hasOpened) return null;
 
   return createPortal(
     <aside
-      className={`wp-dock${open ? "" : " wp-dock-closed"}`}
+      className={`wp-dock${open ? "" : " wp-dock-closed"}${sheet ? " wp-dock-sheet" : ""}`}
       role="complementary"
       aria-label="Workspace files"
       aria-hidden={!open}
       onKeyDown={(e) => {
-        if (e.key === "Escape") onClose();
+        // Only close when nothing inside the explorer already handled Escape
+        // (e.g. the filter clears itself first). preventDefault stops the
+        // window-level sheet handler from closing a second time.
+        if (e.key === "Escape" && !e.defaultPrevented) {
+          e.preventDefault();
+          onClose();
+        }
       }}
     >
       <WorkspaceExplorer


### PR DESCRIPTION
## Summary

Implements the RFC at `.waypoint/specs/rfc-workspace-dock-viewport-fallback.md` (ticket 596). A persisted workspace-dock width wider than the current layout viewport left the dock fixed at that width with its right-edge close control off-screen and unreachable. The dock now falls back to the established full-screen-sheet model whenever it does not fit, and returns to the resizable side dock automatically when it fits again — without ever mutating the saved preference.

## Changes

- `SessionDetail.tsx` tracks `window.innerWidth` and derives a `dockSheet` mode (`viewportWidth <= 640 || dockWidth > viewportWidth`), passes it to the panel, and drives a `data-wp-dock-mode="sheet"` root attribute in a pre-paint `useLayoutEffect`.
- `WorkspaceFilesPanel.tsx` applies a `wp-dock-sheet` modifier and makes Escape dismissal reliable: the dock-local handler honors `defaultPrevented` (so the explorer filter's Escape-to-clear wins), and a bubbling `window` keydown handler — installed only while an open sheet is active — closes it even when focus sits on an underlying session control.
- `globals.css` promotes the sheet appearance (full width, no side border/shadow, all-edge safe-area padding, hidden resize seam) to a single `.wp-dock-sheet` selector shared by the phone and overflow regimes, and excludes sheet mode from the wide-viewport body-padding push.

## Verification

- `npm run lint` and `npm run build` green.
- End-to-end Playwright pass against the deployed app across all RFC scenarios: side dock → shrink to sheet → expand back to side dock, saved width unchanged, explorer not remounted (tree/open-file preserved), Escape-from-outside-focus dismissal, no left-padding gap for a wide-but-overflowing dock, and phone still a sheet.