### PR TITLE
feat: add schedule, browse-workspace, and files actions to terminal popover

### DIFF
--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1749,6 +1749,14 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     setWorkspaceRevealSeq(seq);
     setWorkspaceOpen(true);
   }, []);
+  // Opens the dock at the workspace root — shared by the chat composer and the
+  // terminal-bar "Browse workspace…" items so both start from the same state.
+  const openWorkspaceRoot = useCallback(() => {
+    setWorkspaceInitialPath(undefined);
+    setWorkspaceInitialDir(undefined);
+    setWorkspaceRevealSeq(++workspaceRequestRef.current);
+    setWorkspaceOpen(true);
+  }, []);
   // Route a clicked transcript path (absolute or ~/-relative) through the
   // backend resolver: files open the preview, directories reveal the tree. If
   // it resolves to nothing in the workspace, explicit links degrade to opening
@@ -2044,6 +2052,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           attachmentsEnabled={
             session ? supportsAttachments(session.backend, catalog) : false
           }
+          workspacePreviewEnabled={workspacePreviewEnabled}
           onRequestPaste={requestPaste}
           onTerminalResize={handleTerminalResize}
           onTerminalScrollChip={handleTerminalScrollChip}
@@ -2056,6 +2065,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           onRemoveFromList={removeFromList}
           onSwitchSession={openSwitcher}
           onOpenSettings={() => setSettingsOpen(true)}
+          onBrowseWorkspace={openWorkspaceRoot}
+          onScheduled={scheduledMessages.refresh}
           onError={setError}
         />
       ) : null}
@@ -2360,12 +2371,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           assistant={assistant}
           assistantControls={assistantControls}
           workspacePreviewEnabled={workspacePreviewEnabled}
-          onBrowseWorkspace={() => {
-            setWorkspaceInitialPath(undefined);
-            setWorkspaceInitialDir(undefined);
-            setWorkspaceRevealSeq(++workspaceRequestRef.current);
-            setWorkspaceOpen(true);
-          }}
+          onBrowseWorkspace={openWorkspaceRoot}
         />
       ) : null}
       {workspacePreviewEnabled ? (

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1749,8 +1749,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     setWorkspaceRevealSeq(seq);
     setWorkspaceOpen(true);
   }, []);
-  // Opens the dock at the workspace root — shared by the chat composer and the
-  // terminal-bar "Browse workspace…" items so both start from the same state.
+  // Opens the workspace dock at the root.
   const openWorkspaceRoot = useCallback(() => {
     setWorkspaceInitialPath(undefined);
     setWorkspaceInitialDir(undefined);

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 
+import { ScheduleMessageModal } from "@/components/ScheduleMessageModal";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { TerminalCompose } from "@/components/TerminalCompose";
 import { TerminalScrollChips } from "@/components/TerminalScrollChips";
@@ -61,6 +62,9 @@ interface SessionTerminalViewProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
+  // Local session (no launch target) whose workspace-preview endpoints are
+  // available — gates the terminal-bar "Browse workspace…" item, mirroring chat.
+  workspacePreviewEnabled: boolean;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
   onTerminalScrollChip: (direction: "up" | "down") => void;
@@ -74,6 +78,12 @@ interface SessionTerminalViewProps {
   onRemoveFromList: () => void | Promise<void>;
   onSwitchSession: () => void;
   onOpenSettings: () => void;
+  // Opens the parent-owned root workspace dock, matching the chat overflow's
+  // "Browse workspace…" behavior. SessionDetail keeps sole ownership of the dock.
+  onBrowseWorkspace: () => void;
+  // Refreshes the session-scoped scheduled-message data after a successful
+  // schedule, so returning to chat/session views sees the new item.
+  onScheduled: () => void;
   onError: (message: string) => void;
 }
 
@@ -101,6 +111,7 @@ export function SessionTerminalView({
   onTerminalSubmit,
   onTerminalSubmitWithAttachments,
   attachmentsEnabled,
+  workspacePreviewEnabled,
   onRequestPaste,
   onTerminalResize,
   onTerminalScrollChip,
@@ -113,6 +124,8 @@ export function SessionTerminalView({
   onRemoveFromList,
   onSwitchSession,
   onOpenSettings,
+  onBrowseWorkspace,
+  onScheduled,
   onError,
 }: SessionTerminalViewProps) {
   const catalog = useBackendCatalog(host || null, token || null, null);
@@ -147,6 +160,10 @@ export function SessionTerminalView({
   };
 
   const [composeOpen, setComposeOpen] = useState(false);
+  const [scheduleOpen, setScheduleOpen] = useState(false);
+  // Bumped by the terminal-bar "Files…" item; TerminalCompose opens its own
+  // files panel (the owner of the compose attachment tray) when this advances.
+  const [filesOpenRequest, setFilesOpenRequest] = useState(0);
   // The compose drawer collapses back to a hairline handle when the
   // session isn't interactive, so we don't carry stale "open" state across a
   // disconnect / view switch.
@@ -281,6 +298,48 @@ export function SessionTerminalView({
                   Session settings…
                 </button>
               ) : null}
+              {session ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="composer-overflow-item"
+                  onClick={() => {
+                    closeMenu();
+                    setScheduleOpen(true);
+                  }}
+                >
+                  <span className="glyph">◷</span>
+                  Schedule message…
+                </button>
+              ) : null}
+              {session && workspacePreviewEnabled ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="composer-overflow-item"
+                  onClick={() => {
+                    closeMenu();
+                    onBrowseWorkspace();
+                  }}
+                >
+                  <span className="glyph">◫</span>
+                  Browse workspace…
+                </button>
+              ) : null}
+              {session && attachmentsEnabled && composeEnabled ? (
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="composer-overflow-item"
+                  onClick={() => {
+                    closeMenu();
+                    setFilesOpenRequest((n) => n + 1);
+                  }}
+                >
+                  <span className="glyph">▤</span>
+                  Files…
+                </button>
+              ) : null}
               {session && !sessionExited ? (
                 <>
                   <div className="composer-overflow-separator" />
@@ -373,6 +432,18 @@ export function SessionTerminalView({
           onExpandedChange={setComposeOpen}
           connection={connection}
           refocusTerminal={refocusTerminal}
+          filesOpenRequest={filesOpenRequest}
+        />
+      ) : null}
+      {scheduleOpen && session ? (
+        <ScheduleMessageModal
+          host={host}
+          token={token}
+          sessionId={sessionId}
+          initialDraft=""
+          onClose={() => setScheduleOpen(false)}
+          onScheduled={onScheduled}
+          onError={onError}
         />
       ) : null}
     </section>

--- a/frontend/src/components/SessionTerminalView.tsx
+++ b/frontend/src/components/SessionTerminalView.tsx
@@ -62,8 +62,6 @@ interface SessionTerminalViewProps {
     attachmentIds: string[],
   ) => Promise<TerminalSubmitResult>;
   attachmentsEnabled: boolean;
-  // Local session (no launch target) whose workspace-preview endpoints are
-  // available — gates the terminal-bar "Browse workspace…" item, mirroring chat.
   workspacePreviewEnabled: boolean;
   onRequestPaste: () => void;
   onTerminalResize: (size: { cols: number; rows: number }) => void;
@@ -78,11 +76,7 @@ interface SessionTerminalViewProps {
   onRemoveFromList: () => void | Promise<void>;
   onSwitchSession: () => void;
   onOpenSettings: () => void;
-  // Opens the parent-owned root workspace dock, matching the chat overflow's
-  // "Browse workspace…" behavior. SessionDetail keeps sole ownership of the dock.
   onBrowseWorkspace: () => void;
-  // Refreshes the session-scoped scheduled-message data after a successful
-  // schedule, so returning to chat/session views sees the new item.
   onScheduled: () => void;
   onError: (message: string) => void;
 }
@@ -161,8 +155,7 @@ export function SessionTerminalView({
 
   const [composeOpen, setComposeOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
-  // Bumped by the terminal-bar "Files…" item; TerminalCompose opens its own
-  // files panel (the owner of the compose attachment tray) when this advances.
+  // TerminalCompose owns the files panel; bumping this asks it to open.
   const [filesOpenRequest, setFilesOpenRequest] = useState(0);
   // The compose drawer collapses back to a hairline handle when the
   // session isn't interactive, so we don't carry stale "open" state across a
@@ -312,7 +305,7 @@ export function SessionTerminalView({
                   Schedule message…
                 </button>
               ) : null}
-              {session && workspacePreviewEnabled ? (
+              {workspacePreviewEnabled ? (
                 <button
                   type="button"
                   role="menuitem"
@@ -326,7 +319,7 @@ export function SessionTerminalView({
                   Browse workspace…
                 </button>
               ) : null}
-              {session && attachmentsEnabled && composeEnabled ? (
+              {attachmentsEnabled && composeEnabled ? (
                 <button
                   type="button"
                   role="menuitem"
@@ -435,7 +428,7 @@ export function SessionTerminalView({
           filesOpenRequest={filesOpenRequest}
         />
       ) : null}
-      {scheduleOpen && session ? (
+      {scheduleOpen ? (
         <ScheduleMessageModal
           host={host}
           token={token}

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -53,10 +53,7 @@ interface TerminalComposeProps {
   // Focus target when the user dismisses the drawer via Escape — the
   // xterm canvas, so typing resumes inside the pane.
   refocusTerminal: () => void;
-  // Monotonic counter the terminal-bar "Files…" menu item bumps to open this
-  // component's files panel — the panel owns the compose ``useAttachments``, so
-  // routing the request here preserves add-to-message reference behavior. The
-  // baseline value is ignored so a stale request never opens Files on remount.
+  // A post-mount increment opens the files panel; the mount value is the baseline.
   filesOpenRequest?: number;
 }
 
@@ -87,9 +84,7 @@ export function TerminalCompose({
   const [filesOpen, setFilesOpen] = useState(false);
   const attachments = useAttachments({ host, token, sessionId, onError });
 
-  // Treat the request value present at mount as the baseline; only a later
-  // increment (a user clicking the terminal-bar "Files…" item) opens the
-  // panel, so switching sessions never reopens Files in a fresh compose.
+  // Baseline the mount value so a session switch never reopens Files.
   const filesRequestBaseline = useRef(filesOpenRequest);
   useEffect(() => {
     if (filesOpenRequest === filesRequestBaseline.current) return;

--- a/frontend/src/components/TerminalCompose.tsx
+++ b/frontend/src/components/TerminalCompose.tsx
@@ -53,6 +53,11 @@ interface TerminalComposeProps {
   // Focus target when the user dismisses the drawer via Escape — the
   // xterm canvas, so typing resumes inside the pane.
   refocusTerminal: () => void;
+  // Monotonic counter the terminal-bar "Files…" menu item bumps to open this
+  // component's files panel — the panel owns the compose ``useAttachments``, so
+  // routing the request here preserves add-to-message reference behavior. The
+  // baseline value is ignored so a stale request never opens Files on remount.
+  filesOpenRequest?: number;
 }
 
 
@@ -68,6 +73,7 @@ export function TerminalCompose({
   onExpandedChange,
   connection,
   refocusTerminal,
+  filesOpenRequest = 0,
 }: TerminalComposeProps) {
   const regionId = useId();
   const [draft, setDraft] = useState("");
@@ -80,6 +86,16 @@ export function TerminalCompose({
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [filesOpen, setFilesOpen] = useState(false);
   const attachments = useAttachments({ host, token, sessionId, onError });
+
+  // Treat the request value present at mount as the baseline; only a later
+  // increment (a user clicking the terminal-bar "Files…" item) opens the
+  // panel, so switching sessions never reopens Files in a fresh compose.
+  const filesRequestBaseline = useRef(filesOpenRequest);
+  useEffect(() => {
+    if (filesOpenRequest === filesRequestBaseline.current) return;
+    filesRequestBaseline.current = filesOpenRequest;
+    setFilesOpen(true);
+  }, [filesOpenRequest]);
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const handleRef = useRef<HTMLButtonElement | null>(null);


### PR DESCRIPTION
## Purpose

The terminal session view's **More actions** popover ended after refresh, reconnect/resume, switch, settings, and lifecycle actions, so a terminal-view user could not schedule a message, browse the workspace, or manage session files without leaving the terminal workflow. This brings the terminal popover to parity with the chat composer's overflow by adding **Schedule message…**, **Browse workspace…**, and **Files…**, reusing the existing modal, workspace dock, and files panel. Frontend-only, no API changes.

## Changes

### Frontend
- `components/SessionTerminalView.tsx` — render three gated menu items after **Session settings…** and above the destructive separator: **Schedule message…** (`◷`, any loaded session) opens a local `ScheduleMessageModal` with an empty draft; **Browse workspace…** (`◫`, when `workspacePreviewEnabled`) calls the parent's root-workspace callback; **Files…** (`▤`, when `attachmentsEnabled && composeEnabled`) bumps a monotonic `filesOpenRequest` counter passed to `TerminalCompose`. Each calls `closeMenu()` before opening its surface. Adds the `workspacePreviewEnabled`, `onBrowseWorkspace`, and `onScheduled` props and local `scheduleOpen` / `filesOpenRequest` state.
- `components/TerminalCompose.tsx` — accept an optional `filesOpenRequest` prop; a `useEffect` opens the existing `SessionFilesPanel` only when the value advances past the baseline captured at mount, so a stale request never reopens Files in a freshly mounted compose. Routing the request here keeps the files manager's add-to-message behavior wired to this component's own `useAttachments` tray — no attachment state is lifted or duplicated.
- `components/SessionDetail.tsx` — extract `openWorkspaceRoot` (the previously inlined chat-composer root-workspace callback) and pass it to both `ReplyComposer` and `SessionTerminalView`, plus `workspacePreviewEnabled` and `scheduledMessages.refresh` into the terminal view. `SessionDetail` remains the sole owner of the workspace dock, its width, reveal state, and layout.

## Design

Follows the RFC's recommended option: route each action through its existing owner rather than duplicating panels. The schedule dialog lives in the terminal view; the workspace dock stays owned by `SessionDetail` (one dock, shared with chat); and Files signals `TerminalCompose` — the sole owner of the terminal compose attachment tray — so the file-reference-into-draft behavior is preserved instead of degrading into a view-only manager.

**Files gate.** Files is gated on `attachmentsEnabled && composeEnabled`, not `attachmentsEnabled` alone as the RFC literally stated. `TerminalCompose` — which owns the files panel and attachment tray — only mounts for interactive transports; `claude_tty` reports `terminal_interactive=False`, so it has no terminal composer. Adding the `composeEnabled` term avoids a dead menu item on non-interactive terminals and is consistent with the RFC's explicit rejection of a files manager disconnected from a compose draft. Verified live: Files is absent on a `claude_tty` session and present/functional on a `tmux` one.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, TypeScript clean, all routes generated.
- Playwright against the deployed stack (backend `:8797`, frontend `:3010`, seeded `waypoint.host`, UI login) at 420px, dark and light:
  - Terminal popover renders **Schedule message…** and **Browse workspace…** on a local `claude_tty` session, in the correct order (after Session settings, before Terminate), in both themes.
  - **Schedule message…** opens the reused modal with an empty draft; the popover closes first.
  - **Browse workspace…** opens the shared `.wp-dock`.
  - **Files…** is absent on the non-interactive `claude_tty` session and present on an interactive `tmux` session, where it opens the `SessionFilesPanel` owned by `TerminalCompose`.

## Test Result
- `npm run lint` — no findings. `npm run build` — compiled successfully in ~6s, 11/11 pages generated.
- Playwright: on `claude_tty`, menu items were `[Refresh, Resume pane, Switch session…, Session settings…, Schedule message…, Browse workspace…, Terminate session]` (Files correctly absent); a DOM probe confirmed `.term-compose` count 0 on `claude_tty` and 1 on `tmux`. Schedule modal opened with empty draft and the menu closed; the workspace dock opened; on `tmux` the Files item was present and the session-files panel opened. Confirmed in dark and light themes.

Addresses ticket 1058.