### PR TITLE
feat: per-signal notification config and active-session presence suppression

### DIFF
--- a/.agents/skills/waypoint/SKILL.md
+++ b/.agents/skills/waypoint/SKILL.md
@@ -42,6 +42,8 @@ trusting any flag list reproduced in this skill.
 - Drive the per-project ticket state machine (`waypoint manager ...`) — config,
   re-anchor, ticket transitions, and prompt-template rendering: see
   `references/manager.md`.
+- Check the notification center — channel health and delivery counts (including
+  `suppressed`): `waypoint notifications status`.
 
 ## Guardrails
 

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Annotated, Any
 
+import fastapi
 from fastapi import (
     Depends,
     FastAPI,
@@ -82,6 +83,7 @@ from waypoint.schemas import (
     SessionModelRequest,
     SessionPermissionModeRequest,
     SessionPlanApprovalRequest,
+    SessionPresenceRequest,
     SessionPresetCreateRequest,
     SessionPresetListResponse,
     SessionPresetUpdateRequest,
@@ -631,6 +633,33 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         session = await context.runtime.handle_input(session_id, request)
         return {"session": session.model_dump(mode="json")}
+
+    @app.post(
+        "/api/sessions/{session_id}/presence",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def register_presence(
+        session_id: str,
+        request: SessionPresenceRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        # 404 on an unknown session before touching the registry.
+        context.runtime.get_session(session_id)
+        context.runtime.session_presence.touch(session_id, request.viewer_id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @app.delete(
+        "/api/sessions/{session_id}/presence/{viewer_id}",
+        status_code=status.HTTP_204_NO_CONTENT,
+    )
+    async def release_presence(
+        session_id: str,
+        viewer_id: Annotated[str, fastapi.Path(max_length=128)],
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Response:
+        context.runtime.get_session(session_id)
+        context.runtime.session_presence.release(session_id, viewer_id)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @app.post("/api/sessions/{session_id}/attachments")
     async def upload_attachment(

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -178,6 +178,10 @@ manager_ticket_app = typer.Typer(
     help="Add, inspect, update, and transition manager tickets.",
     no_args_is_help=True,
 )
+notifications_app = typer.Typer(
+    help="Inspect the notification center (channel health, delivery counts).",
+    no_args_is_help=True,
+)
 ManagerIdOption = Annotated[
     str | None,
     typer.Option(
@@ -198,6 +202,7 @@ app.add_typer(presets_app, name="presets")
 app.add_typer(accounts_app, name="accounts")
 app.add_typer(manager_app, name="manager")
 manager_app.add_typer(manager_ticket_app, name="ticket")
+app.add_typer(notifications_app, name="notifications")
 
 
 def _version_callback(value: bool) -> None:
@@ -2708,6 +2713,12 @@ def sessions_output(
         _settings_from_ctx(ctx),
         _get_and_process,
     )
+
+
+@notifications_app.command("status")
+def notifications_status(ctx: typer.Context) -> None:
+    """Show notification channel health and delivery counts (by status)."""
+    _emit(_settings_from_ctx(ctx), lambda c: c.get_notifications_status())
 
 
 @board_app.command("post")

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -243,6 +243,10 @@ class WaypointClient:
         data: dict[str, Any] = self._request("GET", "/api/me").json()
         return data
 
+    def get_notifications_status(self) -> dict[str, Any]:
+        data: dict[str, Any] = self._request("GET", "/api/notifications/status").json()
+        return data
+
     def list_models(
         self,
         backend: str,

--- a/backend/src/waypoint/notifications/__init__.py
+++ b/backend/src/waypoint/notifications/__init__.py
@@ -12,6 +12,7 @@ from waypoint.notifications.contracts import (
     NotificationChannel,
     NotificationIntent,
     NotificationStatus,
+    SuppressionReason,
 )
 from waypoint.notifications.render import (
     intent_from_event,
@@ -27,6 +28,7 @@ __all__ = [
     "NotificationIntent",
     "NotificationService",
     "NotificationStatus",
+    "SuppressionReason",
     "intent_from_event",
     "intent_from_inbox_item",
     "render_message",

--- a/backend/src/waypoint/notifications/contracts.py
+++ b/backend/src/waypoint/notifications/contracts.py
@@ -13,6 +13,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 IntentKind = Literal["inbox", "approval", "question", "plan_approval"]
 
+# Why a delivery row was skipped rather than sent: filtered by a per-signal
+# switch, or suppressed because a browser tab is actively viewing its session.
+SuppressionReason = Literal["signal_disabled", "active_session_presence"]
+
 
 class TextBlock(BaseModel):
     type: Literal["text"] = "text"

--- a/backend/src/waypoint/notifications/service.py
+++ b/backend/src/waypoint/notifications/service.py
@@ -11,6 +11,7 @@ import asyncio
 import contextlib
 import logging
 import random
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 
 from waypoint.notifications.contracts import (
@@ -19,6 +20,7 @@ from waypoint.notifications.contracts import (
     NotificationChannel,
     NotificationIntent,
     NotificationStatus,
+    SuppressionReason,
 )
 from waypoint.notifications.registry import build_channels
 from waypoint.notifications.render import render_message
@@ -37,9 +39,20 @@ _CLEANUP_INTERVAL = timedelta(hours=1)
 
 
 class NotificationService:
-    def __init__(self, settings: NotificationSettings, storage: Storage) -> None:
+    def __init__(
+        self,
+        settings: NotificationSettings,
+        storage: Storage,
+        suppression_reason: (
+            Callable[[NotificationIntent], SuppressionReason | None] | None
+        ) = None,
+    ) -> None:
         self._settings = settings
         self._storage = storage
+        # Late race guard: asked once per row immediately before the channel
+        # send so a row queued before its session became visibly open (or before
+        # a policy change) is retired as ``suppressed`` instead of delivered.
+        self._suppression_reason = suppression_reason
         self._channels: dict[str, NotificationChannel] = {
             channel.id: channel for channel in build_channels(settings)
         }
@@ -173,6 +186,20 @@ class NotificationService:
                 record.id, attempts=attempts, last_error="channel unavailable"
             )
             return
+        if self._suppression_reason is not None:
+            reason = self._suppression_reason(record.intent)
+            if reason is not None:
+                log.info(
+                    "notification delivery suppressed",
+                    extra={
+                        "channel_id": record.channel_id,
+                        "kind": record.intent.kind,
+                        "delivery_id": record.id,
+                        "reason": reason,
+                    },
+                )
+                self._storage.mark_delivery_suppressed(record.id, reason)
+                return
         message = render_message(
             record.intent,
             public_base_url=self._settings.public_base_url or "",

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -63,7 +63,9 @@ from waypoint.git_meta import resolve_git_meta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.manager import ManagerRegistry
 from waypoint.notifications import (
+    NotificationIntent,
     NotificationService,
+    SuppressionReason,
     intent_from_event,
     intent_from_inbox_item,
 )
@@ -111,6 +113,7 @@ from waypoint.schemas import (
     WakeRegisterRequest,
     WakeSubscription,
 )
+from waypoint.session_presence import SessionPresenceRegistry
 from waypoint.settings import Settings
 from waypoint.ssh_master import SshMasterManager, SshMasterStatus
 from waypoint.storage import Storage
@@ -479,8 +482,13 @@ class SessionRuntime:
         self.presets = PresetManager(storage)
         self.managers = ManagerRegistry(storage)
         self.scheduler = Scheduler(self)
+        self.session_presence = SessionPresenceRegistry()
         self.notifications: NotificationService | None = (
-            NotificationService(settings.notifications, storage)
+            NotificationService(
+                settings.notifications,
+                storage,
+                suppression_reason=self._notification_suppression_reason,
+            )
             if settings.notifications.enabled
             and settings.notifications.enabled_channels()
             else None
@@ -568,6 +576,7 @@ class SessionRuntime:
 
     async def stop(self) -> None:
         await self.scheduler.stop()
+        self.session_presence.clear()
         if self.notifications is not None:
             await self.notifications.stop()
         if self._telemetry_backfill_task is not None:
@@ -3361,6 +3370,7 @@ class SessionRuntime:
         # Drop the per-session lock along with the record so the registry
         # doesn't grow unbounded over a long-lived server's session churn.
         self._session_locks.pop(session_id, None)
+        self.session_presence.drop_session(session_id)
         if session.worktree_path is not None:
             self._remove_worktree(session.worktree_path, prune_branches=prune_branches)
         # Reclaim the session's uploaded blobs, which can be large.
@@ -3550,6 +3560,25 @@ class SessionRuntime:
             }
         )
 
+    def _notification_suppression_reason(
+        self, intent: NotificationIntent
+    ) -> SuppressionReason | None:
+        """Why this intent must not be delivered, or ``None`` if it may be.
+
+        Backend-neutral: reads only the persisted intent. A disabled per-signal
+        switch wins over presence; a session interaction whose session has an
+        active visible lease is suppressed. Inbox intents are never
+        presence-suppressed (they may target a different session)."""
+        if not self.settings.notifications.allows_intent(intent.kind):
+            return "signal_disabled"
+        if (
+            intent.source_session_id is not None
+            and intent.kind != "inbox"
+            and self.session_presence.is_active(intent.source_session_id)
+        ):
+            return "active_session_presence"
+        return None
+
     async def post_inbox_item(self, request: InboxPostRequest) -> InboxItem:
         from_label: str | None = None
         if request.from_session_id is not None:
@@ -3565,7 +3594,11 @@ class SessionRuntime:
             for block in request.blocks
         ]
         service = self.notifications
-        if service is not None and service.has_targets():
+        if (
+            service is not None
+            and service.has_targets()
+            and self.settings.notifications.allows_intent("inbox")
+        ):
             item = self.storage.create_inbox_item_with_notifications(
                 from_session_id=request.from_session_id or "",
                 from_label=from_label,
@@ -5174,7 +5207,12 @@ class SessionRuntime:
             intent = intent_from_event(
                 event, session_title=session.title if session is not None else None
             )
-            if intent is not None:
+            # Filter by per-signal switch and active-session presence before any
+            # outbox row is created; the source event is still persisted below.
+            if (
+                intent is not None
+                and self._notification_suppression_reason(intent) is None
+            ):
                 deliveries = service.delivery_rows(intent)
         if deliveries and service is not None:
             persisted = self.storage.append_event_with_notifications(event, deliveries)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1035,6 +1035,16 @@ class SessionPlanApprovalRequest(BaseModel):
     text: str | None = None
 
 
+ViewerId = Annotated[
+    str, StringConstraints(strip_whitespace=True, min_length=1, max_length=128)
+]
+
+
+class SessionPresenceRequest(BaseModel):
+    # Opaque client-generated per-tab identifier; never a user identity.
+    viewer_id: ViewerId
+
+
 class SessionTitleRequest(BaseModel):
     title: Annotated[
         str,

--- a/backend/src/waypoint/session_presence.py
+++ b/backend/src/waypoint/session_presence.py
@@ -1,0 +1,63 @@
+"""In-process browser-presence leases for session pages.
+
+A visible ``/session/<id>`` page registers and renews a short lease keyed by an
+opaque per-tab viewer id. Notification producers consult :meth:`is_active` to
+suppress redundant session-interaction alerts while the operator is looking at
+that exact session. State is memory-only, node-local, and erased on restart;
+leases use ``time.monotonic()`` so a wall-clock adjustment cannot extend them.
+"""
+
+import time
+
+# A visible tab renews every 15s (RFC frontend contract); a 45s lease survives
+# two missed renewals before it expires and fails open.
+LEASE_SECONDS = 45.0
+
+
+class SessionPresenceRegistry:
+    def __init__(self, *, lease_seconds: float = LEASE_SECONDS) -> None:
+        self._lease_seconds = lease_seconds
+        self._leases: dict[str, dict[str, float]] = {}
+
+    def touch(
+        self, session_id: str, viewer_id: str, *, now: float | None = None
+    ) -> None:
+        """Set/renew a lease for ``viewer_id`` on ``session_id`` and prune the
+        session's expired viewers. Identity/authorization is the caller's job."""
+        moment = time.monotonic() if now is None else now
+        viewers = self._leases.setdefault(session_id, {})
+        viewers[viewer_id] = moment + self._lease_seconds
+        self._prune(session_id, moment)
+
+    def release(self, session_id: str, viewer_id: str) -> None:
+        """Drop only the ``(session_id, viewer_id)`` lease. Idempotent."""
+        viewers = self._leases.get(session_id)
+        if viewers is None:
+            return
+        viewers.pop(viewer_id, None)
+        if not viewers:
+            self._leases.pop(session_id, None)
+
+    def is_active(self, session_id: str, *, now: float | None = None) -> bool:
+        """True when any unexpired viewer remains for ``session_id``."""
+        moment = time.monotonic() if now is None else now
+        self._prune(session_id, moment)
+        return bool(self._leases.get(session_id))
+
+    def drop_session(self, session_id: str) -> None:
+        """Forget all leases for a deleted session."""
+        self._leases.pop(session_id, None)
+
+    def clear(self) -> None:
+        """Forget every lease (process-local runtime shutdown)."""
+        self._leases.clear()
+
+    def _prune(self, session_id: str, now: float) -> None:
+        viewers = self._leases.get(session_id)
+        if viewers is None:
+            return
+        expired = [vid for vid, expires_at in viewers.items() if expires_at <= now]
+        for vid in expired:
+            del viewers[vid]
+        if not viewers:
+            self._leases.pop(session_id, None)

--- a/backend/src/waypoint/session_presence.py
+++ b/backend/src/waypoint/session_presence.py
@@ -9,8 +9,8 @@ leases use ``time.monotonic()`` so a wall-clock adjustment cannot extend them.
 
 import time
 
-# A visible tab renews every 15s (RFC frontend contract); a 45s lease survives
-# two missed renewals before it expires and fails open.
+# Longer than the frontend's 15s renewal, so one missed renewal does not drop
+# presence; short enough that a crashed tab stops suppressing within a minute.
 LEASE_SECONDS = 45.0
 
 

--- a/backend/src/waypoint/settings.py
+++ b/backend/src/waypoint/settings.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlsplit
 
 import yaml
@@ -11,6 +11,9 @@ from waypoint.backends.registry import get_registry
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import BackendId, SessionTransportId
 from waypoint.workspace_preview import DEFAULT_WORKSPACE_DENYLIST
+
+if TYPE_CHECKING:
+    from waypoint.notifications.contracts import IntentKind
 
 BACKEND_ROOT = Path(__file__).resolve().parents[2]
 
@@ -156,6 +159,18 @@ _CHANNEL_CONFIG_TYPES: dict[str, type[BaseModel]] = {
 }
 
 
+class NotificationSignalSettings(BaseModel):
+    """Per-signal delivery switches. All default true, so an ``enabled``
+    configuration that omits the block keeps delivering every signal kind."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    inbox: bool = True
+    plan: bool = True
+    permission: bool = True
+    question: bool = True
+
+
 class NotificationSettings(BaseModel):
     """Opt-in notification center. Disabled by default: with ``enabled`` false
     no outbox rows are written and no external content is transmitted."""
@@ -173,6 +188,10 @@ class NotificationSettings(BaseModel):
     http_timeout_seconds: float = Field(default=10.0, gt=0)
     # Sent/failed delivery rows older than this are purged by the worker.
     retention_days: int = Field(default=30, ge=1)
+    # Per-signal delivery switches; omitting the block keeps all signals on.
+    signals: NotificationSignalSettings = Field(
+        default_factory=NotificationSignalSettings
+    )
     channels: list[TelegramChannelConfig] = Field(default_factory=list)
 
     @field_validator("channels", mode="before")
@@ -210,6 +229,17 @@ class NotificationSettings(BaseModel):
 
     def enabled_channels(self) -> list[TelegramChannelConfig]:
         return [c for c in self.channels if c.enabled]
+
+    def allows_intent(self, intent_kind: "IntentKind") -> bool:
+        """Whether the per-signal switch for this intent kind permits delivery."""
+        signals = self.signals
+        by_kind: dict[str, bool] = {
+            "inbox": signals.inbox,
+            "plan_approval": signals.plan,
+            "approval": signals.permission,
+            "question": signals.question,
+        }
+        return by_kind[intent_kind]
 
 
 def _normalize_public_base_url(value: str) -> str:

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1427,6 +1427,26 @@ class Storage:
         self.connection.commit()
 
     @_synchronized
+    def mark_delivery_suppressed(self, delivery_id: str, reason: str) -> None:
+        """Retire a claimed row as terminally ``suppressed`` without a send.
+
+        Used by the worker's pre-send race guard: a row queued before its
+        session became visibly open (or before a policy change) is recorded with
+        a compact, content-free reason and never retried.
+        """
+        now_iso = datetime.now(UTC).isoformat()
+        self.connection.execute(
+            """
+            UPDATE notification_deliveries
+            SET status = 'suppressed', last_error = ?, lease_until = NULL,
+                updated_at = ?
+            WHERE id = ?
+            """,
+            (reason, now_iso, delivery_id),
+        )
+        self.connection.commit()
+
+    @_synchronized
     def recover_stale_deliveries(self, now: datetime) -> int:
         """Return in-flight ``sending`` rows to the queue.
 
@@ -1457,7 +1477,7 @@ class Storage:
         cursor = self.connection.execute(
             """
             DELETE FROM notification_deliveries
-            WHERE status IN ('sent', 'failed') AND created_at < ?
+            WHERE status IN ('sent', 'failed', 'suppressed') AND created_at < ?
             """,
             (cutoff.isoformat(),),
         )

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -98,6 +98,37 @@ def test_backends_help_lists_threads() -> None:
     assert "threads" in result.stdout
 
 
+def test_notifications_status_emits_health_and_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/notifications/status":
+            return httpx.Response(
+                200,
+                json={
+                    "enabled": True,
+                    "channels": [
+                        {"channel_id": "t", "available": True, "detail": None}
+                    ],
+                    "counts": {"sent": 3, "suppressed": 2},
+                },
+            )
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+    result = runner.invoke(
+        app, ["--config", str(_config(tmp_path)), "notifications", "status"]
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["enabled"] is True
+    assert payload["counts"]["suppressed"] == 2
+
+
 def test_help_command_dumps_full_surface() -> None:
     # No server or token configured — recursive help is pure introspection.
     result = runner.invoke(app, ["help"])

--- a/backend/tests/test_notifications_runtime.py
+++ b/backend/tests/test_notifications_runtime.py
@@ -6,6 +6,8 @@ from typing import Any
 import httpx
 
 from waypoint.api import create_app
+from waypoint.backends.events import InteractionChoice, InteractionEnvelope
+from waypoint.notifications import NotificationService
 from waypoint.notifications.contracts import (
     ChannelCapabilities,
     ChannelHealth,
@@ -13,9 +15,15 @@ from waypoint.notifications.contracts import (
     OutboundMessage,
 )
 from waypoint.runtime import SessionRuntime
-from waypoint.schemas import InboxMarkdownBlockInput, InboxPostRequest
+from waypoint.schemas import (
+    EventKind,
+    InboxMarkdownBlockInput,
+    InboxPostRequest,
+    SessionStatus,
+)
 from waypoint.settings import (
     NotificationSettings,
+    NotificationSignalSettings,
     Settings,
     TelegramChannelConfig,
 )
@@ -39,16 +47,130 @@ class FakeChannel:
         return None
 
 
-def _notifications() -> NotificationSettings:
+def _notifications(
+    signals: NotificationSignalSettings | None = None,
+) -> NotificationSettings:
     return NotificationSettings(
         enabled=True,
         public_base_url="https://wp.example.ts.net",
+        signals=signals or NotificationSignalSettings(),
         channels=[
             TelegramChannelConfig(
                 id="t", bot_token_env="WAYPOINT_TEST_TG", chat_ids=["1"]
             )
         ],
     )
+
+
+async def _runtime_with_channel(
+    tmp_path: Path, notifications: NotificationSettings
+) -> tuple[SessionRuntime, Storage, NotificationService]:
+    settings = Settings(data_dir=tmp_path / "data", notifications=notifications)
+    storage = Storage(settings.database_path)
+    runtime = SessionRuntime(settings, storage)
+    service = runtime.notifications
+    assert service is not None
+    service._channels = {"t": FakeChannel(channel_id="t")}
+    await service._prepare_channels()
+    return runtime, storage, service
+
+
+async def _emit_approval(runtime: SessionRuntime, session_id: str) -> None:
+    envelope = InteractionEnvelope(
+        kind="approval",
+        request_id="req1",
+        title="Approve Bash",
+        body="pytest -q",
+        choices=[InteractionChoice(label="approve")],
+    )
+    await runtime._emit_adapter_event(
+        session_id,
+        EventKind.APPROVAL_REQUEST,
+        "approval",
+        {"interaction": envelope.to_metadata()},
+        SessionStatus.WAITING_INPUT,
+    )
+
+
+async def test_interaction_suppressed_by_active_presence(tmp_path: Path) -> None:
+    runtime, storage, service = await _runtime_with_channel(tmp_path, _notifications())
+    try:
+        runtime.session_presence.touch("sessX", "viewer-1")
+        await _emit_approval(runtime, "sessX")
+        # The event is durable, but presence blocked the outbox row.
+        assert len(storage.list_events("sessX")) == 1
+        assert storage.count_deliveries_by_status() == {}
+    finally:
+        await service.stop()
+
+
+async def test_interaction_delivered_when_not_present(tmp_path: Path) -> None:
+    runtime, storage, service = await _runtime_with_channel(tmp_path, _notifications())
+    try:
+        await _emit_approval(runtime, "sessX")
+        assert len(storage.list_events("sessX")) == 1
+        assert storage.count_deliveries_by_status() == {"queued": 1}
+    finally:
+        await service.stop()
+
+
+async def test_interaction_delivered_after_lease_released(tmp_path: Path) -> None:
+    runtime, storage, service = await _runtime_with_channel(tmp_path, _notifications())
+    try:
+        runtime.session_presence.touch("sessX", "viewer-1")
+        runtime.session_presence.release("sessX", "viewer-1")
+        await _emit_approval(runtime, "sessX")
+        assert storage.count_deliveries_by_status() == {"queued": 1}
+    finally:
+        await service.stop()
+
+
+async def test_disabled_permission_signal_persists_event_without_delivery(
+    tmp_path: Path,
+) -> None:
+    runtime, storage, service = await _runtime_with_channel(
+        tmp_path, _notifications(NotificationSignalSettings(permission=False))
+    )
+    try:
+        await _emit_approval(runtime, "sessX")
+        assert len(storage.list_events("sessX")) == 1
+        assert storage.count_deliveries_by_status() == {}
+    finally:
+        await service.stop()
+
+
+async def test_inbox_not_affected_by_session_presence(tmp_path: Path) -> None:
+    runtime, storage, service = await _runtime_with_channel(tmp_path, _notifications())
+    try:
+        runtime.session_presence.touch("sender", "viewer-1")
+        item = await runtime.post_inbox_item(
+            InboxPostRequest(
+                subject="Deploy?",
+                from_session_id="sender",
+                blocks=[InboxMarkdownBlockInput(text="ready")],
+            )
+        )
+        assert storage.get_inbox_item(item.id) is not None
+        # Inbox is never presence-suppressed even when its origin session is open.
+        assert storage.count_deliveries_by_status() == {"queued": 1}
+    finally:
+        await service.stop()
+
+
+async def test_disabled_inbox_signal_persists_item_without_delivery(
+    tmp_path: Path,
+) -> None:
+    runtime, storage, service = await _runtime_with_channel(
+        tmp_path, _notifications(NotificationSignalSettings(inbox=False))
+    )
+    try:
+        item = await runtime.post_inbox_item(
+            InboxPostRequest(subject="Hi", blocks=[InboxMarkdownBlockInput(text="x")])
+        )
+        assert storage.get_inbox_item(item.id) is not None
+        assert storage.count_deliveries_by_status() == {}
+    finally:
+        await service.stop()
 
 
 async def test_runtime_inbox_post_enqueues_and_delivers(tmp_path: Path) -> None:

--- a/backend/tests/test_notifications_service.py
+++ b/backend/tests/test_notifications_service.py
@@ -76,6 +76,63 @@ def _enqueue(
     )
 
 
+async def _service_with_suppression(
+    tmp_path, channel: FakeChannel, reason, **kwargs
+) -> tuple[NotificationService, Storage]:
+    storage = Storage(tmp_path / "waypoint.db")
+    service = NotificationService(
+        _settings(**kwargs), storage, suppression_reason=reason
+    )
+    service._channels = {channel.id: channel}
+    await service._prepare_channels()
+    return service, storage
+
+
+async def test_active_presence_suppresses_at_delivery(tmp_path) -> None:
+    channel = FakeChannel()
+    service, storage = await _service_with_suppression(
+        tmp_path, channel, lambda intent: "active_session_presence"
+    )
+    try:
+        _enqueue(storage, service)
+        did_work = await service._drain_once()
+        assert did_work is True
+        # No channel send; row is terminally suppressed and not retried.
+        assert channel.sent == []
+        assert storage.count_deliveries_by_status() == {"suppressed": 1}
+        assert await service._drain_once() is False
+    finally:
+        await service.stop()
+
+
+async def test_signal_disabled_suppresses_at_delivery(tmp_path) -> None:
+    channel = FakeChannel()
+    service, storage = await _service_with_suppression(
+        tmp_path, channel, lambda intent: "signal_disabled"
+    )
+    try:
+        _enqueue(storage, service)
+        await service._drain_once()
+        assert channel.sent == []
+        assert storage.count_deliveries_by_status() == {"suppressed": 1}
+    finally:
+        await service.stop()
+
+
+async def test_no_suppression_reason_delivers_normally(tmp_path) -> None:
+    channel = FakeChannel()
+    service, storage = await _service_with_suppression(
+        tmp_path, channel, lambda intent: None
+    )
+    try:
+        _enqueue(storage, service)
+        await service._drain_once()
+        assert len(channel.sent) == 1
+        assert storage.count_deliveries_by_status() == {"sent": 1}
+    finally:
+        await service.stop()
+
+
 async def test_successful_delivery(tmp_path) -> None:
     channel = FakeChannel()
     service, storage = await _service_with(tmp_path, channel)

--- a/backend/tests/test_notifications_settings.py
+++ b/backend/tests/test_notifications_settings.py
@@ -1,7 +1,10 @@
 import pytest
 from pydantic import ValidationError
 
+from waypoint.notifications.contracts import IntentKind
 from waypoint.settings import NotificationSettings, Settings
+
+_ALL_KINDS: tuple[IntentKind, ...] = ("inbox", "plan_approval", "approval", "question")
 
 
 def test_disabled_by_default() -> None:
@@ -70,6 +73,45 @@ def test_duplicate_enabled_channel_ids_rejected() -> None:
                 {"id": "dup", "type": "telegram", "bot_token_env": "B"},
             ],
         )
+
+
+def test_signals_default_all_true() -> None:
+    signals = NotificationSettings().signals
+    assert (signals.inbox, signals.plan, signals.permission, signals.question) == (
+        True,
+        True,
+        True,
+        True,
+    )
+
+
+def test_omitted_signals_block_allows_every_intent() -> None:
+    settings = NotificationSettings()
+    for kind in _ALL_KINDS:
+        assert settings.allows_intent(kind) is True
+
+
+@pytest.mark.parametrize(
+    "key, intent_kind",
+    [
+        ("inbox", "inbox"),
+        ("plan", "plan_approval"),
+        ("permission", "approval"),
+        ("question", "question"),
+    ],
+)
+def test_each_signal_can_be_disabled(key: str, intent_kind: IntentKind) -> None:
+    settings = NotificationSettings(signals={key: False})
+    assert settings.allows_intent(intent_kind) is False
+    # Disabling one signal leaves the others on.
+    for other in _ALL_KINDS:
+        if other != intent_kind:
+            assert settings.allows_intent(other) is True
+
+
+def test_unknown_signal_key_fails_validation() -> None:
+    with pytest.raises(ValidationError):
+        NotificationSettings(signals={"bogus": True})
 
 
 def test_secret_never_a_yaml_literal() -> None:

--- a/backend/tests/test_presence_api.py
+++ b/backend/tests/test_presence_api.py
@@ -1,0 +1,119 @@
+"""API coverage for the session-presence endpoints."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from waypoint.api import create_app
+from waypoint.schemas import SessionRecord, SessionSource, SessionStatus
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _seed_session(storage: Storage, tmp_path: Path, session_id: str) -> None:
+    now = datetime.now(UTC)
+    raw_log = tmp_path / f"{session_id}.log"
+    raw_log.touch()
+    storage.create_session(
+        SessionRecord(
+            id=session_id,
+            backend="claude_code",
+            transport="claude_cli",
+            source=SessionSource.MANAGED,
+            title="Test Session",
+            cwd=str(tmp_path),
+            status=SessionStatus.IDLE,
+            created_at=now,
+            updated_at=now,
+            last_event_at=now,
+            raw_log_path=str(raw_log),
+            structured_log_path=str(raw_log),
+            transport_state={},
+        )
+    )
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    context = app.state.context
+    _seed_session(context.storage, tmp_path, "sess1")
+    token = context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_presence_requires_auth(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/sess1/presence", json={"viewer_id": "v1"}
+        )
+    assert resp.status_code == 401
+
+
+async def test_touch_registers_and_release_clears(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    registry = app.state.context.runtime.session_presence
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/sess1/presence",
+            json={"viewer_id": "v1"},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 204
+        assert registry.is_active("sess1") is True
+
+        resp = await client.delete(
+            "/api/sessions/sess1/presence/v1", headers=_auth(token)
+        )
+        assert resp.status_code == 204
+        assert registry.is_active("sess1") is False
+
+
+async def test_release_is_idempotent(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.delete(
+            "/api/sessions/sess1/presence/never-registered", headers=_auth(token)
+        )
+    assert resp.status_code == 204
+
+
+async def test_touch_unknown_session_404(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/nope/presence",
+            json={"viewer_id": "v1"},
+            headers=_auth(token),
+        )
+    assert resp.status_code == 404
+
+
+async def test_viewer_id_must_be_bounded_and_non_empty(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        too_long = await client.post(
+            "/api/sessions/sess1/presence",
+            json={"viewer_id": "x" * 129},
+            headers=_auth(token),
+        )
+        empty = await client.post(
+            "/api/sessions/sess1/presence",
+            json={"viewer_id": ""},
+            headers=_auth(token),
+        )
+    assert too_long.status_code == 422
+    assert empty.status_code == 422

--- a/backend/tests/test_session_presence.py
+++ b/backend/tests/test_session_presence.py
@@ -1,0 +1,70 @@
+from waypoint.session_presence import SessionPresenceRegistry
+
+
+def test_touch_makes_session_active() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    assert reg.is_active("s1", now=0.0) is False
+    reg.touch("s1", "v1", now=0.0)
+    assert reg.is_active("s1", now=0.0) is True
+
+
+def test_lease_expires_after_ttl() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    assert reg.is_active("s1", now=44.0) is True
+    # Boundary is inclusive: a lease at exactly its expiry is gone.
+    assert reg.is_active("s1", now=45.0) is False
+
+
+def test_renew_extends_lease() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    reg.touch("s1", "v1", now=30.0)
+    assert reg.is_active("s1", now=70.0) is True
+
+
+def test_release_drops_only_its_viewer() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    reg.touch("s1", "v2", now=0.0)
+    reg.release("s1", "v1")
+    assert reg.is_active("s1", now=0.0) is True
+    reg.release("s1", "v2")
+    assert reg.is_active("s1", now=0.0) is False
+
+
+def test_release_is_idempotent_for_unknown() -> None:
+    reg = SessionPresenceRegistry()
+    reg.release("nope", "nobody")  # no raise
+    assert reg.is_active("nope") is False
+
+
+def test_two_viewers_keep_session_active_until_last_expires() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    reg.touch("s1", "v2", now=20.0)
+    # v1 expired at 45, v2 still valid until 65.
+    assert reg.is_active("s1", now=50.0) is True
+    assert reg.is_active("s1", now=65.0) is False
+
+
+def test_sessions_are_isolated() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    assert reg.is_active("s2", now=0.0) is False
+
+
+def test_drop_session_forgets_leases() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    reg.drop_session("s1")
+    assert reg.is_active("s1", now=0.0) is False
+
+
+def test_clear_forgets_everything() -> None:
+    reg = SessionPresenceRegistry(lease_seconds=45)
+    reg.touch("s1", "v1", now=0.0)
+    reg.touch("s2", "v2", now=0.0)
+    reg.clear()
+    assert reg.is_active("s1", now=0.0) is False
+    assert reg.is_active("s2", now=0.0) is False

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -169,7 +169,15 @@ plugin_configs:
 #   worker_concurrency: 4         # concurrent sends per worker tick
 #   max_attempts: 8               # retries before a delivery is marked failed
 #   http_timeout_seconds: 10
-#   retention_days: 30            # sent/failed delivery rows purged after this
+#   retention_days: 30            # sent/failed/suppressed delivery rows purged after this
+#   signals:                      # per-signal switches; omit the block to keep all on
+#     inbox: true                 # new inbox items
+#     plan: true                  # plan approvals
+#     permission: true            # permission approvals
+#     question: true              # user questions
+#   # A visible /session/<id> page suppresses that session's plan/permission/
+#   # question alerts while open (inbox alerts are unaffected); a hidden or
+#   # closed page becomes eligible again within ~45s.
 #   channels:
 #     - id: personal-telegram
 #       type: telegram

--- a/docs/telegram-notifications.md
+++ b/docs/telegram-notifications.md
@@ -76,6 +76,43 @@ Session notifications link to `/session/<id>`. Opening any link uses Waypoint's
 normal login — the link itself carries no token. Enabling the feature does not
 retro-notify already-pending items; only new transitions notify.
 
+## Choosing which signals notify
+
+`signals` independently enables each of the four notification kinds. All default
+to `true`, so an `enabled` configuration that omits the block delivers every
+kind exactly as before.
+
+```yaml
+notifications:
+  enabled: true
+  signals:
+    inbox: true         # new inbox items
+    plan: true          # plan approvals
+    permission: false   # permission approvals
+    question: true      # user questions
+```
+
+A disabled signal is a policy decision applied **before** any outbox row is
+created: the source event and inbox item are still stored durably, but no
+delivery is queued and no external message is sent. Unknown keys fail
+validation. The mapping is `inbox` → inbox items, `plan` → plan approvals,
+`permission` → permission approvals, `question` → user questions.
+
+## Active-session presence
+
+A visible `/session/<id>` page suppresses that session's plan, permission, and
+question alerts while it is open — no point pinging a phone about a request the
+operator is already looking at. Inbox alerts are never presence-suppressed
+(an inbox item can originate from a different session).
+
+Presence is a short in-memory lease per browser tab, renewed while the tab is
+visible. A hidden tab, a closed page, a navigation, or a server restart lets
+the lease expire and the session becomes notifiable again within ~45 seconds;
+presence never permanently hides an alert. Two tabs or devices keep a session
+present until the last lease expires. There is no separate switch — presence is
+intrinsic to avoiding redundant active-session messages. To always receive
+every alert, disable no signals and keep the session page closed.
+
 ## `public_base_url`
 
 The operator-controlled origin the deep links are built from. It is **required**
@@ -109,7 +146,11 @@ large ids keep their exact form.
 | `worker_concurrency` | `4` | Concurrent sends per worker tick. |
 | `max_attempts` | `8` | Retries before a delivery is marked failed. |
 | `http_timeout_seconds` | `10` | Per-request Telegram timeout. |
-| `retention_days` | `30` | Sent/failed delivery rows are purged after this. |
+| `retention_days` | `30` | Sent/failed/suppressed delivery rows are purged after this. |
+| `signals.inbox` | `true` | Notify on new inbox items. |
+| `signals.plan` | `true` | Notify on plan approvals. |
+| `signals.permission` | `true` | Notify on permission approvals. |
+| `signals.question` | `true` | Notify on user questions. |
 | `channels[].bot_token_env` | — | Env var holding the bot token. |
 | `channels[].chat_ids` | `[]` | Target chat ids, as strings. |
 

--- a/docs/telegram-notifications.md
+++ b/docs/telegram-notifications.md
@@ -57,9 +57,11 @@ written, no HTTP calls are made, and nothing leaves the host.
    waypointctl restart backend
    ```
    Create an inbox item (or let a session ask for approval) and confirm the
-   message arrives with a working **Open** button. Check health at
-   `GET /api/notifications/status` (authenticated) — `channels[].available`
-   should be `true`.
+   message arrives with a working **Open** button. Check health with:
+   ```bash
+   waypoint notifications status
+   ```
+   `channels[].available` should be `true`.
 
 That is the whole setup. The rest of this page is reference.
 
@@ -78,9 +80,8 @@ retro-notify already-pending items; only new transitions notify.
 
 ## Choosing which signals notify
 
-`signals` independently enables each of the four notification kinds. All default
-to `true`, so an `enabled` configuration that omits the block delivers every
-kind exactly as before.
+`signals` turns each notification kind on or off independently. All four default
+to `true`, so leaving the block out notifies on everything.
 
 ```yaml
 notifications:
@@ -92,26 +93,20 @@ notifications:
     question: true      # user questions
 ```
 
-A disabled signal is a policy decision applied **before** any outbox row is
-created: the source event and inbox item are still stored durably, but no
-delivery is queued and no external message is sent. Unknown keys fail
-validation. The mapping is `inbox` → inbox items, `plan` → plan approvals,
-`permission` → permission approvals, `question` → user questions.
+Turning a signal off stops only its notifications; the inbox item or session
+request still appears in Waypoint as usual. Unknown keys are rejected.
 
 ## Active-session presence
 
-A visible `/session/<id>` page suppresses that session's plan, permission, and
-question alerts while it is open — no point pinging a phone about a request the
-operator is already looking at. Inbox alerts are never presence-suppressed
-(an inbox item can originate from a different session).
+While you have a session's page open and visible, Waypoint skips that session's
+plan, permission, and question notifications — you are already looking at it.
+Inbox notifications always arrive, since an inbox item can come from another
+session.
 
-Presence is a short in-memory lease per browser tab, renewed while the tab is
-visible. A hidden tab, a closed page, a navigation, or a server restart lets
-the lease expire and the session becomes notifiable again within ~45 seconds;
-presence never permanently hides an alert. Two tabs or devices keep a session
-present until the last lease expires. There is no separate switch — presence is
-intrinsic to avoiding redundant active-session messages. To always receive
-every alert, disable no signals and keep the session page closed.
+Closing the tab, switching away, or locking the screen makes the session
+notifiable again within about 45 seconds. Opening the same session on two
+devices keeps it silent until you leave the last one. To always be notified,
+keep the session page closed.
 
 ## `public_base_url`
 
@@ -168,6 +163,8 @@ so a duplicate is harmless.
 
 ## Troubleshooting
 
+Run `waypoint notifications status` to see channel health and delivery counts.
+
 - **`available: false`, "token environment variable … is unset"** — the env var
   named by `bot_token_env` is empty in the backend's environment. Set it and
   restart.
@@ -177,6 +174,8 @@ so a duplicate is harmless.
 - **`counts.queued` stays high** — Telegram is unreachable or rate-limiting.
   Rows retry automatically; check backend logs (structured, non-content fields
   only) for the HTTP status.
+- **`counts.suppressed` grows** — expected when a session page is open or a
+  signal is off. A suppressed message is intentionally not sent.
 - **The Open button asks for login or 404s** — expected: links carry no token,
   so log in as usual. A 404 means `public_base_url` is wrong or the
   item/session no longer exists.

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -451,8 +451,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [loadingOlder, setLoadingOlder] = useState(false);
   const { openSwitcher, setCurrentSession } = useSwitcher();
   const scheduledMessages = useSessionScheduledMessages(host, token, sessionId);
-  // Advertise this visible tab so the backend skips redundant session-
-  // interaction notifications while the operator is looking at this session.
+  // Advertise this visible tab so the backend skips notifications for a session
+  // the user is already looking at.
   useSessionPresence(host, token, sessionId);
   // Auto-dismiss the "Copied!" pill after a beat so it doesn't squat on
   // the toast slot. The fallback "Tap to copy" toast stays until the user

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -79,6 +79,7 @@ import {
   type PlanViewModel,
 } from "@/lib/events";
 import { useSessionScheduledMessages } from "@/lib/useSessionScheduledMessages";
+import { useSessionPresence } from "@/lib/useSessionPresence";
 import { formatRelativeTime } from "@/lib/usage";
 import {
   AttachmentContextProvider,
@@ -450,6 +451,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [loadingOlder, setLoadingOlder] = useState(false);
   const { openSwitcher, setCurrentSession } = useSwitcher();
   const scheduledMessages = useSessionScheduledMessages(host, token, sessionId);
+  // Advertise this visible tab so the backend skips redundant session-
+  // interaction notifications while the operator is looking at this session.
+  useSessionPresence(host, token, sessionId);
   // Auto-dismiss the "Copied!" pill after a beat so it doesn't squat on
   // the toast slot. The fallback "Tap to copy" toast stays until the user
   // acts on it — clipboard access can't be reattempted programmatically

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -695,9 +695,7 @@ export async function generateNLInsight(
   return (await response.json()) as NLGenerateAck;
 }
 
-// Register/renew a visible-tab presence lease for a session. The backend uses
-// it to suppress redundant session-interaction notifications while the operator
-// is looking at that session. Fails open: the caller ignores errors.
+// Register/renew a visible-tab presence lease for a session.
 export async function registerSessionPresence(
   host: string,
   token: string,
@@ -715,8 +713,8 @@ export async function registerSessionPresence(
   await ensureOk(response, "failed to register session presence");
 }
 
-// Release a presence lease. ``keepalive`` lets the request outlive an unmounting
-// page; the lease TTL is the authoritative fallback when it can't be sent.
+// Release a presence lease. `keepalive` lets the request outlive an unmounting
+// page; the lease TTL is the fallback when it can't be sent.
 export async function releaseSessionPresence(
   host: string,
   token: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -695,6 +695,46 @@ export async function generateNLInsight(
   return (await response.json()) as NLGenerateAck;
 }
 
+// Register/renew a visible-tab presence lease for a session. The backend uses
+// it to suppress redundant session-interaction notifications while the operator
+// is looking at that session. Fails open: the caller ignores errors.
+export async function registerSessionPresence(
+  host: string,
+  token: string,
+  sessionId: string,
+  viewerId: string,
+): Promise<void> {
+  const response = await fetch(`${host}/api/sessions/${sessionId}/presence`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ viewer_id: viewerId }),
+  });
+  await ensureOk(response, "failed to register session presence");
+}
+
+// Release a presence lease. ``keepalive`` lets the request outlive an unmounting
+// page; the lease TTL is the authoritative fallback when it can't be sent.
+export async function releaseSessionPresence(
+  host: string,
+  token: string,
+  sessionId: string,
+  viewerId: string,
+  options: { keepalive?: boolean } = {},
+): Promise<void> {
+  const response = await fetch(
+    `${host}/api/sessions/${sessionId}/presence/${encodeURIComponent(viewerId)}`,
+    {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${token}` },
+      keepalive: options.keepalive,
+    },
+  );
+  await ensureOk(response, "failed to release session presence");
+}
+
 export async function setSessionPermissionMode(
   host: string,
   token: string,

--- a/frontend/src/lib/useSessionPresence.ts
+++ b/frontend/src/lib/useSessionPresence.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { registerSessionPresence, releaseSessionPresence } from "@/lib/api";
+
+// Renew cadence for a visible tab. The backend lease is longer (45s), so a
+// single missed renewal does not drop presence.
+const RENEW_INTERVAL_MS = 15_000;
+
+// Advertise this tab as actively viewing a session while it is visible, so the
+// backend suppresses redundant session-interaction notifications for it.
+// Presence is a best-effort lease: it starts only after a successful
+// authenticated touch, renews every 15s while visible, releases when the tab is
+// hidden or unmounted, and the server-side TTL is the authoritative fallback
+// when a release is missed. It never relies on beforeunload/sendBeacon, which
+// cannot carry the bearer token.
+export function useSessionPresence(
+  host: string,
+  token: string,
+  sessionId: string,
+) {
+  useEffect(() => {
+    if (!host || !token || !sessionId) {
+      return;
+    }
+    const viewerId = crypto.randomUUID();
+    let renewTimer: ReturnType<typeof setInterval> | null = null;
+
+    const stopRenew = () => {
+      if (renewTimer !== null) {
+        clearInterval(renewTimer);
+        renewTimer = null;
+      }
+    };
+
+    // Fail open: a transient failure is retried at the next renewal tick.
+    const touch = () => {
+      void registerSessionPresence(host, token, sessionId, viewerId).catch(
+        () => {},
+      );
+    };
+
+    const release = (keepalive: boolean) => {
+      void releaseSessionPresence(host, token, sessionId, viewerId, {
+        keepalive,
+      }).catch(() => {});
+    };
+
+    const activate = () => {
+      touch();
+      if (renewTimer === null) {
+        renewTimer = setInterval(touch, RENEW_INTERVAL_MS);
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        activate();
+      } else {
+        stopRenew();
+        release(false);
+      }
+    };
+
+    if (document.visibilityState === "visible") {
+      activate();
+    }
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      stopRenew();
+      release(true);
+    };
+  }, [host, token, sessionId]);
+}

--- a/frontend/src/lib/useSessionPresence.ts
+++ b/frontend/src/lib/useSessionPresence.ts
@@ -8,13 +8,10 @@ import { registerSessionPresence, releaseSessionPresence } from "@/lib/api";
 // single missed renewal does not drop presence.
 const RENEW_INTERVAL_MS = 15_000;
 
-// Advertise this tab as actively viewing a session while it is visible, so the
-// backend suppresses redundant session-interaction notifications for it.
-// Presence is a best-effort lease: it starts only after a successful
-// authenticated touch, renews every 15s while visible, releases when the tab is
-// hidden or unmounted, and the server-side TTL is the authoritative fallback
-// when a release is missed. It never relies on beforeunload/sendBeacon, which
-// cannot carry the bearer token.
+// Lease presence for a session while its tab is visible, so the backend can
+// suppress notifications the user is already looking at. Best-effort: it fails
+// open, and avoids beforeunload/sendBeacon because those cannot carry the
+// bearer token — the server-side TTL is the fallback when a release is missed.
 export function useSessionPresence(
   host: string,
   token: string,


### PR DESCRIPTION
## Purpose

The notification center shipped in #322 has a single coarse `enabled` switch, and it will ping a phone about a session interaction that the operator is already looking at in an open Waypoint tab. This adds two controls on top of that baseline: a backward-compatible `notifications.signals` map that independently enables `inbox`, `plan`, `permission`, and `question`, and an ephemeral browser-presence lease that suppresses redundant session-interaction alerts while a visible tab is viewing that exact session. The master `enabled` switch, channels, Telegram rendering, retry, and dedupe are unchanged; signal filtering and presence are backend-neutral (no backend-id branches in runtime, api, or service). Implements `.waypoint/specs/rfc-797-per-signal-notifications-session-presence.md`.

## Changes

### Backend
- `settings.py` — `NotificationSignalSettings` (strict, all four signals default `true`) on `NotificationSettings`, plus an `allows_intent(kind)` predicate mapping the four intent kinds to the four switches. An omitted `signals` block is behavior-compatible with the previous release.
- `session_presence.py` — new in-memory `SessionPresenceRegistry`: per-tab leases keyed `{session_id: {viewer_id: expiry}}` on `time.monotonic()`, with `touch`/`release`/`is_active`/`drop_session`/`clear`, opportunistic pruning, and session isolation.
- `runtime.py` — owns the registry (cleared on `stop`, dropped on session `delete`), a single `_notification_suppression_reason(intent)` resolver, and applies it at the two producer seams: `post_inbox_item` gates on `signals.inbox`; `_emit_adapter_event` filters by signal and active-session presence before any outbox row is created. The source event and inbox item stay durable when a notification is filtered.
- `notifications/service.py` — takes a `suppression_reason` callback and, in `_deliver`, re-checks it just before rendering so a row queued before its session became visible (or before a policy change) is retired via `mark_delivery_suppressed` without a channel send and without retry.
- `storage.py` — `mark_delivery_suppressed(delivery_id, reason)` terminal state; the retention purge now also removes `suppressed` rows. Status counts report it automatically. No schema migration (status is plain text).
- `api.py` / `schemas.py` — authenticated `POST /api/sessions/{id}/presence` and idempotent `DELETE /api/sessions/{id}/presence/{viewer_id}`, both 404 on unknown session and 204 on success, with a bounded (≤128 char) non-empty opaque `viewer_id`.

### Frontend
- `useSessionPresence` hook (`lib/useSessionPresence.ts`) mounted by `SessionDetail`: generates one `crypto.randomUUID()` per view, touches on mount when visible, renews every 15s while visible, releases on `visibilitychange`-hidden and on cleanup (`keepalive`), and fails open. API helpers in `lib/api.ts`. No user-visible UI changes — presence is a background heartbeat.

### Docs
- `docs/telegram-notifications.md` — signal reference rows and an active-session presence section. `waypoint.example.yaml` — commented `signals` block and presence note.

## Design

Presence is deliberately in-memory, node-local, and race-tolerant: it is checked before enqueue and again immediately before send, so neither a database migration nor a message queued just before a page opened causes an unnecessary delivery. Leases use a monotonic clock and a 45s TTL against a 15s renewal, so a page close, background tab, crash, or restart fails open — a stale lease expires within the TTL rather than permanently muting an alert. The suppression resolver returns a typed reason (`signal_disabled` | `active_session_presence`) rather than a boolean so the worker can record why a previously queued row was skipped; configuration filtering makes it impossible to queue a new row, while a queued row that survives to a policy change is marked `suppressed` at delivery. Inbox intents are never presence-suppressed (an inbox item can originate from a different session). Presence endpoints accept only an opaque client id, disclose nothing to other clients, and never log the id or bearer token.

## Test plan
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- `cd backend && uv run pytest` — full suite, 2541 passed.
- New/extended suites: `test_notifications_settings` (signal defaults, per-signal disable, unknown-key rejection, omitted-block compatibility), `test_session_presence` (touch/expiry/renew/release, two-viewer, isolation, drop/clear), `test_presence_api` (auth, 404, idempotent release, bounded/empty viewer id), `test_notifications_service` (active-presence and signal-disabled callbacks → `suppressed`, no send, no retry; no-reason path still sends), `test_notifications_runtime` (interaction suppressed by presence / delivered when absent / delivered after release; disabled permission and inbox signals persist source without delivery; inbox unaffected by presence).
- Live HTTP exercise: booted a throwaway backend and confirmed both presence routes over real uvicorn — 401 without auth, 404 unknown session, 422 for oversized/empty `viewer_id`, routes present in the OpenAPI schema.
- `cd frontend && npm run lint && npm run build` — both pass.
- Not run: a live browser session driving the presence heartbeat end-to-end (the deployed backend was not restarted to avoid interrupting this managed session); the hook's request shape and the server routes are covered by the above.