### PR TITLE
feat: project-scope the Waypoint Manager backend for multiple managers

### DIFF
--- a/.agents/skills/waypoint-manager/SKILL.md
+++ b/.agents/skills/waypoint-manager/SKILL.md
@@ -27,7 +27,12 @@ never a `create`/`install`.
 1. **Load config.** `waypoint manager init --manifest <path-to>/waypoint-manager.yaml`
    (idempotent) persists the machine-relevant config and compiles your step templates
    and every child prompt to the templates dir (default `.waypoint/manager/templates`),
-   baking in the manifest's `board`, `roles`, `scale`, and `escalation`. That dir is
+   baking in the manifest's `board`, `roles`, `scale`, and `escalation`. It mints a
+   manager id (`mgr-<hex>`) keyed to this repo on the first init and reuses it on every
+   later init from the same repo; your commands resolve that id from the current repo,
+   so you never pass it. One instance runs one manager per repo, so your board channels
+   (`tickets_channel`, `org_channel`, `ticket_channel_prefix`) must be unique across the
+   instance — `init` rejects a channel already used by another manager. That dir is
    your runtime source of truth; `manager state` reports its path. Confirm `manager
    state` also reports a non-empty `config.owner_session_id` (your own session, from
    `$WAYPOINT_SESSION_ID`) — it scopes reaping and the intake self-exclusion; a missing

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -62,6 +62,7 @@ from waypoint.schemas import (
     LaunchTargetConnectResponse,
     LoginRequest,
     ManagerInitRequest,
+    ManagerListResponse,
     ManagerNextResponse,
     ManagerReconcileReport,
     ManagerStateResponse,
@@ -1850,80 +1851,102 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         return {"deleted": True}
 
     # ── Waypoint Manager ─────────────────────────────────────────────────
+    @app.get("/api/manager", response_model=ManagerListResponse)
+    async def manager_list(
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> ManagerListResponse:
+        return ManagerListResponse(managers=context.runtime.managers.list_summaries())
+
     @app.post("/api/manager/init")
     async def manager_init(
         request: ManagerInitRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        config = context.runtime.manager.init(request)
+        config = context.runtime.managers.init(request)
         return {"config": config.model_dump(mode="json")}
 
-    @app.delete("/api/manager")
+    @app.delete("/api/manager/{manager_id}")
     async def manager_deinit(
+        manager_id: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        removed = context.runtime.manager.deinit()
+        removed = context.runtime.managers.require(manager_id).deinit()
         return {"deinitialized": True, "tickets_deleted": removed}
 
-    @app.get("/api/manager/state", response_model=ManagerStateResponse)
+    @app.get("/api/manager/{manager_id}/state", response_model=ManagerStateResponse)
     async def manager_state(
+        manager_id: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> ManagerStateResponse:
-        return context.runtime.manager.state()
+        return context.runtime.managers.require(manager_id).state()
 
-    @app.get("/api/manager/next", response_model=ManagerNextResponse)
+    @app.get("/api/manager/{manager_id}/next", response_model=ManagerNextResponse)
     async def manager_next(
+        manager_id: str,
         _: Annotated[str, Depends(token_dependency())],
         tried: Annotated[list[str] | None, Query()] = None,
     ) -> ManagerNextResponse:
-        return context.runtime.manager.next(tried or [])
+        return context.runtime.managers.require(manager_id).next(tried or [])
 
-    @app.get("/api/manager/reconcile", response_model=ManagerReconcileReport)
+    @app.get(
+        "/api/manager/{manager_id}/reconcile",
+        response_model=ManagerReconcileReport,
+    )
     async def manager_reconcile(
+        manager_id: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> ManagerReconcileReport:
-        return context.runtime.manager.reconcile(datetime.now(UTC))
+        return context.runtime.managers.require(manager_id).reconcile(datetime.now(UTC))
 
-    @app.post("/api/manager/tickets")
+    @app.post("/api/manager/{manager_id}/tickets")
     async def manager_create_ticket(
+        manager_id: str,
         request: TicketCreateRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        ticket = context.runtime.manager.create_ticket(request)
+        ticket = context.runtime.managers.require(manager_id).create_ticket(request)
         return {"ticket": ticket.model_dump(mode="json")}
 
-    @app.get("/api/manager/tickets/{ticket_id}")
+    @app.get("/api/manager/{manager_id}/tickets/{ticket_id}")
     async def manager_get_ticket(
+        manager_id: str,
         ticket_id: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        ticket = context.runtime.manager.get_ticket(ticket_id)
+        ticket = context.runtime.managers.require(manager_id).get_ticket(ticket_id)
         return {"ticket": ticket.model_dump(mode="json")}
 
-    @app.patch("/api/manager/tickets/{ticket_id}")
+    @app.patch("/api/manager/{manager_id}/tickets/{ticket_id}")
     async def manager_update_ticket(
+        manager_id: str,
         ticket_id: str,
         request: TicketUpdateRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        ticket = context.runtime.manager.update_ticket(ticket_id, request)
+        ticket = context.runtime.managers.require(manager_id).update_ticket(
+            ticket_id, request
+        )
         return {"ticket": ticket.model_dump(mode="json")}
 
-    @app.delete("/api/manager/tickets/{ticket_id}")
+    @app.delete("/api/manager/{manager_id}/tickets/{ticket_id}")
     async def manager_delete_ticket(
+        manager_id: str,
         ticket_id: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        context.runtime.manager.delete_ticket(ticket_id)
+        context.runtime.managers.require(manager_id).delete_ticket(ticket_id)
         return {"deleted": True}
 
-    @app.post("/api/manager/tickets/{ticket_id}/transition")
+    @app.post("/api/manager/{manager_id}/tickets/{ticket_id}/transition")
     async def manager_transition_ticket(
+        manager_id: str,
         ticket_id: str,
         request: TicketTransitionRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        ticket = context.runtime.manager.transition(ticket_id, request)
+        ticket = context.runtime.managers.require(manager_id).transition(
+            ticket_id, request
+        )
         return {"ticket": ticket.model_dump(mode="json")}
 
     @app.get("/api/message-schedules")

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -4078,7 +4078,7 @@ def manager_deinit(
     """
     if not yes:
         typer.confirm(
-            "Clear all manager tickets and config?",
+            "Clear this manager's tickets and config?",
             abort=True,
         )
     _emit(

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -178,6 +178,14 @@ manager_ticket_app = typer.Typer(
     help="Add, inspect, update, and transition manager tickets.",
     no_args_is_help=True,
 )
+# Selects which manager a command targets; defaults to the current repo's manager.
+ManagerIdOption = Annotated[
+    str | None,
+    typer.Option(
+        "--manager",
+        help="Target manager id (default: the manager for the current repo).",
+    ),
+]
 app.add_typer(backends_app, name="backends")
 app.add_typer(session_app, name="session")
 app.add_typer(sessions_app, name="sessions")
@@ -3895,6 +3903,26 @@ def _git_toplevel() -> str:
     return top or str(Path.cwd())
 
 
+def _resolve_manager_id(c: WaypointClient, manager_id: str | None) -> str:
+    """Resolve the target manager: an explicit ``--manager`` id, else the one
+    manager bound to the current repo (one manager per repo)."""
+    if manager_id:
+        return manager_id
+    repo = _git_toplevel()
+    managers = c.manager_list().get("managers") or []
+    matches = [m for m in managers if m.get("repo_dir") == repo]
+    if len(matches) == 1:
+        return str(matches[0]["id"])
+    if not matches:
+        raise typer.BadParameter(
+            f"no manager initialized for repo {repo!r}; run "
+            "`waypoint manager init --manifest <path>` or pass --manager <id>"
+        )
+    raise typer.BadParameter(
+        f"multiple managers for repo {repo!r}; pass --manager <id>"
+    )
+
+
 _PLACEHOLDER_RE = re.compile(r"\{\{(\w+)\}\}")
 _IF_RE = re.compile(r"^\s*\{\{#if (\w+) == (\w+)\}\}\s*$")
 _ENDIF_RE = re.compile(r"^\s*\{\{/if\}\}\s*$")
@@ -3997,6 +4025,9 @@ def manager_init(
     templates_dir = _compiled_templates_root(raw, repo_dir)
     static = _manager_static_bindings(raw, repo_dir, session_id, templates_dir)
     _compile_manager_templates(raw, static, Path(templates_dir))
+    config["repo_dir"] = repo_dir
+    if static.get("project"):
+        config["project"] = static["project"]
     config["render_context"] = {
         "templates_dir": templates_dir,
         "tickets_channel": static["tickets_channel"],
@@ -4007,14 +4038,40 @@ def manager_init(
     _emit(_settings_from_ctx(ctx), lambda c: {"config": c.manager_init(config)})
 
 
+@manager_app.command("ls")
+def manager_ls(
+    ctx: typer.Context,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit structured JSON instead of a summary."),
+    ] = False,
+) -> None:
+    """List every manager initialized in this instance (one per repository)."""
+    result = _run_client(_settings_from_ctx(ctx), lambda c: c.manager_list())
+    if json_output:
+        typer.echo(json.dumps(result, indent=2))
+        return
+    managers = result.get("managers") or []
+    if not managers:
+        typer.echo("(no managers)")
+        return
+    for m in managers:
+        typer.echo(
+            f"  {m.get('id')}  {m.get('project') or '-'}  "
+            f"{m.get('repo_dir') or '-'}  tickets={m.get('ticket_count')} "
+            f"attention={m.get('attention_count')}"
+        )
+
+
 @manager_app.command("deinit")
 def manager_deinit(
     ctx: typer.Context,
+    manager_id: ManagerIdOption = None,
     yes: Annotated[
         bool, typer.Option("--yes", help="Skip the confirmation prompt.")
     ] = False,
 ) -> None:
-    """Clear the manager state: all tickets and the persisted config.
+    """Clear one manager's state: its tickets and persisted config.
 
     Removes state records only — spawned sessions, branches, and board channels
     are reaped separately (`sessions delete`, `board delete`).
@@ -4024,7 +4081,10 @@ def manager_deinit(
             "Clear all manager tickets and config?",
             abort=True,
         )
-    _emit(_settings_from_ctx(ctx), lambda c: c.manager_deinit())
+    _emit(
+        _settings_from_ctx(ctx),
+        lambda c: c.manager_deinit(_resolve_manager_id(c, manager_id)),
+    )
 
 
 @manager_app.command("render")
@@ -4067,6 +4127,7 @@ def manager_render(
             help="Leave unknown {{placeholders}} in place instead of failing.",
         ),
     ] = False,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Render a child prompt from its compiled template and print the body.
 
@@ -4081,8 +4142,9 @@ def manager_render(
     def _fetch(
         c: WaypointClient,
     ) -> tuple[dict[str, Any], dict[str, Any] | None, list[dict[str, Any]]]:
-        rc = (c.manager_state().get("config") or {}).get("render_context") or {}
-        ticket = c.manager_get_ticket(ticket_id) if ticket_id is not None else None
+        mid = _resolve_manager_id(c, manager_id)
+        rc = (c.manager_state(mid).get("config") or {}).get("render_context") or {}
+        ticket = c.manager_get_ticket(mid, ticket_id) if ticket_id is not None else None
         tickets_channel = rc.get("tickets_channel")
         cell = (
             c.read_board(tickets_channel, key=f"ticket:{ticket_id}")
@@ -4139,9 +4201,13 @@ def manager_state(
         bool,
         typer.Option("--json", help="Emit structured JSON instead of a summary."),
     ] = False,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Show the whole ticket set and the derived tree state."""
-    state = _run_client(_settings_from_ctx(ctx), lambda c: c.manager_state())
+    state = _run_client(
+        _settings_from_ctx(ctx),
+        lambda c: c.manager_state(_resolve_manager_id(c, manager_id)),
+    )
     if json_output:
         typer.echo(json.dumps(state, indent=2))
         return
@@ -4172,9 +4238,13 @@ def manager_next(
         bool,
         typer.Option("--json", help="Emit structured JSON instead of a summary."),
     ] = False,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Re-anchor: derived tree state, per-ticket legal transitions, one recommendation."""
-    result = _run_client(_settings_from_ctx(ctx), lambda c: c.manager_next(tried))
+    result = _run_client(
+        _settings_from_ctx(ctx),
+        lambda c: c.manager_next(_resolve_manager_id(c, manager_id), tried),
+    )
     if json_output:
         typer.echo(json.dumps(result, indent=2))
         return
@@ -4203,6 +4273,7 @@ def manager_reconcile(
         bool,
         typer.Option("--json", help="Emit structured JSON instead of a summary."),
     ] = False,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Report the drain's server-derived reconcile signals in one snapshot.
 
@@ -4212,7 +4283,10 @@ def manager_reconcile(
     resolved gates (awaiting tickets whose answered gate has a deferred transition).
     Read-only: the manager acts on each.
     """
-    report = _run_client(_settings_from_ctx(ctx), lambda c: c.manager_reconcile())
+    report = _run_client(
+        _settings_from_ctx(ctx),
+        lambda c: c.manager_reconcile(_resolve_manager_id(c, manager_id)),
+    )
     if json_output:
         typer.echo(json.dumps(report, indent=2))
         return
@@ -4271,6 +4345,7 @@ def manager_ticket_add(
         list[str] | None,
         typer.Option("--dep", help="Dependency ticket id. Repeatable."),
     ] = None,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Create an intake ticket."""
     body: dict[str, Any] = {"title": title, "priority": priority}
@@ -4286,7 +4361,9 @@ def manager_ticket_add(
         body["deps"] = deps
     _emit(
         _settings_from_ctx(ctx),
-        lambda c: {"ticket": c.manager_create_ticket(body)},
+        lambda c: {
+            "ticket": c.manager_create_ticket(_resolve_manager_id(c, manager_id), body)
+        },
     )
 
 
@@ -4294,11 +4371,14 @@ def manager_ticket_add(
 def manager_ticket_delete(
     ctx: typer.Context,
     ticket_id: Annotated[str, typer.Argument(help="Ticket id.")],
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Delete one ticket's state record (not its spawned sessions or branch)."""
     _emit(
         _settings_from_ctx(ctx),
-        lambda c: c.manager_delete_ticket(ticket_id),
+        lambda c: c.manager_delete_ticket(
+            _resolve_manager_id(c, manager_id), ticket_id
+        ),
     )
 
 
@@ -4306,11 +4386,16 @@ def manager_ticket_delete(
 def manager_ticket_show(
     ctx: typer.Context,
     ticket_id: Annotated[str, typer.Argument(help="Ticket id.")],
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Show a single ticket."""
     _emit(
         _settings_from_ctx(ctx),
-        lambda c: {"ticket": c.manager_get_ticket(ticket_id)},
+        lambda c: {
+            "ticket": c.manager_get_ticket(
+                _resolve_manager_id(c, manager_id), ticket_id
+            )
+        },
     )
 
 
@@ -4343,6 +4428,7 @@ def manager_ticket_update(
             help="Zero the lead-restart budget (retry after fixing a dying lead).",
         ),
     ] = False,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Edit ticket metadata (no state change; use 'transition' for that)."""
     body: dict[str, Any] = {}
@@ -4371,7 +4457,11 @@ def manager_ticket_update(
         raise typer.BadParameter("provide at least one field to update")
     _emit(
         _settings_from_ctx(ctx),
-        lambda c: {"ticket": c.manager_update_ticket(ticket_id, body)},
+        lambda c: {
+            "ticket": c.manager_update_ticket(
+                _resolve_manager_id(c, manager_id), ticket_id, body
+            )
+        },
     )
 
 
@@ -4390,6 +4480,7 @@ def manager_ticket_transition(
     is_partial: Annotated[
         bool | None, typer.Option("--is-partial/--not-partial")
     ] = None,
+    manager_id: ManagerIdOption = None,
 ) -> None:
     """Transition a ticket to a target state (server validates legality)."""
     body: dict[str, Any] = {"to": to}
@@ -4408,7 +4499,11 @@ def manager_ticket_transition(
         body["is_partial"] = is_partial
     _emit(
         _settings_from_ctx(ctx),
-        lambda c: {"ticket": c.manager_transition_ticket(ticket_id, body)},
+        lambda c: {
+            "ticket": c.manager_transition_ticket(
+                _resolve_manager_id(c, manager_id), ticket_id, body
+            )
+        },
     )
 
 

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -178,7 +178,6 @@ manager_ticket_app = typer.Typer(
     help="Add, inspect, update, and transition manager tickets.",
     no_args_is_help=True,
 )
-# Selects which manager a command targets; defaults to the current repo's manager.
 ManagerIdOption = Annotated[
     str | None,
     typer.Option(

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -985,62 +985,78 @@ class WaypointClient:
 
     # ── manager state machine ────────────────────────────────────────────
 
+    def manager_list(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("GET", "/api/manager").json()
+        return data
+
     def manager_init(self, config: dict[str, Any]) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
             "POST", "/api/manager/init", json={"config": config}
         ).json()["config"]
         return data
 
-    def manager_state(self) -> dict[str, Any]:
-        data: dict[str, Any] = self._request("GET", "/api/manager/state").json()
-        return data
-
-    def manager_next(self, tried: list[str] | None = None) -> dict[str, Any]:
-        params = {"tried": tried} if tried else None
+    def manager_state(self, manager_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
-            "GET", "/api/manager/next", params=params
+            "GET", f"/api/manager/{manager_id}/state"
         ).json()
         return data
 
-    def manager_reconcile(self) -> dict[str, Any]:
-        data: dict[str, Any] = self._request("GET", "/api/manager/reconcile").json()
+    def manager_next(
+        self, manager_id: str, tried: list[str] | None = None
+    ) -> dict[str, Any]:
+        params = {"tried": tried} if tried else None
+        data: dict[str, Any] = self._request(
+            "GET", f"/api/manager/{manager_id}/next", params=params
+        ).json()
         return data
 
-    def manager_create_ticket(self, body: dict[str, Any]) -> dict[str, Any]:
+    def manager_reconcile(self, manager_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
-            "POST", "/api/manager/tickets", json=body
+            "GET", f"/api/manager/{manager_id}/reconcile"
+        ).json()
+        return data
+
+    def manager_create_ticket(
+        self, manager_id: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "POST", f"/api/manager/{manager_id}/tickets", json=body
         ).json()["ticket"]
         return data
 
-    def manager_get_ticket(self, ticket_id: str) -> dict[str, Any]:
+    def manager_get_ticket(self, manager_id: str, ticket_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
-            "GET", f"/api/manager/tickets/{ticket_id}"
+            "GET", f"/api/manager/{manager_id}/tickets/{ticket_id}"
         ).json()["ticket"]
         return data
 
-    def manager_deinit(self) -> dict[str, Any]:
-        data: dict[str, Any] = self._request("DELETE", "/api/manager").json()
+    def manager_deinit(self, manager_id: str) -> dict[str, Any]:
+        data: dict[str, Any] = self._request(
+            "DELETE", f"/api/manager/{manager_id}"
+        ).json()
         return data
 
-    def manager_delete_ticket(self, ticket_id: str) -> dict[str, Any]:
+    def manager_delete_ticket(self, manager_id: str, ticket_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
-            "DELETE", f"/api/manager/tickets/{ticket_id}"
+            "DELETE", f"/api/manager/{manager_id}/tickets/{ticket_id}"
         ).json()
         return data
 
     def manager_update_ticket(
-        self, ticket_id: str, body: dict[str, Any]
+        self, manager_id: str, ticket_id: str, body: dict[str, Any]
     ) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
-            "PATCH", f"/api/manager/tickets/{ticket_id}", json=body
+            "PATCH", f"/api/manager/{manager_id}/tickets/{ticket_id}", json=body
         ).json()["ticket"]
         return data
 
     def manager_transition_ticket(
-        self, ticket_id: str, body: dict[str, Any]
+        self, manager_id: str, ticket_id: str, body: dict[str, Any]
     ) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
-            "POST", f"/api/manager/tickets/{ticket_id}/transition", json=body
+            "POST",
+            f"/api/manager/{manager_id}/tickets/{ticket_id}/transition",
+            json=body,
         ).json()["ticket"]
         return data
 

--- a/backend/src/waypoint/manager.py
+++ b/backend/src/waypoint/manager.py
@@ -35,6 +35,7 @@ from waypoint.schemas import (
     ManagerRecommendedAction,
     ManagerReconcileReport,
     ManagerStateResponse,
+    ManagerSummary,
     ManagerTicket,
     ManagerTicketScale,
     ManagerTicketState,
@@ -369,37 +370,32 @@ def compute_next(
 
 
 class ManagerManager:
-    """CRUD orchestration for the Waypoint Manager state machine."""
+    """CRUD orchestration for one manager's state machine (scoped by id)."""
 
-    def __init__(self, storage: Storage) -> None:
+    def __init__(self, storage: Storage, manager_id: str) -> None:
         self._storage = storage
+        self._manager_id = manager_id
+
+    @property
+    def manager_id(self) -> str:
+        return self._manager_id
 
     @staticmethod
     def _new_id() -> str:
         return f"ticket-{secrets.token_hex(4)}"
 
     def config(self) -> ManagerConfig:
-        return self._storage.get_manager_config() or ManagerConfig()
-
-    def init(self, request: ManagerInitRequest) -> ManagerConfig:
-        # init replaces the config wholesale from the manifest, which never
-        # carries an owner. Preserve a previously-recorded owner_session_id when
-        # this call does not supply one, so re-running init after a manifest edit
-        # does not silently drop the session-delete cascade binding.
-        config = request.config
-        if config.owner_session_id is None:
-            existing = self._storage.get_manager_config()
-            if existing is not None and existing.owner_session_id is not None:
-                config = config.model_copy(
-                    update={"owner_session_id": existing.owner_session_id}
-                )
-        return self._storage.set_manager_config(config)
+        return self._storage.get_manager_config(self._manager_id) or ManagerConfig(
+            id=self._manager_id
+        )
 
     def list_tickets(self) -> list[ManagerTicket]:
-        return self._storage.list_manager_tickets()
+        return self._storage.list_manager_tickets(manager_id=self._manager_id)
 
     def get_ticket(self, ticket_id: str) -> ManagerTicket:
-        ticket = self._storage.get_manager_ticket(ticket_id)
+        ticket = self._storage.get_manager_ticket(
+            ticket_id, manager_id=self._manager_id
+        )
         if ticket is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
@@ -420,6 +416,7 @@ class ManagerManager:
         now = datetime.now(UTC)
         ticket = ManagerTicket(
             id=request.id or self._new_id(),
+            manager_id=self._manager_id,
             title=request.title,
             priority=request.priority,
             kind=request.kind,
@@ -481,7 +478,11 @@ class ManagerManager:
         if request.reset_lead_restarts:
             updates["lead_restarts"] = 0
         updated = ticket.model_copy(update=updates)
-        others = [t for t in self._storage.list_manager_tickets() if t.id != ticket_id]
+        others = [
+            t
+            for t in self._storage.list_manager_tickets(manager_id=self._manager_id)
+            if t.id != ticket_id
+        ]
         try:
             check_invariants([*others, updated], config)
         except ManagerStateError as exc:
@@ -505,7 +506,9 @@ class ManagerManager:
         try:
             advanced = apply_transition(ticket, request, config, now)
             others = [
-                t for t in self._storage.list_manager_tickets() if t.id != ticket_id
+                t
+                for t in self._storage.list_manager_tickets(manager_id=self._manager_id)
+                if t.id != ticket_id
             ]
             check_invariants([*others, advanced], config)
         except ManagerStateError as exc:
@@ -521,35 +524,32 @@ class ManagerManager:
             ) from exc
 
     def delete_ticket(self, ticket_id: str) -> None:
-        if not self._storage.delete_manager_ticket(ticket_id):
+        if not self._storage.delete_manager_ticket(
+            ticket_id, manager_id=self._manager_id
+        ):
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"unknown ticket: {ticket_id!r}",
             )
 
     def deinit(self) -> int:
-        """Tear the manager state down: drop every ticket and the persisted config.
+        """Tear this manager down: drop its tickets and its persisted config.
         Returns the ticket count removed. Clears state records only — spawned
         sessions, branches, and board channels are reaped separately."""
-        removed = self._storage.clear_manager_tickets()
-        self._storage.clear_manager_config()
+        removed = self._storage.clear_manager_tickets(self._manager_id)
+        self._storage.clear_manager_config(self._manager_id)
         return removed
 
-    def deinit_if_owner(self, session_id: str) -> bool:
-        """Cascade a deinit when the deleted session is the one that ran ``init``
-        (so a deleted manager never leaves orphaned backlog state)."""
-        config = self._storage.get_manager_config()
-        if config is None or config.owner_session_id != session_id:
-            return False
-        self.deinit()
-        return True
-
     def next(self, tried: Iterable[str] = ()) -> ManagerNextResponse:
-        return compute_next(self._storage.list_manager_tickets(), self.config(), tried)
+        return compute_next(
+            self._storage.list_manager_tickets(manager_id=self._manager_id),
+            self.config(),
+            tried,
+        )
 
     def state(self) -> ManagerStateResponse:
-        config = self._storage.get_manager_config()
-        tickets = self._storage.list_manager_tickets()
+        config = self._storage.get_manager_config(self._manager_id)
+        tickets = self._storage.list_manager_tickets(manager_id=self._manager_id)
         return ManagerStateResponse(
             config=config, tree=tree_state(tickets), tickets=tickets
         )
@@ -562,7 +562,7 @@ class ManagerManager:
         acts. External signals (a PR's CI/merge state) stay in the agent's shell.
         """
         config = self.config()
-        tickets = self._storage.list_manager_tickets()
+        tickets = self._storage.list_manager_tickets(manager_id=self._manager_id)
         rc = config.render_context
         owner = config.owner_session_id
 
@@ -720,3 +720,118 @@ class ManagerManager:
             finalize_pending=finalize_pending,
             resolved_gates=resolved_gates,
         )
+
+
+class ManagerRegistry:
+    """Instance-wide registry of managers (one per repository).
+
+    Resolves a scoped :class:`ManagerManager` by id, enumerates managers for the
+    board switcher, and owns the operations that span the set: mint/resolve at
+    ``init`` (keyed by ``repo_dir``), channel-collision enforcement, and the
+    owner-session-delete cascade.
+    """
+
+    def __init__(self, storage: Storage) -> None:
+        self._storage = storage
+
+    @staticmethod
+    def _new_id() -> str:
+        return f"mgr-{secrets.token_hex(4)}"
+
+    def get(self, manager_id: str) -> ManagerManager:
+        return ManagerManager(self._storage, manager_id)
+
+    def exists(self, manager_id: str) -> bool:
+        return self._storage.get_manager_config(manager_id) is not None
+
+    def require(self, manager_id: str) -> ManagerManager:
+        if not self.exists(manager_id):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"unknown manager: {manager_id!r}",
+            )
+        return self.get(manager_id)
+
+    def resolve_by_repo(self, repo_dir: str) -> ManagerManager | None:
+        config = self._storage.get_manager_config_by_repo(repo_dir)
+        return self.get(config.id) if config is not None else None
+
+    def list_summaries(self) -> list[ManagerSummary]:
+        summaries: list[ManagerSummary] = []
+        for config in self._storage.list_manager_configs():
+            tickets = self._storage.list_manager_tickets(manager_id=config.id)
+            attention = sum(1 for t in tickets if t.state in _AWAITING_STATES)
+            summaries.append(
+                ManagerSummary(
+                    id=config.id,
+                    project=config.project,
+                    repo_dir=config.repo_dir,
+                    owner_session_id=config.owner_session_id,
+                    ticket_count=len(tickets),
+                    attention_count=attention,
+                )
+            )
+        return summaries
+
+    def init(self, request: ManagerInitRequest) -> ManagerConfig:
+        """Mint or resolve a manager for ``config.repo_dir`` and persist its config.
+
+        A repo with no manager yet gets a freshly minted id; a re-init from the
+        same repo reuses the existing id and tickets (idempotent). ``init``
+        replaces the config wholesale from the manifest, which never carries an
+        owner; a previously-recorded ``owner_session_id`` is preserved when this
+        call does not supply one, so re-running init after a manifest edit does not
+        drop the session-delete cascade binding. Board channels must not collide
+        with another manager's.
+        """
+        config = request.config
+        existing = (
+            self._storage.get_manager_config_by_repo(config.repo_dir)
+            if config.repo_dir
+            else None
+        )
+        if existing is not None:
+            owner = config.owner_session_id or existing.owner_session_id
+            config = config.model_copy(
+                update={"id": existing.id, "owner_session_id": owner}
+            )
+        else:
+            config = config.model_copy(update={"id": config.id or self._new_id()})
+        self._check_channel_collision(config)
+        return self._storage.set_manager_config(config)
+
+    def deinit_owned_by(self, session_id: str) -> int:
+        """Cascade a deinit for every manager owned by a deleted session, so a
+        deleted manager never leaves orphaned backlog state behind."""
+        count = 0
+        for config in self._storage.get_manager_config_by_owner(session_id):
+            self.get(config.id).deinit()
+            count += 1
+        return count
+
+    def _check_channel_collision(self, config: ManagerConfig) -> None:
+        rc = config.render_context
+        if rc is None:
+            return
+        channels = {c for c in (rc.tickets_channel, rc.ticket_channel_prefix) if c}
+        if not channels:
+            return
+        for other in self._storage.list_manager_configs():
+            if other.id == config.id or other.render_context is None:
+                continue
+            other_rc = other.render_context
+            other_channels = {
+                c
+                for c in (other_rc.tickets_channel, other_rc.ticket_channel_prefix)
+                if c
+            }
+            clash = sorted(channels & other_channels)
+            if clash:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"board channel(s) {clash} already used by manager "
+                        f"{other.id!r} (project {other.project!r}); choose distinct "
+                        "channels for this project"
+                    ),
+                )

--- a/backend/src/waypoint/manager.py
+++ b/backend/src/waypoint/manager.py
@@ -790,6 +790,16 @@ class ManagerRegistry:
             if config.repo_dir
             else None
         )
+        # No repo match: adopt a migrated legacy manager that carries no repo binding
+        # yet (its templates_dir was customized off the default layout, so migration
+        # could not recover its repo). A legacy DB migrates to exactly one manager, so
+        # a lone unbound manager is unambiguous; more than one means a genuine new repo.
+        if existing is None and config.repo_dir:
+            unbound = [
+                c for c in self._storage.list_manager_configs() if not c.repo_dir
+            ]
+            if len(unbound) == 1:
+                existing = unbound[0]
         if existing is not None:
             owner = config.owner_session_id or existing.owner_session_id
             config = config.model_copy(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -61,7 +61,7 @@ from waypoint.backends.transcripts import (
 from waypoint.builtin_completions import waypoint_builtin_completions
 from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
-from waypoint.manager import ManagerManager
+from waypoint.manager import ManagerRegistry
 from waypoint.perf import debug_timer
 from waypoint.presets import PresetManager
 from waypoint.scheduler import Scheduler
@@ -472,7 +472,7 @@ class SessionRuntime:
         for plugin in self.registry.all():
             plugin.setup(self)
         self.presets = PresetManager(storage)
-        self.manager = ManagerManager(storage)
+        self.managers = ManagerRegistry(storage)
         self.scheduler = Scheduler(self)
 
     def transport_for(self, session: SessionRecord) -> TransportAdapter:
@@ -3340,9 +3340,9 @@ class SessionRuntime:
         if cleanup is not None and asyncio.iscoroutinefunction(cleanup):
             await cleanup(self, session)
         self.storage.delete_session(session_id)
-        # If this session ran `manager init`, it owns the manager state machine;
-        # tear that state down with it so no orphaned backlog lingers.
-        self.manager.deinit_if_owner(session_id)
+        # If this session ran `manager init` for any project(s), it owns those
+        # managers; tear their state down with it so no orphaned backlog lingers.
+        self.managers.deinit_owned_by(session_id)
         # Drop the per-session lock along with the record so the registry
         # doesn't grow unbounded over a long-lived server's session churn.
         self._session_locks.pop(session_id, None)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -676,10 +676,12 @@ class ManagerTicketScale(StrEnum):
 
 
 class ManagerTicket(BaseModel):
-    # One record per ticket. Filterable columns (id/title/priority/state/scale/
-    # version/timestamps) are denormalized in storage; the whole model is the
-    # source of truth (persisted as a JSON payload blob).
+    # One record per ticket. Filterable columns (id/manager_id/priority/state/
+    # scale/version/timestamps) are denormalized in storage; the whole model is
+    # the source of truth (persisted as a JSON payload blob).
     id: str
+    # The manager this ticket belongs to (partition key); one manager per repo.
+    manager_id: str = ""
     title: str
     priority: str = "p2"
     kind: str | None = None
@@ -729,6 +731,14 @@ class ManagerConfig(BaseModel):
     # server-side scheduler invariants so a drifting manager context cannot enact
     # an illegal step, plus the render context persisted at init for `manager
     # render`.
+    # Server-minted opaque manager id (``mgr-<hex>``). Empty until `init` mints or
+    # resolves it; the DB/API key that partitions every manager's state.
+    id: str = ""
+    # Human-facing project label (display only; not unique).
+    project: str = ""
+    # The manager's git toplevel. Unique across managers (one manager per repo);
+    # the CLI resolves the target manager from the current repo via this field.
+    repo_dir: str = ""
     max_delegate_attempts: int = Field(default=3, ge=0)
     max_lead_restarts: int = Field(default=3, ge=0)
     backoff_seconds: int = Field(default=60, ge=0)
@@ -890,6 +900,23 @@ class ManagerStateResponse(BaseModel):
     config: ManagerConfig | None = None
     tree: ManagerTreeState
     tickets: list[ManagerTicket] = Field(default_factory=list)
+
+
+class ManagerSummary(BaseModel):
+    # One entry per initialized manager, for the instance-wide manager list
+    # (the board's per-project switcher). Counts are derived, never stored.
+    id: str
+    project: str = ""
+    repo_dir: str = ""
+    owner_session_id: str | None = None
+    ticket_count: int = 0
+    # Tickets in a genuinely awaiting-human state (spec_review/blocked/
+    # review_requested) — the switcher's per-project attention dot.
+    attention_count: int = 0
+
+
+class ManagerListResponse(BaseModel):
+    managers: list[ManagerSummary] = Field(default_factory=list)
 
 
 class MeResponse(BaseModel):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -49,6 +49,31 @@ from waypoint.telemetry.store import TelemetryStore
 
 log = logging.getLogger("waypoint.storage")
 
+# The default compiled-templates layout `manager init` writes under a repo, used
+# to recover the legacy manager's repo binding at migration time.
+_MANAGER_TEMPLATES_SUFFIX = "/.waypoint/manager/templates"
+
+
+def _repo_dir_from_templates_dir(payload: dict[str, Any]) -> str | None:
+    """Recover a legacy manager's ``repo_dir`` from its compiled ``templates_dir``.
+
+    The legacy config never persisted ``repo_dir``, but `manager init` compiled
+    templates to ``<repo_dir>/.waypoint/manager/templates`` by default, so the repo
+    is the ancestor of that path. Returns None when the templates dir is absent or
+    was customized off the default layout (the manager then migrates unbound and is
+    adopted on the next init).
+    """
+    render_context = payload.get("render_context")
+    if not isinstance(render_context, dict):
+        return None
+    templates_dir = render_context.get("templates_dir")
+    if isinstance(templates_dir, str) and templates_dir.endswith(
+        _MANAGER_TEMPLATES_SUFFIX
+    ):
+        return templates_dir[: -len(_MANAGER_TEMPLATES_SUFFIX)]
+    return None
+
+
 # ``UPDATE ... RETURNING`` landed in SQLite 3.35 (2021). When present it lets
 # ``update_session`` fetch the post-update row in the same statement, avoiding
 # the extra existence-check and re-read round-trips on a hot path.
@@ -2100,14 +2125,16 @@ class Storage:
         expected = ticket.version
         bumped = ticket.model_copy(update={"version": expected + 1})
         columns = self._manager_ticket_columns(bumped)
+        # Scope the write by manager_id as well as the version CAS: callers already
+        # fetch scoped, so this is defense-in-depth against a cross-manager write.
         cursor = self.connection.execute(
             """
             UPDATE manager_tickets SET
                 manager_id = ?, title = ?, priority = ?, state = ?, scale = ?,
                 version = ?, created_at = ?, updated_at = ?, payload = ?
-            WHERE id = ? AND version = ?
+            WHERE id = ? AND version = ? AND manager_id = ?
             """,
-            (*columns[1:], ticket.id, expected),
+            (*columns[1:], ticket.id, expected, ticket.manager_id),
         )
         if (cursor.rowcount or 0) == 0:
             self.connection.rollback()
@@ -2767,53 +2794,71 @@ class Storage:
 
         No-op on a fresh DB (the ``CREATE TABLE`` already made the new shape) and
         on an already-migrated DB (the ``repo_dir`` column marks it done). The
-        legacy row never persisted ``repo_dir``, so the migrated manager gets a
-        NULL one; the next idempotent ``manager init`` repopulates it.
+        legacy row never persisted ``repo_dir`` directly, so it is derived from the
+        compiled ``templates_dir`` (default ``<repo>/.waypoint/manager/templates``);
+        when that fails the migrated manager keeps a NULL ``repo_dir`` and the next
+        ``manager init`` adopts it as the lone unbound manager. The whole rebuild
+        runs in one transaction so a mid-rebuild failure rolls back cleanly rather
+        than leaving a half-migrated schema.
         """
         if self._has_column("manager_config", "repo_dir"):
             return
         old = self.connection.execute(
             "SELECT payload FROM manager_config WHERE id = 1"
         ).fetchone()
-        self.connection.execute(
-            "ALTER TABLE manager_config RENAME TO manager_config_legacy"
-        )
-        self.connection.execute("""
-            CREATE TABLE manager_config (
-                id TEXT PRIMARY KEY,
-                project TEXT NOT NULL DEFAULT '',
-                repo_dir TEXT UNIQUE,
-                owner_session_id TEXT,
-                payload TEXT NOT NULL DEFAULT '{}',
-                created_at TEXT NOT NULL DEFAULT ''
-            )
-            """)
-        if old is not None:
-            try:
-                payload = json.loads(old["payload"] or "{}")
-            except json.JSONDecodeError:
-                payload = {}
-            if not isinstance(payload, dict):
-                payload = {}
-            new_id = f"mgr-{secrets.token_hex(4)}"
-            payload["id"] = new_id
+        try:
+            # A SAVEPOINT nests inside _init_db's in-progress transaction, so the
+            # whole rebuild is atomic: a mid-rebuild failure rolls back to here
+            # rather than leaving a half-migrated schema. The final commit is
+            # _init_db's.
+            self.connection.execute("SAVEPOINT manager_migration")
             self.connection.execute(
-                """
-                INSERT INTO manager_config
-                    (id, project, repo_dir, owner_session_id, payload, created_at)
-                VALUES (?, ?, NULL, ?, ?, ?)
-                """,
-                (
-                    new_id,
-                    str(payload.get("project") or ""),
-                    payload.get("owner_session_id"),
-                    json.dumps(payload),
-                    datetime.now(UTC).isoformat(),
-                ),
+                "ALTER TABLE manager_config RENAME TO manager_config_legacy"
             )
-            self.connection.execute(
-                "UPDATE manager_tickets SET manager_id = ? "
-                "WHERE manager_id IS NULL OR manager_id = ''",
-                (new_id,),
-            )
-        self.connection.execute("DROP TABLE manager_config_legacy")
+            self.connection.execute("""
+                CREATE TABLE manager_config (
+                    id TEXT PRIMARY KEY,
+                    project TEXT NOT NULL DEFAULT '',
+                    repo_dir TEXT UNIQUE,
+                    owner_session_id TEXT,
+                    payload TEXT NOT NULL DEFAULT '{}',
+                    created_at TEXT NOT NULL DEFAULT ''
+                )
+                """)
+            if old is not None:
+                try:
+                    payload = json.loads(old["payload"] or "{}")
+                except json.JSONDecodeError:
+                    payload = {}
+                if not isinstance(payload, dict):
+                    payload = {}
+                new_id = f"mgr-{secrets.token_hex(4)}"
+                payload["id"] = new_id
+                repo_dir = _repo_dir_from_templates_dir(payload)
+                payload["repo_dir"] = repo_dir or ""
+                self.connection.execute(
+                    """
+                    INSERT INTO manager_config
+                        (id, project, repo_dir, owner_session_id, payload, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        new_id,
+                        str(payload.get("project") or ""),
+                        repo_dir or None,
+                        payload.get("owner_session_id"),
+                        json.dumps(payload),
+                        datetime.now(UTC).isoformat(),
+                    ),
+                )
+                self.connection.execute(
+                    "UPDATE manager_tickets SET manager_id = ? "
+                    "WHERE manager_id IS NULL OR manager_id = ''",
+                    (new_id,),
+                )
+            self.connection.execute("DROP TABLE manager_config_legacy")
+            self.connection.execute("RELEASE manager_migration")
+        except Exception:
+            self.connection.execute("ROLLBACK TO manager_migration")
+            self.connection.execute("RELEASE manager_migration")
+            raise

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import secrets
 import sqlite3
 import threading
 import uuid
@@ -378,6 +379,7 @@ class Storage:
             -- updated in place via a version-checked read-modify-write.
             CREATE TABLE IF NOT EXISTS manager_tickets (
                 id TEXT PRIMARY KEY,
+                manager_id TEXT NOT NULL DEFAULT '',
                 title TEXT NOT NULL,
                 priority TEXT NOT NULL DEFAULT 'p2',
                 state TEXT NOT NULL DEFAULT 'intake',
@@ -388,11 +390,18 @@ class Storage:
                 payload TEXT NOT NULL DEFAULT '{}'
             );
 
-            -- Single-row persisted ManagerConfig (the machine-relevant subset of
-            -- the project manifest). ``id`` is pinned to 1.
+            -- One row per initialized manager (one manager per repository). The
+            -- whole ManagerConfig is the JSON ``payload``; ``project``/``repo_dir``/
+            -- ``owner_session_id`` are denormalized for cross-manager queries
+            -- (enumeration, repo/owner lookup). ``repo_dir`` is UNIQUE (NULL when
+            -- unknown, e.g. a migrated legacy manager awaiting re-init).
             CREATE TABLE IF NOT EXISTS manager_config (
-                id INTEGER PRIMARY KEY CHECK (id = 1),
-                payload TEXT NOT NULL DEFAULT '{}'
+                id TEXT PRIMARY KEY,
+                project TEXT NOT NULL DEFAULT '',
+                repo_dir TEXT UNIQUE,
+                owner_session_id TEXT,
+                payload TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT ''
             );
             """)
         # Register any channels that predate the board_channels table.
@@ -448,6 +457,11 @@ class Storage:
         self._ensure_column("inbox_items", "from_label", "TEXT")
         self._ensure_column("inbox_items", "read_at", "TEXT")
         self._ensure_column("inbox_items", "version", "INTEGER NOT NULL DEFAULT 0")
+        # Multi-manager migration: partition tickets by manager, then rebuild the
+        # old single-row ``manager_config`` (pinned ``id = 1``) into the per-manager
+        # shape and adopt the one legacy manager under a minted id.
+        self._ensure_column("manager_tickets", "manager_id", "TEXT NOT NULL DEFAULT ''")
+        self._migrate_manager_config_to_multi()
         # Indexes for columns filtered on by the runtime/scheduler. Created
         # after the ALTER TABLE block above so ``spawner_session_id`` exists on
         # databases that predate it.
@@ -468,6 +482,8 @@ class Storage:
                 ON sessions(last_event_at);
             CREATE INDEX IF NOT EXISTS idx_wake_subs_session
                 ON wake_subscriptions(session_id);
+            CREATE INDEX IF NOT EXISTS idx_manager_tickets_manager
+                ON manager_tickets(manager_id, state);
             CREATE INDEX IF NOT EXISTS idx_manager_tickets_state
                 ON manager_tickets(state);
             CREATE INDEX IF NOT EXISTS idx_manager_tickets_priority
@@ -2031,9 +2047,9 @@ class Storage:
         self.connection.execute(
             """
             INSERT INTO manager_tickets (
-                id, title, priority, state, scale, version, created_at,
-                updated_at, payload
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                id, manager_id, title, priority, state, scale, version,
+                created_at, updated_at, payload
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             self._manager_ticket_columns(ticket),
         )
@@ -2041,22 +2057,36 @@ class Storage:
         return ticket
 
     @_synchronized
-    def get_manager_ticket(self, ticket_id: str) -> ManagerTicket | None:
-        row = self.connection.execute(
-            "SELECT * FROM manager_tickets WHERE id = ?", (ticket_id,)
-        ).fetchone()
+    def get_manager_ticket(
+        self, ticket_id: str, *, manager_id: str | None = None
+    ) -> ManagerTicket | None:
+        sql = "SELECT * FROM manager_tickets WHERE id = ?"
+        params: list[Any] = [ticket_id]
+        if manager_id is not None:
+            sql += " AND manager_id = ?"
+            params.append(manager_id)
+        row = self.connection.execute(sql, params).fetchone()
         return self._manager_ticket_from_row(row) if row is not None else None
 
     @_synchronized
     def list_manager_tickets(
-        self, *, states: list[ManagerTicketState] | None = None
+        self,
+        *,
+        manager_id: str | None = None,
+        states: list[ManagerTicketState] | None = None,
     ) -> list[ManagerTicket]:
         sql = "SELECT * FROM manager_tickets"
         params: list[Any] = []
+        conditions: list[str] = []
+        if manager_id is not None:
+            conditions.append("manager_id = ?")
+            params.append(manager_id)
         if states:
             placeholders = ",".join("?" for _ in states)
-            sql += f" WHERE state IN ({placeholders})"
+            conditions.append(f"state IN ({placeholders})")
             params.extend(str(state) for state in states)
+        if conditions:
+            sql += " WHERE " + " AND ".join(conditions)
         sql += " ORDER BY created_at ASC, id ASC"
         rows = self.connection.execute(sql, params).fetchall()
         return [self._manager_ticket_from_row(row) for row in rows]
@@ -2073,8 +2103,8 @@ class Storage:
         cursor = self.connection.execute(
             """
             UPDATE manager_tickets SET
-                title = ?, priority = ?, state = ?, scale = ?, version = ?,
-                created_at = ?, updated_at = ?, payload = ?
+                manager_id = ?, title = ?, priority = ?, state = ?, scale = ?,
+                version = ?, created_at = ?, updated_at = ?, payload = ?
             WHERE id = ? AND version = ?
             """,
             (*columns[1:], ticket.id, expected),
@@ -2086,29 +2116,96 @@ class Storage:
         return bumped
 
     @_synchronized
-    def delete_manager_ticket(self, ticket_id: str) -> bool:
-        cursor = self.connection.execute(
-            "DELETE FROM manager_tickets WHERE id = ?", (ticket_id,)
-        )
+    def delete_manager_ticket(
+        self, ticket_id: str, *, manager_id: str | None = None
+    ) -> bool:
+        sql = "DELETE FROM manager_tickets WHERE id = ?"
+        params: list[Any] = [ticket_id]
+        if manager_id is not None:
+            sql += " AND manager_id = ?"
+            params.append(manager_id)
+        cursor = self.connection.execute(sql, params)
         self.connection.commit()
         return (cursor.rowcount or 0) > 0
 
     @_synchronized
-    def clear_manager_tickets(self) -> int:
-        cursor = self.connection.execute("DELETE FROM manager_tickets")
+    def clear_manager_tickets(self, manager_id: str | None = None) -> int:
+        sql = "DELETE FROM manager_tickets"
+        params: list[Any] = []
+        if manager_id is not None:
+            sql += " WHERE manager_id = ?"
+            params.append(manager_id)
+        cursor = self.connection.execute(sql, params)
         self.connection.commit()
         return cursor.rowcount or 0
 
     @_synchronized
-    def clear_manager_config(self) -> None:
-        self.connection.execute("DELETE FROM manager_config WHERE id = 1")
+    def clear_manager_config(self, manager_id: str) -> None:
+        self.connection.execute(
+            "DELETE FROM manager_config WHERE id = ?", (manager_id,)
+        )
         self.connection.commit()
 
     @_synchronized
-    def get_manager_config(self) -> ManagerConfig | None:
+    def get_manager_config(self, manager_id: str) -> ManagerConfig | None:
         row = self.connection.execute(
-            "SELECT payload FROM manager_config WHERE id = 1"
+            "SELECT payload FROM manager_config WHERE id = ?", (manager_id,)
         ).fetchone()
+        return self._manager_config_from_row(row)
+
+    @_synchronized
+    def get_manager_config_by_repo(self, repo_dir: str) -> ManagerConfig | None:
+        if not repo_dir:
+            return None
+        row = self.connection.execute(
+            "SELECT payload FROM manager_config WHERE repo_dir = ?", (repo_dir,)
+        ).fetchone()
+        return self._manager_config_from_row(row)
+
+    @_synchronized
+    def get_manager_config_by_owner(self, session_id: str) -> list[ManagerConfig]:
+        rows = self.connection.execute(
+            "SELECT payload FROM manager_config WHERE owner_session_id = ?",
+            (session_id,),
+        ).fetchall()
+        configs = [self._manager_config_from_row(row) for row in rows]
+        return [c for c in configs if c is not None]
+
+    @_synchronized
+    def list_manager_configs(self) -> list[ManagerConfig]:
+        rows = self.connection.execute(
+            "SELECT payload FROM manager_config ORDER BY created_at ASC, id ASC"
+        ).fetchall()
+        configs = [self._manager_config_from_row(row) for row in rows]
+        return [c for c in configs if c is not None]
+
+    @_synchronized
+    def set_manager_config(self, config: ManagerConfig) -> ManagerConfig:
+        self.connection.execute(
+            """
+            INSERT INTO manager_config
+                (id, project, repo_dir, owner_session_id, payload, created_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(id) DO UPDATE SET
+                project = excluded.project,
+                repo_dir = excluded.repo_dir,
+                owner_session_id = excluded.owner_session_id,
+                payload = excluded.payload
+            """,
+            (
+                config.id,
+                config.project,
+                config.repo_dir or None,
+                config.owner_session_id,
+                json.dumps(config.model_dump(mode="json")),
+                datetime.now(UTC).isoformat(),
+            ),
+        )
+        self.connection.commit()
+        return config
+
+    @staticmethod
+    def _manager_config_from_row(row: sqlite3.Row | None) -> ManagerConfig | None:
         if row is None:
             return None
         try:
@@ -2117,20 +2214,11 @@ class Storage:
             return None
         return ManagerConfig.model_validate(parsed if isinstance(parsed, dict) else {})
 
-    @_synchronized
-    def set_manager_config(self, config: ManagerConfig) -> ManagerConfig:
-        self.connection.execute(
-            "INSERT INTO manager_config (id, payload) VALUES (1, ?) "
-            "ON CONFLICT(id) DO UPDATE SET payload = excluded.payload",
-            (json.dumps(config.model_dump(mode="json")),),
-        )
-        self.connection.commit()
-        return config
-
     @staticmethod
     def _manager_ticket_columns(ticket: ManagerTicket) -> tuple[Any, ...]:
         return (
             ticket.id,
+            ticket.manager_id,
             ticket.title,
             ticket.priority,
             str(ticket.state),
@@ -2147,7 +2235,13 @@ class Storage:
             parsed = json.loads(raw)
         except json.JSONDecodeError:
             parsed = {}
-        return ManagerTicket.model_validate(parsed if isinstance(parsed, dict) else {})
+        if not isinstance(parsed, dict):
+            parsed = {}
+        # The column is authoritative for manager_id (a migrated legacy ticket's
+        # payload predates the field; the backfilled column carries the id).
+        if row["manager_id"]:
+            parsed["manager_id"] = row["manager_id"]
+        return ManagerTicket.model_validate(parsed)
 
     @_synchronized
     def create_scheduled_message(
@@ -2666,3 +2760,60 @@ class Storage:
         if any(row["name"] == column for row in rows):
             return
         self.connection.execute(f"ALTER TABLE {table} ADD COLUMN {column} {ddl}")
+
+    def _migrate_manager_config_to_multi(self) -> None:
+        """Rebuild the legacy single-row ``manager_config`` (``id = 1``) into the
+        per-manager shape and adopt its one manager under a minted id.
+
+        No-op on a fresh DB (the ``CREATE TABLE`` already made the new shape) and
+        on an already-migrated DB (the ``repo_dir`` column marks it done). The
+        legacy row never persisted ``repo_dir``, so the migrated manager gets a
+        NULL one; the next idempotent ``manager init`` repopulates it.
+        """
+        if self._has_column("manager_config", "repo_dir"):
+            return
+        old = self.connection.execute(
+            "SELECT payload FROM manager_config WHERE id = 1"
+        ).fetchone()
+        self.connection.execute(
+            "ALTER TABLE manager_config RENAME TO manager_config_legacy"
+        )
+        self.connection.execute("""
+            CREATE TABLE manager_config (
+                id TEXT PRIMARY KEY,
+                project TEXT NOT NULL DEFAULT '',
+                repo_dir TEXT UNIQUE,
+                owner_session_id TEXT,
+                payload TEXT NOT NULL DEFAULT '{}',
+                created_at TEXT NOT NULL DEFAULT ''
+            )
+            """)
+        if old is not None:
+            try:
+                payload = json.loads(old["payload"] or "{}")
+            except json.JSONDecodeError:
+                payload = {}
+            if not isinstance(payload, dict):
+                payload = {}
+            new_id = f"mgr-{secrets.token_hex(4)}"
+            payload["id"] = new_id
+            self.connection.execute(
+                """
+                INSERT INTO manager_config
+                    (id, project, repo_dir, owner_session_id, payload, created_at)
+                VALUES (?, ?, NULL, ?, ?, ?)
+                """,
+                (
+                    new_id,
+                    str(payload.get("project") or ""),
+                    payload.get("owner_session_id"),
+                    json.dumps(payload),
+                    datetime.now(UTC).isoformat(),
+                ),
+            )
+            self.connection.execute(
+                "UPDATE manager_tickets SET manager_id = ? "
+                "WHERE manager_id IS NULL OR manager_id = ''",
+                (new_id,),
+            )
+        self.connection.execute("DROP TABLE manager_config_legacy")

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -2797,9 +2797,7 @@ class Storage:
         legacy row never persisted ``repo_dir`` directly, so it is derived from the
         compiled ``templates_dir`` (default ``<repo>/.waypoint/manager/templates``);
         when that fails the migrated manager keeps a NULL ``repo_dir`` and the next
-        ``manager init`` adopts it as the lone unbound manager. The whole rebuild
-        runs in one transaction so a mid-rebuild failure rolls back cleanly rather
-        than leaving a half-migrated schema.
+        ``manager init`` adopts it as the lone unbound manager.
         """
         if self._has_column("manager_config", "repo_dir"):
             return

--- a/backend/tests/test_manager.py
+++ b/backend/tests/test_manager.py
@@ -2,6 +2,8 @@
 invariants / ``next`` policy, plus storage CRUD and ``ManagerManager`` HTTP
 mapping, and config init."""
 
+import json
+import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -11,6 +13,7 @@ from fastapi import HTTPException
 from waypoint.manager import (
     _ADJACENCY,
     ManagerManager,
+    ManagerRegistry,
     ManagerStateError,
     apply_transition,
     check_invariants,
@@ -38,6 +41,9 @@ Sc = ManagerTicketScale
 
 _TERMINALS = {S.MERGED, S.DEFERRED, S.ABANDONED}
 _CONFIG = ManagerConfig(max_delegate_attempts=3, max_lead_restarts=3)
+# The test manager id; ``mk`` stamps it so storage-seeded tickets are visible to a
+# manager scoped to this id.
+MID = "mgr-test"
 
 
 def _now() -> datetime:
@@ -55,10 +61,12 @@ def mk(
     intended_lead_title: str | None = None,
     branch: str | None = None,
     created_at: datetime | None = None,
+    manager_id: str = MID,
 ) -> ManagerTicket:
     now = created_at or _now()
     return ManagerTicket(
         id=ticket_id,
+        manager_id=manager_id,
         title=ticket_id,
         state=state,
         priority=priority,
@@ -76,10 +84,21 @@ def _storage(tmp_path: Path) -> Storage:
     return Storage(tmp_path / "waypoint.db")
 
 
+def _init(
+    storage: Storage, config: ManagerConfig = _CONFIG, mid: str = MID
+) -> ManagerManager:
+    """Init a manager on ``storage`` under a fixed id and return it scoped."""
+    reg = ManagerRegistry(storage)
+    reg.init(
+        ManagerInitRequest(
+            config=config.model_copy(update={"id": mid, "repo_dir": f"/repo/{mid}"})
+        )
+    )
+    return reg.get(mid)
+
+
 def _manager(tmp_path: Path) -> ManagerManager:
-    mgr = ManagerManager(_storage(tmp_path))
-    mgr.init(ManagerInitRequest(config=_CONFIG))
-    return mgr
+    return _init(_storage(tmp_path))
 
 
 # ── Transition table: every on-table edge legal, every off-table edge rejected ──
@@ -481,16 +500,14 @@ def test_next_derives_tree_state() -> None:
 
 def test_reconcile_reports_signals(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
     rc = ManagerRenderContext(
         templates_dir="/x", tickets_channel="tickets", ticket_channel_prefix="ticket-"
     )
-    mgr.init(
-        ManagerInitRequest(
-            config=ManagerConfig(
-                owner_session_id="mgr", human_latency_hours=72, render_context=rc
-            )
-        )
+    mgr = _init(
+        storage,
+        ManagerConfig(
+            owner_session_id="mgr", human_latency_hours=72, render_context=rc
+        ),
     )
     # Intake: a keyless human post whose entry id is not a ticket. The manager's own
     # keyed registry cell must be ignored.
@@ -522,15 +539,10 @@ def test_reconcile_reports_signals(tmp_path: Path) -> None:
 
 def test_reconcile_surfaces_intake_priority(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
     rc = ManagerRenderContext(
         templates_dir="/x", tickets_channel="tickets", ticket_channel_prefix="ticket-"
     )
-    mgr.init(
-        ManagerInitRequest(
-            config=ManagerConfig(owner_session_id="mgr", render_context=rc)
-        )
-    )
+    mgr = _init(storage, ManagerConfig(owner_session_id="mgr", render_context=rc))
     storage.add_board_entry(
         "tickets", "high one", author_session_id="human", metadata={"priority": "p1"}
     )
@@ -549,8 +561,7 @@ def test_reconcile_surfaces_intake_priority(tmp_path: Path) -> None:
 
 def test_reconcile_reports_stale_gates(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # An awaiting ticket with no recorded gate item — a crash between the awaiting
     # transition and the inbox post.
     storage.create_manager_ticket(mk(S.SPEC_REVIEW, "g1"))
@@ -575,8 +586,7 @@ def test_reconcile_reports_stale_gates(tmp_path: Path) -> None:
 
 def test_reconcile_reports_finalize_pending(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # On-tree terminals still holding a branch — a crash between the terminal record
     # and the reap. `abandoned` covers the restart-exhaustion path that keeps its branch.
     storage.create_manager_ticket(mk(S.MERGED, "m", branch="ticket/m"))
@@ -597,8 +607,7 @@ def test_reconcile_reports_finalize_pending(tmp_path: Path) -> None:
 
 def test_reconcile_skips_branchless_blocked_dead_lead(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # An infeasible spec parked in blocked: no branch, and its reaped writer's id
     # lingers. It awaits a human decision, so it is not a lead to resume.
     storage.create_manager_ticket(
@@ -625,8 +634,7 @@ def test_reconcile_skips_branchless_blocked_dead_lead(tmp_path: Path) -> None:
 
 def test_reset_attempts_zeroes_the_delegate_budget(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # A ticket blocked after exhausting the delegate budget; a human fixes the
     # launch config and retries.
     storage.create_manager_ticket(mk(S.BLOCKED, "b", attempts=3, lead_restarts=2))
@@ -641,8 +649,7 @@ def test_reset_attempts_zeroes_the_delegate_budget(tmp_path: Path) -> None:
 
 def test_reconcile_skips_restart_exhausted_blocked_dead_lead(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # A blocked ticket whose lead kept dying until the restart budget was spent keeps its
     # branch (committed work) and waits on the human's retry/abandon gate.
     storage.create_manager_ticket(
@@ -670,8 +677,7 @@ def test_reconcile_skips_restart_exhausted_blocked_dead_lead(tmp_path: Path) -> 
 
 def test_reset_lead_restarts_zeroes_the_restart_budget(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # A ticket blocked after its lead kept dying; a human fixes the cause and retries.
     storage.create_manager_ticket(
         mk(S.BLOCKED, "b", attempts=1, lead_restarts=3, branch="ticket/b")
@@ -687,8 +693,7 @@ def test_reset_lead_restarts_zeroes_the_restart_budget(tmp_path: Path) -> None:
 
 def test_reconcile_latency_measured_from_gate_item(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # The ticket entered the awaiting state long ago, but its gate item was posted
     # recently (a re-opened or human-deleted-then-reposted gate).
     item = storage.create_inbox_item(
@@ -713,8 +718,7 @@ def test_reconcile_latency_measured_from_gate_item(tmp_path: Path) -> None:
 
 def test_reconcile_latency_skips_resolved_gate(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # A merge gate the human already answered: the item is resolved, so the wait falls
     # to the external merge and no latency timeout applies.
     answered = storage.create_inbox_item(
@@ -747,8 +751,7 @@ def test_reconcile_reports_resolved_gate_for_a_deferred_transition(
     tmp_path: Path,
 ) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=_CONFIG))
+    mgr = _init(storage)
     # An awaiting ticket whose gate the human answered (resolved) but whose transition
     # is deferred — surfaced so the drain re-drives the gate handler.
     answered = storage.create_inbox_item(
@@ -773,8 +776,7 @@ def test_reconcile_reports_resolved_gate_for_a_deferred_transition(
 
 def test_reconcile_latency_floors_zero_hour_config(tmp_path: Path) -> None:
     storage = _storage(tmp_path)
-    mgr = ManagerManager(storage)
-    mgr.init(ManagerInitRequest(config=ManagerConfig(human_latency_hours=0)))
+    mgr = _init(storage, ManagerConfig(human_latency_hours=0))
     item = storage.create_inbox_item(
         "mgr", None, "ticket-z: t — spec review", [InboxMarkdownBlockInput(text="x")]
     )
@@ -789,6 +791,76 @@ def test_reconcile_latency_floors_zero_hour_config(tmp_path: Path) -> None:
 
 
 # ── Storage CRUD ────────────────────────────────────────────────────────────
+
+
+def test_storage_scopes_tickets_by_manager(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    storage.create_manager_ticket(mk(S.INTAKE, "a", manager_id="mgr-1"))
+    storage.create_manager_ticket(mk(S.INTAKE, "b", manager_id="mgr-2"))
+    assert [t.id for t in storage.list_manager_tickets(manager_id="mgr-1")] == ["a"]
+    assert [t.id for t in storage.list_manager_tickets(manager_id="mgr-2")] == ["b"]
+    # A cross-manager fetch/delete does not reach the other manager's ticket.
+    assert storage.get_manager_ticket("a", manager_id="mgr-2") is None
+    assert storage.delete_manager_ticket("a", manager_id="mgr-2") is False
+    assert storage.get_manager_ticket("a", manager_id="mgr-1") is not None
+
+
+def test_storage_migrates_legacy_singleton(tmp_path: Path) -> None:
+    # Build a pre-multi-manager DB by hand: the old pinned-id config table and a
+    # tickets table with no manager_id column, then open it through Storage and
+    # assert the migration adopts the one manager under a minted id.
+    db = tmp_path / "waypoint.db"
+    conn = sqlite3.connect(db)
+    conn.executescript("""
+        CREATE TABLE manager_tickets (
+            id TEXT PRIMARY KEY, title TEXT NOT NULL, priority TEXT NOT NULL,
+            state TEXT NOT NULL, scale TEXT, version INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL, updated_at TEXT NOT NULL,
+            payload TEXT NOT NULL DEFAULT '{}'
+        );
+        CREATE TABLE manager_config (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            payload TEXT NOT NULL DEFAULT '{}'
+        );
+        """)
+    now = datetime.now(UTC).isoformat()
+    conn.execute(
+        "INSERT INTO manager_config (id, payload) VALUES (1, ?)",
+        (
+            json.dumps(
+                {"trunk": "develop", "project": "legacy", "owner_session_id": "o"}
+            ),
+        ),
+    )
+    for tid in ("t1", "t2"):
+        payload = {
+            "id": tid,
+            "title": tid,
+            "state": "intake",
+            "priority": "p2",
+            "created_at": now,
+            "updated_at": now,
+        }
+        conn.execute(
+            "INSERT INTO manager_tickets (id, title, priority, state, created_at, "
+            "updated_at, payload) VALUES (?, ?, 'p2', 'intake', ?, ?, ?)",
+            (tid, tid, now, now, json.dumps(payload)),
+        )
+    conn.commit()
+    conn.close()
+
+    storage = Storage(db)
+    configs = storage.list_manager_configs()
+    assert len(configs) == 1
+    migrated = configs[0]
+    assert migrated.id.startswith("mgr-")
+    assert migrated.trunk == "develop"
+    assert migrated.project == "legacy"
+    assert migrated.repo_dir == ""  # unknown until the next init
+    # Every legacy ticket is backfilled onto the migrated manager and visible.
+    tickets = storage.list_manager_tickets(manager_id=migrated.id)
+    assert {t.id for t in tickets} == {"t1", "t2"}
+    assert all(t.manager_id == migrated.id for t in tickets)
 
 
 def test_storage_ticket_round_trip(tmp_path: Path) -> None:
@@ -942,22 +1014,48 @@ def test_budget_exhausted_self_loop_preserves_id() -> None:
 
 
 def test_config_defaults_when_uninitialized(tmp_path: Path) -> None:
-    mgr = ManagerManager(_storage(tmp_path))
+    mgr = ManagerManager(_storage(tmp_path), "nope")
     config = mgr.config()
     assert config.trunk == "main"  # ManagerConfig default
     assert config.max_delegate_attempts == 3
 
 
 def test_init_persists_config(tmp_path: Path) -> None:
-    mgr = ManagerManager(_storage(tmp_path))
-    mgr.init(
-        ManagerInitRequest(
-            config=ManagerConfig(max_delegate_attempts=5, trunk="develop")
-        )
+    mgr = _init(
+        _storage(tmp_path),
+        ManagerConfig(max_delegate_attempts=5, trunk="develop"),
     )
     config = mgr.config()
     assert config.max_delegate_attempts == 5
     assert config.trunk == "develop"
+
+
+def test_init_mints_id_and_keys_by_repo(tmp_path: Path) -> None:
+    reg = ManagerRegistry(_storage(tmp_path))
+    a = reg.init(ManagerInitRequest(config=ManagerConfig(repo_dir="/repo/a")))
+    assert a.id.startswith("mgr-")
+    # Re-init from the same repo reuses the id (idempotent).
+    a2 = reg.init(ManagerInitRequest(config=ManagerConfig(repo_dir="/repo/a")))
+    assert a2.id == a.id
+    # A different repo mints a distinct manager.
+    b = reg.init(ManagerInitRequest(config=ManagerConfig(repo_dir="/repo/b")))
+    assert b.id != a.id
+    assert {m.id for m in reg.list_summaries()} == {a.id, b.id}
+
+
+def test_init_rejects_channel_collision(tmp_path: Path) -> None:
+    reg = ManagerRegistry(_storage(tmp_path))
+    rc = ManagerRenderContext(tickets_channel="tickets", ticket_channel_prefix="tk-")
+    reg.init(
+        ManagerInitRequest(config=ManagerConfig(repo_dir="/repo/a", render_context=rc))
+    )
+    with pytest.raises(HTTPException) as exc:
+        reg.init(
+            ManagerInitRequest(
+                config=ManagerConfig(repo_dir="/repo/b", render_context=rc)
+            )
+        )
+    assert exc.value.status_code == 409
 
 
 # ── deinit / delete / owner cascade ─────────────────────────────────────────
@@ -987,24 +1085,49 @@ def test_delete_ticket_404(tmp_path: Path) -> None:
     assert exc.value.status_code == 404
 
 
-def test_deinit_if_owner_matches_only_the_owner(tmp_path: Path) -> None:
-    mgr = ManagerManager(_storage(tmp_path))
-    mgr.init(ManagerInitRequest(config=ManagerConfig(owner_session_id="mgr")))
-    mgr.create_ticket(TicketCreateRequest(title="a"))
-    assert mgr.deinit_if_owner("other") is False
-    assert len(mgr.list_tickets()) == 1
-    assert mgr.deinit_if_owner("mgr") is True
-    assert mgr.list_tickets() == []
+def test_deinit_owned_by_cascades_only_the_owned_managers(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    reg = ManagerRegistry(storage)
+    a = reg.init(
+        ManagerInitRequest(
+            config=ManagerConfig(repo_dir="/repo/a", owner_session_id="mgr")
+        )
+    )
+    b = reg.init(
+        ManagerInitRequest(
+            config=ManagerConfig(repo_dir="/repo/b", owner_session_id="other")
+        )
+    )
+    reg.get(a.id).create_ticket(TicketCreateRequest(title="a"))
+    reg.get(b.id).create_ticket(TicketCreateRequest(title="b"))
+    # Deleting a non-owner session cascades nothing.
+    assert reg.deinit_owned_by("stranger") == 0
+    # Deleting the owner tears down only its manager; the other survives.
+    assert reg.deinit_owned_by("mgr") == 1
+    assert reg.get(a.id).list_tickets() == []
+    assert reg.exists(a.id) is False
+    assert len(reg.get(b.id).list_tickets()) == 1
+    assert reg.exists(b.id) is True
 
 
 def test_init_preserves_owner_when_not_resupplied(tmp_path: Path) -> None:
-    mgr = ManagerManager(_storage(tmp_path))
-    mgr.init(ManagerInitRequest(config=ManagerConfig(owner_session_id="mgr")))
+    reg = ManagerRegistry(_storage(tmp_path))
+    first = reg.init(
+        ManagerInitRequest(
+            config=ManagerConfig(repo_dir="/repo/a", owner_session_id="mgr")
+        )
+    )
     # Re-init from a manifest (which carries no owner) keeps the recorded owner.
-    mgr.init(ManagerInitRequest(config=ManagerConfig(trunk="develop")))
-    config = mgr.config()
+    reg.init(
+        ManagerInitRequest(config=ManagerConfig(repo_dir="/repo/a", trunk="develop"))
+    )
+    config = reg.get(first.id).config()
     assert config.owner_session_id == "mgr"
     assert config.trunk == "develop"
     # An explicit new owner overrides.
-    mgr.init(ManagerInitRequest(config=ManagerConfig(owner_session_id="mgr2")))
-    assert mgr.config().owner_session_id == "mgr2"
+    reg.init(
+        ManagerInitRequest(
+            config=ManagerConfig(repo_dir="/repo/a", owner_session_id="mgr2")
+        )
+    )
+    assert reg.get(first.id).config().owner_session_id == "mgr2"

--- a/backend/tests/test_manager.py
+++ b/backend/tests/test_manager.py
@@ -805,11 +805,9 @@ def test_storage_scopes_tickets_by_manager(tmp_path: Path) -> None:
     assert storage.get_manager_ticket("a", manager_id="mgr-1") is not None
 
 
-def test_storage_migrates_legacy_singleton(tmp_path: Path) -> None:
-    # Build a pre-multi-manager DB by hand: the old pinned-id config table and a
-    # tickets table with no manager_id column, then open it through Storage and
-    # assert the migration adopts the one manager under a minted id.
-    db = tmp_path / "waypoint.db"
+def _seed_legacy_db(db: Path, config_payload: dict[str, object]) -> None:
+    """Write a pre-multi-manager DB: the old pinned-id config table and a tickets
+    table with no manager_id column, one config row and two tickets."""
     conn = sqlite3.connect(db)
     conn.executescript("""
         CREATE TABLE manager_tickets (
@@ -826,11 +824,7 @@ def test_storage_migrates_legacy_singleton(tmp_path: Path) -> None:
     now = datetime.now(UTC).isoformat()
     conn.execute(
         "INSERT INTO manager_config (id, payload) VALUES (1, ?)",
-        (
-            json.dumps(
-                {"trunk": "develop", "project": "legacy", "owner_session_id": "o"}
-            ),
-        ),
+        (json.dumps(config_payload),),
     )
     for tid in ("t1", "t2"):
         payload = {
@@ -849,6 +843,25 @@ def test_storage_migrates_legacy_singleton(tmp_path: Path) -> None:
     conn.commit()
     conn.close()
 
+
+def test_storage_migrates_legacy_singleton(tmp_path: Path) -> None:
+    # A legacy manager whose compiled templates sit at the default layout has its
+    # repo_dir recovered from templates_dir, and its tickets backfilled.
+    db = tmp_path / "waypoint.db"
+    _seed_legacy_db(
+        db,
+        {
+            "trunk": "develop",
+            "project": "legacy",
+            "owner_session_id": "o",
+            "render_context": {
+                "templates_dir": "/home/me/proj/.waypoint/manager/templates",
+                "tickets_channel": "tickets",
+                "ticket_channel_prefix": "ticket-",
+            },
+        },
+    )
+
     storage = Storage(db)
     configs = storage.list_manager_configs()
     assert len(configs) == 1
@@ -856,11 +869,69 @@ def test_storage_migrates_legacy_singleton(tmp_path: Path) -> None:
     assert migrated.id.startswith("mgr-")
     assert migrated.trunk == "develop"
     assert migrated.project == "legacy"
-    assert migrated.repo_dir == ""  # unknown until the next init
-    # Every legacy ticket is backfilled onto the migrated manager and visible.
+    assert migrated.repo_dir == "/home/me/proj"  # recovered from templates_dir
     tickets = storage.list_manager_tickets(manager_id=migrated.id)
     assert {t.id for t in tickets} == {"t1", "t2"}
     assert all(t.manager_id == migrated.id for t in tickets)
+
+
+def test_migrated_manager_reinit_reuses_id_without_collision(tmp_path: Path) -> None:
+    # The zero-intervention upgrade: after migration, the manager's own re-init
+    # (same repo, same channels) must re-bind the migrated manager — reusing its id
+    # and tickets — not mint a second manager or 409 on its own channels.
+    db = tmp_path / "waypoint.db"
+    _seed_legacy_db(
+        db,
+        {
+            "project": "legacy",
+            "render_context": {
+                "templates_dir": "/home/me/proj/.waypoint/manager/templates",
+                "tickets_channel": "tickets",
+                "ticket_channel_prefix": "ticket-",
+            },
+        },
+    )
+    storage = Storage(db)
+    migrated = storage.list_manager_configs()[0]
+
+    reg = ManagerRegistry(storage)
+    rc = ManagerRenderContext(
+        templates_dir="/home/me/proj/.waypoint/manager/templates",
+        tickets_channel="tickets",
+        ticket_channel_prefix="ticket-",
+    )
+    reinit = reg.init(
+        ManagerInitRequest(
+            config=ManagerConfig(
+                repo_dir="/home/me/proj", project="legacy", render_context=rc
+            )
+        )
+    )
+    assert reinit.id == migrated.id  # same manager, not a second one
+    assert len(storage.list_manager_configs()) == 1
+    assert {t.id for t in reg.get(reinit.id).list_tickets()} == {"t1", "t2"}
+
+
+def test_migrated_manager_without_templates_is_adopted_on_reinit(
+    tmp_path: Path,
+) -> None:
+    # A legacy manager whose templates_dir was customized off the default layout
+    # migrates unbound (repo_dir empty); the next init adopts the lone unbound
+    # manager rather than minting a second one.
+    db = tmp_path / "waypoint.db"
+    _seed_legacy_db(db, {"project": "legacy"})  # no render_context → no repo recovery
+    storage = Storage(db)
+    migrated = storage.list_manager_configs()[0]
+    assert migrated.repo_dir == ""
+
+    reg = ManagerRegistry(storage)
+    reinit = reg.init(
+        ManagerInitRequest(config=ManagerConfig(repo_dir="/home/me/proj"))
+    )
+    assert reinit.id == migrated.id
+    assert reinit.repo_dir == "/home/me/proj"
+    assert len(storage.list_manager_configs()) == 1
+    assert {t.id for t in reg.get(reinit.id).list_tickets()} == {"t1", "t2"}
 
 
 def test_storage_ticket_round_trip(tmp_path: Path) -> None:

--- a/backend/tests/test_manager_api.py
+++ b/backend/tests/test_manager_api.py
@@ -53,17 +53,36 @@ def _make_session(settings: Settings, session_id: str) -> SessionRecord:
     )
 
 
-async def _create(client: httpx.AsyncClient, token: str, **body: Any) -> str:
-    resp = await client.post("/api/manager/tickets", headers=_auth(token), json=body)
+async def _init(
+    client: httpx.AsyncClient, token: str, repo_dir: str = "/repo/x", **config: Any
+) -> str:
+    resp = await client.post(
+        "/api/manager/init",
+        headers=_auth(token),
+        json={"config": {"repo_dir": repo_dir, **config}},
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()["config"]["id"]
+
+
+async def _create(client: httpx.AsyncClient, token: str, mid: str, **body: Any) -> str:
+    resp = await client.post(
+        f"/api/manager/{mid}/tickets", headers=_auth(token), json=body
+    )
     assert resp.status_code == 200, resp.text
     return resp.json()["ticket"]["id"]
 
 
 async def _transition(
-    client: httpx.AsyncClient, token: str, ticket_id: str, to: str, **meta: Any
+    client: httpx.AsyncClient,
+    token: str,
+    mid: str,
+    ticket_id: str,
+    to: str,
+    **meta: Any,
 ) -> httpx.Response:
     return await client.post(
-        f"/api/manager/tickets/{ticket_id}/transition",
+        f"/api/manager/{mid}/tickets/{ticket_id}/transition",
         headers=_auth(token),
         json={"to": to, **meta},
     )
@@ -75,7 +94,7 @@ async def _transition(
 async def test_manager_requires_auth(tmp_path: Path) -> None:
     app, _ = _build(tmp_path)
     async with _client(app) as client:
-        resp = await client.get("/api/manager/state")
+        resp = await client.get("/api/manager/x/state")
     assert resp.status_code == 401
 
 
@@ -85,22 +104,54 @@ async def test_init_sets_config(tmp_path: Path) -> None:
         resp = await client.post(
             "/api/manager/init",
             headers=_auth(token),
-            json={"config": {"max_delegate_attempts": 5, "trunk": "develop"}},
+            json={
+                "config": {
+                    "repo_dir": "/repo/x",
+                    "max_delegate_attempts": 5,
+                    "trunk": "develop",
+                }
+            },
         )
         assert resp.status_code == 200
         config = resp.json()["config"]
+        assert config["id"].startswith("mgr-")
         assert config["max_delegate_attempts"] == 5
         assert config["trunk"] == "develop"
         # The persisted config is reflected back through /state.
-        state = await client.get("/api/manager/state", headers=_auth(token))
+        state = await client.get(
+            f"/api/manager/{config['id']}/state", headers=_auth(token)
+        )
     assert state.json()["config"]["max_delegate_attempts"] == 5
+
+
+async def test_unknown_manager_is_404(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/manager/mgr-nope/state", headers=_auth(token))
+    assert resp.status_code == 404
+
+
+async def test_manager_list_enumerates(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        a = await _init(client, token, repo_dir="/repo/a", project="A")
+        b = await _init(client, token, repo_dir="/repo/b", project="B")
+        await _create(client, token, a, title="t")
+        resp = await client.get("/api/manager", headers=_auth(token))
+        assert resp.status_code == 200
+        managers = {m["id"]: m for m in resp.json()["managers"]}
+    assert set(managers) == {a, b}
+    assert managers[a]["project"] == "A"
+    assert managers[a]["ticket_count"] == 1
+    assert managers[b]["ticket_count"] == 0
 
 
 async def test_create_ticket_starts_in_intake(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
+        mid = await _init(client, token)
         resp = await client.post(
-            "/api/manager/tickets",
+            f"/api/manager/{mid}/tickets",
             headers=_auth(token),
             json={"title": "ship it", "priority": "p1"},
         )
@@ -114,8 +165,9 @@ async def test_create_ticket_starts_in_intake(tmp_path: Path) -> None:
 async def test_next_recommends_triage_for_fresh_intake(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        ticket_id = await _create(client, token, title="fresh")
-        resp = await client.get("/api/manager/next", headers=_auth(token))
+        mid = await _init(client, token)
+        ticket_id = await _create(client, token, mid, title="fresh")
+        resp = await client.get(f"/api/manager/{mid}/next", headers=_auth(token))
         assert resp.status_code == 200
         body = resp.json()
     # Envelope shape the skill's re-anchor depends on: tree state + per-ticket legal
@@ -135,7 +187,8 @@ async def test_next_recommends_triage_for_fresh_intake(tmp_path: Path) -> None:
 async def test_legal_transition_walk_to_merged(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        ticket_id = await _create(client, token, title="walk", scale="trivial")
+        mid = await _init(client, token)
+        ticket_id = await _create(client, token, mid, title="walk", scale="trivial")
         walk = [
             "triaged",
             "ready",
@@ -145,7 +198,7 @@ async def test_legal_transition_walk_to_merged(tmp_path: Path) -> None:
             "merged",
         ]
         for to in walk:
-            resp = await _transition(client, token, ticket_id, to)
+            resp = await _transition(client, token, mid, ticket_id, to)
             assert resp.status_code == 200, (to, resp.text)
             assert resp.json()["ticket"]["state"] == to
 
@@ -153,26 +206,30 @@ async def test_legal_transition_walk_to_merged(tmp_path: Path) -> None:
 async def test_illegal_transition_is_409(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        ticket_id = await _create(client, token, title="x")
+        mid = await _init(client, token)
+        ticket_id = await _create(client, token, mid, title="x")
         # intake -> merged is not on the transition table.
-        resp = await _transition(client, token, ticket_id, "merged")
+        resp = await _transition(client, token, mid, ticket_id, "merged")
     assert resp.status_code == 409
 
 
 async def test_invariant_tree_cap_is_409(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        a = await _create(client, token, title="a", scale="trivial")
+        mid = await _init(client, token)
+        a = await _create(client, token, mid, title="a", scale="trivial")
         for to in ("triaged", "ready", "delegated", "building"):
             meta = {"intended_lead_title": "a-lead"} if to == "delegated" else {}
-            assert (await _transition(client, token, a, to, **meta)).status_code == 200
+            assert (
+                await _transition(client, token, mid, a, to, **meta)
+            ).status_code == 200
         # B reaches ready while A holds the tree; delegating it would put two
         # tickets on the one shared tree -> the second delegate is a 409.
-        b = await _create(client, token, title="b", scale="trivial")
+        b = await _create(client, token, mid, title="b", scale="trivial")
         for to in ("triaged", "ready"):
-            assert (await _transition(client, token, b, to)).status_code == 200
+            assert (await _transition(client, token, mid, b, to)).status_code == 200
         resp = await _transition(
-            client, token, b, "delegated", intended_lead_title="b-lead"
+            client, token, mid, b, "delegated", intended_lead_title="b-lead"
         )
     assert resp.status_code == 409
 
@@ -180,18 +237,21 @@ async def test_invariant_tree_cap_is_409(tmp_path: Path) -> None:
 async def test_invariant_second_spec_pending_is_409(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
+        mid = await _init(client, token)
         ids = []
         for name in ("a", "b"):
-            tid = await _create(client, token, title=name, scale="substantial")
+            tid = await _create(client, token, mid, title=name, scale="substantial")
             assert (
-                await _transition(client, token, tid, "triaged", scale="substantial")
+                await _transition(
+                    client, token, mid, tid, "triaged", scale="substantial"
+                )
             ).status_code == 200
             ids.append(tid)
         assert (
-            await _transition(client, token, ids[0], "spec_pending")
+            await _transition(client, token, mid, ids[0], "spec_pending")
         ).status_code == 200
         # Serial analysis: at most one ticket may be in spec_pending.
-        resp = await _transition(client, token, ids[1], "spec_pending")
+        resp = await _transition(client, token, mid, ids[1], "spec_pending")
     assert resp.status_code == 409
 
     # (The duplicate-intended-lead-title invariant is unreachable through
@@ -203,13 +263,9 @@ async def test_invariant_second_spec_pending_is_409(tmp_path: Path) -> None:
 async def test_state_reports_config_tree_tickets(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        await client.post(
-            "/api/manager/init",
-            headers=_auth(token),
-            json={"config": {"trunk": "develop"}},
-        )
-        ticket_id = await _create(client, token, title="t")
-        resp = await client.get("/api/manager/state", headers=_auth(token))
+        mid = await _init(client, token, trunk="develop")
+        ticket_id = await _create(client, token, mid, title="t")
+        resp = await client.get(f"/api/manager/{mid}/state", headers=_auth(token))
         assert resp.status_code == 200
         body = resp.json()
     assert body["config"]["trunk"] == "develop"
@@ -220,18 +276,14 @@ async def test_state_reports_config_tree_tickets(tmp_path: Path) -> None:
 async def test_reconcile_endpoint_reports_intake(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        await client.post(
-            "/api/manager/init",
-            headers=_auth(token),
-            json={
-                "config": {
-                    "owner_session_id": "mgr",
-                    "render_context": {
-                        "templates_dir": "/x",
-                        "tickets_channel": "tickets",
-                        "ticket_channel_prefix": "ticket-",
-                    },
-                }
+        mid = await _init(
+            client,
+            token,
+            owner_session_id="mgr",
+            render_context={
+                "templates_dir": "/x",
+                "tickets_channel": "tickets",
+                "ticket_channel_prefix": "ticket-",
             },
         )
         await client.post(
@@ -239,7 +291,7 @@ async def test_reconcile_endpoint_reports_intake(tmp_path: Path) -> None:
             headers=_auth(token),
             json={"text": "please fix X", "author_session_id": "human"},
         )
-        resp = await client.get("/api/manager/reconcile", headers=_auth(token))
+        resp = await client.get(f"/api/manager/{mid}/reconcile", headers=_auth(token))
         assert resp.status_code == 200
         body = resp.json()
     assert set(body) == {
@@ -303,24 +355,29 @@ async def test_wake_register_list_delete_round_trip(tmp_path: Path) -> None:
 async def test_deinit_endpoint_clears_state(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        await _create(client, token, title="a")
-        resp = await client.delete("/api/manager", headers=_auth(token))
+        mid = await _init(client, token)
+        await _create(client, token, mid, title="a")
+        resp = await client.delete(f"/api/manager/{mid}", headers=_auth(token))
         assert resp.status_code == 200
         body = resp.json()
         assert body["deinitialized"] is True
         assert body["tickets_deleted"] == 1
-        state = await client.get("/api/manager/state", headers=_auth(token))
-    assert state.json()["tickets"] == []
+        # The manager is gone; its state route now 404s.
+        state = await client.get(f"/api/manager/{mid}/state", headers=_auth(token))
+    assert state.status_code == 404
 
 
 async def test_delete_ticket_endpoint_and_404(tmp_path: Path) -> None:
     app, token = _build(tmp_path)
     async with _client(app) as client:
-        tid = await _create(client, token, title="a")
-        ok = await client.delete(f"/api/manager/tickets/{tid}", headers=_auth(token))
+        mid = await _init(client, token)
+        tid = await _create(client, token, mid, title="a")
+        ok = await client.delete(
+            f"/api/manager/{mid}/tickets/{tid}", headers=_auth(token)
+        )
         assert ok.status_code == 200
         assert ok.json()["deleted"] is True
         missing = await client.delete(
-            f"/api/manager/tickets/{tid}", headers=_auth(token)
+            f"/api/manager/{mid}/tickets/{tid}", headers=_auth(token)
         )
     assert missing.status_code == 404

--- a/backend/tests/test_manager_cli.py
+++ b/backend/tests/test_manager_cli.py
@@ -60,7 +60,7 @@ def test_cli_manager_ticket_add(
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
-        assert request.url.path == "/api/manager/tickets"
+        assert request.url.path == "/api/manager/mgr-1/tickets"
         captured["body"] = json.loads(request.content)
         return httpx.Response(
             200, json={"ticket": {"id": "ticket-1", "state": "intake"}}
@@ -80,6 +80,8 @@ def test_cli_manager_ticket_add(
             "p1",
             "--scale",
             "substantial",
+            "--manager",
+            "mgr-1",
         ],
     )
     assert result.exit_code == 0, result.stdout
@@ -94,7 +96,7 @@ def test_cli_manager_ticket_add(
 def test_cli_manager_next(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"
-        assert request.url.path == "/api/manager/next"
+        assert request.url.path == "/api/manager/mgr-1/next"
         return httpx.Response(
             200,
             json={
@@ -120,7 +122,15 @@ def test_cli_manager_next(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     _mock_cli(monkeypatch, handler)
     result = runner.invoke(
         cli_app,
-        ["--config", str(_cli_config(tmp_path)), "manager", "next", "--json"],
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "manager",
+            "next",
+            "--json",
+            "--manager",
+            "mgr-1",
+        ],
     )
     assert result.exit_code == 0, result.stdout
     body = json.loads(result.stdout)
@@ -131,7 +141,7 @@ def test_cli_manager_next(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
 def test_cli_manager_reconcile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"
-        assert request.url.path == "/api/manager/reconcile"
+        assert request.url.path == "/api/manager/mgr-1/reconcile"
         return httpx.Response(
             200,
             json={
@@ -146,7 +156,15 @@ def test_cli_manager_reconcile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     _mock_cli(monkeypatch, handler)
     result = runner.invoke(
         cli_app,
-        ["--config", str(_cli_config(tmp_path)), "manager", "reconcile", "--json"],
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "manager",
+            "reconcile",
+            "--json",
+            "--manager",
+            "mgr-1",
+        ],
     )
     assert result.exit_code == 0, result.stdout
     body = json.loads(result.stdout)
@@ -156,7 +174,7 @@ def test_cli_manager_reconcile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
 def test_cli_manager_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "GET"
-        assert request.url.path == "/api/manager/state"
+        assert request.url.path == "/api/manager/mgr-1/state"
         return httpx.Response(
             200,
             json={
@@ -169,7 +187,15 @@ def test_cli_manager_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> N
     _mock_cli(monkeypatch, handler)
     result = runner.invoke(
         cli_app,
-        ["--config", str(_cli_config(tmp_path)), "manager", "state", "--json"],
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "manager",
+            "state",
+            "--json",
+            "--manager",
+            "mgr-1",
+        ],
     )
     assert result.exit_code == 0, result.stdout
     body = json.loads(result.stdout)
@@ -184,7 +210,7 @@ def test_cli_manager_ticket_transition(
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "POST"
-        assert request.url.path == "/api/manager/tickets/ticket-1/transition"
+        assert request.url.path == "/api/manager/mgr-1/tickets/ticket-1/transition"
         captured["body"] = json.loads(request.content)
         return httpx.Response(
             200, json={"ticket": {"id": "ticket-1", "state": "triaged"}}
@@ -202,6 +228,8 @@ def test_cli_manager_ticket_transition(
             "ticket-1",
             "--to",
             "triaged",
+            "--manager",
+            "mgr-1",
         ],
     )
     assert result.exit_code == 0, result.stdout
@@ -382,7 +410,7 @@ def test_cli_manager_render_per_ticket_and_set(
     rc = _render_context(root)
 
     def handler(request: httpx.Request) -> httpx.Response:
-        assert request.url.path == "/api/manager/state"
+        assert request.url.path == "/api/manager/mgr-1/state"
         return _state_response(rc)
 
     _mock_cli(monkeypatch, handler)
@@ -393,6 +421,8 @@ def test_cli_manager_render_per_ticket_and_set(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "tech_lead",
             "--step",
@@ -419,6 +449,8 @@ def test_cli_manager_render_unknown_step_fails(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "prd_writer",
             "--step",
@@ -440,6 +472,8 @@ def test_cli_manager_render_requires_context(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "tech_lead",
             "--step",
@@ -464,6 +498,8 @@ def test_cli_manager_render_strict_fails_on_unknown(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "tech_lead",
             "--step",
@@ -488,6 +524,8 @@ def test_cli_manager_render_allow_unresolved(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "tech_lead",
             "--step",
@@ -511,9 +549,9 @@ def test_cli_manager_render_ticket_pulls_record_and_board_cell(
     rc = _render_context(root)
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/api/manager/state":
+        if request.url.path == "/api/manager/mgr-1/state":
             return _state_response(rc)
-        if request.url.path == "/api/manager/tickets/42":
+        if request.url.path == "/api/manager/mgr-1/tickets/42":
             return httpx.Response(
                 200,
                 json={
@@ -551,6 +589,8 @@ def test_cli_manager_render_ticket_pulls_record_and_board_cell(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "tech_lead",
             "--step",
@@ -573,9 +613,9 @@ def test_cli_manager_render_set_overrides_board_body(
     )
 
     def handler(request: httpx.Request) -> httpx.Response:
-        if request.url.path == "/api/manager/state":
+        if request.url.path == "/api/manager/mgr-1/state":
             return _state_response(rc)
-        if request.url.path == "/api/manager/tickets/42":
+        if request.url.path == "/api/manager/mgr-1/tickets/42":
             return httpx.Response(
                 200,
                 json={
@@ -603,6 +643,8 @@ def test_cli_manager_render_set_overrides_board_body(
             str(_cli_config(tmp_path)),
             "manager",
             "render",
+            "--manager",
+            "mgr-1",
             "--role",
             "tech_lead",
             "--step",
@@ -625,14 +667,22 @@ def test_cli_manager_deinit(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "DELETE"
-        assert request.url.path == "/api/manager"
+        assert request.url.path == "/api/manager/mgr-1"
         captured["hit"] = True
         return httpx.Response(200, json={"deinitialized": True, "tickets_deleted": 3})
 
     _mock_cli(monkeypatch, handler)
     result = runner.invoke(
         cli_app,
-        ["--config", str(_cli_config(tmp_path)), "manager", "deinit", "--yes"],
+        [
+            "--config",
+            str(_cli_config(tmp_path)),
+            "manager",
+            "deinit",
+            "--yes",
+            "--manager",
+            "mgr-1",
+        ],
     )
     assert result.exit_code == 0, result.stdout
     assert captured.get("hit")
@@ -663,7 +713,7 @@ def test_cli_manager_ticket_delete(
 ) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.method == "DELETE"
-        assert request.url.path == "/api/manager/tickets/ticket-1"
+        assert request.url.path == "/api/manager/mgr-1/tickets/ticket-1"
         return httpx.Response(200, json={"deleted": True})
 
     _mock_cli(monkeypatch, handler)
@@ -676,9 +726,95 @@ def test_cli_manager_ticket_delete(
             "ticket",
             "delete",
             "ticket-1",
+            "--manager",
+            "mgr-1",
         ],
     )
     assert result.exit_code == 0, result.stdout
+
+
+def test_cli_manager_ls(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert request.url.path == "/api/manager"
+        return httpx.Response(
+            200,
+            json={
+                "managers": [
+                    {
+                        "id": "mgr-a",
+                        "project": "A",
+                        "repo_dir": "/repo/a",
+                        "ticket_count": 2,
+                        "attention_count": 1,
+                    }
+                ]
+            },
+        )
+
+    _mock_cli(monkeypatch, handler)
+    result = runner.invoke(
+        cli_app,
+        ["--config", str(_cli_config(tmp_path)), "manager", "ls", "--json"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout)["managers"][0]["id"] == "mgr-a"
+
+
+def test_cli_manager_resolves_by_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With no --manager, the CLI lists managers and picks the one bound to the
+    # current git toplevel.
+    monkeypatch.setattr("waypoint.cli._git_toplevel", lambda: "/repo/here")
+    seen: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/manager":
+            return httpx.Response(
+                200,
+                json={
+                    "managers": [
+                        {"id": "mgr-other", "repo_dir": "/repo/there"},
+                        {"id": "mgr-here", "repo_dir": "/repo/here"},
+                    ]
+                },
+            )
+        seen["path"] = request.url.path
+        return httpx.Response(
+            200,
+            json={
+                "config": None,
+                "tree": {"free": True, "held_by": None},
+                "tickets": [],
+            },
+        )
+
+    _mock_cli(monkeypatch, handler)
+    result = runner.invoke(
+        cli_app,
+        ["--config", str(_cli_config(tmp_path)), "manager", "state", "--json"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert seen["path"] == "/api/manager/mgr-here/state"
+
+
+def test_cli_manager_no_manager_for_repo_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("waypoint.cli._git_toplevel", lambda: "/repo/absent")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/api/manager"
+        return httpx.Response(200, json={"managers": []})
+
+    _mock_cli(monkeypatch, handler)
+    result = runner.invoke(
+        cli_app,
+        ["--config", str(_cli_config(tmp_path)), "manager", "state"],
+    )
+    assert result.exit_code != 0
+    assert "no manager initialized for repo" in result.output
 
 
 def test_cli_manager_init_sends_owner(

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -533,32 +533,36 @@ async def test_post_board_entry_stamps_author_label_from_session_title(
 @pytest.mark.asyncio
 async def test_delete_owner_session_cascades_manager_deinit(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
-    runtime.manager.init(
-        ManagerInitRequest(config=ManagerConfig(owner_session_id="mgr"))
+    config = runtime.managers.init(
+        ManagerInitRequest(
+            config=ManagerConfig(repo_dir="/repo/m", owner_session_id="mgr")
+        )
     )
-    runtime.manager.create_ticket(TicketCreateRequest(title="t"))
+    runtime.managers.get(config.id).create_ticket(TicketCreateRequest(title="t"))
     storage.create_session(
         make_session(settings, id="mgr", status=SessionStatus.EXITED)
     )
     await runtime.delete("mgr")
     # The manager state machine is torn down with its owner session.
-    assert storage.list_manager_tickets() == []
-    assert storage.get_manager_config() is None
+    assert storage.list_manager_tickets(manager_id=config.id) == []
+    assert storage.get_manager_config(config.id) is None
 
 
 @pytest.mark.asyncio
 async def test_delete_non_owner_session_leaves_manager_state(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
-    runtime.manager.init(
-        ManagerInitRequest(config=ManagerConfig(owner_session_id="mgr"))
+    config = runtime.managers.init(
+        ManagerInitRequest(
+            config=ManagerConfig(repo_dir="/repo/m", owner_session_id="mgr")
+        )
     )
-    runtime.manager.create_ticket(TicketCreateRequest(title="t"))
+    runtime.managers.get(config.id).create_ticket(TicketCreateRequest(title="t"))
     storage.create_session(
         make_session(settings, id="worker", status=SessionStatus.EXITED)
     )
     await runtime.delete("worker")
-    assert len(storage.list_manager_tickets()) == 1
-    assert storage.get_manager_config() is not None
+    assert len(storage.list_manager_tickets(manager_id=config.id)) == 1
+    assert storage.get_manager_config(config.id) is not None
 
 
 @pytest.mark.asyncio

--- a/docs/waypoint-manager.md
+++ b/docs/waypoint-manager.md
@@ -1,7 +1,17 @@
 # Waypoint Manager
 
-The Waypoint Manager is a single long-running Waypoint session that owns one
-project's backlog. It drains a priority-ordered ticket board for its lifetime: for
+The Waypoint Manager is a long-running Waypoint session that owns one project's
+backlog. One instance runs several managers concurrently, one per repository: each
+is keyed by a server-minted opaque id (`mgr-<hex>`), carries a human-facing project
+label, and owns its own config, ticket set, working tree, owner session, and board
+channels. `manager init` mints the id on a repo's first init and reuses it on every
+later init from the same repo; the CLI resolves the target manager from the current
+git toplevel, so a manager's own commands need no id. Board channels
+(`tickets_channel`, `org_channel`, `ticket_channel_prefix`) must be unique across the
+managers on one instance; `manager init` rejects a channel that collides with another
+manager's.
+
+It drains a priority-ordered ticket board for its lifetime: for
 each ticket it assigns a scale and footprint, writes a PRD or RFC through an
 ephemeral writer when the work is substantial, delegates the ticket to an ephemeral
 tech-lead that builds in the manager's own working tree, monitors the build over a


### PR DESCRIPTION
## Purpose

Lets one instance run several Waypoint Managers concurrently, one per repository, instead of the single global manager shipped in #304. Each manager owns its own config, ticket set, working tree, owner session, and board channels. This is the "multi-project manager backend" prerequisite named in `.waypoint/specs/rfc-board-workspace-redesign.md` (FR10 / Prerequisite Dependency); the board page's per-project switcher (Phase 2b) consumes the new API and is out of scope here. Implements the RFC at `.waypoint/specs/rfc-multi-manager-project-scoping.md`.

A manager is keyed by a server-minted opaque id (`mgr-<hex>`) with a human-facing `project` label and a `UNIQUE` `repo_dir`, so one manager exists per repo and the key survives project renames. `manager init` mints the id on a repo's first init and reuses it (idempotent) on later inits from the same repo; the CLI resolves the target manager from the current git toplevel, so a manager never passes its own id.

## Changes

### Backend
- `storage.py` — rebuild `manager_config` (drop the pinned `CHECK (id = 1)`; add `id`/`project`/`repo_dir`/`owner_session_id`/`created_at`, `UNIQUE(repo_dir)`); partition `manager_tickets` by a new `manager_id`; scope all CRUD by manager id; add `list_manager_configs` / `get_manager_config_by_repo` / `get_manager_config_by_owner`; auto-migrate the legacy `id = 1` manager under a minted id with its tickets backfilled.
- `manager.py` — scope `ManagerManager` by manager id (its invariants now apply per manager); add `ManagerRegistry` that mints/resolves by repo at init, enforces board-channel non-collision across managers, enumerates managers, and cascades deinit for every manager a deleted owner session owns.
- `runtime.py` / `api.py` — replace the singleton with the registry; path-segment routes `/api/manager/{manager_id}/*` plus `GET /api/manager` (enumeration); unknown manager 404s.
- `cli.py` / `client.py` — resolve the manager from the current repo with a `--manager` override, add `manager ls`, and thread the id through every command and client call.

### Docs
- `docs/waypoint-manager.md`, `.agents/skills/waypoint-manager/SKILL.md` — one manager per repo, id minted and resolved from the repo, board channels unique per instance.

## Design

`repo_dir` is a `UNIQUE` constraint rather than the primary key, so the API/board key on a stable opaque id while the schema still guarantees one manager per repo. The registry constructs a per-request scoped `ManagerManager` (`manager_for(id)`) rather than caching long-lived instances — there is no per-manager in-memory state to keep warm. The pure state machine (`apply_transition`/`check_invariants`/`compute_next`) is unchanged; only its callers pass a per-manager ticket set, so the tree cap, single-`spec_pending`, and unique-lead-title invariants become per-manager for free. Old flat `/api/manager/*` routes are removed (no shipped external consumer) rather than aliased, which would reintroduce implicit-singleton behavior. Alternatives (project-slug key, repo-path key, many-managers-per-repo) are weighed in the RFC.

## Test Plan

- `cd backend && uv run pre-commit run --all-files` (black/isort/ruff/codespell/mypy).
- `cd backend && uv run pytest` — full suite.
- Isolated end-to-end run: started a throwaway backend on a separate port/data dir and drove the real CLI across two repos.

## Test Result

- pre-commit: all hooks pass.
- pytest: 2455 passed.
- e2e: two managers minted distinct ids keyed by repo; `manager ls` enumerates both with counts; re-init from the same repo is idempotent (same id); a repo reusing another manager's channels is rejected with 409; a bare command from a repo cwd resolves to that repo's manager; manager A sees its ticket while B does not, and the ticket carries the right `manager_id`; deinit of one manager leaves the other intact.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [ ] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional).
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [x] I have updated documentation or config examples (`docs/`) if user-facing behavior changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)