### PR TITLE
fix: match dedicated pages' width to the redesigned homepage

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16260,6 +16260,43 @@ body.wp-dock-resizing .inbox-resizer::after {
   outline: none;
 }
 
+/* ↺ affordance shown only when a custom width is stored; clears it back to the
+   default detent. Sits at the foot of the seam, mirroring the usage popover;
+   an opaque card chip keeps it legible over scrolled list rows. */
+.inbox-resize-reset {
+  position: absolute;
+  bottom: 8px;
+  right: 6px;
+  z-index: 3;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--line);
+  background: var(--bg-card);
+  color: var(--muted-soft);
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition:
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.inbox-resize-reset:hover {
+  color: var(--accent-strong);
+  border-color: var(--line-strong);
+}
+
+.inbox-resize-reset:focus-visible {
+  outline: 2px solid var(--accent-cool);
+  outline-offset: 1px;
+  color: var(--accent-strong);
+}
+
 .inbox-toolbar {
   flex: none;
   display: flex;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16260,43 +16260,6 @@ body.wp-dock-resizing .inbox-resizer::after {
   outline: none;
 }
 
-/* ↺ affordance shown only when a custom width is stored; clears it back to the
-   default detent. Sits at the foot of the seam, mirroring the usage popover;
-   an opaque card chip keeps it legible over scrolled list rows. */
-.inbox-resize-reset {
-  position: absolute;
-  bottom: 8px;
-  right: 6px;
-  z-index: 3;
-  width: 20px;
-  height: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: 1px solid var(--line);
-  background: var(--bg-card);
-  color: var(--muted-soft);
-  font-size: 0.8rem;
-  line-height: 1;
-  cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition:
-    color 120ms ease,
-    border-color 120ms ease;
-}
-
-.inbox-resize-reset:hover {
-  color: var(--accent-strong);
-  border-color: var(--line-strong);
-}
-
-.inbox-resize-reset:focus-visible {
-  outline: 2px solid var(--accent-cool);
-  outline-offset: 1px;
-  color: var(--accent-strong);
-}
-
 .inbox-toolbar {
   flex: none;
   display: flex;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16203,7 +16203,10 @@ html[data-theme="light"] .wp-hl {
    scroll. Mobile collapses to one column via the width query below. */
 .inbox-layout {
   display: grid;
-  grid-template-columns: clamp(300px, 34%, 420px) minmax(0, 1fr);
+  grid-template-columns: var(--inbox-sidebar-w, clamp(300px, 34%, 420px)) minmax(
+      0,
+      1fr
+    );
   min-height: 0;
   border: 1px solid var(--line);
   border-radius: var(--radius);
@@ -16219,6 +16222,42 @@ html[data-theme="light"] .wp-hl {
   min-height: 0;
   min-width: 0;
   border-right: 1px solid var(--line);
+}
+
+/* Draggable seam between the list and item panes (VS Code-style, memorized). */
+.inbox-resizer {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  width: 7px;
+  height: 100%;
+  z-index: 2;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.inbox-resizer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 3px;
+  width: 1px;
+  height: 100%;
+  background: transparent;
+  transition: background-color 120ms ease;
+}
+
+.inbox-resizer:hover::after,
+.inbox-resizer:focus-visible::after,
+body.wp-dock-resizing .inbox-resizer::after {
+  background: var(--accent-cool);
+}
+
+.inbox-resizer:focus-visible {
+  outline: none;
 }
 
 .inbox-toolbar {
@@ -17104,6 +17143,10 @@ html[data-theme="light"] .wp-hl {
 
   .inbox-layout {
     grid-template-columns: 1fr;
+  }
+
+  .inbox-resizer {
+    display: none;
   }
 
   .inbox-layout .wp-mobile-hidden {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -50,6 +50,8 @@
   --radius-sm: 3px;
   --radius-glass: 16px;
   --radius-pill: 999px;
+  /* Shared content width so every page tracks the homepage deck. */
+  --page-max: min(1200px, 100vw);
   --font-sans:
     ui-sans-serif, system-ui, -apple-system, "Helvetica Neue", Arial,
     sans-serif;
@@ -158,7 +160,7 @@ pre {
 /* ─── Page layout ─── */
 .page-shell {
   width: 100%;
-  max-width: min(1024px, 100vw);
+  max-width: var(--page-max);
   margin: 0 auto;
   /* Belt-and-braces against iOS Safari widening the layout viewport when a
    * descendant has wide intrinsic content: explicitly cap to viewport width
@@ -334,7 +336,6 @@ pre {
  * glass on the floating chrome (backend popover, launch/schedule sheets,
  * presence floaters). */
 .page-shell.page-home {
-  max-width: min(1200px, 100vw);
   gap: 16px;
 }
 
@@ -16188,7 +16189,7 @@ html[data-theme="light"] .wp-hl {
 
 /* ─── Inbox ─── */
 .inbox-shell {
-  max-width: min(1180px, 100vw);
+  max-width: var(--page-max);
   height: 100dvh;
   grid-template-rows: auto minmax(0, 1fr);
   overflow: hidden;

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -28,13 +28,27 @@ const LIMIT = 30;
 const SIDEBAR_WIDTH_KEY = "waypoint.inboxSidebarWidth";
 const SIDEBAR_WIDTH_DEFAULT = 340;
 const SIDEBAR_WIDTH_MIN = 260;
+const SIDEBAR_WIDTH_MAX = 560;
+// A drag or key step landing within this many pixels of the default snaps back
+// to it and clears the stored width, so the partition reverts to the original
+// position rather than a near-default custom value.
+const SIDEBAR_SNAP_THRESHOLD = 14;
 
 function clampSidebarWidth(w: number): number {
   const max =
     typeof window === "undefined"
-      ? 560
-      : Math.min(560, Math.round(window.innerWidth * 0.5));
+      ? SIDEBAR_WIDTH_MAX
+      : Math.min(SIDEBAR_WIDTH_MAX, Math.round(window.innerWidth * 0.5));
   return Math.max(SIDEBAR_WIDTH_MIN, Math.min(w, max));
+}
+
+// `undefined` means "use the default width" (nothing stored); a clamped number
+// that snaps to the default detent collapses back to `undefined`.
+function snapSidebarWidth(w: number): number | undefined {
+  const clamped = clampSidebarWidth(w);
+  return Math.abs(clamped - SIDEBAR_WIDTH_DEFAULT) <= SIDEBAR_SNAP_THRESHOLD
+    ? undefined
+    : clamped;
 }
 
 const STATUS_FILTERS: { id: StatusFilter; label: string }[] = [
@@ -202,28 +216,33 @@ function InboxPageInner() {
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState(false);
-  const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
-    if (typeof window === "undefined") return SIDEBAR_WIDTH_DEFAULT;
+  // `undefined` = the default width (no stored preference).
+  const [sidebarWidth, setSidebarWidth] = useState<number | undefined>(() => {
+    if (typeof window === "undefined") return undefined;
     const stored = Number(window.localStorage.getItem(SIDEBAR_WIDTH_KEY));
     return Number.isFinite(stored) && stored > 0
       ? clampSidebarWidth(stored)
-      : SIDEBAR_WIDTH_DEFAULT;
+      : undefined;
   });
   const didInit = useRef(false);
   const filterRef = useRef({ status, q: debouncedQ });
 
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(sidebarWidth));
+    if (sidebarWidth === undefined) {
+      window.localStorage.removeItem(SIDEBAR_WIDTH_KEY);
+    } else {
+      window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(sidebarWidth));
+    }
   }, [sidebarWidth]);
 
   const startSidebarResize = useCallback(
     (e: React.PointerEvent) => {
       e.preventDefault();
       const startX = e.clientX;
-      const startWidth = sidebarWidth;
+      const startWidth = sidebarWidth ?? SIDEBAR_WIDTH_DEFAULT;
       const onMove = (ev: PointerEvent) =>
-        setSidebarWidth(clampSidebarWidth(startWidth + (ev.clientX - startX)));
+        setSidebarWidth(snapSidebarWidth(startWidth + (ev.clientX - startX)));
       const onUp = () => {
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
@@ -239,12 +258,14 @@ function InboxPageInner() {
   const onSidebarResizeKey = useCallback((e: React.KeyboardEvent) => {
     if (e.key === "ArrowRight") {
       e.preventDefault();
-      setSidebarWidth((w) => clampSidebarWidth(w + 24));
+      setSidebarWidth((w) => snapSidebarWidth((w ?? SIDEBAR_WIDTH_DEFAULT) + 24));
     } else if (e.key === "ArrowLeft") {
       e.preventDefault();
-      setSidebarWidth((w) => clampSidebarWidth(w - 24));
+      setSidebarWidth((w) => snapSidebarWidth((w ?? SIDEBAR_WIDTH_DEFAULT) - 24));
     }
   }, []);
+
+  const resetSidebarWidth = useCallback(() => setSidebarWidth(undefined), []);
 
   useEffect(() => {
     filterRef.current = { status, q: debouncedQ };
@@ -533,7 +554,9 @@ function InboxPageInner() {
         <div
           className="inbox-layout"
           style={
-            { "--inbox-sidebar-w": `${sidebarWidth}px` } as React.CSSProperties
+            {
+              "--inbox-sidebar-w": `${sidebarWidth ?? SIDEBAR_WIDTH_DEFAULT}px`,
+            } as React.CSSProperties
           }
         >
           <div
@@ -664,13 +687,24 @@ function InboxPageInner() {
               role="separator"
               aria-orientation="vertical"
               aria-label="Resize inbox sidebar"
-              aria-valuenow={Math.round(sidebarWidth)}
+              aria-valuenow={sidebarWidth ?? SIDEBAR_WIDTH_DEFAULT}
               aria-valuemin={SIDEBAR_WIDTH_MIN}
-              aria-valuemax={560}
+              aria-valuemax={SIDEBAR_WIDTH_MAX}
               tabIndex={0}
               onPointerDown={startSidebarResize}
               onKeyDown={onSidebarResizeKey}
             />
+            {sidebarWidth !== undefined ? (
+              <button
+                type="button"
+                className="inbox-resize-reset"
+                aria-label="Reset sidebar width"
+                title="Reset width"
+                onClick={resetSidebarWidth}
+              >
+                ↺
+              </button>
+            ) : null}
           </div>
 
           <div

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -29,9 +29,6 @@ const SIDEBAR_WIDTH_KEY = "waypoint.inboxSidebarWidth";
 const SIDEBAR_WIDTH_DEFAULT = 340;
 const SIDEBAR_WIDTH_MIN = 260;
 const SIDEBAR_WIDTH_MAX = 560;
-// A drag or key step landing within this many pixels of the default snaps back
-// to it and clears the stored width, so the partition reverts to the original
-// position rather than a near-default custom value.
 const SIDEBAR_SNAP_THRESHOLD = 14;
 
 function clampSidebarWidth(w: number): number {
@@ -42,8 +39,8 @@ function clampSidebarWidth(w: number): number {
   return Math.max(SIDEBAR_WIDTH_MIN, Math.min(w, max));
 }
 
-// `undefined` means "use the default width" (nothing stored); a clamped number
-// that snaps to the default detent collapses back to `undefined`.
+// A width within the snap threshold of the default collapses to `undefined`,
+// the sentinel for "no stored preference" that reverts to the default position.
 function snapSidebarWidth(w: number): number | undefined {
   const clamped = clampSidebarWidth(w);
   return Math.abs(clamped - SIDEBAR_WIDTH_DEFAULT) <= SIDEBAR_SNAP_THRESHOLD
@@ -216,7 +213,6 @@ function InboxPageInner() {
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState(false);
-  // `undefined` = the default width (no stored preference).
   const [sidebarWidth, setSidebarWidth] = useState<number | undefined>(() => {
     if (typeof window === "undefined") return undefined;
     const stored = Number(window.localStorage.getItem(SIDEBAR_WIDTH_KEY));

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -25,6 +25,18 @@ type StatusFilter = InboxStatus | "all";
 
 const LIMIT = 30;
 
+const SIDEBAR_WIDTH_KEY = "waypoint.inboxSidebarWidth";
+const SIDEBAR_WIDTH_DEFAULT = 340;
+const SIDEBAR_WIDTH_MIN = 260;
+
+function clampSidebarWidth(w: number): number {
+  const max =
+    typeof window === "undefined"
+      ? 560
+      : Math.min(560, Math.round(window.innerWidth * 0.5));
+  return Math.max(SIDEBAR_WIDTH_MIN, Math.min(w, max));
+}
+
 const STATUS_FILTERS: { id: StatusFilter; label: string }[] = [
   { id: "open", label: "Open" },
   { id: "resolved", label: "Resolved" },
@@ -190,8 +202,49 @@ function InboxPageInner() {
   const [selectMode, setSelectMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState(false);
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
+    if (typeof window === "undefined") return SIDEBAR_WIDTH_DEFAULT;
+    const stored = Number(window.localStorage.getItem(SIDEBAR_WIDTH_KEY));
+    return Number.isFinite(stored) && stored > 0
+      ? clampSidebarWidth(stored)
+      : SIDEBAR_WIDTH_DEFAULT;
+  });
   const didInit = useRef(false);
   const filterRef = useRef({ status, q: debouncedQ });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(sidebarWidth));
+  }, [sidebarWidth]);
+
+  const startSidebarResize = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      const startX = e.clientX;
+      const startWidth = sidebarWidth;
+      const onMove = (ev: PointerEvent) =>
+        setSidebarWidth(clampSidebarWidth(startWidth + (ev.clientX - startX)));
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        document.body.classList.remove("wp-dock-resizing");
+      };
+      document.body.classList.add("wp-dock-resizing");
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [sidebarWidth],
+  );
+
+  const onSidebarResizeKey = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "ArrowRight") {
+      e.preventDefault();
+      setSidebarWidth((w) => clampSidebarWidth(w + 24));
+    } else if (e.key === "ArrowLeft") {
+      e.preventDefault();
+      setSidebarWidth((w) => clampSidebarWidth(w - 24));
+    }
+  }, []);
 
   useEffect(() => {
     filterRef.current = { status, q: debouncedQ };
@@ -477,7 +530,12 @@ function InboxPageInner() {
       </header>
 
       {host && token ? (
-        <div className="inbox-layout">
+        <div
+          className="inbox-layout"
+          style={
+            { "--inbox-sidebar-w": `${sidebarWidth}px` } as React.CSSProperties
+          }
+        >
           <div
             className={`inbox-list-pane${mobileView === "item" ? " wp-mobile-hidden" : ""}`}
           >
@@ -601,6 +659,18 @@ function InboxPageInner() {
                 </button>
               </div>
             ) : null}
+            <div
+              className="inbox-resizer"
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize inbox sidebar"
+              aria-valuenow={Math.round(sidebarWidth)}
+              aria-valuemin={SIDEBAR_WIDTH_MIN}
+              aria-valuemax={560}
+              tabIndex={0}
+              onPointerDown={startSidebarResize}
+              onKeyDown={onSidebarResizeKey}
+            />
           </div>
 
           <div

--- a/frontend/src/app/inbox/page.tsx
+++ b/frontend/src/app/inbox/page.tsx
@@ -265,8 +265,6 @@ function InboxPageInner() {
     }
   }, []);
 
-  const resetSidebarWidth = useCallback(() => setSidebarWidth(undefined), []);
-
   useEffect(() => {
     filterRef.current = { status, q: debouncedQ };
   }, [status, debouncedQ]);
@@ -694,17 +692,6 @@ function InboxPageInner() {
               onPointerDown={startSidebarResize}
               onKeyDown={onSidebarResizeKey}
             />
-            {sidebarWidth !== undefined ? (
-              <button
-                type="button"
-                className="inbox-resize-reset"
-                aria-label="Reset sidebar width"
-                title="Reset width"
-                onClick={resetSidebarWidth}
-              >
-                ↺
-              </button>
-            ) : null}
           </div>
 
           <div


### PR DESCRIPTION
## Purpose

PR #325 widened the homepage to a `min(1200px, 100vw)` control deck, but every dedicated page kept the old width: `.page-shell` (session, telemetry, board, assistant) capped at `min(1024px, 100vw)` and the inbox at `min(1180px, 100vw)`. On desktop each of those pages rendered in a noticeably narrower centered column than the homepage they link out of. This aligns them all to the homepage width from a single source so they cannot drift again. Frontend-only, no API changes.

## Changes

### Frontend
- `app/globals.css` — add a shared `--page-max: min(1200px, 100vw)` token and point both `.page-shell` and `.inbox-shell` at it, dropping the hardcoded `1024px`/`1180px` widths and the now-redundant `max-width` override on `.page-shell.page-home` (its `gap` override stays). Every authenticated page — home, session, inbox, telemetry, board, assistant — now derives its content width from one token.

## Design

The homepage already established `min(1200px, 100vw)` as the deck width; promoting it to a `:root` token and consuming it everywhere makes width a single source of truth rather than a value copied per page. The token caps at `100vw`, so mobile stays edge-to-edge exactly as before. No component markup changed.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`/`waypoint-theme`): home, inbox, telemetry, board, assistant, and a session page at 390px and 1440px in both dark and light themes — confirmed every page matches the homepage width on desktop and stays full-width on mobile, both themes correct.

## Test Result
- `npm run lint` — no findings.
- `npm run build` — compiled successfully, 11/11 pages generated.
- Screenshots captured at 390px/1440px × dark/light for all six pages; dedicated pages now share the homepage container width.