### PR TITLE
fix: detect claude_tty dialogs when queued messages render below the footer

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -84,18 +84,11 @@ _PLAN_FOOTER = "to approve with this feedback"
 _COMPOSER_PROMPT_RE = re.compile(r"^\s*❯(?:\s|$)")
 _OPTION_PROMPT_RE = re.compile(r"^\s*❯\s*\d+\.")
 
-# The bottom edge of a live inline dialog. When the human sends a follow-up while
-# a turn is still generating, Claude Code queues it and renders each queued message
-# as a leading-❯ line *below* the dialog's footer; a free-text answer field ("Type
-# something") renders the same way. A trailing run of blank / leading-❯ lines that
-# rests directly on such a footer is that dialog output, not the live composer, so
-# `_active_region` skips it rather than slicing the pane to it. "Esc to cancel"
-# ends every inline dialog `classify` recognizes — approval, question, trust,
-# model, effort — so it is the one anchor needed; a new inline dialog adds its
-# footer token here. The plan dialog is excluded on purpose: it renders as a
-# full-pane overlay that covers the transcript, so no queued line ever falls below
-# its footer, and its option rows (`❯ 1.`) are not composer lines, so it already
-# classifies correctly without a guard.
+# Footer tokens marking the bottom edge of a live inline dialog. A trailing run of
+# blank / leading-❯ lines resting on one is queued-message or free-text-field
+# output, not the composer. "Esc to cancel" ends every inline dialog `classify`
+# recognizes; the plan dialog is a full-pane overlay with nothing below its footer,
+# so it needs no token.
 _DIALOG_FOOTER_TOKENS = ("Esc to cancel",)
 
 
@@ -207,12 +200,11 @@ def _is_composer_line(line: str) -> bool:
 
 
 def _rests_on_dialog_footer(lines: list[str], run_end: int) -> int | None:
-    """The footer index a trailing blank / leading-❯ run rests on, else None.
+    """Index of the dialog footer the trailing run ending at ``run_end`` rests on.
 
-    Walks up from ``run_end`` over the contiguous run of blank and composer
-    (leading-``❯``) lines and returns the index of the first line below the run
-    when that line is a live dialog footer. Such a run is queued-message or
-    free-text-field output the TUI draws beneath a dialog, not the live composer.
+    Walks up over the contiguous run of blank and composer (leading-``❯``) lines;
+    returns the index of the line below it when that line is a dialog footer, else
+    None.
     """
     j = run_end
     while j >= 0 and (not lines[j].strip() or _is_composer_line(lines[j])):
@@ -225,16 +217,10 @@ def _rests_on_dialog_footer(lines: list[str], run_end: int) -> int | None:
 def _active_region(lines: list[str]) -> list[str]:
     """The pane text at and below the bottom-most live composer prompt.
 
-    Settled transcript sits above the live composer, so scoping here drops a
-    dialog-signature string an agent merely quoted or pasted into the
-    conversation. A dialog's interactive rows are options (``❯ 1.``), so those
-    never bound the region; but Claude Code renders queued follow-up messages and
-    a dialog's free-text answer field as leading-``❯`` lines *below* the dialog
-    footer, which would otherwise be read as the live composer and slice the
-    dialog above away. A trailing run of such lines resting on a live dialog
-    footer is therefore skipped, and the scan continues above the footer for a
-    real composer boundary; keying on a live footer preserves the scrollback-quote
-    guard, since a quoted marker is not followed by a footer beneath a ``❯`` run.
+    Scoping here drops dialog signatures quoted higher in settled transcript. A
+    trailing run of blank / leading-``❯`` lines resting on a dialog footer is
+    queued messages or a free-text answer field, not the composer, so it is
+    skipped and the scan continues above the footer.
     """
     i = len(lines) - 1
     while i >= 0:

--- a/backend/src/waypoint/backends/claude_tty/pane_dialog.py
+++ b/backend/src/waypoint/backends/claude_tty/pane_dialog.py
@@ -84,6 +84,20 @@ _PLAN_FOOTER = "to approve with this feedback"
 _COMPOSER_PROMPT_RE = re.compile(r"^\s*❯(?:\s|$)")
 _OPTION_PROMPT_RE = re.compile(r"^\s*❯\s*\d+\.")
 
+# The bottom edge of a live inline dialog. When the human sends a follow-up while
+# a turn is still generating, Claude Code queues it and renders each queued message
+# as a leading-❯ line *below* the dialog's footer; a free-text answer field ("Type
+# something") renders the same way. A trailing run of blank / leading-❯ lines that
+# rests directly on such a footer is that dialog output, not the live composer, so
+# `_active_region` skips it rather than slicing the pane to it. "Esc to cancel"
+# ends every inline dialog `classify` recognizes — approval, question, trust,
+# model, effort — so it is the one anchor needed; a new inline dialog adds its
+# footer token here. The plan dialog is excluded on purpose: it renders as a
+# full-pane overlay that covers the transcript, so no queued line ever falls below
+# its footer, and its option rows (`❯ 1.`) are not composer lines, so it already
+# classifies correctly without a guard.
+_DIALOG_FOOTER_TOKENS = ("Esc to cancel",)
+
 
 def _strip_ansi(text: str) -> str:
     return strip_ansi(text)
@@ -192,19 +206,46 @@ def _is_composer_line(line: str) -> bool:
     )
 
 
+def _rests_on_dialog_footer(lines: list[str], run_end: int) -> int | None:
+    """The footer index a trailing blank / leading-❯ run rests on, else None.
+
+    Walks up from ``run_end`` over the contiguous run of blank and composer
+    (leading-``❯``) lines and returns the index of the first line below the run
+    when that line is a live dialog footer. Such a run is queued-message or
+    free-text-field output the TUI draws beneath a dialog, not the live composer.
+    """
+    j = run_end
+    while j >= 0 and (not lines[j].strip() or _is_composer_line(lines[j])):
+        j -= 1
+    if j >= 0 and any(token in lines[j] for token in _DIALOG_FOOTER_TOKENS):
+        return j
+    return None
+
+
 def _active_region(lines: list[str]) -> list[str]:
     """The pane text at and below the bottom-most live composer prompt.
 
     Settled transcript sits above the live composer, so scoping here drops a
     dialog-signature string an agent merely quoted or pasted into the
-    conversation. A real dialog's interactive rows are options (``❯ 1.``), never
-    a leading free-text prompt, so the boundary never slices an actual dialog.
+    conversation. A dialog's interactive rows are options (``❯ 1.``), so those
+    never bound the region; but Claude Code renders queued follow-up messages and
+    a dialog's free-text answer field as leading-``❯`` lines *below* the dialog
+    footer, which would otherwise be read as the live composer and slice the
+    dialog above away. A trailing run of such lines resting on a live dialog
+    footer is therefore skipped, and the scan continues above the footer for a
+    real composer boundary; keying on a live footer preserves the scrollback-quote
+    guard, since a quoted marker is not followed by a footer beneath a ``❯`` run.
     """
-    last_composer = next(
-        (i for i in range(len(lines) - 1, -1, -1) if _is_composer_line(lines[i])),
-        None,
-    )
-    return lines if last_composer is None else lines[last_composer:]
+    i = len(lines) - 1
+    while i >= 0:
+        if not _is_composer_line(lines[i]):
+            i -= 1
+            continue
+        footer_idx = _rests_on_dialog_footer(lines, i)
+        if footer_idx is None:
+            return lines[i:]
+        i = footer_idx - 1
+    return lines
 
 
 def composer_ready(screen: str) -> bool:

--- a/backend/tests/fixtures/claude_tty_pane/approval_with_queued.txt
+++ b/backend/tests/fixtures/claude_tty_pane/approval_with_queued.txt
@@ -1,0 +1,17 @@
+● Write(probe.txt)
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ Create file
+ probe.txt                                                                                                             
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+  1 waypoint-probe
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+ Do you want to create probe.txt?                                                                                       
+ ❯ 1. Yes                                                                                                             
+   2. Yes, allow all edits during this session (shift+tab)                                                            
+   3. No                                                                                                               
+                                                                                                                       
+ Esc to cancel · Tab to amend                                                                                           
+
+  ❯ QMSG-ONE queued during the turn                                                                                     
+  ❯ QMSG-TWO queued during the turn                                                                                   

--- a/backend/tests/fixtures/claude_tty_pane/question_with_one_queued.txt
+++ b/backend/tests/fixtures/claude_tty_pane/question_with_one_queued.txt
@@ -1,0 +1,35 @@
+❯ Use your AskUserQuestion tool right now to ask my favorite color with options red, green, blue. Call the tool as your 
+  very first action, nothing else.                                                                                      
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Fav color 
+
+What is your favorite color?
+
+❯ 1. Red
+     Red
+  2. Green
+     Green
+  3. Blue
+     Blue
+  4. Type something.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                                      
+                                                                                                                      
+
+
+
+  ❯ QMSG-ONE queued during the turn                                                                                     

--- a/backend/tests/fixtures/claude_tty_pane/question_with_two_queued.txt
+++ b/backend/tests/fixtures/claude_tty_pane/question_with_two_queued.txt
@@ -1,0 +1,36 @@
+❯ Use your AskUserQuestion tool right now to ask my favorite color with options red, green, blue. Call the tool as your 
+  very first action, nothing else.                                                                                      
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+ ☐ Fav color 
+
+What is your favorite color?
+
+❯ 1. Red
+     Red
+  2. Green
+     Green
+  3. Blue
+     Blue
+  4. Type something.
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+  5. Chat about this
+
+Enter to select · ↑/↓ to navigate · Esc to cancel
+
+
+
+
+
+
+
+
+
+
+
+                                                                                                                      
+                                                                                                                      
+
+
+
+  ❯ QMSG-ONE queued during the turn                                                                                     
+  ❯ QMSG-TWO queued during the turn                                                                                   

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -35,6 +35,9 @@ def _load(name: str) -> str:
         ("question_dialog.txt", PaneScreen.QUESTION),
         ("question_dialog_single.txt", PaneScreen.QUESTION),
         ("question_dialog_notes.txt", PaneScreen.QUESTION),
+        ("question_with_one_queued.txt", PaneScreen.QUESTION),
+        ("question_with_two_queued.txt", PaneScreen.QUESTION),
+        ("approval_with_queued.txt", PaneScreen.APPROVAL),
         ("trust_dialog.txt", PaneScreen.TRUST),
         ("model_selector.txt", PaneScreen.MODEL_SELECTOR),
         ("effort_popup.txt", PaneScreen.EFFORT_POPUP),
@@ -53,6 +56,9 @@ def test_classify(fixture: str, expected: PaneScreen) -> None:
         ("approval_bash.txt", True),
         ("plan_approval.txt", True),
         ("question_dialog.txt", True),
+        ("question_with_one_queued.txt", True),
+        ("question_with_two_queued.txt", True),
+        ("approval_with_queued.txt", True),
         ("trust_dialog.txt", True),
         ("model_selector.txt", True),
         ("effort_popup.txt", True),
@@ -393,6 +399,96 @@ def test_glyph_in_dialog_body_does_not_truncate_region() -> None:
     assert (
         dialog is not None and dialog.question == "Do you want to create probe_out.txt?"
     )
+
+
+def test_queued_messages_below_footer_do_not_mask_dialog() -> None:
+    # Captured live (Claude Code 2.1.x): a human who sends a follow-up while the
+    # turn is still generating has it queued and rendered as a leading-❯ line below
+    # the live dialog's footer. The region selector must skip that trailing run
+    # (any depth) rather than slice the pane to it, or the dialog above is dropped
+    # and classify returns OTHER — the session hangs on an unanswerable prompt.
+    one = _load("question_with_one_queued.txt")
+    two = _load("question_with_two_queued.txt")
+    assert "❯ QMSG-ONE" in one
+    assert "❯ QMSG-ONE" in two and "❯ QMSG-TWO" in two
+    assert classify(one) is PaneScreen.QUESTION
+    assert classify(two) is PaneScreen.QUESTION
+    assert shows_blocking_dialog(one) is True
+    assert shows_blocking_dialog(two) is True
+
+
+def test_approval_with_queued_still_parses() -> None:
+    # A tool-approval dialog with queued messages beneath its footer must both
+    # classify as APPROVAL and parse the live tool/target/options — the tailer
+    # surfaces the card and the transport still refuses to send into it.
+    dialog = parse_approval(_load("approval_with_queued.txt"))
+    assert dialog is not None
+    assert dialog.tool_name == "Write"
+    assert dialog.target == "probe.txt"
+    assert dialog.question == "Do you want to create probe.txt?"
+    assert [o.number for o in dialog.options] == [1, 2, 3]
+    assert dialog.approve_option is not None and dialog.approve_option.number == 1
+    assert dialog.decline_option is not None and dialog.decline_option.number == 3
+
+
+def test_freetext_answer_field_below_footer_classifies() -> None:
+    # The AskUserQuestion "Type something" option opens a free-text ❯ field that
+    # renders below the footer exactly like a single queued message (the N=1 case).
+    # It must not be read as the live composer.
+    screen = "\n".join(
+        [
+            " ☐ Fav color",
+            "What is your favorite color?",
+            "❯ 1. Red",
+            "  2. Green",
+            "  3. Blue",
+            "  4. Type something.",
+            "Enter to select · ↑/↓ to navigate · Esc to cancel",
+            "",
+            "  ❯ ",
+        ]
+    )
+    assert classify(screen) is PaneScreen.QUESTION
+    assert shows_blocking_dialog(screen) is True
+
+
+def test_queued_messages_with_no_dialog_do_not_classify() -> None:
+    # The no-dialog counterpart: queued messages sit in the transcript flow above
+    # the *true* composer (the dim "Press up to edit queued messages" ghost),
+    # whose status footer is present below it. No dialog footer rests under the
+    # trailing run, so the region bounds at the true composer and stays OTHER.
+    screen = "\n".join(
+        [
+            "❯ QMSG-ONE queued during the turn",
+            "",
+            "❯ QMSG-TWO queued during the turn",
+            "────────────────────────────",
+            "❯ Press up to edit queued messages",
+            "────────────────────────────",
+            "  ⏸ manual mode on · esc to interrupt · ← for agents",
+        ]
+    )
+    assert classify(screen) is PaneScreen.OTHER
+    assert shows_blocking_dialog(screen) is False
+
+
+def test_quoted_footer_directly_above_composer_does_not_mask_it() -> None:
+    # FR4 guard under the new run-aware skip: a dialog footer quoted in transcript,
+    # directly above a live composer holding a typed reply (its status footer
+    # below), must not be read as a live dialog. The composer does not rest on the
+    # quoted footer — a rule line and the status footer sit between — so the skip
+    # never fires and the region bounds at the composer.
+    screen = "\n".join(
+        [
+            "● As I said the footer reads Esc to cancel · Tab to amend",
+            "────────────────────────────",
+            "❯ yes, go ahead and implement it",
+            "────────────────────────────",
+            "  ⏸ manual mode on · ? for shortcuts · ← for agents",
+        ]
+    )
+    assert classify(screen) is PaneScreen.OTHER
+    assert shows_blocking_dialog(screen) is False
 
 
 def test_composer_is_empty_for_bare_prompt() -> None:


### PR DESCRIPTION
## Purpose

The `claude_tty` transport classifies Claude Code dialogs (approval, plan, question, trust, model, effort) by reading the rendered tmux pane. When the human sends a follow-up while a turn is still generating, Claude Code queues it and renders each queued message as a leading-`❯` line *below* the live dialog's footer. `_active_region` treated the bottom-most such line as the live composer and sliced the pane to it, dropping the dialog above; `classify` then returned `OTHER`, so the tailer never surfaced the dialog and never dismissed it — the session hung on an unanswerable prompt that was invisible in Waypoint, and `shows_blocking_dialog` returned `False` so the transport would paste straight into the dialog. Autonomously-spawned sessions stalled indefinitely. Implements the approved RFC at `.waypoint/specs/rfc-claude-tty-queued-message-active-region.md`.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_tty/pane_dialog.py` — `_active_region` now skips a contiguous trailing run of blank / leading-`❯` lines that rests directly on a live dialog footer and keeps scanning above the footer for a real composer boundary (returning the full pane when none exists), instead of stopping at the bottom-most `❯` line. New helper `_rests_on_dialog_footer` walks the run and matches the footer against `_DIALOG_FOOTER_TOKENS`. `shows_blocking_dialog` is fixed transitively; the tailer is unchanged.
- `backend/tests/test_claude_tty_pane_dialog.py` — cover the queued-message layout at depth 1 and 2, approval-with-queue (classify + `parse_approval`), the free-text answer field (the N=1 case), the no-dialog queued-messages-in-transcript case, and the scrollback-quote guard under the new skip. Existing fixtures keep their classifications.
- `backend/tests/fixtures/claude_tty_pane/{question_with_one_queued,question_with_two_queued,approval_with_queued}.txt` — live captures (Claude Code 2.1.x) of a dialog with queued messages beneath its footer.

## Design

The skip fires only when a live dialog footer sits directly beneath the trailing `❯` run, which preserves the existing scrollback-quote guard: a marker quoted in settled transcript is not followed by a live footer under a `❯` run, and a true composer rests on a rule/status-footer line, not a dialog footer. `_DIALOG_FOOTER_TOKENS` is the single anchor `Esc to cancel`, which ends every *inline* dialog `classify` recognizes (approval, question, trust, model, effort). The plan (ExitPlanMode) dialog is excluded on purpose: live captures confirm it renders as a full-pane overlay that covers the transcript, so no queued line ever falls below its footer, and its option rows (`❯ 1.`) are already excluded from the composer probe — it classifies correctly without a guard. Detection stays a pure O(lines) function of the snapshot; no new pane captures.

## Test Plan
- `cd backend && uv run pytest tests/test_claude_tty_pane_dialog.py` — 62 passed.
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- End-to-end against the deployed backend (`waypointctl restart backend` on this branch): started a throwaway `claude_tty` session, drove an `AskUserQuestion` popup, and queued two messages during the turn so they rendered below the footer — the exact failing layout.

## Test Result
- `uv run pytest tests/test_claude_tty_pane_dialog.py` — 62 passed.
- Pre-fix control (same real fixtures, old boundary): region collapses to a single line and `classify` returns `other`. Post-fix: `question_with_one_queued` and `question_with_two_queued` classify `question`, `approval_with_queued` classifies `approval` and `parse_approval` still returns the correct tool/target/options.
- E2E on the deployed fix: the queued-below `AskUserQuestion` pane classified `question`, the tailer dismissed the popup and flushed the structured question into the transcript (surfaced in the session's events with full question + options), and the session returned to `idle` (unblocked). Pre-fix the same layout hangs the session with no card in Waypoint.

Addresses ticket 1178.