### PR TITLE
feat: break down the Database metric in telemetry instance health

### DIFF
--- a/backend/src/waypoint/telemetry/instance/collect.py
+++ b/backend/src/waypoint/telemetry/instance/collect.py
@@ -46,8 +46,16 @@ class _DbReadout:
     valid_ids: set[str] | None = None  # None => classification unknown
     running_ids: set[str] = field(default_factory=set)
     table_rows: dict[str, int] = field(default_factory=dict)
+    table_bytes: dict[str, int] = field(default_factory=dict)
     events_by_kind: dict[str, int] = field(default_factory=dict)
     reclaim: DatabaseReclaim = field(default_factory=DatabaseReclaim)
+
+
+# dbstat scans every page, so it runs well past the per-query lock budget; the
+# whole collection is already an off-request-path, multi-second walk, so this
+# one measurement gets a wider ceiling and degrades to empty (sizes hidden)
+# rather than blocking when it cannot finish.
+_DBSTAT_BUDGET_MS = 4000
 
 
 def _read_database(db_path: Path) -> _DbReadout:
@@ -78,8 +86,38 @@ def _read_database(db_path: Path) -> _DbReadout:
         )
         for row in kinds or ():
             out.events_by_kind[row["kind"]] = int(row["n"])
+        out.table_bytes = _read_table_bytes(conn)
         out.reclaim = _read_reclaim(conn)
     return out
+
+
+def _read_table_bytes(conn: sqlite3.Connection) -> dict[str, int]:
+    """Measured page usage per table (its btree plus its indexes), via dbstat.
+
+    Attributes every index's pages to its owning table so a table's size is its
+    whole on-disk footprint. Returns an empty mapping when dbstat is absent from
+    the SQLite build or the scan exceeds its budget — the caller then reports
+    record counts without sizes rather than a fabricated breakdown.
+    """
+    schema = budgeted_query(
+        conn,
+        "SELECT name, tbl_name, type FROM sqlite_schema WHERE type IN ('table', 'index')",
+    )
+    owner = {
+        row["name"]: row["tbl_name"] for row in schema or () if row["type"] == "index"
+    }
+    pages = budgeted_query(
+        conn,
+        "SELECT name, SUM(pgsize) AS b FROM dbstat GROUP BY name",
+        budget_ms=_DBSTAT_BUDGET_MS,
+    )
+    if pages is None:
+        return {}
+    table_bytes: dict[str, int] = {}
+    for row in pages:
+        table = owner.get(row["name"], row["name"])
+        table_bytes[table] = table_bytes.get(table, 0) + int(row["b"])
+    return table_bytes
 
 
 def _read_reclaim(conn: sqlite3.Connection) -> DatabaseReclaim:
@@ -283,6 +321,7 @@ def collect_snapshot(
         filesystem=filesystem,
         counts=InstanceCounts(
             table_rows=db.table_rows,
+            table_bytes=db.table_bytes,
             events_by_kind=db.events_by_kind,
             session_dir_count=session_dir_count,
             orphan_dir_count=orphan_dir_count,

--- a/backend/src/waypoint/telemetry/instance/collect.py
+++ b/backend/src/waypoint/telemetry/instance/collect.py
@@ -51,10 +51,8 @@ class _DbReadout:
     reclaim: DatabaseReclaim = field(default_factory=DatabaseReclaim)
 
 
-# dbstat scans every page, so it runs well past the per-query lock budget; the
-# whole collection is already an off-request-path, multi-second walk, so this
-# one measurement gets a wider ceiling and degrades to empty (sizes hidden)
-# rather than blocking when it cannot finish.
+# dbstat scans every page, so it needs more headroom than the 250 ms per-query
+# lock budget; the collection runs off the request path.
 _DBSTAT_BUDGET_MS = 4000
 
 
@@ -96,8 +94,8 @@ def _read_table_bytes(conn: sqlite3.Connection) -> dict[str, int]:
 
     Attributes every index's pages to its owning table so a table's size is its
     whole on-disk footprint. Returns an empty mapping when dbstat is absent from
-    the SQLite build or the scan exceeds its budget — the caller then reports
-    record counts without sizes rather than a fabricated breakdown.
+    the SQLite build or the scan exceeds its budget; the caller then reports
+    record counts without sizes.
     """
     schema = budgeted_query(
         conn,

--- a/backend/src/waypoint/telemetry/instance/model.py
+++ b/backend/src/waypoint/telemetry/instance/model.py
@@ -119,6 +119,9 @@ class InstanceCounts(BaseModel):
     """Privacy-safe counts that make the footprint interpretable (PRD FR-1)."""
 
     table_rows: dict[str, int] = Field(default_factory=dict)
+    # Measured page usage (btree + indexes) per table, from dbstat; keyed by the
+    # owning table. Empty when dbstat is unavailable or the read budget is spent.
+    table_bytes: dict[str, int] = Field(default_factory=dict)
     events_by_kind: dict[str, int] = Field(default_factory=dict)
     session_dir_count: int = 0
     orphan_dir_count: int = 0

--- a/backend/tests/test_telemetry_instance_collect.py
+++ b/backend/tests/test_telemetry_instance_collect.py
@@ -8,12 +8,13 @@ unavailable labeling on failure.
 """
 
 import os
+import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 
 from waypoint.settings import Settings
 from waypoint.storage import Storage
-from waypoint.telemetry.instance.collect import collect_snapshot
+from waypoint.telemetry.instance.collect import _read_table_bytes, collect_snapshot
 from waypoint.telemetry.instance.model import DataQuality, StorageCategory
 from waypoint.telemetry.instance.roconn import budgeted_query, open_readonly
 from waypoint.telemetry.instance.walk import FootprintWalker
@@ -70,6 +71,26 @@ def test_open_readonly_live_wal_pragmas(tmp_path: Path) -> None:
                 assert rows is not None and int(rows[0][0]) >= 0
     finally:
         storage.close()
+
+
+def test_read_table_bytes_folds_indexes_into_owning_table(tmp_path: Path) -> None:
+    db_path = tmp_path / "widgets.db"
+    con = sqlite3.connect(db_path)
+    con.execute("CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT)")
+    con.execute("CREATE INDEX idx_widgets_name ON widgets (name)")
+    con.executemany(
+        "INSERT INTO widgets (name) VALUES (?)", [(f"w{i}",) for i in range(2000)]
+    )
+    con.commit()
+    con.close()
+
+    with open_readonly(db_path) as conn:
+        assert conn is not None
+        table_bytes = _read_table_bytes(conn)
+
+    assert table_bytes.get("widgets", 0) > 0
+    assert "idx_widgets_name" not in table_bytes
+    assert not any(key.startswith(("idx_", "sqlite_autoindex_")) for key in table_bytes)
 
 
 # ── walker (symlink skip, hard-link dedup, budget truncation) ──────────────

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -17826,11 +17826,23 @@ html[data-theme="light"] .wp-hl {
   display: grid;
   gap: 4px;
 }
+.tm-inst-db-heading-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
 .tm-inst-db-heading {
   margin: 0;
   font-size: 0.75rem;
   font-weight: 600;
   color: var(--text-strong);
+}
+.tm-inst-db-group-size {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text-strong);
+  font-variant-numeric: tabular-nums;
 }
 .tm-inst-db-dl {
   margin: 0;
@@ -17850,9 +17862,23 @@ html[data-theme="light"] .wp-hl {
 }
 .tm-inst-db-item dd {
   margin: 0;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  align-items: baseline;
+}
+.tm-inst-db-count {
   font-family: var(--font-mono);
   color: var(--text);
   font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+.tm-inst-db-size {
+  font-family: var(--font-mono);
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+  min-width: 5.5em;
   text-align: right;
 }
 .tm-inst-db-other {
@@ -17917,6 +17943,10 @@ html[data-theme="light"] .wp-hl {
     gap: 1px;
   }
   .tm-inst-db-item dd {
+    justify-content: flex-start;
+  }
+  .tm-inst-db-size {
+    min-width: 0;
     text-align: left;
   }
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -17765,6 +17765,162 @@ html[data-theme="light"] .wp-hl {
   padding: 0 4px;
 }
 
+/* Database content disclosure */
+.tm-inst-db-toggle {
+  margin-left: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  background: none;
+  border: none;
+  padding: 1px 3px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.tm-inst-db-toggle:hover {
+  color: var(--text);
+}
+.tm-inst-db-caret {
+  font-size: 0.72em;
+  line-height: 1;
+}
+
+.tm-inst-db-row > .tm-inst-db-cell {
+  text-align: left;
+  font-family: var(--font);
+  padding: 0 8px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--line) 55%, transparent);
+}
+.tm-inst-db {
+  display: grid;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--bg-card-soft);
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+}
+.tm-inst-db-title {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+  font-weight: 500;
+}
+.tm-inst-db-note {
+  margin: 0;
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+.tm-inst-db-groups {
+  display: grid;
+  gap: 10px;
+}
+.tm-inst-db-group {
+  display: grid;
+  gap: 4px;
+}
+.tm-inst-db-heading {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+.tm-inst-db-dl {
+  margin: 0;
+  display: grid;
+  gap: 2px;
+}
+.tm-inst-db-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  gap: 12px;
+  padding: 2px 0;
+}
+.tm-inst-db-item dt {
+  color: var(--muted);
+  font-size: 0.78rem;
+}
+.tm-inst-db-item dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  color: var(--text);
+  font-size: 0.82rem;
+  text-align: right;
+}
+.tm-inst-db-other {
+  margin: 0;
+  font-family: var(--font-mono);
+  color: var(--text);
+  font-size: 0.82rem;
+}
+.tm-inst-db-eventmix {
+  margin-top: 4px;
+  padding-left: 10px;
+  border-left: 1px solid var(--line);
+  display: grid;
+  gap: 5px;
+}
+.tm-inst-db-eventmix-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.tm-inst-db-subheading {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+.tm-inst-db-toggle-sm {
+  margin-left: 0;
+  font-size: 0.66rem;
+}
+.tm-inst-db-kinds {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+}
+.tm-inst-db-kind {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 5px;
+  font-size: 0.76rem;
+}
+.tm-inst-db-kind-label {
+  color: var(--muted);
+}
+.tm-inst-db-kind-count {
+  font-family: var(--font-mono);
+  color: var(--text);
+}
+.tm-inst-db-unavail {
+  margin: 0;
+  font-size: 0.76rem;
+  line-height: 1.4;
+}
+@media (max-width: 640px) {
+  .tm-inst-db-item {
+    grid-template-columns: 1fr;
+    gap: 1px;
+  }
+  .tm-inst-db-item dd {
+    text-align: left;
+  }
+}
+
 .tm-inst-overlays {
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/telemetry/InstanceHealthPanel.tsx
+++ b/frontend/src/components/telemetry/InstanceHealthPanel.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { Fragment, useCallback, useMemo, useState } from "react";
 
 import {
+  DatabaseContentModel,
+  DatabaseCountRow,
+  deriveDatabaseContent,
   formatBytes,
   formatExactBytes,
   INSTANCE_CATEGORY_ORDER,
@@ -12,11 +15,24 @@ import {
 } from "@/lib/telemetry";
 import {
   CategoryFootprint,
+  DatabaseReclaim,
   Insight,
   InstanceDataQuality,
   InstanceHistoryPoint,
+  InstanceSnapshot,
   TelemetryInstance,
 } from "@/lib/types";
+
+const DB_DETAILS_REGION_ID = "tm-inst-db-details";
+const DB_DETAILS_HEADING_ID = "tm-inst-db-details-heading";
+const DB_DETAILS_TOGGLE_ID = "tm-inst-db-details-toggle";
+const DB_EVENT_MIX_ID = "tm-inst-db-event-mix";
+const DB_EVENT_MIX_COLLAPSED_LIMIT = 4;
+
+const DB_CONTENT_UNAVAILABLE =
+  "Database content details are unavailable because the database could not be queried read-only.";
+const DB_RECORD_COUNT_NOTE =
+  "Record counts explain database contents; they do not divide the database file size.";
 
 interface InstanceHealthPanelProps {
   instance: TelemetryInstance | null;
@@ -87,10 +103,177 @@ function ProportionBar({ categories, total }: { categories: CategoryFootprint[];
   );
 }
 
-function CategoryTable({ categories }: { categories: CategoryFootprint[] }) {
+function CountRows({ rows }: { rows: DatabaseCountRow[] }) {
+  return (
+    <dl className="tm-inst-db-dl">
+      {rows.map((row) => (
+        <div key={row.key} className="tm-inst-db-item">
+          <dt>{row.label}</dt>
+          <dd>{row.count.toLocaleString("en-US")}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+function EventMix({
+  content,
+  expanded,
+  onToggle,
+}: {
+  content: DatabaseContentModel;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  if (content.eventMix.length === 0) return null;
+  const collapsible = content.eventMix.length > DB_EVENT_MIX_COLLAPSED_LIMIT;
+  const visible =
+    collapsible && !expanded
+      ? content.eventMix.slice(0, DB_EVENT_MIX_COLLAPSED_LIMIT)
+      : content.eventMix;
+  return (
+    <div className="tm-inst-db-eventmix">
+      <div className="tm-inst-db-eventmix-head">
+        <span className="tm-inst-db-subheading">Event mix</span>
+        {collapsible ? (
+          <button
+            type="button"
+            className="tm-inst-db-toggle tm-inst-db-toggle-sm"
+            aria-expanded={expanded}
+            aria-controls={DB_EVENT_MIX_ID}
+            onClick={onToggle}
+          >
+            <span className="tm-inst-db-caret" aria-hidden="true">
+              {expanded ? "▾" : "▸"}
+            </span>
+            {expanded ? "Show fewer" : `Show all ${content.eventMix.length}`}
+          </button>
+        ) : null}
+      </div>
+      <ul id={DB_EVENT_MIX_ID} className="tm-inst-db-kinds">
+        {visible.map((kind) => (
+          <li key={kind.kind} className="tm-inst-db-kind">
+            <span className="tm-inst-db-kind-label">{kind.label}</span>
+            <span className="tm-inst-db-kind-count">{kind.count.toLocaleString("en-US")}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function DatabaseDetails({
+  bytes,
+  categoryUnavailable,
+  database,
+  content,
+  tableRowsEmpty,
+  eventMixExpanded,
+  onToggleEventMix,
+}: {
+  bytes: number;
+  categoryUnavailable: boolean;
+  database: DatabaseReclaim;
+  content: DatabaseContentModel;
+  tableRowsEmpty: boolean;
+  eventMixExpanded: boolean;
+  onToggleEventMix: () => void;
+}) {
+  const contentUnavailable = tableRowsEmpty && !database.measured;
+  return (
+    <section id={DB_DETAILS_REGION_ID} className="tm-inst-db" aria-labelledby={DB_DETAILS_HEADING_ID}>
+      <h4 id={DB_DETAILS_HEADING_ID} className="tm-inst-db-title">
+        Database details
+      </h4>
+      {categoryUnavailable ? (
+        <p className="tm-inst-db-unavail muted">{DB_CONTENT_UNAVAILABLE}</p>
+      ) : (
+        <>
+          <p className="tm-inst-db-note muted">{DB_RECORD_COUNT_NOTE}</p>
+          <div className="tm-inst-db-groups">
+            <div className="tm-inst-db-group">
+              <h5 className="tm-inst-db-heading">Storage</h5>
+              <dl className="tm-inst-db-dl">
+                <div className="tm-inst-db-item">
+                  <dt>Database file</dt>
+                  <dd>
+                    <ByteValue bytes={bytes} />
+                  </dd>
+                </div>
+                {database.measured ? (
+                  <div className="tm-inst-db-item">
+                    <dt>Reclaimable free pages</dt>
+                    <dd>
+                      <ByteValue bytes={database.free_bytes} /> (
+                      {(database.free_percent * 100).toFixed(0)}%)
+                    </dd>
+                  </div>
+                ) : null}
+              </dl>
+            </div>
+
+            {content.hasContent ? (
+              <>
+                {content.session.length > 0 ? (
+                  <div className="tm-inst-db-group">
+                    <h5 className="tm-inst-db-heading">Session data</h5>
+                    <CountRows rows={content.session} />
+                    <EventMix
+                      content={content}
+                      expanded={eventMixExpanded}
+                      onToggle={onToggleEventMix}
+                    />
+                  </div>
+                ) : null}
+
+                {content.telemetry.length > 0 ? (
+                  <div className="tm-inst-db-group">
+                    <h5 className="tm-inst-db-heading">Telemetry data</h5>
+                    <CountRows rows={content.telemetry} />
+                  </div>
+                ) : null}
+
+                {content.otherManagedRecords !== null ? (
+                  <div className="tm-inst-db-group">
+                    <h5 className="tm-inst-db-heading">Other managed records</h5>
+                    <p className="tm-inst-db-other">
+                      {content.otherManagedRecords.toLocaleString("en-US")}{" "}
+                      {content.otherManagedRecords === 1 ? "record" : "records"}
+                    </p>
+                  </div>
+                ) : null}
+              </>
+            ) : contentUnavailable ? (
+              <p className="tm-inst-db-unavail muted">{DB_CONTENT_UNAVAILABLE}</p>
+            ) : null}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function CategoryTable({
+  snapshot,
+  detailsExpanded,
+  onToggleDetails,
+  eventMixExpanded,
+  onToggleEventMix,
+}: {
+  snapshot: InstanceSnapshot;
+  detailsExpanded: boolean;
+  onToggleDetails: () => void;
+  eventMixExpanded: boolean;
+  onToggleEventMix: () => void;
+}) {
   const ordered = INSTANCE_CATEGORY_ORDER.map((cat) =>
-    categories.find((c) => c.category === cat),
+    snapshot.categories.find((c) => c.category === cat),
   ).filter((c): c is CategoryFootprint => c !== undefined);
+  const content = useMemo(
+    () => deriveDatabaseContent(snapshot.counts.table_rows, snapshot.counts.events_by_kind),
+    [snapshot.counts.table_rows, snapshot.counts.events_by_kind],
+  );
+  const tableRowsEmpty = Object.keys(snapshot.counts.table_rows).length === 0;
   return (
     <table className="tm-inst-table">
       <thead>
@@ -103,27 +286,62 @@ function CategoryTable({ categories }: { categories: CategoryFootprint[] }) {
         </tr>
       </thead>
       <tbody>
-        {ordered.map((cat) => (
-          <tr key={cat.category}>
-            <th scope="row">
-              <span
-                className="tm-inst-swatch"
-                aria-hidden="true"
-                style={{ background: instanceCategoryColor(cat.category) }}
-              />
-              {instanceCategoryLabel(cat.category)}
-              {cat.unavailable ? (
-                <span className="tm-inst-tag">unavailable</span>
-              ) : cat.partial ? (
-                <span className="tm-inst-tag">partial</span>
+        {ordered.map((cat) => {
+          const isDatabase = cat.category === "database";
+          return (
+            <Fragment key={cat.category}>
+              <tr>
+                <th scope="row">
+                  <span
+                    className="tm-inst-swatch"
+                    aria-hidden="true"
+                    style={{ background: instanceCategoryColor(cat.category) }}
+                  />
+                  {instanceCategoryLabel(cat.category)}
+                  {cat.unavailable ? (
+                    <span className="tm-inst-tag">unavailable</span>
+                  ) : cat.partial ? (
+                    <span className="tm-inst-tag">partial</span>
+                  ) : null}
+                  {isDatabase ? (
+                    <button
+                      type="button"
+                      id={DB_DETAILS_TOGGLE_ID}
+                      className="tm-inst-db-toggle"
+                      aria-expanded={detailsExpanded}
+                      aria-controls={DB_DETAILS_REGION_ID}
+                      onClick={onToggleDetails}
+                    >
+                      Details
+                      <span className="tm-inst-db-caret" aria-hidden="true">
+                        {detailsExpanded ? "▾" : "›"}
+                      </span>
+                    </button>
+                  ) : null}
+                </th>
+                <td>
+                  <ByteValue bytes={cat.bytes} />
+                </td>
+                <td className="tm-inst-num">{cat.entry_count.toLocaleString("en-US")}</td>
+              </tr>
+              {isDatabase && detailsExpanded ? (
+                <tr className="tm-inst-db-row">
+                  <td colSpan={3} className="tm-inst-db-cell">
+                    <DatabaseDetails
+                      bytes={cat.bytes}
+                      categoryUnavailable={cat.unavailable}
+                      database={snapshot.database}
+                      content={content}
+                      tableRowsEmpty={tableRowsEmpty}
+                      eventMixExpanded={eventMixExpanded}
+                      onToggleEventMix={onToggleEventMix}
+                    />
+                  </td>
+                </tr>
               ) : null}
-            </th>
-            <td>
-              <ByteValue bytes={cat.bytes} />
-            </td>
-            <td className="tm-inst-num">{cat.entry_count.toLocaleString("en-US")}</td>
-          </tr>
-        ))}
+            </Fragment>
+          );
+        })}
       </tbody>
     </table>
   );
@@ -271,6 +489,20 @@ export function InstanceHealthPanel({
     : (snapshot?.data_quality ?? "unavailable");
   const meta = QUALITY_META[quality];
 
+  const [databaseDetailsExpanded, setDatabaseDetailsExpanded] = useState(false);
+  const [eventMixExpanded, setEventMixExpanded] = useState(false);
+
+  // A database-vacuum maintenance card focuses "database"; open the details so
+  // the reclaimability metric is visible without a second click, then let the
+  // parent perform its existing scroll.
+  const handleInsightFocus = useCallback(
+    (focus: string | undefined) => {
+      if (focus === "database") setDatabaseDetailsExpanded(true);
+      onInsightFocus(focus);
+    },
+    [onInsightFocus],
+  );
+
   const totalCount = useMemo(() => {
     if (!snapshot) return 0;
     return snapshot.categories.reduce((sum, c) => sum + c.entry_count, 0);
@@ -332,7 +564,13 @@ export function InstanceHealthPanel({
           </div>
 
           <ProportionBar categories={snapshot.categories} total={snapshot.total_bytes} />
-          <CategoryTable categories={snapshot.categories} />
+          <CategoryTable
+            snapshot={snapshot}
+            detailsExpanded={databaseDetailsExpanded}
+            onToggleDetails={() => setDatabaseDetailsExpanded((prev) => !prev)}
+            eventMixExpanded={eventMixExpanded}
+            onToggleEventMix={() => setEventMixExpanded((prev) => !prev)}
+          />
 
           {snapshot.structured_logs.length > 0 || snapshot.redundant_logs.count > 0 ? (
             <div className="tm-inst-overlays">
@@ -431,7 +669,7 @@ export function InstanceHealthPanel({
             insights={instance?.insights ?? []}
             dismissingSignature={dismissingSignature}
             onDismiss={onDismiss}
-            onFocus={onInsightFocus}
+            onFocus={handleInsightFocus}
           />
 
           <HistoryTrend history={instance?.history ?? []} />

--- a/frontend/src/components/telemetry/InstanceHealthPanel.tsx
+++ b/frontend/src/components/telemetry/InstanceHealthPanel.tsx
@@ -350,7 +350,7 @@ function CategoryTable({
                     >
                       Details
                       <span className="tm-inst-db-caret" aria-hidden="true">
-                        {detailsExpanded ? "▾" : "›"}
+                        {detailsExpanded ? "▾" : "▸"}
                       </span>
                     </button>
                   ) : null}
@@ -529,8 +529,7 @@ export function InstanceHealthPanel({
   const [eventMixExpanded, setEventMixExpanded] = useState(false);
 
   // A database-vacuum maintenance card focuses "database"; open the details so
-  // the reclaimability metric is visible without a second click, then let the
-  // parent perform its existing scroll.
+  // the reclaimability metric is visible without a second click.
   const handleInsightFocus = useCallback(
     (focus: string | undefined) => {
       if (focus === "database") setDatabaseDetailsExpanded(true);

--- a/frontend/src/components/telemetry/InstanceHealthPanel.tsx
+++ b/frontend/src/components/telemetry/InstanceHealthPanel.tsx
@@ -261,16 +261,18 @@ function DatabaseDetails({
                   </div>
                 ) : null}
 
-                {content.otherManagedRecords !== null ? (
+                {content.otherManagedRecords !== null || content.otherManagedBytes !== null ? (
                   <div className="tm-inst-db-group">
                     <GroupHeading
                       title="Other managed records"
                       bytes={content.otherManagedBytes}
                     />
-                    <p className="tm-inst-db-other">
-                      {content.otherManagedRecords.toLocaleString("en-US")}{" "}
-                      {content.otherManagedRecords === 1 ? "record" : "records"}
-                    </p>
+                    {content.otherManagedRecords !== null ? (
+                      <p className="tm-inst-db-other">
+                        {content.otherManagedRecords.toLocaleString("en-US")}{" "}
+                        {content.otherManagedRecords === 1 ? "record" : "records"}
+                      </p>
+                    ) : null}
                   </div>
                 ) : null}
               </>

--- a/frontend/src/components/telemetry/InstanceHealthPanel.tsx
+++ b/frontend/src/components/telemetry/InstanceHealthPanel.tsx
@@ -31,8 +31,10 @@ const DB_EVENT_MIX_COLLAPSED_LIMIT = 4;
 
 const DB_CONTENT_UNAVAILABLE =
   "Database content details are unavailable because the database could not be queried read-only.";
-const DB_RECORD_COUNT_NOTE =
-  "Record counts explain database contents; they do not divide the database file size.";
+const DB_NOTE_WITH_BYTES =
+  "Sizes are measured page usage — each table plus its indexes; free pages are listed under Storage.";
+const DB_NOTE_COUNTS_ONLY =
+  "Record counts explain database contents; per-table sizes could not be measured on this database.";
 
 interface InstanceHealthPanelProps {
   instance: TelemetryInstance | null;
@@ -109,10 +111,30 @@ function CountRows({ rows }: { rows: DatabaseCountRow[] }) {
       {rows.map((row) => (
         <div key={row.key} className="tm-inst-db-item">
           <dt>{row.label}</dt>
-          <dd>{row.count.toLocaleString("en-US")}</dd>
+          <dd>
+            <span className="tm-inst-db-count">{row.count.toLocaleString("en-US")}</span>
+            {row.bytes !== null ? (
+              <span className="tm-inst-db-size">
+                <ByteValue bytes={row.bytes} />
+              </span>
+            ) : null}
+          </dd>
         </div>
       ))}
     </dl>
+  );
+}
+
+function GroupHeading({ title, bytes }: { title: string; bytes: number | null }) {
+  return (
+    <div className="tm-inst-db-heading-row">
+      <h5 className="tm-inst-db-heading">{title}</h5>
+      {bytes !== null ? (
+        <span className="tm-inst-db-group-size">
+          <ByteValue bytes={bytes} />
+        </span>
+      ) : null}
+    </div>
   );
 }
 
@@ -189,23 +211,29 @@ function DatabaseDetails({
         <p className="tm-inst-db-unavail muted">{DB_CONTENT_UNAVAILABLE}</p>
       ) : (
         <>
-          <p className="tm-inst-db-note muted">{DB_RECORD_COUNT_NOTE}</p>
+          <p className="tm-inst-db-note muted">
+            {content.hasBytes ? DB_NOTE_WITH_BYTES : DB_NOTE_COUNTS_ONLY}
+          </p>
           <div className="tm-inst-db-groups">
             <div className="tm-inst-db-group">
-              <h5 className="tm-inst-db-heading">Storage</h5>
+              <GroupHeading title="Storage" bytes={null} />
               <dl className="tm-inst-db-dl">
                 <div className="tm-inst-db-item">
                   <dt>Database file</dt>
                   <dd>
-                    <ByteValue bytes={bytes} />
+                    <span className="tm-inst-db-size">
+                      <ByteValue bytes={bytes} />
+                    </span>
                   </dd>
                 </div>
                 {database.measured ? (
                   <div className="tm-inst-db-item">
                     <dt>Reclaimable free pages</dt>
                     <dd>
-                      <ByteValue bytes={database.free_bytes} /> (
-                      {(database.free_percent * 100).toFixed(0)}%)
+                      <span className="tm-inst-db-size">
+                        <ByteValue bytes={database.free_bytes} /> (
+                        {(database.free_percent * 100).toFixed(0)}%)
+                      </span>
                     </dd>
                   </div>
                 ) : null}
@@ -216,7 +244,7 @@ function DatabaseDetails({
               <>
                 {content.session.length > 0 ? (
                   <div className="tm-inst-db-group">
-                    <h5 className="tm-inst-db-heading">Session data</h5>
+                    <GroupHeading title="Session data" bytes={content.sessionBytes} />
                     <CountRows rows={content.session} />
                     <EventMix
                       content={content}
@@ -228,14 +256,17 @@ function DatabaseDetails({
 
                 {content.telemetry.length > 0 ? (
                   <div className="tm-inst-db-group">
-                    <h5 className="tm-inst-db-heading">Telemetry data</h5>
+                    <GroupHeading title="Telemetry data" bytes={content.telemetryBytes} />
                     <CountRows rows={content.telemetry} />
                   </div>
                 ) : null}
 
                 {content.otherManagedRecords !== null ? (
                   <div className="tm-inst-db-group">
-                    <h5 className="tm-inst-db-heading">Other managed records</h5>
+                    <GroupHeading
+                      title="Other managed records"
+                      bytes={content.otherManagedBytes}
+                    />
                     <p className="tm-inst-db-other">
                       {content.otherManagedRecords.toLocaleString("en-US")}{" "}
                       {content.otherManagedRecords === 1 ? "record" : "records"}
@@ -270,8 +301,13 @@ function CategoryTable({
     snapshot.categories.find((c) => c.category === cat),
   ).filter((c): c is CategoryFootprint => c !== undefined);
   const content = useMemo(
-    () => deriveDatabaseContent(snapshot.counts.table_rows, snapshot.counts.events_by_kind),
-    [snapshot.counts.table_rows, snapshot.counts.events_by_kind],
+    () =>
+      deriveDatabaseContent(
+        snapshot.counts.table_rows,
+        snapshot.counts.table_bytes,
+        snapshot.counts.events_by_kind,
+      ),
+    [snapshot.counts.table_rows, snapshot.counts.table_bytes, snapshot.counts.events_by_kind],
   );
   const tableRowsEmpty = Object.keys(snapshot.counts.table_rows).length === 0;
   return (

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -379,6 +379,7 @@ export interface DatabaseCountRow {
   key: string;
   label: string;
   count: number;
+  bytes: number | null;
 }
 
 export interface DatabaseEventKind {
@@ -390,17 +391,27 @@ export interface DatabaseEventKind {
 export interface DatabaseContentModel {
   session: DatabaseCountRow[];
   telemetry: DatabaseCountRow[];
+  sessionBytes: number | null;
+  telemetryBytes: number | null;
   otherManagedRecords: number | null;
+  otherManagedBytes: number | null;
   eventMix: DatabaseEventKind[];
   hasContent: boolean;
+  hasBytes: boolean;
 }
 
 function isValidCount(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value >= 0;
 }
 
+function rowBytes(tableBytes: Record<string, number>, key: string): number | null {
+  const value = tableBytes[key];
+  return isValidCount(value) ? value : null;
+}
+
 function collectGroup(
   tableRows: Record<string, number>,
+  tableBytes: Record<string, number>,
   keys: readonly string[],
 ): DatabaseCountRow[] {
   const rows: DatabaseCountRow[] = [];
@@ -408,9 +419,25 @@ function collectGroup(
     if (!(key in tableRows)) continue;
     const count = tableRows[key];
     if (!isValidCount(count)) continue;
-    rows.push({ key, label: DATABASE_CONTENT_LABELS[key] ?? key, count });
+    rows.push({
+      key,
+      label: DATABASE_CONTENT_LABELS[key] ?? key,
+      count,
+      bytes: rowBytes(tableBytes, key),
+    });
   }
   return rows;
+}
+
+function sumRowBytes(rows: DatabaseCountRow[]): number | null {
+  let sum = 0;
+  let seen = false;
+  for (const row of rows) {
+    if (row.bytes === null) continue;
+    sum += row.bytes;
+    seen = true;
+  }
+  return seen ? sum : null;
 }
 
 function titleCaseKind(kind: string): string {
@@ -423,10 +450,11 @@ function titleCaseKind(kind: string): string {
 
 export function deriveDatabaseContent(
   tableRows: Record<string, number>,
+  tableBytes: Record<string, number>,
   eventsByKind: Record<string, number>,
 ): DatabaseContentModel {
-  const session = collectGroup(tableRows, DATABASE_CONTENT_GROUPS.session);
-  const telemetry = collectGroup(tableRows, DATABASE_CONTENT_GROUPS.telemetry);
+  const session = collectGroup(tableRows, tableBytes, DATABASE_CONTENT_GROUPS.session);
+  const telemetry = collectGroup(tableRows, tableBytes, DATABASE_CONTENT_GROUPS.telemetry);
 
   const claimed = new Set<string>([
     ...DATABASE_CONTENT_GROUPS.session,
@@ -434,10 +462,17 @@ export function deriveDatabaseContent(
   ]);
   let otherSum = 0;
   let otherSeen = false;
+  let otherByteSum = 0;
+  let otherByteSeen = false;
   for (const [key, count] of Object.entries(tableRows)) {
     if (claimed.has(key) || !isValidCount(count)) continue;
     otherSum += count;
     otherSeen = true;
+    const bytes = rowBytes(tableBytes, key);
+    if (bytes !== null) {
+      otherByteSum += bytes;
+      otherByteSeen = true;
+    }
   }
 
   const eventMix: DatabaseEventKind[] = Object.entries(eventsByKind)
@@ -448,10 +483,14 @@ export function deriveDatabaseContent(
   return {
     session,
     telemetry,
+    sessionBytes: sumRowBytes(session),
+    telemetryBytes: sumRowBytes(telemetry),
     otherManagedRecords: otherSeen ? otherSum : null,
+    otherManagedBytes: otherByteSeen ? otherByteSum : null,
     eventMix,
     hasContent:
       session.length > 0 || telemetry.length > 0 || otherSeen || eventMix.length > 0,
+    hasBytes: Object.keys(tableBytes).length > 0,
   };
 }
 

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -344,6 +344,117 @@ export function instanceCategoryColor(category: string): string {
   return INSTANCE_CATEGORY_COLORS[category as InstanceStorageCategory] ?? "var(--tm-series-6)";
 }
 
+// ── Database content breakdown ───────────────────────────────────────────
+//
+// The instance snapshot already carries `counts.table_rows` (a per-table
+// COUNT(*)) and `counts.events_by_kind`. These derive a bounded,
+// presentation-only view of what the SQLite file holds. Record counts are NOT
+// bytes — they explain database contents without dividing the file size. Only
+// the allowlisted user-facing tables are named; every other returned table
+// folds into a single generic remainder so schema additions stay aggregate.
+
+const DATABASE_CONTENT_GROUPS = {
+  session: ["sessions", "events", "session_token_usage_records"],
+  telemetry: [
+    "telemetry_facts",
+    "telemetry_fact_tag",
+    "telemetry_daily_rollup",
+    "telemetry_insight_dismissal",
+    "telemetry_instance_snapshot",
+  ],
+} as const;
+
+const DATABASE_CONTENT_LABELS: Record<string, string> = {
+  sessions: "Session records",
+  events: "Session events",
+  session_token_usage_records: "Usage records",
+  telemetry_facts: "Telemetry facts",
+  telemetry_fact_tag: "Tag records",
+  telemetry_daily_rollup: "Daily rollups",
+  telemetry_insight_dismissal: "Dismissed insights",
+  telemetry_instance_snapshot: "Saved instance snapshots",
+};
+
+export interface DatabaseCountRow {
+  key: string;
+  label: string;
+  count: number;
+}
+
+export interface DatabaseEventKind {
+  kind: string;
+  label: string;
+  count: number;
+}
+
+export interface DatabaseContentModel {
+  session: DatabaseCountRow[];
+  telemetry: DatabaseCountRow[];
+  otherManagedRecords: number | null;
+  eventMix: DatabaseEventKind[];
+  hasContent: boolean;
+}
+
+function isValidCount(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function collectGroup(
+  tableRows: Record<string, number>,
+  keys: readonly string[],
+): DatabaseCountRow[] {
+  const rows: DatabaseCountRow[] = [];
+  for (const key of keys) {
+    if (!(key in tableRows)) continue;
+    const count = tableRows[key];
+    if (!isValidCount(count)) continue;
+    rows.push({ key, label: DATABASE_CONTENT_LABELS[key] ?? key, count });
+  }
+  return rows;
+}
+
+function titleCaseKind(kind: string): string {
+  const words = kind
+    .split(/[^A-Za-z0-9]+/)
+    .filter((part) => part.length > 0)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1));
+  return words.length > 0 ? words.join(" ") : kind;
+}
+
+export function deriveDatabaseContent(
+  tableRows: Record<string, number>,
+  eventsByKind: Record<string, number>,
+): DatabaseContentModel {
+  const session = collectGroup(tableRows, DATABASE_CONTENT_GROUPS.session);
+  const telemetry = collectGroup(tableRows, DATABASE_CONTENT_GROUPS.telemetry);
+
+  const claimed = new Set<string>([
+    ...DATABASE_CONTENT_GROUPS.session,
+    ...DATABASE_CONTENT_GROUPS.telemetry,
+  ]);
+  let otherSum = 0;
+  let otherSeen = false;
+  for (const [key, count] of Object.entries(tableRows)) {
+    if (claimed.has(key) || !isValidCount(count)) continue;
+    otherSum += count;
+    otherSeen = true;
+  }
+
+  const eventMix: DatabaseEventKind[] = Object.entries(eventsByKind)
+    .filter(([, count]) => isValidCount(count))
+    .map(([kind, count]) => ({ kind, label: titleCaseKind(kind), count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+
+  return {
+    session,
+    telemetry,
+    otherManagedRecords: otherSeen ? otherSum : null,
+    eventMix,
+    hasContent:
+      session.length > 0 || telemetry.length > 0 || otherSeen || eventMix.length > 0,
+  };
+}
+
 export interface TokenTierSplit {
   newWork: number;
   reread: number;

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -492,7 +492,11 @@ export function deriveDatabaseContent(
     otherManagedBytes: otherByteSeen ? otherByteSum : null,
     eventMix,
     hasContent:
-      session.length > 0 || telemetry.length > 0 || otherSeen || eventMix.length > 0,
+      session.length > 0 ||
+      telemetry.length > 0 ||
+      otherSeen ||
+      otherByteSeen ||
+      eventMix.length > 0,
     hasBytes: Object.keys(tableBytes).length > 0,
   };
 }

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -346,12 +346,11 @@ export function instanceCategoryColor(category: string): string {
 
 // ── Database content breakdown ───────────────────────────────────────────
 //
-// The instance snapshot already carries `counts.table_rows` (a per-table
-// COUNT(*)) and `counts.events_by_kind`. These derive a bounded,
-// presentation-only view of what the SQLite file holds. Record counts are NOT
-// bytes — they explain database contents without dividing the file size. Only
-// the allowlisted user-facing tables are named; every other returned table
-// folds into a single generic remainder so schema additions stay aggregate.
+// Derives a bounded, presentation-only view of the SQLite file's contents from
+// the snapshot's per-table row counts (`counts.table_rows`), measured page
+// usage (`counts.table_bytes`), and event-kind counts. Only allowlisted
+// user-facing tables are named; every other returned table folds into a single
+// remainder so schema additions stay aggregate.
 
 const DATABASE_CONTENT_GROUPS = {
   session: ["sessions", "events", "session_token_usage_records"],
@@ -462,17 +461,21 @@ export function deriveDatabaseContent(
   ]);
   let otherSum = 0;
   let otherSeen = false;
-  let otherByteSum = 0;
-  let otherByteSeen = false;
   for (const [key, count] of Object.entries(tableRows)) {
     if (claimed.has(key) || !isValidCount(count)) continue;
     otherSum += count;
     otherSeen = true;
-    const bytes = rowBytes(tableBytes, key);
-    if (bytes !== null) {
-      otherByteSum += bytes;
-      otherByteSeen = true;
-    }
+  }
+
+  // Byte remainder spans every unclaimed table in table_bytes, including btrees
+  // with no counted rows (sqlite internals), so the three group subtotals sum to
+  // the used pages.
+  let otherByteSum = 0;
+  let otherByteSeen = false;
+  for (const [key, bytes] of Object.entries(tableBytes)) {
+    if (claimed.has(key) || !isValidCount(bytes)) continue;
+    otherByteSum += bytes;
+    otherByteSeen = true;
   }
 
   const eventMix: DatabaseEventKind[] = Object.entries(eventsByKind)

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1155,6 +1155,7 @@ export interface FilesystemSignal {
 
 export interface InstanceCounts {
   table_rows: Record<string, number>;
+  table_bytes: Record<string, number>;
   events_by_kind: Record<string, number>;
   session_dir_count: number;
   orphan_dir_count: number;


### PR DESCRIPTION
## Summary

Replaces the opaque "Database" storage row in the telemetry instance-health panel with an on-demand **Database details** disclosure that explains what the SQLite file holds — session data, telemetry data, and a bounded "other managed records" remainder — with both **record counts** and **measured on-disk sizes**. Implements the RFC at `.waypoint/specs/rfc-626-database-metric-breakdown.md` (Option 1). Ticket 626.

The initial cut was frontend-only over the counts the snapshot already carried. A review round asked for sizes too; per-table bytes are now measured accurately (not estimated) from SQLite's `dbstat` virtual table, so the disclosure reports a size per table, a per-group subtotal, and the file/reclaimable totals — and the groups' sizes sum to the database file minus free pages.

## Changes

### Backend
- `backend/src/waypoint/telemetry/instance/collect.py` — `_read_table_bytes` reads `SELECT name, SUM(pgsize) FROM dbstat GROUP BY name` on the existing read-only connection and attributes each index's pages to its owning table (via `sqlite_schema.tbl_name`), yielding measured page usage per table. dbstat scans every page, so it runs under a wider dedicated budget (`_DBSTAT_BUDGET_MS`) than the 250 ms per-query lock budget; the whole collection is already an off-request-path multi-second walk. It degrades to an empty mapping — sizes hidden, never fabricated — when dbstat is absent from the build or the budget is spent.
- `backend/src/waypoint/telemetry/instance/model.py` — add `counts.table_bytes: dict[str, int]`, defaulting empty so older persisted snapshots deserialize unchanged.

### Frontend
- `frontend/src/lib/telemetry.ts` — `deriveDatabaseContent` now also folds `table_bytes` in: a byte value per named row, per-group subtotals, an other-managed byte remainder, and a `hasBytes` flag. Named Session/Telemetry groups render only returned tables (preserving returned zeros, skipping absent keys and malformed values); every other returned table folds into a single aggregate without leaking its name; `eventMix` is title-cased and sorted by count then label.
- `frontend/src/components/telemetry/InstanceHealthPanel.tsx` — a quiet `Details` toggle after the Database label opens a valid detail `<tr>` (`<td colSpan={3}>`) holding a labelled `DatabaseDetails` section: Storage (file size + reclaimability), Session/Telemetry/Other groups each with a size subtotal and per-row count + size, and a nested Event mix that collapses past four kinds. Toggles are native `<button>`s with `aria-expanded`/`aria-controls`. The note reflects whether sizes were measured; unavailable database facts show a path-free explanation rather than an all-zero breakdown. A database-vacuum insight (`focus: "database"`) auto-expands the region before the existing scroll.
- `frontend/src/lib/types.ts` — add `table_bytes` to `InstanceCounts`.
- `frontend/src/app/globals.css` — scoped `tm-inst-db*` styles using existing tokens only: opaque `--bg-card-soft` surface with hairlines and `--radius-sm`, aligned count/size columns (tabular-nums) that stack below 640px, group-heading subtotals, and the quiet toggle/caret. No gradient, blur, shadow, hover lift, or hard-coded theme color; both themes resolve from tokens.

## Verification

- Backend: `uv run pre-commit run` (black/isort/ruff/codespell/mypy) clean on the changed files; `uv run pytest -k instance` — 41 passed (path-free instance test included). `_read_table_bytes` verified against the live 747 MB database: `events` 713 MiB (btree + index), `telemetry_facts` 29 MiB, per-table sums ≈ file size, 0.47 s scan.
- Frontend: `npm run lint` and `npm run build` green (TypeScript passes).
- End-to-end: restarted the stack and drove the deployed `/telemetry` with Playwright (desktop 1100px dark, mobile 390px light) against the backend serving real `table_bytes` — details collapsed by default; toggle and keyboard flip `aria-expanded`/`aria-controls`; each group shows a subtotal and per-row count + size aligned in columns; returned zeros render (`Dismissed insights 0 / 8.0 KiB`); the groups sum to the database file; rows stack without horizontal scroll on narrow; surfaces resolve from tokens in both themes.