### PR TITLE
fix: add client-persisted toggle to show/hide exited sessions

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9690,8 +9690,7 @@ html[data-theme="light"] .preset-modal-overlay {
   min-width: 0;
 }
 
-/* Keep the Delete-exited button on one line and pinned to the top while the
-   summary text beside it wraps. */
+/* Pin the Delete button to the top as the counts wrap. */
 .session-list-header {
   align-items: flex-start;
 }
@@ -9700,9 +9699,7 @@ html[data-theme="light"] .preset-modal-overlay {
   white-space: nowrap;
 }
 
-/* On narrow screens the nowrap Delete button would squeeze the summary column
-   and force the counts to wrap across many lines, so stack instead: full-width
-   summary (counts wrap at most twice) above a left-aligned Delete button. */
+/* Narrow: stack the summary above the Delete button. */
 @media (max-width: 600px) {
   .session-list-header {
     flex-direction: column;
@@ -9715,10 +9712,6 @@ html[data-theme="light"] .preset-modal-overlay {
   }
 }
 
-/* Quiet text toggle that rides the right end of the search row on both the
-   panel and the switcher (adds no row of its own): small muted mono that
-   brightens on hover, reading as a secondary affordance rather than a prominent
-   control. */
 .exited-toggle {
   flex: none;
   background: transparent;
@@ -9749,8 +9742,6 @@ html[data-theme="light"] .preset-modal-overlay {
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
-/* The search input shares its row with the exited toggle on the panel, mirroring
-   the switcher, so the toggle sits just past the search help icon. */
 .session-list-search-row {
   display: flex;
   align-items: center;
@@ -9761,7 +9752,6 @@ html[data-theme="light"] .preset-modal-overlay {
 .session-list-search-row .session-list-search {
   flex: 1;
   min-width: 0;
-  margin-bottom: 0;
 }
 
 .session-section {
@@ -11478,10 +11468,6 @@ html[data-theme="light"] .advanced-warning {
   color: var(--text);
 }
 
-.session-list-search {
-  margin-bottom: 12px;
-}
-
 .thread-panel-search {
   margin-top: 8px;
 }
@@ -11519,8 +11505,6 @@ html[data-theme="light"] .advanced-warning {
   overflow: hidden;
 }
 
-/* The search row also hosts the exited toggle on its right, so the two share a
-   single row (the toggle adds no vertical space of its own). */
 .session-switcher-search {
   display: flex;
   align-items: center;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9715,16 +9715,19 @@ html[data-theme="light"] .preset-modal-overlay {
   }
 }
 
-/* Quiet text toggle folded into an existing line (the panel count row, the
-   switcher search row): bare mono that brightens on hover, reading as a
-   secondary affordance rather than a prominent control and adding no row of
-   its own. Inherits the count line's muted color on the panel. */
+/* Quiet text toggle that rides the right end of the search row on both the
+   panel and the switcher (adds no row of its own): small muted mono that
+   brightens on hover, reading as a secondary affordance rather than a prominent
+   control. */
 .exited-toggle {
+  flex: none;
   background: transparent;
   border: none;
   padding: 0;
-  font: inherit;
-  color: inherit;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--muted);
   cursor: pointer;
   white-space: nowrap;
   text-decoration: underline;
@@ -9744,6 +9747,21 @@ html[data-theme="light"] .preset-modal-overlay {
   outline: none;
   border-radius: var(--radius-sm);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
+}
+
+/* The search input shares its row with the exited toggle on the panel, mirroring
+   the switcher, so the toggle sits just past the search help icon. */
+.session-list-search-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.session-list-search-row .session-list-search {
+  flex: 1;
+  min-width: 0;
+  margin-bottom: 0;
 }
 
 .session-section {
@@ -11518,13 +11536,6 @@ html[data-theme="light"] .advanced-warning {
 
 .session-switcher-search input {
   background: var(--bg-input);
-}
-
-.session-switcher-search .exited-toggle {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  color: var(--muted);
 }
 
 .session-switcher-list {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9690,6 +9690,34 @@ html[data-theme="light"] .preset-modal-overlay {
   min-width: 0;
 }
 
+/* Header wraps on narrow widths so the summary and the exited-session controls
+   stack instead of overflowing the panel. */
+.session-list-header {
+  flex-wrap: wrap;
+}
+
+.session-list-controls {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.session-filter-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.session-filter-toggle-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
 .session-section {
   display: grid;
   gap: 12px;
@@ -11452,6 +11480,23 @@ html[data-theme="light"] .advanced-warning {
 
 .session-switcher-search input {
   background: var(--bg-input);
+}
+
+.session-switcher-filter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.session-switcher-filter-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
 }
 
 .session-switcher-list {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9690,32 +9690,60 @@ html[data-theme="light"] .preset-modal-overlay {
   min-width: 0;
 }
 
-/* Header wraps on narrow widths so the summary and the exited-session controls
-   stack instead of overflowing the panel. */
+/* Keep the Delete-exited button on one line and pinned to the top while the
+   summary text beside it wraps. */
 .session-list-header {
-  flex-wrap: wrap;
+  align-items: flex-start;
 }
 
-.session-list-controls {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  flex-wrap: wrap;
-}
-
-.session-filter-toggle {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.session-filter-toggle-label {
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--muted);
+.session-list-header .secondary {
   white-space: nowrap;
+}
+
+/* On narrow screens the nowrap Delete button would squeeze the summary column
+   and force the counts to wrap across many lines, so stack instead: full-width
+   summary (counts wrap at most twice) above a left-aligned Delete button. */
+@media (max-width: 600px) {
+  .session-list-header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .session-list-header .secondary {
+    align-self: flex-start;
+  }
+}
+
+/* Quiet text toggle folded into an existing line (the panel count row, the
+   switcher search row): bare mono that brightens on hover, reading as a
+   secondary affordance rather than a prominent control and adding no row of
+   its own. Inherits the count line's muted color on the panel. */
+.exited-toggle {
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, currentColor 35%, transparent);
+  text-underline-offset: 2px;
+  transition:
+    color 140ms ease,
+    text-decoration-color 140ms ease;
+}
+
+.exited-toggle:hover {
+  color: var(--text);
+  text-decoration-color: currentColor;
+}
+
+.exited-toggle:focus-visible {
+  outline: none;
+  border-radius: var(--radius-sm);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 25%, transparent);
 }
 
 .session-section {
@@ -11473,29 +11501,29 @@ html[data-theme="light"] .advanced-warning {
   overflow: hidden;
 }
 
+/* The search row also hosts the exited toggle on its right, so the two share a
+   single row (the toggle adds no vertical space of its own). */
 .session-switcher-search {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   padding: 14px 14px 10px;
   border-bottom: 1px solid var(--line);
+}
+
+.session-switcher-search .search-bar {
+  flex: 1;
+  min-width: 0;
 }
 
 .session-switcher-search input {
   background: var(--bg-input);
 }
 
-.session-switcher-filter {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 10px 16px;
-  border-bottom: 1px solid var(--line);
-}
-
-.session-switcher-filter-label {
+.session-switcher-search .exited-toggle {
   font-family: var(--font-mono);
   font-size: 0.72rem;
   letter-spacing: 0.04em;
-  text-transform: uppercase;
   color: var(--muted);
 }
 

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -21,7 +21,7 @@ export function SearchInput({
   autoFocus = false,
 }: SearchInputProps) {
   const [tooltipOpen, setTooltipOpen] = useState(false);
-  const [tooltipPos, setTooltipPos] = useState<{ top: number; right: number } | null>(null);
+  const [tooltipPos, setTooltipPos] = useState<{ top: number; left: number; maxWidth: number } | null>(null);
   const iconRef = useRef<HTMLDivElement | null>(null);
   const closeTimerRef = useRef<number | null>(null);
   const isTouchRef = useRef(false);
@@ -40,9 +40,19 @@ export function SearchInput({
       return;
     }
     const rect = el.getBoundingClientRect();
+    // Right-align the popover to the help icon, but clamp it inside the viewport
+    // so it never runs off either edge on narrow screens (e.g. the switcher
+    // modal, where the icon sits well inside the right edge).
+    const margin = 12;
+    const maxWidth = Math.min(320, window.innerWidth - margin * 2);
+    const left = Math.max(
+      margin,
+      Math.min(rect.right - maxWidth, window.innerWidth - maxWidth - margin),
+    );
     setTooltipPos({
       top: rect.bottom + 8,
-      right: window.innerWidth - rect.right,
+      left,
+      maxWidth,
     });
   }
 
@@ -105,7 +115,7 @@ export function SearchInput({
           <div
             className="help-tooltip"
             role="tooltip"
-            style={{ position: "fixed", top: tooltipPos.top, right: tooltipPos.right }}
+            style={{ position: "fixed", top: tooltipPos.top, left: tooltipPos.left, maxWidth: tooltipPos.maxWidth }}
             onMouseEnter={openTooltip}
             onMouseLeave={scheduleClose}
           >

--- a/frontend/src/components/SearchInput.tsx
+++ b/frontend/src/components/SearchInput.tsx
@@ -40,9 +40,7 @@ export function SearchInput({
       return;
     }
     const rect = el.getBoundingClientRect();
-    // Right-align the popover to the help icon, but clamp it inside the viewport
-    // so it never runs off either edge on narrow screens (e.g. the switcher
-    // modal, where the icon sits well inside the right edge).
+    // Right-align to the help icon, clamped inside the viewport.
     const margin = 12;
     const maxWidth = Math.min(320, window.innerWidth - margin * 2);
     const left = Math.max(

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -346,19 +346,6 @@ export function SessionList({
           <p className="muted">
             {sessions.length} total · {activeCount} active · {exitedCount} exited
             {pinnedSessions.length ? ` · ${pinnedSessions.length} pinned` : null}
-            {exitedCount > 0 ? (
-              <>
-                {" · "}
-                <button
-                  type="button"
-                  className="exited-toggle"
-                  aria-pressed={!showExited}
-                  onClick={() => setShowExited(!showExited)}
-                >
-                  {showExited ? "hide exited" : "show exited"}
-                </button>
-              </>
-            ) : null}
           </p>
         </div>
         {onDeleteExited && exitedCount > 0 ? (
@@ -368,12 +355,24 @@ export function SessionList({
         ) : null}
       </div>
 
-      <SearchInput
-        className="session-list-search"
-        value={query}
-        onChange={setQuery}
-        placeholder='Search sessions... (e.g. "title:bug OR branch:main")'
-      />
+      <div className="session-list-search-row">
+        <SearchInput
+          className="session-list-search"
+          value={query}
+          onChange={setQuery}
+          placeholder='Search sessions... (e.g. "title:bug OR branch:main")'
+        />
+        {exitedCount > 0 ? (
+          <button
+            type="button"
+            className="exited-toggle"
+            aria-pressed={!showExited}
+            onClick={() => setShowExited(!showExited)}
+          >
+            {showExited ? "hide exited" : "show exited"}
+          </button>
+        ) : null}
+      </div>
 
       {flatSearchResults !== null ? (
         <section className="session-section">

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -346,29 +346,25 @@ export function SessionList({
           <p className="muted">
             {sessions.length} total · {activeCount} active · {exitedCount} exited
             {pinnedSessions.length ? ` · ${pinnedSessions.length} pinned` : null}
+            {exitedCount > 0 ? (
+              <>
+                {" · "}
+                <button
+                  type="button"
+                  className="exited-toggle"
+                  aria-pressed={!showExited}
+                  onClick={() => setShowExited(!showExited)}
+                >
+                  {showExited ? "hide exited" : "show exited"}
+                </button>
+              </>
+            ) : null}
           </p>
         </div>
-        {exitedCount > 0 ? (
-          <div className="session-list-controls">
-            <div className="session-filter-toggle">
-              <span className="session-filter-toggle-label">Show exited</span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={showExited}
-                aria-label="Show exited sessions"
-                className="switch"
-                onClick={() => setShowExited(!showExited)}
-              >
-                <span className="switch-thumb" />
-              </button>
-            </div>
-            {onDeleteExited ? (
-              <button className="secondary" type="button" onClick={handleDeleteExited}>
-                Delete exited ({exitedCount})
-              </button>
-            ) : null}
-          </div>
+        {onDeleteExited && exitedCount > 0 ? (
+          <button className="secondary" type="button" onClick={handleDeleteExited}>
+            Delete exited ({exitedCount})
+          </button>
         ) : null}
       </div>
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -13,6 +13,7 @@ import {
 import { matchesQuery, parseQuery } from "@/lib/search";
 import { formatClock } from "@/lib/scheduleTime";
 import { SessionRecord } from "@/lib/types";
+import { useShowExitedSessions } from "@/lib/useShowExitedSessions";
 
 import { SearchInput } from "./SearchInput";
 import { Pager } from "@/components/Pager";
@@ -44,6 +45,7 @@ export function SessionList({
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [draftTitle, setDraftTitle] = useState("");
   const [query, setQuery] = useState("");
+  const [showExited, setShowExited] = useShowExitedSessions();
 
   function handleDelete(event: MouseEvent<HTMLButtonElement>, sessionId: string) {
     event.preventDefault();
@@ -145,19 +147,22 @@ export function SessionList({
   } = useMemo(() => {
     const exited = sessions.filter((session) => session.status === "exited").length;
     const active = sessions.length - exited;
+    const visible = showExited
+      ? sessions
+      : sessions.filter((session) => session.status !== "exited");
 
     if (query.trim() === "") {
-      const pinned = sessions
+      const pinned = visible
         .filter((session) => session.pinned_at)
         .sort((a, b) => (b.pinned_at ?? "").localeCompare(a.pinned_at ?? ""));
-      const recent = sessions.filter((session) => !session.pinned_at);
+      const recent = visible.filter((session) => !session.pinned_at);
       return { pinnedSessions: pinned, recentSessions: recent, flatSearchResults: null, exitedCount: exited, activeCount: active };
     }
 
     const terms = parseQuery(query.trim());
     const defaultFields = ["title", "cwd", "repo_name", "branch", "backend", "search_status"];
 
-    const matched = sessions.filter((session) => {
+    const matched = visible.filter((session) => {
       return matchesQuery(session, terms, defaultFields);
     });
 
@@ -170,7 +175,7 @@ export function SessionList({
     });
 
     return { pinnedSessions: [], recentSessions: [], flatSearchResults: matched, exitedCount: exited, activeCount: active };
-  }, [sessions, query]);
+  }, [sessions, query, showExited]);
 
   const listToPaginate = flatSearchResults !== null ? flatSearchResults : recentSessions;
   const totalPages = Math.max(1, Math.ceil(listToPaginate.length / PAGE_SIZE));
@@ -335,7 +340,7 @@ export function SessionList({
 
   return (
     <section className="panel stack session-list-shell">
-      <div className="field-row">
+      <div className="field-row session-list-header">
         <div className="session-list-summary">
           <h3>Sessions</h3>
           <p className="muted">
@@ -343,10 +348,27 @@ export function SessionList({
             {pinnedSessions.length ? ` · ${pinnedSessions.length} pinned` : null}
           </p>
         </div>
-        {onDeleteExited && exitedCount > 0 ? (
-          <button className="secondary" type="button" onClick={handleDeleteExited}>
-            Delete exited ({exitedCount})
-          </button>
+        {exitedCount > 0 ? (
+          <div className="session-list-controls">
+            <div className="session-filter-toggle">
+              <span className="session-filter-toggle-label">Show exited</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={showExited}
+                aria-label="Show exited sessions"
+                className="switch"
+                onClick={() => setShowExited(!showExited)}
+              >
+                <span className="switch-thumb" />
+              </button>
+            </div>
+            {onDeleteExited ? (
+              <button className="secondary" type="button" onClick={handleDeleteExited}>
+                Delete exited ({exitedCount})
+              </button>
+            ) : null}
+          </div>
         ) : null}
       </div>
 

--- a/frontend/src/components/SessionList.tsx
+++ b/frontend/src/components/SessionList.tsx
@@ -13,7 +13,7 @@ import {
 import { matchesQuery, parseQuery } from "@/lib/search";
 import { formatClock } from "@/lib/scheduleTime";
 import { SessionRecord } from "@/lib/types";
-import { useShowExitedSessions } from "@/lib/useShowExitedSessions";
+import { PANEL_SHOW_EXITED_KEY, useShowExitedSessions } from "@/lib/useShowExitedSessions";
 
 import { SearchInput } from "./SearchInput";
 import { Pager } from "@/components/Pager";
@@ -45,7 +45,7 @@ export function SessionList({
   const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
   const [draftTitle, setDraftTitle] = useState("");
   const [query, setQuery] = useState("");
-  const [showExited, setShowExited] = useShowExitedSessions();
+  const [showExited, setShowExited] = useShowExitedSessions(PANEL_SHOW_EXITED_KEY);
 
   function handleDelete(event: MouseEvent<HTMLButtonElement>, sessionId: string) {
     event.preventDefault();

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -10,7 +10,7 @@ import { matchesQuery, parseQuery } from "@/lib/search";
 import { SessionEnvelope, SessionRecord } from "@/lib/types";
 import { SearchInput } from "@/components/SearchInput";
 import { humaniseBackend, useBackendCatalog } from "@/lib/backends";
-import { useShowExitedSessions } from "@/lib/useShowExitedSessions";
+import { SWITCHER_SHOW_EXITED_KEY, useShowExitedSessions } from "@/lib/useShowExitedSessions";
 
 interface SessionSwitcherProps {
   host: string;
@@ -57,7 +57,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const toggleHint = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform) ? "⌘K" : "Ctrl+K";
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
   const [query, setQuery] = useState("");
-  const [showExited, setShowExited] = useShowExitedSessions();
+  const [showExited, setShowExited] = useShowExitedSessions(SWITCHER_SHOW_EXITED_KEY);
   const [page, setPage] = useState(1);
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -358,7 +358,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
         }
       >
         <div className="session-switcher-search">
-          <SearchInput 
+          <SearchInput
             value={query}
             onChange={(val) => {
               setQuery(val);
@@ -369,23 +369,17 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
             autoFocus={!isMobile}
             showStatusExample={false}
           />
-        </div>
-
-        {filteredSessions.hasExited ? (
-          <div className="session-switcher-filter">
-            <span className="session-switcher-filter-label">Show exited</span>
+          {filteredSessions.hasExited ? (
             <button
               type="button"
-              role="switch"
-              aria-checked={showExited}
-              aria-label="Show exited sessions"
-              className="switch"
+              className="exited-toggle"
+              aria-pressed={!showExited}
               onClick={() => setShowExited(!showExited)}
             >
-              <span className="switch-thumb" />
+              {showExited ? "hide exited" : "show exited"}
             </button>
-          </div>
-        ) : null}
+          ) : null}
+        </div>
 
         <div className="session-switcher-list" ref={listRef}>
           {currentSession && !query ? (

--- a/frontend/src/components/SessionSwitcher.tsx
+++ b/frontend/src/components/SessionSwitcher.tsx
@@ -10,6 +10,7 @@ import { matchesQuery, parseQuery } from "@/lib/search";
 import { SessionEnvelope, SessionRecord } from "@/lib/types";
 import { SearchInput } from "@/components/SearchInput";
 import { humaniseBackend, useBackendCatalog } from "@/lib/backends";
+import { useShowExitedSessions } from "@/lib/useShowExitedSessions";
 
 interface SessionSwitcherProps {
   host: string;
@@ -56,6 +57,7 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
   const toggleHint = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform) ? "⌘K" : "Ctrl+K";
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
   const [query, setQuery] = useState("");
+  const [showExited, setShowExited] = useShowExitedSessions();
   const [page, setPage] = useState(1);
   const [activeIndex, setActiveIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
@@ -131,6 +133,10 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
 
   const filteredSessions = useMemo(() => {
     let list = sessions.filter((s) => s.id !== currentSession?.id);
+    const hasExited = list.some((s) => s.status === "exited");
+    if (!showExited) {
+      list = list.filter((s) => s.status !== "exited");
+    }
     const parsed = parseQuery(query);
     list = list.filter((s) =>
       matchesQuery(s, parsed, ["title", "cwd", "repo_name", "branch", "backend", "search_status"]),
@@ -144,14 +150,15 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
 
     const totalPages = Math.ceil(recent.length / PAGE_SIZE) || 1;
     const cappedRecent = recent.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
-    
+
     return {
       pinned,
       recent: cappedRecent,
       totalPages,
-      totalRecent: recent.length
+      totalRecent: recent.length,
+      hasExited
     };
-  }, [sessions, query, currentSession?.id, page]);
+  }, [sessions, query, currentSession?.id, page, showExited]);
 
   const flatItems = useMemo(() => {
     return [...filteredSessions.pinned, ...filteredSessions.recent];
@@ -363,7 +370,23 @@ export function SessionSwitcher({ host, token, currentSession, onAuthFailure, on
             showStatusExample={false}
           />
         </div>
-        
+
+        {filteredSessions.hasExited ? (
+          <div className="session-switcher-filter">
+            <span className="session-switcher-filter-label">Show exited</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showExited}
+              aria-label="Show exited sessions"
+              className="switch"
+              onClick={() => setShowExited(!showExited)}
+            >
+              <span className="switch-thumb" />
+            </button>
+          </div>
+        ) : null}
+
         <div className="session-switcher-list" ref={listRef}>
           {currentSession && !query ? (
             <div className="session-switcher-here">

--- a/frontend/src/lib/useShowExitedSessions.ts
+++ b/frontend/src/lib/useShowExitedSessions.ts
@@ -12,14 +12,9 @@ function readShowExited(): boolean {
   return window.localStorage.getItem(STORAGE_KEY) !== "0";
 }
 
-// Client preference shared by the sessions panel and the session switcher: a
-// single persisted flag kept live across both surfaces (and across tabs) so a
-// toggle on one reflects on the other. Default ON preserves the prior
-// behavior of showing exited sessions.
+// Persisted flag synced across the panel, the switcher, and tabs; default on.
 export function useShowExitedSessions(): [boolean, (next: boolean) => void] {
-  // Init true and hydrate in the effect to avoid an SSR/client hydration
-  // mismatch; the only visible cost is a one-frame flash when the stored
-  // preference is the non-default "hidden".
+  // Init true and hydrate in the effect to avoid an SSR/client hydration mismatch.
   const [showExited, setShowExited] = useState(true);
 
   useEffect(() => {

--- a/frontend/src/lib/useShowExitedSessions.ts
+++ b/frontend/src/lib/useShowExitedSessions.ts
@@ -2,45 +2,45 @@
 
 import { useCallback, useEffect, useState } from "react";
 
-const STORAGE_KEY = "waypoint.show-exited-sessions";
-const CHANGE_EVENT = "waypoint:show-exited-sessions-change";
+export const PANEL_SHOW_EXITED_KEY = "waypoint.show-exited-sessions.panel";
+export const SWITCHER_SHOW_EXITED_KEY = "waypoint.show-exited-sessions.switcher";
 
-function readShowExited(): boolean {
+function readShowExited(storageKey: string): boolean {
   if (typeof window === "undefined") {
     return true;
   }
-  return window.localStorage.getItem(STORAGE_KEY) !== "0";
+  return window.localStorage.getItem(storageKey) !== "0";
 }
 
-// Persisted flag synced across the panel, the switcher, and tabs; default on.
-export function useShowExitedSessions(): [boolean, (next: boolean) => void] {
+// Persisted show-exited flag for one surface; default on. Synced across tabs.
+export function useShowExitedSessions(storageKey: string): [boolean, (next: boolean) => void] {
   // Init true and hydrate in the effect to avoid an SSR/client hydration mismatch.
   const [showExited, setShowExited] = useState(true);
 
   useEffect(() => {
-    setShowExited(readShowExited());
-    function handleChange() {
-      setShowExited(readShowExited());
-    }
-    window.addEventListener(CHANGE_EVENT, handleChange);
-    window.addEventListener("storage", handleChange);
-    return () => {
-      window.removeEventListener(CHANGE_EVENT, handleChange);
-      window.removeEventListener("storage", handleChange);
-    };
-  }, []);
-
-  const update = useCallback((next: boolean) => {
-    if (typeof window !== "undefined") {
-      if (next) {
-        window.localStorage.removeItem(STORAGE_KEY);
-      } else {
-        window.localStorage.setItem(STORAGE_KEY, "0");
+    setShowExited(readShowExited(storageKey));
+    function handleStorage(event: StorageEvent) {
+      if (event.key === storageKey) {
+        setShowExited(readShowExited(storageKey));
       }
-      window.dispatchEvent(new Event(CHANGE_EVENT));
     }
-    setShowExited(next);
-  }, []);
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [storageKey]);
+
+  const update = useCallback(
+    (next: boolean) => {
+      if (typeof window !== "undefined") {
+        if (next) {
+          window.localStorage.removeItem(storageKey);
+        } else {
+          window.localStorage.setItem(storageKey, "0");
+        }
+      }
+      setShowExited(next);
+    },
+    [storageKey],
+  );
 
   return [showExited, update];
 }

--- a/frontend/src/lib/useShowExitedSessions.ts
+++ b/frontend/src/lib/useShowExitedSessions.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "waypoint.show-exited-sessions";
+const CHANGE_EVENT = "waypoint:show-exited-sessions-change";
+
+function readShowExited(): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+  return window.localStorage.getItem(STORAGE_KEY) !== "0";
+}
+
+// Client preference shared by the sessions panel and the session switcher: a
+// single persisted flag kept live across both surfaces (and across tabs) so a
+// toggle on one reflects on the other. Default ON preserves the prior
+// behavior of showing exited sessions.
+export function useShowExitedSessions(): [boolean, (next: boolean) => void] {
+  // Init true and hydrate in the effect to avoid an SSR/client hydration
+  // mismatch; the only visible cost is a one-frame flash when the stored
+  // preference is the non-default "hidden".
+  const [showExited, setShowExited] = useState(true);
+
+  useEffect(() => {
+    setShowExited(readShowExited());
+    function handleChange() {
+      setShowExited(readShowExited());
+    }
+    window.addEventListener(CHANGE_EVENT, handleChange);
+    window.addEventListener("storage", handleChange);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, handleChange);
+      window.removeEventListener("storage", handleChange);
+    };
+  }, []);
+
+  const update = useCallback((next: boolean) => {
+    if (typeof window !== "undefined") {
+      if (next) {
+        window.localStorage.removeItem(STORAGE_KEY);
+      } else {
+        window.localStorage.setItem(STORAGE_KEY, "0");
+      }
+      window.dispatchEvent(new Event(CHANGE_EVENT));
+    }
+    setShowExited(next);
+  }, []);
+
+  return [showExited, update];
+}


### PR DESCRIPTION
## Purpose

The sessions panel and the session switcher always listed every session, including exited ones, which dominate the list once a host has run many sessions. This adds a **Show exited** toggle to both surfaces so exited sessions can be hidden, with the choice persisted per client. Frontend-only, no API changes.

## Changes

### Frontend
- `lib/useShowExitedSessions.ts` — new hook backing a single client preference (`waypoint.show-exited-sessions` in localStorage). It defaults to on (preserving the prior always-show behavior), stores only the non-default `"0"` (mirroring `readUsageDashboardOpen`), and keeps every mounted instance in sync — a toggle on one surface reflects on the other and across tabs — via a same-tab custom event plus the native `storage` event. State inits `true` and hydrates from storage in an effect to avoid an SSR/client hydration mismatch.
- `components/SessionList.tsx` — consume the hook; render the reused flat `.switch` instrument in the panel header (shown only when there are exited sessions), and filter exited sessions out of the pinned/recent/search lists when hidden. The `N total · A active · E exited` summary and the existing **Delete exited** action still report the true counts.
- `components/SessionSwitcher.tsx` — consume the hook; add a compact **Show exited** filter row between the search box and the list (shown only when the switcher has exited candidates), and filter exited sessions out of the pinned/recent split. The current-session "here" row is always shown.
- `app/globals.css` — styles for the two toggle rows: the panel header wraps its controls on narrow widths, and both rows use mono uppercase labels beside the switch, deriving from tokens so both themes resolve with no per-theme override.

## Design

The toggle is a single shared preference rather than one per surface, since "hide exited" is a viewing choice a user makes once. It reuses the existing `.switch` in-flow instrument (no new glass on content) and the established `read/write` localStorage pattern from `store.ts`. The control renders only where it is actionable (there are exited sessions), so an empty or all-active list stays uncluttered while the persisted preference still applies the moment exited sessions appear.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`/`waypoint-theme`) at 390px and 1440px, dark and light:
  - Panel and switcher both render the **Show exited** toggle.
  - Toggling off hides exited sessions from the panel (pinned + recent) and the switcher; toggling on restores them.
  - Reload preserves the toggle state (`aria-checked` intact).
  - The switcher toggle reflects the state set on the panel (cross-surface sync).

## Test Result
- `npm run lint` — no findings. `npm run build` — compiled successfully, 11/11 pages generated.
- Playwright: panel toggle flipped to off, persisted as off across reload, and the switcher's filter read off (synced) — verified across mobile/desktop × dark/light. Toggling off dropped the exited pinned card and exited recent rows while the `180 exited` summary stayed accurate; toggling back on restored the full list. Screenshots captured for panel (on/off/reload) and switcher (synced/on) in both themes.