### PR TITLE
fix: open the launch sheet preselected on preset click instead of launching

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -656,18 +656,8 @@ html[data-theme="light"] .launch-deck-new {
   transition: border-color 0.16s ease, opacity 0.16s ease;
 }
 
-.launch-chip:hover:not(:disabled) {
+.launch-chip:hover {
   border-color: var(--line-strong);
-}
-
-.launch-chip:disabled {
-  opacity: 0.55;
-  cursor: default;
-}
-
-.launch-chip[data-loading] {
-  opacity: 0.7;
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--line));
 }
 
 .launch-chip.is-ghost {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -174,8 +174,7 @@ export default function HomePage() {
   const [launchSheetOpen, setLaunchSheetOpen] = useState(false);
   const [launchSheetMode, setLaunchSheetMode] = useState<LaunchSheetMode>("new");
   const [scheduleSheetOpen, setScheduleSheetOpen] = useState(false);
-  // Which preset (if any) the launch sheet should preselect on its next open.
-  // The sheet remounts LaunchPanel every open, so this is read once at mount;
+  // The sheet remounts LaunchPanel on every open, so this is read once at mount;
   // every open path sets it explicitly so a stale value never bleeds through.
   const [presetSelection, setPresetSelection] = useState<PresetSelection>({
     kind: "default",
@@ -759,9 +758,7 @@ export default function HomePage() {
     setLaunchSheetOpen(true);
   }
 
-  // Open the launch sheet on the New tab with a preset chip preselected, so the
-  // human confirms cwd/title before launching rather than creating immediately
-  // in the default working directory. A null preset opens with no selection.
+  // A null preset opens the sheet with no preset selected (backend default).
   function openLaunchSheetWithPreset(preset: SessionPresetSummary | null) {
     setLaunchSheetMode("new");
     setPresetSelection({ kind: "preset", presetId: preset?.id ?? null });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,7 +8,7 @@ import { BackendSwitcher } from "@/components/BackendSwitcher";
 import { CompactLaunch, type LaunchSheetMode } from "@/components/CompactLaunch";
 import { HomeNav } from "@/components/HomeNav";
 import { InstrumentRail } from "@/components/InstrumentRail";
-import { LaunchPanel } from "@/components/LaunchPanel";
+import { LaunchPanel, type PresetSelection } from "@/components/LaunchPanel";
 import { LoginForm } from "@/components/LoginForm";
 import { PresenceFloaters } from "@/components/PresenceFloaters";
 import { SchedulePanel } from "@/components/SchedulePanel";
@@ -174,7 +174,12 @@ export default function HomePage() {
   const [launchSheetOpen, setLaunchSheetOpen] = useState(false);
   const [launchSheetMode, setLaunchSheetMode] = useState<LaunchSheetMode>("new");
   const [scheduleSheetOpen, setScheduleSheetOpen] = useState(false);
-  const [launchingPresetId, setLaunchingPresetId] = useState<string | null>(null);
+  // Which preset (if any) the launch sheet should preselect on its next open.
+  // The sheet remounts LaunchPanel every open, so this is read once at mount;
+  // every open path sets it explicitly so a stale value never bleeds through.
+  const [presetSelection, setPresetSelection] = useState<PresetSelection>({
+    kind: "default",
+  });
   const inboxCount = useInboxCount(host, token);
   const [recentCwds, setRecentCwds] = useState<string[]>([]);
   const [threadsByBackend, setThreadsByBackend] = useState<
@@ -748,51 +753,18 @@ export default function HomePage() {
     }
   }
 
-  // One-tap launch from a preset chip on the compact launch deck. Resolves the
-  // preset spec (fetching the full, env-carrying spec only when the preset pins
-  // env vars) and routes through handleCreate so cwd-not-found, SSH-master
-  // retry, and auth handling stay identical to the sheet form. cwd/title are
-  // per-launch specifics absent from preset specs, so the effective default cwd
-  // is used. A null preset launches the plain backend default.
-  async function handleLaunchPreset(preset: SessionPresetSummary | null) {
-    if (launchingPresetId) {
-      return;
-    }
-    const marker = preset?.id ?? "__default__";
-    setLaunchingPresetId(marker);
-    try {
-      const spec = preset?.spec ?? null;
-      const backend = (spec?.backend ?? effectiveDefaultBackend) as Backend;
-      let launchEnv: Record<string, string> = {};
-      if (preset && (spec?.launch_env_keys?.length ?? 0) > 0) {
-        try {
-          const full = await fetchSessionPreset(host, token, preset.id, true);
-          launchEnv = full.spec.launch_env ?? {};
-        } catch {
-          // Fall through with empty env — handleCreate surfaces any failure.
-        }
-      }
-      await handleCreate(
-        backend,
-        effectiveDefaultCwd,
-        "",
-        spec?.model ?? null,
-        spec?.effort ?? null,
-        spec?.transport ?? null,
-        spec?.args ?? [],
-        spec?.config_overrides ?? [],
-        launchEnv,
-        spec?.permission_mode ?? null,
-        preset?.id ?? null,
-        spec?.account_profile_id ?? null,
-      );
-    } finally {
-      setLaunchingPresetId(null);
-    }
-  }
-
   function openLaunchSheet(mode: LaunchSheetMode) {
     setLaunchSheetMode(mode);
+    setPresetSelection({ kind: "default" });
+    setLaunchSheetOpen(true);
+  }
+
+  // Open the launch sheet on the New tab with a preset chip preselected, so the
+  // human confirms cwd/title before launching rather than creating immediately
+  // in the default working directory. A null preset opens with no selection.
+  function openLaunchSheetWithPreset(preset: SessionPresetSummary | null) {
+    setLaunchSheetMode("new");
+    setPresetSelection({ kind: "preset", presetId: preset?.id ?? null });
     setLaunchSheetOpen(true);
   }
 
@@ -1239,8 +1211,7 @@ export default function HomePage() {
               presets={sessionPresets}
               defaultPresetId={defaultPresetId}
               defaultBackend={effectiveDefaultBackend}
-              launchingPresetId={launchingPresetId}
-              onLaunchPreset={handleLaunchPreset}
+              onOpenPreset={openLaunchSheetWithPreset}
               onOpenSheet={openLaunchSheet}
             />
             <div className="home-main">
@@ -1326,6 +1297,7 @@ export default function HomePage() {
             onDeletePreset={handleDeletePreset}
             mode={launchSheetMode}
             onModeChange={setLaunchSheetMode}
+            initialPreset={presetSelection}
           />
         </Sheet>
       ) : null}

--- a/frontend/src/components/CompactLaunch.tsx
+++ b/frontend/src/components/CompactLaunch.tsx
@@ -5,8 +5,8 @@ import type { Backend, SessionPresetSummary } from "@/lib/types";
 // Compact launch action that replaces the always-open form on the homepage: a
 // row of preset quick-launch chips plus a "New session" button, both of which
 // open the full launch form in a glass sheet. A preset chip opens the sheet on
-// the New tab with that preset preselected (so cwd/title can be confirmed
-// before launch); Resume / Schedule are dashed chips that open their tab.
+// the New tab with that preset preselected; Resume / Schedule are dashed chips
+// that open their tab.
 export type LaunchSheetMode = "new" | "resume" | "attach" | "schedule";
 
 // Keep the quick-launch row to a scannable size; the rest live in the sheet's

--- a/frontend/src/components/CompactLaunch.tsx
+++ b/frontend/src/components/CompactLaunch.tsx
@@ -3,9 +3,10 @@
 import type { Backend, SessionPresetSummary } from "@/lib/types";
 
 // Compact launch action that replaces the always-open form on the homepage: a
-// row of preset quick-launch chips (one-tap create) plus a "New session"
-// button that opens the full launch form in a glass sheet. Resume / Attach are
-// dashed chips that open the sheet on their respective tab.
+// row of preset quick-launch chips plus a "New session" button, both of which
+// open the full launch form in a glass sheet. A preset chip opens the sheet on
+// the New tab with that preset preselected (so cwd/title can be confirmed
+// before launch); Resume / Schedule are dashed chips that open their tab.
 export type LaunchSheetMode = "new" | "resume" | "attach" | "schedule";
 
 // Keep the quick-launch row to a scannable size; the rest live in the sheet's
@@ -17,8 +18,7 @@ interface CompactLaunchProps {
   presets: SessionPresetSummary[];
   defaultPresetId: string | null;
   defaultBackend: Backend;
-  launchingPresetId: string | null;
-  onLaunchPreset: (preset: SessionPresetSummary | null) => void;
+  onOpenPreset: (preset: SessionPresetSummary | null) => void;
   onOpenSheet: (mode: LaunchSheetMode) => void;
 }
 
@@ -27,11 +27,9 @@ export function CompactLaunch({
   presets,
   defaultPresetId,
   defaultBackend,
-  launchingPresetId,
-  onLaunchPreset,
+  onOpenPreset,
   onOpenSheet,
 }: CompactLaunchProps) {
-  const busy = launchingPresetId !== null;
   // Lead with the default preset, then the rest by recency-of-list order.
   const ordered = [...presets].sort((a, b) => {
     if (a.id === defaultPresetId) return -1;
@@ -64,10 +62,8 @@ export function CompactLaunch({
                 key={preset.id}
                 type="button"
                 className="launch-chip"
-                disabled={busy}
-                data-loading={launchingPresetId === preset.id ? "" : undefined}
-                onClick={() => onLaunchPreset(preset)}
-                title={`Launch ${preset.name}`}
+                onClick={() => onOpenPreset(preset)}
+                title={`Launch ${preset.name}…`}
               >
                 <span className="launch-chip-dot" data-owner={backend} />
                 {preset.name}
@@ -78,10 +74,8 @@ export function CompactLaunch({
           <button
             type="button"
             className="launch-chip"
-            disabled={busy}
-            data-loading={launchingPresetId === "__default__" ? "" : undefined}
-            onClick={() => onLaunchPreset(null)}
-            title="Launch with defaults"
+            onClick={() => onOpenPreset(null)}
+            title="Launch with defaults…"
           >
             <span className="launch-chip-dot" data-owner={defaultBackend} />
             Default

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -41,9 +41,8 @@ interface ThreadSummary {
 
 type PanelMode = "new" | "resume" | "attach" | "schedule";
 
-// Which preset the panel should preselect when it mounts. `default` reuses the
-// once-on-load default-preset hydration; `preset` hydrates a specific preset
-// (or clears the selection when `presetId` is null, for the backend default).
+// `default` uses the default-preset hydration; `preset` hydrates a specific
+// preset, or clears the selection when `presetId` is null (backend default).
 export type PresetSelection =
   | { kind: "default" }
   | { kind: "preset"; presetId: string | null };
@@ -119,7 +118,6 @@ interface LaunchPanelProps {
   // owns which mode is shown; otherwise the panel tracks it internally.
   mode?: PanelMode;
   onModeChange?: (mode: PanelMode) => void;
-  // Which preset to seed into the form when the panel mounts.
   initialPreset?: PresetSelection;
 }
 
@@ -201,11 +199,10 @@ export function LaunchPanel({
     [presets, onFetchPresetSpec, form],
   );
 
-  // Seed the shared form's preset once on mount. A caller-requested preset wins
-  // (a chip click); otherwise hydrate the default preset, waiting for its id to
-  // arrive (bootstrap resolves after mount) before consuming the once-guard so
-  // the first null run doesn't disable it. The panel remounts on every sheet
-  // open, so this runs fresh each time.
+  // Seed the form's preset once per mount: a caller-requested preset wins,
+  // otherwise the default. Wait for defaultPresetId to arrive (bootstrap
+  // resolves after mount) before consuming the once-guard, or the first null
+  // run disables it.
   useEffect(() => {
     if (presetHydratedRef.current) return;
     if (initialPreset?.kind === "preset") {

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -41,6 +41,13 @@ interface ThreadSummary {
 
 type PanelMode = "new" | "resume" | "attach" | "schedule";
 
+// Which preset the panel should preselect when it mounts. `default` reuses the
+// once-on-load default-preset hydration; `preset` hydrates a specific preset
+// (or clears the selection when `presetId` is null, for the backend default).
+export type PresetSelection =
+  | { kind: "default" }
+  | { kind: "preset"; presetId: string | null };
+
 type ScheduleTiming = "delay" | "datetime";
 
 interface LaunchPanelProps {
@@ -112,6 +119,8 @@ interface LaunchPanelProps {
   // owns which mode is shown; otherwise the panel tracks it internally.
   mode?: PanelMode;
   onModeChange?: (mode: PanelMode) => void;
+  // Which preset to seed into the form when the panel mounts.
+  initialPreset?: PresetSelection;
 }
 
 export function LaunchPanel({
@@ -145,6 +154,7 @@ export function LaunchPanel({
   onDeletePreset,
   mode: controlledMode,
   onModeChange,
+  initialPreset,
 }: LaunchPanelProps) {
   const [internalMode, setInternalMode] = useState<PanelMode>("new");
   const mode = controlledMode ?? internalMode;
@@ -191,15 +201,22 @@ export function LaunchPanel({
     [presets, onFetchPresetSpec, form],
   );
 
-  // Hydrate the default preset into the shared form once on first load. Wait
-  // for the id to actually arrive (bootstrap resolves after mount) before
-  // consuming the once-guard, otherwise the first null run would disable it.
+  // Seed the shared form's preset once on mount. A caller-requested preset wins
+  // (a chip click); otherwise hydrate the default preset, waiting for its id to
+  // arrive (bootstrap resolves after mount) before consuming the once-guard so
+  // the first null run doesn't disable it. The panel remounts on every sheet
+  // open, so this runs fresh each time.
   useEffect(() => {
     if (presetHydratedRef.current) return;
+    if (initialPreset?.kind === "preset") {
+      presetHydratedRef.current = true;
+      void applyPresetById(initialPreset.presetId);
+      return;
+    }
     if (!defaultPresetId) return;
     presetHydratedRef.current = true;
     void applyPresetById(defaultPresetId);
-  }, [defaultPresetId, applyPresetById]);
+  }, [defaultPresetId, applyPresetById, initialPreset]);
   const [tmuxTarget, setTmuxTarget] = useState("");
   const [prompt, setPrompt] = useState("");
   const [scheduleTiming, setScheduleTiming] = useState<ScheduleTiming>("delay");


### PR DESCRIPTION
## Purpose

Clicking a preset chip in the homepage launch tile immediately created a session with the default title and working directory. The default working directory is only the common prefix of frequently-used directories, so it is rarely where the human actually wants the session — the one-tap create was effectively useless. This routes a preset chip through the launch sheet instead: it opens on the **New** tab with that preset preselected, mirroring how **Schedule…** opens the schedule sheet, so cwd and title can be confirmed before launch. Frontend-only, no API changes.

## Changes

### Frontend
- `app/page.tsx` — remove `handleLaunchPreset`/`launchingPresetId` (the immediate-create path) and add `openLaunchSheetWithPreset`, which opens the sheet on the New tab and records the requested preset. A new `presetSelection` state (a `{ kind: "default" } | { kind: "preset"; presetId }` union) is set explicitly by every sheet-open path so a stale value never bleeds across opens, and passed to `LaunchPanel` as `initialPreset`.
- `components/CompactLaunch.tsx` — preset chips (and the zero-presets "Default" fallback) now call the new `onOpenPreset` prop instead of `onLaunchPreset`; drop the busy/loading (`data-loading`, `disabled`) wiring that the async create needed.
- `components/LaunchPanel.tsx` — export the `PresetSelection` type and accept `initialPreset`. The `Sheet` unmounts its children when closed, so `LaunchPanel` remounts on every open; the existing once-on-mount hydration effect now seeds the requested preset when one is present (reusing `applyPresetById`, which fetches the full env-carrying spec when needed) and otherwise falls back to the default preset as before.
- `app/globals.css` — drop the now-dead `.launch-chip[data-loading]` and `.launch-chip:disabled` rules (no chip is ever disabled now) and simplify the hover rule.

## Design

Because `Sheet` returns `null` when closed and `LaunchPanel` is its only child, the panel remounts fresh on every open, resetting `selectedPresetId` and the `presetHydratedRef` once-guard. The preselection is therefore a **mount-time initial selection**, not a persistent-panel signal — no nonce or effect-ordering dance is needed. The discriminated union distinguishes three intents at mount: hydrate the default preset (New / +N more / Resume / Schedule), hydrate a specific preset (a chip), or clear the selection to the backend default (the zero-presets "Default" chip). cwd/title stay per-launch, which is exactly the requested behavior.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`/`waypoint-theme`) on the homepage at 420px:
  - Click each visible preset chip (including `claude-deepseek`, which pins 8 env vars, exercising the full-spec fetch path) → the launch sheet opens on the New tab with that preset selected in the dropdown and the form hydrated.
  - "+ New session" → sheet opens with the default preset selected (unchanged).
  - Assert the session count is unchanged (no session created by a chip click).
  - Both dark and light themes.

## Test Result
- `npm run lint` — no findings.
- `npm run build` — compiled successfully, 11/11 pages generated.
- Playwright: sessions `184 → 184` (no session created); `claude-deepseek` chip → New tab, `claude-deepseek` selected; `claude-main` chip → `claude-main · default`; "+ New session" → `claude-main · default`; light-theme chip click → `claude-deepseek` selected. Screenshots captured for the opened sheet in both dark and light themes.