### PR TITLE
fix: stop inbox sidebar rows from squishing instead of scrolling

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -16484,6 +16484,9 @@ body.wp-dock-resizing .inbox-resizer::after {
    hover/focus delete button above it — the row itself is a sibling, never a
    parent of another button. */
 .inbox-row-wrap {
+  /* The list is a flex column; without this, many rows shrink to fit the pane
+     instead of scrolling, and each row's overflow:hidden clips its content. */
+  flex: none;
   position: relative;
   overflow: hidden;
 }
@@ -16724,6 +16727,7 @@ body.wp-dock-resizing .inbox-resizer::after {
 }
 
 .inbox-load-more {
+  flex: none;
   margin: 12px auto;
   padding: 6px 16px;
   border: 1px solid var(--line);
@@ -16870,6 +16874,7 @@ body.wp-dock-resizing .inbox-resizer::after {
 
 /* ── Skeleton (loading) ── */
 .inbox-row-skeleton {
+  flex: none;
   display: flex;
   flex-direction: column;
   gap: 8px;


### PR DESCRIPTION
## Purpose

The inbox page sidebar truncated its rows: on a long list (e.g. the **Resolved** or **All** filters) every row collapsed to a sliver, clipping the sender line's descenders and hiding the subject and chips entirely. Frontend-only CSS fix, no API changes.

## Changes

### Frontend
- `frontend/src/app/globals.css` — add `flex: none` to `.inbox-row-wrap`, `.inbox-row-skeleton`, and `.inbox-load-more`. `.inbox-list` is a `display: flex; flex-direction: column` container with a constrained height (so the empty-state child can `flex: 1` center-fill). Its scrollable content items inherited the default `flex-shrink: 1`, so once the rows' combined height exceeded the pane the flex algorithm shrank every row to fit instead of letting the list scroll. Each shrunk `.inbox-row-wrap` (which is `overflow: hidden` for the swipe-to-delete panel) then clipped its full-height `.inbox-row`, producing the truncated rows. Pinning the content items with `flex: none` makes them keep their natural height so the list overflows and scrolls.

## Design

The list must stay a flex column because the empty state relies on `flex: 1` to fill and center within the pane, so the fix targets only the scrollable content items rather than changing the container to `display: block`. The `overflow: hidden` on `.inbox-row-wrap` is retained — it is intentional (it hides the swipe-reveal delete panel until a row is dragged) and is no longer a problem once the wrapper is sized to its row.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, all routes generated.
- Playwright against the deployed stack (backend `:8797`, seeded `waypoint.host`/`waypoint.token`/`waypoint-theme`) at 430px and 1440px, dark and light, on the **Resolved** filter (30 items): confirmed rows render at full height with sender, subject (ellipsized), and chip; measured `scrollHeight > clientHeight` (list scrolls, no squish).
- Verified the empty-state (`.inbox-empty-list`) still fills and centers the list after the change.

## Test Result
- `npm run lint` — no findings. `npm run build` — compiled successfully, 11/11 pages generated.
- Before: `.inbox-list` `scrollHeight === clientHeight === 604` with 30 rows squished to ~20px each, sender clipped, subject/chip not painted. After: `scrollHeight 2434` vs `clientHeight 604` (scrolls), each row 79px with sender, subject, and `1 APPROVAL` chip visible — verified across mobile/desktop × dark/light. Empty state stayed centered (top/bottom flush with the list).