### PR TITLE
fix: restore telemetry rate-limit refresh on the homepage tile

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -757,22 +757,13 @@ button.inst:hover {
   font-size: 0.85rem;
 }
 
-/* Telemetry header row carries a refresh control between the name link and the
-   go-arrow: the name link grows, the button and arrow sit flush right. */
-.inst-top-link-grow {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.inst-go-link {
-  display: inline-flex;
-  margin-left: 4px;
-  color: inherit;
-  text-decoration: none;
-}
-
-.inst-go-link:hover .inst-go {
-  color: var(--accent);
+/* Telemetry status row: the lamp on the left, the refresh control flush right
+   directly under the go-arrow. */
+.inst-lamp-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
 }
 
 /* Flat in-flow icon button — no glass: bare glyph in the muted hue with a

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -757,8 +757,6 @@ button.inst:hover {
   font-size: 0.85rem;
 }
 
-/* Telemetry status row: the lamp on the left, the refresh control flush right
-   directly under the go-arrow. */
 .inst-lamp-row {
   display: flex;
   align-items: center;
@@ -766,8 +764,7 @@ button.inst:hover {
   gap: 8px;
 }
 
-/* Flat in-flow icon button — no glass: bare glyph in the muted hue with a
-   subtle accent tint on hover, spinning while a refresh is in flight. */
+/* Flat in-flow icon button: no glass, since in-flow content never uses it. */
 .inst-refresh {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -757,6 +757,66 @@ button.inst:hover {
   font-size: 0.85rem;
 }
 
+/* Telemetry header row carries a refresh control between the name link and the
+   go-arrow: the name link grows, the button and arrow sit flush right. */
+.inst-top-link-grow {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.inst-go-link {
+  display: inline-flex;
+  margin-left: 4px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.inst-go-link:hover .inst-go {
+  color: var(--accent);
+}
+
+/* Flat in-flow icon button — no glass: bare glyph in the muted hue with a
+   subtle accent tint on hover, spinning while a refresh is in flight. */
+.inst-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--muted-soft);
+  cursor: pointer;
+  transition:
+    color 0.16s ease,
+    background-color 0.16s ease;
+}
+
+.inst-refresh:hover:not(:disabled) {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.inst-refresh:disabled {
+  cursor: default;
+}
+
+.inst-refresh-glyph {
+  display: block;
+}
+
+.inst-refresh.is-spinning .inst-refresh-glyph {
+  animation: inst-refresh-spin 0.8s linear infinite;
+}
+
+@keyframes inst-refresh-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .inst-lamp {
   display: inline-flex;
   align-items: center;

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -47,6 +47,7 @@ import {
   isAuthError,
   login,
   postAction,
+  refreshUsageDashboard,
   setDefaultSessionPreset,
   setSessionPinned,
   setSessionTitle,
@@ -169,6 +170,7 @@ export default function HomePage() {
   const [usageBuckets, setUsageBuckets] = useState<UsageDashboardBucket[] | null>(
     null,
   );
+  const [refreshingUsage, setRefreshingUsage] = useState(false);
   const [launchSheetOpen, setLaunchSheetOpen] = useState(false);
   const [launchSheetMode, setLaunchSheetMode] = useState<LaunchSheetMode>("new");
   const [scheduleSheetOpen, setScheduleSheetOpen] = useState(false);
@@ -272,6 +274,27 @@ export default function HomePage() {
   const handleAuthFailure = useCallback(() => {
     resetAuthState("Session expired. Log in again.");
   }, [resetAuthState]);
+
+  const handleRefreshUsage = useCallback(async () => {
+    if (!host || !token) return;
+    setRefreshingUsage(true);
+    try {
+      const response = await refreshUsageDashboard(host, token);
+      setUsageBuckets(response.buckets);
+    } catch (refreshError) {
+      if (isAuthError(refreshError)) {
+        handleAuthFailure();
+        return;
+      }
+      setError(
+        refreshError instanceof Error
+          ? refreshError.message
+          : "failed to refresh usage",
+      );
+    } finally {
+      setRefreshingUsage(false);
+    }
+  }, [host, token, handleAuthFailure]);
 
   useEffect(() => {
     const currentHost = readHost();
@@ -1234,6 +1257,8 @@ export default function HomePage() {
             </div>
             <InstrumentRail
               usageBuckets={usageBuckets}
+              refreshingUsage={refreshingUsage}
+              onRefreshUsage={handleRefreshUsage}
               telemetryEnabled={telemetryEnabled}
               boardChannels={boardChannels}
               schedules={schedules}

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -197,7 +197,6 @@ function TelemetryTile({
   );
 }
 
-// Circular-arrow refresh mark; spins via the `.is-spinning` parent class.
 function RefreshGlyph() {
   return (
     <svg

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -146,10 +146,14 @@ function TelemetryTile({
 
   return (
     <section className="inst">
-      <div className="inst-top">
-        <Link className="inst-top-link inst-top-link-grow" href="/telemetry">
-          <span className="inst-name">Telemetry</span>
-        </Link>
+      <Link className="inst-top inst-top-link" href="/telemetry">
+        <span className="inst-name">Telemetry</span>
+        <span className="inst-go" aria-hidden="true">
+          →
+        </span>
+      </Link>
+      <div className="inst-lamp-row">
+        <span className={`inst-lamp tone-${lampTone}`}>{lampText}</span>
         <button
           type="button"
           className={`inst-refresh${refreshing ? " is-spinning" : ""}`}
@@ -161,13 +165,7 @@ function TelemetryTile({
         >
           <RefreshGlyph />
         </button>
-        <Link className="inst-go-link" href="/telemetry" aria-label="Open telemetry">
-          <span className="inst-go" aria-hidden="true">
-            →
-          </span>
-        </Link>
       </div>
-      <span className={`inst-lamp tone-${lampTone}`}>{lampText}</span>
       <h4 className="inst-headline">
         {buckets.length} account{buckets.length === 1 ? "" : "s"}
       </h4>

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -25,6 +25,8 @@ import type {
 
 interface InstrumentRailProps {
   usageBuckets: UsageDashboardBucket[] | null;
+  refreshingUsage: boolean;
+  onRefreshUsage: () => void;
   telemetryEnabled: boolean;
   boardChannels: BoardChannel[];
   schedules: ScheduledSession[];
@@ -35,6 +37,8 @@ interface InstrumentRailProps {
 
 export function InstrumentRail({
   usageBuckets,
+  refreshingUsage,
+  onRefreshUsage,
   telemetryEnabled,
   boardChannels,
   schedules,
@@ -44,7 +48,12 @@ export function InstrumentRail({
 }: InstrumentRailProps) {
   return (
     <aside className="rail" aria-label="Instruments">
-      <TelemetryTile buckets={usageBuckets} telemetryEnabled={telemetryEnabled} />
+      <TelemetryTile
+        buckets={usageBuckets}
+        telemetryEnabled={telemetryEnabled}
+        refreshing={refreshingUsage}
+        onRefresh={onRefreshUsage}
+      />
       <ScheduledTile
         schedules={schedules}
         messageSchedules={messageSchedules}
@@ -87,9 +96,13 @@ function bucketPeak(bucket: UsageDashboardBucket): number {
 function TelemetryTile({
   buckets,
   telemetryEnabled,
+  refreshing,
+  onRefresh,
 }: {
   buckets: UsageDashboardBucket[] | null;
   telemetryEnabled: boolean;
+  refreshing: boolean;
+  onRefresh: () => void;
 }) {
   // Degrade to a plain link when usage is unavailable or there are no accounts:
   // lamp keyed off the master telemetry opt-in rather than live figures.
@@ -132,12 +145,27 @@ function TelemetryTile({
   const ordered = [...buckets].sort((a, b) => bucketPeak(b) - bucketPeak(a));
 
   return (
-    <Link className="inst" href="/telemetry">
+    <section className="inst">
       <div className="inst-top">
-        <span className="inst-name">Telemetry</span>
-        <span className="inst-go" aria-hidden="true">
-          →
-        </span>
+        <Link className="inst-top-link inst-top-link-grow" href="/telemetry">
+          <span className="inst-name">Telemetry</span>
+        </Link>
+        <button
+          type="button"
+          className={`inst-refresh${refreshing ? " is-spinning" : ""}`}
+          onClick={onRefresh}
+          disabled={refreshing}
+          aria-busy={refreshing}
+          aria-label={refreshing ? "Refreshing usage" : "Refresh usage"}
+          title="Refresh usage"
+        >
+          <RefreshGlyph />
+        </button>
+        <Link className="inst-go-link" href="/telemetry" aria-label="Open telemetry">
+          <span className="inst-go" aria-hidden="true">
+            →
+          </span>
+        </Link>
       </div>
       <span className={`inst-lamp tone-${lampTone}`}>{lampText}</span>
       <h4 className="inst-headline">
@@ -167,7 +195,28 @@ function TelemetryTile({
           );
         })}
       </ul>
-    </Link>
+    </section>
+  );
+}
+
+// Circular-arrow refresh mark; spins via the `.is-spinning` parent class.
+function RefreshGlyph() {
+  return (
+    <svg
+      className="inst-refresh-glyph"
+      viewBox="0 0 24 24"
+      width="14"
+      height="14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+      <path d="M21 3v6h-6" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## Purpose

PR #325 trimmed the telemetry surface and dropped the rate-limit refresh affordance. The backend `POST /api/usage/refresh` endpoint and its client helper `refreshUsageDashboard` survived the trim, so only the UI was gone — a session had no way to force a fresh rate-limit snapshot from the homepage. This restores that capability on the new Telemetry instrument tile. Frontend-only, no API changes.

## Changes

### Frontend
- `components/InstrumentRail.tsx` — add a refresh control to the populated `TelemetryTile`. The tile becomes a `<section>` with the standard full-row header link (matching `BoardTile`); the refresh button sits on the status/lamp row, flush right under the go-arrow. Clicking it calls `onRefreshUsage`, spins an inline circular-arrow glyph, disables the button (`aria-busy`) while the request is in flight, and lets the updated snapshot re-render on success. Thread `refreshingUsage`/`onRefreshUsage` through `InstrumentRail`.
- `app/page.tsx` — add `refreshingUsage` state and a `handleRefreshUsage` callback that calls `refreshUsageDashboard`, writes the returned buckets into `usageBuckets`, and reuses the existing auth-failure/error handling. Import `refreshUsageDashboard`.
- `app/globals.css` — add `.inst-lamp-row` (lamp left, refresh flush right) and a flat `.inst-refresh` icon button with a token-derived hover tint and an `.is-spinning` rotation, both themes from `:root` tokens.

## Design

The pre-325 dashboard exposed both a refresh-all button and a per-account button, but the per-account button also called the same full-dashboard `POST /api/usage/refresh` — the endpoint refreshes every account at once and there is no distinct per-account operation at `account_key` granularity. So a single refresh-all control preserves the full data capability while keeping the compact instrument tile clean. The control follows the flat-instruments language (no glass on in-flow content): a bare glyph in the muted mono hue, matching the go-arrow, with a subtle accent-tinted circular hover.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`/`waypoint.theme`): homepage Telemetry tile at 390px and 1440px in both dark and light themes — confirmed the refresh control renders under the go-arrow, clicking it applies the spinning/disabled loading state, and the per-account usage numbers update from the response.

## Test Result
- `npm run lint` — no findings.
- `npm run build` — compiled successfully, 11/11 pages generated.
- Screenshots captured at 390px/1440px × dark/light; the `.is-spinning` state and post-refresh number changes (e.g. 5h 9% → 8%) observed in all four configs.