### PR TITLE
feat: add recurring (cron) schedules for sessions and messages

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -11,6 +11,7 @@ license = "MIT"
 requires-python = ">=3.12"
 dependencies = [
   "aiohttp>=3.10.0",
+  "croniter>=6.0.0",
   "fastapi>=0.139.0",
   "openai-codex==0.1.0b3",
   "pydantic>=2.11.0",
@@ -18,6 +19,7 @@ dependencies = [
   "python-multipart>=0.0.9",
   "PyYAML>=6.0.0",
   "typer>=0.26.8",
+  "tzdata>=2024.1",
   "uvicorn>=0.51.0",
   "websockets>=16.1",
 ]
@@ -30,6 +32,7 @@ dev = [
   "pytest>=8.4.0",
   "pytest-asyncio>=0.24.0",
   "ruff>=0.15.21",
+  "types-croniter>=6.0.0",
   "types-PyYAML>=6.0.0",
 ]
 

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -46,7 +46,11 @@ from waypoint.presets import (
     resolve_schedule_create_request,
     resolve_session_create_request,
 )
-from waypoint.recurrence import RecurrenceError, next_occurrences
+from waypoint.recurrence import (
+    RecurrenceError,
+    next_occurrences,
+    resolve_recurrence_base,
+)
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     AccountProbeResult,
@@ -1798,10 +1802,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         # Authoritative next-run source shared by both creation UIs.
         try:
+            base = resolve_recurrence_base(
+                datetime.now(UTC), request.timezone, request.start_at
+            )
             occurrences = next_occurrences(
                 request.cron,
                 request.timezone,
-                datetime.now(UTC),
+                base,
                 max(1, min(request.count, 10)),
             )
         except RecurrenceError as exc:

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -46,6 +46,7 @@ from waypoint.presets import (
     resolve_schedule_create_request,
     resolve_session_create_request,
 )
+from waypoint.recurrence import RecurrenceError, next_occurrences
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
     AccountProbeResult,
@@ -72,6 +73,8 @@ from waypoint.schemas import (
     ProfileDoctorReport,
     ScheduledMessageCreateRequest,
     ScheduleLaunchRequest,
+    SchedulePreviewRequest,
+    SchedulePreviewResponse,
     SessionAnswerQuestionRequest,
     SessionApprovalRequest,
     SessionAttachRequest,
@@ -1787,6 +1790,26 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     ) -> Any:
         removed = context.runtime.scheduler.clear_history()
         return {"removed": removed}
+
+    @app.post("/api/schedules/preview", response_model=SchedulePreviewResponse)
+    async def preview_schedule(
+        request: SchedulePreviewRequest,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        # Single authoritative source of cron/DST math, shared by the launch and
+        # message creation UIs so their preview matches what actually fires.
+        try:
+            occurrences = next_occurrences(
+                request.cron,
+                request.timezone,
+                datetime.now(UTC),
+                max(1, min(request.count, 10)),
+            )
+        except RecurrenceError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+        return SchedulePreviewResponse(occurrences=occurrences)
 
     # ── Session presets ──────────────────────────────────────────────────
     @app.get("/api/session-presets", response_model=SessionPresetListResponse)

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1796,8 +1796,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         request: SchedulePreviewRequest,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        # Single authoritative source of cron/DST math, shared by the launch and
-        # message creation UIs so their preview matches what actually fires.
+        # Authoritative next-run source shared by both creation UIs.
         try:
             occurrences = next_occurrences(
                 request.cron,

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -150,6 +150,17 @@ inbox_app = typer.Typer(
     help="Durable human-facing inbox for lead-initiated checkpoints.",
     no_args_is_help=True,
 )
+_CRON_HELP = (
+    "Recurring five-field cron expression (minute hour day-of-month month "
+    "day-of-week), e.g. '0 9 * * 1-5' for 09:00 on weekdays. Requires "
+    "--timezone and cannot be combined with --delay-seconds/--scheduled-at. "
+    "Aliases like '@daily' and second-level fields are not supported."
+)
+_TIMEZONE_HELP = (
+    "IANA timezone for --cron, e.g. 'Asia/Singapore' or 'America/New_York'. "
+    "Required with --cron; the next run is computed in this zone (DST-aware)."
+)
+
 schedule_app = typer.Typer(
     help="Manage scheduled session launches on a running Waypoint server.",
     no_args_is_help=True,
@@ -3426,6 +3437,14 @@ def schedule_create(
         str | None,
         typer.Option(help="ISO 8601 datetime at which to launch the session."),
     ] = None,
+    cron: Annotated[
+        str | None,
+        typer.Option(help=_CRON_HELP),
+    ] = None,
+    timezone: Annotated[
+        str | None,
+        typer.Option(help=_TIMEZONE_HELP),
+    ] = None,
     account_profile: Annotated[
         str | None,
         typer.Option(
@@ -3467,6 +3486,8 @@ def schedule_create(
                 args=list(args or []),
                 delay_seconds=delay_seconds,
                 scheduled_at=scheduled_at,
+                cron=cron,
+                timezone=timezone,
                 launch_env=launch_env_map,
                 account_profile_id=account_profile,
                 preset_id=preset,
@@ -4757,12 +4778,20 @@ def schedule_message_create(
         str | None,
         typer.Option(help="ISO 8601 datetime at which to send the message."),
     ] = None,
+    cron: Annotated[
+        str | None,
+        typer.Option(help=_CRON_HELP),
+    ] = None,
+    timezone: Annotated[
+        str | None,
+        typer.Option(help=_TIMEZONE_HELP),
+    ] = None,
     no_submit: Annotated[
         bool,
         typer.Option("--no-submit", help="Do not auto-submit the message."),
     ] = False,
 ) -> None:
-    """Schedule a message to be sent to a session."""
+    """Schedule a message to be sent to a session, once or on a recurring cron."""
     _emit(
         _settings_from_ctx(ctx),
         lambda c: {
@@ -4772,6 +4801,8 @@ def schedule_message_create(
                 submit=not no_submit,
                 delay_seconds=delay_seconds,
                 scheduled_at=scheduled_at,
+                cron=cron,
+                timezone=timezone,
             )
         },
     )

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -160,6 +160,11 @@ _TIMEZONE_HELP = (
     "IANA timezone for --cron, e.g. 'Asia/Singapore' or 'America/New_York'. "
     "Required with --cron; the next run is computed in this zone (DST-aware)."
 )
+_START_AT_HELP = (
+    "Wall-clock start for a recurrence in --timezone (e.g. '2026-07-25T09:00'). "
+    "The first run is the first cron occurrence at or after it; a past start is "
+    "not backfilled. Only valid with --cron."
+)
 
 schedule_app = typer.Typer(
     help="Manage scheduled session launches on a running Waypoint server.",
@@ -3445,6 +3450,10 @@ def schedule_create(
         str | None,
         typer.Option(help=_TIMEZONE_HELP),
     ] = None,
+    start_at: Annotated[
+        str | None,
+        typer.Option(help=_START_AT_HELP),
+    ] = None,
     account_profile: Annotated[
         str | None,
         typer.Option(
@@ -3488,6 +3497,7 @@ def schedule_create(
                 scheduled_at=scheduled_at,
                 cron=cron,
                 timezone=timezone,
+                start_at=start_at,
                 launch_env=launch_env_map,
                 account_profile_id=account_profile,
                 preset_id=preset,
@@ -4786,6 +4796,10 @@ def schedule_message_create(
         str | None,
         typer.Option(help=_TIMEZONE_HELP),
     ] = None,
+    start_at: Annotated[
+        str | None,
+        typer.Option(help=_START_AT_HELP),
+    ] = None,
     no_submit: Annotated[
         bool,
         typer.Option("--no-submit", help="Do not auto-submit the message."),
@@ -4803,6 +4817,7 @@ def schedule_message_create(
                 scheduled_at=scheduled_at,
                 cron=cron,
                 timezone=timezone,
+                start_at=start_at,
             )
         },
     )

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -888,6 +888,8 @@ class WaypointClient:
         config_overrides: list[str] | None = None,
         delay_seconds: int | None = None,
         scheduled_at: str | None = None,
+        cron: str | None = None,
+        timezone: str | None = None,
         launch_env: dict[str, str] | None = None,
         account_profile_id: str | None = None,
         preset_id: str | None = None,
@@ -910,6 +912,8 @@ class WaypointClient:
             "initial_prompt": initial_prompt,
             "delay_seconds": delay_seconds,
             "scheduled_at": scheduled_at,
+            "cron": cron,
+            "timezone": timezone,
             "launch_env": launch_env,
             "account_profile_id": account_profile_id,
             "preset_id": preset_id,
@@ -1085,6 +1089,8 @@ class WaypointClient:
         submit: bool = True,
         delay_seconds: int | None = None,
         scheduled_at: str | None = None,
+        cron: str | None = None,
+        timezone: str | None = None,
         attachments: list[str] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"text": text, "submit": submit}
@@ -1092,6 +1098,10 @@ class WaypointClient:
             body["delay_seconds"] = delay_seconds
         if scheduled_at is not None:
             body["scheduled_at"] = scheduled_at
+        if cron is not None:
+            body["cron"] = cron
+        if timezone is not None:
+            body["timezone"] = timezone
         if attachments:
             body["attachments"] = attachments
         data: dict[str, Any] = self._request(
@@ -1100,6 +1110,15 @@ class WaypointClient:
             json=body,
         ).json()["message_schedule"]
         return data
+
+    def preview_schedule(self, cron: str, timezone: str, count: int = 3) -> list[str]:
+        data: dict[str, Any] = self._request(
+            "POST",
+            "/api/schedules/preview",
+            json={"cron": cron, "timezone": timezone, "count": count},
+        ).json()
+        occurrences: list[str] = data["occurrences"]
+        return occurrences
 
     def delete_message_schedule(self, schedule_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -1111,15 +1111,6 @@ class WaypointClient:
         ).json()["message_schedule"]
         return data
 
-    def preview_schedule(self, cron: str, timezone: str, count: int = 3) -> list[str]:
-        data: dict[str, Any] = self._request(
-            "POST",
-            "/api/schedules/preview",
-            json={"cron": cron, "timezone": timezone, "count": count},
-        ).json()
-        occurrences: list[str] = data["occurrences"]
-        return occurrences
-
     def delete_message_schedule(self, schedule_id: str) -> dict[str, Any]:
         data: dict[str, Any] = self._request(
             "DELETE", f"/api/message-schedules/{schedule_id}"

--- a/backend/src/waypoint/client.py
+++ b/backend/src/waypoint/client.py
@@ -890,6 +890,7 @@ class WaypointClient:
         scheduled_at: str | None = None,
         cron: str | None = None,
         timezone: str | None = None,
+        start_at: str | None = None,
         launch_env: dict[str, str] | None = None,
         account_profile_id: str | None = None,
         preset_id: str | None = None,
@@ -914,6 +915,7 @@ class WaypointClient:
             "scheduled_at": scheduled_at,
             "cron": cron,
             "timezone": timezone,
+            "start_at": start_at,
             "launch_env": launch_env,
             "account_profile_id": account_profile_id,
             "preset_id": preset_id,
@@ -1091,6 +1093,7 @@ class WaypointClient:
         scheduled_at: str | None = None,
         cron: str | None = None,
         timezone: str | None = None,
+        start_at: str | None = None,
         attachments: list[str] | None = None,
     ) -> dict[str, Any]:
         body: dict[str, Any] = {"text": text, "submit": submit}
@@ -1102,6 +1105,8 @@ class WaypointClient:
             body["cron"] = cron
         if timezone is not None:
             body["timezone"] = timezone
+        if start_at is not None:
+            body["start_at"] = start_at
         if attachments:
             body["attachments"] = attachments
         data: dict[str, Any] = self._request(

--- a/backend/src/waypoint/recurrence.py
+++ b/backend/src/waypoint/recurrence.py
@@ -1,0 +1,133 @@
+"""Cron recurrence evaluation for scheduled sessions and messages.
+
+Wraps ``croniter`` and ``zoneinfo`` so the five-field grammar, timezone
+validation, and daylight-saving policy live at Waypoint's boundary and are
+tested here rather than scattered across the scheduler.
+
+DST policy (wall-clock in the stored zone):
+
+* A nonexistent local time during a forward transition (spring-forward) is
+  **skipped**.
+* A repeated local time during a backward transition (fall-back) runs **once**,
+  at the earlier occurrence.
+
+Both fall out of iterating croniter in *naive* local time and localizing each
+candidate with ``fold=0``: the ambiguous fall-back wall-clock appears once in
+the naive sequence (earlier instant chosen by the fold), and a nonexistent
+spring-forward wall-clock fails the round-trip check and is dropped. Passing a
+tz-aware base to croniter instead reproduces croniter's own behavior (roll the
+nonexistent time forward, emit the fall-back time twice), which violates the
+policy above.
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from croniter import CroniterBadCronError, CroniterBadDateError, croniter
+
+CRON_FIELD_COUNT = 5
+
+# How long after a recurring occurrence's due time the scheduler may still run
+# it. Sized well above the worst-case poll-loop latency (a batch of due
+# schedules is fired sequentially and a session launch can take seconds), so a
+# legitimately due occurrence is never misclassified as missed, while a real
+# downtime of minutes is. Not a UI option.
+MISSED_RUN_GRACE_SECONDS = 60.0
+
+# Bound on how far ahead we search for a next occurrence before treating the
+# expression as non-advancing (e.g. an impossible day/month combination).
+_MAX_SEARCH_ITERATIONS = 4 * 366
+
+
+class RecurrenceError(ValueError):
+    """A cron expression or timezone that Waypoint cannot schedule."""
+
+
+def validate_timezone(timezone: str) -> ZoneInfo:
+    """Return the :class:`ZoneInfo` for an IANA zone or raise ``RecurrenceError``."""
+    try:
+        return ZoneInfo(timezone)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise RecurrenceError(
+            f"invalid timezone: {timezone!r}; expected an IANA zone such as "
+            "'Asia/Singapore' or 'America/New_York'"
+        ) from exc
+
+
+def validate_cron(expression: str) -> None:
+    """Validate a five-field cron expression.
+
+    Rejects anything but exactly five whitespace-separated fields (six/seven
+    field, second-level, and ``@daily``-style aliases are unsupported), invalid
+    field grammar, and expressions that never advance.
+    """
+    if expression.strip().startswith("@"):
+        raise RecurrenceError(
+            "cron aliases such as '@daily' are not supported; use five fields: "
+            "minute hour day-of-month month day-of-week"
+        )
+    fields = expression.split()
+    if len(fields) != CRON_FIELD_COUNT:
+        raise RecurrenceError(
+            f"cron must have exactly {CRON_FIELD_COUNT} fields "
+            "(minute hour day-of-month month day-of-week), "
+            f"got {len(fields)}"
+        )
+    try:
+        croniter(expression)
+    except (CroniterBadCronError, ValueError) as exc:
+        raise RecurrenceError(f"invalid cron expression: {exc}") from exc
+
+
+def _localize(naive: datetime, tz: ZoneInfo) -> datetime | None:
+    """Attach ``tz`` to a naive local time, or ``None`` if it does not exist.
+
+    ``fold=0`` selects the earlier instant for an ambiguous (fall-back) time. A
+    nonexistent (spring-forward) time is detected by a UTC round-trip that no
+    longer matches the requested wall clock.
+    """
+    aware = naive.replace(tzinfo=tz, fold=0)
+    roundtrip = aware.astimezone(UTC).astimezone(tz).replace(tzinfo=None)
+    if roundtrip != naive:
+        return None
+    return aware
+
+
+def next_occurrences(
+    expression: str, timezone: str, after: datetime, count: int
+) -> list[datetime]:
+    """Return the next ``count`` UTC occurrences strictly after ``after``.
+
+    Applies the module DST policy. Raises ``RecurrenceError`` for an invalid
+    expression/timezone or one that cannot yield a finite next occurrence.
+    """
+    if count <= 0:
+        return []
+    validate_cron(expression)
+    tz = validate_timezone(timezone)
+    base_naive = after.astimezone(tz).replace(tzinfo=None)
+    iterator = croniter(expression, base_naive)
+    occurrences: list[datetime] = []
+    iterations = 0
+    while len(occurrences) < count:
+        iterations += 1
+        if iterations > _MAX_SEARCH_ITERATIONS:
+            raise RecurrenceError(
+                f"cron expression {expression!r} has no upcoming occurrence"
+            )
+        try:
+            naive = iterator.get_next(datetime)
+        except CroniterBadDateError as exc:
+            raise RecurrenceError(
+                f"cron expression {expression!r} has no upcoming occurrence"
+            ) from exc
+        aware = _localize(naive, tz)
+        if aware is None:
+            continue
+        occurrences.append(aware.astimezone(UTC))
+    return occurrences
+
+
+def next_occurrence_after(expression: str, timezone: str, after: datetime) -> datetime:
+    """Return the first UTC occurrence strictly after ``after``."""
+    return next_occurrences(expression, timezone, after, 1)[0]

--- a/backend/src/waypoint/recurrence.py
+++ b/backend/src/waypoint/recurrence.py
@@ -1,23 +1,16 @@
 """Cron recurrence evaluation for scheduled sessions and messages.
 
-Wraps ``croniter`` and ``zoneinfo`` so the five-field grammar, timezone
-validation, and daylight-saving policy live at Waypoint's boundary and are
-tested here rather than scattered across the scheduler.
-
-DST policy (wall-clock in the stored zone):
+Wraps ``croniter`` and ``zoneinfo`` behind the five-field grammar, timezone
+validation, and this DST policy (wall-clock in the stored zone):
 
 * A nonexistent local time during a forward transition (spring-forward) is
-  **skipped**.
-* A repeated local time during a backward transition (fall-back) runs **once**,
-  at the earlier occurrence.
+  skipped.
+* A repeated local time during a backward transition (fall-back) runs once, at
+  the earlier occurrence.
 
-Both fall out of iterating croniter in *naive* local time and localizing each
-candidate with ``fold=0``: the ambiguous fall-back wall-clock appears once in
-the naive sequence (earlier instant chosen by the fold), and a nonexistent
-spring-forward wall-clock fails the round-trip check and is dropped. Passing a
-tz-aware base to croniter instead reproduces croniter's own behavior (roll the
-nonexistent time forward, emit the fall-back time twice), which violates the
-policy above.
+Occurrences are computed by iterating croniter in naive local time and
+localizing each candidate with ``fold=0``; a candidate whose wall clock does
+not survive a UTC round-trip is a spring-forward gap and is dropped.
 """
 
 from datetime import UTC, datetime
@@ -27,11 +20,8 @@ from croniter import CroniterBadCronError, CroniterBadDateError, croniter
 
 CRON_FIELD_COUNT = 5
 
-# How long after a recurring occurrence's due time the scheduler may still run
-# it. Sized well above the worst-case poll-loop latency (a batch of due
-# schedules is fired sequentially and a session launch can take seconds), so a
-# legitimately due occurrence is never misclassified as missed, while a real
-# downtime of minutes is. Not a UI option.
+# Seconds past its due time within which a recurring occurrence still fires;
+# beyond this it is treated as a missed run (downtime) and skipped.
 MISSED_RUN_GRACE_SECONDS = 60.0
 
 # Bound on how far ahead we search for a next occurrence before treating the

--- a/backend/src/waypoint/recurrence.py
+++ b/backend/src/waypoint/recurrence.py
@@ -13,7 +13,7 @@ localizing each candidate with ``fold=0``; a candidate whose wall clock does
 not survive a UTC round-trip is a spring-forward gap and is dropped.
 """
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from croniter import CroniterBadCronError, CroniterBadDateError, croniter
@@ -121,3 +121,26 @@ def next_occurrences(
 def next_occurrence_after(expression: str, timezone: str, after: datetime) -> datetime:
     """Return the first UTC occurrence strictly after ``after``."""
     return next_occurrences(expression, timezone, after, 1)[0]
+
+
+def resolve_recurrence_base(
+    now: datetime, timezone: str, start_at: str | None
+) -> datetime:
+    """Base instant to compute the first occurrence from.
+
+    A future ``start_at`` (wall-clock in ``timezone``) makes the first run its
+    first cron occurrence at or after it; a past or absent start uses ``now``,
+    so a start in the past is not backfilled.
+    """
+    if not start_at:
+        return now
+    try:
+        naive = datetime.fromisoformat(start_at)
+    except ValueError as exc:
+        raise RecurrenceError(f"invalid start_at: {start_at!r}") from exc
+    tz = validate_timezone(timezone)
+    aware = naive if naive.tzinfo is not None else naive.replace(tzinfo=tz)
+    start = aware.astimezone(UTC)
+    if start <= now:
+        return now
+    return start - timedelta(microseconds=1)

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -1,8 +1,9 @@
 import asyncio
 import logging
 import secrets
+from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import HTTPException, status
 
@@ -343,17 +344,21 @@ class Scheduler:
         return min(delta, POLL_INTERVAL_SECONDS)
 
     async def _fire_due_schedules(self) -> None:
-        # Capture ``now`` once for the whole batch: due schedules are fired
-        # sequentially and a launch can take seconds, so re-reading the clock
-        # per item would let a slow earlier fire push a legitimately due
-        # recurring occurrence past its grace window and misclassify it.
+        # One clock read for the batch so a slow sequential fire can't shift the
+        # grace window under a later due occurrence.
         now = datetime.now(UTC)
         pending = self._runtime.storage.list_schedules([ScheduleStatus.PENDING])
         for schedule in pending:
             if schedule.scheduled_at > now:
                 continue
             if schedule.cron is not None:
-                await self._fire_due_recurring_schedule(schedule, now)
+                await self._claim_and_fire(
+                    schedule,
+                    now,
+                    self._runtime.storage.claim_recurring_schedule,
+                    self._fire_recurring,
+                    "schedule_id",
+                )
             else:
                 await self._fire(schedule)
         pending_msgs = self._runtime.storage.list_scheduled_messages(
@@ -363,68 +368,44 @@ class Scheduler:
             if msg.scheduled_at > now:
                 continue
             if msg.cron is not None:
-                await self._fire_due_recurring_message(msg, now)
+                await self._claim_and_fire(
+                    msg,
+                    now,
+                    self._runtime.storage.claim_recurring_message,
+                    self._fire_recurring_message,
+                    "msg_id",
+                )
             else:
                 await self._fire_message(msg)
 
-    async def _fire_due_recurring_schedule(
-        self, schedule: ScheduledSessionRecord, now: datetime
+    async def _claim_and_fire(
+        self,
+        record: ScheduledSessionRecord | ScheduledMessageRecord,
+        now: datetime,
+        claim: Callable[
+            [str, datetime, datetime],
+            ScheduledSessionRecord | ScheduledMessageRecord | None,
+        ],
+        fire: Callable[[Any, datetime], Awaitable[None]],
+        id_key: str,
     ) -> None:
-        occurrence = schedule.scheduled_at
-        if schedule.cron is None or schedule.timezone is None:
-            return
-        try:
-            next_at = next_occurrence_after(schedule.cron, schedule.timezone, now)
-        except RecurrenceError:
-            log.exception(
-                "recurrence advance failed", extra={"schedule_id": schedule.id}
-            )
-            return
-        claimed = self._runtime.storage.claim_recurring_schedule(
-            schedule.id, occurrence, next_at
-        )
-        if claimed is None:
-            return
-        log.info(
-            "recurrence claimed",
-            extra={
-                "schedule_id": schedule.id,
-                "occurrence": occurrence.isoformat(),
-                "next_run": next_at.isoformat(),
-            },
-        )
-        if (now - occurrence).total_seconds() > MISSED_RUN_GRACE_SECONDS:
-            log.info(
-                "recurrence misfire skipped",
-                extra={
-                    "schedule_id": schedule.id,
-                    "occurrence": occurrence.isoformat(),
-                },
-            )
-            await self._publish_update()
-            return
-        await self._fire_recurring(claimed, occurrence)
-
-    async def _fire_due_recurring_message(
-        self, record: ScheduledMessageRecord, now: datetime
-    ) -> None:
+        # Advance the recurrence to its next occurrence before running, so a
+        # second poll or a restart cannot fire the same occurrence twice.
         occurrence = record.scheduled_at
         if record.cron is None or record.timezone is None:
             return
         try:
             next_at = next_occurrence_after(record.cron, record.timezone, now)
         except RecurrenceError:
-            log.exception("recurrence advance failed", extra={"msg_id": record.id})
+            log.exception("recurrence advance failed", extra={id_key: record.id})
             return
-        claimed = self._runtime.storage.claim_recurring_message(
-            record.id, occurrence, next_at
-        )
+        claimed = claim(record.id, occurrence, next_at)
         if claimed is None:
             return
         log.info(
             "recurrence claimed",
             extra={
-                "msg_id": record.id,
+                id_key: record.id,
                 "occurrence": occurrence.isoformat(),
                 "next_run": next_at.isoformat(),
             },
@@ -432,11 +413,53 @@ class Scheduler:
         if (now - occurrence).total_seconds() > MISSED_RUN_GRACE_SECONDS:
             log.info(
                 "recurrence misfire skipped",
-                extra={"msg_id": record.id, "occurrence": occurrence.isoformat()},
+                extra={id_key: record.id, "occurrence": occurrence.isoformat()},
             )
             await self._publish_update()
             return
-        await self._fire_recurring_message(claimed, occurrence)
+        await fire(claimed, occurrence)
+
+    async def _launch_session(self, schedule: ScheduledSessionRecord) -> str:
+        session = await self._runtime.create_session(
+            SessionCreateRequest(
+                backend=schedule.backend,
+                cwd=schedule.cwd,
+                launch_target_id=schedule.launch_target_id,
+                launch_mode=schedule.launch_mode,
+                transport=schedule.transport,
+                title=schedule.title,
+                args=schedule.args,
+                config_overrides=schedule.config_overrides,
+                launch_env=schedule.launch_env,
+                source_mode=SessionSource.MANAGED,
+                permission_mode=schedule.permission_mode,
+                model=schedule.model,
+                effort=schedule.effort,
+                account_profile_id=schedule.account_profile_id,
+            ),
+            preset_id=schedule.preset_id,
+            preset_name=schedule.preset_name,
+        )
+        if schedule.initial_prompt:
+            # Some backends aren't idle the tick they finish boot.
+            await asyncio.sleep(0.1)
+            await self._runtime.handle_input(
+                session.id,
+                SessionInputRequest(text=schedule.initial_prompt, submit=True),
+            )
+        return session.id
+
+    async def _send_input(self, record: ScheduledMessageRecord) -> None:
+        await self._runtime.handle_input(
+            record.session_id,
+            SessionInputRequest(
+                text=record.text,
+                submit=record.submit,
+                command=record.command,
+                items=record.items,
+                attachments=list(record.attachments) if record.attachments else None,
+            ),
+        )
 
     async def _fire_message(self, record: ScheduledMessageRecord) -> None:
         try:
@@ -448,26 +471,12 @@ class Scheduler:
                     failure_reason="session not found",
                 )
                 return
-            await self._runtime.handle_input(
-                record.session_id,
-                SessionInputRequest(
-                    text=record.text,
-                    submit=record.submit,
-                    command=record.command,
-                    items=record.items,
-                    attachments=(
-                        list(record.attachments) if record.attachments else None
-                    ),
-                ),
-            )
+            await self._send_input(record)
             self._runtime.storage.update_scheduled_message(
                 record.id, status=ScheduledMessageStatus.SENT
             )
         except Exception as exc:  # noqa: BLE001
-            log.exception(
-                "scheduled message fire failed",
-                extra={"msg_id": record.id},
-            )
+            log.exception("scheduled message fire failed", extra={"msg_id": record.id})
             self._runtime.storage.update_scheduled_message(
                 record.id,
                 status=ScheduledMessageStatus.FAILED,
@@ -477,39 +486,12 @@ class Scheduler:
 
     async def _fire(self, schedule: ScheduledSessionRecord) -> None:
         try:
-            session = await self._runtime.create_session(
-                SessionCreateRequest(
-                    backend=schedule.backend,
-                    cwd=schedule.cwd,
-                    launch_target_id=schedule.launch_target_id,
-                    launch_mode=schedule.launch_mode,
-                    transport=schedule.transport,
-                    title=schedule.title,
-                    args=schedule.args,
-                    config_overrides=schedule.config_overrides,
-                    launch_env=schedule.launch_env,
-                    source_mode=SessionSource.MANAGED,
-                    permission_mode=schedule.permission_mode,
-                    model=schedule.model,
-                    effort=schedule.effort,
-                    account_profile_id=schedule.account_profile_id,
-                ),
-                preset_id=schedule.preset_id,
-                preset_name=schedule.preset_name,
-            )
+            session_id = await self._launch_session(schedule)
             self._runtime.storage.update_schedule(
                 schedule.id,
                 status=ScheduleStatus.LAUNCHED,
-                session_id=session.id,
+                session_id=session_id,
             )
-            if schedule.initial_prompt:
-                # Brief grace window before the first input; some backends are
-                # not yet idle the same tick they finish boot.
-                await asyncio.sleep(0.1)
-                await self._runtime.handle_input(
-                    session.id,
-                    SessionInputRequest(text=schedule.initial_prompt, submit=True),
-                )
         except Exception as exc:  # noqa: BLE001
             log.exception(
                 "scheduled session launch failed",
@@ -525,42 +507,13 @@ class Scheduler:
     async def _fire_recurring(
         self, schedule: ScheduledSessionRecord, occurrence: datetime
     ) -> None:
-        """Launch a recurring session, recording only the latest outcome.
-
-        The schedule stays ``pending`` (its ``scheduled_at`` was already
-        advanced by the claim); a failure is recorded in ``last_run_*`` and does
-        not disable the recurrence.
-        """
+        # Stays pending — the claim already advanced scheduled_at; a failure is
+        # recorded in last_run_* without disabling the recurrence.
         try:
-            session = await self._runtime.create_session(
-                SessionCreateRequest(
-                    backend=schedule.backend,
-                    cwd=schedule.cwd,
-                    launch_target_id=schedule.launch_target_id,
-                    launch_mode=schedule.launch_mode,
-                    transport=schedule.transport,
-                    title=schedule.title,
-                    args=schedule.args,
-                    config_overrides=schedule.config_overrides,
-                    launch_env=schedule.launch_env,
-                    source_mode=SessionSource.MANAGED,
-                    permission_mode=schedule.permission_mode,
-                    model=schedule.model,
-                    effort=schedule.effort,
-                    account_profile_id=schedule.account_profile_id,
-                ),
-                preset_id=schedule.preset_id,
-                preset_name=schedule.preset_name,
-            )
-            if schedule.initial_prompt:
-                await asyncio.sleep(0.1)
-                await self._runtime.handle_input(
-                    session.id,
-                    SessionInputRequest(text=schedule.initial_prompt, submit=True),
-                )
+            session_id = await self._launch_session(schedule)
             self._runtime.storage.update_schedule(
                 schedule.id,
-                session_id=session.id,
+                session_id=session_id,
                 last_run_at=occurrence,
                 last_run_status=ScheduleStatus.LAUNCHED.value,
                 last_failure_reason=None,
@@ -588,7 +541,6 @@ class Scheduler:
     async def _fire_recurring_message(
         self, record: ScheduledMessageRecord, occurrence: datetime
     ) -> None:
-        """Deliver a recurring message, recording only the latest outcome."""
         try:
             session = self._runtime.storage.get_session(record.session_id)
             if session is None:
@@ -599,23 +551,11 @@ class Scheduler:
                     last_failure_reason="session not found",
                 )
                 log.warning(
-                    "recurring message target missing",
-                    extra={"msg_id": record.id},
+                    "recurring message target missing", extra={"msg_id": record.id}
                 )
                 await self._publish_update()
                 return
-            await self._runtime.handle_input(
-                record.session_id,
-                SessionInputRequest(
-                    text=record.text,
-                    submit=record.submit,
-                    command=record.command,
-                    items=record.items,
-                    attachments=(
-                        list(record.attachments) if record.attachments else None
-                    ),
-                ),
-            )
+            await self._send_input(record)
             self._runtime.storage.update_scheduled_message(
                 record.id,
                 last_run_at=occurrence,

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -7,6 +7,11 @@ from typing import TYPE_CHECKING
 from fastapi import HTTPException, status
 
 from waypoint.backends.registry import get_registry
+from waypoint.recurrence import (
+    MISSED_RUN_GRACE_SECONDS,
+    RecurrenceError,
+    next_occurrence_after,
+)
 from waypoint.schemas import (
     ScheduleCreateRequest,
     ScheduledMessageCreateRequest,
@@ -26,6 +31,52 @@ if TYPE_CHECKING:
 log = logging.getLogger("waypoint.scheduler")
 
 POLL_INTERVAL_SECONDS = 5.0
+
+
+def validate_timing_mode(
+    delay_seconds: int | None,
+    scheduled_at: datetime | None,
+    cron: str | None,
+    timezone: str | None,
+) -> None:
+    """Enforce the timing-mode exclusivity matrix, raising HTTP 400.
+
+    Runs at the scheduler boundary rather than as a Pydantic validator so the
+    API returns 400 (not the 422 a request-body validator would produce).
+    """
+    if cron is not None and timezone is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="a recurring schedule needs both cron and timezone",
+        )
+    if timezone is not None and cron is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="timezone is only valid together with cron for a recurring schedule",
+        )
+    recurring = cron is not None
+    has_one_time = delay_seconds is not None or scheduled_at is not None
+    if recurring and has_one_time:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "one-time timing (delay_seconds/scheduled_at) cannot be combined "
+                "with a recurring cron schedule"
+            ),
+        )
+    if delay_seconds is not None and scheduled_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="provide either delay_seconds or scheduled_at, not both",
+        )
+    if not recurring and not has_one_time:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "provide one-time timing (delay_seconds or scheduled_at) or a "
+                "recurring cron and timezone"
+            ),
+        )
 
 
 def validate_permission_mode_for_backend(backend: str, mode: str | None) -> str | None:
@@ -133,6 +184,8 @@ class Scheduler:
             scheduled_at=scheduled_at,
             created_at=now,
             status=ScheduleStatus.PENDING,
+            cron=request.cron,
+            timezone=request.timezone,
             preset_id=preset_id,
             preset_name=preset_name,
             account_profile_id=request.account_profile_id,
@@ -203,6 +256,8 @@ class Scheduler:
             scheduled_at=scheduled_at,
             created_at=now,
             status=ScheduledMessageStatus.PENDING,
+            cron=request.cron,
+            timezone=request.timezone,
         )
         self._runtime.storage.create_scheduled_message(record)
         self._wakeup.set()
@@ -288,19 +343,100 @@ class Scheduler:
         return min(delta, POLL_INTERVAL_SECONDS)
 
     async def _fire_due_schedules(self) -> None:
+        # Capture ``now`` once for the whole batch: due schedules are fired
+        # sequentially and a launch can take seconds, so re-reading the clock
+        # per item would let a slow earlier fire push a legitimately due
+        # recurring occurrence past its grace window and misclassify it.
         now = datetime.now(UTC)
         pending = self._runtime.storage.list_schedules([ScheduleStatus.PENDING])
         for schedule in pending:
             if schedule.scheduled_at > now:
                 continue
-            await self._fire(schedule)
+            if schedule.cron is not None:
+                await self._fire_due_recurring_schedule(schedule, now)
+            else:
+                await self._fire(schedule)
         pending_msgs = self._runtime.storage.list_scheduled_messages(
             [ScheduledMessageStatus.PENDING]
         )
         for msg in pending_msgs:
             if msg.scheduled_at > now:
                 continue
-            await self._fire_message(msg)
+            if msg.cron is not None:
+                await self._fire_due_recurring_message(msg, now)
+            else:
+                await self._fire_message(msg)
+
+    async def _fire_due_recurring_schedule(
+        self, schedule: ScheduledSessionRecord, now: datetime
+    ) -> None:
+        occurrence = schedule.scheduled_at
+        if schedule.cron is None or schedule.timezone is None:
+            return
+        try:
+            next_at = next_occurrence_after(schedule.cron, schedule.timezone, now)
+        except RecurrenceError:
+            log.exception(
+                "recurrence advance failed", extra={"schedule_id": schedule.id}
+            )
+            return
+        claimed = self._runtime.storage.claim_recurring_schedule(
+            schedule.id, occurrence, next_at
+        )
+        if claimed is None:
+            return
+        log.info(
+            "recurrence claimed",
+            extra={
+                "schedule_id": schedule.id,
+                "occurrence": occurrence.isoformat(),
+                "next_run": next_at.isoformat(),
+            },
+        )
+        if (now - occurrence).total_seconds() > MISSED_RUN_GRACE_SECONDS:
+            log.info(
+                "recurrence misfire skipped",
+                extra={
+                    "schedule_id": schedule.id,
+                    "occurrence": occurrence.isoformat(),
+                },
+            )
+            await self._publish_update()
+            return
+        await self._fire_recurring(claimed, occurrence)
+
+    async def _fire_due_recurring_message(
+        self, record: ScheduledMessageRecord, now: datetime
+    ) -> None:
+        occurrence = record.scheduled_at
+        if record.cron is None or record.timezone is None:
+            return
+        try:
+            next_at = next_occurrence_after(record.cron, record.timezone, now)
+        except RecurrenceError:
+            log.exception("recurrence advance failed", extra={"msg_id": record.id})
+            return
+        claimed = self._runtime.storage.claim_recurring_message(
+            record.id, occurrence, next_at
+        )
+        if claimed is None:
+            return
+        log.info(
+            "recurrence claimed",
+            extra={
+                "msg_id": record.id,
+                "occurrence": occurrence.isoformat(),
+                "next_run": next_at.isoformat(),
+            },
+        )
+        if (now - occurrence).total_seconds() > MISSED_RUN_GRACE_SECONDS:
+            log.info(
+                "recurrence misfire skipped",
+                extra={"msg_id": record.id, "occurrence": occurrence.isoformat()},
+            )
+            await self._publish_update()
+            return
+        await self._fire_recurring_message(claimed, occurrence)
 
     async def _fire_message(self, record: ScheduledMessageRecord) -> None:
         try:
@@ -386,6 +522,120 @@ class Scheduler:
             )
         await self._publish_update()
 
+    async def _fire_recurring(
+        self, schedule: ScheduledSessionRecord, occurrence: datetime
+    ) -> None:
+        """Launch a recurring session, recording only the latest outcome.
+
+        The schedule stays ``pending`` (its ``scheduled_at`` was already
+        advanced by the claim); a failure is recorded in ``last_run_*`` and does
+        not disable the recurrence.
+        """
+        try:
+            session = await self._runtime.create_session(
+                SessionCreateRequest(
+                    backend=schedule.backend,
+                    cwd=schedule.cwd,
+                    launch_target_id=schedule.launch_target_id,
+                    launch_mode=schedule.launch_mode,
+                    transport=schedule.transport,
+                    title=schedule.title,
+                    args=schedule.args,
+                    config_overrides=schedule.config_overrides,
+                    launch_env=schedule.launch_env,
+                    source_mode=SessionSource.MANAGED,
+                    permission_mode=schedule.permission_mode,
+                    model=schedule.model,
+                    effort=schedule.effort,
+                    account_profile_id=schedule.account_profile_id,
+                ),
+                preset_id=schedule.preset_id,
+                preset_name=schedule.preset_name,
+            )
+            if schedule.initial_prompt:
+                await asyncio.sleep(0.1)
+                await self._runtime.handle_input(
+                    session.id,
+                    SessionInputRequest(text=schedule.initial_prompt, submit=True),
+                )
+            self._runtime.storage.update_schedule(
+                schedule.id,
+                session_id=session.id,
+                last_run_at=occurrence,
+                last_run_status=ScheduleStatus.LAUNCHED.value,
+                last_failure_reason=None,
+            )
+            log.info(
+                "recurrence launched",
+                extra={
+                    "schedule_id": schedule.id,
+                    "occurrence": occurrence.isoformat(),
+                },
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.exception(
+                "recurring session launch failed",
+                extra={"schedule_id": schedule.id},
+            )
+            self._runtime.storage.update_schedule(
+                schedule.id,
+                last_run_at=occurrence,
+                last_run_status=ScheduleStatus.FAILED.value,
+                last_failure_reason=str(exc),
+            )
+        await self._publish_update()
+
+    async def _fire_recurring_message(
+        self, record: ScheduledMessageRecord, occurrence: datetime
+    ) -> None:
+        """Deliver a recurring message, recording only the latest outcome."""
+        try:
+            session = self._runtime.storage.get_session(record.session_id)
+            if session is None:
+                self._runtime.storage.update_scheduled_message(
+                    record.id,
+                    last_run_at=occurrence,
+                    last_run_status=ScheduledMessageStatus.FAILED.value,
+                    last_failure_reason="session not found",
+                )
+                log.warning(
+                    "recurring message target missing",
+                    extra={"msg_id": record.id},
+                )
+                await self._publish_update()
+                return
+            await self._runtime.handle_input(
+                record.session_id,
+                SessionInputRequest(
+                    text=record.text,
+                    submit=record.submit,
+                    command=record.command,
+                    items=record.items,
+                    attachments=(
+                        list(record.attachments) if record.attachments else None
+                    ),
+                ),
+            )
+            self._runtime.storage.update_scheduled_message(
+                record.id,
+                last_run_at=occurrence,
+                last_run_status=ScheduledMessageStatus.SENT.value,
+                last_failure_reason=None,
+            )
+            log.info(
+                "recurrence sent",
+                extra={"msg_id": record.id, "occurrence": occurrence.isoformat()},
+            )
+        except Exception as exc:  # noqa: BLE001
+            log.exception("recurring message send failed", extra={"msg_id": record.id})
+            self._runtime.storage.update_scheduled_message(
+                record.id,
+                last_run_at=occurrence,
+                last_run_status=ScheduledMessageStatus.FAILED.value,
+                last_failure_reason=str(exc),
+            )
+        await self._publish_update()
+
     async def _publish_update(self) -> None:
         await self._runtime.broadcast.publish(
             SessionEnvelope(
@@ -412,6 +662,21 @@ class Scheduler:
     def _resolve_scheduled_at(
         request: ScheduleCreateRequest | ScheduledMessageCreateRequest,
     ) -> datetime:
+        validate_timing_mode(
+            request.delay_seconds,
+            request.scheduled_at,
+            request.cron,
+            request.timezone,
+        )
+        if request.cron is not None and request.timezone is not None:
+            try:
+                return next_occurrence_after(
+                    request.cron, request.timezone, datetime.now(UTC)
+                )
+            except RecurrenceError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+                ) from exc
         if request.scheduled_at is not None:
             scheduled_at = request.scheduled_at
             if scheduled_at.tzinfo is None:

--- a/backend/src/waypoint/scheduler.py
+++ b/backend/src/waypoint/scheduler.py
@@ -12,6 +12,7 @@ from waypoint.recurrence import (
     MISSED_RUN_GRACE_SECONDS,
     RecurrenceError,
     next_occurrence_after,
+    resolve_recurrence_base,
 )
 from waypoint.schemas import (
     ScheduleCreateRequest,
@@ -39,6 +40,7 @@ def validate_timing_mode(
     scheduled_at: datetime | None,
     cron: str | None,
     timezone: str | None,
+    start_at: str | None = None,
 ) -> None:
     """Enforce the timing-mode exclusivity matrix, raising HTTP 400.
 
@@ -56,6 +58,11 @@ def validate_timing_mode(
             detail="timezone is only valid together with cron for a recurring schedule",
         )
     recurring = cron is not None
+    if start_at is not None and not recurring:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="start_at is only valid for a recurring schedule",
+        )
     has_one_time = delay_seconds is not None or scheduled_at is not None
     if recurring and has_one_time:
         raise HTTPException(
@@ -607,12 +614,14 @@ class Scheduler:
             request.scheduled_at,
             request.cron,
             request.timezone,
+            request.start_at,
         )
         if request.cron is not None and request.timezone is not None:
             try:
-                return next_occurrence_after(
-                    request.cron, request.timezone, datetime.now(UTC)
+                base = resolve_recurrence_base(
+                    datetime.now(UTC), request.timezone, request.start_at
                 )
+                return next_occurrence_after(request.cron, request.timezone, base)
             except RecurrenceError as exc:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1240,9 +1240,7 @@ class ScheduleCreateRequest(BaseModel):
     effort: str | None = None
     delay_seconds: int | None = None
     scheduled_at: datetime | None = None
-    # Recurring timing: five-field cron + IANA timezone, mutually exclusive with
-    # the one-time fields above (enforced by the scheduler, not this model, so
-    # the API returns 400 rather than a 422 body-validation error).
+    # Recurring timing: five-field cron + IANA timezone.
     cron: str | None = None
     timezone: str | None = None
     # See SessionCreateRequest — apply a preset before validation. Explicit
@@ -1261,8 +1259,6 @@ class ScheduleLaunchRequest(ScheduleCreateRequest):
 
 
 class SchedulePreviewRequest(BaseModel):
-    # Shared cron preview for both creation surfaces; the backend is the single
-    # authority for cron/DST math so preview matches what actually fires.
     cron: str
     timezone: str
     count: int = 3

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1240,9 +1240,12 @@ class ScheduleCreateRequest(BaseModel):
     effort: str | None = None
     delay_seconds: int | None = None
     scheduled_at: datetime | None = None
-    # Recurring timing: five-field cron + IANA timezone.
+    # Recurring timing: five-field cron + IANA timezone. ``start_at`` is the
+    # recurrence's not-before wall-clock in that timezone (the first run is the
+    # first cron occurrence at or after it); null starts now.
     cron: str | None = None
     timezone: str | None = None
+    start_at: str | None = None
     # See SessionCreateRequest — apply a preset before validation. Explicit
     # request fields win; schedule timing/prompt fields are never taken from a
     # preset.
@@ -1261,6 +1264,7 @@ class ScheduleLaunchRequest(ScheduleCreateRequest):
 class SchedulePreviewRequest(BaseModel):
     cron: str
     timezone: str
+    start_at: str | None = None
     count: int = 3
 
 
@@ -1311,6 +1315,7 @@ class ScheduledMessageCreateRequest(BaseModel):
     # Recurring timing — see ScheduleCreateRequest.
     cron: str | None = None
     timezone: str | None = None
+    start_at: str | None = None
 
 
 class SideQuestionStatus(StrEnum):

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1204,6 +1204,14 @@ class ScheduledSessionRecord(BaseModel):
     status: ScheduleStatus = ScheduleStatus.PENDING
     session_id: str | None = None
     failure_reason: str | None = None
+    # Recurrence: ``cron`` (five-field) + ``timezone`` (IANA) mark a recurring
+    # definition; both null means one-time. ``scheduled_at`` is always the next
+    # run. ``last_run_*`` carry the most recent claimed occurrence's outcome.
+    cron: str | None = None
+    timezone: str | None = None
+    last_run_at: datetime | None = None
+    last_run_status: str | None = None
+    last_failure_reason: str | None = None
     # Preset provenance snapshotted at schedule-creation time (see SessionRecord).
     preset_id: str | None = None
     preset_name: str | None = None
@@ -1232,6 +1240,11 @@ class ScheduleCreateRequest(BaseModel):
     effort: str | None = None
     delay_seconds: int | None = None
     scheduled_at: datetime | None = None
+    # Recurring timing: five-field cron + IANA timezone, mutually exclusive with
+    # the one-time fields above (enforced by the scheduler, not this model, so
+    # the API returns 400 rather than a 422 body-validation error).
+    cron: str | None = None
+    timezone: str | None = None
     # See SessionCreateRequest — apply a preset before validation. Explicit
     # request fields win; schedule timing/prompt fields are never taken from a
     # preset.
@@ -1245,6 +1258,18 @@ class ScheduleLaunchRequest(ScheduleCreateRequest):
     # Boundary input for POST /api/schedules — see SessionLaunchRequest.
     backend: BackendId | None = None  # type: ignore[assignment]
     cwd: str | None = None  # type: ignore[assignment]
+
+
+class SchedulePreviewRequest(BaseModel):
+    # Shared cron preview for both creation surfaces; the backend is the single
+    # authority for cron/DST math so preview matches what actually fires.
+    cron: str
+    timezone: str
+    count: int = 3
+
+
+class SchedulePreviewResponse(BaseModel):
+    occurrences: list[datetime]
 
 
 class SessionEnvelope(BaseModel):
@@ -1271,6 +1296,12 @@ class ScheduledMessageRecord(BaseModel):
     created_at: datetime
     status: ScheduledMessageStatus = ScheduledMessageStatus.PENDING
     failure_reason: str | None = None
+    # Recurrence — see ScheduledSessionRecord.
+    cron: str | None = None
+    timezone: str | None = None
+    last_run_at: datetime | None = None
+    last_run_status: str | None = None
+    last_failure_reason: str | None = None
 
 
 class ScheduledMessageCreateRequest(BaseModel):
@@ -1281,6 +1312,9 @@ class ScheduledMessageCreateRequest(BaseModel):
     attachments: list[str] = Field(default_factory=list)
     delay_seconds: int | None = None
     scheduled_at: datetime | None = None
+    # Recurring timing — see ScheduleCreateRequest.
+    cron: str | None = None
+    timezone: str | None = None
 
 
 class SideQuestionStatus(StrEnum):

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -326,7 +326,12 @@ class Storage:
                 created_at TEXT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'pending',
                 session_id TEXT,
-                failure_reason TEXT
+                failure_reason TEXT,
+                cron TEXT,
+                timezone TEXT,
+                last_run_at TEXT,
+                last_run_status TEXT,
+                last_failure_reason TEXT
             );
 
             CREATE TABLE IF NOT EXISTS scheduled_messages (
@@ -341,6 +346,11 @@ class Storage:
                 created_at TEXT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'pending',
                 failure_reason TEXT,
+                cron TEXT,
+                timezone TEXT,
+                last_run_at TEXT,
+                last_run_status TEXT,
+                last_failure_reason TEXT,
                 FOREIGN KEY (session_id) REFERENCES sessions(id)
             );
 
@@ -499,6 +509,13 @@ class Storage:
         self._ensure_column("scheduled_sessions", "preset_name", "TEXT")
         self._ensure_column("scheduled_sessions", "account_profile_id", "TEXT")
         self._ensure_column("scheduled_sessions", "account_profile_label", "TEXT")
+        # Recurrence (ticket 1076): additive, null means one-time.
+        for _sched_table in ("scheduled_sessions", "scheduled_messages"):
+            self._ensure_column(_sched_table, "cron", "TEXT")
+            self._ensure_column(_sched_table, "timezone", "TEXT")
+            self._ensure_column(_sched_table, "last_run_at", "TEXT")
+            self._ensure_column(_sched_table, "last_run_status", "TEXT")
+            self._ensure_column(_sched_table, "last_failure_reason", "TEXT")
         # Additive migration for the inbox table on databases that predate it.
         # (No-ops on a fresh DB where the CREATE TABLE above already made the
         # complete table; only load-bearing for columns added in a later release.)
@@ -2052,8 +2069,9 @@ class Storage:
                 id, backend, cwd, launch_target_id, launch_mode, transport, title, args,
                 config_overrides, launch_env, initial_prompt, permission_mode, model, effort, scheduled_at,
                 created_at, status, session_id, failure_reason, preset_id, preset_name,
-                account_profile_id, account_profile_label
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                account_profile_id, account_profile_label,
+                cron, timezone, last_run_at, last_run_status, last_failure_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 schedule.id,
@@ -2079,6 +2097,11 @@ class Storage:
                 schedule.preset_name,
                 schedule.account_profile_id,
                 schedule.account_profile_label,
+                schedule.cron,
+                schedule.timezone,
+                schedule.last_run_at.isoformat() if schedule.last_run_at else None,
+                schedule.last_run_status,
+                schedule.last_failure_reason,
             ),
         )
         self.connection.commit()
@@ -2127,6 +2150,34 @@ class Storage:
         if updated is None:
             raise KeyError(schedule_id)
         return updated
+
+    @_synchronized
+    def claim_recurring_schedule(
+        self,
+        schedule_id: str,
+        expected_scheduled_at: datetime,
+        next_scheduled_at: datetime,
+    ) -> ScheduledSessionRecord | None:
+        """Atomically advance a due recurring session schedule to its next run.
+
+        Conditional on the row still being ``pending`` at the expected due time,
+        so a second poll or a restarted scheduler cannot claim the same
+        occurrence twice. Returns the advanced record, or ``None`` when another
+        pass already claimed or cancelled it.
+        """
+        cursor = self.connection.execute(
+            "UPDATE scheduled_sessions SET scheduled_at = ? "
+            "WHERE id = ? AND status = 'pending' AND scheduled_at = ?",
+            (
+                next_scheduled_at.isoformat(),
+                schedule_id,
+                expected_scheduled_at.isoformat(),
+            ),
+        )
+        self.connection.commit()
+        if (cursor.rowcount or 0) == 0:
+            return None
+        return self.get_schedule(schedule_id)
 
     @_synchronized
     def delete_schedule(self, schedule_id: str) -> bool:
@@ -2549,8 +2600,9 @@ class Storage:
             """
             INSERT INTO scheduled_messages (
                 id, session_id, text, submit, command, items, attachments,
-                scheduled_at, created_at, status, failure_reason
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                scheduled_at, created_at, status, failure_reason,
+                cron, timezone, last_run_at, last_run_status, last_failure_reason
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 record.id,
@@ -2572,6 +2624,11 @@ class Storage:
                 record.created_at.isoformat(),
                 record.status,
                 record.failure_reason,
+                record.cron,
+                record.timezone,
+                record.last_run_at.isoformat() if record.last_run_at else None,
+                record.last_run_status,
+                record.last_failure_reason,
             ),
         )
         self.connection.commit()
@@ -2628,6 +2685,31 @@ class Storage:
         if updated is None:
             raise KeyError(message_id)
         return updated
+
+    @_synchronized
+    def claim_recurring_message(
+        self,
+        message_id: str,
+        expected_scheduled_at: datetime,
+        next_scheduled_at: datetime,
+    ) -> ScheduledMessageRecord | None:
+        """Atomically advance a due recurring message schedule to its next run.
+
+        See :meth:`claim_recurring_schedule`.
+        """
+        cursor = self.connection.execute(
+            "UPDATE scheduled_messages SET scheduled_at = ? "
+            "WHERE id = ? AND status = 'pending' AND scheduled_at = ?",
+            (
+                next_scheduled_at.isoformat(),
+                message_id,
+                expected_scheduled_at.isoformat(),
+            ),
+        )
+        self.connection.commit()
+        if (cursor.rowcount or 0) == 0:
+            return None
+        return self.get_scheduled_message(message_id)
 
     @_synchronized
     def delete_scheduled_message(self, message_id: str) -> bool:
@@ -2883,6 +2965,8 @@ class Storage:
         payload = dict(row)
         for field_name in ("scheduled_at", "created_at"):
             payload[field_name] = datetime.fromisoformat(payload[field_name])
+        if payload.get("last_run_at"):
+            payload["last_run_at"] = datetime.fromisoformat(payload["last_run_at"])
         payload["status"] = ScheduleStatus(payload.get("status", "pending"))
         payload["launch_mode"] = payload.get("launch_mode") or "auto"
         raw_args = payload.get("args") or "[]"
@@ -2913,6 +2997,8 @@ class Storage:
         payload = dict(row)
         for field_name in ("scheduled_at", "created_at"):
             payload[field_name] = datetime.fromisoformat(payload[field_name])
+        if payload.get("last_run_at"):
+            payload["last_run_at"] = datetime.fromisoformat(payload["last_run_at"])
         payload["status"] = ScheduledMessageStatus(payload.get("status", "pending"))
         payload["submit"] = bool(payload.get("submit", 1))
         raw_command = payload.pop("command", None)

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -153,6 +153,11 @@ def test_help_json_is_structured() -> None:
     assert any("--preset" in o["flags"] for o in start["options"])
     schedule_create = by_path["schedule create"]
     assert any("--launch-env" in o["flags"] for o in schedule_create["options"])
+    assert any("--cron" in o["flags"] for o in schedule_create["options"])
+    assert any("--timezone" in o["flags"] for o in schedule_create["options"])
+    schedule_message_create = by_path["schedule message create"]
+    assert any("--cron" in o["flags"] for o in schedule_message_create["options"])
+    assert any("--timezone" in o["flags"] for o in schedule_message_create["options"])
 
 
 def _walk_leaf_paths(group: click.Group, prefix: str) -> list[str]:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -228,11 +228,6 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             return httpx.Response(200, json={"removed": 3})
         if request.url.path == "/api/schedules" and request.method == "GET":
             return httpx.Response(200, json={"schedules": [{"id": "sc1"}]})
-        if request.url.path == "/api/schedules/preview" and request.method == "POST":
-            state["preview_body"] = json.loads(request.content)
-            return httpx.Response(
-                200, json={"occurrences": ["2026-07-20T01:00:00+00:00"]}
-            )
         if request.url.path == "/api/schedules" and request.method == "POST":
             payload = json.loads(request.content)
             state["schedule_create"] = payload
@@ -821,21 +816,6 @@ def test_create_schedule_passes_cron_and_timezone(
     assert state["schedule_create"]["cron"] == "0 9 * * 1-5"
     assert state["schedule_create"]["timezone"] == "Asia/Singapore"
     assert "delay_seconds" not in state["schedule_create"]
-
-
-def test_preview_schedule_posts_body(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
-    state: dict = {}
-    with _client(_settings(tmp_path), state) as client:
-        occ = client.preview_schedule("0 9 * * 1-5", "Asia/Singapore", count=1)
-    assert occ == ["2026-07-20T01:00:00+00:00"]
-    assert state["preview_body"] == {
-        "cron": "0 9 * * 1-5",
-        "timezone": "Asia/Singapore",
-        "count": 1,
-    }
 
 
 def test_delete_schedule(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_client.py
+++ b/backend/tests/test_client.py
@@ -228,6 +228,11 @@ def _make_handler(state: dict) -> "httpx.MockTransport":
             return httpx.Response(200, json={"removed": 3})
         if request.url.path == "/api/schedules" and request.method == "GET":
             return httpx.Response(200, json={"schedules": [{"id": "sc1"}]})
+        if request.url.path == "/api/schedules/preview" and request.method == "POST":
+            state["preview_body"] = json.loads(request.content)
+            return httpx.Response(
+                200, json={"occurrences": ["2026-07-20T01:00:00+00:00"]}
+            )
         if request.url.path == "/api/schedules" and request.method == "POST":
             payload = json.loads(request.content)
             state["schedule_create"] = payload
@@ -799,6 +804,38 @@ def test_create_schedule_posts_payload(
     # Unset optionals must be omitted, not sent as null: the server validates
     # launch_mode against its enum even though it has a default.
     assert "launch_mode" not in state["schedule_create"]
+
+
+def test_create_schedule_passes_cron_and_timezone(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        client.create_schedule(
+            backend="codex",
+            cwd="/tmp",
+            cron="0 9 * * 1-5",
+            timezone="Asia/Singapore",
+        )
+    assert state["schedule_create"]["cron"] == "0 9 * * 1-5"
+    assert state["schedule_create"]["timezone"] == "Asia/Singapore"
+    assert "delay_seconds" not in state["schedule_create"]
+
+
+def test_preview_schedule_posts_body(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("WAYPOINT_TOKEN", VALID_TOKEN)
+    state: dict = {}
+    with _client(_settings(tmp_path), state) as client:
+        occ = client.preview_schedule("0 9 * * 1-5", "Asia/Singapore", count=1)
+    assert occ == ["2026-07-20T01:00:00+00:00"]
+    assert state["preview_body"] == {
+        "cron": "0 9 * * 1-5",
+        "timezone": "Asia/Singapore",
+        "count": 1,
+    }
 
 
 def test_delete_schedule(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/test_recurrence.py
+++ b/backend/tests/test_recurrence.py
@@ -8,6 +8,7 @@ from waypoint.recurrence import (
     RecurrenceError,
     next_occurrence_after,
     next_occurrences,
+    resolve_recurrence_base,
     validate_cron,
     validate_timezone,
 )
@@ -99,3 +100,35 @@ def test_dst_fall_back_repeated_time_runs_once_at_earlier() -> None:
 
 def test_grace_constant_is_named() -> None:
     assert MISSED_RUN_GRACE_SECONDS == 60.0
+
+
+def test_resolve_base_uses_now_without_start() -> None:
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
+    assert resolve_recurrence_base(now, "UTC", None) == now
+
+
+def test_resolve_base_ignores_past_start() -> None:
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
+    assert resolve_recurrence_base(now, "UTC", "2020-01-01T00:00") == now
+
+
+def test_future_start_makes_first_occurrence_at_or_after_it() -> None:
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
+    # Daily 09:00 SGT starting Fri 2026-07-24 → first run is 2026-07-24 09:00 SGT.
+    base = resolve_recurrence_base(now, "Asia/Singapore", "2026-07-24T09:00")
+    first = next_occurrence_after("0 9 * * *", "Asia/Singapore", base)
+    assert first == datetime(2026, 7, 24, 1, 0, tzinfo=UTC)  # 09:00 SGT
+
+
+def test_start_interpreted_in_recurrence_timezone() -> None:
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
+    # 09:00 wall-clock resolves against the zone, not UTC/browser.
+    base = resolve_recurrence_base(now, "America/New_York", "2026-07-24T09:00")
+    first = next_occurrence_after("0 9 * * *", "America/New_York", base)
+    assert first == datetime(2026, 7, 24, 13, 0, tzinfo=UTC)  # 09:00 EDT
+
+
+def test_invalid_start_raises() -> None:
+    now = datetime(2026, 7, 20, 12, 0, tzinfo=UTC)
+    with pytest.raises(RecurrenceError):
+        resolve_recurrence_base(now, "UTC", "not-a-date")

--- a/backend/tests/test_recurrence.py
+++ b/backend/tests/test_recurrence.py
@@ -1,0 +1,101 @@
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from waypoint.recurrence import (
+    MISSED_RUN_GRACE_SECONDS,
+    RecurrenceError,
+    next_occurrence_after,
+    next_occurrences,
+    validate_cron,
+    validate_timezone,
+)
+
+NY = ZoneInfo("America/New_York")
+SG = ZoneInfo("Asia/Singapore")
+
+
+def test_validate_cron_accepts_five_fields() -> None:
+    validate_cron("0 9 * * 1-5")
+    validate_cron("*/15 * * * *")
+    validate_cron("30 8 1,15 * *")
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "0 9 * * ",  # four fields
+        "0 9 * * 1-5 *",  # six fields
+        "@daily",  # alias
+        "0 0 30 2 *",  # impossible (Feb 30)
+        "99 9 * * *",  # out of range
+        "not a cron",
+    ],
+)
+def test_validate_cron_rejects(expr: str) -> None:
+    with pytest.raises(RecurrenceError):
+        # ``next_occurrence_after`` also exercises the non-advancing guard for
+        # the impossible expression, which ``validate_cron`` alone does not.
+        validate_cron(expr)
+        next_occurrence_after(expr, "UTC", datetime.now(UTC))
+
+
+def test_validate_timezone() -> None:
+    assert validate_timezone("Asia/Singapore") == SG
+    with pytest.raises(RecurrenceError):
+        validate_timezone("Not/AZone")
+    with pytest.raises(RecurrenceError):
+        validate_timezone("+08:00")
+
+
+def test_next_occurrence_is_utc_and_strictly_after() -> None:
+    after = datetime(2025, 7, 18, 12, 0, tzinfo=UTC)
+    nxt = next_occurrence_after("0 9 * * *", "Asia/Singapore", after)
+    assert nxt.tzinfo == UTC
+    assert nxt > after
+    # 09:00 SGT == 01:00 UTC, next day.
+    assert nxt == datetime(2025, 7, 19, 1, 0, tzinfo=UTC)
+
+
+def test_weekdays_skips_weekend() -> None:
+    # 2025-07-18 is a Friday; next weekday 09:00 SGT is Monday 2025-07-21.
+    after = datetime(2025, 7, 18, 12, 0, tzinfo=UTC)
+    occ = next_occurrences("0 9 * * 1-5", "Asia/Singapore", after, 3)
+    locals_ = [o.astimezone(SG) for o in occ]
+    assert [d.strftime("%A %H:%M") for d in locals_] == [
+        "Monday 09:00",
+        "Tuesday 09:00",
+        "Wednesday 09:00",
+    ]
+
+
+def test_dst_spring_forward_nonexistent_time_skipped() -> None:
+    # US spring-forward 2025-03-09: 02:00 -> 03:00, so 02:30 does not exist.
+    after = datetime(2025, 3, 8, 12, 0, tzinfo=UTC)
+    occ = next_occurrences("30 2 * * *", "America/New_York", after, 3)
+    locals_ = [o.astimezone(NY) for o in occ]
+    # 2025-03-09 is skipped entirely; the series resumes 2025-03-10.
+    assert [d.date().isoformat() for d in locals_] == [
+        "2025-03-10",
+        "2025-03-11",
+        "2025-03-12",
+    ]
+    assert all(d.hour == 2 and d.minute == 30 for d in locals_)
+
+
+def test_dst_fall_back_repeated_time_runs_once_at_earlier() -> None:
+    # US fall-back 2025-11-02: 02:00 -> 01:00, so 01:30 occurs twice.
+    after = datetime(2025, 11, 1, 12, 0, tzinfo=UTC)
+    occ = next_occurrences("30 1 * * *", "America/New_York", after, 2)
+    # The transition day yields a single occurrence at the earlier (EDT/-04:00)
+    # instant, not both.
+    assert occ[0] == datetime(2025, 11, 2, 5, 30, tzinfo=UTC)
+    offset = occ[0].astimezone(NY).utcoffset()
+    assert offset is not None and offset.total_seconds() == -4 * 3600
+    # Following day is the ordinary EST occurrence.
+    assert occ[1] == datetime(2025, 11, 3, 6, 30, tzinfo=UTC)
+
+
+def test_grace_constant_is_named() -> None:
+    assert MISSED_RUN_GRACE_SECONDS == 60.0

--- a/backend/tests/test_schedule_api.py
+++ b/backend/tests/test_schedule_api.py
@@ -96,6 +96,20 @@ async def test_preview_endpoint(tmp_path: Path) -> None:
         )
         assert bad.status_code == 400
 
+        # A future start shifts the previewed occurrences to begin at it.
+        started = await client.post(
+            "/api/schedules/preview",
+            json={
+                "cron": "0 9 * * *",
+                "timezone": "Asia/Singapore",
+                "start_at": "2099-01-05T09:00",
+                "count": 2,
+            },
+            headers=_auth(token),
+        )
+        assert started.status_code == 200
+        assert started.json()["occurrences"][0] == "2099-01-05T01:00:00Z"
+
 
 async def test_preview_requires_auth(tmp_path: Path) -> None:
     app, _ = _build(tmp_path)

--- a/backend/tests/test_schedule_api.py
+++ b/backend/tests/test_schedule_api.py
@@ -1,0 +1,107 @@
+"""Route-level tests for recurring schedule endpoints over the real app."""
+
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from waypoint.api import create_app
+from waypoint.settings import Settings
+
+
+def _build(tmp_path: Path) -> tuple[Any, str]:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    context = app.state.context
+    token = context.tokens.issue().token
+    return app, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+def _auth(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+async def test_create_recurring_schedule_returns_recurrence_fields(
+    tmp_path: Path,
+) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/schedules",
+            json={
+                "backend": "codex",
+                "cwd": "/tmp/project",
+                "cron": "0 9 * * 1-5",
+                "timezone": "Asia/Singapore",
+            },
+            headers=_auth(token),
+        )
+    assert resp.status_code == 200
+    schedule = resp.json()["schedule"]
+    assert schedule["cron"] == "0 9 * * 1-5"
+    assert schedule["timezone"] == "Asia/Singapore"
+    assert schedule["status"] == "pending"
+    assert schedule["last_run_at"] is None
+    assert "launch_env" not in schedule
+
+
+async def test_invalid_timing_returns_400_not_422(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    bad_bodies = [
+        {"backend": "codex", "cwd": "/tmp/p"},  # no timing
+        {"backend": "codex", "cwd": "/tmp/p", "cron": "* * * * *"},  # no tz
+        {"backend": "codex", "cwd": "/tmp/p", "timezone": "UTC"},  # no cron
+        {
+            "backend": "codex",
+            "cwd": "/tmp/p",
+            "delay_seconds": 60,
+            "cron": "* * * * *",
+            "timezone": "UTC",
+        },  # mixed
+        {
+            "backend": "codex",
+            "cwd": "/tmp/p",
+            "cron": "nope",
+            "timezone": "UTC",
+        },  # bad cron
+    ]
+    async with _client(app) as client:
+        for body in bad_bodies:
+            resp = await client.post("/api/schedules", json=body, headers=_auth(token))
+            assert resp.status_code == 400, body
+
+
+async def test_preview_endpoint(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        ok = await client.post(
+            "/api/schedules/preview",
+            json={"cron": "0 9 * * 1-5", "timezone": "Asia/Singapore", "count": 3},
+            headers=_auth(token),
+        )
+        assert ok.status_code == 200
+        occ = ok.json()["occurrences"]
+        assert len(occ) == 3
+
+        bad = await client.post(
+            "/api/schedules/preview",
+            json={"cron": "totally invalid", "timezone": "UTC"},
+            headers=_auth(token),
+        )
+        assert bad.status_code == 400
+
+
+async def test_preview_requires_auth(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/schedules/preview",
+            json={"cron": "0 9 * * *", "timezone": "UTC"},
+        )
+    assert resp.status_code == 401

--- a/backend/tests/test_scheduled_messages.py
+++ b/backend/tests/test_scheduled_messages.py
@@ -439,6 +439,119 @@ async def test_fire_due_message_schedule_records_failure(tmp_path, monkeypatch) 
     assert refreshed.failure_reason == "boom"
 
 
+# ── Recurring (cron) message schedules ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_recurring_message_sets_next_run(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+
+    record = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(
+            text="stand-up",
+            cron="0 9 * * 1-5",
+            timezone="Asia/Singapore",
+        ),
+    )
+    assert record.status == ScheduledMessageStatus.PENDING
+    assert record.cron == "0 9 * * 1-5"
+    assert record.timezone == "Asia/Singapore"
+    assert record.scheduled_at > datetime.now(UTC)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"cron": "* * * * *"},  # cron without timezone
+        {"timezone": "UTC"},  # timezone without cron
+        {"delay_seconds": 60, "cron": "* * * * *", "timezone": "UTC"},  # mix
+        {"cron": "bad", "timezone": "UTC"},  # invalid cron
+    ],
+)
+async def test_create_recurring_message_invalid_timing_400(tmp_path, kwargs) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_message_schedule(
+            "sess-1", ScheduledMessageCreateRequest(text="hi", **kwargs)
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_recurring_message_stays_pending_and_advances(
+    tmp_path, monkeypatch
+) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+    record = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="tick", cron="* * * * *", timezone="UTC"),
+    )
+    occurrence = datetime.now(UTC) - timedelta(seconds=1)
+    runtime.storage.update_scheduled_message(record.id, scheduled_at=occurrence)
+
+    sends = 0
+
+    async def fake_handle_input(session_id, request) -> SessionRecord:
+        nonlocal sends
+        sends += 1
+        return session
+
+    monkeypatch.setattr(runtime, "handle_input", fake_handle_input)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    refreshed = runtime.storage.get_scheduled_message(record.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduledMessageStatus.PENDING
+    assert refreshed.scheduled_at > datetime.now(UTC)
+    assert refreshed.last_run_status == "sent"
+    assert refreshed.last_run_at == occurrence
+    assert sends == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_history_never_deletes_active_recurrence(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+    recurring = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="daily", cron="0 9 * * *", timezone="UTC"),
+    )
+    # Simulate a run that left a failure on the still-active recurrence.
+    runtime.storage.update_scheduled_message(
+        recurring.id, last_run_status="failed", last_failure_reason="nope"
+    )
+
+    removed = runtime.scheduler.clear_message_history(session_id="sess-1")
+    assert removed == 0
+    still_there = runtime.storage.get_scheduled_message(recurring.id)
+    assert still_there is not None
+    assert still_there.status == ScheduledMessageStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_session_deletion_removes_recurring_messages(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    session = make_session(runtime.settings, "sess-1")
+    runtime.storage.create_session(session)
+    recurring = runtime.scheduler.create_message_schedule(
+        "sess-1",
+        ScheduledMessageCreateRequest(text="daily", cron="0 9 * * *", timezone="UTC"),
+    )
+    removed = await runtime.scheduler.purge_session_messages("sess-1")
+    assert removed == 1
+    assert runtime.storage.get_scheduled_message(recurring.id) is None
+
+
 # ── API tests ────────────────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -614,6 +614,37 @@ async def test_multiple_due_recurring_all_fire_in_one_batch(
 
 
 @pytest.mark.asyncio
+async def test_recurring_start_at_sets_first_run(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex",
+            cwd="/tmp/project",
+            cron="0 9 * * *",
+            timezone="Asia/Singapore",
+            start_at="2099-01-05T09:00",
+        )
+    )
+    # First run is the start day's 09:00 SGT (01:00 UTC), not today.
+    assert schedule.scheduled_at == datetime(2099, 1, 5, 1, 0, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_start_at_without_cron_returns_400(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_schedule(
+            ScheduleCreateRequest(
+                backend="codex",
+                cwd="/tmp/project",
+                delay_seconds=60,
+                start_at="2099-01-05T09:00",
+            )
+        )
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_cancel_recurring_stops_future_claims(tmp_path) -> None:
     runtime = make_runtime(tmp_path)
     schedule = runtime.scheduler.create_schedule(

--- a/backend/tests/test_scheduler.py
+++ b/backend/tests/test_scheduler.py
@@ -408,3 +408,228 @@ async def test_fire_passes_transport_to_create_session(tmp_path, monkeypatch) ->
     await runtime.scheduler._fire_due_schedules()
 
     assert captured == ["claude_tty"]
+
+
+# ── Recurring (cron) schedules ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_recurring_schedule_sets_next_run(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex",
+            cwd="/tmp/project",
+            cron="0 9 * * 1-5",
+            timezone="Asia/Singapore",
+        )
+    )
+    assert schedule.status == ScheduleStatus.PENDING
+    assert schedule.cron == "0 9 * * 1-5"
+    assert schedule.timezone == "Asia/Singapore"
+    assert schedule.scheduled_at > datetime.now(UTC)
+    assert schedule.last_run_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},  # no timing at all
+        {"delay_seconds": 60, "scheduled_at": "unused"},  # both one-time
+        {"delay_seconds": 60, "cron": "* * * * *", "timezone": "UTC"},  # mix
+        {"cron": "* * * * *"},  # cron without timezone
+        {"timezone": "UTC"},  # timezone without cron
+        {"cron": "not valid", "timezone": "UTC"},  # bad cron
+        {"cron": "* * * * *", "timezone": "Not/AZone"},  # bad timezone
+    ],
+)
+async def test_create_schedule_invalid_timing_returns_400(tmp_path, kwargs) -> None:
+    runtime = make_runtime(tmp_path)
+    if kwargs.get("scheduled_at") == "unused":
+        kwargs["scheduled_at"] = cast(Any, datetime.now(UTC) + timedelta(minutes=5))
+    with pytest.raises(HTTPException) as exc:
+        runtime.scheduler.create_schedule(
+            ScheduleCreateRequest(backend="codex", cwd="/tmp/project", **kwargs)
+        )
+    assert exc.value.status_code == 400
+
+
+async def _make_due_recurring(runtime, *, seconds_ago: int):
+    schedule = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex",
+            cwd="/tmp/project",
+            initial_prompt="daily",
+            cron="* * * * *",
+            timezone="UTC",
+        )
+    )
+    occurrence = datetime.now(UTC) - timedelta(seconds=seconds_ago)
+    runtime.storage.update_schedule(schedule.id, scheduled_at=occurrence)
+    return schedule, occurrence
+
+
+@pytest.mark.asyncio
+async def test_recurring_schedule_stays_pending_and_advances(
+    tmp_path, monkeypatch
+) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule, occurrence = await _make_due_recurring(runtime, seconds_ago=1)
+    created_session = make_session(runtime.settings, "codex-rec-1")
+    runtime.storage.create_session(created_session)
+    launches = 0
+
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
+        nonlocal launches
+        launches += 1
+        return created_session
+
+    async def fake_handle_input(session_id: str, request) -> SessionRecord:
+        return created_session
+
+    monkeypatch.setattr(runtime, "create_session", fake_create_session)
+    monkeypatch.setattr(runtime, "handle_input", fake_handle_input)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    refreshed = runtime.storage.get_schedule(schedule.id)
+    assert refreshed is not None
+    assert refreshed.status == ScheduleStatus.PENDING  # never terminal
+    assert refreshed.scheduled_at > datetime.now(UTC)  # advanced
+    assert refreshed.last_run_status == "launched"
+    assert refreshed.last_run_at == occurrence  # claimed occurrence, not now
+    assert refreshed.last_failure_reason is None
+    assert launches == 1
+
+    # Fire a second occurrence: still pending, advances again, still runs.
+    next_occurrence = datetime.now(UTC) - timedelta(seconds=1)
+    runtime.storage.update_schedule(schedule.id, scheduled_at=next_occurrence)
+    await runtime.scheduler._fire_due_schedules()
+    refreshed2 = runtime.storage.get_schedule(schedule.id)
+    assert refreshed2 is not None
+    assert refreshed2.status == ScheduleStatus.PENDING
+    assert launches == 2
+    assert refreshed2.last_run_at == next_occurrence
+
+
+@pytest.mark.asyncio
+async def test_recurring_failure_keeps_pending_then_clears_on_success(
+    tmp_path, monkeypatch
+) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule, occurrence = await _make_due_recurring(runtime, seconds_ago=1)
+    created_session = make_session(runtime.settings, "codex-rec-2")
+    runtime.storage.create_session(created_session)
+    should_fail = True
+
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
+        if should_fail:
+            raise RuntimeError("launch boom")
+        return created_session
+
+    async def fake_handle_input(session_id: str, request) -> SessionRecord:
+        return created_session
+
+    monkeypatch.setattr(runtime, "create_session", fake_create_session)
+    monkeypatch.setattr(runtime, "handle_input", fake_handle_input)
+
+    await runtime.scheduler._fire_due_schedules()
+    failed = runtime.storage.get_schedule(schedule.id)
+    assert failed is not None
+    assert failed.status == ScheduleStatus.PENDING  # RFC req 9: not disabled
+    assert failed.last_run_status == "failed"
+    assert failed.last_failure_reason == "launch boom"
+
+    # Next occurrence succeeds → latest error cleared, still pending.
+    should_fail = False
+    runtime.storage.update_schedule(
+        schedule.id, scheduled_at=datetime.now(UTC) - timedelta(seconds=1)
+    )
+    await runtime.scheduler._fire_due_schedules()
+    recovered = runtime.storage.get_schedule(schedule.id)
+    assert recovered is not None
+    assert recovered.status == ScheduleStatus.PENDING
+    assert recovered.last_run_status == "launched"
+    assert recovered.last_failure_reason is None
+
+
+@pytest.mark.asyncio
+async def test_recurring_missed_occurrence_skips_action_but_advances(
+    tmp_path, monkeypatch
+) -> None:
+    runtime = make_runtime(tmp_path)
+    # Due an hour ago — well beyond the grace window (downtime).
+    schedule, _ = await _make_due_recurring(runtime, seconds_ago=3600)
+    launches = 0
+
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
+        nonlocal launches
+        launches += 1
+        raise AssertionError("missed occurrence must not launch")
+
+    monkeypatch.setattr(runtime, "create_session", fake_create_session)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    refreshed = runtime.storage.get_schedule(schedule.id)
+    assert refreshed is not None
+    assert launches == 0  # no backlog replay
+    assert refreshed.status == ScheduleStatus.PENDING
+    assert refreshed.scheduled_at > datetime.now(UTC)  # still advanced
+    assert refreshed.last_run_status is None  # never ran
+
+
+@pytest.mark.asyncio
+async def test_multiple_due_recurring_all_fire_in_one_batch(
+    tmp_path, monkeypatch
+) -> None:
+    # Guards the batch-``now`` fix: every due recurring item in a batch is
+    # classified against the same captured ``now``, so none is misclassified
+    # as missed because an earlier item's launch consumed wall-clock time.
+    runtime = make_runtime(tmp_path)
+    ids = []
+    for _ in range(3):
+        schedule, _ = await _make_due_recurring(runtime, seconds_ago=1)
+        ids.append(schedule.id)
+    session = make_session(runtime.settings, "codex-batch")
+    runtime.storage.create_session(session)
+
+    async def fake_create_session(request, **_kwargs) -> SessionRecord:
+        return session
+
+    async def fake_handle_input(session_id: str, request) -> SessionRecord:
+        return session
+
+    monkeypatch.setattr(runtime, "create_session", fake_create_session)
+    monkeypatch.setattr(runtime, "handle_input", fake_handle_input)
+
+    await runtime.scheduler._fire_due_schedules()
+
+    for schedule_id in ids:
+        refreshed = runtime.storage.get_schedule(schedule_id)
+        assert refreshed is not None
+        assert refreshed.last_run_status == "launched"
+        assert refreshed.status == ScheduleStatus.PENDING
+
+
+@pytest.mark.asyncio
+async def test_cancel_recurring_stops_future_claims(tmp_path) -> None:
+    runtime = make_runtime(tmp_path)
+    schedule = runtime.scheduler.create_schedule(
+        ScheduleCreateRequest(
+            backend="codex",
+            cwd="/tmp/project",
+            cron="* * * * *",
+            timezone="UTC",
+        )
+    )
+    cancelled = runtime.scheduler.cancel_schedule(schedule.id)
+    assert cancelled.status == ScheduleStatus.CANCELLED
+    # A claim racing the cancel is a no-op (WHERE status='pending').
+    claimed = runtime.storage.claim_recurring_schedule(
+        schedule.id,
+        cancelled.scheduled_at,
+        datetime.now(UTC) + timedelta(minutes=1),
+    )
+    assert claimed is None

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -304,6 +304,104 @@ def test_schedule_round_trip_persists_launch_mode(tmp_path) -> None:
     assert storage.list_schedules()[0].launch_mode == LaunchMode.TMUX_WRAPPER
 
 
+def test_schedule_recurrence_fields_round_trip(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    occurrence = now - timedelta(minutes=1)
+    schedule = ScheduledSessionRecord(
+        id="rec-1",
+        backend="codex",
+        cwd="/tmp/project",
+        cron="0 9 * * 1-5",
+        timezone="America/New_York",
+        last_run_at=occurrence,
+        last_run_status="launched",
+        last_failure_reason="prior boom",
+        scheduled_at=now + timedelta(minutes=15),
+        created_at=now,
+        status=ScheduleStatus.PENDING,
+    )
+    storage.create_schedule(schedule)
+    loaded = storage.get_schedule("rec-1")
+    assert loaded is not None
+    assert loaded.cron == "0 9 * * 1-5"
+    assert loaded.timezone == "America/New_York"
+    assert loaded.last_run_at == occurrence
+    assert loaded.last_run_status == "launched"
+    assert loaded.last_failure_reason == "prior boom"
+
+
+def test_claim_recurring_schedule_is_conditional(tmp_path) -> None:
+    storage = Storage(tmp_path / "waypoint.db")
+    now = datetime.now(UTC)
+    due = now - timedelta(seconds=1)
+    nxt = now + timedelta(minutes=1)
+    storage.create_schedule(
+        ScheduledSessionRecord(
+            id="rec-2",
+            backend="codex",
+            cwd="/tmp/project",
+            cron="* * * * *",
+            timezone="UTC",
+            scheduled_at=due,
+            created_at=now,
+            status=ScheduleStatus.PENDING,
+        )
+    )
+    claimed = storage.claim_recurring_schedule("rec-2", due, nxt)
+    assert claimed is not None
+    assert claimed.scheduled_at == nxt
+    # A second claim at the stale due time no longer matches → None.
+    assert storage.claim_recurring_schedule("rec-2", due, nxt) is None
+    # A cancelled row is never claimed.
+    storage.update_schedule("rec-2", status=ScheduleStatus.CANCELLED)
+    assert storage.claim_recurring_schedule("rec-2", nxt, now) is None
+
+
+def test_recurrence_columns_added_to_legacy_tables(tmp_path) -> None:
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    # Pre-recurrence schema (no cron/timezone/last_run_* columns).
+    conn.executescript("""
+        CREATE TABLE scheduled_sessions (
+            id TEXT PRIMARY KEY,
+            backend TEXT NOT NULL,
+            cwd TEXT NOT NULL,
+            scheduled_at TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending'
+        );
+        CREATE TABLE scheduled_messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            text TEXT NOT NULL DEFAULT '',
+            scheduled_at TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'pending'
+        );
+        """)
+    conn.commit()
+    conn.close()
+
+    Storage(db_path)  # additive migration must not raise
+
+    check = sqlite3.connect(db_path)
+    for table in ("scheduled_sessions", "scheduled_messages"):
+        cols = {
+            row[1] for row in check.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        assert {
+            "cron",
+            "timezone",
+            "last_run_at",
+            "last_run_status",
+            "last_failure_reason",
+        } <= cols
+    check.close()
+
+
 def _seed_session(
     tmp_path,
     *,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -249,6 +249,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/57/2e2a65aee2a70483cb28e2b7e15a072d00a523207593b44400d4717bb100/croniter-6.2.4.tar.gz", hash = "sha256:fc124f751b1b04805c2a04b061898b436b45ab2320b045e1e052ea895de65189", size = 166267, upload-time = "2026-07-10T09:52:59.955Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/ba/d678e5bd329646ca51d3c92addbc77804e86d21f4b6b6a027218e6abb010/croniter-6.2.4-py3-none-any.whl", hash = "sha256:8ef3d544107a5c05a150a2d78f8bf5a8eb9c5c4d93405a736b824109574e3f4d", size = 46677, upload-time = "2026-07-10T09:52:58.425Z" },
 ]
 
 [[package]]
@@ -996,6 +1008,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1111,6 +1135,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1136,6 +1169,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
+name = "types-croniter"
+version = "6.2.4.20260711"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/e1/ef8900515a103efa41b29ce81e59efb18e72bc9642139c5a3a17f6022641/types_croniter-6.2.4.20260711.tar.gz", hash = "sha256:807793e109f4e0d51ec18f6277a1a5f1d133e425ac6bee3a7c3254ab1793e0ea", size = 12164, upload-time = "2026-07-11T04:51:18.624Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/3f/896a98180a55f855bd068b97e8c99fd4ce1885a4b43f68fd7b29641084f6/types_croniter-6.2.4.20260711-py3-none-any.whl", hash = "sha256:601b68139a47fe1b2177f433132cc81fd91155f3059a49c5cb63404c389dff01", size = 9746, upload-time = "2026-07-11T04:51:17.662Z" },
 ]
 
 [[package]]
@@ -1166,6 +1208,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]
@@ -1201,6 +1252,7 @@ name = "waypoint"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
+    { name = "croniter" },
     { name = "fastapi" },
     { name = "openai-codex" },
     { name = "pydantic" },
@@ -1208,6 +1260,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "typer" },
+    { name = "tzdata" },
     { name = "uvicorn" },
     { name = "websockets" },
 ]
@@ -1220,12 +1273,14 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-croniter" },
     { name = "types-pyyaml" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.10.0" },
+    { name = "croniter", specifier = ">=6.0.0" },
     { name = "fastapi", specifier = ">=0.139.0" },
     { name = "openai-codex", specifier = "==0.1.0b3" },
     { name = "pydantic", specifier = ">=2.11.0" },
@@ -1233,6 +1288,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0.0" },
     { name = "typer", specifier = ">=0.26.8" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "uvicorn", specifier = ">=0.51.0" },
     { name = "websockets", specifier = ">=16.1" },
 ]
@@ -1245,6 +1301,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.15.21" },
+    { name = "types-croniter", specifier = ">=6.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0.0" },
 ]
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1063,6 +1063,13 @@ button.inst:hover {
   color: var(--muted-soft);
 }
 
+.inst-sched-recur {
+  flex: none;
+  color: var(--accent);
+  font-size: 0.7rem;
+  line-height: 1;
+}
+
 .inst-sched-preview {
   font-family: var(--font-mono);
   font-size: 0.66rem;
@@ -10003,6 +10010,146 @@ html[data-theme="light"] .preset-modal-overlay {
   font-size: 0.86rem;
 }
 
+/* ── Recurrence control (shared by launch panel + schedule-message modal) ── */
+.recurrence {
+  display: grid;
+  gap: 12px;
+}
+
+.recurrence__body {
+  display: grid;
+  gap: 12px;
+}
+
+.recurrence__cadences {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.recurrence__chip {
+  min-height: 30px;
+  padding: 0 12px;
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.01em;
+  color: var(--muted);
+  background: var(--bg-input);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition:
+    color 0.12s ease,
+    border-color 0.12s ease,
+    background 0.12s ease;
+}
+
+.recurrence__chip:hover {
+  color: var(--text-strong);
+}
+
+.recurrence__chip.is-active {
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+
+.recurrence__preset-fields {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.recurrence__preset-fields .field {
+  flex: 1 1 120px;
+}
+
+.recurrence__hint {
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+.recurrence__hint code {
+  font-family: var(--font-mono);
+  color: var(--accent-cool);
+}
+
+.recurrence__preview {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-soft);
+}
+
+.recurrence__preview-label {
+  font-size: 0.68rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.recurrence__preview-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 3px;
+}
+
+.recurrence__preview-list li {
+  font-size: 0.84rem;
+  font-family: var(--font-mono);
+  color: var(--text-strong);
+}
+
+.recurrence__preview-tz {
+  color: var(--accent-cool);
+  font-size: 0.76rem;
+}
+
+.recurrence__preview-empty {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--muted);
+}
+
+.recurrence__error {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--danger);
+}
+
+/* Recurrence cadence label: bare mono text in the accent hue, no fill. */
+.badge.schedule-recurrence {
+  background: transparent;
+  border-color: transparent;
+  color: var(--accent);
+  padding-inline: 0;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.schedule-when-label {
+  font-size: 0.64rem;
+  font-family: var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-right: 4px;
+}
+
+.schedule-last {
+  margin: 0;
+  font-size: 0.8rem;
+}
+
+.schedule-last-error {
+  font-size: 0.82rem;
+}
+
 .schedule-row {
   display: grid;
   gap: 6px;
@@ -10627,6 +10774,22 @@ html[data-theme="light"] .sched-dock-scrim {
 
 .sched-dock-item-body {
   min-width: 0;
+}
+
+.sched-dock-recur {
+  color: var(--accent);
+  font-size: 0.72rem;
+  line-height: 1;
+  margin-left: 4px;
+}
+
+.sched-dock-item-cadence {
+  display: block;
+  margin-top: 2px;
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.02em;
+  color: var(--accent);
 }
 
 .sched-dock-item-text {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -142,6 +142,17 @@ select {
   color: inherit;
 }
 
+/* Native date/time pickers report a large intrinsic min-width and overflow
+   narrow (mobile) containers; cap the width and let them shrink so they don't. */
+input[type="datetime-local"],
+input[type="date"],
+input[type="time"],
+input[type="month"],
+input[type="week"] {
+  max-width: 100%;
+  min-width: 0;
+}
+
 button {
   cursor: pointer;
   border: 0;
@@ -11021,6 +11032,9 @@ html[data-theme="light"] .schedule-msg-preset.active {
 
 .schedule-msg-field-inline .schedule-msg-dialog-number {
   width: 96px;
+}
+.schedule-msg-field .schedule-msg-dialog-number {
+  width: 100%;
 }
 
 .schedule-msg-field-suffix {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -17569,16 +17569,6 @@ body.wp-dock-resizing .inbox-resizer::after {
   gap: 8px;
 }
 
-.tm-date-input {
-  padding: 8px 11px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-sm);
-  background: var(--bg-input);
-  color: var(--text);
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-}
-
 .tm-date-input,
 .tm-text-input {
   font-family: var(--font-mono);

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -10003,13 +10003,15 @@ html[data-theme="light"] .preset-modal-overlay {
   gap: 10px;
 }
 
-/* Full-width segmented toggle for the One time / Repeat mode. */
-.recurrence__mode {
+/* Timing toggles read as flat in-flow controls: full-width segments and no
+   dark container fill, so no black void shows behind the inactive segment. */
+.recurrence .segmented {
   display: flex;
   width: 100%;
+  background: transparent;
 }
 
-.recurrence__mode .segmented-item {
+.recurrence .segmented .segmented-item {
   flex: 1;
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -153,6 +153,28 @@ input[type="week"] {
   min-width: 0;
 }
 
+/* iOS Safari sizes native date/time controls to their intrinsic value width and
+   ignores the box model, so the cap above is not enough and they overflow the
+   viewport. Dropping the native appearance makes them honor width; scoped to
+   iOS via the touch-callout probe so desktop keeps its native picker chrome. */
+@supports (-webkit-touch-callout: none) {
+  input[type="datetime-local"],
+  input[type="date"],
+  input[type="time"],
+  input[type="month"],
+  input[type="week"] {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+  }
+  input[type="datetime-local"]::-webkit-date-and-time-value,
+  input[type="date"]::-webkit-date-and-time-value,
+  input[type="time"]::-webkit-date-and-time-value {
+    min-width: 0;
+    text-align: left;
+  }
+}
+
 button {
   cursor: pointer;
   border: 0;
@@ -17545,6 +17567,16 @@ body.wp-dock-resizing .inbox-resizer::after {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+}
+
+.tm-date-input {
+  padding: 8px 11px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
 }
 
 .tm-date-input,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9997,28 +9997,30 @@ html[data-theme="light"] .preset-modal-overlay {
   border-color: var(--line);
 }
 
-.schedule-mode-row {
-  display: flex;
-  gap: 8px;
-  flex-wrap: wrap;
-}
-
-.schedule-mode-row .primary,
-.schedule-mode-row .secondary {
-  min-height: 36px;
-  padding: 0 14px;
-  font-size: 0.86rem;
-}
-
 /* ── Recurrence control (shared by launch panel + schedule-message modal) ── */
 .recurrence {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
-.recurrence__body {
+/* Full-width segmented toggle for the One time / Repeat mode. */
+.recurrence__mode {
+  display: flex;
+  width: 100%;
+}
+
+.recurrence__mode .segmented-item {
+  flex: 1;
+}
+
+/* Partitions the controls the mode toggle governs from the rest of the form. */
+.recurrence__section {
   display: grid;
   gap: 12px;
+  padding: 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-soft);
 }
 
 .recurrence__cadences {
@@ -10052,16 +10054,6 @@ html[data-theme="light"] .preset-modal-overlay {
   color: var(--accent);
   background: color-mix(in srgb, var(--accent) 12%, transparent);
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
-}
-
-.recurrence__preset-fields {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.recurrence__preset-fields .field {
-  flex: 1 1 120px;
 }
 
 .recurrence__hint {

--- a/frontend/src/components/InstrumentRail.tsx
+++ b/frontend/src/components/InstrumentRail.tsx
@@ -11,6 +11,7 @@ import {
   usageTone,
   type UsageTone,
 } from "@/lib/usage";
+import { isRecurring } from "@/lib/recurrence";
 import type {
   BoardChannel,
   MessageSchedule,
@@ -330,6 +331,7 @@ interface ScheduledItem {
   whenLabel: string;
   target: string;
   preview: string;
+  recurring: boolean;
 }
 
 function formatShortWhen(iso: string | null | undefined): string {
@@ -385,6 +387,7 @@ function ScheduledTile({
       whenLabel: formatShortWhen(s.scheduled_at),
       target: s.title?.trim() || `${s.backend} session`,
       preview: s.initial_prompt?.trim() || s.cwd,
+      recurring: isRecurring(s),
     })),
     ...pendingMessages.map((m) => ({
       key: `message:${m.id}`,
@@ -393,6 +396,7 @@ function ScheduledTile({
       whenLabel: formatShortWhen(m.scheduled_at),
       target: titleById.get(m.session_id)?.trim() || "session",
       preview: m.text?.trim() || "",
+      recurring: isRecurring(m),
     })),
   ].sort((a, b) => (a.when ?? Infinity) - (b.when ?? Infinity));
 
@@ -419,6 +423,11 @@ function ScheduledTile({
                 {item.kind === "message" ? "→ " : ""}
                 {item.target}
               </span>
+              {item.recurring ? (
+                <span className="inst-sched-recur" aria-label="recurring">
+                  ↻
+                </span>
+              ) : null}
               <span className="inst-sched-when">{item.whenLabel}</span>
             </span>
             {item.preview ? (

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -14,7 +14,14 @@ import {
   useLaunchForm,
 } from "@/components/LaunchFormFields";
 import { PresetSaveActions, PresetSelect } from "@/components/PresetBar";
+import { RecurrenceControl } from "@/components/RecurrenceControl";
 import { ResumeThreadPanel } from "@/components/ResumeThreadPanel";
+import {
+  cronFromState,
+  defaultRecurrenceState,
+  RecurrenceState,
+  TimingMode,
+} from "@/lib/recurrence";
 import type { BackendCatalog } from "@/lib/backends";
 import { humaniseBackend } from "@/lib/backends";
 import {
@@ -220,6 +227,11 @@ export function LaunchPanel({
   const [delayMinutes, setDelayMinutes] = useState("15");
   const [scheduledAt, setScheduledAt] = useState(defaultScheduledAt());
   const [scheduleError, setScheduleError] = useState("");
+  const [timingMode, setTimingMode] = useState<TimingMode>("once");
+  const [recurrence, setRecurrence] = useState<RecurrenceState>(
+    defaultRecurrenceState,
+  );
+  const [recurrenceValid, setRecurrenceValid] = useState(false);
   const [formBusy, setFormBusy] = useState(false);
 
   async function submitCreate(event: FormEvent<HTMLFormElement>) {
@@ -283,7 +295,15 @@ export function LaunchPanel({
       preset_id: selectedPresetId,
       account_profile_id: form.accountProfileId || null,
     };
-    if (scheduleTiming === "delay") {
+    if (timingMode === "repeat") {
+      const cron = cronFromState(recurrence);
+      if (!cron) {
+        setScheduleError("Enter a valid recurrence.");
+        return;
+      }
+      payload.cron = cron;
+      payload.timezone = recurrence.timezone;
+    } else if (scheduleTiming === "delay") {
       const minutes = Number.parseFloat(delayMinutes);
       if (!Number.isFinite(minutes) || minutes < 0) {
         setScheduleError("Enter a non-negative delay in minutes.");
@@ -401,43 +421,55 @@ export function LaunchPanel({
               placeholder="Optional — sent automatically once the session starts"
             />
           </label>
-          <div className="schedule-mode-row">
-            <button
-              type="button"
-              className={scheduleTiming === "delay" ? "primary" : "secondary"}
-              onClick={() => setScheduleTiming("delay")}
-            >
-              After delay
-            </button>
-            <button
-              type="button"
-              className={scheduleTiming === "datetime" ? "primary" : "secondary"}
-              onClick={() => setScheduleTiming("datetime")}
-            >
-              At specific time
-            </button>
-          </div>
-          {scheduleTiming === "delay" ? (
-            <label className="field">
-              <span>Minutes from now</span>
-              <input
-                type="number"
-                min="0"
-                step="1"
-                value={delayMinutes}
-                onChange={(event) => setDelayMinutes(event.target.value)}
-              />
-            </label>
-          ) : (
-            <label className="field">
-              <span>Local time</span>
-              <input
-                type="datetime-local"
-                value={scheduledAt}
-                onChange={(event) => setScheduledAt(event.target.value)}
-              />
-            </label>
-          )}
+          <RecurrenceControl
+            host={host}
+            token={token}
+            timing={timingMode}
+            onTimingChange={setTimingMode}
+            state={recurrence}
+            onStateChange={setRecurrence}
+            onValidChange={setRecurrenceValid}
+          >
+            <div className="schedule-mode-row">
+              <button
+                type="button"
+                className={scheduleTiming === "delay" ? "primary" : "secondary"}
+                onClick={() => setScheduleTiming("delay")}
+              >
+                After delay
+              </button>
+              <button
+                type="button"
+                className={
+                  scheduleTiming === "datetime" ? "primary" : "secondary"
+                }
+                onClick={() => setScheduleTiming("datetime")}
+              >
+                At specific time
+              </button>
+            </div>
+            {scheduleTiming === "delay" ? (
+              <label className="field">
+                <span>Minutes from now</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={delayMinutes}
+                  onChange={(event) => setDelayMinutes(event.target.value)}
+                />
+              </label>
+            ) : (
+              <label className="field">
+                <span>Local time</span>
+                <input
+                  type="datetime-local"
+                  value={scheduledAt}
+                  onChange={(event) => setScheduledAt(event.target.value)}
+                />
+              </label>
+            )}
+          </RecurrenceControl>
           {scheduleError ? <p className="error">{scheduleError}</p> : null}
           <PresetSaveActions
             form={form}
@@ -450,8 +482,16 @@ export function LaunchPanel({
           />
           <div className="launch-actions">
             <span className="grow" />
-            <button className="primary" disabled={formBusy} type="submit">
-              {formBusy ? "Scheduling…" : "Schedule"}
+            <button
+              className="primary"
+              disabled={formBusy || (timingMode === "repeat" && !recurrenceValid)}
+              type="submit"
+            >
+              {formBusy
+                ? "Scheduling…"
+                : timingMode === "repeat"
+                  ? "Create recurrence"
+                  : "Schedule once"}
             </button>
           </div>
         </form>

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -494,11 +494,7 @@ export function LaunchPanel({
               disabled={formBusy || (timingMode === "repeat" && !recurrenceValid)}
               type="submit"
             >
-              {formBusy
-                ? "Scheduling…"
-                : timingMode === "repeat"
-                  ? "Create recurrence"
-                  : "Schedule once"}
+              {formBusy ? "Scheduling…" : "Schedule"}
             </button>
           </div>
         </form>

--- a/frontend/src/components/LaunchPanel.tsx
+++ b/frontend/src/components/LaunchPanel.tsx
@@ -303,6 +303,7 @@ export function LaunchPanel({
       }
       payload.cron = cron;
       payload.timezone = recurrence.timezone;
+      payload.start_at = recurrence.startAt || null;
     } else if (scheduleTiming === "delay") {
       const minutes = Number.parseFloat(delayMinutes);
       if (!Number.isFinite(minutes) || minutes < 0) {
@@ -430,19 +431,25 @@ export function LaunchPanel({
             onStateChange={setRecurrence}
             onValidChange={setRecurrenceValid}
           >
-            <div className="schedule-mode-row">
+            <div className="segmented" role="tablist" aria-label="One-time timing">
               <button
                 type="button"
-                className={scheduleTiming === "delay" ? "primary" : "secondary"}
+                role="tab"
+                aria-selected={scheduleTiming === "delay"}
+                className={`segmented-item${
+                  scheduleTiming === "delay" ? " active" : ""
+                }`}
                 onClick={() => setScheduleTiming("delay")}
               >
                 After delay
               </button>
               <button
                 type="button"
-                className={
-                  scheduleTiming === "datetime" ? "primary" : "secondary"
-                }
+                role="tab"
+                aria-selected={scheduleTiming === "datetime"}
+                className={`segmented-item${
+                  scheduleTiming === "datetime" ? " active" : ""
+                }`}
                 onClick={() => setScheduleTiming("datetime")}
               >
                 At specific time

--- a/frontend/src/components/RecurrenceControl.tsx
+++ b/frontend/src/components/RecurrenceControl.tsx
@@ -58,8 +58,7 @@ export function RecurrenceControl({
   const cron = timing === "repeat" ? cronFromState(state) : null;
   const custom = state.cadence === "custom";
 
-  // Debounced server preview — the backend is authoritative for cron/DST, so
-  // the preview always matches what the scheduler will fire.
+  // Debounced server preview of the next occurrences.
   useEffect(() => {
     if (timing !== "repeat") {
       onValidChange(true);

--- a/frontend/src/components/RecurrenceControl.tsx
+++ b/frontend/src/components/RecurrenceControl.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { ReactNode, useEffect, useId, useState } from "react";
+
+import { previewSchedule } from "@/lib/api";
+import {
+  Cadence,
+  CADENCES,
+  cronFromState,
+  formatInZone,
+  RecurrenceState,
+  supportedTimezones,
+  timezoneAbbrev,
+  TimingMode,
+  WEEKDAY_LABELS,
+} from "@/lib/recurrence";
+
+const CADENCE_LABELS: Record<Cadence, string> = {
+  daily: "Daily",
+  weekdays: "Weekdays",
+  weekly: "Weekly",
+  monthly: "Monthly",
+  custom: "Custom",
+};
+
+interface RecurrenceControlProps {
+  host: string;
+  token: string;
+  timing: TimingMode;
+  onTimingChange: (mode: TimingMode) => void;
+  state: RecurrenceState;
+  onStateChange: (state: RecurrenceState) => void;
+  // Reports whether the current recurrence previews cleanly, so the parent can
+  // gate its submit button. Always true while timing is "once".
+  onValidChange: (valid: boolean) => void;
+  // The one-time timing UI, owned by the parent (delay/datetime differ per
+  // surface). Rendered only while timing is "once".
+  children: ReactNode;
+}
+
+export function RecurrenceControl({
+  host,
+  token,
+  timing,
+  onTimingChange,
+  state,
+  onStateChange,
+  onValidChange,
+  children,
+}: RecurrenceControlProps) {
+  const uid = useId();
+  const tzListId = `${uid}-tz`;
+  const [occurrences, setOccurrences] = useState<string[]>([]);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewing, setPreviewing] = useState(false);
+  const [zones] = useState<string[]>(() => supportedTimezones());
+
+  const cron = timing === "repeat" ? cronFromState(state) : null;
+
+  // Debounced server preview — the backend is authoritative for cron/DST, so
+  // the preview always matches what the scheduler will fire.
+  useEffect(() => {
+    if (timing !== "repeat") {
+      onValidChange(true);
+      setPreviewError(null);
+      setOccurrences([]);
+      return;
+    }
+    if (!cron) {
+      onValidChange(false);
+      setPreviewError(null);
+      setOccurrences([]);
+      return;
+    }
+    let cancelled = false;
+    setPreviewing(true);
+    const handle = window.setTimeout(async () => {
+      try {
+        const next = await previewSchedule(host, token, cron, state.timezone, 3);
+        if (cancelled) return;
+        setOccurrences(next);
+        setPreviewError(null);
+        onValidChange(true);
+      } catch (error) {
+        if (cancelled) return;
+        setOccurrences([]);
+        setPreviewError(error instanceof Error ? error.message : "invalid recurrence");
+        onValidChange(false);
+      } finally {
+        if (!cancelled) setPreviewing(false);
+      }
+    }, 350);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [timing, cron, state.timezone, host, token, onValidChange]);
+
+  function update(patch: Partial<RecurrenceState>) {
+    onStateChange({ ...state, ...patch });
+  }
+
+  return (
+    <div className="recurrence">
+      <div className="schedule-mode-row" role="tablist" aria-label="Timing">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={timing === "once"}
+          className={timing === "once" ? "primary" : "secondary"}
+          onClick={() => onTimingChange("once")}
+        >
+          One time
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={timing === "repeat"}
+          className={timing === "repeat" ? "primary" : "secondary"}
+          onClick={() => onTimingChange("repeat")}
+        >
+          Repeat
+        </button>
+      </div>
+
+      {timing === "once" ? (
+        children
+      ) : (
+        <div className="recurrence__body">
+          <div
+            className="recurrence__cadences"
+            role="tablist"
+            aria-label="Cadence"
+          >
+            {CADENCES.map((cadence) => (
+              <button
+                key={cadence}
+                type="button"
+                role="tab"
+                aria-selected={state.cadence === cadence}
+                className={`recurrence__chip${
+                  state.cadence === cadence ? " is-active" : ""
+                }`}
+                onClick={() => update({ cadence })}
+              >
+                {CADENCE_LABELS[cadence]}
+              </button>
+            ))}
+          </div>
+
+          {state.cadence === "custom" ? (
+            <label className="field">
+              <span>Cron expression</span>
+              <input
+                type="text"
+                value={state.customCron}
+                spellCheck={false}
+                autoCapitalize="none"
+                autoCorrect="off"
+                placeholder="0 9 * * 1-5"
+                onChange={(event) => update({ customCron: event.target.value })}
+              />
+              <span className="recurrence__hint">
+                Five fields: minute hour day-of-month month day-of-week — e.g.{" "}
+                <code>0 9 * * 1-5</code> is 09:00 on weekdays.
+              </span>
+            </label>
+          ) : (
+            <div className="recurrence__preset-fields">
+              <label className="field">
+                <span>Time</span>
+                <input
+                  type="time"
+                  value={state.time}
+                  onChange={(event) => update({ time: event.target.value })}
+                />
+              </label>
+              {state.cadence === "weekly" ? (
+                <label className="field">
+                  <span>Day</span>
+                  <select
+                    value={state.weekday}
+                    onChange={(event) =>
+                      update({ weekday: Number(event.target.value) })
+                    }
+                  >
+                    {WEEKDAY_LABELS.map((label, index) => (
+                      <option key={label} value={index}>
+                        {label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
+              {state.cadence === "monthly" ? (
+                <label className="field">
+                  <span>Day of month</span>
+                  <input
+                    type="number"
+                    min="1"
+                    max="31"
+                    step="1"
+                    value={state.dayOfMonth}
+                    onChange={(event) =>
+                      update({
+                        dayOfMonth: Math.min(
+                          31,
+                          Math.max(1, Number(event.target.value) || 1),
+                        ),
+                      })
+                    }
+                  />
+                </label>
+              ) : null}
+            </div>
+          )}
+
+          <label className="field">
+            <span>Timezone</span>
+            <input
+              type="text"
+              list={tzListId}
+              value={state.timezone}
+              spellCheck={false}
+              autoCapitalize="none"
+              autoCorrect="off"
+              onChange={(event) => update({ timezone: event.target.value })}
+            />
+            <datalist id={tzListId}>
+              {zones.map((zone) => (
+                <option key={zone} value={zone} />
+              ))}
+            </datalist>
+          </label>
+
+          <div className="recurrence__preview" aria-live="polite">
+            <span className="recurrence__preview-label">Next runs</span>
+            {previewError ? (
+              <p className="recurrence__error">{previewError}</p>
+            ) : occurrences.length > 0 ? (
+              <ul className="recurrence__preview-list">
+                {occurrences.map((iso) => {
+                  const when = new Date(iso);
+                  return (
+                    <li key={iso}>
+                      {formatInZone(when, state.timezone)}{" "}
+                      <span className="recurrence__preview-tz">
+                        {timezoneAbbrev(when, state.timezone)}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="recurrence__preview-empty">
+                {previewing ? "Calculating…" : "Enter a valid recurrence."}
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/RecurrenceControl.tsx
+++ b/frontend/src/components/RecurrenceControl.tsx
@@ -56,6 +56,7 @@ export function RecurrenceControl({
   const [zones] = useState<string[]>(() => supportedTimezones());
 
   const cron = timing === "repeat" ? cronFromState(state) : null;
+  const custom = state.cadence === "custom";
 
   // Debounced server preview — the backend is authoritative for cron/DST, so
   // the preview always matches what the scheduler will fire.
@@ -76,7 +77,14 @@ export function RecurrenceControl({
     setPreviewing(true);
     const handle = window.setTimeout(async () => {
       try {
-        const next = await previewSchedule(host, token, cron, state.timezone, 3);
+        const next = await previewSchedule(
+          host,
+          token,
+          cron,
+          state.timezone,
+          state.startAt || null,
+          3,
+        );
         if (cancelled) return;
         setOccurrences(next);
         setPreviewError(null);
@@ -84,7 +92,9 @@ export function RecurrenceControl({
       } catch (error) {
         if (cancelled) return;
         setOccurrences([]);
-        setPreviewError(error instanceof Error ? error.message : "invalid recurrence");
+        setPreviewError(
+          error instanceof Error ? error.message : "invalid recurrence",
+        );
         onValidChange(false);
       } finally {
         if (!cancelled) setPreviewing(false);
@@ -94,7 +104,7 @@ export function RecurrenceControl({
       cancelled = true;
       window.clearTimeout(handle);
     };
-  }, [timing, cron, state.timezone, host, token, onValidChange]);
+  }, [timing, cron, state.timezone, state.startAt, host, token, onValidChange]);
 
   function update(patch: Partial<RecurrenceState>) {
     onStateChange({ ...state, ...patch });
@@ -102,12 +112,16 @@ export function RecurrenceControl({
 
   return (
     <div className="recurrence">
-      <div className="schedule-mode-row" role="tablist" aria-label="Timing">
+      <div
+        className="segmented recurrence__mode"
+        role="tablist"
+        aria-label="Timing"
+      >
         <button
           type="button"
           role="tab"
           aria-selected={timing === "once"}
-          className={timing === "once" ? "primary" : "secondary"}
+          className={`segmented-item${timing === "once" ? " active" : ""}`}
           onClick={() => onTimingChange("once")}
         >
           One time
@@ -116,149 +130,158 @@ export function RecurrenceControl({
           type="button"
           role="tab"
           aria-selected={timing === "repeat"}
-          className={timing === "repeat" ? "primary" : "secondary"}
+          className={`segmented-item${timing === "repeat" ? " active" : ""}`}
           onClick={() => onTimingChange("repeat")}
         >
           Repeat
         </button>
       </div>
 
-      {timing === "once" ? (
-        children
-      ) : (
-        <div className="recurrence__body">
-          <div
-            className="recurrence__cadences"
-            role="tablist"
-            aria-label="Cadence"
-          >
-            {CADENCES.map((cadence) => (
-              <button
-                key={cadence}
-                type="button"
-                role="tab"
-                aria-selected={state.cadence === cadence}
-                className={`recurrence__chip${
-                  state.cadence === cadence ? " is-active" : ""
-                }`}
-                onClick={() => update({ cadence })}
-              >
-                {CADENCE_LABELS[cadence]}
-              </button>
-            ))}
-          </div>
+      <div className="recurrence__section">
+        {timing === "once" ? (
+          children
+        ) : (
+          <>
+            <div
+              className="recurrence__cadences"
+              role="tablist"
+              aria-label="Cadence"
+            >
+              {CADENCES.map((cadence) => (
+                <button
+                  key={cadence}
+                  type="button"
+                  role="tab"
+                  aria-selected={state.cadence === cadence}
+                  className={`recurrence__chip${
+                    state.cadence === cadence ? " is-active" : ""
+                  }`}
+                  onClick={() => update({ cadence })}
+                >
+                  {CADENCE_LABELS[cadence]}
+                </button>
+              ))}
+            </div>
 
-          {state.cadence === "custom" ? (
+            {custom ? (
+              <label className="field">
+                <span>Cron expression</span>
+                <input
+                  type="text"
+                  value={state.customCron}
+                  spellCheck={false}
+                  autoCapitalize="none"
+                  autoCorrect="off"
+                  placeholder="0 9 * * 1-5"
+                  onChange={(event) =>
+                    update({ customCron: event.target.value })
+                  }
+                />
+                <span className="recurrence__hint">
+                  Five fields: minute hour day-of-month month day-of-week — e.g.{" "}
+                  <code>0 9 * * 1-5</code> is 09:00 on weekdays.
+                </span>
+              </label>
+            ) : null}
+
+            {state.cadence === "weekly" ? (
+              <label className="field">
+                <span>Day of week</span>
+                <select
+                  value={state.weekday}
+                  onChange={(event) =>
+                    update({ weekday: Number(event.target.value) })
+                  }
+                >
+                  {WEEKDAY_LABELS.map((label, index) => (
+                    <option key={label} value={index}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ) : null}
+
+            {state.cadence === "monthly" ? (
+              <label className="field">
+                <span>Day of month</span>
+                <input
+                  type="number"
+                  min="1"
+                  max="31"
+                  step="1"
+                  value={state.dayOfMonth}
+                  onChange={(event) =>
+                    update({
+                      dayOfMonth: Math.min(
+                        31,
+                        Math.max(1, Number(event.target.value) || 1),
+                      ),
+                    })
+                  }
+                />
+              </label>
+            ) : null}
+
             <label className="field">
-              <span>Cron expression</span>
+              <span>Starts</span>
+              <input
+                type="datetime-local"
+                value={state.startAt}
+                onChange={(event) => update({ startAt: event.target.value })}
+              />
+              <span className="recurrence__hint">
+                {custom
+                  ? "The recurrence begins at or after this; the cron sets the run times."
+                  : "Runs at this time of day, repeating from this date."}
+              </span>
+            </label>
+
+            <label className="field">
+              <span>Timezone</span>
               <input
                 type="text"
-                value={state.customCron}
+                list={tzListId}
+                value={state.timezone}
                 spellCheck={false}
                 autoCapitalize="none"
                 autoCorrect="off"
-                placeholder="0 9 * * 1-5"
-                onChange={(event) => update({ customCron: event.target.value })}
+                onChange={(event) => update({ timezone: event.target.value })}
               />
-              <span className="recurrence__hint">
-                Five fields: minute hour day-of-month month day-of-week — e.g.{" "}
-                <code>0 9 * * 1-5</code> is 09:00 on weekdays.
-              </span>
+              <datalist id={tzListId}>
+                {zones.map((zone) => (
+                  <option key={zone} value={zone} />
+                ))}
+              </datalist>
             </label>
-          ) : (
-            <div className="recurrence__preset-fields">
-              <label className="field">
-                <span>Time</span>
-                <input
-                  type="time"
-                  value={state.time}
-                  onChange={(event) => update({ time: event.target.value })}
-                />
-              </label>
-              {state.cadence === "weekly" ? (
-                <label className="field">
-                  <span>Day</span>
-                  <select
-                    value={state.weekday}
-                    onChange={(event) =>
-                      update({ weekday: Number(event.target.value) })
-                    }
-                  >
-                    {WEEKDAY_LABELS.map((label, index) => (
-                      <option key={label} value={index}>
-                        {label}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-              ) : null}
-              {state.cadence === "monthly" ? (
-                <label className="field">
-                  <span>Day of month</span>
-                  <input
-                    type="number"
-                    min="1"
-                    max="31"
-                    step="1"
-                    value={state.dayOfMonth}
-                    onChange={(event) =>
-                      update({
-                        dayOfMonth: Math.min(
-                          31,
-                          Math.max(1, Number(event.target.value) || 1),
-                        ),
-                      })
-                    }
-                  />
-                </label>
-              ) : null}
+
+            <div className="recurrence__preview" aria-live="polite">
+              <span className="recurrence__preview-label">Next runs</span>
+              {previewError ? (
+                <p className="recurrence__error">{previewError}</p>
+              ) : occurrences.length > 0 ? (
+                <ul className="recurrence__preview-list">
+                  {occurrences.map((iso) => {
+                    const when = new Date(iso);
+                    return (
+                      <li key={iso}>
+                        {formatInZone(when, state.timezone)}{" "}
+                        <span className="recurrence__preview-tz">
+                          {timezoneAbbrev(when, state.timezone)}
+                        </span>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <p className="recurrence__preview-empty">
+                  {previewing ? "Calculating…" : "Enter a valid recurrence."}
+                </p>
+              )}
             </div>
-          )}
-
-          <label className="field">
-            <span>Timezone</span>
-            <input
-              type="text"
-              list={tzListId}
-              value={state.timezone}
-              spellCheck={false}
-              autoCapitalize="none"
-              autoCorrect="off"
-              onChange={(event) => update({ timezone: event.target.value })}
-            />
-            <datalist id={tzListId}>
-              {zones.map((zone) => (
-                <option key={zone} value={zone} />
-              ))}
-            </datalist>
-          </label>
-
-          <div className="recurrence__preview" aria-live="polite">
-            <span className="recurrence__preview-label">Next runs</span>
-            {previewError ? (
-              <p className="recurrence__error">{previewError}</p>
-            ) : occurrences.length > 0 ? (
-              <ul className="recurrence__preview-list">
-                {occurrences.map((iso) => {
-                  const when = new Date(iso);
-                  return (
-                    <li key={iso}>
-                      {formatInZone(when, state.timezone)}{" "}
-                      <span className="recurrence__preview-tz">
-                        {timezoneAbbrev(when, state.timezone)}
-                      </span>
-                    </li>
-                  );
-                })}
-              </ul>
-            ) : (
-              <p className="recurrence__preview-empty">
-                {previewing ? "Calculating…" : "Enter a valid recurrence."}
-              </p>
-            )}
-          </div>
-        </div>
-      )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ScheduleMessageModal.tsx
+++ b/frontend/src/components/ScheduleMessageModal.tsx
@@ -100,6 +100,7 @@ export function ScheduleMessageModal({
       scheduledAt?: string;
       cron?: string;
       timezone?: string;
+      startAt?: string;
     } = { submit };
     if (timingMode === "repeat") {
       const cron = cronFromState(recurrence);
@@ -109,6 +110,7 @@ export function ScheduleMessageModal({
       }
       options.cron = cron;
       options.timezone = recurrence.timezone;
+      if (recurrence.startAt) options.startAt = recurrence.startAt;
     } else if (timing === "delay") {
       const minutes = Number.parseFloat(delay);
       if (!Number.isFinite(minutes) || minutes < 0) {

--- a/frontend/src/components/ScheduleMessageModal.tsx
+++ b/frontend/src/components/ScheduleMessageModal.tsx
@@ -305,11 +305,7 @@ export function ScheduleMessageModal({
               (timingMode === "repeat" && !recurrenceValid)
             }
           >
-            {sending
-              ? "Scheduling…"
-              : timingMode === "repeat"
-                ? "Create recurrence"
-                : "Schedule once"}
+            {sending ? "Scheduling…" : "Schedule"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ScheduleMessageModal.tsx
+++ b/frontend/src/components/ScheduleMessageModal.tsx
@@ -3,8 +3,15 @@
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { RecurrenceControl } from "@/components/RecurrenceControl";
 import { createMessageSchedule } from "@/lib/api";
 import { trapTabFocus } from "@/lib/keyboard";
+import {
+  cronFromState,
+  defaultRecurrenceState,
+  RecurrenceState,
+  TimingMode,
+} from "@/lib/recurrence";
 
 interface ScheduleMessageModalProps {
   host: string;
@@ -46,6 +53,11 @@ export function ScheduleMessageModal({
   const [submit, setSubmit] = useState(true);
   const [error, setError] = useState("");
   const [sending, setSending] = useState(false);
+  const [timingMode, setTimingMode] = useState<TimingMode>("once");
+  const [recurrence, setRecurrence] = useState<RecurrenceState>(
+    defaultRecurrenceState,
+  );
+  const [recurrenceValid, setRecurrenceValid] = useState(false);
   const modalRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -86,8 +98,18 @@ export function ScheduleMessageModal({
       submit: boolean;
       delaySeconds?: number;
       scheduledAt?: string;
+      cron?: string;
+      timezone?: string;
     } = { submit };
-    if (timing === "delay") {
+    if (timingMode === "repeat") {
+      const cron = cronFromState(recurrence);
+      if (!cron) {
+        setError("Enter a valid recurrence.");
+        return;
+      }
+      options.cron = cron;
+      options.timezone = recurrence.timezone;
+    } else if (timing === "delay") {
       const minutes = Number.parseFloat(delay);
       if (!Number.isFinite(minutes) || minutes < 0) {
         setError("Enter a non-negative delay in minutes.");
@@ -158,77 +180,91 @@ export function ScheduleMessageModal({
           placeholder="Message text…"
           aria-label="Message text"
         />
-        <div className="segmented schedule-msg-modes" role="tablist">
-          <button
-            type="button"
-            role="tab"
-            aria-selected={timing === "delay"}
-            className={`segmented-item${timing === "delay" ? " active" : ""}`}
-            onClick={() => setTiming("delay")}
-          >
-            After delay
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={timing === "datetime"}
-            className={`segmented-item${timing === "datetime" ? " active" : ""}`}
-            onClick={() => setTiming("datetime")}
-          >
-            At a time
-          </button>
-        </div>
-        {timing === "delay" ? (
-          <div className="schedule-msg-delay">
-            <div className="schedule-msg-presets">
-              {DELAY_PRESETS.map((preset) => (
-                <button
-                  key={preset.minutes}
-                  type="button"
-                  className={`schedule-msg-preset${
-                    delay === String(preset.minutes) ? " active" : ""
-                  }`}
-                  onClick={() => setDelay(String(preset.minutes))}
-                >
-                  {preset.label}
-                </button>
-              ))}
-            </div>
-            <label className="schedule-msg-field-inline">
-              <input
-                type="number"
-                className="schedule-msg-dialog-number"
-                min={0}
-                step={1}
-                value={delay}
-                onChange={(e) => setDelay(e.target.value)}
-                placeholder="15"
-                aria-label="Delay in minutes"
-              />
-              <span className="schedule-msg-field-suffix">minutes</span>
-            </label>
+        <RecurrenceControl
+          host={host}
+          token={token}
+          timing={timingMode}
+          onTimingChange={setTimingMode}
+          state={recurrence}
+          onStateChange={setRecurrence}
+          onValidChange={setRecurrenceValid}
+        >
+          <div className="segmented schedule-msg-modes" role="tablist">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={timing === "delay"}
+              className={`segmented-item${timing === "delay" ? " active" : ""}`}
+              onClick={() => setTiming("delay")}
+            >
+              After delay
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={timing === "datetime"}
+              className={`segmented-item${
+                timing === "datetime" ? " active" : ""
+              }`}
+              onClick={() => setTiming("datetime")}
+            >
+              At a time
+            </button>
           </div>
-        ) : (
-          <label className="schedule-msg-field">
-            <span className="schedule-msg-field-label">Local time</span>
-            <input
-              type="datetime-local"
-              className="schedule-msg-dialog-number"
-              value={at}
-              onChange={(e) => setAt(e.target.value)}
-              aria-label="Scheduled local time"
-            />
-          </label>
-        )}
-        {preview ? (
-          <p className="schedule-msg-preview">
-            <span className="schedule-msg-preview-glyph" aria-hidden="true">
-              →
-            </span>
-            Sends&nbsp;<strong>{preview.absolute}</strong>
-            <span className="schedule-msg-preview-rel">{preview.relative}</span>
-          </p>
-        ) : null}
+          {timing === "delay" ? (
+            <div className="schedule-msg-delay">
+              <div className="schedule-msg-presets">
+                {DELAY_PRESETS.map((preset) => (
+                  <button
+                    key={preset.minutes}
+                    type="button"
+                    className={`schedule-msg-preset${
+                      delay === String(preset.minutes) ? " active" : ""
+                    }`}
+                    onClick={() => setDelay(String(preset.minutes))}
+                  >
+                    {preset.label}
+                  </button>
+                ))}
+              </div>
+              <label className="schedule-msg-field-inline">
+                <input
+                  type="number"
+                  className="schedule-msg-dialog-number"
+                  min={0}
+                  step={1}
+                  value={delay}
+                  onChange={(e) => setDelay(e.target.value)}
+                  placeholder="15"
+                  aria-label="Delay in minutes"
+                />
+                <span className="schedule-msg-field-suffix">minutes</span>
+              </label>
+            </div>
+          ) : (
+            <label className="schedule-msg-field">
+              <span className="schedule-msg-field-label">Local time</span>
+              <input
+                type="datetime-local"
+                className="schedule-msg-dialog-number"
+                value={at}
+                onChange={(e) => setAt(e.target.value)}
+                aria-label="Scheduled local time"
+              />
+            </label>
+          )}
+          {preview ? (
+            <p className="schedule-msg-preview">
+              <span className="schedule-msg-preview-glyph" aria-hidden="true">
+                →
+              </span>
+              Sends&nbsp;<strong>{preview.absolute}</strong>
+              <span className="schedule-msg-preview-rel">
+                {preview.relative}
+              </span>
+            </p>
+          ) : null}
+        </RecurrenceControl>
         <div className="schedule-msg-submit-row">
           <span className="schedule-msg-submit-label">On delivery</span>
           <div className="segmented segmented-quiet schedule-msg-submit">
@@ -261,9 +297,17 @@ export function ScheduleMessageModal({
             type="button"
             className="primary"
             onClick={() => void handleSchedule()}
-            disabled={!draft.trim() || sending}
+            disabled={
+              !draft.trim() ||
+              sending ||
+              (timingMode === "repeat" && !recurrenceValid)
+            }
           >
-            {sending ? "Scheduling…" : "Schedule"}
+            {sending
+              ? "Scheduling…"
+              : timingMode === "repeat"
+                ? "Create recurrence"
+                : "Schedule once"}
           </button>
         </div>
       </div>

--- a/frontend/src/components/ScheduledMessagesDock.tsx
+++ b/frontend/src/components/ScheduledMessagesDock.tsx
@@ -107,7 +107,7 @@ export function ScheduledMessagesDock({
                     {isRecurring(m) ? (
                       <span
                         className="sched-dock-recur"
-                        title={cronToLabel(m.cron!, m.timezone)}
+                        title={cronToLabel(m.cron, m.timezone)}
                       >
                         ↻
                       </span>
@@ -121,7 +121,7 @@ export function ScheduledMessagesDock({
                     />
                     {isRecurring(m) ? (
                       <span className="sched-dock-item-cadence">
-                        {cronToLabel(m.cron!, m.timezone)}
+                        {cronToLabel(m.cron, m.timezone)}
                       </span>
                     ) : null}
                   </div>

--- a/frontend/src/components/ScheduledMessagesDock.tsx
+++ b/frontend/src/components/ScheduledMessagesDock.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import { ExpandableText } from "@/components/ExpandableText";
+import { cronToLabel, isRecurring } from "@/lib/recurrence";
 import { MessageSchedule } from "@/lib/types";
 
 // A single chevron glyph (pointing up); orientation handled with a CSS rotation,
@@ -103,6 +104,14 @@ export function ScheduledMessagesDock({
                 <div key={m.id} className="sched-dock-item">
                   <span className="sched-dock-item-when">
                     {relativeFromNow(m)}
+                    {isRecurring(m) ? (
+                      <span
+                        className="sched-dock-recur"
+                        title={cronToLabel(m.cron!, m.timezone)}
+                      >
+                        ↻
+                      </span>
+                    ) : null}
                   </span>
                   <div className="sched-dock-item-body">
                     <ExpandableText
@@ -110,6 +119,11 @@ export function ScheduledMessagesDock({
                       text={m.text || "(no text)"}
                       collapsedMaxHeight="3em"
                     />
+                    {isRecurring(m) ? (
+                      <span className="sched-dock-item-cadence">
+                        {cronToLabel(m.cron!, m.timezone)}
+                      </span>
+                    ) : null}
                   </div>
                   <button
                     type="button"
@@ -135,6 +149,11 @@ export function ScheduledMessagesDock({
             <span className="sched-dock-glyph" aria-hidden>
               ◷
             </span>
+            {isRecurring(next) ? (
+              <span className="sched-dock-recur" aria-hidden>
+                ↻
+              </span>
+            ) : null}
             <span className="sched-dock-label">{label}</span>
             <span className="sched-dock-when">{relativeFromNow(next)}</span>
             <span className="sched-dock-count">{messages.length}</span>

--- a/frontend/src/components/ScheduledMessagesPanel.tsx
+++ b/frontend/src/components/ScheduledMessagesPanel.tsx
@@ -126,7 +126,7 @@ function MessageRow({
   const zone = schedule.timezone ?? undefined;
   const absolute = when
     ? recurring
-      ? `${formatInZone(when, zone!)} ${timezoneAbbrev(when, zone!)}`
+      ? `${formatInZone(when, zone)} ${timezoneAbbrev(when, zone)}`
       : formatClock(when)
     : "";
   const isPending = schedule.status === "pending";
@@ -143,7 +143,7 @@ function MessageRow({
         </span>
         {recurring ? (
           <span className="badge schedule-recurrence" title="Recurring message">
-            {cronToLabel(schedule.cron!, schedule.timezone)}
+            {cronToLabel(schedule.cron, schedule.timezone)}
           </span>
         ) : null}
         <a
@@ -185,7 +185,7 @@ function MessageRow({
       {recurring && lastRun ? (
         <p className="schedule-last muted">
           <span className="schedule-when-label">Last</span>{" "}
-          {formatInZone(lastRun, zone!)} {timezoneAbbrev(lastRun, zone!)}
+          {formatInZone(lastRun, zone)} {timezoneAbbrev(lastRun, zone)}
           {schedule.last_run_status ? ` · ${schedule.last_run_status}` : ""}
         </p>
       ) : null}

--- a/frontend/src/components/ScheduledMessagesPanel.tsx
+++ b/frontend/src/components/ScheduledMessagesPanel.tsx
@@ -6,6 +6,12 @@ import { ExpandableText } from "@/components/ExpandableText";
 import { Pager } from "@/components/Pager";
 import { usePagination } from "@/lib/usePagination";
 import { formatClock, formatRelative } from "@/lib/scheduleTime";
+import {
+  cronToLabel,
+  formatInZone,
+  isRecurring,
+  timezoneAbbrev,
+} from "@/lib/recurrence";
 import { MessageSchedule, SessionRecord } from "@/lib/types";
 
 const PAGE_SIZE = 5;
@@ -116,9 +122,16 @@ function MessageRow({
     : schedule.created_at
       ? new Date(schedule.created_at)
       : null;
-  const absolute = when ? formatClock(when) : "";
+  const recurring = isRecurring(schedule);
+  const zone = schedule.timezone ?? undefined;
+  const absolute = when
+    ? recurring
+      ? `${formatInZone(when, zone!)} ${timezoneAbbrev(when, zone!)}`
+      : formatClock(when)
+    : "";
   const isPending = schedule.status === "pending";
-  const relative = isPending && when ? formatRelative(when) : null;
+  const relative = isPending && when && !recurring ? formatRelative(when) : null;
+  const lastRun = schedule.last_run_at ? new Date(schedule.last_run_at) : null;
   const label = sessionTitle?.trim() || shortSessionId(schedule.session_id);
 
   return (
@@ -128,6 +141,11 @@ function MessageRow({
         <span className={`badge schedule-status ${schedule.status}`}>
           {schedule.status}
         </span>
+        {recurring ? (
+          <span className="badge schedule-recurrence" title="Recurring message">
+            {cronToLabel(schedule.cron!, schedule.timezone)}
+          </span>
+        ) : null}
         <a
           className="msg-session-link"
           href={`/session/${schedule.session_id}`}
@@ -140,6 +158,7 @@ function MessageRow({
         </a>
         <span className="msg-row-right">
           <span className="msg-row-when">
+            {recurring ? <span className="schedule-when-label">Next</span> : null}
             {relative ? <span className="msg-countdown">{relative}</span> : null}
             <span className="muted">{absolute}</span>
           </span>
@@ -163,7 +182,19 @@ function MessageRow({
           <em className="muted">(no text)</em>
         </p>
       )}
-      {schedule.failure_reason ? (
+      {recurring && lastRun ? (
+        <p className="schedule-last muted">
+          <span className="schedule-when-label">Last</span>{" "}
+          {formatInZone(lastRun, zone!)} {timezoneAbbrev(lastRun, zone!)}
+          {schedule.last_run_status ? ` · ${schedule.last_run_status}` : ""}
+        </p>
+      ) : null}
+      {recurring && schedule.last_failure_reason ? (
+        <p className="error msg-error">
+          Last run failed: {schedule.last_failure_reason}
+        </p>
+      ) : null}
+      {!recurring && schedule.failure_reason ? (
         <p className="error msg-error">{schedule.failure_reason}</p>
       ) : null}
     </article>

--- a/frontend/src/components/ScheduledSessionsPanel.tsx
+++ b/frontend/src/components/ScheduledSessionsPanel.tsx
@@ -151,7 +151,7 @@ function ScheduleRow({
   const recurring = isRecurring(schedule);
   const zone = schedule.timezone ?? undefined;
   const formatted = recurring
-    ? `${formatInZone(when, zone!)} ${timezoneAbbrev(when, zone!)}`
+    ? `${formatInZone(when, zone)} ${timezoneAbbrev(when, zone)}`
     : formatClock(when);
   const relative = schedule.status === "pending" ? formatRelative(when) : null;
   const lastRun = schedule.last_run_at ? new Date(schedule.last_run_at) : null;
@@ -173,7 +173,7 @@ function ScheduleRow({
         <span className={`badge schedule-status ${schedule.status}`}>{schedule.status}</span>
         {recurring ? (
           <span className="badge schedule-recurrence" title="Recurring schedule">
-            {cronToLabel(schedule.cron!, schedule.timezone)}
+            {cronToLabel(schedule.cron, schedule.timezone)}
           </span>
         ) : null}
         {modeLabel ? (
@@ -224,7 +224,7 @@ function ScheduleRow({
       {recurring && lastRun ? (
         <p className="schedule-last muted">
           <span className="schedule-when-label">Last</span>{" "}
-          {formatInZone(lastRun, zone!)} {timezoneAbbrev(lastRun, zone!)}
+          {formatInZone(lastRun, zone)} {timezoneAbbrev(lastRun, zone)}
           {schedule.last_run_status ? ` · ${schedule.last_run_status}` : ""}
         </p>
       ) : null}

--- a/frontend/src/components/ScheduledSessionsPanel.tsx
+++ b/frontend/src/components/ScheduledSessionsPanel.tsx
@@ -12,6 +12,12 @@ import { Pager } from "@/components/Pager";
 import { usePagination } from "@/lib/usePagination";
 import { formatClock, formatRelative } from "@/lib/scheduleTime";
 import {
+  cronToLabel,
+  formatInZone,
+  isRecurring,
+  timezoneAbbrev,
+} from "@/lib/recurrence";
+import {
   Backend,
   BackendModelOption,
   ScheduledSession,
@@ -142,8 +148,13 @@ function ScheduleRow({
   modelsByBackend: Record<string, BackendModelOption[]>;
 }) {
   const when = new Date(schedule.scheduled_at);
-  const formatted = formatClock(when);
+  const recurring = isRecurring(schedule);
+  const zone = schedule.timezone ?? undefined;
+  const formatted = recurring
+    ? `${formatInZone(when, zone!)} ${timezoneAbbrev(when, zone!)}`
+    : formatClock(when);
   const relative = schedule.status === "pending" ? formatRelative(when) : null;
+  const lastRun = schedule.last_run_at ? new Date(schedule.last_run_at) : null;
   const modelCacheKey = scheduleModelCacheKey(
     schedule.backend,
     schedule.launch_target_id ?? null,
@@ -160,6 +171,11 @@ function ScheduleRow({
           {catalog.byId(schedule.backend)?.label ?? humaniseBackend(schedule.backend)}
         </span>
         <span className={`badge schedule-status ${schedule.status}`}>{schedule.status}</span>
+        {recurring ? (
+          <span className="badge schedule-recurrence" title="Recurring schedule">
+            {cronToLabel(schedule.cron!, schedule.timezone)}
+          </span>
+        ) : null}
         {modeLabel ? (
           <span className="badge schedule-mode">{modeLabel}</span>
         ) : null}
@@ -183,6 +199,7 @@ function ScheduleRow({
         ) : null}
         <span className="msg-row-right">
           <span className="msg-row-when">
+            {recurring ? <span className="schedule-when-label">Next</span> : null}
             {relative ? <span className="msg-countdown">{relative}</span> : null}
             <span className="muted">{formatted}</span>
           </span>
@@ -204,7 +221,19 @@ function ScheduleRow({
       {schedule.initial_prompt ? (
         <p className="muted schedule-prompt">“{schedule.initial_prompt}”</p>
       ) : null}
-      {schedule.failure_reason ? (
+      {recurring && lastRun ? (
+        <p className="schedule-last muted">
+          <span className="schedule-when-label">Last</span>{" "}
+          {formatInZone(lastRun, zone!)} {timezoneAbbrev(lastRun, zone!)}
+          {schedule.last_run_status ? ` · ${schedule.last_run_status}` : ""}
+        </p>
+      ) : null}
+      {recurring && schedule.last_failure_reason ? (
+        <p className="error schedule-last-error">
+          Last run failed: {schedule.last_failure_reason}
+        </p>
+      ) : null}
+      {!recurring && schedule.failure_reason ? (
         <p className="error">{schedule.failure_reason}</p>
       ) : null}
       {schedule.session_id ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -916,6 +916,26 @@ export async function createSchedule(
   return body.schedule as ScheduledSession;
 }
 
+export async function previewSchedule(
+  host: string,
+  token: string,
+  cron: string,
+  timezone: string,
+  count = 3,
+): Promise<string[]> {
+  const response = await fetch(`${host}/api/schedules/preview`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ cron, timezone, count }),
+  });
+  await ensureOk(response, "failed to preview schedule");
+  const payload = await response.json();
+  return payload.occurrences as string[];
+}
+
 export async function cancelSchedule(host: string, token: string, scheduleId: string): Promise<void> {
   const response = await fetch(`${host}/api/schedules/${scheduleId}`, {
     method: "DELETE",
@@ -1053,11 +1073,15 @@ export async function createMessageSchedule(
     submit?: boolean;
     delaySeconds?: number | null;
     scheduledAt?: string | null;
+    cron?: string | null;
+    timezone?: string | null;
   } = {},
 ): Promise<MessageSchedule> {
   const body: Record<string, unknown> = { text, submit: options.submit ?? true };
   if (options.delaySeconds != null) body.delay_seconds = options.delaySeconds;
   if (options.scheduledAt != null) body.scheduled_at = options.scheduledAt;
+  if (options.cron != null) body.cron = options.cron;
+  if (options.timezone != null) body.timezone = options.timezone;
   const response = await fetch(
     `${host}/api/sessions/${sessionId}/message-schedules`,
     {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -921,6 +921,7 @@ export async function previewSchedule(
   token: string,
   cron: string,
   timezone: string,
+  startAt?: string | null,
   count = 3,
 ): Promise<string[]> {
   const response = await fetch(`${host}/api/schedules/preview`, {
@@ -929,7 +930,7 @@ export async function previewSchedule(
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ cron, timezone, count }),
+    body: JSON.stringify({ cron, timezone, start_at: startAt ?? null, count }),
   });
   await ensureOk(response, "failed to preview schedule");
   const payload = await response.json();
@@ -1075,6 +1076,7 @@ export async function createMessageSchedule(
     scheduledAt?: string | null;
     cron?: string | null;
     timezone?: string | null;
+    startAt?: string | null;
   } = {},
 ): Promise<MessageSchedule> {
   const body: Record<string, unknown> = { text, submit: options.submit ?? true };
@@ -1082,6 +1084,7 @@ export async function createMessageSchedule(
   if (options.scheduledAt != null) body.scheduled_at = options.scheduledAt;
   if (options.cron != null) body.cron = options.cron;
   if (options.timezone != null) body.timezone = options.timezone;
+  if (options.startAt != null) body.start_at = options.startAt;
   const response = await fetch(
     `${host}/api/sessions/${sessionId}/message-schedules`,
     {

--- a/frontend/src/lib/recurrence.ts
+++ b/frontend/src/lib/recurrence.ts
@@ -1,0 +1,175 @@
+/**
+ * Client-side recurrence helpers shared by the schedule-session and
+ * schedule-message creation surfaces and the readout rows.
+ *
+ * This module is pure string/label logic: it maps friendly cadence presets to
+ * canonical five-field cron expressions and formats cron + timezone for
+ * display. It deliberately does NOT evaluate cron or compute occurrences — the
+ * backend `/api/schedules/preview` endpoint is the single authority for that,
+ * so the preview always matches what the scheduler actually fires.
+ */
+
+export type TimingMode = "once" | "repeat";
+export type Cadence = "daily" | "weekdays" | "weekly" | "monthly" | "custom";
+
+export const CADENCES: Cadence[] = [
+  "daily",
+  "weekdays",
+  "weekly",
+  "monthly",
+  "custom",
+];
+
+export const WEEKDAY_LABELS = [
+  "Sun",
+  "Mon",
+  "Tue",
+  "Wed",
+  "Thu",
+  "Fri",
+  "Sat",
+];
+
+export interface RecurrenceState {
+  cadence: Cadence;
+  time: string; // "HH:mm" local wall-clock, for the four presets
+  weekday: number; // 0=Sun … 6=Sat, for the weekly cadence
+  dayOfMonth: number; // 1–31, for the monthly cadence
+  customCron: string; // raw five-field expression, for the custom cadence
+  timezone: string; // IANA zone
+}
+
+export function defaultRecurrenceState(): RecurrenceState {
+  return {
+    cadence: "daily",
+    time: "09:00",
+    weekday: 1,
+    dayOfMonth: 1,
+    customCron: "0 9 * * 1-5",
+    timezone: browserTimezone(),
+  };
+}
+
+function parseTime(time: string): { minute: number; hour: number } | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
+  if (!match) return null;
+  const hour = Number(match[1]);
+  const minute = Number(match[2]);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) return null;
+  return { minute, hour };
+}
+
+/**
+ * Build a five-field cron expression from the current recurrence state, or
+ * `null` when the state is not yet valid enough to submit (bad time, empty
+ * custom expression). The custom expression is passed through verbatim; the
+ * backend remains authoritative for validating it.
+ */
+export function cronFromState(state: RecurrenceState): string | null {
+  if (state.cadence === "custom") {
+    const trimmed = state.customCron.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  const parsed = parseTime(state.time);
+  if (!parsed) return null;
+  const { minute, hour } = parsed;
+  switch (state.cadence) {
+    case "daily":
+      return `${minute} ${hour} * * *`;
+    case "weekdays":
+      return `${minute} ${hour} * * 1-5`;
+    case "weekly":
+      return `${minute} ${hour} * * ${state.weekday}`;
+    case "monthly":
+      return `${minute} ${hour} ${state.dayOfMonth} * *`;
+  }
+}
+
+export function browserTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+/**
+ * All IANA zones the runtime knows, with the browser zone guaranteed present
+ * and first. Falls back to just the browser zone on older engines.
+ */
+export function supportedTimezones(): string[] {
+  const browser = browserTimezone();
+  const withValues = Intl as typeof Intl & {
+    supportedValuesOf?: (key: string) => string[];
+  };
+  let zones: string[] = [];
+  try {
+    zones = withValues.supportedValuesOf?.("timeZone") ?? [];
+  } catch {
+    zones = [];
+  }
+  if (zones.length === 0) return [browser];
+  return [browser, ...zones.filter((z) => z !== browser)];
+}
+
+/** Short timezone abbreviation for a moment in a zone, e.g. "EDT", "GMT+8". */
+export function timezoneAbbrev(when: Date, timezone: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "short",
+    }).formatToParts(when);
+    return parts.find((p) => p.type === "timeZoneName")?.value ?? timezone;
+  } catch {
+    return timezone;
+  }
+}
+
+/** Format an instant in a specific IANA zone: "Jul 21, 09:00". */
+export function formatInZone(when: Date, timezone: string): string {
+  try {
+    return when.toLocaleString(undefined, {
+      timeZone: timezone,
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return when.toLocaleString();
+  }
+}
+
+const HHMM = /^(\d{1,2}) (\d{1,2})$/;
+
+/**
+ * A compact, uppercase cadence label for a stored cron + timezone, recognizing
+ * the canonical preset shapes and otherwise showing the raw expression. Shape:
+ * `WEEKDAYS · 09:00 · America/New_York`.
+ */
+export function cronToLabel(cron: string, timezone?: string | null): string {
+  const zone = timezone ? ` · ${timezone}` : "";
+  const fields = cron.trim().split(/\s+/);
+  if (fields.length !== 5) return `CRON ${cron}${zone}`;
+  const [minute, hour, dom, month, dow] = fields;
+  const clock = HHMM.exec(`${minute} ${hour}`)
+    ? `${hour.padStart(2, "0")}:${minute.padStart(2, "0")}`
+    : null;
+  if (clock && month === "*") {
+    if (dom === "*" && dow === "*") return `DAILY · ${clock}${zone}`;
+    if (dom === "*" && dow === "1-5") return `WEEKDAYS · ${clock}${zone}`;
+    if (dom === "*" && /^[0-6]$/.test(dow)) {
+      return `WEEKLY ${WEEKDAY_LABELS[Number(dow)].toUpperCase()} · ${clock}${zone}`;
+    }
+    if (/^\d{1,2}$/.test(dom) && dow === "*") {
+      return `MONTHLY ${dom} · ${clock}${zone}`;
+    }
+  }
+  return `CUSTOM ${cron}${zone}`;
+}
+
+export function isRecurring(
+  schedule: { cron?: string | null } | null | undefined,
+): boolean {
+  return Boolean(schedule?.cron);
+}

--- a/frontend/src/lib/recurrence.ts
+++ b/frontend/src/lib/recurrence.ts
@@ -2,11 +2,9 @@
  * Client-side recurrence helpers shared by the schedule-session and
  * schedule-message creation surfaces and the readout rows.
  *
- * This module is pure string/label logic: it maps friendly cadence presets to
- * canonical five-field cron expressions and formats cron + timezone for
- * display. It deliberately does NOT evaluate cron or compute occurrences — the
- * backend `/api/schedules/preview` endpoint is the single authority for that,
- * so the preview always matches what the scheduler actually fires.
+ * Pure string/label logic: maps cadence presets to five-field cron expressions
+ * and formats cron + timezone for display. Cron evaluation and occurrence
+ * computation live in the backend `/api/schedules/preview` endpoint.
  */
 
 export type TimingMode = "once" | "repeat";
@@ -41,7 +39,7 @@ export interface RecurrenceState {
   timezone: string; // IANA zone
 }
 
-export function defaultStartAt(): string {
+function defaultStartAt(): string {
   const now = new Date();
   const pad = (n: number) => String(n).padStart(2, "0");
   return (

--- a/frontend/src/lib/recurrence.ts
+++ b/frontend/src/lib/recurrence.ts
@@ -113,23 +113,29 @@ export function supportedTimezones(): string[] {
 }
 
 /** Short timezone abbreviation for a moment in a zone, e.g. "EDT", "GMT+8". */
-export function timezoneAbbrev(when: Date, timezone: string): string {
+export function timezoneAbbrev(
+  when: Date,
+  timezone: string | null | undefined,
+): string {
   try {
     const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
+      timeZone: timezone ?? undefined,
       timeZoneName: "short",
     }).formatToParts(when);
-    return parts.find((p) => p.type === "timeZoneName")?.value ?? timezone;
+    return parts.find((p) => p.type === "timeZoneName")?.value ?? (timezone ?? "");
   } catch {
-    return timezone;
+    return timezone ?? "";
   }
 }
 
 /** Format an instant in a specific IANA zone: "Jul 21, 09:00". */
-export function formatInZone(when: Date, timezone: string): string {
+export function formatInZone(
+  when: Date,
+  timezone: string | null | undefined,
+): string {
   try {
     return when.toLocaleString(undefined, {
-      timeZone: timezone,
+      timeZone: timezone ?? undefined,
       month: "short",
       day: "numeric",
       hour: "2-digit",
@@ -147,7 +153,11 @@ const HHMM = /^(\d{1,2}) (\d{1,2})$/;
  * the canonical preset shapes and otherwise showing the raw expression. Shape:
  * `WEEKDAYS · 09:00 · America/New_York`.
  */
-export function cronToLabel(cron: string, timezone?: string | null): string {
+export function cronToLabel(
+  cron: string | null | undefined,
+  timezone?: string | null,
+): string {
+  if (!cron) return "";
   const zone = timezone ? ` · ${timezone}` : "";
   const fields = cron.trim().split(/\s+/);
   if (fields.length !== 5) return `CRON ${cron}${zone}`;

--- a/frontend/src/lib/recurrence.ts
+++ b/frontend/src/lib/recurrence.ts
@@ -32,17 +32,28 @@ export const WEEKDAY_LABELS = [
 
 export interface RecurrenceState {
   cadence: Cadence;
-  time: string; // "HH:mm" local wall-clock, for the four presets
+  // "YYYY-MM-DDTHH:MM" wall-clock in `timezone`: the recurrence start, and for
+  // the four presets also the time of day.
+  startAt: string;
   weekday: number; // 0=Sun … 6=Sat, for the weekly cadence
   dayOfMonth: number; // 1–31, for the monthly cadence
   customCron: string; // raw five-field expression, for the custom cadence
   timezone: string; // IANA zone
 }
 
+export function defaultStartAt(): string {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return (
+    `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}` +
+    `T09:00`
+  );
+}
+
 export function defaultRecurrenceState(): RecurrenceState {
   return {
     cadence: "daily",
-    time: "09:00",
+    startAt: defaultStartAt(),
     weekday: 1,
     dayOfMonth: 1,
     customCron: "0 9 * * 1-5",
@@ -50,8 +61,8 @@ export function defaultRecurrenceState(): RecurrenceState {
   };
 }
 
-function parseTime(time: string): { minute: number; hour: number } | null {
-  const match = /^(\d{1,2}):(\d{2})$/.exec(time.trim());
+function timeFields(startAt: string): { minute: number; hour: number } | null {
+  const match = /T(\d{1,2}):(\d{2})/.exec(startAt);
   if (!match) return null;
   const hour = Number(match[1]);
   const minute = Number(match[2]);
@@ -61,16 +72,15 @@ function parseTime(time: string): { minute: number; hour: number } | null {
 
 /**
  * Build a five-field cron expression from the current recurrence state, or
- * `null` when the state is not yet valid enough to submit (bad time, empty
- * custom expression). The custom expression is passed through verbatim; the
- * backend remains authoritative for validating it.
+ * `null` when the state is not yet valid enough to submit. The custom
+ * expression is passed through verbatim; the backend validates it.
  */
 export function cronFromState(state: RecurrenceState): string | null {
   if (state.cadence === "custom") {
     const trimmed = state.customCron.trim();
     return trimmed.length > 0 ? trimmed : null;
   }
-  const parsed = parseTime(state.time);
+  const parsed = timeFields(state.startAt);
   if (!parsed) return null;
   const { minute, hour } = parsed;
   switch (state.cadence) {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -529,6 +529,14 @@ export interface ScheduledSession {
   failure_reason?: string | null;
   account_profile_id?: string | null;
   account_profile_label?: string | null;
+  // Recurrence: cron + timezone mark a recurring definition (both null =
+  // one-time). scheduled_at is always the next run; last_run_* carry the most
+  // recent occurrence's outcome.
+  cron?: string | null;
+  timezone?: string | null;
+  last_run_at?: string | null;
+  last_run_status?: string | null;
+  last_failure_reason?: string | null;
 }
 
 export interface ScheduleCreateRequest {
@@ -549,6 +557,10 @@ export interface ScheduleCreateRequest {
   effort?: string | null;
   delay_seconds?: number | null;
   scheduled_at?: string | null;
+  // Recurring timing — mutually exclusive with delay_seconds/scheduled_at,
+  // enforced server-side.
+  cron?: string | null;
+  timezone?: string | null;
   // Provenance only — the frontend submits already-resolved fields; sending the
   // selected preset id lets the server stamp it onto the scheduled record.
   preset_id?: string | null;
@@ -687,6 +699,12 @@ export interface MessageSchedule {
   status: MessageScheduleStatus;
   created_at: string;
   failure_reason?: string | null;
+  // Recurrence — see ScheduledSession.
+  cron?: string | null;
+  timezone?: string | null;
+  last_run_at?: string | null;
+  last_run_status?: string | null;
+  last_failure_reason?: string | null;
 }
 
 export interface SessionEnvelope {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -558,9 +558,10 @@ export interface ScheduleCreateRequest {
   delay_seconds?: number | null;
   scheduled_at?: string | null;
   // Recurring timing — mutually exclusive with delay_seconds/scheduled_at,
-  // enforced server-side.
+  // enforced server-side. start_at is the recurrence's wall-clock start.
   cron?: string | null;
   timezone?: string | null;
+  start_at?: string | null;
   // Provenance only — the frontend submits already-resolved fields; sending the
   // selected preset id lets the server stamp it onto the scheduled record.
   preset_id?: string | null;

--- a/frontend/src/lib/useSessionScheduledMessages.ts
+++ b/frontend/src/lib/useSessionScheduledMessages.ts
@@ -90,7 +90,9 @@ function sameSchedules(a: MessageSchedule[], b: MessageSchedule[]): boolean {
     return (
       m.id === other.id &&
       m.status === other.status &&
-      m.scheduled_at === other.scheduled_at
+      m.scheduled_at === other.scheduled_at &&
+      m.cron === other.cron &&
+      m.last_run_at === other.last_run_at
     );
   });
 }


### PR DESCRIPTION
## Purpose

`schedule-message` and `schedule-session` only supported one-time timing (`delay_seconds`/`scheduled_at`), so a user could not ask Waypoint to send a daily stand-up prompt or launch a weekday coding session without recreating the schedule each time. This adds durable recurring schedules to both surfaces: a five-field cron expression plus an explicit IANA timezone. A recurring definition stays active after each run — the scheduler advances it to its next occurrence before acting (at-most-once), records the latest outcome, and skips occurrences missed during downtime rather than replaying a backlog. Implements the ticket-1076 RFC (Option 1: extend the existing schedule tables).

## Changes

### Backend
- `recurrence.py` (new) — wraps `croniter` + `zoneinfo` at Waypoint's boundary: `validate_cron` (exactly five fields; rejects 6/7-field, second-level, and `@daily` aliases), `validate_timezone`, and `next_occurrence_after`/`next_occurrences` returning UTC. DST policy is resolved by iterating croniter in *naive* local time and localizing with `fold=0`, so a nonexistent spring-forward time is skipped and a repeated fall-back time runs once at the earlier instant. Passing a tz-aware base to croniter (which rolls the gap forward and doubles the fall-back) is explicitly avoided. Exposes the named `MISSED_RUN_GRACE_SECONDS = 60.0`.
- `schemas.py` — add nullable `cron`, `timezone`, `last_run_at`, `last_run_status`, `last_failure_reason` to `ScheduledSessionRecord`/`ScheduledMessageRecord`; add `cron`/`timezone` to both create requests; add `SchedulePreview{Request,Response}`.
- `storage.py` — additive `_ensure_column` migration of the five columns on both schedule tables (null = one-time), INSERT/row-mapper coverage, and atomic `claim_recurring_schedule`/`claim_recurring_message` (conditional `UPDATE ... WHERE status='pending' AND scheduled_at=?`) for advance-before-run claiming.
- `scheduler.py` — `validate_timing_mode` raising HTTP 400 for the timing-exclusivity matrix (enforced in the create methods, not a Pydantic validator, so the API returns 400 not 422); `_resolve_scheduled_at` derives the first occurrence for a recurrence; `_fire_due_schedules` captures `now` once per batch and, for a due recurring row, claims (advances) before running, decides run-vs-skip against the grace window, and runs a recurring fire variant that updates only `last_run_*` and leaves the row `pending` (a failure is recorded, not disabling). Structured claim/misfire/completion logging carries schedule id + occurrence, never message text or `launch_env`.
- `api.py` — `POST /api/schedules/preview` (auth) as the single shared, authoritative next-run source.
- `client.py`, `cli.py` — thread `--cron`/`--timezone` through `schedule create` and `schedule message create` with help explaining the five-field grammar and mutual exclusion; add `preview_schedule`.

### Frontend
- `lib/recurrence.ts` (new) — pure preset↔cron mapping, cadence labels (`WEEKDAYS · 09:00 · America/New_York`), and timezone helpers. No cron evaluation client-side.
- `components/RecurrenceControl.tsx` (new) — shared One time / Repeat control used by both creation surfaces: Daily/Weekdays/Weekly/Monthly presets + a custom cron field, an IANA timezone datalist seeded from the browser zone, and a debounced live preview of the next three occurrences fetched from `/api/schedules/preview` (so preview matches what fires). An invalid recurrence disables submission and shows the server error.
- `components/LaunchPanel.tsx`, `components/ScheduleMessageModal.tsx` — embed the control; submit label switches to **Create recurrence** / **Schedule once**.
- `components/ScheduledSessionsPanel.tsx`, `components/ScheduledMessagesPanel.tsx`, `components/ScheduledMessagesDock.tsx`, `components/InstrumentRail.tsx` — recurring rows show a bare-mono cadence label, **Next**/**Last** in the stored timezone, and any last failure inline without flipping the active row to failed; the dock and rail mark recurrences.
- `lib/api.ts`, `lib/types.ts`, `lib/useSessionScheduledMessages.ts`, `app/globals.css` — types, `previewSchedule`/message-schedule cron+timezone plumbing, dock equality on `cron`/`last_run_at`, and token-derived styles for both themes.

## Design

Extends the two existing schedule tables (Option 1) rather than adding a parallel cron-job family, so the REST routes, `schedule_list_update` websocket shape, list ordering, cancellation, and one-time records are unchanged; `scheduled_at` remains the indexed next-run for both modes. Duplicate prevention is prioritized: the claim advances `scheduled_at` before running, giving at-most-once per occurrence (a crash after the claim may skip that one occurrence). Missed-run recovery advances to the first occurrence strictly after `now`; the grace constant (60s, sized above worst-case sequential-fire latency) distinguishes a normally-due occurrence from real downtime. The backend is the single authority for cron/DST math — the frontend never re-implements it and previews via the endpoint, guaranteeing preview == fire.

## Test Plan
- `cd backend && uv run pre-commit run --all-files` — black, isort, ruff, codespell, mypy.
- `cd backend && uv run pytest` — full suite, incl. new `test_recurrence.py` (grammar, timezone, UTC normalization, both DST policies for `America/New_York`), recurring scheduler tests (fire-twice, advance, stay-pending, missed-skip, batch-`now`, failure-then-clear), storage tests (additive migration, conditional claim, cancel race), message tests (session-deletion cleanup, clear-history never deletes an active recurrence), and API tests (preview, 400-not-422 for every invalid-timing row).
- `cd frontend && npm run lint && npm run build`.
- Playwright at 402px, dark + light, against an isolated backend+frontend running this branch: exercised the Repeat control (presets, timezone, custom cron), the live preview, invalid→disabled / valid→enabled submission, and the scheduled-panel row over a recurrence created via the API.

## Test Result
- Backend: 2591 passed; pre-commit clean.
- Frontend: `npm run lint` no findings; `npm run build` compiled, 11/11 routes generated.
- Playwright: created a recurring session over the API and observed the row render `CODEX · PENDING · CUSTOM */2 * * * · UTC` with `NEXT in 1m … UTC`, `LAST … · failed`, and the last-failure inline while the row stayed **pending** (the failure was the isolated env's missing cwd). The Repeat form showed the One time/Repeat toggle, five cadence chips, the timezone field seeded to the browser zone, and a live preview `NEXT RUNS / Jul 21–23, 09:00 AM GMT+8` for Weekdays in Asia/Singapore; an invalid custom cron surfaced an error and disabled **Create recurrence**, a valid one re-enabled it. The instrument rail marked the recurrence. Verified in dark and light themes.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work. — Recurrence is backend-neutral; no per-plugin branching added.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title. — Not a breaking change; migration is additive.
- [x] I have updated documentation or config examples if user-facing behavior changed. — CLI `--cron`/`--timezone` help documents the grammar, timezone, and mutual exclusion.

</details>

Addresses ticket 1076.