### PR TITLE
fix: recover claude_tty approval tool from the transcript when the dialog overflows the pane

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -115,9 +115,27 @@ class TranscriptNormalizer:
         # the body captured here when it surfaces the plan-approval card.
         self.last_plan_path: str | None = None
         self.last_plan_content: str | None = None
+        # tool_use records flushed to the transcript but not yet resolved by a
+        # tool_result, keyed by tool_use id in submission order. A permission
+        # dialog (Bash, file op, MCP …) flushes its tool_use — with the full,
+        # untruncated input — before the TUI draws the box, so the tailer reads
+        # the pending tool here to build the approval card when a tall dialog
+        # overflows the pane and drops the tool label/header (ticket 1191).
+        self._pending_tool_uses: dict[str, tuple[str, dict[str, Any]]] = {}
 
     def arm_question_dismissal(self) -> None:
         self._expect_dismissed_question = True
+
+    @property
+    def pending_tool_use(self) -> tuple[str, dict[str, Any]] | None:
+        """The oldest unresolved tool_use (name, input), or None.
+
+        The pane prompts batched tool calls in submission order, so the oldest
+        still-unresolved record is the one the current dialog is asking about.
+        """
+        for name, tool_input in self._pending_tool_uses.values():
+            return name, tool_input
+        return None
 
     def process_record(self, record: dict[str, Any]) -> list[NormalizedEvent]:
         rec_type = record.get("type")
@@ -274,6 +292,11 @@ class TranscriptNormalizer:
                     self._maybe_capture_plan(tool_name, block.get("input") or {})
                     if tool_use_id:
                         self._file_edit_tool_use_ids.add(tool_use_id)
+                if tool_use_id:
+                    self._pending_tool_uses[tool_use_id] = (
+                        tool_name,
+                        block.get("input") or {},
+                    )
                 input_text = json.dumps(block.get("input") or {}, indent=2)
                 events.append(
                     NormalizedEvent(
@@ -315,6 +338,10 @@ class TranscriptNormalizer:
         ):
             if message_id:
                 self._result_emitted_ids.add(message_id)
+            # The turn resolved with no tool_use pending approval; any survivors
+            # in the map are stale (never resolved by a tool_result) and must not
+            # leak into the next turn's approval recovery.
+            self._pending_tool_uses.clear()
             usage_payload: dict[str, Any] = usage if first_seen else {}
             output_tokens = int(usage.get("output_tokens") or 0)
             if stop_reason == "end_turn":
@@ -382,6 +409,8 @@ class TranscriptNormalizer:
             if block.get("type") != "tool_result":
                 continue
             tool_use_id = str(block.get("tool_use_id") or "")
+            if tool_use_id:
+                self._pending_tool_uses.pop(tool_use_id, None)
             if tool_use_id and tool_use_id in self._dismissed_question_ids:
                 # The "user rejected" result the TUI writes when we Esc the
                 # popup to surface it. Drop it so the question card stays

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -115,12 +115,10 @@ class TranscriptNormalizer:
         # the body captured here when it surfaces the plan-approval card.
         self.last_plan_path: str | None = None
         self.last_plan_content: str | None = None
-        # tool_use records flushed to the transcript but not yet resolved by a
-        # tool_result, keyed by tool_use id in submission order. A permission
-        # dialog (Bash, file op, MCP …) flushes its tool_use — with the full,
-        # untruncated input — before the TUI draws the box, so the tailer reads
-        # the pending tool here to build the approval card when a tall dialog
-        # overflows the pane and drops the tool label/header (ticket 1191).
+        # Unresolved tool_use records (name + full input) in submission order.
+        # The tool_use is flushed with its untruncated input before the
+        # permission dialog blocks, so the tailer recovers the tool from here
+        # when a tall dialog overflows the pane and drops its label off-screen.
         self._pending_tool_uses: dict[str, tuple[str, dict[str, Any]]] = {}
 
     def arm_question_dismissal(self) -> None:
@@ -130,8 +128,8 @@ class TranscriptNormalizer:
     def pending_tool_use(self) -> tuple[str, dict[str, Any]] | None:
         """The oldest unresolved tool_use (name, input), or None.
 
-        The pane prompts batched tool calls in submission order, so the oldest
-        still-unresolved record is the one the current dialog is asking about.
+        Batched calls prompt in submission order, so the oldest is the one the
+        current dialog is asking about.
         """
         for name, tool_input in self._pending_tool_uses.values():
             return name, tool_input
@@ -338,9 +336,8 @@ class TranscriptNormalizer:
         ):
             if message_id:
                 self._result_emitted_ids.add(message_id)
-            # The turn resolved with no tool_use pending approval; any survivors
-            # in the map are stale (never resolved by a tool_result) and must not
-            # leak into the next turn's approval recovery.
+            # Turn resolved; drop any tool_use that never got a result so it
+            # cannot leak into the next turn's approval recovery.
             self._pending_tool_uses.clear()
             usage_payload: dict[str, Any] = usage if first_seen else {}
             output_tokens = int(usage.get("output_tokens") or 0)

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -368,15 +368,29 @@ class TranscriptTailer:
         decline_num = decline_opt.number if decline_opt else None
 
         approval_id = str(uuid.uuid4())
-        tool_name = dialog.tool_name or "Unknown"
         target = dialog.target or ""
 
-        if tool_name == "Bash":
-            tool_input: dict[str, str] = {"command": target}
-        elif tool_name in {"Write", "Edit", "MultiEdit"}:
-            tool_input = {"file_path": target}
-        else:
-            tool_input = {"description": target}
+        # A dialog whose box overflows the pane drops its tool label/header, so
+        # `parse_approval` yields tool_name=None (the "Approve Unknown" card of
+        # ticket 1191). The pending tool_use in the transcript carries the real
+        # tool and its full, untruncated input — recover from there, the way the
+        # plan-approval card reads the plan body off the normalizer.
+        tool_name = dialog.tool_name
+        tool_input: dict[str, Any] | None = None
+        if tool_name is None:
+            pending = self._normalizer.pending_tool_use
+            if pending is not None:
+                tool_name, pending_input = pending
+                tool_input = dict(pending_input)
+        if tool_name is None:
+            tool_name = "Unknown"
+        if tool_input is None:
+            if tool_name == "Bash":
+                tool_input = {"command": target}
+            elif tool_name in {"Write", "Edit", "MultiEdit"}:
+                tool_input = {"file_path": target}
+            else:
+                tool_input = {"description": target}
 
         payload: dict[str, Any] = {"tool_name": tool_name, "tool_input": tool_input}
         text = format_approval_text(payload)

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -369,28 +369,7 @@ class TranscriptTailer:
 
         approval_id = str(uuid.uuid4())
         target = dialog.target or ""
-
-        # A dialog whose box overflows the pane drops its tool label/header, so
-        # `parse_approval` yields tool_name=None (the "Approve Unknown" card of
-        # ticket 1191). The pending tool_use in the transcript carries the real
-        # tool and its full, untruncated input — recover from there, the way the
-        # plan-approval card reads the plan body off the normalizer.
-        tool_name = dialog.tool_name
-        tool_input: dict[str, Any] | None = None
-        if tool_name is None:
-            pending = self._normalizer.pending_tool_use
-            if pending is not None:
-                tool_name, pending_input = pending
-                tool_input = dict(pending_input)
-        if tool_name is None:
-            tool_name = "Unknown"
-        if tool_input is None:
-            if tool_name == "Bash":
-                tool_input = {"command": target}
-            elif tool_name in {"Write", "Edit", "MultiEdit"}:
-                tool_input = {"file_path": target}
-            else:
-                tool_input = {"description": target}
+        tool_name, tool_input = self._resolve_approval_tool(dialog)
 
         payload: dict[str, Any] = {"tool_name": tool_name, "tool_input": tool_input}
         text = format_approval_text(payload)
@@ -429,6 +408,28 @@ class TranscriptTailer:
             },
             SessionStatus.WAITING_INPUT,
         )
+
+    def _resolve_approval_tool(
+        self, dialog: pane_dialog.ApprovalDialog
+    ) -> tuple[str, dict[str, Any]]:
+        """Tool name and input for the approval card.
+
+        A dialog whose box overflows the pane drops its tool label, so
+        `parse_approval` yields tool_name=None; recover the tool and its full,
+        untruncated input from the pending transcript tool_use in that case.
+        """
+        if dialog.tool_name is None:
+            pending = self._normalizer.pending_tool_use
+            if pending is not None:
+                name, tool_input = pending
+                return name, dict(tool_input)
+        tool_name = dialog.tool_name or "Unknown"
+        target = dialog.target or ""
+        if tool_name == "Bash":
+            return tool_name, {"command": target}
+        if tool_name in {"Write", "Edit", "MultiEdit"}:
+            return tool_name, {"file_path": target}
+        return tool_name, {"description": target}
 
     async def _surface_plan_dialog(self, session: SessionRecord, snapshot: str) -> None:
         """Surface the ExitPlanMode dialog as the same approval card Chat shows.

--- a/backend/tests/fixtures/claude_tty_pane/overflow_bash.txt
+++ b/backend/tests/fixtures/claude_tty_pane/overflow_bash.txt
@@ -1,0 +1,50 @@
+   touch "$BASE/item_32.txt"
+   touch "$BASE/item_33.txt"
+   touch "$BASE/item_34.txt"
+   touch "$BASE/item_35.txt"
+   touch "$BASE/item_36.txt"
+   touch "$BASE/item_37.txt"
+   touch "$BASE/item_38.txt"
+   touch "$BASE/item_39.txt"
+   touch "$BASE/item_40.txt"
+   touch "$BASE/item_41.txt"
+   touch "$BASE/item_42.txt"
+   touch "$BASE/item_43.txt"
+   touch "$BASE/item_44.txt"
+   touch "$BASE/item_45.txt"
+   touch "$BASE/item_46.txt"
+   touch "$BASE/item_47.txt"
+   touch "$BASE/item_48.txt"
+   touch "$BASE/item_49.txt"
+   touch "$BASE/item_50.txt"
+   touch "$BASE/item_51.txt"
+   touch "$BASE/item_52.txt"
+   touch "$BASE/item_53.txt"
+   touch "$BASE/item_54.txt"
+   touch "$BASE/item_55.txt"
+   touch "$BASE/item_56.txt"
+   touch "$BASE/item_57.txt"
+   touch "$BASE/item_58.txt"
+   touch "$BASE/item_59.txt"
+   touch "$BASE/item_60.txt"
+   touch "$BASE/item_61.txt"
+   touch "$BASE/item_62.txt"
+   touch "$BASE/item_63.txt"
+   touch "$BASE/item_64.txt"
+   touch "$BASE/item_65.txt"
+   touch "$BASE/item_66.txt"
+   touch "$BASE/item_67.txt"
+   touch "$BASE/item_68.txt"
+   touch "$BASE/item_69.txt"
+   touch "$BASE/item_70.txt"
+   echo "bigtree created with 70 items under $BASE"
+   Run shell command
+
+ This command requires approval
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and don't ask again for similar commands in /tmp/cctty-repro-1191
+   3. No
+
+ Esc to cancel · Tab to amend · ctrl+e to explain

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -196,6 +196,55 @@ async def test_stable_plan_dialog_emits_exit_plan_approval() -> None:
     assert pending.is_plan is True
 
 
+async def test_overflow_bash_dialog_recovers_tool_from_transcript() -> None:
+    # A long Bash command's approval box overflows the pane, so the "Bash
+    # command" label + header scroll off and parse_approval yields tool_name=None
+    # (the "Approve Unknown" card of ticket 1191). The pending tool_use in the
+    # transcript carries the real tool + full command, so the surfaced card is a
+    # proper Bash approval with the complete command.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("overflow_bash.txt"))
+    tailer = _make_tailer(plugin, runtime)
+    command = "\n".join(f'touch "$BASE/item_{i:02d}.txt"' for i in range(1, 71))
+    tailer._normalizer._pending_tool_uses["tu-1"] = ("Bash", {"command": command})
+
+    await tailer._poll_dialog()  # tick 1: debounce
+    await tailer._poll_dialog()  # tick 2: stable → emit
+    runtime._emit_adapter_event.assert_called_once()
+
+    call = runtime._emit_adapter_event.call_args
+    assert call.args[1] is EventKind.APPROVAL_REQUEST
+    assert call.args[2] == f"Approve Bash command:\n{command}"
+    meta = call.args[3]
+    assert meta["tool_name"] == "Bash"
+    assert meta["tool_input"] == {"command": command}
+    assert meta["method"] == "tty_permission"
+
+    pending = plugin._pending_approvals["sess-1"]
+    assert pending.tool_name == "Bash"
+    assert pending.approve_number == 1
+    assert pending.decline_number == 3
+
+
+async def test_overflow_dialog_without_transcript_falls_back_to_unknown() -> None:
+    # With nothing pending in the transcript the surfaced card degrades to the
+    # prior "Unknown" behaviour rather than crashing — the recovery is additive
+    # and never leaves `target` unbound.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("overflow_bash.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    await tailer._poll_dialog()
+    await tailer._poll_dialog()
+    runtime._emit_adapter_event.assert_called_once()
+
+    meta = runtime._emit_adapter_event.call_args.args[3]
+    assert meta["tool_name"] == "Unknown"
+    assert meta["tool_input"] == {"description": ""}
+
+
 async def test_plan_dialog_restores_auto_mode_via_auto_option() -> None:
     plugin = ClaudeTtyPlugin()
     session = _make_session(permission_mode="plan")

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -1169,3 +1169,62 @@ def test_non_plan_file_write_does_not_capture_plan() -> None:
     )
     assert norm.last_plan_path is None
     assert norm.last_plan_content is None
+
+
+# ── pending tool_use tracking (approval recovery for overflowing dialogs) ──────
+
+
+def test_pending_tool_use_tracks_bash_until_result() -> None:
+    # A tall Bash approval drops its label off the pane, so the tailer recovers
+    # the tool + full command from the pending (unresolved) transcript tool_use.
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "m1",
+            [_tool_use_block("tu-1", "Bash", {"command": "echo hi"})],
+            stop_reason="tool_use",
+        )
+    )
+    assert norm.pending_tool_use == ("Bash", {"command": "echo hi"})
+
+    norm.process_record(_user_record([_tool_result_block("tu-1", "hi")]))
+    assert norm.pending_tool_use is None
+
+
+def test_pending_tool_use_is_fifo_oldest_first() -> None:
+    # Batched tool calls are prompted in submission order, so the oldest
+    # unresolved tool_use is the one the current dialog is asking about.
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "m1",
+            [
+                _tool_use_block("tu-1", "Bash", {"command": "first"}),
+                _tool_use_block("tu-2", "Bash", {"command": "second"}),
+            ],
+            stop_reason="tool_use",
+        )
+    )
+    assert norm.pending_tool_use == ("Bash", {"command": "first"})
+
+    norm.process_record(_user_record([_tool_result_block("tu-1", "ok")]))
+    assert norm.pending_tool_use == ("Bash", {"command": "second"})
+
+
+def test_pending_tool_use_cleared_on_turn_complete() -> None:
+    # A pending tool_use that never got a matching result must not leak into the
+    # next turn's approval recovery once the turn resolves.
+    norm = TranscriptNormalizer()
+    norm.process_record(
+        _assistant_record(
+            "m1",
+            [_tool_use_block("tu-1", "Bash", {"command": "echo hi"})],
+            stop_reason="tool_use",
+        )
+    )
+    assert norm.pending_tool_use is not None
+
+    norm.process_record(
+        _assistant_record("m2", [_text_block("done")], stop_reason="end_turn")
+    )
+    assert norm.pending_tool_use is None

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -315,12 +315,10 @@ def test_body_extraction_ignores_earlier_scrollback_label() -> None:
 
 
 def test_overflow_bash_approval_yields_no_tool_but_valid_options() -> None:
-    # A long Bash command's approval box is taller than the pane, so Claude Code
-    # drops the box top — the "Bash command" label and the tool header scroll off
-    # and are absent from the capture. The tool/target can no longer be read off
-    # the pane, but classify still recognizes the approval and the options parse.
-    # That is what lets the tailer approve/decline correctly while it recovers the
-    # tool name + full command from the transcript instead (ticket 1191).
+    # A long Bash command's box overflows the pane, dropping the "Bash command"
+    # label and tool header off the capture. The tool can no longer be read off
+    # the pane, but classify and the options still parse — enough for the tailer
+    # to approve/decline while it recovers the tool from the transcript.
     dialog = parse_approval(_load("overflow_bash.txt"))
     assert dialog is not None
     assert dialog.tool_name is None

--- a/backend/tests/test_claude_tty_pane_dialog.py
+++ b/backend/tests/test_claude_tty_pane_dialog.py
@@ -38,6 +38,7 @@ def _load(name: str) -> str:
         ("question_with_one_queued.txt", PaneScreen.QUESTION),
         ("question_with_two_queued.txt", PaneScreen.QUESTION),
         ("approval_with_queued.txt", PaneScreen.APPROVAL),
+        ("overflow_bash.txt", PaneScreen.APPROVAL),
         ("trust_dialog.txt", PaneScreen.TRUST),
         ("model_selector.txt", PaneScreen.MODEL_SELECTOR),
         ("effort_popup.txt", PaneScreen.EFFORT_POPUP),
@@ -59,6 +60,7 @@ def test_classify(fixture: str, expected: PaneScreen) -> None:
         ("question_with_one_queued.txt", True),
         ("question_with_two_queued.txt", True),
         ("approval_with_queued.txt", True),
+        ("overflow_bash.txt", True),
         ("trust_dialog.txt", True),
         ("model_selector.txt", True),
         ("effort_popup.txt", True),
@@ -310,6 +312,22 @@ def test_body_extraction_ignores_earlier_scrollback_label() -> None:
     assert dialog.tool_name == "Bash"
     assert dialog.target == "mkdir /tmp/cc-tty-probe/probe_subdir"
     assert dialog.target != "rm -rf /decoy"
+
+
+def test_overflow_bash_approval_yields_no_tool_but_valid_options() -> None:
+    # A long Bash command's approval box is taller than the pane, so Claude Code
+    # drops the box top — the "Bash command" label and the tool header scroll off
+    # and are absent from the capture. The tool/target can no longer be read off
+    # the pane, but classify still recognizes the approval and the options parse.
+    # That is what lets the tailer approve/decline correctly while it recovers the
+    # tool name + full command from the transcript instead (ticket 1191).
+    dialog = parse_approval(_load("overflow_bash.txt"))
+    assert dialog is not None
+    assert dialog.tool_name is None
+    assert dialog.target is None
+    assert dialog.question == "Do you want to proceed?"
+    assert dialog.approve_option is not None and dialog.approve_option.number == 1
+    assert dialog.decline_option is not None and dialog.decline_option.number == 3
 
 
 def test_classify_robust_to_wrapped_footer() -> None:


### PR DESCRIPTION
## Purpose

Follow-up to #355. Users reported (bug1.png/bug2.png) that a `claude_tty` tool-permission card can render as the useless `Approve Unknown: {"description": ""}`. The `claude_tty` transport reads permission dialogs off the rendered tmux pane, and the pane has no scrollback — Claude Code redraws in place, so `capture-pane -S -N` only ever returns the visible rows (verified: a 120×50 pane returns 50 lines even at `-S -500`). When a Bash command is long enough that its permission box is taller than the pane, Claude Code drops the box top: the `────` border, the ` Bash command` label, and the tool header all scroll out of the capture, leaving only the command tail + `Do you want to proceed?` + options + footer. `parse_approval` then finds no body label, no file-op question, and no `● Tool(arg)` header, so `_extract_tool_target` returns `(None, None)`; the tailer maps that to `tool_name="Unknown"`, empty target → `tool_input={"description": ""}` → the malformed card. bug1.png is the ground-truth overflowing pane; bug2.png is the card Waypoint produced from it. The queued message beneath the footer in bug1.png is incidental — the malformed extraction reproduces with or without it, and #355's active-region logic still classifies the pane as `APPROVAL`.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_tty/normalize.py` — `TranscriptNormalizer` now tracks unresolved `tool_use` records (name + full input) keyed by id in submission order: recorded when a non-suppressed `tool_use` block is seen, popped when its matching `tool_result` arrives, and cleared wholesale when a turn resolves without a pending approval (so a stale entry cannot leak into the next turn). A `pending_tool_use` property returns the oldest unresolved record — the one a batched, sequentially-prompted dialog is currently asking about.
- `backend/src/waypoint/backends/claude_tty/tailer.py` — `_surface_approval` falls back to `self._normalizer.pending_tool_use` for the tool name and full `tool_input` **only when the pane yielded `tool_name is None`** (the overflow case), mirroring how `_surface_plan_dialog` reads the plan body off the normalizer. The pane still supplies the approve/decline option numbers, question, and debounce signature, and a genuinely unrecoverable dialog degrades to the prior `Unknown` behavior instead of crashing. The working short-dialog and file-op paths are untouched.
- `backend/tests/fixtures/claude_tty_pane/overflow_bash.txt` — a live capture (Claude Code 2.1.x) of a 70-line Bash command whose box overflows the pane and drops the label/header.

### Tests
- `test_claude_tty_pane_dialog.py` — the overflow fixture classifies `APPROVAL` and blocks, and `parse_approval` returns `tool_name=None`/`target=None` with the options and question still parsed (documents the pane limitation the tailer compensates for).
- `test_claude_tty_normalize.py` — a Bash `tool_use` sets `pending_tool_use`; its `tool_result` clears it; batched calls return oldest-first (FIFO); a turn completing clears a never-resolved survivor.
- `test_claude_tty_approval.py` — surfacing an overflow-Bash approval with a seeded pending `tool_use` emits a proper `Approve Bash` card with the full multi-line command, and with nothing pending it falls back to `Unknown`/`{"description": ""}` without error.

## Design

The assistant's `tool_use` record — carrying the full, untruncated input — is flushed to the transcript while the permission dialog blocks (verified: the complete 70-line command is present in the thread JSONL before the human answers). This is unlike `AskUserQuestion`, whose `tool_use` is withheld until the Esc dismissal, so no analogous latch is needed here. The recovery keys on the transcript, not on guessing a truncated command out of the pane, so the card matches the Chat card exactly. The debounce `signature` stays pane-based (`tool_name:target:question`) rather than incorporating the recovered name: the pane values are stable across polls, the tailer drains the transcript into the normalizer immediately before each dialog poll, and surfacing waits two stable ticks — so the pending `tool_use` is in hand by the time the card is emitted. Recovery fires for any `tool_name is None` (not only Bash); the transcript is ground truth for whichever tool is running, and the FIFO + clear-on-result/clear-on-turn-complete rules keep it pointed at the currently-prompting call.

## Test Plan
- `cd backend && uv run pytest tests/test_claude_tty_*.py` — 248 passed.
- `cd backend && uv run pytest` — 2615 passed.
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.

## Test Result
- Root cause confirmed against a live `claude_tty` session driven to overflow: `parse_approval` on the real capture returns `classify=approval`, `tool_name=None`, `target=None`, options `[1 Yes / 2 Yes-always / 3 No]`.
- Post-fix the tailer surfaces `Approve Bash command:\n<full command>` from that same capture (via the seeded transcript `tool_use`) instead of `Approve Unknown: {"description": ""}`. Full-suite green as above. Live end-to-end screenshotting was not run — driving a long/dangerous Bash approval is flaky (the sub-agent refuses) and a stack restart would interrupt the running tech-lead session; the exact surfacing path is exercised by the tailer test against the genuine captured overflow pane.

Addresses ticket 1191.