### PR TITLE
feat: rework the board page into a mobile-first board workspace with manager mode

### DIFF
--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type KeyboardEvent,
@@ -20,21 +21,50 @@ import {
   deleteBoardEntry,
   fetchBoardChannel,
   fetchBoardChannels,
+  fetchManagers,
+  fetchManagerState,
   isAuthError,
   postBoardEntry,
   updateBoardEntry,
 } from "@/lib/api";
+import {
+  CHANNEL_GROUP_COLLAPSED_DEFAULT,
+  CHANNEL_GROUP_LABELS,
+  CHANNEL_GROUP_ORDER,
+  classifyChannel,
+  isAwaiting,
+  kindTone,
+  laneForState,
+  LANES,
+  priorityTone,
+  rollupTickets,
+  stateLabel,
+  stateTone,
+  ticketIdFromChannel,
+  type ChannelGroupKey,
+} from "@/lib/board";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
-import { BoardChannel, BoardEntry, SessionEnvelope } from "@/lib/types";
+import {
+  BoardChannel,
+  BoardEntry,
+  ManagerStateResponse,
+  ManagerSummary,
+  ManagerTicket,
+  SessionEnvelope,
+} from "@/lib/types";
 import { formatRelativeTime } from "@/lib/usage";
 
 const RECONNECT_BASE_MS = 500;
 const RECONNECT_MAX_MS = 15000;
 const BOARD_REFRESH_DEBOUNCE_MS = 300;
 const LOG_LIMIT = 100;
+const MOBILE_BREAKPOINT = 720;
+const COLLAPSED_GROUPS_KEY = "waypoint.board.collapsedGroups";
+const SELECTED_MANAGER_KEY = "waypoint.board.manager";
 
 type LoadState = "loading" | "ready" | "error";
+type BoardView = "board" | "channels";
 
 function shortId(value: string): string {
   return value.length > 16 ? `${value.slice(0, 16)}…` : value;
@@ -50,6 +80,8 @@ function isScalarCell(entry: BoardEntry): boolean {
 
 // The brief cell, promoted above the rest of the board.
 const HERO_CELL_KEY = "plan";
+// The tech-lead feedback cell, promoted into a semantic state banner.
+const STATUS_CELL_KEY = "status";
 
 // The common author of a set of entries, or null when they disagree or none
 // has one. Lets the board state authorship once instead of on every card.
@@ -60,6 +92,93 @@ function uniformAuthor(entries: BoardEntry[]): string | null {
   return entries.every((entry) => entry.author_session_id === first)
     ? first
     : null;
+}
+
+// ─── Semantic metadata ───
+
+function metaString(
+  metadata: Record<string, unknown>,
+  key: string,
+): string | null {
+  const value = metadata[key];
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number") return String(value);
+  return null;
+}
+
+// Meta keys the semantic renderers pull out as first-class facts (PR link, CI
+// lamp, commit sha) plus `kind`, which surfaces as a tone/tag. Everything else
+// falls back to chips.
+const SEMANTIC_META_KEYS = new Set(["kind", "pr", "pr_url", "checks", "commit"]);
+
+interface SemanticFacts {
+  pr: string | null;
+  checks: string | null;
+  commit: string | null;
+  rest: Record<string, unknown>;
+}
+
+function semanticFacts(metadata: Record<string, unknown>): SemanticFacts {
+  const pr = metaString(metadata, "pr_url") ?? metaString(metadata, "pr");
+  const checks = metaString(metadata, "checks");
+  const commit = metaString(metadata, "commit");
+  const rest: Record<string, unknown> = {};
+  for (const key of Object.keys(metadata)) {
+    if (!SEMANTIC_META_KEYS.has(key)) rest[key] = metadata[key];
+  }
+  return { pr, checks, commit, rest };
+}
+
+function prNumber(pr: string): string | null {
+  const match = pr.match(/\/pull\/(\d+)|#(\d+)|\/(\d+)(?:$|[/?#])/);
+  return match ? match[1] ?? match[2] ?? match[3] ?? null : null;
+}
+
+// Green/passing → success, failing → danger, running/pending → warn.
+function ciTone(checks: string): "success" | "danger" | "warn" | "muted" {
+  const value = checks.toLowerCase();
+  if (/pass|green|success|ok/.test(value)) return "success";
+  if (/fail|red|error|broke/.test(value)) return "danger";
+  if (/pend|run|queue|progress/.test(value)) return "warn";
+  return "muted";
+}
+
+function SemanticFactRow({ facts }: { facts: SemanticFacts }) {
+  if (!facts.pr && !facts.checks && !facts.commit) return null;
+  const num = facts.pr ? prNumber(facts.pr) : null;
+  const isUrl = facts.pr ? /^https?:\/\//.test(facts.pr) : false;
+  return (
+    <div className="board-facts">
+      {facts.pr ? (
+        isUrl ? (
+          <a
+            className="board-fact board-fact-pr"
+            href={facts.pr}
+            target="_blank"
+            rel="noreferrer"
+            onClick={(event) => event.stopPropagation()}
+          >
+            ↗ PR{num ? ` #${num}` : ""}
+          </a>
+        ) : (
+          <span className="board-fact board-fact-pr">
+            PR{num ? ` #${num}` : ` ${facts.pr}`}
+          </span>
+        )
+      ) : null}
+      {facts.checks ? (
+        <span className="board-fact board-fact-ci">
+          <span className="board-lamp" data-tone={ciTone(facts.checks)} />
+          checks {facts.checks}
+        </span>
+      ) : null}
+      {facts.commit ? (
+        <span className="board-fact board-fact-commit">
+          ◇ {facts.commit.slice(0, 8)}
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 function MetaChips({ metadata }: { metadata: Record<string, unknown> }) {
@@ -293,6 +412,403 @@ function EntryExpansion({
   );
 }
 
+// ─── Navigator ───
+
+interface NavigatorProps {
+  channels: BoardChannel[];
+  activeChannel: string | null;
+  search: string;
+  onSearch: (value: string) => void;
+  collapsed: Set<string>;
+  onToggleGroup: (group: string) => void;
+  channelTicket: (channel: string) => ManagerTicket | null;
+  attention: (channel: string) => boolean;
+  onSelect: (channel: string) => void;
+}
+
+function Navigator({
+  channels,
+  activeChannel,
+  search,
+  onSearch,
+  collapsed,
+  onToggleGroup,
+  channelTicket,
+  attention,
+  onSelect,
+}: NavigatorProps) {
+  const grouped = useMemo(() => {
+    const filter = search.trim().toLowerCase();
+    const groups: Record<ChannelGroupKey, BoardChannel[]> = {
+      manager: [],
+      ticket: [],
+      job: [],
+      other: [],
+    };
+    for (const channel of channels) {
+      if (filter && !channel.channel.toLowerCase().includes(filter)) continue;
+      groups[classifyChannel(channel.channel)].push(channel);
+    }
+    return groups;
+  }, [channels, search]);
+
+  return (
+    <div className="board-nav">
+      <div className="board-nav-search">
+        <span className="board-nav-search-cue" aria-hidden="true">
+          ⌕
+        </span>
+        <input
+          className="board-nav-search-input"
+          type="search"
+          placeholder="Filter channels"
+          value={search}
+          onChange={(event) => onSearch(event.target.value)}
+          aria-label="Filter channels"
+        />
+      </div>
+      <div className="board-nav-groups">
+        {CHANNEL_GROUP_ORDER.map((group) => {
+          const rows = grouped[group];
+          if (rows.length === 0) return null;
+          const isCollapsed = collapsed.has(group);
+          const attentionCount = rows.filter((row) =>
+            attention(row.channel),
+          ).length;
+          return (
+            <section key={group} className="board-nav-group">
+              <button
+                type="button"
+                className="board-nav-group-head"
+                onClick={() => onToggleGroup(group)}
+                aria-expanded={!isCollapsed}
+              >
+                <span className="board-nav-group-chevron" aria-hidden="true">
+                  ›
+                </span>
+                <span className="board-nav-group-label">
+                  {CHANNEL_GROUP_LABELS[group]}
+                </span>
+                {attentionCount > 0 ? (
+                  <span
+                    className="board-nav-group-attention"
+                    title={`${attentionCount} awaiting you`}
+                  />
+                ) : null}
+                <span className="board-nav-group-count">{rows.length}</span>
+              </button>
+              {isCollapsed ? null : (
+                <ul className="board-nav-list">
+                  {rows.map((row) => {
+                    const ticket = channelTicket(row.channel);
+                    const needsYou = attention(row.channel);
+                    return (
+                      <li key={row.channel}>
+                        <button
+                          type="button"
+                          className={`board-nav-item${
+                            row.channel === activeChannel ? " is-active" : ""
+                          }`}
+                          onClick={() => onSelect(row.channel)}
+                        >
+                          {ticket ? (
+                            <span
+                              className="board-lamp board-nav-lamp"
+                              data-tone={stateTone(ticket.state)}
+                              title={stateLabel(ticket.state)}
+                            />
+                          ) : (
+                            <span className="board-nav-lamp-spacer" />
+                          )}
+                          <span className="board-nav-name">{row.channel}</span>
+                          {needsYou ? (
+                            <span
+                              className="board-nav-attention"
+                              title="Awaiting you"
+                            />
+                          ) : null}
+                          <span className="board-nav-count">
+                            {row.entry_count}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─── Manager ticket board ───
+
+interface TicketCardProps {
+  ticket: ManagerTicket;
+  onOpen: (ticket: ManagerTicket) => void;
+}
+
+function TicketCard({ ticket, onOpen }: TicketCardProps) {
+  const awaiting = isAwaiting(ticket.state);
+  const num = ticket.pr_url ? prNumber(ticket.pr_url) : null;
+  return (
+    <article
+      className={`board-ticket${awaiting ? " is-awaiting" : ""}`}
+      role="button"
+      tabIndex={0}
+      onClick={() => onOpen(ticket)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          onOpen(ticket);
+        }
+      }}
+    >
+      <header className="board-ticket-head">
+        <span className="board-ticket-id">#{ticket.id}</span>
+        <span
+          className="board-ticket-priority"
+          data-tone={priorityTone(ticket.priority)}
+        >
+          {ticket.priority}
+        </span>
+      </header>
+      <p className="board-ticket-title">{ticket.title}</p>
+      <footer className="board-ticket-foot">
+        <span className="board-ticket-state">
+          <span className="board-lamp" data-tone={stateTone(ticket.state)} />
+          {stateLabel(ticket.state)}
+        </span>
+        {ticket.lead_session_id ? (
+          <span className="board-ticket-assignee">
+            {shortId(ticket.lead_session_id)}
+          </span>
+        ) : null}
+        {ticket.pr_url ? (
+          <span className="board-ticket-pr">↗ PR{num ? ` #${num}` : ""}</span>
+        ) : null}
+      </footer>
+    </article>
+  );
+}
+
+interface ManagerBoardProps {
+  managerState: ManagerStateResponse;
+  onOpenTicket: (ticket: ManagerTicket) => void;
+}
+
+function ManagerBoard({ managerState, onOpenTicket }: ManagerBoardProps) {
+  const tickets = managerState.tickets;
+  const rollup = useMemo(() => rollupTickets(tickets), [tickets]);
+  const needsYou = useMemo(
+    () =>
+      tickets
+        .filter((ticket) => isAwaiting(ticket.state))
+        .sort((a, b) => a.priority.localeCompare(b.priority)),
+    [tickets],
+  );
+  const byLane = useMemo(() => {
+    const map = new Map<string, ManagerTicket[]>();
+    for (const lane of LANES) map.set(lane.key, []);
+    for (const ticket of tickets) {
+      const lane = laneForState(ticket.state);
+      map.get(lane)?.push(ticket);
+    }
+    return map;
+  }, [tickets]);
+
+  return (
+    <div className="board-manager">
+      <div className="board-rollup" role="status">
+        <span className="board-rollup-item board-rollup-need">
+          <strong>{rollup.needYou}</strong> need you
+        </span>
+        <span className="board-rollup-sep" aria-hidden="true">
+          ·
+        </span>
+        <span className="board-rollup-item">
+          <strong>{rollup.inFlight}</strong> in flight
+        </span>
+        <span className="board-rollup-sep" aria-hidden="true">
+          ·
+        </span>
+        <span className="board-rollup-item">
+          <strong>{rollup.blocked}</strong> blocked
+        </span>
+        <span className="board-rollup-sep" aria-hidden="true">
+          ·
+        </span>
+        <span className="board-rollup-item">
+          <strong>{rollup.merged}</strong> merged
+        </span>
+      </div>
+
+      {needsYou.length > 0 ? (
+        <section className="board-needs" aria-label="Needs you">
+          <h3 className="board-needs-title">Needs you</h3>
+          <div className="board-needs-strip">
+            {needsYou.map((ticket) => (
+              <NeedsYouCard
+                key={ticket.id}
+                ticket={ticket}
+                onOpen={onOpenTicket}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      <section className="board-lanes" aria-label="Lifecycle board">
+        {LANES.map((lane) => {
+          const laneTickets = byLane.get(lane.key) ?? [];
+          const isDone = lane.key === "done";
+          if (laneTickets.length === 0) {
+            return (
+              <div key={lane.key} className="board-lane is-empty">
+                <div className="board-lane-head">
+                  <span className="board-lane-label">{lane.label}</span>
+                  <span className="board-lane-count">0</span>
+                </div>
+              </div>
+            );
+          }
+          return (
+            <div
+              key={lane.key}
+              className={`board-lane${isDone ? " is-done" : ""}`}
+            >
+              <div className="board-lane-head">
+                <span className="board-lane-label">{lane.label}</span>
+                <span className="board-lane-count">{laneTickets.length}</span>
+              </div>
+              <div className="board-lane-cards">
+                {laneTickets.map((ticket) => (
+                  <TicketCard
+                    key={ticket.id}
+                    ticket={ticket}
+                    onOpen={onOpenTicket}
+                  />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </section>
+    </div>
+  );
+}
+
+function NeedsYouCard({
+  ticket,
+  onOpen,
+}: {
+  ticket: ManagerTicket;
+  onOpen: (ticket: ManagerTicket) => void;
+}) {
+  const gate =
+    ticket.state === "review_requested"
+      ? "PR review"
+      : ticket.state === "spec_review"
+        ? "Spec review"
+        : "Blocked";
+  const num = ticket.pr_url ? prNumber(ticket.pr_url) : null;
+  const summary =
+    ticket.state === "review_requested" && ticket.pr_url
+      ? `Review PR${num ? ` #${num}` : ""} and merge, request changes, or abort.`
+      : ticket.state === "spec_review"
+        ? "Approve the spec, request changes, or reject."
+        : "The tech-lead is blocked and needs your decision.";
+  return (
+    <article className="board-need-card board-dogear">
+      <header className="board-need-head">
+        <span className="board-need-id">#{ticket.id}</span>
+        <span
+          className="board-ticket-priority"
+          data-tone={priorityTone(ticket.priority)}
+        >
+          {ticket.priority}
+        </span>
+        <span className="board-need-gate" data-tone={stateTone(ticket.state)}>
+          <span className="board-lamp" data-tone={stateTone(ticket.state)} />
+          {gate}
+        </span>
+      </header>
+      <p className="board-need-ticket-title">{ticket.title}</p>
+      <p className="board-need-summary">{summary}</p>
+      <div className="board-need-actions">
+        {ticket.inbox_item_id ? (
+          <Link
+            className="board-need-link"
+            href={`/inbox?item=${encodeURIComponent(ticket.inbox_item_id)}`}
+          >
+            open in inbox →
+          </Link>
+        ) : (
+          <span className="board-need-link is-disabled">no inbox item</span>
+        )}
+        <button
+          type="button"
+          className="board-need-open"
+          onClick={() => onOpen(ticket)}
+        >
+          open channel
+        </button>
+      </div>
+    </article>
+  );
+}
+
+interface ManagerSwitcherProps {
+  managers: ManagerSummary[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}
+
+function ManagerSwitcher({
+  managers,
+  selectedId,
+  onSelect,
+}: ManagerSwitcherProps) {
+  const selected =
+    managers.find((manager) => manager.id === selectedId) ?? managers[0];
+  if (managers.length === 1) {
+    return (
+      <div className="board-switcher board-switcher-static">
+        <span className="board-switcher-label">project</span>
+        <span className="board-switcher-project">{selected.project}</span>
+      </div>
+    );
+  }
+  return (
+    <label className="board-switcher">
+      <span className="board-switcher-label">project</span>
+      <span className="board-switcher-select">
+        <select
+          value={selected.id}
+          onChange={(event) => onSelect(event.target.value)}
+          aria-label="Select manager project"
+        >
+          {managers.map((manager) => (
+            <option key={manager.id} value={manager.id}>
+              {manager.project}
+              {manager.attention_count > 0 ? ` (${manager.attention_count})` : ""}
+            </option>
+          ))}
+        </select>
+        {selected.attention_count > 0 ? (
+          <span
+            className="board-switcher-attention"
+            title={`${selected.attention_count} awaiting you`}
+          />
+        ) : null}
+      </span>
+    </label>
+  );
+}
+
 export default function BoardPage() {
   const router = useRouter();
   const { theme } = useTheme();
@@ -315,6 +831,21 @@ export default function BoardPage() {
   const [editDraft, setEditDraft] = useState("");
   const [savingEdit, setSavingEdit] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+
+  // Board workspace: view switch, manager mode, grouped navigator, mobile drawer.
+  const [view, setView] = useState<BoardView>("channels");
+  const [managers, setManagers] = useState<ManagerSummary[]>([]);
+  const [selectedManagerId, setSelectedManagerId] = useState<string | null>(null);
+  const [managerState, setManagerState] = useState<ManagerStateResponse | null>(
+    null,
+  );
+  const [search, setSearch] = useState("");
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [navOpen, setNavOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+  const drawerRef = useRef<HTMLDivElement | null>(null);
+
+  const managerMode = managers.length > 0;
 
   // Expand/collapse a card. Never collapse the card you're editing (that would
   // drop the draft); activating a different card cancels any open edit/confirm
@@ -343,9 +874,20 @@ export default function BoardPage() {
   useEffect(() => {
     activeChannelRef.current = activeChannel;
   }, [activeChannel]);
+  const selectedManagerRef = useRef<string | null>(null);
+  useEffect(() => {
+    selectedManagerRef.current = selectedManagerId;
+  }, [selectedManagerId]);
 
   // A `?channel=` deep link selects that channel once it loads.
   const pendingChannelRef = useRef<string | null>(null);
+  // Resolve the initial view once, after channels and managers first load.
+  const viewResolvedRef = useRef(false);
+  const requestedViewRef = useRef<BoardView | null>(null);
+  // Whether the load carried a `?channel=` deep link. `pendingChannelRef` is
+  // cleared as soon as the channel is selected, so the view resolver reads this
+  // stable flag instead to open Channels for a deep link.
+  const deepLinkRef = useRef(false);
 
   const handleAuthFailure = useCallback(() => {
     clearToken();
@@ -358,12 +900,48 @@ export default function BoardPage() {
     const currentToken = readToken();
     setHost(currentHost);
     setToken(currentToken);
-    const requested = new URLSearchParams(window.location.search).get("channel");
-    if (requested) pendingChannelRef.current = requested;
+    const params = new URLSearchParams(window.location.search);
+    const requestedChannel = params.get("channel");
+    if (requestedChannel) {
+      pendingChannelRef.current = requestedChannel;
+      deepLinkRef.current = true;
+    }
+    const requestedView = params.get("view");
+    if (requestedView === "board" || requestedView === "channels") {
+      requestedViewRef.current = requestedView;
+    }
+    try {
+      const stored = window.localStorage.getItem(COLLAPSED_GROUPS_KEY);
+      if (stored) {
+        setCollapsedGroups(new Set(JSON.parse(stored) as string[]));
+      } else {
+        setCollapsedGroups(
+          new Set(
+            CHANNEL_GROUP_ORDER.filter(
+              (group) => CHANNEL_GROUP_COLLAPSED_DEFAULT[group],
+            ),
+          ),
+        );
+      }
+      const storedManager = window.localStorage.getItem(SELECTED_MANAGER_KEY);
+      if (storedManager) setSelectedManagerId(storedManager);
+    } catch {
+      // localStorage may be unavailable; defaults are fine.
+    }
     if (!currentHost || !currentToken) {
       router.replace("/");
     }
   }, [router]);
+
+  // Track the mobile breakpoint so the navigator becomes a drawer and the
+  // focus-trap engages only below it.
+  useEffect(() => {
+    const query = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`);
+    const update = () => setIsMobile(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
 
   const refreshChannels = useCallback(async () => {
     if (!host || !token) return;
@@ -388,6 +966,42 @@ export default function BoardPage() {
       setState("error");
     }
   }, [host, token, handleAuthFailure]);
+
+  const refreshManagers = useCallback(async () => {
+    if (!host || !token) return;
+    try {
+      const list = await fetchManagers(host, token);
+      setManagers(list);
+      setSelectedManagerId((current) => {
+        if (current && list.some((m) => m.id === current)) return current;
+        return list[0]?.id ?? null;
+      });
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      // Manager read failures degrade to general mode rather than block the page.
+      setManagers([]);
+    }
+  }, [host, token, handleAuthFailure]);
+
+  const refreshManagerState = useCallback(
+    async (managerId: string) => {
+      if (!host || !token) return;
+      try {
+        const next = await fetchManagerState(host, token, managerId);
+        setManagerState(next);
+      } catch (err) {
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return;
+        }
+        setManagerState(null);
+      }
+    },
+    [host, token, handleAuthFailure],
+  );
 
   const refreshEntries = useCallback(
     async (channel: string) => {
@@ -441,7 +1055,37 @@ export default function BoardPage() {
 
   useEffect(() => {
     void refreshChannels();
-  }, [refreshChannels]);
+    void refreshManagers();
+  }, [refreshChannels, refreshManagers]);
+
+  // Once channels and managers have loaded, resolve the initial view: an explicit
+  // `?view=` wins; a `?channel=` deep link opens Channels; otherwise open Board
+  // when a manager exists, else Channels.
+  useEffect(() => {
+    if (viewResolvedRef.current || state !== "ready") return;
+    viewResolvedRef.current = true;
+    if (requestedViewRef.current) {
+      setView(requestedViewRef.current);
+    } else if (deepLinkRef.current) {
+      setView("channels");
+    } else {
+      setView(managers.length > 0 ? "board" : "channels");
+    }
+  }, [state, managers]);
+
+  // Fetch the selected manager's board data when it changes.
+  useEffect(() => {
+    if (!selectedManagerId) {
+      setManagerState(null);
+      return;
+    }
+    try {
+      window.localStorage.setItem(SELECTED_MANAGER_KEY, selectedManagerId);
+    } catch {
+      // ignore
+    }
+    void refreshManagerState(selectedManagerId);
+  }, [selectedManagerId, refreshManagerState]);
 
   useEffect(() => {
     setExpandedId(null);
@@ -451,16 +1095,21 @@ export default function BoardPage() {
     if (activeChannel) {
       setDraftChannel(activeChannel);
       void refreshEntries(activeChannel);
-      // Keep the URL shareable without triggering a navigation.
-      window.history.replaceState(
-        null,
-        "",
-        `/board?channel=${encodeURIComponent(activeChannel)}`,
-      );
     } else {
       setEntries([]);
     }
   }, [activeChannel, refreshEntries]);
+
+  // Keep the URL shareable (view + channel) without triggering a navigation.
+  useEffect(() => {
+    if (state !== "ready") return;
+    const params = new URLSearchParams();
+    params.set("view", view);
+    if (view === "channels" && activeChannel) {
+      params.set("channel", activeChannel);
+    }
+    window.history.replaceState(null, "", `/board?${params.toString()}`);
+  }, [view, activeChannel, state]);
 
   useEffect(() => {
     if (!host || !token) return;
@@ -481,6 +1130,11 @@ export default function BoardPage() {
         boardRefreshTimer = null;
         if (!active) return;
         void refreshChannels();
+        // A gate arrival or ticket-state change shows up on the manager board
+        // without a reload: refresh the switcher and the selected manager.
+        void refreshManagers();
+        const manager = selectedManagerRef.current;
+        if (manager) void refreshManagerState(manager);
         if (entriesDirty) {
           entriesDirty = false;
           const current = activeChannelRef.current;
@@ -533,7 +1187,46 @@ export default function BoardPage() {
       if (boardRefreshTimer !== null) clearTimeout(boardRefreshTimer);
       socket?.close();
     };
-  }, [host, token, refreshChannels, refreshEntries, handleAuthFailure]);
+  }, [
+    host,
+    token,
+    refreshChannels,
+    refreshManagers,
+    refreshManagerState,
+    refreshEntries,
+    handleAuthFailure,
+  ]);
+
+  // Close the mobile drawer on Escape and trap focus within it while open.
+  useEffect(() => {
+    if (!navOpen) return;
+    const node = drawerRef.current;
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setNavOpen(false);
+        return;
+      }
+      if (event.key !== "Tab" || !node) return;
+      const focusables = node.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled]), input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    const search = node?.querySelector<HTMLElement>(".board-nav-search-input");
+    search?.focus();
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [navOpen]);
 
   const handlePost = useCallback(async () => {
     const channel = draftChannel.trim();
@@ -549,6 +1242,7 @@ export default function BoardPage() {
       setDraftText("");
       setDraftKey("");
       setActiveChannel(channel);
+      setView("channels");
       await refreshChannels();
       await refreshEntries(channel);
     } catch (err) {
@@ -703,6 +1397,68 @@ export default function BoardPage() {
     ],
   );
 
+  const toggleGroup = useCallback((group: string) => {
+    setCollapsedGroups((current) => {
+      const next = new Set(current);
+      if (next.has(group)) next.delete(group);
+      else next.add(group);
+      try {
+        window.localStorage.setItem(
+          COLLAPSED_GROUPS_KEY,
+          JSON.stringify([...next]),
+        );
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  const selectChannel = useCallback(
+    (channel: string) => {
+      setActiveChannel(channel);
+      setView("channels");
+      setNavOpen(false);
+    },
+    [],
+  );
+
+  const openTicket = useCallback(
+    (ticket: ManagerTicket) => {
+      const prefix = managerState?.config?.render_context?.ticket_channel_prefix;
+      if (prefix) {
+        const channel = `${prefix}${ticket.id}`;
+        if (channels.some((c) => c.channel === channel)) {
+          selectChannel(channel);
+          return;
+        }
+      }
+      if (ticket.inbox_item_id) {
+        router.push(`/inbox?item=${encodeURIComponent(ticket.inbox_item_id)}`);
+      }
+    },
+    [managerState, channels, selectChannel, router],
+  );
+
+  // Map ticket channels to their manager ticket for navigator lamps + attention.
+  const ticketByChannel = useCallback(
+    (channel: string): ManagerTicket | null => {
+      const prefix = managerState?.config?.render_context?.ticket_channel_prefix;
+      const id = ticketIdFromChannel(channel, prefix);
+      if (!id) return null;
+      return managerState?.tickets.find((t) => t.id === id) ?? null;
+    },
+    [managerState],
+  );
+
+  const channelAttention = useCallback(
+    (channel: string): boolean => {
+      const ticket = ticketByChannel(channel);
+      return ticket ? isAwaiting(ticket.state) : false;
+    },
+    [ticketByChannel],
+  );
+
   // The two shapes the board is built on: keyed cells (latest-wins
   // variables, pinned) and the append-only log (newest first).
   const cells = entries
@@ -711,11 +1467,14 @@ export default function BoardPage() {
   const log = entries.filter((entry) => !entry.key).reverse();
   const hasOlder = log.length < logTotal;
 
-  // Cells are ranked by shape rather than rendered uniformly: `plan` is the
-  // brief and leads as a hero; short scalars collapse into a state strip; the
-  // rest stay as cards.
+  // Cells are ranked by shape rather than rendered uniformly: `status` is the
+  // tech-lead feedback banner, `plan` is the brief hero, short scalars collapse
+  // into a state strip, the rest stay as cards.
+  const statusCell = cells.find((entry) => entry.key === STATUS_CELL_KEY) ?? null;
   const heroCell = cells.find((entry) => entry.key === HERO_CELL_KEY) ?? null;
-  const bodyCells = cells.filter((entry) => entry !== heroCell);
+  const bodyCells = cells.filter(
+    (entry) => entry !== heroCell && entry !== statusCell,
+  );
   const scalarCells = bodyCells.filter(isScalarCell);
   const cardCells = bodyCells.filter((entry) => !isScalarCell(entry));
   // When every cell shares an author, name them once above the grid and drop
@@ -741,10 +1500,34 @@ export default function BoardPage() {
     onCancelDelete: cancelDelete,
   };
 
+  const navigator = (
+    <Navigator
+      channels={channels}
+      activeChannel={activeChannel}
+      search={search}
+      onSearch={setSearch}
+      collapsed={collapsedGroups}
+      onToggleGroup={toggleGroup}
+      channelTicket={ticketByChannel}
+      attention={channelAttention}
+      onSelect={selectChannel}
+    />
+  );
+
   return (
-    <main className="page-shell">
+    <main className="page-shell board-shell">
       <header className="app-bar">
         <div className="app-bar-brand">
+          {isMobile ? (
+            <button
+              type="button"
+              className="board-hamburger"
+              onClick={() => setNavOpen(true)}
+              aria-label="Open channels"
+            >
+              ☰
+            </button>
+          ) : null}
           <Link className="app-bar-mark" href="/" aria-label="Waypoint home">
             <Image
               src={theme === "light" ? "/waypoint-light.svg" : "/waypoint.svg"}
@@ -760,6 +1543,34 @@ export default function BoardPage() {
           </div>
         </div>
         <div className="app-bar-meta">
+          <div
+            className="board-viewswitch"
+            role="tablist"
+            aria-label="Board view"
+          >
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "board"}
+              className={`board-viewswitch-tab${
+                view === "board" ? " is-active" : ""
+              }`}
+              onClick={() => setView("board")}
+            >
+              Board
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={view === "channels"}
+              className={`board-viewswitch-tab${
+                view === "channels" ? " is-active" : ""
+              }`}
+              onClick={() => setView("channels")}
+            >
+              Channels
+            </button>
+          </div>
           <Link className="back-link" href="/">
             ← all sessions
           </Link>
@@ -848,7 +1659,7 @@ export default function BoardPage() {
         ) : null}
       </section>
 
-      {state === "ready" && channels.length === 0 ? (
+      {state === "ready" && channels.length === 0 && !managerMode ? (
         <section className="panel bordered board-empty">
           <h2>The board is empty</h2>
           <p className="muted">
@@ -859,277 +1670,374 @@ export default function BoardPage() {
         </section>
       ) : null}
 
-      {state === "ready" && channels.length > 0 ? (
+      {state === "ready" && (channels.length > 0 || managerMode) ? (
         <section className="board-grid">
-          <aside className="panel board-rail" aria-label="Channels">
-            <div className="board-rail-head">
-              <h2 className="board-rail-title">Channels</h2>
-              <span className="board-rail-count">{channels.length}</span>
-            </div>
-            <ul className="board-rail-list">
-              {channels.map((channel) => (
-                <li key={channel.channel}>
+          {/* Desktop navigator; on mobile this is hidden and the drawer takes over. */}
+          {!isMobile ? (
+            <aside className="panel board-rail" aria-label="Channels">
+              {navigator}
+            </aside>
+          ) : null}
+
+          {isMobile && navOpen ? (
+            <div className="board-drawer-scrim" onClick={() => setNavOpen(false)}>
+              <div
+                className="board-drawer"
+                ref={drawerRef}
+                role="dialog"
+                aria-modal="true"
+                aria-label="Channels"
+                onClick={stopEvent}
+              >
+                <div className="board-drawer-head">
+                  <h2 className="board-drawer-title">Channels</h2>
                   <button
                     type="button"
-                    className={`board-rail-item${
-                      channel.channel === activeChannel ? " is-active" : ""
-                    }`}
-                    onClick={() => setActiveChannel(channel.channel)}
+                    className="board-drawer-close"
+                    onClick={() => setNavOpen(false)}
+                    aria-label="Close channels"
                   >
-                    <span className="board-rail-name">{channel.channel}</span>
-                    <span className="board-rail-meta">
-                      <span className="board-rail-badge">
-                        {channel.entry_count}
-                      </span>
-                      <span className="board-rail-time">
-                        {formatRelativeTime(channel.last_created_at)}
-                      </span>
-                    </span>
+                    ×
                   </button>
-                </li>
-              ))}
-            </ul>
-          </aside>
+                </div>
+                {navigator}
+              </div>
+            </div>
+          ) : null}
 
           <div className="board-main">
-            {activeChannel ? (
-              <div className="board-main-head">
-                <div>
-                  <p className="board-main-eyebrow">channel</p>
-                  <h2 className="board-main-title">{activeChannel}</h2>
-                </div>
-                <div className="board-actions">
-                  <button
-                    type="button"
-                    className="board-action"
-                    onClick={() => void handleClear(activeChannel)}
-                  >
-                    Clear posts
-                  </button>
-                  <button
-                    type="button"
-                    className="board-action board-action-danger"
-                    onClick={() => void handleDeleteChannel(activeChannel)}
-                  >
-                    Delete channel
-                  </button>
-                </div>
-              </div>
-            ) : null}
-
-            {cells.length > 0 ? (
-              <section className="board-cells" aria-label="Cells">
-                <h3 className="board-group-label">
-                  Cells · latest value
-                  {cellAuthor ? (
-                    <span className="board-group-by">
-                      {" · all by "}
-                      {shortId(cellAuthor)}
-                    </span>
+            {view === "board" ? (
+              <div className="board-workspace">
+                <div className="board-context">
+                  <div className="board-context-titles">
+                    <p className="board-main-eyebrow">workspace</p>
+                    <h2 className="board-main-title">
+                      {managerMode ? "Ticket board" : "Channels overview"}
+                    </h2>
+                  </div>
+                  {managerMode && managers.length > 0 ? (
+                    <ManagerSwitcher
+                      managers={managers}
+                      selectedId={selectedManagerId}
+                      onSelect={setSelectedManagerId}
+                    />
                   ) : null}
-                </h3>
+                </div>
 
-                {heroCell ? (
-                  <article
-                    className={`board-hero${
-                      expandedId === heroCell.id ? " is-expanded" : ""
-                    }`}
-                    role="button"
-                    tabIndex={0}
-                    aria-expanded={expandedId === heroCell.id}
-                    onClick={() => activateEntry(heroCell.id)}
-                    onKeyDown={(event) => onEntryKeyDown(event, heroCell.id)}
-                  >
-                    <header className="board-hero-head">
-                      <span className="board-hero-key">{heroCell.key}</span>
-                      <span className="board-cell-time">
-                        {formatRelativeTime(heroCell.created_at)}
-                        {heroCell.edited_at ? (
-                          <span className="board-edited"> · edited</span>
-                        ) : null}
-                        <span className="board-expand-cue" aria-hidden="true">
-                          ›
+                {managerMode && managerState ? (
+                  <ManagerBoard
+                    managerState={managerState}
+                    onOpenTicket={openTicket}
+                  />
+                ) : managerMode ? (
+                  <p className="board-log-empty">Loading manager board…</p>
+                ) : (
+                  <ChannelsOverview
+                    channels={channels}
+                    onSelect={selectChannel}
+                  />
+                )}
+              </div>
+            ) : (
+              <div className="board-detail-view">
+                {activeChannel ? (
+                  <div className="board-context">
+                    <div className="board-context-titles">
+                      <p className="board-main-eyebrow">channel</p>
+                      <h2 className="board-main-title">{activeChannel}</h2>
+                    </div>
+                    <div className="board-actions">
+                      <button
+                        type="button"
+                        className="board-action"
+                        onClick={() => void handleClear(activeChannel)}
+                      >
+                        Clear posts
+                      </button>
+                      <button
+                        type="button"
+                        className="board-action board-action-danger"
+                        onClick={() => void handleDeleteChannel(activeChannel)}
+                      >
+                        Delete channel
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+
+                {statusCell ? (
+                  <StatusBanner
+                    entry={statusCell}
+                    controls={controls}
+                    expanded={expandedId === statusCell.id}
+                    onActivate={() => activateEntry(statusCell.id)}
+                    onKeyDown={(event) => onEntryKeyDown(event, statusCell.id)}
+                  />
+                ) : null}
+
+                {cells.length > 0 ? (
+                  <section className="board-cells" aria-label="Cells">
+                    <h3 className="board-group-label">
+                      Cells · latest value
+                      {cellAuthor ? (
+                        <span className="board-group-by">
+                          {" · all by "}
+                          {shortId(cellAuthor)}
                         </span>
-                      </span>
-                    </header>
-                    <EntryExpansion entry={heroCell} controls={controls}>
-                      <>
-                        <p className="board-hero-value">{heroCell.text}</p>
-                        <MetaChips metadata={heroCell.metadata} />
-                      </>
-                    </EntryExpansion>
-                  </article>
-                ) : null}
+                      ) : null}
+                    </h3>
 
-                {scalarCells.length > 0 ? (
-                  <ul className="board-state-list">
-                    {scalarCells.map((entry) => (
-                      <li key={entry.id} className="board-state-wrap">
-                        <div
-                          className={`board-state-row${
-                            expandedId === entry.id ? " is-expanded" : ""
-                          }`}
-                          role="button"
-                          tabIndex={0}
-                          aria-expanded={expandedId === entry.id}
-                          onClick={() => activateEntry(entry.id)}
-                          onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
-                        >
-                          <span className="board-state-key">{entry.key}</span>
-                          {editingId === entry.id ? null : (
-                            <span className="board-state-value">
-                              {entry.text}
-                            </span>
-                          )}
-                          <MetaChips metadata={entry.metadata} />
-                          {cellAuthor ? null : (
-                            <span className="board-state-author">
-                              {entry.author_session_id
-                                ? shortId(entry.author_session_id)
-                                : "—"}
-                            </span>
-                          )}
-                          <span className="board-state-time">
-                            {formatRelativeTime(entry.created_at)}
-                            {entry.edited_at ? (
-                              <span className="board-edited"> · edited</span>
-                            ) : null}
-                            <span className="board-expand-cue" aria-hidden="true">
-                              ›
-                            </span>
-                          </span>
-                        </div>
-                        <EntryExpansion entry={entry} controls={controls}>
-                          {null}
-                        </EntryExpansion>
-                      </li>
-                    ))}
-                  </ul>
-                ) : null}
-
-                {cardCells.length > 0 ? (
-                  <div className="board-cell-grid">
-                    {cardCells.map((entry) => (
+                    {heroCell ? (
                       <article
-                        key={entry.id}
-                        className={`board-cell${
-                          expandedId === entry.id ? " is-expanded" : ""
+                        className={`board-hero${
+                          expandedId === heroCell.id ? " is-expanded" : ""
                         }`}
                         role="button"
                         tabIndex={0}
-                        aria-expanded={expandedId === entry.id}
-                        onClick={() => activateEntry(entry.id)}
-                        onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
+                        aria-expanded={expandedId === heroCell.id}
+                        onClick={() => activateEntry(heroCell.id)}
+                        onKeyDown={(event) => onEntryKeyDown(event, heroCell.id)}
                       >
-                        <header className="board-cell-head">
-                          <span className="board-cell-key">{entry.key}</span>
+                        <header className="board-hero-head">
+                          <span className="board-hero-key">{heroCell.key}</span>
                           <span className="board-cell-time">
-                            {formatRelativeTime(entry.created_at)}
-                            {entry.edited_at ? (
+                            {formatRelativeTime(heroCell.created_at)}
+                            {heroCell.edited_at ? (
                               <span className="board-edited"> · edited</span>
                             ) : null}
-                            <span className="board-expand-cue" aria-hidden="true">
+                            <span
+                              className="board-expand-cue"
+                              aria-hidden="true"
+                            >
                               ›
                             </span>
                           </span>
                         </header>
-                        <EntryExpansion entry={entry} controls={controls}>
+                        <EntryExpansion entry={heroCell} controls={controls}>
                           <>
-                            <p className="board-cell-value">{entry.text}</p>
-                            {cellAuthor ? null : (
-                              <footer className="board-cell-foot">
-                                <span className="board-cell-author">
-                                  {entry.author_session_id
-                                    ? shortId(entry.author_session_id)
-                                    : "—"}
-                                </span>
-                              </footer>
-                            )}
-                            <MetaChips metadata={entry.metadata} />
+                            <p className="board-hero-value">{heroCell.text}</p>
+                            <MetaChips metadata={heroCell.metadata} />
                           </>
                         </EntryExpansion>
                       </article>
-                    ))}
-                  </div>
-                ) : null}
-              </section>
-            ) : null}
+                    ) : null}
 
-            <section className="board-log" aria-label="Log">
-              {cells.length > 0 ? (
-                <h3 className="board-group-label">
-                  Log · newest first
-                  {logAuthor ? (
-                    <span className="board-group-by">
-                      {" · all by "}
-                      {shortId(logAuthor)}
-                    </span>
-                  ) : null}
-                </h3>
-              ) : null}
-              {log.length === 0 ? (
-                <p className="board-log-empty">
-                  {cells.length > 0
-                    ? "No log posts in this channel."
-                    : "No entries yet."}
-                </p>
-              ) : (
-                <ol className="board-log-list">
-                  {log.map((entry) => (
-                    <li key={entry.id} className="board-log-item">
-                      <div className="board-log-rail" aria-hidden="true" />
-                      <div
-                        className={`board-log-body${
-                          expandedId === entry.id ? " is-expanded" : ""
-                        }`}
-                        role="button"
-                        tabIndex={0}
-                        aria-expanded={expandedId === entry.id}
-                        onClick={() => activateEntry(entry.id)}
-                        onKeyDown={(event) => onEntryKeyDown(event, entry.id)}
-                      >
-                        <EntryExpansion entry={entry} controls={controls}>
-                          <div className="board-log-main">
-                            <p className="board-log-text">{entry.text}</p>
-                            <div className="board-log-meta">
-                              <span className="board-log-time">
-                                {formatRelativeTime(entry.created_at)}
-                                {entry.edited_at ? (
-                                  <span className="board-edited"> · edited</span>
-                                ) : null}
+                    {scalarCells.length > 0 ? (
+                      <ul className="board-state-list">
+                        {scalarCells.map((entry) => (
+                          <li key={entry.id} className="board-state-wrap">
+                            <div
+                              className={`board-state-row${
+                                expandedId === entry.id ? " is-expanded" : ""
+                              }`}
+                              role="button"
+                              tabIndex={0}
+                              aria-expanded={expandedId === entry.id}
+                              onClick={() => activateEntry(entry.id)}
+                              onKeyDown={(event) =>
+                                onEntryKeyDown(event, entry.id)
+                              }
+                            >
+                              <span className="board-state-key">
+                                {entry.key}
                               </span>
-                              {logAuthor ? null : (
-                                <span className="board-log-author">
+                              {editingId === entry.id ? null : (
+                                <span className="board-state-value">
+                                  {entry.text}
+                                </span>
+                              )}
+                              <MetaChips metadata={entry.metadata} />
+                              {cellAuthor ? null : (
+                                <span className="board-state-author">
                                   {entry.author_session_id
                                     ? shortId(entry.author_session_id)
                                     : "—"}
                                 </span>
                               )}
-                              <MetaChips metadata={entry.metadata} />
+                              <span className="board-state-time">
+                                {formatRelativeTime(entry.created_at)}
+                                {entry.edited_at ? (
+                                  <span className="board-edited"> · edited</span>
+                                ) : null}
+                                <span
+                                  className="board-expand-cue"
+                                  aria-hidden="true"
+                                >
+                                  ›
+                                </span>
+                              </span>
                             </div>
-                          </div>
-                        </EntryExpansion>
+                            <EntryExpansion entry={entry} controls={controls}>
+                              {null}
+                            </EntryExpansion>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+
+                    {cardCells.length > 0 ? (
+                      <div className="board-cell-grid">
+                        {cardCells.map((entry) => (
+                          <article
+                            key={entry.id}
+                            className={`board-cell${
+                              expandedId === entry.id ? " is-expanded" : ""
+                            }`}
+                            role="button"
+                            tabIndex={0}
+                            aria-expanded={expandedId === entry.id}
+                            onClick={() => activateEntry(entry.id)}
+                            onKeyDown={(event) =>
+                              onEntryKeyDown(event, entry.id)
+                            }
+                          >
+                            <header className="board-cell-head">
+                              <span className="board-cell-key">
+                                {entry.key}
+                              </span>
+                              <span className="board-cell-time">
+                                {formatRelativeTime(entry.created_at)}
+                                {entry.edited_at ? (
+                                  <span className="board-edited"> · edited</span>
+                                ) : null}
+                                <span
+                                  className="board-expand-cue"
+                                  aria-hidden="true"
+                                >
+                                  ›
+                                </span>
+                              </span>
+                            </header>
+                            <EntryExpansion entry={entry} controls={controls}>
+                              <>
+                                <p className="board-cell-value">{entry.text}</p>
+                                {cellAuthor ? null : (
+                                  <footer className="board-cell-foot">
+                                    <span className="board-cell-author">
+                                      {entry.author_session_id
+                                        ? shortId(entry.author_session_id)
+                                        : "—"}
+                                    </span>
+                                  </footer>
+                                )}
+                                <SemanticFactRow
+                                  facts={semanticFacts(entry.metadata)}
+                                />
+                                <MetaChips
+                                  metadata={semanticFacts(entry.metadata).rest}
+                                />
+                              </>
+                            </EntryExpansion>
+                          </article>
+                        ))}
                       </div>
-                    </li>
-                  ))}
-                </ol>
-              )}
-              {hasOlder ? (
-                <div className="board-log-more">
-                  <button
-                    type="button"
-                    className="board-load-older"
-                    onClick={() => void loadOlder()}
-                    disabled={loadingOlder}
-                  >
-                    {loadingOlder ? "Loading…" : "Load older"}
-                  </button>
-                  <span className="board-log-count">
-                    {log.length} of {logTotal}
-                  </span>
-                </div>
-              ) : null}
-            </section>
+                    ) : null}
+                  </section>
+                ) : null}
+
+                <section className="board-log" aria-label="Log">
+                  {cells.length > 0 ? (
+                    <h3 className="board-group-label">
+                      Log · newest first
+                      {logAuthor ? (
+                        <span className="board-group-by">
+                          {" · all by "}
+                          {shortId(logAuthor)}
+                        </span>
+                      ) : null}
+                    </h3>
+                  ) : null}
+                  {log.length === 0 ? (
+                    <p className="board-log-empty">
+                      {cells.length > 0
+                        ? "No log posts in this channel."
+                        : "No entries yet."}
+                    </p>
+                  ) : (
+                    <ol className="board-log-list">
+                      {log.map((entry) => {
+                        const kind = metaString(entry.metadata, "kind");
+                        const tone = kindTone(kind);
+                        const facts = semanticFacts(entry.metadata);
+                        const isRelay = kind === "relay";
+                        return (
+                          <li
+                            key={entry.id}
+                            className={`board-log-item${
+                              isRelay ? " is-relay" : ""
+                            }`}
+                            data-tone={tone}
+                          >
+                            <div className="board-log-rail" aria-hidden="true" />
+                            <div
+                              className={`board-log-body${
+                                expandedId === entry.id ? " is-expanded" : ""
+                              }`}
+                              role="button"
+                              tabIndex={0}
+                              aria-expanded={expandedId === entry.id}
+                              onClick={() => activateEntry(entry.id)}
+                              onKeyDown={(event) =>
+                                onEntryKeyDown(event, entry.id)
+                              }
+                            >
+                              <EntryExpansion entry={entry} controls={controls}>
+                                <div className="board-log-main">
+                                  {kind ? (
+                                    <span
+                                      className="board-log-tag"
+                                      data-tone={tone}
+                                    >
+                                      {isRelay ? "from you (via inbox)" : kind}
+                                    </span>
+                                  ) : null}
+                                  <p className="board-log-text">{entry.text}</p>
+                                  <SemanticFactRow facts={facts} />
+                                  <div className="board-log-meta">
+                                    <span className="board-log-time">
+                                      {formatRelativeTime(entry.created_at)}
+                                      {entry.edited_at ? (
+                                        <span className="board-edited">
+                                          {" "}
+                                          · edited
+                                        </span>
+                                      ) : null}
+                                    </span>
+                                    {logAuthor ? null : (
+                                      <span className="board-log-author">
+                                        {entry.author_session_id
+                                          ? shortId(entry.author_session_id)
+                                          : "—"}
+                                      </span>
+                                    )}
+                                    <MetaChips metadata={facts.rest} />
+                                  </div>
+                                </div>
+                              </EntryExpansion>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  )}
+                  {hasOlder ? (
+                    <div className="board-log-more">
+                      <button
+                        type="button"
+                        className="board-load-older"
+                        onClick={() => void loadOlder()}
+                        disabled={loadingOlder}
+                      >
+                        {loadingOlder ? "Loading…" : "Load older"}
+                      </button>
+                      <span className="board-log-count">
+                        {log.length} of {logTotal}
+                      </span>
+                    </div>
+                  ) : null}
+                </section>
+              </div>
+            )}
           </div>
         </section>
       ) : null}
@@ -1157,5 +2065,126 @@ export default function BoardPage() {
         </section>
       ) : null}
     </main>
+  );
+}
+
+// ─── Semantic status banner ───
+
+interface StatusBannerProps {
+  entry: BoardEntry;
+  controls: EntryControls;
+  expanded: boolean;
+  onActivate: () => void;
+  onKeyDown: (event: KeyboardEvent) => void;
+}
+
+function StatusBanner({
+  entry,
+  controls,
+  expanded,
+  onActivate,
+  onKeyDown,
+}: StatusBannerProps) {
+  const kind = metaString(entry.metadata, "kind");
+  const tone = kindTone(kind);
+  const facts = semanticFacts(entry.metadata);
+  return (
+    <article
+      className={`board-status-banner${expanded ? " is-expanded" : ""}`}
+      data-tone={tone}
+      role="button"
+      tabIndex={0}
+      aria-expanded={expanded}
+      onClick={onActivate}
+      onKeyDown={onKeyDown}
+    >
+      <header className="board-status-head">
+        <span className="board-status-lamp">
+          <span className="board-lamp" data-tone={tone} />
+          <span className="board-status-kind">{kind ?? "status"}</span>
+        </span>
+        <span className="board-cell-time">
+          {formatRelativeTime(entry.created_at)}
+          {entry.edited_at ? (
+            <span className="board-edited"> · edited</span>
+          ) : null}
+          <span className="board-expand-cue" aria-hidden="true">
+            ›
+          </span>
+        </span>
+      </header>
+      <EntryExpansion entry={entry} controls={controls}>
+        <>
+          <p className="board-status-text">{entry.text}</p>
+          <SemanticFactRow facts={facts} />
+          <MetaChips metadata={facts.rest} />
+        </>
+      </EntryExpansion>
+    </article>
+  );
+}
+
+// ─── General channels overview (no manager) ───
+
+function ChannelsOverview({
+  channels,
+  onSelect,
+}: {
+  channels: BoardChannel[];
+  onSelect: (channel: string) => void;
+}) {
+  const grouped = useMemo(() => {
+    const groups: Record<ChannelGroupKey, BoardChannel[]> = {
+      manager: [],
+      ticket: [],
+      job: [],
+      other: [],
+    };
+    for (const channel of channels) {
+      groups[classifyChannel(channel.channel)].push(channel);
+    }
+    return groups;
+  }, [channels]);
+
+  return (
+    <div className="board-overview">
+      {CHANNEL_GROUP_ORDER.map((group) => {
+        const rows = grouped[group];
+        if (rows.length === 0) return null;
+        const total = rows.reduce((sum, row) => sum + row.entry_count, 0);
+        return (
+          <section key={group} className="board-overview-group">
+            <div className="board-overview-head">
+              <h3 className="board-overview-label">
+                {CHANNEL_GROUP_LABELS[group]}
+              </h3>
+              <span className="board-overview-rollup">
+                {rows.length} channels · {total} posts
+              </span>
+            </div>
+            <div className="board-overview-cards">
+              {rows.map((row) => (
+                <button
+                  key={row.channel}
+                  type="button"
+                  className="board-overview-card"
+                  onClick={() => onSelect(row.channel)}
+                >
+                  <span className="board-overview-name">{row.channel}</span>
+                  <span className="board-overview-meta">
+                    <span className="board-overview-count">
+                      {row.entry_count}
+                    </span>
+                    <span className="board-overview-time">
+                      {formatRelativeTime(row.last_created_at)}
+                    </span>
+                  </span>
+                </button>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
   );
 }

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -809,6 +809,39 @@ function ManagerSwitcher({
   );
 }
 
+function ViewSwitch({
+  view,
+  onChange,
+}: {
+  view: BoardView;
+  onChange: (view: BoardView) => void;
+}) {
+  return (
+    <div className="board-viewswitch" role="tablist" aria-label="Board view">
+      <button
+        type="button"
+        role="tab"
+        aria-selected={view === "board"}
+        className={`board-viewswitch-tab${view === "board" ? " is-active" : ""}`}
+        onClick={() => onChange("board")}
+      >
+        Board
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={view === "channels"}
+        className={`board-viewswitch-tab${
+          view === "channels" ? " is-active" : ""
+        }`}
+        onClick={() => onChange("channels")}
+      >
+        Channels
+      </button>
+    </div>
+  );
+}
+
 export default function BoardPage() {
   const router = useRouter();
   const { theme } = useTheme();
@@ -1518,16 +1551,6 @@ export default function BoardPage() {
     <main className="page-shell board-shell">
       <header className="app-bar">
         <div className="app-bar-brand">
-          {isMobile ? (
-            <button
-              type="button"
-              className="board-hamburger"
-              onClick={() => setNavOpen(true)}
-              aria-label="Open channels"
-            >
-              ☰
-            </button>
-          ) : null}
           <Link className="app-bar-mark" href="/" aria-label="Waypoint home">
             <Image
               src={theme === "light" ? "/waypoint-light.svg" : "/waypoint.svg"}
@@ -1543,34 +1566,9 @@ export default function BoardPage() {
           </div>
         </div>
         <div className="app-bar-meta">
-          <div
-            className="board-viewswitch"
-            role="tablist"
-            aria-label="Board view"
-          >
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "board"}
-              className={`board-viewswitch-tab${
-                view === "board" ? " is-active" : ""
-              }`}
-              onClick={() => setView("board")}
-            >
-              Board
-            </button>
-            <button
-              type="button"
-              role="tab"
-              aria-selected={view === "channels"}
-              className={`board-viewswitch-tab${
-                view === "channels" ? " is-active" : ""
-              }`}
-              onClick={() => setView("channels")}
-            >
-              Channels
-            </button>
-          </div>
+          {/* On mobile the view switch and channel opener live in the sticky
+              workspace toolbar below, keeping navigation out of the app bar. */}
+          {!isMobile ? <ViewSwitch view={view} onChange={setView} /> : null}
           <Link className="back-link" href="/">
             ← all sessions
           </Link>
@@ -1658,6 +1656,28 @@ export default function BoardPage() {
           </div>
         ) : null}
       </section>
+
+      {isMobile && state === "ready" && (channels.length > 0 || managerMode) ? (
+        <div className="board-toolbar">
+          <button
+            type="button"
+            className="board-toolbar-nav"
+            onClick={() => setNavOpen(true)}
+            aria-label="Open channels"
+          >
+            <span aria-hidden="true">☰</span>
+            <span>Channels</span>
+          </button>
+          <span className="board-toolbar-context">
+            {view === "board"
+              ? managerMode
+                ? "Ticket board"
+                : "Overview"
+              : (activeChannel ?? "—")}
+          </span>
+          <ViewSwitch view={view} onChange={setView} />
+        </div>
+      ) : null}
 
       {state === "ready" && channels.length === 0 && !managerMode ? (
         <section className="panel bordered board-empty">

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -1256,8 +1256,10 @@ export default function BoardPage() {
       }
     };
     document.addEventListener("keydown", onKeyDown);
-    const search = node?.querySelector<HTMLElement>(".board-nav-search-input");
-    search?.focus();
+    // Move focus into the drawer for the trap and Escape handling, but land on
+    // the panel itself — not the search box — so opening it never pops the
+    // mobile keyboard or steals typing focus.
+    node?.focus();
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [navOpen]);
 
@@ -1518,6 +1520,14 @@ export default function BoardPage() {
   const cellAuthor = uniformAuthor(cells);
   const logAuthor = hasOlder ? null : uniformAuthor(log);
 
+  // Channel-detail layout: a summary header plus a two-column split (cells |
+  // log) on wide screens when both halves carry content, so the log timeline
+  // fills the space the single-column stack used to waste.
+  const activeChannelMeta =
+    channels.find((c) => c.channel === activeChannel) ?? null;
+  const hasPrimary = statusCell !== null || cells.length > 0;
+  const splitDetail = hasPrimary && log.length > 0;
+
   const controls: EntryControls = {
     editingId,
     editDraft,
@@ -1707,6 +1717,7 @@ export default function BoardPage() {
                 role="dialog"
                 aria-modal="true"
                 aria-label="Channels"
+                tabIndex={-1}
                 onClick={stopEvent}
               >
                 <div className="board-drawer-head">
@@ -1761,10 +1772,30 @@ export default function BoardPage() {
             ) : (
               <div className="board-detail-view">
                 {activeChannel ? (
-                  <div className="board-context">
-                    <div className="board-context-titles">
+                  <header className="board-channel-header">
+                    <div className="board-channel-headmain">
                       <p className="board-main-eyebrow">channel</p>
-                      <h2 className="board-main-title">{activeChannel}</h2>
+                      <h2 className="board-channel-title">{activeChannel}</h2>
+                      <div className="board-channel-summary">
+                        <span>
+                          {cells.length} {cells.length === 1 ? "cell" : "cells"}
+                        </span>
+                        <span aria-hidden="true">·</span>
+                        <span>
+                          {logTotal} {logTotal === 1 ? "post" : "posts"}
+                        </span>
+                        {activeChannelMeta ? (
+                          <>
+                            <span aria-hidden="true">·</span>
+                            <span>
+                              updated{" "}
+                              {formatRelativeTime(
+                                activeChannelMeta.last_created_at,
+                              )}
+                            </span>
+                          </>
+                        ) : null}
+                      </div>
                     </div>
                     <div className="board-actions">
                       <button
@@ -1782,280 +1813,294 @@ export default function BoardPage() {
                         Delete channel
                       </button>
                     </div>
-                  </div>
+                  </header>
                 ) : null}
 
-                {statusCell ? (
-                  <StatusBanner
-                    entry={statusCell}
-                    controls={controls}
-                    expanded={expandedId === statusCell.id}
-                    onActivate={() => activateEntry(statusCell.id)}
-                    onKeyDown={(event) => onEntryKeyDown(event, statusCell.id)}
-                  />
-                ) : null}
-
-                {cells.length > 0 ? (
-                  <section className="board-cells" aria-label="Cells">
-                    <h3 className="board-group-label">
-                      Cells · latest value
-                      {cellAuthor ? (
-                        <span className="board-group-by">
-                          {" · all by "}
-                          {shortId(cellAuthor)}
-                        </span>
+                <div
+                  className={`board-detail-columns${
+                    splitDetail ? " is-split" : ""
+                  }`}
+                >
+                  {hasPrimary ? (
+                    <div className="board-detail-primary">
+                      {statusCell ? (
+                        <StatusBanner
+                          entry={statusCell}
+                          controls={controls}
+                          expanded={expandedId === statusCell.id}
+                          onActivate={() => activateEntry(statusCell.id)}
+                          onKeyDown={(event) =>
+                            onEntryKeyDown(event, statusCell.id)
+                          }
+                        />
                       ) : null}
-                    </h3>
 
-                    {heroCell ? (
-                      <article
-                        className={`board-hero${
-                          expandedId === heroCell.id ? " is-expanded" : ""
-                        }`}
-                        role="button"
-                        tabIndex={0}
-                        aria-expanded={expandedId === heroCell.id}
-                        onClick={() => activateEntry(heroCell.id)}
-                        onKeyDown={(event) => onEntryKeyDown(event, heroCell.id)}
-                      >
-                        <header className="board-hero-head">
-                          <span className="board-hero-key">{heroCell.key}</span>
-                          <span className="board-cell-time">
-                            {formatRelativeTime(heroCell.created_at)}
-                            {heroCell.edited_at ? (
-                              <span className="board-edited"> · edited</span>
+                      {cells.length > 0 ? (
+                        <section className="board-cells" aria-label="Cells">
+                          <h3 className="board-group-label">
+                            Cells · latest value
+                            {cellAuthor ? (
+                              <span className="board-group-by">
+                                {" · all by "}
+                                {shortId(cellAuthor)}
+                              </span>
                             ) : null}
-                            <span
-                              className="board-expand-cue"
-                              aria-hidden="true"
-                            >
-                              ›
-                            </span>
-                          </span>
-                        </header>
-                        <EntryExpansion entry={heroCell} controls={controls}>
-                          <>
-                            <p className="board-hero-value">{heroCell.text}</p>
-                            <MetaChips metadata={heroCell.metadata} />
-                          </>
-                        </EntryExpansion>
-                      </article>
-                    ) : null}
+                          </h3>
 
-                    {scalarCells.length > 0 ? (
-                      <ul className="board-state-list">
-                        {scalarCells.map((entry) => (
-                          <li key={entry.id} className="board-state-wrap">
-                            <div
-                              className={`board-state-row${
-                                expandedId === entry.id ? " is-expanded" : ""
+                          {heroCell ? (
+                            <article
+                              className={`board-hero${
+                                expandedId === heroCell.id ? " is-expanded" : ""
                               }`}
                               role="button"
                               tabIndex={0}
-                              aria-expanded={expandedId === entry.id}
-                              onClick={() => activateEntry(entry.id)}
-                              onKeyDown={(event) =>
-                                onEntryKeyDown(event, entry.id)
-                              }
+                              aria-expanded={expandedId === heroCell.id}
+                              onClick={() => activateEntry(heroCell.id)}
+                              onKeyDown={(event) => onEntryKeyDown(event, heroCell.id)}
                             >
-                              <span className="board-state-key">
-                                {entry.key}
-                              </span>
-                              {editingId === entry.id ? null : (
-                                <span className="board-state-value">
-                                  {entry.text}
-                                </span>
-                              )}
-                              <MetaChips metadata={entry.metadata} />
-                              {cellAuthor ? null : (
-                                <span className="board-state-author">
-                                  {entry.author_session_id
-                                    ? shortId(entry.author_session_id)
-                                    : "—"}
-                                </span>
-                              )}
-                              <span className="board-state-time">
-                                {formatRelativeTime(entry.created_at)}
-                                {entry.edited_at ? (
-                                  <span className="board-edited"> · edited</span>
-                                ) : null}
-                                <span
-                                  className="board-expand-cue"
-                                  aria-hidden="true"
-                                >
-                                  ›
-                                </span>
-                              </span>
-                            </div>
-                            <EntryExpansion entry={entry} controls={controls}>
-                              {null}
-                            </EntryExpansion>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : null}
-
-                    {cardCells.length > 0 ? (
-                      <div className="board-cell-grid">
-                        {cardCells.map((entry) => (
-                          <article
-                            key={entry.id}
-                            className={`board-cell${
-                              expandedId === entry.id ? " is-expanded" : ""
-                            }`}
-                            role="button"
-                            tabIndex={0}
-                            aria-expanded={expandedId === entry.id}
-                            onClick={() => activateEntry(entry.id)}
-                            onKeyDown={(event) =>
-                              onEntryKeyDown(event, entry.id)
-                            }
-                          >
-                            <header className="board-cell-head">
-                              <span className="board-cell-key">
-                                {entry.key}
-                              </span>
-                              <span className="board-cell-time">
-                                {formatRelativeTime(entry.created_at)}
-                                {entry.edited_at ? (
-                                  <span className="board-edited"> · edited</span>
-                                ) : null}
-                                <span
-                                  className="board-expand-cue"
-                                  aria-hidden="true"
-                                >
-                                  ›
-                                </span>
-                              </span>
-                            </header>
-                            <EntryExpansion entry={entry} controls={controls}>
-                              <>
-                                <p className="board-cell-value">{entry.text}</p>
-                                {cellAuthor ? null : (
-                                  <footer className="board-cell-foot">
-                                    <span className="board-cell-author">
-                                      {entry.author_session_id
-                                        ? shortId(entry.author_session_id)
-                                        : "—"}
-                                    </span>
-                                  </footer>
-                                )}
-                                <SemanticFactRow
-                                  facts={semanticFacts(entry.metadata)}
-                                />
-                                <MetaChips
-                                  metadata={semanticFacts(entry.metadata).rest}
-                                />
-                              </>
-                            </EntryExpansion>
-                          </article>
-                        ))}
-                      </div>
-                    ) : null}
-                  </section>
-                ) : null}
-
-                <section className="board-log" aria-label="Log">
-                  {cells.length > 0 ? (
-                    <h3 className="board-group-label">
-                      Log · newest first
-                      {logAuthor ? (
-                        <span className="board-group-by">
-                          {" · all by "}
-                          {shortId(logAuthor)}
-                        </span>
-                      ) : null}
-                    </h3>
-                  ) : null}
-                  {log.length === 0 ? (
-                    <p className="board-log-empty">
-                      {cells.length > 0
-                        ? "No log posts in this channel."
-                        : "No entries yet."}
-                    </p>
-                  ) : (
-                    <ol className="board-log-list">
-                      {log.map((entry) => {
-                        const kind = metaString(entry.metadata, "kind");
-                        const tone = kindTone(kind);
-                        const facts = semanticFacts(entry.metadata);
-                        const isRelay = kind === "relay";
-                        return (
-                          <li
-                            key={entry.id}
-                            className={`board-log-item${
-                              isRelay ? " is-relay" : ""
-                            }`}
-                            data-tone={tone}
-                          >
-                            <div className="board-log-rail" aria-hidden="true" />
-                            <div
-                              className={`board-log-body${
-                                expandedId === entry.id ? " is-expanded" : ""
-                              }`}
-                              role="button"
-                              tabIndex={0}
-                              aria-expanded={expandedId === entry.id}
-                              onClick={() => activateEntry(entry.id)}
-                              onKeyDown={(event) =>
-                                onEntryKeyDown(event, entry.id)
-                              }
-                            >
-                              <EntryExpansion entry={entry} controls={controls}>
-                                <div className="board-log-main">
-                                  {kind ? (
-                                    <span
-                                      className="board-log-tag"
-                                      data-tone={tone}
-                                    >
-                                      {isRelay ? "from you (via inbox)" : kind}
-                                    </span>
+                              <header className="board-hero-head">
+                                <span className="board-hero-key">{heroCell.key}</span>
+                                <span className="board-cell-time">
+                                  {formatRelativeTime(heroCell.created_at)}
+                                  {heroCell.edited_at ? (
+                                    <span className="board-edited"> · edited</span>
                                   ) : null}
-                                  <p className="board-log-text">{entry.text}</p>
-                                  <SemanticFactRow facts={facts} />
-                                  <div className="board-log-meta">
-                                    <span className="board-log-time">
-                                      {formatRelativeTime(entry.created_at)}
-                                      {entry.edited_at ? (
-                                        <span className="board-edited">
-                                          {" "}
-                                          · edited
-                                        </span>
-                                      ) : null}
+                                  <span
+                                    className="board-expand-cue"
+                                    aria-hidden="true"
+                                  >
+                                    ›
+                                  </span>
+                                </span>
+                              </header>
+                              <EntryExpansion entry={heroCell} controls={controls}>
+                                <>
+                                  <p className="board-hero-value">{heroCell.text}</p>
+                                  <MetaChips metadata={heroCell.metadata} />
+                                </>
+                              </EntryExpansion>
+                            </article>
+                          ) : null}
+
+                          {scalarCells.length > 0 ? (
+                            <ul className="board-state-list">
+                              {scalarCells.map((entry) => (
+                                <li key={entry.id} className="board-state-wrap">
+                                  <div
+                                    className={`board-state-row${
+                                      expandedId === entry.id ? " is-expanded" : ""
+                                    }`}
+                                    role="button"
+                                    tabIndex={0}
+                                    aria-expanded={expandedId === entry.id}
+                                    onClick={() => activateEntry(entry.id)}
+                                    onKeyDown={(event) =>
+                                      onEntryKeyDown(event, entry.id)
+                                    }
+                                  >
+                                    <span className="board-state-key">
+                                      {entry.key}
                                     </span>
-                                    {logAuthor ? null : (
-                                      <span className="board-log-author">
+                                    {editingId === entry.id ? null : (
+                                      <span className="board-state-value">
+                                        {entry.text}
+                                      </span>
+                                    )}
+                                    <MetaChips metadata={entry.metadata} />
+                                    {cellAuthor ? null : (
+                                      <span className="board-state-author">
                                         {entry.author_session_id
                                           ? shortId(entry.author_session_id)
                                           : "—"}
                                       </span>
                                     )}
-                                    <MetaChips metadata={facts.rest} />
+                                    <span className="board-state-time">
+                                      {formatRelativeTime(entry.created_at)}
+                                      {entry.edited_at ? (
+                                        <span className="board-edited"> · edited</span>
+                                      ) : null}
+                                      <span
+                                        className="board-expand-cue"
+                                        aria-hidden="true"
+                                      >
+                                        ›
+                                      </span>
+                                    </span>
                                   </div>
-                                </div>
-                              </EntryExpansion>
+                                  <EntryExpansion entry={entry} controls={controls}>
+                                    {null}
+                                  </EntryExpansion>
+                                </li>
+                              ))}
+                            </ul>
+                          ) : null}
+
+                          {cardCells.length > 0 ? (
+                            <div className="board-cell-grid">
+                              {cardCells.map((entry) => (
+                                <article
+                                  key={entry.id}
+                                  className={`board-cell${
+                                    expandedId === entry.id ? " is-expanded" : ""
+                                  }`}
+                                  role="button"
+                                  tabIndex={0}
+                                  aria-expanded={expandedId === entry.id}
+                                  onClick={() => activateEntry(entry.id)}
+                                  onKeyDown={(event) =>
+                                    onEntryKeyDown(event, entry.id)
+                                  }
+                                >
+                                  <header className="board-cell-head">
+                                    <span className="board-cell-key">
+                                      {entry.key}
+                                    </span>
+                                    <span className="board-cell-time">
+                                      {formatRelativeTime(entry.created_at)}
+                                      {entry.edited_at ? (
+                                        <span className="board-edited"> · edited</span>
+                                      ) : null}
+                                      <span
+                                        className="board-expand-cue"
+                                        aria-hidden="true"
+                                      >
+                                        ›
+                                      </span>
+                                    </span>
+                                  </header>
+                                  <EntryExpansion entry={entry} controls={controls}>
+                                    <>
+                                      <p className="board-cell-value">{entry.text}</p>
+                                      {cellAuthor ? null : (
+                                        <footer className="board-cell-foot">
+                                          <span className="board-cell-author">
+                                            {entry.author_session_id
+                                              ? shortId(entry.author_session_id)
+                                              : "—"}
+                                          </span>
+                                        </footer>
+                                      )}
+                                      <SemanticFactRow
+                                        facts={semanticFacts(entry.metadata)}
+                                      />
+                                      <MetaChips
+                                        metadata={semanticFacts(entry.metadata).rest}
+                                      />
+                                    </>
+                                  </EntryExpansion>
+                                </article>
+                              ))}
                             </div>
-                          </li>
-                        );
-                      })}
-                    </ol>
-                  )}
-                  {hasOlder ? (
-                    <div className="board-log-more">
-                      <button
-                        type="button"
-                        className="board-load-older"
-                        onClick={() => void loadOlder()}
-                        disabled={loadingOlder}
-                      >
-                        {loadingOlder ? "Loading…" : "Load older"}
-                      </button>
-                      <span className="board-log-count">
-                        {log.length} of {logTotal}
-                      </span>
+                          ) : null}
+                        </section>
+                      ) : null}
                     </div>
                   ) : null}
-                </section>
+
+                  <div className="board-detail-secondary">
+                    <section className="board-log" aria-label="Log">
+                      {log.length > 0 || hasPrimary ? (
+                        <h3 className="board-group-label">
+                          Log · newest first
+                          {logAuthor ? (
+                            <span className="board-group-by">
+                              {" · all by "}
+                              {shortId(logAuthor)}
+                            </span>
+                          ) : null}
+                        </h3>
+                      ) : null}
+                      {log.length === 0 ? (
+                        <p className="board-log-empty">
+                          {cells.length > 0
+                            ? "No log posts in this channel."
+                            : "No entries yet."}
+                        </p>
+                      ) : (
+                        <ol className="board-log-list">
+                          {log.map((entry) => {
+                            const kind = metaString(entry.metadata, "kind");
+                            const tone = kindTone(kind);
+                            const facts = semanticFacts(entry.metadata);
+                            const isRelay = kind === "relay";
+                            return (
+                              <li
+                                key={entry.id}
+                                className={`board-log-item${
+                                  isRelay ? " is-relay" : ""
+                                }`}
+                                data-tone={tone}
+                              >
+                                <div className="board-log-rail" aria-hidden="true" />
+                                <div
+                                  className={`board-log-body${
+                                    expandedId === entry.id ? " is-expanded" : ""
+                                  }`}
+                                  role="button"
+                                  tabIndex={0}
+                                  aria-expanded={expandedId === entry.id}
+                                  onClick={() => activateEntry(entry.id)}
+                                  onKeyDown={(event) =>
+                                    onEntryKeyDown(event, entry.id)
+                                  }
+                                >
+                                  <EntryExpansion entry={entry} controls={controls}>
+                                    <div className="board-log-main">
+                                      {kind ? (
+                                        <span
+                                          className="board-log-tag"
+                                          data-tone={tone}
+                                        >
+                                          {isRelay ? "from you (via inbox)" : kind}
+                                        </span>
+                                      ) : null}
+                                      <p className="board-log-text">{entry.text}</p>
+                                      <SemanticFactRow facts={facts} />
+                                      <div className="board-log-meta">
+                                        <span className="board-log-time">
+                                          {formatRelativeTime(entry.created_at)}
+                                          {entry.edited_at ? (
+                                            <span className="board-edited">
+                                              {" "}
+                                              · edited
+                                            </span>
+                                          ) : null}
+                                        </span>
+                                        {logAuthor ? null : (
+                                          <span className="board-log-author">
+                                            {entry.author_session_id
+                                              ? shortId(entry.author_session_id)
+                                              : "—"}
+                                          </span>
+                                        )}
+                                        <MetaChips metadata={facts.rest} />
+                                      </div>
+                                    </div>
+                                  </EntryExpansion>
+                                </div>
+                              </li>
+                            );
+                          })}
+                        </ol>
+                      )}
+                      {hasOlder ? (
+                        <div className="board-log-more">
+                          <button
+                            type="button"
+                            className="board-load-older"
+                            onClick={() => void loadOlder()}
+                            disabled={loadingOlder}
+                          >
+                            {loadingOlder ? "Loading…" : "Load older"}
+                          </button>
+                          <span className="board-log-count">
+                            {log.length} of {logTotal}
+                          </span>
+                        </div>
+                      ) : null}
+                    </section>
+                  </div>
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -1676,7 +1676,6 @@ export default function BoardPage() {
             aria-label="Open channels"
           >
             <span aria-hidden="true">☰</span>
-            <span>Channels</span>
           </button>
           <span className="board-toolbar-context">
             {view === "board"

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -106,9 +106,8 @@ function metaString(
   return null;
 }
 
-// Meta keys the semantic renderers pull out as first-class facts (PR link, CI
-// lamp, commit sha) plus `kind`, which surfaces as a tone/tag. Everything else
-// falls back to chips.
+// Keys rendered as first-class facts (PR/CI/commit) or a tone/tag (kind); the
+// rest fall back to chips.
 const SEMANTIC_META_KEYS = new Set(["kind", "pr", "pr_url", "checks", "commit"]);
 
 interface SemanticFacts {
@@ -917,9 +916,8 @@ export default function BoardPage() {
   // Resolve the initial view once, after channels and managers first load.
   const viewResolvedRef = useRef(false);
   const requestedViewRef = useRef<BoardView | null>(null);
-  // Whether the load carried a `?channel=` deep link. `pendingChannelRef` is
-  // cleared as soon as the channel is selected, so the view resolver reads this
-  // stable flag instead to open Channels for a deep link.
+  // `pendingChannelRef` is cleared once the channel is selected, so the view
+  // resolver reads this stable flag to open Channels for a deep link.
   const deepLinkRef = useRef(false);
 
   const handleAuthFailure = useCallback(() => {
@@ -1091,9 +1089,8 @@ export default function BoardPage() {
     void refreshManagers();
   }, [refreshChannels, refreshManagers]);
 
-  // Once channels and managers have loaded, resolve the initial view: an explicit
-  // `?view=` wins; a `?channel=` deep link opens Channels; otherwise open Board
-  // when a manager exists, else Channels.
+  // Resolve the initial view once: `?view=` wins, then a `?channel=` deep link
+  // opens Channels, else Board when a manager exists.
   useEffect(() => {
     if (viewResolvedRef.current || state !== "ready") return;
     viewResolvedRef.current = true;
@@ -1106,7 +1103,6 @@ export default function BoardPage() {
     }
   }, [state, managers]);
 
-  // Fetch the selected manager's board data when it changes.
   useEffect(() => {
     if (!selectedManagerId) {
       setManagerState(null);
@@ -1256,9 +1252,8 @@ export default function BoardPage() {
       }
     };
     document.addEventListener("keydown", onKeyDown);
-    // Move focus into the drawer for the trap and Escape handling, but land on
-    // the panel itself — not the search box — so opening it never pops the
-    // mobile keyboard or steals typing focus.
+    // Focus the panel, not the search box, so opening the drawer never pops the
+    // mobile keyboard.
     node?.focus();
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [navOpen]);
@@ -1520,9 +1515,7 @@ export default function BoardPage() {
   const cellAuthor = uniformAuthor(cells);
   const logAuthor = hasOlder ? null : uniformAuthor(log);
 
-  // Channel-detail layout: a summary header plus a two-column split (cells |
-  // log) on wide screens when both halves carry content, so the log timeline
-  // fills the space the single-column stack used to waste.
+  // Two-column split (cells | log) on wide screens when both halves have content.
   const activeChannelMeta =
     channels.find((c) => c.channel === activeChannel) ?? null;
   const hasPrimary = statusCell !== null || cells.length > 0;
@@ -1576,8 +1569,7 @@ export default function BoardPage() {
           </div>
         </div>
         <div className="app-bar-meta">
-          {/* On mobile the view switch and channel opener live in the sticky
-              workspace toolbar below, keeping navigation out of the app bar. */}
+          {/* On mobile the view switch and opener live in the sticky toolbar below. */}
           {!isMobile ? <ViewSwitch view={view} onChange={setView} /> : null}
           <Link className="back-link" href="/">
             ← all sessions

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13404,15 +13404,48 @@ html[data-theme="light"] .session-switcher-row.selected {
   color: var(--accent-cool);
 }
 
-.board-hamburger {
-  padding: 4px 8px;
+/* Mobile workspace toolbar — a sticky glass bar carrying the channel opener,
+   current context, and view switch, so navigation never sits in the app bar. */
+.board-toolbar {
+  position: sticky;
+  top: 8px;
+  z-index: 40;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: var(--radius-glass);
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-line);
+  box-shadow: inset 0 1px 0 var(--glass-hi), var(--shadow);
+}
+
+.board-toolbar-nav {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 6px 11px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-input);
   color: var(--text);
-  font-size: 1rem;
-  line-height: 1;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.04em;
   cursor: pointer;
+}
+
+.board-toolbar-context {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--accent-cool);
 }
 
 /* Navigator — grouped, searchable channel list (fills the rail / drawer). */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14236,6 +14236,125 @@ a.board-fact-pr:hover {
   padding: 8px 12px;
 }
 
+/* App bar (board page) — keep it a single non-wrapping row: the meta cluster
+   holds its size and the brand truncates first, so the theme toggle can never
+   drop to a second line. A hairline divides the view switch from the session
+   link + theme toggle so the three controls read as two groups, not a jumble. */
+.board-shell .app-bar {
+  flex-wrap: nowrap;
+}
+
+.board-shell .app-bar-brand {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.board-shell .app-bar-title,
+.board-shell .app-bar-eyebrow {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.board-shell .app-bar-meta {
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+  gap: 14px;
+}
+
+.board-shell .app-bar-meta .back-link {
+  padding-left: 14px;
+  border-left: 1px solid var(--line);
+  white-space: nowrap;
+}
+
+/* Channel detail header — a summary line under the channel name, sticky glass
+   on desktop so the channel stays identified while its log scrolls. */
+.board-channel-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.board-channel-headmain {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.board-channel-title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  letter-spacing: 0.01em;
+  color: var(--text-strong);
+  overflow-wrap: anywhere;
+}
+
+.board-channel-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+}
+
+@media (min-width: 721px) {
+  .board-channel-header {
+    position: sticky;
+    top: 8px;
+    z-index: 20;
+    /* Let the actions wrap below the title when the column is narrow, so the
+       channel name keeps its width and never breaks mid-word. */
+    flex-wrap: wrap;
+    align-items: center;
+    row-gap: 12px;
+    padding: 12px 16px;
+    border: 1px solid var(--glass-line);
+    border-radius: var(--radius-glass);
+    background: var(--glass-bg-thick);
+    backdrop-filter: var(--glass-blur);
+    box-shadow: inset 0 1px 0 var(--glass-hi), var(--shadow);
+  }
+  .board-channel-headmain {
+    flex: 1 1 240px;
+  }
+  .board-channel-header .board-actions {
+    flex-shrink: 0;
+  }
+}
+
+/* Two-column detail: cells (primary) beside the log (secondary) on wide
+   screens when both carry content, so the log fills the space the single stack
+   used to waste. Collapses to one column when a half is empty or on mobile. */
+.board-detail-columns {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 18px;
+  align-items: start;
+}
+
+.board-detail-primary,
+.board-detail-secondary {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+@media (min-width: 1080px) {
+  .board-detail-columns.is-split {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    gap: 22px;
+  }
+}
+
 @media (max-width: 720px) {
   .board-grid {
     grid-template-columns: 1fr;
@@ -14244,13 +14363,15 @@ a.board-fact-pr:hover {
   .board-rail {
     display: none;
   }
-  /* Stack the context title above its actions so a long channel name doesn't
-     collide with the Clear/Delete buttons. */
-  .board-context {
+  /* Stack the context/channel title above its actions so a long channel name
+     doesn't collide with the Clear/Delete buttons. */
+  .board-context,
+  .board-channel-header {
     flex-direction: column;
     align-items: stretch;
   }
-  .board-main-title {
+  .board-main-title,
+  .board-channel-title {
     font-size: 1.25rem;
   }
   .board-actions {
@@ -14262,8 +14383,8 @@ a.board-fact-pr:hover {
   .board-viewswitch-tab {
     padding: 5px 10px;
   }
-  /* Eyebrow + secondary link hide below the breakpoint to fit hamburger +
-     title + view switch. */
+  /* The mobile app bar carries only the mark, title, and theme toggle; the
+     eyebrow and session link are dropped and nav lives in the sticky toolbar. */
   .board-shell .app-bar-eyebrow,
   .board-shell .back-link {
     display: none;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13310,16 +13310,910 @@ html[data-theme="light"] .session-switcher-row.selected {
   color: var(--text-strong);
 }
 
+/* ── Board workspace: lamps, tones, navigator, views ── */
+
+/* A state/CI/kind lamp: a currentColor dot whose hue names a tone. Color always
+   pairs with a text label elsewhere, so the dot is a reinforcement, not the only
+   cue (NFR4). One tone→token map drives lamps, tags, and pills. */
+.board-lamp {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex: none;
+  color: var(--muted-soft);
+}
+
+[data-tone="idle"],
+[data-tone="muted"] {
+  --tone: var(--muted-soft);
+}
+[data-tone="spec"],
+[data-tone="strategy"] {
+  --tone: var(--todo-glyph);
+}
+[data-tone="awaiting"],
+[data-tone="relay"] {
+  --tone: var(--accent-strong);
+}
+[data-tone="active"],
+[data-tone="writer"] {
+  --tone: var(--accent-cool);
+}
+[data-tone="revising"],
+[data-tone="warn"] {
+  --tone: var(--warn);
+}
+[data-tone="blocked"],
+[data-tone="danger"] {
+  --tone: var(--danger);
+}
+[data-tone="done"],
+[data-tone="success"] {
+  --tone: var(--success);
+}
+/* Priority hues: p0 loudest → p3 quietest. */
+[data-tone="p0"] {
+  --tone: var(--danger);
+}
+[data-tone="p1"] {
+  --tone: var(--warn);
+}
+[data-tone="p2"] {
+  --tone: var(--accent-cool);
+}
+[data-tone="p3"] {
+  --tone: var(--muted-soft);
+}
+.board-lamp[data-tone] {
+  color: var(--tone);
+}
+
+/* App-bar view switch — a flat segmented control (the app bar never floats). */
+.board-viewswitch {
+  display: inline-flex;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+}
+
+.board-viewswitch-tab {
+  padding: 5px 13px;
+  border: none;
+  border-radius: calc(var(--radius-sm) - 2px);
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background 0.14s ease,
+    color 0.14s ease;
+}
+
+.board-viewswitch-tab:hover {
+  color: var(--text);
+}
+
+.board-viewswitch-tab.is-active {
+  background: color-mix(in srgb, var(--accent-cool) 16%, transparent);
+  color: var(--accent-cool);
+}
+
+.board-hamburger {
+  padding: 4px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 1rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+/* Navigator — grouped, searchable channel list (fills the rail / drawer). */
+.board-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.board-nav-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+}
+
+.board-nav-search-cue {
+  color: var(--muted-soft);
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.board-nav-search-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.board-nav-search-input:focus {
+  outline: none;
+}
+
+.board-nav-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.board-nav-group-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 6px 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--muted-soft);
+}
+
+.board-nav-group-chevron {
+  font-size: 0.85rem;
+  line-height: 1;
+  color: var(--muted-soft);
+  transition: transform 0.14s ease;
+}
+
+.board-nav-group-head[aria-expanded="true"] .board-nav-group-chevron {
+  transform: rotate(90deg);
+}
+
+.board-nav-group-label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.board-nav-group-attention {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent-strong);
+}
+
+.board-nav-group-count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+}
+
+.board-nav-list {
+  list-style: none;
+  margin: 2px 0 4px;
+  padding: 0 0 0 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.board-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+
+.board-nav-item:hover {
+  background: var(--bg-card-soft);
+}
+
+.board-nav-item.is-active {
+  border-color: color-mix(in srgb, var(--accent-cool) 40%, var(--line));
+  background: color-mix(in srgb, var(--accent-cool) 10%, transparent);
+}
+
+.board-nav-lamp-spacer {
+  width: 7px;
+  flex: none;
+}
+
+.board-nav-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.board-nav-attention {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--accent-strong);
+}
+
+.board-nav-count {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
+/* Mobile drawer — off-canvas glass navigator (floating chrome). */
+.board-drawer-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: color-mix(in srgb, var(--bg-deep) 55%, transparent);
+  display: flex;
+}
+
+.board-drawer {
+  width: min(84vw, 340px);
+  height: 100%;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--glass-bg-thick);
+  backdrop-filter: var(--glass-blur);
+  border-right: 1px solid var(--glass-line);
+  box-shadow: inset 0 1px 0 var(--glass-hi), var(--shadow);
+}
+
+.board-drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.board-drawer-title {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-drawer-close {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.board-drawer-close:hover {
+  color: var(--text);
+}
+
+/* Workspace context header (shared by Board and Channels views). */
+.board-context {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--line);
+}
+
+.board-context-titles {
+  min-width: 0;
+}
+
+.board-workspace,
+.board-detail-view {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  min-width: 0;
+}
+
+/* Manager switcher (per-project). */
+.board-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.board-switcher-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-switcher-project {
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  color: var(--accent-cool);
+}
+
+.board-switcher-select {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.board-switcher-select select {
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.board-switcher-attention {
+  position: absolute;
+  top: -3px;
+  right: -3px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent-strong);
+}
+
+/* Manager board: rollup, Needs-you, lifecycle lanes. */
+.board-manager {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+}
+
+.board-rollup {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.board-rollup-item strong {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.board-rollup-need strong {
+  color: var(--accent-strong);
+}
+
+.board-rollup-sep {
+  color: var(--muted-soft);
+}
+
+/* Needs you — the single glass strip of everything awaiting the human. */
+.board-needs {
+  padding: 14px 16px;
+  border-radius: var(--radius-glass);
+  background: var(--glass-bg);
+  backdrop-filter: var(--glass-blur);
+  border: 1px solid var(--glass-line);
+  box-shadow: inset 0 1px 0 var(--glass-hi), var(--shadow);
+}
+
+.board-needs-title {
+  margin: 0 0 10px;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-strong);
+}
+
+.board-needs-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 10px;
+}
+
+.board-need-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-card);
+}
+
+/* Dog-ear fold marks a human-gated card (matches pinned cards elsewhere). */
+.board-dogear {
+  border-top-right-radius: 0;
+}
+
+.board-dogear::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  border-top: 14px solid var(--accent-strong);
+  border-left: 14px solid transparent;
+}
+
+.board-need-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.board-need-id {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.board-need-gate {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--tone, var(--muted));
+}
+
+.board-need-ticket-title {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.board-need-summary {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.board-need-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 2px;
+}
+
+.board-need-link {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  color: var(--accent-strong);
+  text-decoration: none;
+}
+
+.board-need-link:hover {
+  text-decoration: underline;
+}
+
+.board-need-link.is-disabled {
+  color: var(--muted-soft);
+  pointer-events: none;
+}
+
+.board-need-open {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  cursor: pointer;
+  padding: 0;
+}
+
+.board-need-open:hover {
+  color: var(--text);
+}
+
+/* Lifecycle board — lanes scroll horizontally (Trello-style). */
+.board-lanes {
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding-bottom: 6px;
+  /* Peek + fade signals more lanes past the edge. */
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 12px,
+    #000 calc(100% - 16px),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 12px,
+    #000 calc(100% - 16px),
+    transparent 100%
+  );
+}
+
+.board-lane {
+  flex: 0 0 clamp(212px, 24vw, 248px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 10px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--bg-card-soft);
+}
+
+.board-lane.is-empty {
+  flex-basis: 128px;
+  background: transparent;
+  border-style: dashed;
+}
+
+.board-lane.is-done {
+  opacity: 0.72;
+}
+
+.board-lane-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.board-lane-label {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-lane-count {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted);
+}
+
+.board-lane-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+/* Ticket card. */
+.board-ticket {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 11px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-card);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    border-color 0.14s ease,
+    background 0.14s ease;
+}
+
+.board-ticket:hover {
+  border-color: var(--line-strong);
+}
+
+.board-ticket:focus-visible {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 2px;
+}
+
+.board-ticket.is-awaiting {
+  border-top-right-radius: 0;
+  border-color: color-mix(in srgb, var(--accent-strong) 40%, var(--line));
+}
+
+.board-ticket.is-awaiting::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  border-top: 13px solid var(--accent-strong);
+  border-left: 13px solid transparent;
+}
+
+.board-ticket-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.board-ticket-id {
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.board-ticket-priority {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--tone, var(--muted));
+}
+
+.board-ticket-title {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+.board-ticket-foot {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
+.board-ticket-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+}
+
+.board-ticket-assignee {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 12ch;
+}
+
+.board-ticket-pr {
+  color: var(--accent-cool);
+}
+
+/* General channels overview (no manager). */
+.board-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.board-overview-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.board-overview-label {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-overview-rollup {
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.board-overview-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 8px;
+}
+
+.board-overview-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 11px 13px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-card);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.14s ease;
+}
+
+.board-overview-card:hover {
+  border-color: var(--line-strong);
+}
+
+.board-overview-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text);
+}
+
+.board-overview-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--muted-soft);
+}
+
+.board-overview-count {
+  color: var(--accent-cool);
+}
+
+/* Semantic status banner (the `status` cell). */
+.board-status-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 13px 15px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--tone, var(--line-strong));
+  background: color-mix(in srgb, var(--tone, var(--accent-cool)) 5%, var(--bg-card));
+  cursor: pointer;
+  transition: border-color 0.14s ease;
+}
+
+.board-status-banner:focus-visible {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 2px;
+}
+
+.board-status-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.board-status-lamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.board-status-kind {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--tone, var(--text-strong));
+}
+
+.board-status-text {
+  margin: 0;
+  color: var(--text-strong);
+  font-size: 0.92rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+/* Semantic facts row (PR link, CI lamp, commit sha). */
+.board-facts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px 12px;
+  margin-top: 4px;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+}
+
+.board-fact {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.board-fact-pr {
+  color: var(--accent-cool);
+  text-decoration: none;
+}
+
+a.board-fact-pr:hover {
+  text-decoration: underline;
+}
+
+.board-fact-ci {
+  color: var(--muted);
+}
+
+.board-fact-commit {
+  color: var(--muted-soft);
+}
+
+/* Kind-aware log timeline: the rail node and a tag take the kind's tone. */
+.board-log-item[data-tone] .board-log-rail::before {
+  background: var(--tone, var(--accent-cool));
+}
+
+.board-log-tag {
+  align-self: flex-start;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--tone, var(--muted));
+}
+
+.board-log-item.is-relay .board-log-body {
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 32%, var(--line));
+  background: color-mix(in srgb, var(--accent-strong) 6%, transparent);
+  padding: 8px 12px;
+}
+
 @media (max-width: 720px) {
   .board-grid {
     grid-template-columns: 1fr;
   }
+  /* The desktop rail is hidden; the drawer takes over on mobile. */
   .board-rail {
-    position: static;
+    display: none;
   }
-  /* Stack the title above its actions so a long channel name doesn't collide
-     with the Clear/Delete buttons. */
-  .board-main-head {
+  /* Stack the context title above its actions so a long channel name doesn't
+     collide with the Clear/Delete buttons. */
+  .board-context {
     flex-direction: column;
     align-items: stretch;
   }
@@ -13328,6 +14222,18 @@ html[data-theme="light"] .session-switcher-row.selected {
   }
   .board-actions {
     flex-wrap: wrap;
+  }
+  .board-needs-strip {
+    grid-template-columns: 1fr;
+  }
+  .board-viewswitch-tab {
+    padding: 5px 10px;
+  }
+  /* Eyebrow + secondary link hide below the breakpoint to fit hamburger +
+     title + view switch. */
+  .board-shell .app-bar-eyebrow,
+  .board-shell .back-link {
+    display: none;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14397,6 +14397,17 @@ a.board-fact-pr:hover {
   .board-shell .back-link {
     display: none;
   }
+  /* Override the global mobile app bar, which stacks its meta zone onto a
+     second row (flex-direction: column). With nav moved to the toolbar the
+     board's meta is just the theme toggle, so keep the bar a single row with
+     the toggle trailing the title instead of orphaned on a line of its own. */
+  .board-shell .app-bar {
+    flex-direction: row;
+    align-items: center;
+  }
+  .board-shell .app-bar-meta {
+    width: auto;
+  }
 }
 
 /* ─── Workspace preview ─── */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13312,9 +13312,8 @@ html[data-theme="light"] .session-switcher-row.selected {
 
 /* ── Board workspace: lamps, tones, navigator, views ── */
 
-/* A state/CI/kind lamp: a currentColor dot whose hue names a tone. Color always
-   pairs with a text label elsewhere, so the dot is a reinforcement, not the only
-   cue (NFR4). One tone→token map drives lamps, tags, and pills. */
+/* A currentColor dot whose hue names a tone, always paired with a text label
+   (NFR4). One tone→token map drives lamps, tags, and pills. */
 .board-lamp {
   display: inline-block;
   width: 7px;
@@ -13404,8 +13403,8 @@ html[data-theme="light"] .session-switcher-row.selected {
   color: var(--accent-cool);
 }
 
-/* Mobile workspace toolbar — a sticky glass bar carrying the channel opener,
-   current context, and view switch, so navigation never sits in the app bar. */
+/* Mobile workspace toolbar: sticky glass bar with the channel opener, context,
+   and view switch, keeping nav out of the app bar. */
 .board-toolbar {
   position: sticky;
   top: 8px;
@@ -13779,8 +13778,8 @@ html[data-theme="light"] .session-switcher-row.selected {
   gap: 14px;
 }
 
-/* Opaque, lifted cards with a stronger hairline so each reads as its own item
-   against the translucent strip instead of merging with its neighbours. */
+/* Opaque cards with a stronger hairline so each reads as its own item on the
+   translucent strip. */
 .board-need-card {
   position: relative;
   display: flex;
@@ -14237,12 +14236,9 @@ a.board-fact-pr:hover {
   padding: 8px 12px;
 }
 
-/* App bar (board page) — a single non-wrapping row that always fits the
-   viewport: nowrap keeps the theme toggle from dropping to a second line, while
-   min-width:0 on both zones lets them shrink (the brand truncates first) so the
-   bar can never exceed the viewport and rescale the page. A page-level clip is
-   the final backstop against any stray horizontal overflow. A hairline divides
-   the view switch from the session link + theme toggle. */
+/* App bar (board page): a single non-wrapping row (nowrap) that still fits the
+   viewport (min-width:0 lets the brand truncate first); overflow-x:clip is the
+   backstop. A hairline divides the view switch from the session link + theme. */
 .page-shell.board-shell {
   overflow-x: clip;
 }
@@ -14276,8 +14272,7 @@ a.board-fact-pr:hover {
   white-space: nowrap;
 }
 
-/* Channel detail header — a summary line under the channel name, sticky glass
-   on desktop so the channel stays identified while its log scrolls. */
+/* Channel detail header: summary line under the name; sticky glass on desktop. */
 .board-channel-header {
   display: flex;
   align-items: flex-end;
@@ -14338,9 +14333,8 @@ a.board-fact-pr:hover {
   }
 }
 
-/* Two-column detail: cells (primary) beside the log (secondary) on wide
-   screens when both carry content, so the log fills the space the single stack
-   used to waste. Collapses to one column when a half is empty or on mobile. */
+/* Two-column detail: cells (primary) beside the log (secondary) on wide screens
+   when both carry content; one column otherwise. */
 .board-detail-columns {
   display: grid;
   grid-template-columns: 1fr;
@@ -14397,10 +14391,9 @@ a.board-fact-pr:hover {
   .board-shell .back-link {
     display: none;
   }
-  /* Override the global mobile app bar, which stacks its meta zone onto a
-     second row (flex-direction: column). With nav moved to the toolbar the
-     board's meta is just the theme toggle, so keep the bar a single row with
-     the toggle trailing the title instead of orphaned on a line of its own. */
+  /* The global mobile app bar stacks its meta onto a second row
+     (flex-direction: column); with nav in the toolbar the board's meta is just
+     the theme toggle, so keep it a single row. */
   .board-shell .app-bar {
     flex-direction: row;
     align-items: center;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13424,16 +13424,15 @@ html[data-theme="light"] .session-switcher-row.selected {
 .board-toolbar-nav {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  justify-content: center;
   flex-shrink: 0;
-  padding: 6px 11px;
+  padding: 7px 11px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-input);
   color: var(--text);
-  font-family: var(--font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.04em;
+  font-size: 1rem;
+  line-height: 1;
   cursor: pointer;
 }
 
@@ -13776,19 +13775,21 @@ html[data-theme="light"] .session-switcher-row.selected {
 
 .board-needs-strip {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(264px, 1fr));
+  gap: 14px;
 }
 
+/* Opaque, lifted cards with a stronger hairline so each reads as its own item
+   against the translucent strip instead of merging with its neighbours. */
 .board-need-card {
   position: relative;
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 12px 14px;
+  padding: 13px 15px;
   border-radius: var(--radius-sm);
-  border: 1px solid var(--line);
-  background: var(--bg-card);
+  border: 1px solid var(--line-strong);
+  background: var(--bg-card-soft);
 }
 
 /* Dog-ear fold marks a human-gated card (matches pinned cards elsewhere). */
@@ -14236,12 +14237,19 @@ a.board-fact-pr:hover {
   padding: 8px 12px;
 }
 
-/* App bar (board page) — keep it a single non-wrapping row: the meta cluster
-   holds its size and the brand truncates first, so the theme toggle can never
-   drop to a second line. A hairline divides the view switch from the session
-   link + theme toggle so the three controls read as two groups, not a jumble. */
+/* App bar (board page) — a single non-wrapping row that always fits the
+   viewport: nowrap keeps the theme toggle from dropping to a second line, while
+   min-width:0 on both zones lets them shrink (the brand truncates first) so the
+   bar can never exceed the viewport and rescale the page. A page-level clip is
+   the final backstop against any stray horizontal overflow. A hairline divides
+   the view switch from the session link + theme toggle. */
+.page-shell.board-shell {
+  overflow-x: clip;
+}
+
 .board-shell .app-bar {
   flex-wrap: nowrap;
+  min-width: 0;
 }
 
 .board-shell .app-bar-brand {
@@ -14257,7 +14265,7 @@ a.board-fact-pr:hover {
 }
 
 .board-shell .app-bar-meta {
-  flex-shrink: 0;
+  min-width: 0;
   flex-wrap: nowrap;
   gap: 14px;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,6 +18,8 @@ import {
   InboxQuestionAnswer,
   InboxStatus,
   LaunchSettingsUpdate,
+  ManagerStateResponse,
+  ManagerSummary,
   MeResponse,
   MessageSchedule,
   ScheduleCreateRequest,
@@ -1218,6 +1220,42 @@ export async function updateBoardEntry(
   await ensureOk(response, "failed to update board entry");
   const payload = await response.json();
   return payload.entry as BoardEntry;
+}
+
+// Enumerate initialized managers for the board's per-project switcher. An
+// unavailable endpoint (older backend) or an empty list means general mode, so
+// a 404 degrades to [] rather than failing the page. Auth errors still surface.
+export async function fetchManagers(
+  host: string,
+  token: string,
+): Promise<ManagerSummary[]> {
+  const response = await fetch(`${host}/api/manager`, {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: "no-store",
+  });
+  if (response.status === 404) return [];
+  await ensureOk(response, "failed to fetch managers");
+  const payload = await response.json();
+  return (payload.managers ?? []) as ManagerSummary[];
+}
+
+// Read one manager's board data: config (with render context), tree, and the
+// authoritative ticket records. Tickets come from /state — there is no separate
+// /tickets list route.
+export async function fetchManagerState(
+  host: string,
+  token: string,
+  managerId: string,
+): Promise<ManagerStateResponse> {
+  const response = await fetch(
+    `${host}/api/manager/${encodeURIComponent(managerId)}/state`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch manager state");
+  return (await response.json()) as ManagerStateResponse;
 }
 
 export async function deleteSession(host: string, token: string, sessionId: string): Promise<void> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1222,9 +1222,8 @@ export async function updateBoardEntry(
   return payload.entry as BoardEntry;
 }
 
-// Enumerate initialized managers for the board's per-project switcher. An
-// unavailable endpoint (older backend) or an empty list means general mode, so
-// a 404 degrades to [] rather than failing the page. Auth errors still surface.
+// A 404 (endpoint unavailable) degrades to [] so the page runs in general mode
+// instead of failing.
 export async function fetchManagers(
   host: string,
   token: string,
@@ -1239,9 +1238,7 @@ export async function fetchManagers(
   return (payload.managers ?? []) as ManagerSummary[];
 }
 
-// Read one manager's board data: config (with render context), tree, and the
-// authoritative ticket records. Tickets come from /state — there is no separate
-// /tickets list route.
+// Tickets come from /state; there is no /tickets list route.
 export async function fetchManagerState(
   host: string,
   token: string,

--- a/frontend/src/lib/board.ts
+++ b/frontend/src/lib/board.ts
@@ -1,6 +1,5 @@
-// Board-workspace taxonomy: how channels group, how manager ticket states map
-// to lifecycle lanes and status lamps, and how post kinds and priorities pick a
-// tone. Pure functions so the board page stays a view and this stays testable.
+// Board-workspace taxonomy: channel grouping, ticket-state to lane/lamp
+// mapping, and kind/priority tones.
 
 import { ManagerTicket, ManagerTicketState } from "@/lib/types";
 
@@ -30,9 +29,7 @@ export const CHANNEL_GROUP_COLLAPSED_DEFAULT: Record<ChannelGroupKey, boolean> =
   other: false,
 };
 
-// Classify a channel by namespace. `<x>-tickets` / `<x>-org` are the manager's
-// intake and outcome channels; `<x>-ticket-<id>` are per-ticket. The trailing
-// dash in `-ticket-` keeps `waypoint-tickets` out of the ticket group.
+// The trailing dash in `-ticket-` keeps `<x>-tickets` out of the ticket group.
 export function classifyChannel(channel: string): ChannelGroupKey {
   if (channel.startsWith("job:")) return "job";
   const name = channel.toLowerCase();
@@ -48,9 +45,6 @@ export function classifyChannel(channel: string): ChannelGroupKey {
   return "other";
 }
 
-// The ticket id embedded in a per-ticket channel, given the manager's
-// `ticket_channel_prefix` (e.g. `waypoint-ticket-`). Null when the channel isn't
-// one of this manager's ticket channels.
 export function ticketIdFromChannel(
   channel: string,
   prefix: string | null | undefined,
@@ -91,8 +85,7 @@ export function laneForState(state: ManagerTicketState): string {
   return STATE_TO_LANE[state] ?? "other";
 }
 
-// Tickets awaiting a human decision — the three approval gates. These carry a
-// dog-ear pin, feed the Needs-you strip, and drive navigator attention dots.
+// The three approval gates — tickets awaiting a human decision.
 export const AWAITING_STATES: ReadonlySet<ManagerTicketState> = new Set([
   "spec_review",
   "blocked",
@@ -103,7 +96,7 @@ export function isAwaiting(state: ManagerTicketState): boolean {
   return AWAITING_STATES.has(state);
 }
 
-// ─── State lamp: a tone token + a human label (color is never the only cue) ───
+// ─── Ticket state → lamp tone + label ───
 
 export type StateTone =
   | "idle"
@@ -154,7 +147,7 @@ export function stateLabel(state: ManagerTicketState): string {
   return STATE_LABEL[state] ?? state;
 }
 
-// ─── Post kind → tone (kind-aware log timeline) ───
+// ─── Post kind → tone ───
 
 export type KindTone =
   | "muted"
@@ -186,7 +179,7 @@ export function kindTone(kind: string | null | undefined): KindTone {
   return KIND_TONE[kind] ?? "muted";
 }
 
-// ─── Priority tone (p0 loudest → p3 quietest) ───
+// ─── Priority tone ───
 
 export type PriorityTone = "p0" | "p1" | "p2" | "p3";
 
@@ -203,7 +196,7 @@ export function priorityTone(priority: string | null | undefined): PriorityTone 
   }
 }
 
-// ─── Board rollup (Needs you · In flight · Blocked · Merged) ───
+// ─── Board rollup ───
 
 export interface BoardRollup {
   needYou: number;

--- a/frontend/src/lib/board.ts
+++ b/frontend/src/lib/board.ts
@@ -1,0 +1,230 @@
+// Board-workspace taxonomy: how channels group, how manager ticket states map
+// to lifecycle lanes and status lamps, and how post kinds and priorities pick a
+// tone. Pure functions so the board page stays a view and this stays testable.
+
+import { ManagerTicket, ManagerTicketState } from "@/lib/types";
+
+// ─── Channel grouping (navigator) ───
+
+export type ChannelGroupKey = "manager" | "ticket" | "job" | "other";
+
+export const CHANNEL_GROUP_ORDER: ChannelGroupKey[] = [
+  "manager",
+  "ticket",
+  "job",
+  "other",
+];
+
+export const CHANNEL_GROUP_LABELS: Record<ChannelGroupKey, string> = {
+  manager: "Manager",
+  ticket: "Tickets",
+  job: "Jobs",
+  other: "Other",
+};
+
+// `job:*` is history and starts collapsed; the manager's own channels stay open.
+export const CHANNEL_GROUP_COLLAPSED_DEFAULT: Record<ChannelGroupKey, boolean> = {
+  manager: false,
+  ticket: false,
+  job: true,
+  other: false,
+};
+
+// Classify a channel by namespace. `<x>-tickets` / `<x>-org` are the manager's
+// intake and outcome channels; `<x>-ticket-<id>` are per-ticket. The trailing
+// dash in `-ticket-` keeps `waypoint-tickets` out of the ticket group.
+export function classifyChannel(channel: string): ChannelGroupKey {
+  if (channel.startsWith("job:")) return "job";
+  const name = channel.toLowerCase();
+  if (
+    name === "tickets" ||
+    name === "org" ||
+    name.endsWith("-tickets") ||
+    name.endsWith("-org")
+  ) {
+    return "manager";
+  }
+  if (name.startsWith("ticket-") || name.includes("-ticket-")) return "ticket";
+  return "other";
+}
+
+// The ticket id embedded in a per-ticket channel, given the manager's
+// `ticket_channel_prefix` (e.g. `waypoint-ticket-`). Null when the channel isn't
+// one of this manager's ticket channels.
+export function ticketIdFromChannel(
+  channel: string,
+  prefix: string | null | undefined,
+): string | null {
+  if (prefix && channel.startsWith(prefix)) {
+    return channel.slice(prefix.length) || null;
+  }
+  return null;
+}
+
+// ─── Ticket state → lifecycle lane ───
+
+export interface Lane {
+  key: string;
+  label: string;
+  states: ManagerTicketState[];
+}
+
+export const LANES: Lane[] = [
+  { key: "intake", label: "Intake · Triage", states: ["intake", "triaged"] },
+  { key: "spec", label: "Spec", states: ["spec_pending", "spec_review"] },
+  { key: "ready", label: "Ready", states: ["ready"] },
+  {
+    key: "build",
+    label: "Building · Revising",
+    states: ["delegated", "building", "revising"],
+  },
+  { key: "blocked", label: "Blocked", states: ["blocked"] },
+  { key: "review", label: "Review", states: ["review_requested"] },
+  { key: "done", label: "Done", states: ["merged", "deferred", "abandoned"] },
+];
+
+const STATE_TO_LANE: Record<ManagerTicketState, string> = Object.fromEntries(
+  LANES.flatMap((lane) => lane.states.map((state) => [state, lane.key])),
+) as Record<ManagerTicketState, string>;
+
+export function laneForState(state: ManagerTicketState): string {
+  return STATE_TO_LANE[state] ?? "other";
+}
+
+// Tickets awaiting a human decision — the three approval gates. These carry a
+// dog-ear pin, feed the Needs-you strip, and drive navigator attention dots.
+export const AWAITING_STATES: ReadonlySet<ManagerTicketState> = new Set([
+  "spec_review",
+  "blocked",
+  "review_requested",
+]);
+
+export function isAwaiting(state: ManagerTicketState): boolean {
+  return AWAITING_STATES.has(state);
+}
+
+// ─── State lamp: a tone token + a human label (color is never the only cue) ───
+
+export type StateTone =
+  | "idle"
+  | "spec"
+  | "awaiting"
+  | "active"
+  | "revising"
+  | "blocked"
+  | "done";
+
+const STATE_TONE: Record<ManagerTicketState, StateTone> = {
+  intake: "idle",
+  triaged: "idle",
+  spec_pending: "spec",
+  spec_review: "awaiting",
+  ready: "spec",
+  delegated: "active",
+  building: "active",
+  revising: "revising",
+  blocked: "blocked",
+  review_requested: "awaiting",
+  merged: "done",
+  deferred: "idle",
+  abandoned: "idle",
+};
+
+const STATE_LABEL: Record<ManagerTicketState, string> = {
+  intake: "Intake",
+  triaged: "Triaged",
+  spec_pending: "Spec pending",
+  spec_review: "Spec review",
+  ready: "Ready",
+  delegated: "Delegated",
+  building: "Building",
+  revising: "Revising",
+  blocked: "Blocked",
+  review_requested: "Review requested",
+  merged: "Merged",
+  deferred: "Deferred",
+  abandoned: "Abandoned",
+};
+
+export function stateTone(state: ManagerTicketState): StateTone {
+  return STATE_TONE[state] ?? "idle";
+}
+
+export function stateLabel(state: ManagerTicketState): string {
+  return STATE_LABEL[state] ?? state;
+}
+
+// ─── Post kind → tone (kind-aware log timeline) ───
+
+export type KindTone =
+  | "muted"
+  | "strategy"
+  | "success"
+  | "danger"
+  | "warn"
+  | "relay"
+  | "writer";
+
+const KIND_TONE: Record<string, KindTone> = {
+  progress: "muted",
+  intake_open: "muted",
+  strategy: "strategy",
+  done: "success",
+  partial: "success",
+  decision: "danger",
+  error: "danger",
+  attention: "warn",
+  respec: "warn",
+  relay: "relay",
+  spec_ready: "writer",
+  infeasible: "writer",
+  recommendation: "writer",
+};
+
+export function kindTone(kind: string | null | undefined): KindTone {
+  if (!kind) return "muted";
+  return KIND_TONE[kind] ?? "muted";
+}
+
+// ─── Priority tone (p0 loudest → p3 quietest) ───
+
+export type PriorityTone = "p0" | "p1" | "p2" | "p3";
+
+export function priorityTone(priority: string | null | undefined): PriorityTone {
+  switch (priority) {
+    case "p0":
+      return "p0";
+    case "p1":
+      return "p1";
+    case "p3":
+      return "p3";
+    default:
+      return "p2";
+  }
+}
+
+// ─── Board rollup (Needs you · In flight · Blocked · Merged) ───
+
+export interface BoardRollup {
+  needYou: number;
+  inFlight: number;
+  blocked: number;
+  merged: number;
+}
+
+const IN_FLIGHT_STATES: ReadonlySet<ManagerTicketState> = new Set([
+  "delegated",
+  "building",
+  "revising",
+]);
+
+export function rollupTickets(tickets: ManagerTicket[]): BoardRollup {
+  const rollup: BoardRollup = { needYou: 0, inFlight: 0, blocked: 0, merged: 0 };
+  for (const ticket of tickets) {
+    if (isAwaiting(ticket.state)) rollup.needYou += 1;
+    if (IN_FLIGHT_STATES.has(ticket.state)) rollup.inFlight += 1;
+    if (ticket.state === "blocked") rollup.blocked += 1;
+    if (ticket.state === "merged") rollup.merged += 1;
+  }
+  return rollup;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -591,6 +591,88 @@ export interface BoardChannel {
   last_created_at: string;
 }
 
+// ─── Waypoint Manager ───
+// The 13 states of a ticket in the manager state machine. Awaiting-human:
+// spec_review, blocked, review_requested. Terminal: merged, deferred, abandoned.
+export type ManagerTicketState =
+  | "intake"
+  | "triaged"
+  | "spec_pending"
+  | "spec_review"
+  | "ready"
+  | "delegated"
+  | "building"
+  | "blocked"
+  | "review_requested"
+  | "revising"
+  | "merged"
+  | "deferred"
+  | "abandoned";
+
+export type ManagerTicketScale = "trivial" | "substantial";
+
+export interface ManagerTicket {
+  id: string;
+  manager_id: string;
+  title: string;
+  priority: string;
+  kind?: string | null;
+  scale?: ManagerTicketScale | null;
+  state: ManagerTicketState;
+  footprint: string[];
+  is_partial: boolean;
+  spec_ref?: string | null;
+  intended_lead_title?: string | null;
+  lead_session_id?: string | null;
+  branch?: string | null;
+  pr_url?: string | null;
+  inbox_item_id?: string | null;
+  attempts: number;
+  lead_restarts: number;
+  deps: string[];
+  awaiting_since?: string | null;
+  created_at: string;
+  updated_at: string;
+  version: number;
+}
+
+export interface ManagerTreeState {
+  free: boolean;
+  held_by?: string | null;
+}
+
+export interface ManagerRenderContext {
+  templates_dir: string;
+  tickets_channel: string;
+  ticket_channel_prefix: string;
+}
+
+export interface ManagerConfig {
+  id: string;
+  project: string;
+  repo_dir: string;
+  trunk: string;
+  priority_levels: string[];
+  owner_session_id?: string | null;
+  render_context?: ManagerRenderContext | null;
+}
+
+export interface ManagerStateResponse {
+  config?: ManagerConfig | null;
+  tree: ManagerTreeState;
+  tickets: ManagerTicket[];
+}
+
+// One entry per initialized manager, for the board's per-project switcher.
+export interface ManagerSummary {
+  id: string;
+  project: string;
+  repo_dir: string;
+  owner_session_id?: string | null;
+  ticket_count: number;
+  attention_count: number;
+}
+
 export type MessageScheduleStatus = "pending" | "sent" | "cancelled" | "failed";
 
 export interface MessageSchedule {


### PR DESCRIPTION
## Purpose

Reframes the board page from a single-channel viewer into a **board workspace**: a grouped, searchable, mobile-drawer navigator; a manager **ticket board** (a Needs-you gate strip over lifecycle lanes) shown when a manager is initialized; and semantic rendering of the board's existing `kind`/`state`/`priority`/`pr`/`checks` metadata using the design system's lamp and dog-ear vocabulary. The navigation and rendering gains are manager-agnostic and also benefit workqueue and ad-hoc boards. Implements `.waypoint/specs/rfc-board-workspace-redesign.md` (Phases 1–2); the multi-manager backend it consumes landed in #317. Frontend-only, no board or manager API changes.

## Changes

### Frontend
- `frontend/src/lib/types.ts` — add `ManagerTicket`, `ManagerTicketState`, `ManagerTreeState`, `ManagerConfig`/`ManagerRenderContext`, `ManagerStateResponse`, and `ManagerSummary`.
- `frontend/src/lib/api.ts` — add `fetchManagers` (`GET /api/manager`, degrades to `[]` on 404 for general mode) and `fetchManagerState` (`GET /api/manager/{id}/state` — tickets come from `/state`, not a `/tickets` list route).
- `frontend/src/lib/board.ts` — new pure taxonomy module: channel→navigator group, ticket state→lifecycle lane, state/kind/priority→tone, and the Needs-you rollup.
- `frontend/src/app/board/page.tsx` — `Board | Channels` view switch with a deterministic default (Board when a manager exists, else Channels; `?view=`/`?channel=` still override); grouped/searchable navigator with state lamps and attention dots; off-canvas mobile drawer (focus-trap, Escape, backdrop); manager ticket board with a per-project switcher (FR10), header rollup, Needs-you glass strip deep-linking to inbox items, and horizontally-scrolling lifecycle lanes; a general channels overview when no manager; semantic rendering of the `status` cell (state banner), `strategy` cell, and a kind-aware log timeline with PR/CI/commit facts; live refresh of the manager board on `board_update`.
- `frontend/src/app/globals.css` — Blackboard section: tone palette (lamps/tags/priority pills), view switch, navigator, mobile drawer, manager board/rollup/Needs-you/lanes/ticket cards, semantic status banner and facts row, kind-aware timeline, and the mobile layout; token-driven in both themes with glass only on floating chrome.

## Design

The Board view is gated strictly on `GET /api/manager` returning at least one manager, so general boards have no manager dependency and no regression; a manager-read failure degrades rather than blocking. Navigator grouping is a name heuristic (`job:*`, `*-tickets`/`*-org`, `*-ticket-*`, other) so it needs no per-channel fan-out; the per-project switcher (fed by `GET /api/manager` with each manager's `attention_count`) scopes the ticket board, and attention dots on ticket channels come from the selected manager's awaiting-human tickets rather than scanning every channel (NFR3). Ticket state maps to lanes and to a tone token that colors a lamp always paired with a text label (NFR4); awaiting-human tickets carry the dog-ear pin. Inline gate answering (RFC Phase 3 / OQ-B) is deliberately out of scope — Needs-you links out to the inbox item.

## Test Plan

- `cd frontend && npm run lint && npm run build`.
- Playwright screenshots at 390 px and 1280 px in dark and light: manager board with seeded `spec_review`/`blocked`/`review_requested` gates (route-intercepted fixtures, so the real manager board is untouched), ticket detail (real `waypoint-ticket-656`), and the workqueue `job:*` board.
- Manual e2e against the live stack (frontend redeployed via `waypointctl restart frontend`): confirmed the `?channel=` deep link opens Channels on a manager instance, the manager board renders the live manager, and the mobile drawer opens.

## Test Result

- lint: clean. build: passes (board route prerenders).
- Manager board: Needs-you strip surfaces all three gate states with dog-ear pins and inbox deep-links; lanes place each ticket by state with hued priority chips and state lamps; rollup counts match. Mobile: Needs-you full-width first, lanes scroll horizontally, drawer is focus-trapped. Both themes resolve from tokens.
- Regression: `job:*` workqueue board navigates and renders (hero plan, state strip, task cards, log timeline); `?channel=` deep link opens the right channel in Channels view.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [ ] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [ ] I have added or updated tests covering my changes (if applicable).
- [ ] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [ ] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional).
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [ ] I have updated documentation or config examples (`.env.example`, `backend/waypoint.example.yaml`, `docs/`) if user-facing behavior changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)