### PR TITLE
feat: redesign the board page and streamline ticket posting

### DIFF
--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -13,6 +13,13 @@ import {
   type ReactNode,
 } from "react";
 
+import {
+  BoardPostSheet,
+  type SubmitResult,
+  type TicketSubmit,
+  type UpdateSubmit,
+} from "@/components/board/BoardPostSheet";
+import { Sheet } from "@/components/Sheet";
 import { ThemeToggle } from "@/components/ThemeToggle";
 import {
   clearBoardChannel,
@@ -66,6 +73,13 @@ const RAIL_COLLAPSED_KEY = "waypoint.board.railCollapsed";
 
 type LoadState = "loading" | "ready" | "error";
 type BoardView = "board" | "channels";
+type ComposerMode = "closed" | "ticket" | "update";
+
+// A truthful, non-blocking acknowledgement shown after a successful post.
+interface PostConfirm {
+  text: string;
+  action: { label: string; channel: string };
+}
 
 function shortId(value: string): string {
   return value.length > 16 ? `${value.slice(0, 16)}…` : value;
@@ -904,11 +918,18 @@ export default function BoardPage() {
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [state, setState] = useState<LoadState>("loading");
   const [error, setError] = useState("");
-  const [draftChannel, setDraftChannel] = useState("");
-  const [draftText, setDraftText] = useState("");
-  const [draftKey, setDraftKey] = useState("");
   const [posting, setPosting] = useState(false);
-  const [composerOpen, setComposerOpen] = useState(false);
+  // The unified Post sheet: "closed" when hidden, else the mode it opened in.
+  // The sheet owns its own live mode toggle; this only records the open state
+  // and the opening default.
+  const [composerMode, setComposerMode] = useState<ComposerMode>("closed");
+  const [postConfirm, setPostConfirm] = useState<PostConfirm | null>(null);
+  // Set synchronously before the first await so two fast clicks can't enqueue a
+  // duplicate keyless intake post; the disabled button is only a backstop.
+  const postingRef = useRef(false);
+  // Initial focus target for the sheet; the child attaches it to the right
+  // field for its opening mode.
+  const postFocusRef = useRef<HTMLElement | null>(null);
   const [expandedId, setExpandedId] = useState<number | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editDraft, setEditDraft] = useState("");
@@ -1179,7 +1200,6 @@ export default function BoardPage() {
     setEditDraft("");
     setConfirmDeleteId(null);
     if (activeChannel) {
-      setDraftChannel(activeChannel);
       void refreshEntries(activeChannel);
     } else {
       setEntries([]);
@@ -1315,42 +1335,101 @@ export default function BoardPage() {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [navOpen]);
 
-  const handlePost = useCallback(async () => {
-    const channel = draftChannel.trim();
-    const text = draftText.trim();
-    if (!host || !token || !channel || !text) return;
-    setPosting(true);
-    setError("");
-    try {
-      await postBoardEntry(host, token, channel, {
-        text,
-        key: draftKey.trim() || null,
-      });
-      setDraftText("");
-      setDraftKey("");
-      setActiveChannel(channel);
-      setView("channels");
-      await refreshChannels();
-      await refreshEntries(channel);
-    } catch (err) {
-      if (isAuthError(err)) {
-        handleAuthFailure();
-        return;
+  const closePost = useCallback(() => setComposerMode("closed"), []);
+
+  const handleSubmitTicket = useCallback(
+    async (draft: TicketSubmit): Promise<SubmitResult> => {
+      if (postingRef.current) return { ok: false };
+      const channel = managerState?.config?.render_context?.tickets_channel;
+      // Guard on identity: managerState may still be the previously selected
+      // manager's while the new one loads, so never post to a stale intake.
+      const ready =
+        managerState?.config?.id === selectedManagerId && !!channel;
+      if (!host || !token || !channel || !ready) return { ok: false };
+      const project = managerState?.config?.project ?? "the project";
+      const title = draft.title.trim();
+      const details = draft.details.trim();
+      const text = details ? `${title}\n\n${details}` : title;
+      postingRef.current = true;
+      setPosting(true);
+      try {
+        await postBoardEntry(host, token, channel, {
+          text,
+          key: null,
+          metadata: { priority: draft.priority },
+        });
+        setComposerMode("closed");
+        setPostConfirm({
+          text: `Sent to ${project} intake. The manager will register it shortly.`,
+          action: { label: "Open intake", channel },
+        });
+        await refreshChannels();
+        void refreshManagerState(selectedManagerId!);
+        return { ok: true };
+      } catch (err) {
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return { ok: false };
+        }
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : "failed to post ticket",
+        };
+      } finally {
+        postingRef.current = false;
+        setPosting(false);
       }
-      setError(err instanceof Error ? err.message : "failed to post entry");
-    } finally {
-      setPosting(false);
-    }
-  }, [
-    host,
-    token,
-    draftChannel,
-    draftText,
-    draftKey,
-    refreshChannels,
-    refreshEntries,
-    handleAuthFailure,
-  ]);
+    },
+    [
+      host,
+      token,
+      managerState,
+      selectedManagerId,
+      refreshChannels,
+      refreshManagerState,
+      handleAuthFailure,
+    ],
+  );
+
+  const handleSubmitUpdate = useCallback(
+    async (draft: UpdateSubmit): Promise<SubmitResult> => {
+      if (postingRef.current) return { ok: false };
+      const channel = draft.channel.trim();
+      const text = draft.text.trim();
+      if (!host || !token || !channel || !text) return { ok: false };
+      postingRef.current = true;
+      setPosting(true);
+      try {
+        await postBoardEntry(host, token, channel, {
+          text,
+          key: draft.key?.trim() || null,
+        });
+        setComposerMode("closed");
+        setActiveChannel(channel);
+        setView("channels");
+        setPostConfirm({
+          text: `Posted to ${channel}.`,
+          action: { label: "Open channel", channel },
+        });
+        await refreshChannels();
+        await refreshEntries(channel);
+        return { ok: true };
+      } catch (err) {
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return { ok: false };
+        }
+        return {
+          ok: false,
+          error: err instanceof Error ? err.message : "failed to post update",
+        };
+      } finally {
+        postingRef.current = false;
+        setPosting(false);
+      }
+    },
+    [host, token, refreshChannels, refreshEntries, handleAuthFailure],
+  );
 
   const handleClear = useCallback(
     async (channel: string) => {
@@ -1558,6 +1637,39 @@ export default function BoardPage() {
     [ticketByChannel],
   );
 
+  // Ticket posting reads the selected manager's loaded state. Gate on config
+  // identity so a project switch (which refetches async) can't post to the
+  // old project's intake while the new state is still loading.
+  const managerStateForSelection =
+    managerState?.config?.id === selectedManagerId ? managerState : null;
+  const managerReady =
+    managerMode &&
+    !!managerStateForSelection?.config?.render_context?.tickets_channel;
+  const managerMisconfigured =
+    managerMode &&
+    managerStateForSelection !== null &&
+    !managerStateForSelection.config?.render_context?.tickets_channel;
+  const selectedProject =
+    managers.find((manager) => manager.id === selectedManagerId)?.project ??
+    null;
+  const ticketsChannel =
+    managerStateForSelection?.config?.render_context?.tickets_channel ?? null;
+  const priorityLevels =
+    managerStateForSelection?.config?.priority_levels ?? [];
+  const defaultUpdateChannel = activeChannel ?? channels[0]?.channel ?? null;
+
+  // Toolbar Post follows the view: Ticket on a manager Board, Update on
+  // Channels. Update opens directly for a channel shortcut or the empty state.
+  const openPost = useCallback(() => {
+    setPostConfirm(null);
+    setComposerMode(view === "board" && managerMode ? "ticket" : "update");
+  }, [view, managerMode]);
+
+  const openUpdate = useCallback(() => {
+    setPostConfirm(null);
+    setComposerMode("update");
+  }, []);
+
   // The two shapes the board is built on: keyed cells (latest-wins
   // variables, pinned) and the append-only log (newest first).
   const cells = entries
@@ -1660,73 +1772,31 @@ export default function BoardPage() {
         </div>
       ) : null}
 
-      <section
-        className={`panel board-composer${composerOpen ? " is-open" : ""}`}
-        aria-label="Post to a channel"
-      >
-        <button
-          type="button"
-          className="board-composer-toggle"
-          onClick={() => setComposerOpen((open) => !open)}
-          aria-expanded={composerOpen}
-        >
-          <span className="board-composer-cue" aria-hidden="true">
-            ＋
-          </span>
-          <span className="board-composer-toggle-label">Post to a channel</span>
-          {!composerOpen && (draftChannel.trim() || activeChannel) ? (
-            <span className="board-composer-target">
-              {draftChannel.trim() || activeChannel}
-            </span>
-          ) : null}
-          <span className="board-composer-chevron" aria-hidden="true">
-            ›
-          </span>
-        </button>
-        {composerOpen ? (
-          <div className="board-composer-body">
-            <div className="board-composer-fields">
-              <input
-                className="board-input board-input-channel"
-                placeholder="channel — e.g. topic:plan"
-                value={draftChannel}
-                onChange={(event) => setDraftChannel(event.target.value)}
-                aria-label="Channel"
-              />
-              <span className="board-composer-sep" aria-hidden="true">
-                /
-              </span>
-              <input
-                className="board-input board-input-key"
-                placeholder="key — blank appends to the log"
-                value={draftKey}
-                onChange={(event) => setDraftKey(event.target.value)}
-                aria-label="Key"
-              />
-            </div>
-            <div className="board-composer-row">
-              <input
-                className="board-input board-input-text"
-                placeholder="message"
-                value={draftText}
-                onChange={(event) => setDraftText(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") void handlePost();
-                }}
-                aria-label="Message"
-              />
-              <button
-                type="button"
-                className="primary"
-                onClick={() => void handlePost()}
-                disabled={posting || !draftChannel.trim() || !draftText.trim()}
-              >
-                {draftKey.trim() ? "Set cell" : "Post"}
-              </button>
-            </div>
+      {postConfirm ? (
+        <div className="board-post-confirm" role="status">
+          <span className="board-post-confirm-text">{postConfirm.text}</span>
+          <div className="board-post-confirm-actions">
+            <button
+              type="button"
+              className="board-post-confirm-link"
+              onClick={() => {
+                selectChannel(postConfirm.action.channel);
+                setPostConfirm(null);
+              }}
+            >
+              {postConfirm.action.label} →
+            </button>
+            <button
+              type="button"
+              className="board-post-confirm-dismiss"
+              onClick={() => setPostConfirm(null)}
+              aria-label="Dismiss"
+            >
+              ×
+            </button>
           </div>
-        ) : null}
-      </section>
+        </div>
+      ) : null}
 
       {state === "ready" && (channels.length > 0 || managerMode) ? (
         <div className="board-toolbar">
@@ -1761,6 +1831,25 @@ export default function BoardPage() {
               : (activeChannel ?? "—")}
           </span>
           <ViewSwitch view={view} onChange={setView} />
+          <div className="board-toolbar-actions">
+            {managerMode && managers.length > 0 ? (
+              <ManagerSwitcher
+                managers={managers}
+                selectedId={selectedManagerId}
+                onSelect={setSelectedManagerId}
+              />
+            ) : null}
+            <button
+              type="button"
+              className="primary board-toolbar-post"
+              onClick={openPost}
+            >
+              <span className="board-toolbar-post-cue" aria-hidden="true">
+                ＋
+              </span>
+              Post
+            </button>
+          </div>
         </div>
       ) : null}
 
@@ -1770,8 +1859,14 @@ export default function BoardPage() {
           <p className="muted">
             Nothing has been posted yet. Sessions post with{" "}
             <code>waypoint board post &lt;channel&gt; &lt;message&gt;</code>, or
-            use the composer above.
+            post one now.
           </p>
+          <button type="button" className="primary" onClick={openUpdate}>
+            <span className="board-toolbar-post-cue" aria-hidden="true">
+              ＋
+            </span>
+            Post to a channel
+          </button>
         </section>
       ) : null}
 
@@ -1825,13 +1920,6 @@ export default function BoardPage() {
                       {managerMode ? "Ticket board" : "Channels overview"}
                     </h2>
                   </div>
-                  {managerMode && managers.length > 0 ? (
-                    <ManagerSwitcher
-                      managers={managers}
-                      selectedId={selectedManagerId}
-                      onSelect={setSelectedManagerId}
-                    />
-                  ) : null}
                 </div>
 
                 {managerMode && managerState ? (
@@ -1877,6 +1965,13 @@ export default function BoardPage() {
                       </div>
                     </div>
                     <div className="board-actions">
+                      <button
+                        type="button"
+                        className="board-action board-action-post"
+                        onClick={openUpdate}
+                      >
+                        Post here
+                      </button>
                       <button
                         type="button"
                         className="board-action"
@@ -2208,6 +2303,35 @@ export default function BoardPage() {
           </button>
         </section>
       ) : null}
+
+      <Sheet
+        open={composerMode !== "closed"}
+        onClose={closePost}
+        eyebrow={view === "board" && managerMode ? "Board · post" : "Channels · post"}
+        title="Post"
+        initialFocusRef={postFocusRef}
+      >
+        {composerMode !== "closed" ? (
+          <BoardPostSheet
+            initialMode={composerMode}
+            initialFocusRef={postFocusRef}
+            ticketAvailable={managerMode}
+            managerReady={managerReady}
+            managerMisconfigured={managerMisconfigured}
+            project={selectedProject}
+            ticketsChannel={ticketsChannel}
+            priorityLevels={priorityLevels}
+            managers={managers}
+            selectedManagerId={selectedManagerId}
+            onSelectManager={setSelectedManagerId}
+            channels={channels}
+            defaultUpdateChannel={defaultUpdateChannel}
+            posting={posting}
+            onSubmitTicket={handleSubmitTicket}
+            onSubmitUpdate={handleSubmitUpdate}
+          />
+        ) : null}
+      </Sheet>
     </main>
   );
 }

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -1920,6 +1920,17 @@ export default function BoardPage() {
                       {managerMode ? "Ticket board" : "Channels overview"}
                     </h2>
                   </div>
+                  {/* The toolbar project switcher is hidden on mobile for space;
+                      surface it here, in the always-visible workspace header. */}
+                  {managerMode && managers.length > 0 ? (
+                    <div className="board-context-project">
+                      <ManagerSwitcher
+                        managers={managers}
+                        selectedId={selectedManagerId}
+                        onSelect={setSelectedManagerId}
+                      />
+                    </div>
+                  ) : null}
                 </div>
 
                 {managerMode && managerState ? (

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -1832,13 +1832,6 @@ export default function BoardPage() {
           </span>
           <ViewSwitch view={view} onChange={setView} />
           <div className="board-toolbar-actions">
-            {managerMode && managers.length > 0 ? (
-              <ManagerSwitcher
-                managers={managers}
-                selectedId={selectedManagerId}
-                onSelect={setSelectedManagerId}
-              />
-            ) : null}
             <button
               type="button"
               className="primary board-toolbar-post"
@@ -1919,18 +1912,18 @@ export default function BoardPage() {
                     <h2 className="board-main-title">
                       {managerMode ? "Ticket board" : "Channels overview"}
                     </h2>
+                    {/* The selected project lives under the title — one location
+                        across desktop and mobile. */}
+                    {managerMode && managers.length > 0 ? (
+                      <div className="board-context-project">
+                        <ManagerSwitcher
+                          managers={managers}
+                          selectedId={selectedManagerId}
+                          onSelect={setSelectedManagerId}
+                        />
+                      </div>
+                    ) : null}
                   </div>
-                  {/* The toolbar project switcher is hidden on mobile for space;
-                      surface it here, in the always-visible workspace header. */}
-                  {managerMode && managers.length > 0 ? (
-                    <div className="board-context-project">
-                      <ManagerSwitcher
-                        managers={managers}
-                        selectedId={selectedManagerId}
-                        onSelect={setSelectedManagerId}
-                      />
-                    </div>
-                  ) : null}
                 </div>
 
                 {managerMode && managerState ? (

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -38,7 +38,7 @@ import {
   CHANNEL_GROUP_COLLAPSED_DEFAULT,
   CHANNEL_GROUP_LABELS,
   CHANNEL_GROUP_ORDER,
-  classifyChannel,
+  groupChannels,
   isAwaiting,
   kindTone,
   laneForState,
@@ -48,7 +48,6 @@ import {
   stateLabel,
   stateTone,
   ticketIdFromChannel,
-  type ChannelGroupKey,
 } from "@/lib/board";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
@@ -451,20 +450,10 @@ function Navigator({
   attention,
   onSelect,
 }: NavigatorProps) {
-  const grouped = useMemo(() => {
-    const filter = search.trim().toLowerCase();
-    const groups: Record<ChannelGroupKey, BoardChannel[]> = {
-      manager: [],
-      ticket: [],
-      job: [],
-      other: [],
-    };
-    for (const channel of channels) {
-      if (filter && !channel.channel.toLowerCase().includes(filter)) continue;
-      groups[classifyChannel(channel.channel)].push(channel);
-    }
-    return groups;
-  }, [channels, search]);
+  const grouped = useMemo(
+    () => groupChannels(channels, search),
+    [channels, search],
+  );
 
   return (
     <div className="board-nav">
@@ -1750,8 +1739,6 @@ export default function BoardPage() {
           </div>
         </div>
         <div className="app-bar-meta">
-          {/* The view switch and nav controls live in the workspace toolbar
-              below, not on the app bar. */}
           <Link className="back-link" href="/">
             ← all sessions
           </Link>
@@ -1869,7 +1856,6 @@ export default function BoardPage() {
             !isMobile && railCollapsed ? " is-rail-collapsed" : ""
           }`}
         >
-          {/* Desktop navigator; on mobile this is hidden and the drawer takes over. */}
           {!isMobile ? (
             <aside className="panel board-rail" aria-label="Channels">
               {navigator}
@@ -2405,18 +2391,7 @@ function ChannelsOverview({
   channels: BoardChannel[];
   onSelect: (channel: string) => void;
 }) {
-  const grouped = useMemo(() => {
-    const groups: Record<ChannelGroupKey, BoardChannel[]> = {
-      manager: [],
-      ticket: [],
-      job: [],
-      other: [],
-    };
-    for (const channel of channels) {
-      groups[classifyChannel(channel.channel)].push(channel);
-    }
-    return groups;
-  }, [channels]);
+  const grouped = useMemo(() => groupChannels(channels), [channels]);
 
   return (
     <div className="board-overview">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14100,11 +14100,9 @@ html[data-theme="light"] .session-switcher-row.selected {
   }
 }
 
-/* Mobile: the toolbar has little width, so it sheds redundant labels to keep
-   the Post action on screen. The context echoes the workspace heading / channel
-   title below it, and a single-manager project label repeats the intake
-   readout in the sheet — both are dropped so ☰ · Board|Channels · Post always
-   fit. The multi-manager project select stays but is width-capped. */
+/* Mobile: the toolbar has little width, so the context label — which just
+   echoes the workspace heading / channel title below it — is dropped to keep
+   ☰ · Board|Channels · Post on screen. */
 @media (max-width: 720px) {
   .board-toolbar-context {
     display: none;
@@ -14112,14 +14110,6 @@ html[data-theme="light"] .session-switcher-row.selected {
 
   .board-toolbar-actions {
     margin-left: auto;
-  }
-
-  .board-toolbar-actions .board-switcher-static {
-    display: none;
-  }
-
-  .board-toolbar-actions .board-switcher select {
-    max-width: 116px;
   }
 
   .board-toolbar-post {
@@ -14346,17 +14336,11 @@ html[data-theme="light"] .session-switcher-row.selected {
   min-width: 0;
 }
 
-/* The selected project lives in the toolbar on desktop; on mobile that switcher
-   is dropped for space, so surface it here in the workspace header instead. */
+/* The selected project sits directly under the workspace title — one location
+   on every viewport. */
 .board-context-project {
-  display: none;
-  flex-shrink: 0;
-}
-
-@media (max-width: 720px) {
-  .board-context-project {
-    display: flex;
-  }
+  display: flex;
+  margin-top: 4px;
 }
 
 .board-workspace,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -12739,120 +12739,6 @@ html[data-theme="light"] .session-switcher-row.selected {
 /* Composer */
 /* Composer collapses to a slim bar so reading the board, not posting, owns the
    top of the page. */
-.board-composer {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  padding: 0;
-  overflow: hidden;
-}
-
-.board-composer-toggle {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 100%;
-  padding: 12px 16px;
-  background: transparent;
-  border: none;
-  color: var(--text);
-  cursor: pointer;
-  text-align: left;
-  font: inherit;
-}
-
-.board-composer-cue {
-  font-family: var(--font-mono);
-  font-size: 1rem;
-  line-height: 1;
-  color: var(--accent-cool);
-}
-
-.board-composer-toggle-label {
-  flex-shrink: 0;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-}
-
-.board-composer-toggle:hover .board-composer-toggle-label {
-  color: var(--text);
-}
-
-.board-composer-target {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: 0.78rem;
-  color: var(--accent-cool);
-}
-
-.board-composer-chevron {
-  margin-left: auto;
-  font-size: 1.1rem;
-  line-height: 1;
-  color: var(--muted-soft);
-  transition: transform 0.16s ease;
-}
-
-.board-composer.is-open .board-composer-chevron {
-  transform: rotate(90deg);
-}
-
-.board-composer-body {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 0 16px 14px;
-}
-
-.board-composer-fields {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.board-composer-sep {
-  color: var(--muted-soft);
-  font-family: var(--font-mono);
-}
-
-.board-composer-row {
-  display: flex;
-  gap: 10px;
-}
-
-.board-input {
-  min-width: 0;
-  padding: 10px 12px;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--line);
-  background: var(--bg-input);
-  color: var(--text);
-  font: inherit;
-}
-
-.board-input:focus {
-  outline: none;
-  border-color: var(--accent-cool);
-}
-
-.board-input-channel,
-.board-input-key {
-  flex: 1;
-  font-family: var(--font-mono);
-  font-size: 0.85rem;
-}
-
-.board-input-text {
-  flex: 1;
-}
-
 /* Two-pane layout */
 .board-grid {
   display: grid;
@@ -13725,6 +13611,10 @@ html[data-theme="light"] .session-switcher-row.selected {
   display: flex;
   align-items: center;
   gap: 10px;
+  /* Without this the toolbar's flex content min-width can force the page-shell
+     grid track wider than the viewport on mobile, pushing the trailing Post
+     action off screen. */
+  min-width: 0;
   padding: 8px 10px;
   border-radius: var(--radius-glass);
   background: var(--glass-bg);
@@ -13757,6 +13647,435 @@ html[data-theme="light"] .session-switcher-row.selected {
   font-family: var(--font-mono);
   font-size: 0.78rem;
   color: var(--accent-cool);
+}
+
+/* Trailing action cluster: project switcher (multi-manager) + the single Post
+   action. The context label's flex:1 pushes this to the toolbar's far edge. */
+.board-toolbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.board-toolbar-post {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding: 8px 15px;
+}
+
+.board-toolbar-post-cue {
+  font-family: var(--font-mono);
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+/* ─── Post: confirmation + unified sheet ─── */
+
+/* Truthful, non-blocking acknowledgement after a post. In-flow and flat (not
+   glass — it sits in the content column, not on floating chrome). */
+.board-post-confirm {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px 10px 14px;
+  border-radius: var(--radius);
+  border: 1px solid color-mix(in srgb, var(--success) 40%, var(--line));
+  background: color-mix(in srgb, var(--success) 10%, var(--bg-card));
+  animation: board-post-confirm-in 0.18s ease;
+}
+
+@keyframes board-post-confirm-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+}
+
+.board-post-confirm-text {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.88rem;
+  color: var(--text);
+}
+
+.board-post-confirm-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.board-post-confirm-link {
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--success) 45%, transparent);
+  background: transparent;
+  color: color-mix(in srgb, var(--success) 88%, var(--text));
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+
+.board-post-confirm-link:hover {
+  background: color-mix(in srgb, var(--success) 16%, transparent);
+  border-color: color-mix(in srgb, var(--success) 65%, transparent);
+}
+
+.board-post-confirm-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.15rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+}
+
+.board-post-confirm-dismiss:hover {
+  color: var(--text);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+}
+
+/* The sheet body content is flat opaque instruments; the glass lives on the
+   Sheet chrome around it. */
+.board-post {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+/* Peer Ticket | Update toggle — equal-width segments so neither mode reads as
+   secondary. */
+.board-post-modes.segmented {
+  display: flex;
+  width: 100%;
+}
+
+.board-post-modes .segmented-item {
+  flex: 1;
+}
+
+.board-post-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.board-post-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.board-post-field-inline {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.board-post-field-inline .board-post-select {
+  flex: 1;
+}
+
+.board-post-label {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.board-post-optional {
+  margin-left: 6px;
+  color: var(--muted-soft);
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.board-post-input,
+.board-post-textarea {
+  width: 100%;
+  min-width: 0;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.9rem;
+}
+
+.board-post-textarea {
+  resize: vertical;
+  min-height: 84px;
+  line-height: 1.5;
+}
+
+.board-post-input:focus,
+.board-post-textarea:focus {
+  outline: none;
+  border-color: var(--accent-cool);
+}
+
+.board-post-select {
+  position: relative;
+  display: inline-flex;
+}
+
+.board-post-select select {
+  width: 100%;
+  padding: 9px 30px 9px 12px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+  font: inherit;
+  font-size: 0.88rem;
+  cursor: pointer;
+  appearance: none;
+}
+
+.board-post-select select:focus {
+  outline: none;
+  border-color: var(--accent-cool);
+}
+
+.board-post-select::after {
+  content: "›";
+  position: absolute;
+  right: 11px;
+  top: 50%;
+  transform: translateY(-50%) rotate(90deg);
+  color: var(--muted-soft);
+  pointer-events: none;
+  font-size: 0.95rem;
+}
+
+/* Ticket destination readout: the project + its human-readable intake target,
+   never an editable channel field. */
+.board-post-target {
+  display: flex;
+  align-items: flex-start;
+  gap: 11px;
+  padding: 12px 14px;
+  border-radius: var(--radius);
+  border: 1px solid var(--line);
+  background: var(--bg-card-soft);
+}
+
+.board-post-target-cue {
+  font-family: var(--font-mono);
+  font-size: 1rem;
+  line-height: 1.3;
+  color: var(--accent);
+}
+
+.board-post-target-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.board-post-target-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.board-post-target-sub {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  color: var(--muted);
+}
+
+.board-post-project {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+/* Update target picker. */
+.board-post-target-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.board-post-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.board-post-picker-search {
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+}
+
+.board-post-picker-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 190px;
+  overflow-y: auto;
+  padding: 8px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+}
+
+.board-post-picker-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.board-post-picker-grouplabel {
+  padding: 2px 6px;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-post-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 9px;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.12s ease;
+}
+
+.board-post-picker-item:hover {
+  background: color-mix(in srgb, var(--text) 6%, transparent);
+}
+
+.board-post-picker-item.is-active {
+  background: color-mix(in srgb, var(--accent-cool) 16%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-cool) 34%, transparent);
+}
+
+.board-post-picker-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.board-post-picker-count {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--muted-soft);
+}
+
+.board-post-named {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.board-post-named .board-post-input {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+}
+
+.board-post-writemode.segmented {
+  display: flex;
+  align-self: flex-start;
+}
+
+.board-post-linkbtn {
+  align-self: flex-start;
+  padding: 2px 0;
+  border: none;
+  background: transparent;
+  color: var(--accent-cool);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.03em;
+  cursor: pointer;
+}
+
+.board-post-linkbtn:hover {
+  color: var(--accent-strong);
+  text-decoration: underline;
+}
+
+.board-post-inlineswitch {
+  display: inline;
+}
+
+.board-post-note {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.45;
+  color: var(--muted);
+}
+
+.board-post-note-warn {
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--warn) 42%, transparent);
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+  color: color-mix(in srgb, var(--warn) 30%, var(--text));
+}
+
+.board-post-error {
+  margin: 0;
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  border: 1px solid color-mix(in srgb, var(--danger) 45%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: color-mix(in srgb, var(--danger) 30%, var(--text));
+  font-size: 0.83rem;
+}
+
+.board-post-foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
+  margin-top: 2px;
+}
+
+.board-post-hint {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--muted-soft);
+}
+
+.board-post-submit {
+  flex-shrink: 0;
 }
 
 /* The desktop rail toggle is an icon-only instrument — a sidebar-panel glyph
@@ -13796,6 +14115,33 @@ html[data-theme="light"] .session-switcher-row.selected {
 
   .board-rail-toggle {
     padding: 7px;
+  }
+}
+
+/* Mobile: the toolbar has little width, so it sheds redundant labels to keep
+   the Post action on screen. The context echoes the workspace heading / channel
+   title below it, and a single-manager project label repeats the intake
+   readout in the sheet — both are dropped so ☰ · Board|Channels · Post always
+   fit. The multi-manager project select stays but is width-capped. */
+@media (max-width: 720px) {
+  .board-toolbar-context {
+    display: none;
+  }
+
+  .board-toolbar-actions {
+    margin-left: auto;
+  }
+
+  .board-toolbar-actions .board-switcher-static {
+    display: none;
+  }
+
+  .board-toolbar-actions .board-switcher select {
+    max-width: 116px;
+  }
+
+  .board-toolbar-post {
+    padding: 8px 13px;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14346,6 +14346,19 @@ html[data-theme="light"] .session-switcher-row.selected {
   min-width: 0;
 }
 
+/* The selected project lives in the toolbar on desktop; on mobile that switcher
+   is dropped for space, so surface it here in the workspace header instead. */
+.board-context-project {
+  display: none;
+  flex-shrink: 0;
+}
+
+@media (max-width: 720px) {
+  .board-context-project {
+    display: flex;
+  }
+}
+
 .board-workspace,
 .board-detail-view {
   display: flex;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -13867,27 +13867,13 @@ html[data-theme="light"] .session-switcher-row.selected {
    never an editable channel field. */
 .board-post-target {
   display: flex;
-  align-items: flex-start;
-  gap: 11px;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
   padding: 12px 14px;
   border-radius: var(--radius);
   border: 1px solid var(--line);
   background: var(--bg-card-soft);
-}
-
-.board-post-target-cue {
-  font-family: var(--font-mono);
-  font-size: 1rem;
-  line-height: 1.3;
-  color: var(--accent);
-}
-
-.board-post-target-lines {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 0;
-  flex: 1;
 }
 
 .board-post-target-name {
@@ -13898,15 +13884,10 @@ html[data-theme="light"] .session-switcher-row.selected {
 
 .board-post-target-sub {
   font-family: var(--font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.05em;
+  font-size: 0.8rem;
+  font-weight: 400;
+  letter-spacing: 0.03em;
   color: var(--muted);
-}
-
-.board-post-project {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
 }
 
 /* Update target picker. */
@@ -13998,12 +13979,13 @@ html[data-theme="light"] .session-switcher-row.selected {
 
 .board-post-named {
   display: flex;
-  align-items: center;
-  gap: 10px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .board-post-named .board-post-input {
-  flex: 1;
+  width: 100%;
   font-family: var(--font-mono);
   font-size: 0.84rem;
 }

--- a/frontend/src/components/Sheet.tsx
+++ b/frontend/src/components/Sheet.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, type ReactNode, type RefObject } from "react";
 
 import { trapTabFocus } from "@/lib/keyboard";
 
@@ -13,9 +13,21 @@ interface SheetProps {
   eyebrow: string;
   title: string;
   children: ReactNode;
+  // When set, initial focus lands on this element instead of the panel. A
+  // child's `autoFocus` can't win here: the open rAF below runs after commit
+  // and would steal focus back to the panel, so a field that wants focus must
+  // route through this ref.
+  initialFocusRef?: RefObject<HTMLElement | null>;
 }
 
-export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
+export function Sheet({
+  open,
+  onClose,
+  eyebrow,
+  title,
+  children,
+  initialFocusRef,
+}: SheetProps) {
   const panelRef = useRef<HTMLDivElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   // Key the focus effect on `open` alone; a fresh inline onClose each render
@@ -31,9 +43,11 @@ export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
     }
     restoreFocusRef.current =
       document.activeElement instanceof HTMLElement ? document.activeElement : null;
-    // Move focus into the sheet on open.
+    // Move focus into the sheet on open — a named field if one asked for it,
+    // otherwise the panel.
     const raf = requestAnimationFrame(() => {
-      panelRef.current?.focus();
+      const target = initialFocusRef?.current ?? panelRef.current;
+      target?.focus();
     });
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -49,7 +63,9 @@ export function Sheet({ open, onClose, eyebrow, title, children }: SheetProps) {
       document.removeEventListener("keydown", onKeyDown);
       restoreFocusRef.current?.focus();
     };
-  }, [open]);
+    // `initialFocusRef` is a stable ref object from the parent, so listing it
+    // here satisfies exhaustive-deps without re-running the effect on renders.
+  }, [open, initialFocusRef]);
 
   if (!open) {
     return null;

--- a/frontend/src/components/board/BoardPostSheet.tsx
+++ b/frontend/src/components/board/BoardPostSheet.tsx
@@ -214,40 +214,31 @@ export function BoardPostSheet({
       {mode === "ticket" ? (
         <div className="board-post-form">
           <div className="board-post-target" aria-label="Ticket destination">
-            <span className="board-post-target-cue" aria-hidden="true">
-              ⁂
-            </span>
-            <div className="board-post-target-lines">
-              {managers.length > 1 ? (
-                <label className="board-post-project">
-                  <span className="board-post-label">Project</span>
-                  <span className="board-post-select">
-                    <select
-                      value={selectedManagerId ?? ""}
-                      onChange={(event) => onSelectManager(event.target.value)}
-                      aria-label="Project"
-                    >
-                      {managers.map((manager) => (
-                        <option key={manager.id} value={manager.id}>
-                          {manager.project}
-                        </option>
-                      ))}
-                    </select>
-                  </span>
-                </label>
-              ) : (
-                <span className="board-post-target-name">
-                  {project ?? "manager"}
-                </span>
-              )}
-              <span className="board-post-target-sub">
-                {managerReady
-                  ? "manager intake"
-                  : managerMisconfigured
-                    ? "no intake channel configured"
-                    : "loading manager…"}
+            <span className="board-post-label">Destination</span>
+            {managers.length > 1 ? (
+              <span className="board-post-select">
+                <select
+                  value={selectedManagerId ?? ""}
+                  onChange={(event) => onSelectManager(event.target.value)}
+                  aria-label="Project"
+                >
+                  {managers.map((manager) => (
+                    <option key={manager.id} value={manager.id}>
+                      {manager.project} · manager intake
+                    </option>
+                  ))}
+                </select>
               </span>
-            </div>
+            ) : (
+              <span className="board-post-target-name">
+                {project ?? "manager"}
+                {managerReady ? (
+                  <span className="board-post-target-sub"> · manager intake</span>
+                ) : !managerMisconfigured ? (
+                  <span className="board-post-target-sub"> · loading…</span>
+                ) : null}
+              </span>
+            )}
           </div>
 
           <label className="board-post-field">
@@ -320,8 +311,7 @@ export function BoardPostSheet({
             </p>
           ) : (
             <p className="board-post-note">
-              Submitting sends your request to the project’s manager intake. The
-              manager registers it as a ticket shortly after.
+              The manager registers this as a ticket shortly after you submit.
             </p>
           )}
 
@@ -369,7 +359,7 @@ export function BoardPostSheet({
                     className="board-post-linkbtn"
                     onClick={() => setUseNamed(false)}
                   >
-                    Pick existing
+                    ← Pick an existing channel
                   </button>
                 ) : null}
               </div>
@@ -441,6 +431,7 @@ export function BoardPostSheet({
               }`}
               aria-pressed={writeMode === "append"}
               onClick={() => setWriteMode("append")}
+              title="Appends a new post to the channel log"
             >
               Append
             </button>
@@ -449,15 +440,11 @@ export function BoardPostSheet({
               className={`segmented-item${writeMode === "cell" ? " active" : ""}`}
               aria-pressed={writeMode === "cell"}
               onClick={() => setWriteMode("cell")}
+              title="Sets a keyed cell — the latest value for that key wins"
             >
               Set cell
             </button>
           </div>
-          <p className="board-post-note">
-            {writeMode === "append"
-              ? "Appends a new post to the channel log."
-              : "Sets a keyed cell — the latest value for that key wins."}
-          </p>
 
           {intakeWarning ? (
             <p className="board-post-note board-post-note-warn" role="alert">

--- a/frontend/src/components/board/BoardPostSheet.tsx
+++ b/frontend/src/components/board/BoardPostSheet.tsx
@@ -10,8 +10,7 @@ import {
 import {
   CHANNEL_GROUP_LABELS,
   CHANNEL_GROUP_ORDER,
-  classifyChannel,
-  type ChannelGroupKey,
+  groupChannels,
 } from "@/lib/board";
 import { BoardChannel, ManagerSummary } from "@/lib/types";
 
@@ -95,7 +94,6 @@ export function BoardPostSheet({
     ticketAvailable ? initialMode : "update",
   );
 
-  // Ticket draft.
   const [title, setTitle] = useState("");
   const [details, setDetails] = useState("");
   const [priority, setPriority] = useState(() =>
@@ -106,7 +104,7 @@ export function BoardPostSheet({
   // no channels to pick, start there so a first post is possible.
   const [useNamed, setUseNamed] = useState(channels.length === 0);
   const [existingChannel, setExistingChannel] = useState(
-    defaultUpdateChannel ?? channels[0]?.channel ?? "",
+    defaultUpdateChannel ?? "",
   );
   const [namedChannel, setNamedChannel] = useState("");
   const [writeMode, setWriteMode] = useState<UpdateWriteMode>("append");
@@ -133,20 +131,10 @@ export function BoardPostSheet({
   const intakeWarning =
     targetsIntake && writeMode === "append" && targetChannel.length > 0;
 
-  const groupedChannels = useMemo(() => {
-    const filter = pickerSearch.trim().toLowerCase();
-    const groups: Record<ChannelGroupKey, BoardChannel[]> = {
-      manager: [],
-      ticket: [],
-      job: [],
-      other: [],
-    };
-    for (const channel of channels) {
-      if (filter && !channel.channel.toLowerCase().includes(filter)) continue;
-      groups[classifyChannel(channel.channel)].push(channel);
-    }
-    return groups;
-  }, [channels, pickerSearch]);
+  const groupedChannels = useMemo(
+    () => groupChannels(channels, pickerSearch),
+    [channels, pickerSearch],
+  );
 
   const ticketValid = title.trim().length > 0 && managerReady;
   const updateValid =

--- a/frontend/src/components/board/BoardPostSheet.tsx
+++ b/frontend/src/components/board/BoardPostSheet.tsx
@@ -1,0 +1,546 @@
+"use client";
+
+import {
+  useMemo,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
+
+import {
+  CHANNEL_GROUP_LABELS,
+  CHANNEL_GROUP_ORDER,
+  classifyChannel,
+  type ChannelGroupKey,
+} from "@/lib/board";
+import { BoardChannel, ManagerSummary } from "@/lib/types";
+
+export type PostMode = "ticket" | "update";
+export type UpdateWriteMode = "append" | "cell";
+
+export interface TicketSubmit {
+  title: string;
+  details: string;
+  priority: string;
+}
+
+export interface UpdateSubmit {
+  channel: string;
+  text: string;
+  key: string | null;
+}
+
+export type SubmitResult = { ok: boolean; error?: string };
+
+interface BoardPostSheetProps {
+  initialMode: PostMode;
+  // Focus lands here on open (routed through Sheet's initialFocusRef, which
+  // wins the open-focus race against a child autoFocus).
+  initialFocusRef: RefObject<HTMLElement | null>;
+  // Whether Ticket mode is offered at all. False → no manager, Update only.
+  ticketAvailable: boolean;
+  // Ticket mode can post: the selected manager's state is loaded for the
+  // current selection and carries an intake channel.
+  managerReady: boolean;
+  // Loaded but misconfigured (no intake channel) vs. simply still loading.
+  managerMisconfigured: boolean;
+  project: string | null;
+  ticketsChannel: string | null;
+  priorityLevels: string[];
+  managers: ManagerSummary[];
+  selectedManagerId: string | null;
+  onSelectManager: (id: string) => void;
+  channels: BoardChannel[];
+  // The Update target the current view implies.
+  defaultUpdateChannel: string | null;
+  posting: boolean;
+  onSubmitTicket: (draft: TicketSubmit) => Promise<SubmitResult>;
+  onSubmitUpdate: (draft: UpdateSubmit) => Promise<SubmitResult>;
+}
+
+const DEFAULT_PRIORITY = "p2";
+
+function pickDefaultPriority(levels: string[]): string {
+  if (levels.includes(DEFAULT_PRIORITY)) return DEFAULT_PRIORITY;
+  return levels[0] ?? DEFAULT_PRIORITY;
+}
+
+// A modified-Enter (⌘/Ctrl+Enter) submit, the repo-wide convention for
+// multi-line composers.
+function isSubmitChord(event: KeyboardEvent): boolean {
+  return event.key === "Enter" && (event.metaKey || event.ctrlKey);
+}
+
+export function BoardPostSheet({
+  initialMode,
+  initialFocusRef,
+  ticketAvailable,
+  managerReady,
+  managerMisconfigured,
+  project,
+  ticketsChannel,
+  priorityLevels,
+  managers,
+  selectedManagerId,
+  onSelectManager,
+  channels,
+  defaultUpdateChannel,
+  posting,
+  onSubmitTicket,
+  onSubmitUpdate,
+}: BoardPostSheetProps) {
+  // The sheet owns its two drafts so toggling modes never leaks a field or
+  // target across; closing the sheet unmounts this component and resets them.
+  const [mode, setMode] = useState<PostMode>(
+    ticketAvailable ? initialMode : "update",
+  );
+
+  // Ticket draft.
+  const [title, setTitle] = useState("");
+  const [details, setDetails] = useState("");
+  const [priority, setPriority] = useState(() =>
+    pickDefaultPriority(priorityLevels),
+  );
+
+  // Update draft. `useNamed` reveals a typed channel field; when the board has
+  // no channels to pick, start there so a first post is possible.
+  const [useNamed, setUseNamed] = useState(channels.length === 0);
+  const [existingChannel, setExistingChannel] = useState(
+    defaultUpdateChannel ?? channels[0]?.channel ?? "",
+  );
+  const [namedChannel, setNamedChannel] = useState("");
+  const [writeMode, setWriteMode] = useState<UpdateWriteMode>("append");
+  const [updateKey, setUpdateKey] = useState("");
+  const [updateText, setUpdateText] = useState("");
+  const [pickerSearch, setPickerSearch] = useState("");
+
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  const priorityDefault = useMemo(
+    () => pickDefaultPriority(priorityLevels),
+    [priorityLevels],
+  );
+  // Keep the chosen priority valid as the manager (and its levels) load in.
+  const effectivePriority = priorityLevels.includes(priority)
+    ? priority
+    : priorityDefault;
+
+  const targetChannel = (
+    useNamed ? namedChannel : existingChannel
+  ).trim();
+  const targetsIntake =
+    !!ticketsChannel && targetChannel === ticketsChannel;
+  const intakeWarning =
+    targetsIntake && writeMode === "append" && targetChannel.length > 0;
+
+  const groupedChannels = useMemo(() => {
+    const filter = pickerSearch.trim().toLowerCase();
+    const groups: Record<ChannelGroupKey, BoardChannel[]> = {
+      manager: [],
+      ticket: [],
+      job: [],
+      other: [],
+    };
+    for (const channel of channels) {
+      if (filter && !channel.channel.toLowerCase().includes(filter)) continue;
+      groups[classifyChannel(channel.channel)].push(channel);
+    }
+    return groups;
+  }, [channels, pickerSearch]);
+
+  const ticketValid = title.trim().length > 0 && managerReady;
+  const updateValid =
+    targetChannel.length > 0 &&
+    updateText.trim().length > 0 &&
+    (writeMode === "append" || updateKey.trim().length > 0);
+
+  async function submitTicket() {
+    if (posting || !ticketValid) return;
+    setSubmitError(null);
+    const res = await onSubmitTicket({
+      title: title.trim(),
+      details: details,
+      priority: effectivePriority,
+    });
+    // On success the parent closes the sheet (unmounting us); only a failure
+    // returns here with the draft still mounted.
+    if (!res.ok && res.error) setSubmitError(res.error);
+  }
+
+  async function submitUpdate() {
+    if (posting || !updateValid) return;
+    setSubmitError(null);
+    const res = await onSubmitUpdate({
+      channel: targetChannel,
+      text: updateText.trim(),
+      key: writeMode === "cell" ? updateKey.trim() : null,
+    });
+    if (!res.ok && res.error) setSubmitError(res.error);
+  }
+
+  return (
+    <div className="board-post">
+      {ticketAvailable ? (
+        <div
+          className="segmented board-post-modes"
+          role="group"
+          aria-label="Posting mode"
+        >
+          <button
+            type="button"
+            className={`segmented-item${mode === "ticket" ? " active" : ""}`}
+            aria-pressed={mode === "ticket"}
+            onClick={() => {
+              setMode("ticket");
+              setSubmitError(null);
+            }}
+          >
+            Ticket
+          </button>
+          <button
+            type="button"
+            className={`segmented-item${mode === "update" ? " active" : ""}`}
+            aria-pressed={mode === "update"}
+            onClick={() => {
+              setMode("update");
+              setSubmitError(null);
+            }}
+          >
+            Update
+          </button>
+        </div>
+      ) : null}
+
+      {mode === "ticket" ? (
+        <div className="board-post-form">
+          <div className="board-post-target" aria-label="Ticket destination">
+            <span className="board-post-target-cue" aria-hidden="true">
+              ⁂
+            </span>
+            <div className="board-post-target-lines">
+              {managers.length > 1 ? (
+                <label className="board-post-project">
+                  <span className="board-post-label">Project</span>
+                  <span className="board-post-select">
+                    <select
+                      value={selectedManagerId ?? ""}
+                      onChange={(event) => onSelectManager(event.target.value)}
+                      aria-label="Project"
+                    >
+                      {managers.map((manager) => (
+                        <option key={manager.id} value={manager.id}>
+                          {manager.project}
+                        </option>
+                      ))}
+                    </select>
+                  </span>
+                </label>
+              ) : (
+                <span className="board-post-target-name">
+                  {project ?? "manager"}
+                </span>
+              )}
+              <span className="board-post-target-sub">
+                {managerReady
+                  ? "manager intake"
+                  : managerMisconfigured
+                    ? "no intake channel configured"
+                    : "loading manager…"}
+              </span>
+            </div>
+          </div>
+
+          <label className="board-post-field">
+            <span className="board-post-label">Title</span>
+            <input
+              className="board-post-input"
+              ref={
+                initialMode === "ticket"
+                  ? (initialFocusRef as RefObject<HTMLInputElement | null>)
+                  : undefined
+              }
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              onKeyDown={(event) => {
+                if (isSubmitChord(event)) {
+                  event.preventDefault();
+                  void submitTicket();
+                }
+              }}
+              placeholder="What needs to happen"
+              aria-label="Ticket title"
+            />
+          </label>
+
+          <label className="board-post-field">
+            <span className="board-post-label">
+              Details <span className="board-post-optional">optional</span>
+            </span>
+            <textarea
+              className="board-post-textarea"
+              value={details}
+              onChange={(event) => setDetails(event.target.value)}
+              onKeyDown={(event) => {
+                if (isSubmitChord(event)) {
+                  event.preventDefault();
+                  void submitTicket();
+                }
+              }}
+              rows={5}
+              placeholder="Context, acceptance criteria, links…"
+              aria-label="Ticket details"
+            />
+          </label>
+
+          <label className="board-post-field board-post-field-inline">
+            <span className="board-post-label">Priority</span>
+            <span className="board-post-select">
+              <select
+                value={effectivePriority}
+                onChange={(event) => setPriority(event.target.value)}
+                aria-label="Priority"
+                disabled={priorityLevels.length === 0}
+              >
+                {(priorityLevels.length > 0
+                  ? priorityLevels
+                  : [DEFAULT_PRIORITY]
+                ).map((level) => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
+              </select>
+            </span>
+          </label>
+
+          {managerMisconfigured ? (
+            <p className="board-post-note board-post-note-warn" role="alert">
+              This project has no configured intake channel. It can’t receive a
+              ticket until that’s set.
+            </p>
+          ) : (
+            <p className="board-post-note">
+              Submitting sends your request to the project’s manager intake. The
+              manager registers it as a ticket shortly after.
+            </p>
+          )}
+
+          {submitError ? (
+            <p className="board-post-error" role="alert">
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="board-post-foot">
+            <span className="board-post-hint" aria-hidden="true">
+              ⌘↵ submit
+            </span>
+            <button
+              type="button"
+              className="primary board-post-submit"
+              onClick={() => void submitTicket()}
+              disabled={posting || !ticketValid}
+            >
+              {posting ? "Submitting…" : "Submit ticket"}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="board-post-form">
+          <div className="board-post-target-picker">
+            <span className="board-post-label">Channel</span>
+            {useNamed ? (
+              <div className="board-post-named">
+                <input
+                  className="board-post-input"
+                  ref={
+                    initialMode === "update" && channels.length === 0
+                      ? (initialFocusRef as RefObject<HTMLInputElement | null>)
+                      : undefined
+                  }
+                  value={namedChannel}
+                  onChange={(event) => setNamedChannel(event.target.value)}
+                  placeholder="channel — e.g. topic:notes"
+                  aria-label="New or named channel"
+                />
+                {channels.length > 0 ? (
+                  <button
+                    type="button"
+                    className="board-post-linkbtn"
+                    onClick={() => setUseNamed(false)}
+                  >
+                    Pick existing
+                  </button>
+                ) : null}
+              </div>
+            ) : (
+              <div className="board-post-picker">
+                <input
+                  className="board-post-input board-post-picker-search"
+                  type="search"
+                  value={pickerSearch}
+                  onChange={(event) => setPickerSearch(event.target.value)}
+                  placeholder="Filter channels"
+                  aria-label="Filter channels"
+                />
+                <div className="board-post-picker-list" role="listbox">
+                  {CHANNEL_GROUP_ORDER.map((group) => {
+                    const rows = groupedChannels[group];
+                    if (rows.length === 0) return null;
+                    return (
+                      <div key={group} className="board-post-picker-group">
+                        <span className="board-post-picker-grouplabel">
+                          {CHANNEL_GROUP_LABELS[group]}
+                        </span>
+                        {rows.map((row) => (
+                          <button
+                            key={row.channel}
+                            type="button"
+                            role="option"
+                            aria-selected={row.channel === existingChannel}
+                            className={`board-post-picker-item${
+                              row.channel === existingChannel ? " is-active" : ""
+                            }`}
+                            onClick={() => setExistingChannel(row.channel)}
+                          >
+                            <span className="board-post-picker-name">
+                              {row.channel}
+                            </span>
+                            <span className="board-post-picker-count">
+                              {row.entry_count}
+                            </span>
+                          </button>
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
+                <button
+                  type="button"
+                  className="board-post-linkbtn"
+                  onClick={() => {
+                    setUseNamed(true);
+                    setNamedChannel("");
+                  }}
+                >
+                  + New or named channel
+                </button>
+              </div>
+            )}
+          </div>
+
+          <div
+            className="segmented segmented-quiet board-post-writemode"
+            role="group"
+            aria-label="Write mode"
+          >
+            <button
+              type="button"
+              className={`segmented-item${
+                writeMode === "append" ? " active" : ""
+              }`}
+              aria-pressed={writeMode === "append"}
+              onClick={() => setWriteMode("append")}
+            >
+              Append
+            </button>
+            <button
+              type="button"
+              className={`segmented-item${writeMode === "cell" ? " active" : ""}`}
+              aria-pressed={writeMode === "cell"}
+              onClick={() => setWriteMode("cell")}
+            >
+              Set cell
+            </button>
+          </div>
+          <p className="board-post-note">
+            {writeMode === "append"
+              ? "Appends a new post to the channel log."
+              : "Sets a keyed cell — the latest value for that key wins."}
+          </p>
+
+          {intakeWarning ? (
+            <p className="board-post-note board-post-note-warn" role="alert">
+              A keyless post here is treated as manager ticket intake.{" "}
+              {ticketAvailable ? (
+                <button
+                  type="button"
+                  className="board-post-linkbtn board-post-inlineswitch"
+                  onClick={() => {
+                    setMode("ticket");
+                    setSubmitError(null);
+                  }}
+                >
+                  Switch to Ticket
+                </button>
+              ) : null}{" "}
+              or choose Set cell / another channel.
+            </p>
+          ) : null}
+
+          {writeMode === "cell" ? (
+            <label className="board-post-field">
+              <span className="board-post-label">Key</span>
+              <input
+                className="board-post-input"
+                value={updateKey}
+                onChange={(event) => setUpdateKey(event.target.value)}
+                placeholder="key — e.g. status"
+                aria-label="Cell key"
+              />
+            </label>
+          ) : null}
+
+          <label className="board-post-field">
+            <span className="board-post-label">Message</span>
+            <textarea
+              className="board-post-textarea"
+              ref={
+                initialMode === "update" && channels.length > 0
+                  ? (initialFocusRef as RefObject<HTMLTextAreaElement | null>)
+                  : undefined
+              }
+              value={updateText}
+              onChange={(event) => setUpdateText(event.target.value)}
+              onKeyDown={(event) => {
+                if (isSubmitChord(event)) {
+                  event.preventDefault();
+                  void submitUpdate();
+                }
+              }}
+              rows={4}
+              placeholder="Message"
+              aria-label="Message"
+            />
+          </label>
+
+          {submitError ? (
+            <p className="board-post-error" role="alert">
+              {submitError}
+            </p>
+          ) : null}
+
+          <div className="board-post-foot">
+            <span className="board-post-hint" aria-hidden="true">
+              ⌘↵ submit
+            </span>
+            <button
+              type="button"
+              className="primary board-post-submit"
+              onClick={() => void submitUpdate()}
+              disabled={posting || !updateValid}
+            >
+              {posting
+                ? writeMode === "cell"
+                  ? "Setting…"
+                  : "Posting…"
+                : writeMode === "cell"
+                  ? "Set cell"
+                  : "Post update"}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/board/BoardPostSheet.tsx
+++ b/frontend/src/components/board/BoardPostSheet.tsx
@@ -309,11 +309,7 @@ export function BoardPostSheet({
               This project has no configured intake channel. It can’t receive a
               ticket until that’s set.
             </p>
-          ) : (
-            <p className="board-post-note">
-              The manager registers this as a ticket shortly after you submit.
-            </p>
-          )}
+          ) : null}
 
           {submitError ? (
             <p className="board-post-error" role="alert">
@@ -359,7 +355,7 @@ export function BoardPostSheet({
                     className="board-post-linkbtn"
                     onClick={() => setUseNamed(false)}
                   >
-                    ← Pick an existing channel
+                    ← Existing channels
                   </button>
                 ) : null}
               </div>

--- a/frontend/src/lib/board.ts
+++ b/frontend/src/lib/board.ts
@@ -1,7 +1,7 @@
 // Board-workspace taxonomy: channel grouping, ticket-state to lane/lamp
 // mapping, and kind/priority tones.
 
-import { ManagerTicket, ManagerTicketState } from "@/lib/types";
+import { BoardChannel, ManagerTicket, ManagerTicketState } from "@/lib/types";
 
 // ─── Channel grouping (navigator) ───
 
@@ -28,6 +28,25 @@ export const CHANNEL_GROUP_COLLAPSED_DEFAULT: Record<ChannelGroupKey, boolean> =
   job: true,
   other: false,
 };
+
+// Bucket channels by group, optionally keeping only those matching a filter.
+export function groupChannels(
+  channels: BoardChannel[],
+  filter?: string,
+): Record<ChannelGroupKey, BoardChannel[]> {
+  const needle = filter?.trim().toLowerCase() ?? "";
+  const groups: Record<ChannelGroupKey, BoardChannel[]> = {
+    manager: [],
+    ticket: [],
+    job: [],
+    other: [],
+  };
+  for (const channel of channels) {
+    if (needle && !channel.channel.toLowerCase().includes(needle)) continue;
+    groups[classifyChannel(channel.channel)].push(channel);
+  }
+  return groups;
+}
 
 // The trailing dash in `-ticket-` keeps `<x>-tickets` out of the ticket group.
 export function classifyChannel(channel: string): ChannelGroupKey {


### PR DESCRIPTION
## Purpose

The board page's posting UI was a raw, always-present `channel / key / message` composer sitting above the lifecycle board. Filing a manager ticket meant knowing which channel is the selected project's intake, finding it in the sidebar (or typing it), then posting free-form text — slow, and in multi-manager mode a valid-looking post could land in the wrong project's intake. This reorganizes the board workspace so the ticket board comes first and replaces the raw composer with one focused **Post** action and a unified sheet that gives ticket intake and generic posting equal standing. Frontend-only; no backend, API, or schema change.

Implements the approved RFC at `.waypoint/specs/rfc-1142-manager-first-board-intake.md`.

## Changes

### Frontend
- `frontend/src/components/board/BoardPostSheet.tsx` — new presentational sheet with peer **Ticket** and **Update** modes (an equal-width `.segmented` control). Ticket mode: project readout, required title, optional details, native priority select; Update mode: a searchable grouped channel picker, append vs. keyed-cell toggle, `New or named channel` creation, and an inline warning when a keyless append targets the selected manager's intake channel. Owns its own isolated per-mode draft state and surfaces submission errors in-sheet.
- `frontend/src/app/board/page.tsx` — removed the raw composer section and its `draftChannel/draftKey/draftText/composerOpen/handlePost` state. Added a single **Post** action plus the project switcher to the workspace toolbar, a channel-header **Post here** shortcut, and an empty-state Post button. Added the `composerMode` model, ticket/update submit handlers (deriving the intake channel from live manager state), a truthful non-blocking confirmation banner, and a synchronous in-flight ref to block duplicate posts. Ticket serializes to a keyless `<title>\n\n<details>` post with `metadata.priority` through the existing `postBoardEntry` intake path.
- `frontend/src/components/Sheet.tsx` — added an optional `initialFocusRef` so the sheet lands initial focus on a named field (the title) instead of the panel, since its open-time `requestAnimationFrame` otherwise steals focus back from a child `autoFocus`.
- `frontend/src/app/globals.css` — removed the `.board-composer*` styles; added `.board-post-*` sheet/form/picker/warning styles, the toolbar action cluster, and the confirmation banner, all tokenized for dark and light. Fixed a mobile overflow where the toolbar's flex content forced the page-shell grid track wider than the viewport (`min-width: 0` on `.board-toolbar`) and dropped redundant labels on narrow screens so the Post action stays reachable.

## Design

The sheet reuses the existing `Sheet` primitive (focus trap, Escape/scrim dismissal, glass chrome, mobile bottom-sheet) rather than a board-local dialog. The opening mode follows the current view — Ticket on a ready manager board, Update on channels, Update when no manager exists — but both modes stay one toggle away and keep their own draft, so a view switch never silently turns a generic update into a ticket intake. Ticket readiness is gated on `managerState.config.id === selectedManagerId`, not merely non-null state, so switching projects (which refetches asynchronously) can never post to the previously selected project's intake. Ticket filing deliberately posts keyless through the board intake channel instead of the direct manager-ticket endpoint, preserving the manager's durable source-of-truth contract: the manager reconciles the keyless post and registers the ticket, so the confirmation copy promises registration "shortly" rather than inventing a ticket id. All colors derive from `:root` tokens and `color-mix()`, so light/dark parity holds without per-theme overrides.

## Test Plan
- `cd frontend && npm run lint` — clean.
- `cd frontend && npm run build` — compiles, TypeScript clean, all routes generated.
- Playwright against the deployed stack (backend `:8797`, frontend `:3010`, seeded `waypoint.host` / `waypoint.token` / `waypoint-theme`) at 1280px and 390px, dark and light: Ticket opens by default on the manager board with initial focus on Title; the ticket POST body was intercepted and asserted to be a keyless `<title>\n\n<details>` with `metadata.priority` to the configured intake channel; Update mode's picker, intake-channel warning (shown on append, hidden on Set cell), keyed-cell key field, and named-channel reveal all work; a real Update post to a throwaway channel showed the truthful confirmation and refreshed live; no-manager mode omits the Ticket toggle and opens Update directly; the mobile toolbar keeps Post fully on-screen.
- Verified no test pollution remained on the live board afterward (throwaway channel deleted; intake channel unchanged).

## Test Result
- `npm run lint` — no findings. `npm run build` — compiled successfully, 11/11 pages generated, TypeScript clean.
- Playwright: all flows above pass across mobile (390px) and desktop (1280px) × dark and light. Captured ticket POST body: `{"text":"E2E smoke title\n\nline one\n\nline two","key":null,"metadata":{"priority":"p1"}}` to `waypoint-tickets`. Post button measured fully within the 390px viewport after the toolbar overflow fix. Light theme resolves the sheet glass, segmented control, warning, and confirmation from tokens.

Addresses ticket 1142.