### PR TITLE
fix: restore rate-limit reset time on the homepage telemetry tile

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -920,11 +920,13 @@ button.inst:hover {
 }
 
 /* Window row: [cap] [meter] [pct] [◷ reset]. Only the meter flexes (1fr); percent
-   and reset are fixed-width so their variable text never resizes the bar, keeping
-   every row's meter full-width and identical across both windows. */
+   and reset are narrow fixed columns so their variable text never resizes the bar,
+   keeping every row's meter identical across both windows. The reset uses a terse
+   label ("4h") in a tight, right-flushed column so the bar stays the dominant
+   element and no dead space trails the reset text. */
 .inst-window {
   display: grid;
-  grid-template-columns: 1.6rem minmax(0, 1fr) 2.2rem 6.5rem;
+  grid-template-columns: 1.6rem minmax(0, 1fr) 2.2rem 2.75rem;
   align-items: center;
   gap: 7px;
 }
@@ -970,6 +972,7 @@ button.inst:hover {
 .inst-window-reset {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 3px;
   font-family: var(--font-mono);
   font-size: 0.6rem;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -919,11 +919,8 @@ button.inst:hover {
   white-space: nowrap;
 }
 
-/* Window row: [cap] [meter] [pct] [◷ reset]. Only the meter flexes (1fr); percent
-   and reset are narrow fixed columns so their variable text never resizes the bar,
-   keeping every row's meter identical across both windows. The reset uses a terse
-   label ("in 4h" / "3d ago") in a tight, right-flushed column so the bar stays the
-   dominant element and no dead space trails the reset text. */
+/* Window row: [cap] [meter] [pct] [◷ reset]. Only the meter flexes (1fr); the fixed
+   percent and reset columns keep every row's meter identical across both windows. */
 .inst-window {
   display: grid;
   grid-template-columns: 1.6rem minmax(0, 1fr) 2.2rem 4rem;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -922,11 +922,11 @@ button.inst:hover {
 /* Window row: [cap] [meter] [pct] [◷ reset]. Only the meter flexes (1fr); percent
    and reset are narrow fixed columns so their variable text never resizes the bar,
    keeping every row's meter identical across both windows. The reset uses a terse
-   label ("4h") in a tight, right-flushed column so the bar stays the dominant
-   element and no dead space trails the reset text. */
+   label ("in 4h" / "3d ago") in a tight, right-flushed column so the bar stays the
+   dominant element and no dead space trails the reset text. */
 .inst-window {
   display: grid;
-  grid-template-columns: 1.6rem minmax(0, 1fr) 2.2rem 2.75rem;
+  grid-template-columns: 1.6rem minmax(0, 1fr) 2.2rem 4rem;
   align-items: center;
   gap: 7px;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -919,11 +919,12 @@ button.inst:hover {
   white-space: nowrap;
 }
 
-/* Labelled window row: [cap] [────meter────] [pct] on one line, so 5h and
-   weekly each read as a bar plus its number. */
+/* Labelled window row: [cap] [────meter────] [pct] [◷ reset] on one line, so 5h
+   and weekly each read as a bar, its number, and when it resets. The reset column
+   is content-sized and collapses to nothing when no reset time is known. */
 .inst-window {
   display: grid;
-  grid-template-columns: 1.6rem 1fr 2.2rem;
+  grid-template-columns: 1.6rem 1fr 2.2rem auto;
   align-items: center;
   gap: 7px;
 }
@@ -964,6 +965,21 @@ button.inst:hover {
   color: var(--text);
   text-align: right;
   font-variant-numeric: tabular-nums;
+}
+
+.inst-window-reset {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  color: var(--muted-soft);
+  white-space: nowrap;
+}
+
+.inst-window-reset-glyph {
+  font-size: 0.66rem;
+  line-height: 1;
 }
 
 /* Top channels list: the most-recently-active channels with their post counts. */

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -919,14 +919,12 @@ button.inst:hover {
   white-space: nowrap;
 }
 
-/* Labelled window row: [cap] [──meter──] [pct] [◷ reset] as a fixed-column table,
-   so 5h and weekly each read as a bar, its number, and when it resets. The meter
-   column is a fixed width so every bar is identical across rows and windows; the
-   reset column takes the remaining space and never stretches or shrinks the bar,
-   whatever the reset text (or the "—" no-data row) is. */
+/* Window row: [cap] [meter] [pct] [◷ reset]. Only the meter flexes (1fr); percent
+   and reset are fixed-width so their variable text never resizes the bar, keeping
+   every row's meter full-width and identical across both windows. */
 .inst-window {
   display: grid;
-  grid-template-columns: 1.6rem 8rem 2.2rem minmax(0, 1fr);
+  grid-template-columns: 1.6rem minmax(0, 1fr) 2.2rem 6.5rem;
   align-items: center;
   gap: 7px;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -919,12 +919,14 @@ button.inst:hover {
   white-space: nowrap;
 }
 
-/* Labelled window row: [cap] [────meter────] [pct] [◷ reset] on one line, so 5h
-   and weekly each read as a bar, its number, and when it resets. The reset column
-   is content-sized and collapses to nothing when no reset time is known. */
+/* Labelled window row: [cap] [──meter──] [pct] [◷ reset] as a fixed-column table,
+   so 5h and weekly each read as a bar, its number, and when it resets. The meter
+   column is a fixed width so every bar is identical across rows and windows; the
+   reset column takes the remaining space and never stretches or shrinks the bar,
+   whatever the reset text (or the "—" no-data row) is. */
 .inst-window {
   display: grid;
-  grid-template-columns: 1.6rem 1fr 2.2rem auto;
+  grid-template-columns: 1.6rem 8rem 2.2rem minmax(0, 1fr);
   align-items: center;
   gap: 7px;
 }
@@ -975,6 +977,7 @@ button.inst:hover {
   font-size: 0.6rem;
   color: var(--muted-soft);
   white-space: nowrap;
+  overflow: hidden;
 }
 
 .inst-window-reset-glyph {

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 
 import {
+  formatRateLimitWindowReset,
   formatRelativeTime,
   rateLimitUsageTone,
   rateLimitWindowPercent,
@@ -175,6 +176,8 @@ function TelemetryTile({
           const weekly = findWindow(bucket, "weekly");
           const fivePct = five ? rateLimitWindowPercent(five) : null;
           const weekPct = weekly ? rateLimitWindowPercent(weekly) : null;
+          const fiveReset = five ? formatRateLimitWindowReset(five) : null;
+          const weekReset = weekly ? formatRateLimitWindowReset(weekly) : null;
           const peak = bucketPeak(bucket);
           return (
             <li className="inst-account" key={bucket.account_key}>
@@ -187,8 +190,8 @@ function TelemetryTile({
                   {bucket.account_label}
                 </span>
               </span>
-              <UsageWindowMeter label="5h" percent={fivePct} />
-              <UsageWindowMeter label="wk" percent={weekPct} />
+              <UsageWindowMeter label="5h" percent={fivePct} reset={fiveReset} />
+              <UsageWindowMeter label="wk" percent={weekPct} reset={weekReset} />
             </li>
           );
         })}
@@ -222,13 +225,16 @@ function toneOf(percent: number | null): "ok" | "warn" | "danger" {
   return t === "good" ? "ok" : t === "warn" ? "warn" : "danger";
 }
 
-// One labelled window row: a caption, a tone-filled meter, and the percentage.
+// One labelled window row: a caption, a tone-filled meter, the percentage, and a
+// compact reset hint (time until the quota window resets) when one is known.
 function UsageWindowMeter({
   label,
   percent,
+  reset,
 }: {
   label: string;
   percent: number | null;
+  reset: string | null;
 }) {
   const tone = toneOf(percent);
   return (
@@ -243,6 +249,14 @@ function UsageWindowMeter({
       <span className="inst-window-pct">
         {percent !== null ? `${percent}%` : "—"}
       </span>
+      {reset ? (
+        <span className="inst-window-reset" title={`Resets ${reset}`}>
+          <span aria-hidden="true" className="inst-window-reset-glyph">
+            ◷
+          </span>
+          {reset}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import {
   formatRateLimitWindowReset,
+  formatRateLimitWindowResetShort,
   formatRelativeTime,
   rateLimitUsageTone,
   rateLimitWindowPercent,
@@ -176,8 +177,10 @@ function TelemetryTile({
           const weekly = findWindow(bucket, "weekly");
           const fivePct = five ? rateLimitWindowPercent(five) : null;
           const weekPct = weekly ? rateLimitWindowPercent(weekly) : null;
-          const fiveReset = five ? formatRateLimitWindowReset(five) : null;
-          const weekReset = weekly ? formatRateLimitWindowReset(weekly) : null;
+          const fiveReset = five ? formatRateLimitWindowResetShort(five) : null;
+          const weekReset = weekly ? formatRateLimitWindowResetShort(weekly) : null;
+          const fiveResetFull = five ? formatRateLimitWindowReset(five) : null;
+          const weekResetFull = weekly ? formatRateLimitWindowReset(weekly) : null;
           const peak = bucketPeak(bucket);
           return (
             <li className="inst-account" key={bucket.account_key}>
@@ -190,8 +193,18 @@ function TelemetryTile({
                   {bucket.account_label}
                 </span>
               </span>
-              <UsageWindowMeter label="5h" percent={fivePct} reset={fiveReset} />
-              <UsageWindowMeter label="wk" percent={weekPct} reset={weekReset} />
+              <UsageWindowMeter
+                label="5h"
+                percent={fivePct}
+                reset={fiveReset}
+                resetTitle={fiveResetFull}
+              />
+              <UsageWindowMeter
+                label="wk"
+                percent={weekPct}
+                reset={weekReset}
+                resetTitle={weekResetFull}
+              />
             </li>
           );
         })}
@@ -231,10 +244,12 @@ function UsageWindowMeter({
   label,
   percent,
   reset,
+  resetTitle,
 }: {
   label: string;
   percent: number | null;
   reset: string | null;
+  resetTitle: string | null;
 }) {
   const tone = toneOf(percent);
   return (
@@ -250,7 +265,11 @@ function UsageWindowMeter({
         {percent !== null ? `${percent}%` : "—"}
       </span>
       {reset ? (
-        <span className="inst-window-reset" title={reset}>
+        <span
+          className="inst-window-reset"
+          title={resetTitle ?? reset}
+          aria-label={resetTitle ?? reset}
+        >
           <span aria-hidden="true" className="inst-window-reset-glyph">
             ◷
           </span>

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -172,42 +172,21 @@ function TelemetryTile({
         {buckets.length} account{buckets.length === 1 ? "" : "s"}
       </h4>
       <ul className="inst-accounts">
-        {ordered.map((bucket) => {
-          const five = findWindow(bucket, "5h");
-          const weekly = findWindow(bucket, "weekly");
-          const fivePct = five ? rateLimitWindowPercent(five) : null;
-          const weekPct = weekly ? rateLimitWindowPercent(weekly) : null;
-          const fiveReset = five ? formatRateLimitWindowResetShort(five) : null;
-          const weekReset = weekly ? formatRateLimitWindowResetShort(weekly) : null;
-          const fiveResetFull = five ? formatRateLimitWindowReset(five) : null;
-          const weekResetFull = weekly ? formatRateLimitWindowReset(weekly) : null;
-          const peak = bucketPeak(bucket);
-          return (
-            <li className="inst-account" key={bucket.account_key}>
-              <span className="inst-account-head">
-                <span
-                  className={`inst-account-dot tone-${toneOf(peak)}`}
-                  aria-hidden="true"
-                />
-                <span className="inst-account-name" title={bucket.account_label}>
-                  {bucket.account_label}
-                </span>
+        {ordered.map((bucket) => (
+          <li className="inst-account" key={bucket.account_key}>
+            <span className="inst-account-head">
+              <span
+                className={`inst-account-dot tone-${toneOf(bucketPeak(bucket))}`}
+                aria-hidden="true"
+              />
+              <span className="inst-account-name" title={bucket.account_label}>
+                {bucket.account_label}
               </span>
-              <UsageWindowMeter
-                label="5h"
-                percent={fivePct}
-                reset={fiveReset}
-                resetTitle={fiveResetFull}
-              />
-              <UsageWindowMeter
-                label="wk"
-                percent={weekPct}
-                reset={weekReset}
-                resetTitle={weekResetFull}
-              />
-            </li>
-          );
-        })}
+            </span>
+            <UsageWindowMeter label="5h" window={findWindow(bucket, "5h")} />
+            <UsageWindowMeter label="wk" window={findWindow(bucket, "weekly")} />
+          </li>
+        ))}
       </ul>
     </section>
   );
@@ -238,19 +217,16 @@ function toneOf(percent: number | null): "ok" | "warn" | "danger" {
   return t === "good" ? "ok" : t === "warn" ? "warn" : "danger";
 }
 
-// One labelled window row: a caption, a tone-filled meter, the percentage, and a
-// compact reset hint (time until the quota window resets) when one is known.
 function UsageWindowMeter({
   label,
-  percent,
-  reset,
-  resetTitle,
+  window,
 }: {
   label: string;
-  percent: number | null;
-  reset: string | null;
-  resetTitle: string | null;
+  window: UsageWindow | null;
 }) {
+  const percent = window ? rateLimitWindowPercent(window) : null;
+  const reset = window ? formatRateLimitWindowResetShort(window) : null;
+  const resetTitle = window ? formatRateLimitWindowReset(window) : null;
   const tone = toneOf(percent);
   return (
     <span className="inst-window">

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -250,7 +250,7 @@ function UsageWindowMeter({
         {percent !== null ? `${percent}%` : "—"}
       </span>
       {reset ? (
-        <span className="inst-window-reset" title={`Resets ${reset}`}>
+        <span className="inst-window-reset" title={reset}>
           <span aria-hidden="true" className="inst-window-reset-glyph">
             ◷
           </span>

--- a/frontend/src/lib/usage.ts
+++ b/frontend/src/lib/usage.ts
@@ -13,8 +13,7 @@ export function formatTokens(value: number): string {
 
 type RelativeTimeUnit = "second" | "minute" | "hour" | "day";
 
-// Signed magnitude + unit for a timestamp relative to now, so the verbose and
-// terse renderings below stay on the same buckets and can never disagree by a unit.
+// Shared by the verbose and terse relative-time formatters below.
 function relativeTimeParts(
   value: string,
 ): { value: number; unit: RelativeTimeUnit } | null {
@@ -104,11 +103,8 @@ const RELATIVE_TIME_SUFFIX: Record<RelativeTimeUnit, string> = {
   day: "d",
 };
 
-// Terse reset label ("in 4h", "3d ago", "now") for tight, glanceable surfaces
-// where the verbose relative phrase would crowd out the meter. Keeps the "in"/"ago"
-// direction so a stale, already-elapsed window is not mistaken for an upcoming one.
-// Falls back to the backend's free-form description when no machine-readable reset
-// time is available.
+// Terse reset label ("in 4h", "3d ago", "now") for compact surfaces; falls back to
+// the backend's free-form description when no machine-readable reset time is known.
 export function formatRateLimitWindowResetShort(window: UsageWindow): string | null {
   if (window.resets_at) {
     const parts = relativeTimeParts(window.resets_at);

--- a/frontend/src/lib/usage.ts
+++ b/frontend/src/lib/usage.ts
@@ -11,23 +11,37 @@ export function formatTokens(value: number): string {
   return TOKEN_FORMATTER.format(value);
 }
 
-export function formatRelativeTime(value: string): string {
+type RelativeTimeUnit = "second" | "minute" | "hour" | "day";
+
+// Signed magnitude + unit for a timestamp relative to now, so the verbose and
+// terse renderings below stay on the same buckets and can never disagree by a unit.
+function relativeTimeParts(
+  value: string,
+): { value: number; unit: RelativeTimeUnit } | null {
   const timestamp = Date.parse(value);
   if (!Number.isFinite(timestamp)) {
-    return "Unknown";
+    return null;
   }
   const diffSeconds = Math.round((timestamp - Date.now()) / 1000);
   const absSeconds = Math.abs(diffSeconds);
   if (absSeconds < 60) {
-    return RELATIVE_TIME_FORMATTER.format(diffSeconds, "second");
+    return { value: diffSeconds, unit: "second" };
   }
   if (absSeconds < 3600) {
-    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 60), "minute");
+    return { value: Math.round(diffSeconds / 60), unit: "minute" };
   }
   if (absSeconds < 86400) {
-    return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 3600), "hour");
+    return { value: Math.round(diffSeconds / 3600), unit: "hour" };
   }
-  return RELATIVE_TIME_FORMATTER.format(Math.round(diffSeconds / 86400), "day");
+  return { value: Math.round(diffSeconds / 86400), unit: "day" };
+}
+
+export function formatRelativeTime(value: string): string {
+  const parts = relativeTimeParts(value);
+  if (!parts) {
+    return "Unknown";
+  }
+  return RELATIVE_TIME_FORMATTER.format(parts.value, parts.unit);
 }
 
 export function clampPercent(percent: number | null): number | null {
@@ -79,6 +93,27 @@ export function formatRateLimitWindowTokens(window: UsageWindow): string | null 
 export function formatRateLimitWindowReset(window: UsageWindow): string | null {
   if (window.resets_at) {
     return formatRelativeTime(window.resets_at);
+  }
+  return window.reset_description ?? null;
+}
+
+const RELATIVE_TIME_SUFFIX: Record<RelativeTimeUnit, string> = {
+  second: "s",
+  minute: "m",
+  hour: "h",
+  day: "d",
+};
+
+// Terse reset label ("4h", "3d", "45m") for tight, glanceable surfaces where the
+// verbose relative phrase would crowd out the meter. Falls back to the backend's
+// free-form description when no machine-readable reset time is available.
+export function formatRateLimitWindowResetShort(window: UsageWindow): string | null {
+  if (window.resets_at) {
+    const parts = relativeTimeParts(window.resets_at);
+    if (!parts) {
+      return null;
+    }
+    return `${parts.value}${RELATIVE_TIME_SUFFIX[parts.unit]}`;
   }
   return window.reset_description ?? null;
 }

--- a/frontend/src/lib/usage.ts
+++ b/frontend/src/lib/usage.ts
@@ -104,16 +104,22 @@ const RELATIVE_TIME_SUFFIX: Record<RelativeTimeUnit, string> = {
   day: "d",
 };
 
-// Terse reset label ("4h", "3d", "45m") for tight, glanceable surfaces where the
-// verbose relative phrase would crowd out the meter. Falls back to the backend's
-// free-form description when no machine-readable reset time is available.
+// Terse reset label ("in 4h", "3d ago", "now") for tight, glanceable surfaces
+// where the verbose relative phrase would crowd out the meter. Keeps the "in"/"ago"
+// direction so a stale, already-elapsed window is not mistaken for an upcoming one.
+// Falls back to the backend's free-form description when no machine-readable reset
+// time is available.
 export function formatRateLimitWindowResetShort(window: UsageWindow): string | null {
   if (window.resets_at) {
     const parts = relativeTimeParts(window.resets_at);
     if (!parts) {
       return null;
     }
-    return `${parts.value}${RELATIVE_TIME_SUFFIX[parts.unit]}`;
+    if (parts.value === 0) {
+      return "now";
+    }
+    const magnitude = `${Math.abs(parts.value)}${RELATIVE_TIME_SUFFIX[parts.unit]}`;
+    return parts.value < 0 ? `${magnitude} ago` : `in ${magnitude}`;
   }
   return window.reset_description ?? null;
 }


### PR DESCRIPTION
## Purpose

PR #325 trimmed the telemetry surface and dropped the per-window rate-limit reset-time display. The `UsageWindow.resets_at` field and the `formatRateLimitWindowReset` helper both survived the trim, so only the UI was gone — the homepage Telemetry tile showed each account's 5h and weekly usage meters but no longer told the human when each quota window resets. This restores that display on the redesigned instrument tile. Frontend-only, no API changes.

## Changes

### Frontend
- `components/InstrumentRail.tsx` — import `formatRateLimitWindowReset`; compute the reset text for the 5h and weekly windows and thread it into `UsageWindowMeter` via a new `reset` prop. Each window row renders a compact reset hint (the pre-325 `◷` glyph plus the relative reset time, e.g. `◷ in 4 hours`) as a trailing element, or nothing when no reset time is known.
- `app/globals.css` — add a content-sized fourth column to the `.inst-window` grid (`1.6rem 1fr 2.2rem auto`) and style `.inst-window-reset` / `.inst-window-reset-glyph` as bare mono text in the `--muted-soft` hue. The column collapses to nothing when a row has no reset, and the `1fr` meter shrinks to make room, so the tile keeps a single line per window in both themes.

## Design

The pre-325 `UsageReadout` rendered the reset next to each window label as `◷ <relative time>`; that component still lives on the per-session usage pill, so this reuses the same `formatRateLimitWindowReset` output and glyph for visual continuity. On the compact instrument tile there is no room for a separate label row, so the reset sits as a muted trailing hint on the existing meter line rather than adding vertical height — the human asked for the tile to stay minimal and compact. It follows the flat-instruments language (no glass on in-flow content): bare mono text in the muted hue, glyphs left-aligned so the 5h and weekly hints line up.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`/`waypoint-theme`): homepage Telemetry tile at 390px and 1440px in both dark and light themes, with three live accounts — confirmed the reset time renders on both the 5h and weekly rows, the meter shrinks gracefully at the narrowest 336px desktop rail with no width overflow, and the hint reads correctly in both themes.

## Test Result
- `npm run lint` — no findings.
- `npm run build` — compiled successfully, 11/11 pages generated.
- Screenshots captured at 390px/1440px × dark/light; both windows show their reset time (e.g. `◷ in 4 hours` for 5h, `◷ in 3 days` for weekly) and the tile stays compact in all four configs.