### PR TITLE
fix: stop the launch sheet from stealing input focus on re-render

### DIFF
--- a/frontend/src/components/Sheet.tsx
+++ b/frontend/src/components/Sheet.tsx
@@ -18,6 +18,16 @@ interface SheetProps {
 export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
+  // Read onClose through a ref so the focus-management effect below keys on
+  // `open` alone. Callers pass a fresh inline onClose each render, and the
+  // homepage re-renders continuously as live session/board updates stream in;
+  // depending on onClose would re-run the effect every render, and its cleanup
+  // (restoreFocusRef.current?.focus()) would yank focus out of whatever field
+  // the user is typing in back to the trigger.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   useEffect(() => {
     if (!open) {
@@ -32,7 +42,7 @@ export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
         return;
       }
       trapTabFocus(event, panelRef.current, { preventWhenEmpty: true });
@@ -43,7 +53,7 @@ export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
       document.removeEventListener("keydown", onKeyDown);
       restoreFocusRef.current?.focus();
     };
-  }, [open, onClose]);
+  }, [open]);
 
   if (!open) {
     return null;

--- a/frontend/src/components/Sheet.tsx
+++ b/frontend/src/components/Sheet.tsx
@@ -18,12 +18,8 @@ interface SheetProps {
 export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
-  // Read onClose through a ref so the focus-management effect below keys on
-  // `open` alone. Callers pass a fresh inline onClose each render, and the
-  // homepage re-renders continuously as live session/board updates stream in;
-  // depending on onClose would re-run the effect every render, and its cleanup
-  // (restoreFocusRef.current?.focus()) would yank focus out of whatever field
-  // the user is typing in back to the trigger.
+  // Key the focus effect on `open` alone; a fresh inline onClose each render
+  // would otherwise re-run it and its cleanup would steal focus mid-typing.
   const onCloseRef = useRef(onClose);
   useEffect(() => {
     onCloseRef.current = onClose;

--- a/frontend/src/lib/useSessionPresence.ts
+++ b/frontend/src/lib/useSessionPresence.ts
@@ -8,9 +8,8 @@ import { registerSessionPresence, releaseSessionPresence } from "@/lib/api";
 // single missed renewal does not drop presence.
 const RENEW_INTERVAL_MS = 15_000;
 
-// crypto.randomUUID is gated on a secure context, so it is undefined when the
-// app is served over plain HTTP (e.g. a tailnet IP on mobile). The viewer id is
-// a non-security-sensitive per-tab tag, so fall back to a random string there.
+// crypto.randomUUID is undefined outside a secure context (plain HTTP on
+// mobile); fall back to a random string for this non-security viewer id.
 function makeViewerId(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
     return crypto.randomUUID();

--- a/frontend/src/lib/useSessionPresence.ts
+++ b/frontend/src/lib/useSessionPresence.ts
@@ -8,6 +8,16 @@ import { registerSessionPresence, releaseSessionPresence } from "@/lib/api";
 // single missed renewal does not drop presence.
 const RENEW_INTERVAL_MS = 15_000;
 
+// crypto.randomUUID is gated on a secure context, so it is undefined when the
+// app is served over plain HTTP (e.g. a tailnet IP on mobile). The viewer id is
+// a non-security-sensitive per-tab tag, so fall back to a random string there.
+function makeViewerId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `v-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
 // Lease presence for a session while its tab is visible, so the backend can
 // suppress notifications the user is already looking at. Best-effort: it fails
 // open, and avoids beforeunload/sendBeacon because those cannot carry the
@@ -21,7 +31,7 @@ export function useSessionPresence(
     if (!host || !token || !sessionId) {
       return;
     }
-    const viewerId = crypto.randomUUID();
+    const viewerId = makeViewerId();
     let renewTimer: ReturnType<typeof setInterval> | null = null;
 
     const stopRenew = () => {


### PR DESCRIPTION
## Purpose

Two frontend-only mobile/focus fixes, no API changes.

1. **Launch sheet steals input focus (regression from #325).** Typing in the launch-sheet **Title** box periodically lost focus — the human had to click back into the field repeatedly. PR #325 moved the launch form into the glass `Sheet` component, which introduced the focus-management effect at fault.
2. **Session page crashes on insecure-context mobile clients (pre-existing).** On an iPhone reaching the app over plain HTTP (a tailnet IP), the session page showed "This page couldn't load" with `TypeError: crypto.randomUUID is not a function`. Desktop clients on `localhost`/HTTPS were unaffected.

## Changes

### Frontend
- `components/Sheet.tsx` — the focus-management effect was keyed on `[open, onClose]`. Callers pass a fresh inline `onClose` each render (`onClose={() => setLaunchSheetOpen(false)}`), and the homepage re-renders continuously as live session/board updates stream in over the WebSocket, so the effect re-ran on nearly every render and its cleanup (`restoreFocusRef.current?.focus()`) yanked focus out of whatever field was being typed, back to the trigger. Read `onClose` through a ref and depend on `[open]` alone, so the effect runs only on genuine open/close transitions while Escape-to-close still calls the latest handler.
- `lib/useSessionPresence.ts` — `crypto.randomUUID()` is gated on a secure context, so it is `undefined` when the app is served over plain HTTP (e.g. a tailnet IP on mobile), and the unguarded call threw and crashed the session page into the error boundary. The viewer id is a non-security-sensitive per-tab tag, so `makeViewerId()` falls back to a random string when `crypto.randomUUID` is unavailable.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`), each verified against a temporary rebuild of the pre-fix code to confirm the repro:
  - **Focus:** open the launch sheet, type continuously into the Title box while forcing live re-renders (board updates over the socket).
  - **crypto:** open a session page with `crypto.randomUUID` stubbed to `undefined` (simulating an insecure context) and observe `pageerror` + the error boundary.

## Test Result
- `npm run lint` — no findings. `npm run build` — compiled successfully, all pages generated.
- **Focus, buggy build (fix stashed):** typed value came out scrambled (`k-brown-fox-sessionthe-quic` instead of `the-quick-brown-fox-session`) and focus dropped mid-typing. **Fixed build:** `0` focus losses, value intact, focus held throughout.
- **crypto, buggy build (fix stashed):** `pageerror: "TypeError: crypto.randomUUID is not a function"` and the page rendered the exact "This page couldn't load — Reload to try again, or go back" fallback. **Fixed build:** no `pageerror`, the session page rendered normally.