### PR TITLE
feat: add custom model catalogue (extra_models) for the Claude agent

### DIFF
--- a/backend/src/waypoint/backends/claude_code/__init__.py
+++ b/backend/src/waypoint/backends/claude_code/__init__.py
@@ -1,6 +1,7 @@
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
+    merge_model_catalogue,
 )
 from waypoint.backends.claude_code.permission_modes import (
     CLAUDE_ACCEPT_EDITS_TOOLS,
@@ -30,4 +31,5 @@ __all__ = [
     "ClaudeThreadSummary",
     "DEFAULT_CLAUDE_MODELS",
     "build_plugin",
+    "merge_model_catalogue",
 ]

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -5,7 +5,7 @@ binary; bumped manually when a new alias ships. Codex has a runtime
 ``model/list`` RPC, Claude does not.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 
 from waypoint.schemas import BackendModelOption
 
@@ -64,6 +64,9 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         id="haiku",
         label="Haiku 4.5",
         description="Fast and lightweight",
+        # No --effort knob; pinned to [] so the three-state default flip
+        # (None = unknown/lenient) keeps rejecting an effort on Haiku.
+        supported_efforts=[],
     ),
     BackendModelOption(
         id="opus[1m]",
@@ -95,6 +98,41 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         default_effort="high",
     ),
 )
+
+
+_BUILTIN_MODEL_IDS: frozenset[str] = frozenset(opt.id for opt in DEFAULT_CLAUDE_MODELS)
+
+
+def merge_model_catalogue(
+    base: Sequence[BackendModelOption],
+    extra: list[BackendModelOption],
+) -> list[BackendModelOption]:
+    """Append ``extra`` to ``base``.
+
+    An extra whose id matches a base entry replaces that entry in place
+    (preserving position), which lets an operator relabel or re-effort a
+    built-in. Net-new extras append in declared order.
+    """
+    merged = list(base)
+    index_by_id = {opt.id: i for i, opt in enumerate(merged)}
+    for opt in extra:
+        existing = index_by_id.get(opt.id)
+        if existing is None:
+            index_by_id[opt.id] = len(merged)
+            merged.append(opt)
+        else:
+            merged[existing] = opt
+    return merged
+
+
+def overridden_builtin_ids(extra: list[BackendModelOption]) -> list[str]:
+    """The ``extra`` ids that collide with a current-epoch built-in.
+
+    A startup-time approximation: the reference set is ``DEFAULT_CLAUDE_MODELS``
+    and does not know a target's CLI version, which is sufficient for surfacing
+    an accidental override of a shipping alias.
+    """
+    return [opt.id for opt in extra if opt.id in _BUILTIN_MODEL_IDS]
 
 
 def normalize_claude_model_id(model: str | None) -> str | None:

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -64,8 +64,7 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         id="haiku",
         label="Haiku 4.5",
         description="Fast and lightweight",
-        # No --effort knob; pinned to [] so the three-state default flip
-        # (None = unknown/lenient) keeps rejecting an effort on Haiku.
+        # No effort knob; explicit [] so the None default (unknown) still rejects.
         supported_efforts=[],
     ),
     BackendModelOption(
@@ -126,11 +125,10 @@ def merge_model_catalogue(
 
 
 def overridden_builtin_ids(extra: list[BackendModelOption]) -> list[str]:
-    """The ``extra`` ids that collide with a current-epoch built-in.
+    """The ``extra`` ids that shadow a current-epoch built-in.
 
-    A startup-time approximation: the reference set is ``DEFAULT_CLAUDE_MODELS``
-    and does not know a target's CLI version, which is sufficient for surfacing
-    an accidental override of a shipping alias.
+    The reference set is ``DEFAULT_CLAUDE_MODELS`` (startup-time; not gated on a
+    target's CLI version).
     """
     return [opt.id for opt in extra if opt.id in _BUILTIN_MODEL_IDS]
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -187,6 +187,12 @@ def offered_claude_models(
     return merge_model_catalogue(base, config.extra_models), version
 
 
+def log_extra_model_overrides(extra: list[BackendModelOption]) -> None:
+    """Log one line per ``extra`` id that shadows a built-in Claude model."""
+    for model_id in overridden_builtin_ids(extra):
+        log.info("extra_models entry %r overrides a built-in Claude model", model_id)
+
+
 def raise_for_unsupported_selection(
     models: list[BackendModelOption],
     version: tuple[int, ...] | None,
@@ -231,9 +237,8 @@ class ClaudeCodePluginConfig(PluginConfig):
     models: list[BackendModelOption] = Field(
         default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
     )
-    # Custom models appended to the catalogue (built-in or explicit `models`)
-    # without opting out of the CLI-version gate. An entry whose id matches a
-    # catalogue entry replaces it in place. See offered_claude_models.
+    # Custom models appended to the version-gated catalogue; see
+    # offered_claude_models.
     extra_models: list[BackendModelOption] = Field(default_factory=list)
     default_model_id: str | None = Field(default_factory=claude_default_model_id)
     # Deprecated no-op: tool approval moved from the PreToolUse HTTP hook to
@@ -247,10 +252,7 @@ class ClaudeCodePluginConfig(PluginConfig):
 
     @model_validator(mode="after")
     def _warn_extra_model_overrides(self) -> Self:
-        for model_id in overridden_builtin_ids(self.extra_models):
-            log.info(
-                "extra_models entry %r overrides a built-in Claude model", model_id
-            )
+        log_extra_model_overrides(self.extra_models)
         return self
 
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -15,10 +15,10 @@ import uuid
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, Self
 
 from fastapi import FastAPI, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from waypoint.backends.base import (
     ConfigDirNotReadyError,
@@ -51,6 +51,8 @@ from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
     claude_models_for_version,
+    merge_model_catalogue,
+    overridden_builtin_ids,
     resolve_import_model_id,
 )
 from waypoint.backends.claude_code.permission_modes import (
@@ -150,6 +152,7 @@ class ClaudeCatalogueConfig(Protocol):
     """
 
     models: list[BackendModelOption]
+    extra_models: list[BackendModelOption]
     local_bin: str | None
 
     @property
@@ -175,11 +178,13 @@ def offered_claude_models(
     loop should run it via ``asyncio.to_thread``.
     """
     if "models" in config.model_fields_set:
-        return list(config.models), None
-    version = detect_claude_cli_version(
-        config.local_bin or cli_binary or "claude", launch_target
-    )
-    return list(claude_models_for_version(version)), version
+        base, version = list(config.models), None
+    else:
+        version = detect_claude_cli_version(
+            config.local_bin or cli_binary or "claude", launch_target
+        )
+        base = list(claude_models_for_version(version))
+    return merge_model_catalogue(base, config.extra_models), version
 
 
 def raise_for_unsupported_selection(
@@ -193,13 +198,19 @@ def raise_for_unsupported_selection(
     ``model`` is looked up in the version-gated catalogue ``list_models`` would
     offer for the target. A model that isn't in it is free text (or an id from
     a newer/unknown CLI) -- nothing to check it against, so it passes through
-    unrejected. Only a *recognized* model paired with an effort that catalogue
-    entry doesn't list is provably unsupported.
+    unrejected. A recognized model whose ``supported_efforts`` is ``None``
+    (efforts unknown, e.g. a gateway model) forwards the effort unchecked. Only
+    a *recognized* model with a concrete ``supported_efforts`` list that omits
+    the requested effort is provably unsupported.
     """
     if effort is None:
         return None
     option = next((opt for opt in models if opt.id == model), None)
-    if option is None or effort in option.supported_efforts:
+    if (
+        option is None
+        or option.supported_efforts is None
+        or effort in option.supported_efforts
+    ):
         return None
     version_label = ".".join(str(part) for part in version) if version else "unknown"
     supported = ", ".join(option.supported_efforts) or "none"
@@ -220,6 +231,10 @@ class ClaudeCodePluginConfig(PluginConfig):
     models: list[BackendModelOption] = Field(
         default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
     )
+    # Custom models appended to the catalogue (built-in or explicit `models`)
+    # without opting out of the CLI-version gate. An entry whose id matches a
+    # catalogue entry replaces it in place. See offered_claude_models.
+    extra_models: list[BackendModelOption] = Field(default_factory=list)
     default_model_id: str | None = Field(default_factory=claude_default_model_id)
     # Deprecated no-op: tool approval moved from the PreToolUse HTTP hook to
     # the `can_use_tool` control protocol, which has no network timeout.
@@ -229,6 +244,14 @@ class ClaudeCodePluginConfig(PluginConfig):
     # backends that own a config-dir env var carry this field; the base config
     # model rejects it for other backends via extra="forbid".
     account_profiles: dict[str, AccountProfileConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _warn_extra_model_overrides(self) -> Self:
+        for model_id in overridden_builtin_ids(self.extra_models):
+            log.info(
+                "extra_models entry %r overrides a built-in Claude model", model_id
+            )
+        return self
 
 
 class ClaudeCodeLaunchTargetConfig(PluginLaunchTargetConfig):
@@ -834,6 +857,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             "default_model_label": default_model_label,
             "default_effort": default_effort,
             "supports_free_text": True,
+            "effort_levels": list(CLAUDE_EFFORT_LEVELS),
         }
 
     async def list_command_completions(

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -29,10 +29,10 @@ import uuid
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 from fastapi import HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from waypoint.backends.base import (
     TerminalAppearance,
@@ -47,8 +47,10 @@ from waypoint.backends.claude_code.history import (
     read_local_claude_token_usage_history,
 )
 from waypoint.backends.claude_code.models import (
+    CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
+    overridden_builtin_ids,
     resolve_import_model_id,
 )
 from waypoint.backends.claude_code.plugin import (
@@ -128,8 +130,19 @@ class ClaudeTtyPluginConfig(PluginConfig):
     models: list[BackendModelOption] = Field(
         default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
     )
+    # Appended to the catalogue without opting out of the CLI-version gate;
+    # honored identically to claude_code (the two transports of the same agent).
+    extra_models: list[BackendModelOption] = Field(default_factory=list)
     default_model_id: str | None = Field(default_factory=claude_default_model_id)
     default_effort: str | None = None
+
+    @model_validator(mode="after")
+    def _warn_extra_model_overrides(self) -> Self:
+        for model_id in overridden_builtin_ids(self.extra_models):
+            log.info(
+                "extra_models entry %r overrides a built-in Claude model", model_id
+            )
+        return self
 
 
 class ClaudeTtyPlugin:
@@ -382,6 +395,7 @@ class ClaudeTtyPlugin:
             "default_model_label": default_model_label,
             "default_effort": config.default_effort,
             "supports_free_text": True,
+            "effort_levels": list(CLAUDE_EFFORT_LEVELS),
         }
 
     def validate_new_session_selection(

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -50,11 +50,11 @@ from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
     claude_default_model_id,
-    overridden_builtin_ids,
     resolve_import_model_id,
 )
 from waypoint.backends.claude_code.plugin import (
     ClaudeCodePlugin,
+    log_extra_model_overrides,
     offered_claude_models,
     raise_for_unsupported_selection,
 )
@@ -130,18 +130,14 @@ class ClaudeTtyPluginConfig(PluginConfig):
     models: list[BackendModelOption] = Field(
         default_factory=lambda: list(DEFAULT_CLAUDE_MODELS)
     )
-    # Appended to the catalogue without opting out of the CLI-version gate;
-    # honored identically to claude_code (the two transports of the same agent).
+    # Appended to the version-gated catalogue; honored identically to claude_code.
     extra_models: list[BackendModelOption] = Field(default_factory=list)
     default_model_id: str | None = Field(default_factory=claude_default_model_id)
     default_effort: str | None = None
 
     @model_validator(mode="after")
     def _warn_extra_model_overrides(self) -> Self:
-        for model_id in overridden_builtin_ids(self.extra_models):
-            log.info(
-                "extra_models entry %r overrides a built-in Claude model", model_id
-            )
+        log_extra_model_overrides(self.extra_models)
         return self
 
 

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1146,11 +1146,9 @@ class BackendModelOption(BaseModel):
     is_default: bool = False
     hidden: bool = False
     # Reasoning-effort levels this model accepts (three-state):
-    #   None -> efforts unknown; accept and forward any level unvalidated
-    #           (the honest default for a gateway model Waypoint can't probe).
-    #   []   -> model has no effort knob (e.g. Claude Haiku); any effort is
-    #           rejected.
-    #   list -> the accepted set; membership is enforced.
+    #   None -> efforts unknown; any level is accepted and forwarded unvalidated
+    #   []   -> no effort knob (e.g. Claude Haiku); any effort is rejected
+    #   list -> the accepted set; membership is enforced
     supported_efforts: list[str] | None = None
     default_effort: str | None = None
 
@@ -1166,9 +1164,8 @@ class BackendModelListResponse(BaseModel):
     # Backend-wide default effort (used when no model-specific default
     # applies); falls back to None to mean "let the runtime pick".
     default_effort: str | None = None
-    # The agent's full effort vocabulary. The frontend offers this as the
-    # effort options for a selected model whose `supported_efforts` is None
-    # (unknown). Empty means no fallback vocabulary is advertised.
+    # The agent's full effort vocabulary; the frontend offers it as the effort
+    # options for a selected model whose `supported_efforts` is None.
     effort_levels: list[str] = Field(default_factory=list)
 
 

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1145,10 +1145,13 @@ class BackendModelOption(BaseModel):
     description: str | None = None
     is_default: bool = False
     hidden: bool = False
-    # Reasoning-effort levels this model accepts. Empty list means the model
-    # has no effort knob (e.g. Claude Haiku, or Codex models without an
-    # entry in `supported_reasoning_efforts`).
-    supported_efforts: list[str] = Field(default_factory=list)
+    # Reasoning-effort levels this model accepts (three-state):
+    #   None -> efforts unknown; accept and forward any level unvalidated
+    #           (the honest default for a gateway model Waypoint can't probe).
+    #   []   -> model has no effort knob (e.g. Claude Haiku); any effort is
+    #           rejected.
+    #   list -> the accepted set; membership is enforced.
+    supported_efforts: list[str] | None = None
     default_effort: str | None = None
 
 
@@ -1163,6 +1166,10 @@ class BackendModelListResponse(BaseModel):
     # Backend-wide default effort (used when no model-specific default
     # applies); falls back to None to mean "let the runtime pick".
     default_effort: str | None = None
+    # The agent's full effort vocabulary. The frontend offers this as the
+    # effort options for a selected model whose `supported_efforts` is None
+    # (unknown). Empty means no fallback vocabulary is advertised.
+    effort_levels: list[str] = Field(default_factory=list)
 
 
 class AskQuestionAnswer(BaseModel):

--- a/backend/tests/test_claude_code_list_models.py
+++ b/backend/tests/test_claude_code_list_models.py
@@ -157,7 +157,9 @@ async def test_list_models_surfaces_extra_model_with_null_effort_as_json_null(
         lambda binary, launch_target: (2, 1, 197),
     )
     config = ClaudeCodePluginConfig(
-        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")]
+        extra_models=[
+            BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M context)")
+        ]
     )
 
     result = await plugin.list_models(cast(Any, _fake_runtime(config=config)))

--- a/backend/tests/test_claude_code_list_models.py
+++ b/backend/tests/test_claude_code_list_models.py
@@ -5,12 +5,16 @@ from typing import Any, cast
 
 import pytest
 
-from waypoint.backends.claude_code.models import DEFAULT_CLAUDE_MODELS
+from waypoint.backends.claude_code.models import (
+    CLAUDE_EFFORT_LEVELS,
+    DEFAULT_CLAUDE_MODELS,
+)
 from waypoint.backends.claude_code.plugin import (
     ClaudeCodePlugin,
     ClaudeCodePluginConfig,
 )
 from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.schemas import BackendModelOption
 
 
 def _fake_runtime(
@@ -126,3 +130,42 @@ async def test_list_models_honors_explicit_models_override(
 
     assert not called
     assert [m["id"] for m in result["models"]] == [custom[0].id]
+
+
+@pytest.mark.asyncio
+async def test_list_models_includes_effort_levels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 197),
+    )
+
+    result = await plugin.list_models(cast(Any, _fake_runtime()))
+
+    assert result["effort_levels"] == list(CLAUDE_EFFORT_LEVELS)
+
+
+@pytest.mark.asyncio
+async def test_list_models_surfaces_extra_model_with_null_effort_as_json_null(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 197),
+    )
+    config = ClaudeCodePluginConfig(
+        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")]
+    )
+
+    result = await plugin.list_models(cast(Any, _fake_runtime(config=config)))
+
+    kimi = next(m for m in result["models"] if m["id"] == "kimi-k3[1m]")
+    # Unknown efforts must serialize as JSON null (distinct from []) so the
+    # frontend can tell "unknown" from "no knob".
+    assert kimi["supported_efforts"] is None
+    # Haiku's pinned [] stays an empty list, not null.
+    haiku = next(m for m in result["models"] if m["id"] == "haiku")
+    assert haiku["supported_efforts"] == []

--- a/backend/tests/test_claude_code_preflight.py
+++ b/backend/tests/test_claude_code_preflight.py
@@ -17,6 +17,7 @@ from waypoint.backends.claude_code.plugin import (
     ClaudeCodePlugin,
     ClaudeCodePluginConfig,
 )
+from waypoint.schemas import BackendModelOption
 
 
 def _fake_runtime(config: ClaudeCodePluginConfig | None = None) -> Any:
@@ -175,3 +176,48 @@ def test_honors_explicit_models_override(monkeypatch: pytest.MonkeyPatch) -> Non
     plugin.validate_new_session_selection(
         cast(Any, _fake_runtime(config=config)), "sonnet", "low", None
     )
+
+
+def test_null_supported_efforts_forwards_any_effort_unvalidated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A recognized model with supported_efforts=None (the default for a gateway
+    # extra_models entry) forwards the effort to the CLI unchecked -- even one
+    # not in the built-in ladder -- while the version gate on the built-ins is
+    # preserved (detection still runs).
+    plugin = ClaudeCodePlugin()
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: (2, 1, 197),
+    )
+    config = ClaudeCodePluginConfig(
+        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")]
+    )
+
+    plugin.validate_new_session_selection(
+        cast(Any, _fake_runtime(config=config)), "kimi-k3[1m]", "ludicrous", None
+    )
+
+
+def test_empty_supported_efforts_names_none_in_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An explicit [] (no effort knob) rejects any effort and reports the
+    # supported set as "none".
+    plugin = ClaudeCodePlugin()
+
+    def fail_detect(binary: str, launch_target: Any) -> tuple[int, ...] | None:
+        raise AssertionError("explicit models opt out of version detection")
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fail_detect
+    )
+    config = ClaudeCodePluginConfig(
+        models=[BackendModelOption(id="no-knob", label="No Knob", supported_efforts=[])]
+    )
+
+    with pytest.raises(ValueError) as exc:
+        plugin.validate_new_session_selection(
+            cast(Any, _fake_runtime(config=config)), "no-knob", "high", None
+        )
+    assert "supported efforts: none" in str(exc.value)

--- a/backend/tests/test_claude_code_preflight.py
+++ b/backend/tests/test_claude_code_preflight.py
@@ -191,7 +191,9 @@ def test_null_supported_efforts_forwards_any_effort_unvalidated(
         lambda binary, launch_target: (2, 1, 197),
     )
     config = ClaudeCodePluginConfig(
-        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")]
+        extra_models=[
+            BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M context)")
+        ]
     )
 
     plugin.validate_new_session_selection(

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -6,13 +6,22 @@ and version-independent. This file covers claude_models_for_version, which
 decides which *offering* (subset/labels) a given CLI build should see.
 """
 
+import logging
+
 import pytest
 
 from waypoint.backends.claude_code.models import (
     DEFAULT_CLAUDE_MODELS,
     SONNET5_MIN_CLI_VERSION,
     claude_models_for_version,
+    merge_model_catalogue,
+    overridden_builtin_ids,
 )
+from waypoint.backends.claude_code.plugin import (
+    ClaudeCodePluginConfig,
+    offered_claude_models,
+)
+from waypoint.schemas import BackendModelOption
 
 
 def _by_id(models: tuple, model_id: str):
@@ -61,3 +70,103 @@ def test_legacy_offering_has_same_model_ids_as_default() -> None:
     legacy = claude_models_for_version((2, 0, 0))
     assert {opt.id for opt in legacy} == {opt.id for opt in DEFAULT_CLAUDE_MODELS}
     assert sum(opt.is_default for opt in legacy) == 1
+
+
+# --- merge_model_catalogue ------------------------------------------------
+
+
+def test_merge_appends_net_new_in_declared_order() -> None:
+    base = list(DEFAULT_CLAUDE_MODELS)
+    extra = [
+        BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)"),
+        BackendModelOption(id="gw-mini", label="Gateway Mini"),
+    ]
+    merged = merge_model_catalogue(base, extra)
+    assert [opt.id for opt in merged] == (
+        [opt.id for opt in base] + ["kimi-k3[1m]", "gw-mini"]
+    )
+
+
+def test_merge_replaces_colliding_id_in_place() -> None:
+    base = list(DEFAULT_CLAUDE_MODELS)
+    sonnet_index = next(i for i, opt in enumerate(base) if opt.id == "sonnet")
+    replacement = BackendModelOption(id="sonnet", label="Sonnet (relabeled)")
+    merged = merge_model_catalogue(base, [replacement])
+
+    assert len(merged) == len(base)
+    assert [opt.id for opt in merged] == [opt.id for opt in base]
+    assert merged[sonnet_index] is replacement
+    assert merged[sonnet_index].label == "Sonnet (relabeled)"
+
+
+def test_merge_empty_extra_is_noop() -> None:
+    base = list(DEFAULT_CLAUDE_MODELS)
+    merged = merge_model_catalogue(base, [])
+    assert merged == base
+    assert merged is not base  # a fresh list, not the caller's
+
+
+# --- overridden_builtin_ids ----------------------------------------------
+
+
+def test_overridden_builtin_ids_returns_only_colliding() -> None:
+    extra = [
+        BackendModelOption(id="sonnet", label="X"),
+        BackendModelOption(id="kimi-k3[1m]", label="Y"),
+        BackendModelOption(id="opus", label="Z"),
+    ]
+    assert overridden_builtin_ids(extra) == ["sonnet", "opus"]
+
+
+def test_config_logs_override_line(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.INFO, logger="waypoint.backends.claude_code"):
+        ClaudeCodePluginConfig(
+            extra_models=[BackendModelOption(id="sonnet", label="Relabeled")]
+        )
+    assert "sonnet" in caplog.text
+    assert "overrides a built-in" in caplog.text
+
+
+# --- offered_claude_models with extra_models ------------------------------
+
+
+def test_offered_appends_extras_and_keeps_version_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: SONNET5_MIN_CLI_VERSION,
+    )
+    config = ClaudeCodePluginConfig(
+        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")]
+    )
+
+    models, version = offered_claude_models(config, "claude", None)
+
+    # Version gate preserved (extras did not opt out of it).
+    assert version == SONNET5_MIN_CLI_VERSION
+    ids = [opt.id for opt in models]
+    assert ids[: len(DEFAULT_CLAUDE_MODELS)] == [
+        opt.id for opt in DEFAULT_CLAUDE_MODELS
+    ]
+    assert ids[-1] == "kimi-k3[1m]"
+
+
+def test_offered_merges_extras_on_explicit_models_with_none_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_detect(binary: str, launch_target: object) -> tuple[int, ...] | None:
+        raise AssertionError("explicit models opt out of version detection")
+
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version", fail_detect
+    )
+    config = ClaudeCodePluginConfig(
+        models=[BackendModelOption(id="only-model", label="Only")],
+        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")],
+    )
+
+    models, version = offered_claude_models(config, "claude", None)
+
+    assert version is None
+    assert [opt.id for opt in models] == ["only-model", "kimi-k3[1m]"]

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -78,7 +78,7 @@ def test_legacy_offering_has_same_model_ids_as_default() -> None:
 def test_merge_appends_net_new_in_declared_order() -> None:
     base = list(DEFAULT_CLAUDE_MODELS)
     extra = [
-        BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)"),
+        BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M context)"),
         BackendModelOption(id="gw-mini", label="Gateway Mini"),
     ]
     merged = merge_model_catalogue(base, extra)
@@ -138,7 +138,9 @@ def test_offered_appends_extras_and_keeps_version_gate(
         lambda binary, launch_target: SONNET5_MIN_CLI_VERSION,
     )
     config = ClaudeCodePluginConfig(
-        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")]
+        extra_models=[
+            BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M context)")
+        ]
     )
 
     models, version = offered_claude_models(config, "claude", None)
@@ -163,7 +165,9 @@ def test_offered_merges_extras_on_explicit_models_with_none_version(
     )
     config = ClaudeCodePluginConfig(
         models=[BackendModelOption(id="only-model", label="Only")],
-        extra_models=[BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M)")],
+        extra_models=[
+            BackendModelOption(id="kimi-k3[1m]", label="Kimi K3 (1M context)")
+        ],
     )
 
     models, version = offered_claude_models(config, "claude", None)

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -62,7 +62,7 @@ plugin_configs:
     #     config_dir: ~/.codex-work
     #     transcript_policy: copy_thread_on_switch  # require_existing | symlink_shared | copy_thread_on_switch
     #     expected_account_key: codex:work@example.com   # gate the switch to this account (optional)
-  claude_code:
+  claude_code:                             # claude_tty honors the same catalogue fields
     # default_model_id: opus
     # default_effort: high
     # local_bin: /opt/claude/bin/claude
@@ -70,6 +70,19 @@ plugin_configs:
     #   ANTHROPIC_AUTH_TOKEN: sk-ant-your-key
     # cli_args:
     #   - "--dangerously-skip-permissions"
+    # APPEND custom models to the built-in, version-gated catalogue. Each entry
+    # is selectable in every model picker; an entry whose id matches a built-in
+    # replaces it in place (relabel / re-effort).
+    # extra_models:
+    #   - id: kimi-k3[1m]
+    #     label: Kimi K3 (1M)
+    #     description: Custom gateway model
+    #     # supported_efforts omitted -> efforts unknown: the picker offers the
+    #     # full ladder (low..max) and forwards the choice unvalidated. Set an
+    #     # explicit list to enforce it; set [] for a model with no effort knob.
+    #     default_effort: high             # advisory: preselects in the picker
+    # default_model_id: kimi-k3[1m]        # may point at an extra id
+    # REPLACE the whole catalogue instead (opts out of CLI-version gating) -- rarely needed:
     # models:
     #   - id: opus
     #     label: Opus 4.7

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -75,7 +75,7 @@ plugin_configs:
     # replaces it in place (relabel / re-effort).
     # extra_models:
     #   - id: kimi-k3[1m]
-    #     label: Kimi K3 (1M)
+    #     label: Kimi K3 (1M context)
     #     description: Custom gateway model
     #     # supported_efforts omitted -> efforts unknown: the picker offers the
     #     # full ladder (low..max) and forwards the choice unvalidated. Set an

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -335,8 +335,18 @@ async def delete_thread(self, runtime, thread_id, launch_target_id=None, account
 
 `list_models` returns the same payload shape `/api/backends/{id}/models`
 serves to the frontend (`{models, default_model_id, default_model_label,
-default_effort, supports_free_text}`). `list_threads` returns plugin-specific
-summary objects; the API serialises via `model_dump`.
+default_effort, supports_free_text, effort_levels}`). `effort_levels` is the
+agent's full effort vocabulary; the frontend offers it as the effort options
+for a selected model whose `supported_efforts` is `null` (see below).
+`list_threads` returns plugin-specific summary objects; the API serialises via
+`model_dump`.
+
+Each model entry (`BackendModelOption`) carries a three-state
+`supported_efforts`: `null` means efforts are unknown, so the picker offers
+`effort_levels` and forwards the chosen level to the CLI unvalidated; `[]` means
+the model has no effort knob (any effort is rejected); an explicit list is the
+accepted set (membership enforced). `null` is the default — the honest state for
+a model Waypoint cannot probe.
 
 The optional `account_profile_id` scopes this session-less discovery to a named
 account profile: the runtime resolves it to the profile's config-dir env via
@@ -353,6 +363,34 @@ so scoping is a no-op there; Codex's is a live per-account RPC that runs under
 the resolved env. Remote (SSH launch target) profile scoping is not yet wired —
 the remote branches read the target's default store (see
 [`account_profiles.md`](account_profiles.md)).
+
+#### Model catalogue (Claude)
+
+Claude has no runtime `model/list` RPC (Codex does), so its catalogue is static
+config in `backends/claude_code/models.py`, gated on the detected CLI version.
+Two `waypoint.yaml` keys shape it (both honored identically by `claude_code` and
+`claude_tty`, the two transports of the Claude agent):
+
+- **`extra_models`** — *appends* custom `BackendModelOption` entries to the
+  built-in catalogue while keeping the CLI-version gate. An entry whose `id`
+  matches a built-in replaces that entry in place (relabel / re-effort);
+  net-new ids append in declared order, and a collision logs one line at config
+  load. This is the recommended way to surface a gateway-served `--model` id
+  (e.g. `kimi-k3[1m]`) as a selectable picker option. `default_model_id` may
+  point at an extra id.
+- **`models`** — *replaces* the whole catalogue and opts out of the version
+  gate (`version` becomes `None`). The full-control escape hatch; you must
+  redeclare every built-in you still want, and they no longer get version-aware
+  effort labels. `extra_models` still appends on top of an explicit `models`
+  list.
+
+Leave a custom model's `supported_efforts` unset (`null`) to keep its effort
+picker working (offered `effort_levels`) without Waypoint validating the level —
+the CLI/gateway is the authority, matching how a free-text `--model` id is
+already forwarded unchecked. Setting neither key is unchanged behavior. The CLI
+`waypoint launch --model <id>` free-text passthrough (warns, never blocks) is
+also unchanged; the merged catalogue is what the frontend pickers and
+`waypoint models` show.
 
 `import_thread` adopts an externally-created native thread into a brand-new
 session. When the import request's `import_history` flag is set (it defaults to

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -342,11 +342,10 @@ for a selected model whose `supported_efforts` is `null` (see below).
 `model_dump`.
 
 Each model entry (`BackendModelOption`) carries a three-state
-`supported_efforts`: `null` means efforts are unknown, so the picker offers
-`effort_levels` and forwards the chosen level to the CLI unvalidated; `[]` means
-the model has no effort knob (any effort is rejected); an explicit list is the
-accepted set (membership enforced). `null` is the default — the honest state for
-a model Waypoint cannot probe.
+`supported_efforts`: `null` (the default) means efforts are unknown, so the
+picker offers `effort_levels` and forwards the chosen level to the CLI
+unvalidated; `[]` means the model has no effort knob (any effort is rejected);
+an explicit list is the accepted set (membership enforced).
 
 The optional `account_profile_id` scopes this session-less discovery to a named
 account profile: the runtime resolves it to the profile's config-dir env via
@@ -373,24 +372,21 @@ Two `waypoint.yaml` keys shape it (both honored identically by `claude_code` and
 
 - **`extra_models`** — *appends* custom `BackendModelOption` entries to the
   built-in catalogue while keeping the CLI-version gate. An entry whose `id`
-  matches a built-in replaces that entry in place (relabel / re-effort);
-  net-new ids append in declared order, and a collision logs one line at config
-  load. This is the recommended way to surface a gateway-served `--model` id
-  (e.g. `kimi-k3[1m]`) as a selectable picker option. `default_model_id` may
-  point at an extra id.
+  matches a built-in replaces it in place (relabel / re-effort); net-new ids
+  append in declared order, and a collision logs one line at config load. Use
+  it to surface a gateway-served `--model` id (e.g. `kimi-k3[1m]`) as a picker
+  option. `default_model_id` may point at an extra id.
 - **`models`** — *replaces* the whole catalogue and opts out of the version
-  gate (`version` becomes `None`). The full-control escape hatch; you must
-  redeclare every built-in you still want, and they no longer get version-aware
-  effort labels. `extra_models` still appends on top of an explicit `models`
-  list.
+  gate (`version` becomes `None`); you redeclare every built-in you still want,
+  and they lose version-aware effort labels. `extra_models` still appends on top
+  of an explicit `models` list.
 
-Leave a custom model's `supported_efforts` unset (`null`) to keep its effort
-picker working (offered `effort_levels`) without Waypoint validating the level —
-the CLI/gateway is the authority, matching how a free-text `--model` id is
-already forwarded unchecked. Setting neither key is unchanged behavior. The CLI
-`waypoint launch --model <id>` free-text passthrough (warns, never blocks) is
-also unchanged; the merged catalogue is what the frontend pickers and
-`waypoint models` show.
+Leave a custom model's `supported_efforts` unset to offer `effort_levels` in the
+picker and forward the level unvalidated; set an explicit list to enforce it, or
+`[]` for a model with no effort knob. Setting neither catalogue key leaves
+behavior unchanged; the CLI `waypoint launch --model <id>` free-text passthrough
+still warns without blocking, and the merged catalogue is what the frontend
+pickers and `waypoint models` show.
 
 `import_thread` adopts an externally-created native thread into a brand-new
 session. When the import request's `import_history` flag is set (it defaults to

--- a/frontend/src/components/LaunchFormFields.tsx
+++ b/frontend/src/components/LaunchFormFields.tsx
@@ -213,7 +213,11 @@ export function useLaunchForm({
     if (resolvedModelId) {
       const opt = modelInfo.models.find((entry) => entry.id === resolvedModelId);
       if (opt) {
-        return opt.supported_efforts ?? [];
+        // null/undefined efforts → unknown: offer the agent's full vocabulary;
+        // [] → no control; explicit list → that list.
+        return opt.supported_efforts == null
+          ? (modelInfo.effort_levels ?? [])
+          : opt.supported_efforts;
       }
     }
 

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -440,6 +440,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   const [showScrollToTop, setShowScrollToTop] = useState(false);
   const [modeBusy, setModeBusy] = useState(false);
   const [modelOptions, setModelOptions] = useState<BackendModelOption[]>([]);
+  const [effortLevels, setEffortLevels] = useState<string[]>([]);
   const [defaultModelId, setDefaultModelId] = useState<string | null>(null);
   const [defaultModelLabel, setDefaultModelLabel] = useState<string | null>(null);
   const [defaultEffort, setDefaultEffort] = useState<string | null>(null);
@@ -585,6 +586,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       .then((response) => {
         if (cancelled) return;
         setModelOptions(response.models);
+        setEffortLevels(response.effort_levels ?? []);
         setDefaultModelId(response.default_model_id ?? null);
         setDefaultModelLabel(response.default_model_label ?? null);
         setDefaultEffort(response.default_effort ?? null);
@@ -598,6 +600,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         // Discovery failure is non-fatal: the picker just falls back to
         // showing whatever model the session already has.
         setModelOptions([]);
+        setEffortLevels([]);
         setDefaultModelId(null);
         setDefaultModelLabel(null);
         setDefaultEffort(null);
@@ -2323,6 +2326,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           modeBusy={modeBusy}
           modelBusy={modelBusy}
           modelOptions={modelOptions}
+          effortLevels={effortLevels}
           defaultModelId={defaultModelId}
           defaultModelLabel={defaultModelLabel}
           defaultEffort={defaultEffort}
@@ -2426,6 +2430,7 @@ interface ReplyComposerProps {
   modeBusy: boolean;
   modelBusy: boolean;
   modelOptions: BackendModelOption[];
+  effortLevels: string[];
   defaultModelId: string | null;
   defaultModelLabel: string | null;
   defaultEffort: string | null;
@@ -2482,6 +2487,7 @@ const ReplyComposer = memo(function ReplyComposer({
   modeBusy,
   modelBusy,
   modelOptions,
+  effortLevels,
   defaultModelId,
   defaultModelLabel,
   defaultEffort,
@@ -2802,7 +2808,9 @@ const ReplyComposer = memo(function ReplyComposer({
     ? modelOptions.find((opt) => opt.id === resolvedModelId)
     : undefined;
   const effortOptions: string[] = matchingModelEntry
-    ? matchingModelEntry.supported_efforts ?? []
+    ? matchingModelEntry.supported_efforts == null
+      ? effortLevels // unknown → the agent's full vocabulary
+      : matchingModelEntry.supported_efforts
     : Array.from(
         new Set(
           modelOptions.flatMap((opt) => opt.supported_efforts ?? []),

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -109,6 +109,7 @@ export function SessionSettingsModal({
     launchSettings,
     caps,
     models,
+    effortLevels,
     defaultModelLabel,
     title,
     permissionMode,
@@ -230,11 +231,16 @@ export function SessionSettingsModal({
   const permissionModes = permissionModesFor(backend, catalog);
   const effortOptions = useMemo(() => {
     const selectedModel = models.find((m) => m.id === (model ?? ""));
-    if (selectedModel) return selectedModel.supported_efforts ?? [];
+    if (selectedModel) {
+      // null/undefined efforts → unknown: offer the agent's full vocabulary.
+      return selectedModel.supported_efforts == null
+        ? effortLevels
+        : selectedModel.supported_efforts;
+    }
     return Array.from(
       new Set(models.flatMap((m) => m.supported_efforts ?? [])),
     );
-  }, [models, model]);
+  }, [models, model, effortLevels]);
   const accountProfiles = launchSettings?.account_profiles ?? [];
 
   // The transport option describing the current-or-staged interface; drives the

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -574,7 +574,9 @@ export interface BackendModelOption {
   description?: string | null;
   is_default?: boolean;
   hidden?: boolean;
-  supported_efforts?: string[];
+  // Three-state: null = efforts unknown (offer the agent's full vocabulary),
+  // [] = no effort knob, list = the accepted set.
+  supported_efforts?: string[] | null;
   default_effort?: string | null;
 }
 
@@ -585,6 +587,9 @@ export interface BackendModelListResponse {
   default_model_label?: string | null;
   default_effort?: string | null;
   supports_free_text?: boolean;
+  // The agent's full effort vocabulary; offered as the effort options when a
+  // selected model's supported_efforts is null (unknown).
+  effort_levels?: string[];
 }
 
 export interface BoardEntry {

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -98,6 +98,7 @@ export interface SessionSettingsController {
   launchSettings: SessionLaunchSettings | null;
   caps: BackendCapabilities | undefined;
   models: BackendModelOption[];
+  effortLevels: string[];
   defaultModelLabel: string | null;
 
   // Draft state.
@@ -192,6 +193,7 @@ export function useSessionSettings(
   const [launchSettings, setLaunchSettings] =
     useState<SessionLaunchSettings | null>(null);
   const [models, setModels] = useState<BackendModelOption[]>([]);
+  const [effortLevels, setEffortLevels] = useState<string[]>([]);
   const [defaultModelLabel, setDefaultModelLabel] = useState<string | null>(
     null,
   );
@@ -281,6 +283,7 @@ export function useSessionSettings(
       ]);
       let modelList: BackendModelOption[] = [];
       let defaultLabel: string | null = null;
+      let effortVocabulary: string[] = [];
       try {
         const resp = await fetchBackendModels(host, token, backend, {
           launchTargetId,
@@ -288,6 +291,7 @@ export function useSessionSettings(
         });
         modelList = resp.models ?? [];
         defaultLabel = resp.default_model_label ?? null;
+        effortVocabulary = resp.effort_levels ?? [];
       } catch {
         // Model discovery is best-effort; the picker degrades to the current
         // value when it fails (e.g. a backend with no live model list).
@@ -296,6 +300,7 @@ export function useSessionSettings(
       setSession(record);
       setLaunchSettings(settings);
       setModels(modelList);
+      setEffortLevels(effortVocabulary);
       setDefaultModelLabel(defaultLabel);
       resetDraft(record, settings);
     } catch (error) {
@@ -319,6 +324,7 @@ export function useSessionSettings(
       loadToken.current += 1;
       setLaunchSettings(null);
       setModels([]);
+      setEffortLevels([]);
       setExistingEnv([]);
       setNewEnv([]);
       setArgsText("");
@@ -730,6 +736,7 @@ export function useSessionSettings(
     launchSettings,
     caps,
     models,
+    effortLevels,
     defaultModelLabel,
     title,
     permissionMode,


### PR DESCRIPTION
## Purpose

Operators who point the Claude Code CLI at custom `--model` ids (gateway-served models such as `kimi-k3[1m]`, or private aliases) cannot conveniently pick those models in Waypoint. The CLI path already works — `waypoint launch --model <id>` passes free text straight through and only warns on an unknown id — but the frontend model picker is a closed dropdown fed by the backend catalogue, and the only knob that shapes it, `ClaudeCodePluginConfig.models`, *replaces* the whole list and *opts out* of the CLI-version gate. To surface one custom model an operator must re-declare every built-in and forfeit version-aware effort gating. This PR adds an additive `extra_models` key that appends custom models to the version-gated built-in catalogue, and refines `supported_efforts` into a three-state field so a gateway model can keep a usable effort picker without Waypoint asserting knowledge it does not have. Implements the approved RFC at `.waypoint/specs/rfc-claude-custom-model-catalogue.md`.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_code/models.py` — `merge_model_catalogue` (pure helper: append net-new extras, replace a colliding id in place preserving position) and `overridden_builtin_ids`; Haiku pinned to an explicit `supported_efforts=[]` so it survives the default flip.
- `backend/src/waypoint/backends/claude_code/plugin.py` — `extra_models` on the `ClaudeCatalogueConfig` protocol and `ClaudeCodePluginConfig`, a `model_validator` that logs any built-in override at config load, the merge call in the shared `offered_claude_models` reader (version gate preserved for the built-ins), a skip-on-`None` guard in `raise_for_unsupported_selection`, and `effort_levels` in `list_models`.
- `backend/src/waypoint/backends/claude_tty/plugin.py` — the same `extra_models` field + override-logging validator on `ClaudeTtyPluginConfig`, and `effort_levels` in `list_models`, so both transports of the Claude agent honor the key identically.
- `backend/src/waypoint/backends/claude_code/__init__.py` — export `merge_model_catalogue`.
- `backend/src/waypoint/schemas.py` — `BackendModelOption.supported_efforts` becomes `list[str] | None = None` (three-state: null = unknown/forward-unvalidated, [] = no knob, list = enforced); `BackendModelListResponse.effort_levels: list[str]`.

### Frontend
- `frontend/src/lib/types.ts` — `supported_efforts?: string[] | null` and `effort_levels?: string[]`.
- `frontend/src/components/LaunchFormFields.tsx`, `SessionDetail.tsx`, `SessionSettingsModal.tsx` (+ `frontend/src/lib/useSessionSettings.ts`) — the effort-option derivation now offers `effort_levels` when the selected model's `supported_efforts` is `null`, keeps `[]` as no control, and uses an explicit list as-is; `effort_levels` threads through the model-list fetch into all three pickers. No new markup — configured `extra_models` surface through the existing `response.models` mapping.

### Docs / config
- `docs/coding_agent_plugins.md` — a "Model catalogue (Claude)" subsection covering append (`extra_models`, keeps the gate) vs replace (`models`, disables it) and the three-state effort field.
- `backend/waypoint.example.yaml` — commented `extra_models` / `models` examples under `claude_code`.

### Tests
- `backend/tests/test_claude_models_offering.py` — merge append/replace-in-place/no-op, `overridden_builtin_ids`, the config-load override log line, and `offered_claude_models` appending to version-gated built-ins (gate preserved) and to an explicit `models` list (version `None`).
- `backend/tests/test_claude_code_preflight.py` — `null` forwards any effort unvalidated, `[]` reports "supported efforts: none".
- `backend/tests/test_claude_code_list_models.py` — `effort_levels == CLAUDE_EFFORT_LEVELS`, a `null` model serializes `supported_efforts` as JSON null distinct from Haiku's `[]`.

## Design

`extra_models` merges on top of whichever base `offered_claude_models` already computes — the version-gated built-ins (gate kept) or an explicit `models` list (still `version=None`) — so the merge is one call in the single shared reader and every surface (pickers, `waypoint models`, effort validation) lights up through existing plumbing. A colliding id replaces in place to double as a relabel/re-effort hook, with a config-load log line naming the override. The `supported_efforts` default flips to `null` because the intuitive "leave it blank" should be the lenient path for a model Waypoint cannot probe (forward the level, let the CLI/gateway be the authority, matching how free-text `--model` is already unvalidated); Haiku is the only built-in that relied on the old `[]` default and is pinned explicitly, and Codex/OpenCode always emit explicit lists so they are unaffected. `effort_levels` on the model-list response is preferred over reusing a catalogue-wide union so a `null` model keeps a working effort picker even when the catalogue is entirely custom (the `models:` replace case). `null` reaches the client as JSON `null` (Pydantic serializes `None`), so the frontend branches on `=== null` rather than the old `?? []` collapse.

## Test Plan
- `cd backend && uv run pytest` — 2626 passed.
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- `cd frontend && npm run lint && npm run build` — clean; production build + TypeScript check pass.
- End-to-end on the deployed stack (`waypointctl restart` on this branch) with two temporary `extra_models` entries (a `null`-effort `kimi-k3[1m]` and a `[]`-effort `gw-noknob`).

## Test Result
- `uv run pytest` — 2626 passed; pre-commit green; frontend lint + build green.
- `waypoint models claude_code` and the HTTP `/api/backends/claude_code/models` response both list the two custom models appended after the version-gated built-ins (Sonnet 5, full ladder), carry `effort_levels: [low, medium, high, xhigh, max]`, and serialize `kimi-k3[1m]`'s efforts as JSON `null` versus `gw-noknob`'s `[]`.
- Playwright against the deployed launch panel (mobile width): the model picker lists both custom models; selecting `kimi-k3[1m]` (null) offers the full effort ladder, `gw-noknob` ([]) shows no effort control, `opus` shows its explicit list, and `haiku` ([]) shows none — the three-state derivation working live. Temporary entries were removed and the stack restarted to restore a clean deployment afterward.

Addresses ticket 1204.