### PR TITLE
feat: add Claude Opus 5 to the claude model catalogue (CLI 2.1.219 epoch)

### DIFF
--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -135,14 +135,10 @@ def overridden_builtin_ids(extra: list[BackendModelOption]) -> list[str]:
     return [opt.id for opt in extra if opt.id in _BUILTIN_MODEL_IDS]
 
 
-def normalize_claude_model_id(model: str | None) -> str | None:
-    if model is None or not isinstance(model, str):
-        return None
-    candidate = model.strip()
-    if not candidate:
-        return None
-    if candidate in CLAUDE_CONTEXT_WINDOWS:
-        return candidate
+_ONE_M_SUFFIX = "[1m]"
+
+
+def _resolve_claude_model_base(candidate: str) -> str:
     normalized = CLAUDE_MODEL_ALIASES.get(candidate)
     if normalized is not None:
         return normalized
@@ -162,6 +158,29 @@ def normalize_claude_model_id(model: str | None) -> str | None:
         if family in lowered:
             return family
     return candidate
+
+
+def normalize_claude_model_id(model: str | None) -> str | None:
+    if model is None or not isinstance(model, str):
+        return None
+    candidate = model.strip()
+    if not candidate:
+        return None
+    if candidate in CLAUDE_CONTEXT_WINDOWS:
+        return candidate
+    # A concrete id may carry the 1M entitlement as a suffix
+    # (``claude-opus-5[1m]``). Resolve the base family, then re-attach the
+    # suffix so the entitlement survives normalization instead of collapsing to
+    # the bare 200K family id. Families with no 1M offering (haiku) have no
+    # ``[1m]`` catalogue entry, so the suffix is correctly dropped for them. An
+    # id whose base resolves to nothing known keeps passing through untouched.
+    if candidate.endswith(_ONE_M_SUFFIX):
+        base = _resolve_claude_model_base(candidate[: -len(_ONE_M_SUFFIX)])
+        if base not in CLAUDE_CONTEXT_WINDOWS:
+            return candidate
+        with_suffix = f"{base}{_ONE_M_SUFFIX}"
+        return with_suffix if with_suffix in CLAUDE_CONTEXT_WINDOWS else base
+    return _resolve_claude_model_base(candidate)
 
 
 def claude_model_family(model: str | None) -> str | None:

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -9,12 +9,12 @@ from collections.abc import Callable, Sequence
 
 from waypoint.schemas import BackendModelOption
 
-# Effort levels the CLI accepts per model (verified against the binary's
-# per-capability exclusion lists -- `effort` for effort at all, plus
-# `xhigh_effort` and `max_effort`). opus-5, opus-4-8, sonnet-5, and fable-5
-# accept the full set; haiku and pre-4.6 opus/sonnet don't accept --effort at
-# all. The server can still clamp a request at runtime via the account's
-# `max_effort_level` entitlement.
+# The effort vocabulary. Per-model `supported_efforts` below is the ladder Waypoint
+# *offers and enforces*, not a mirror of what the CLI refuses: the binary carries
+# per-capability lists (`effort`, `xhigh_effort`, `max_effort`) that drive its own
+# picker, but the flag itself is accepted regardless -- `claude --model haiku --effort
+# max` runs. So a narrower list here only ever narrows Waypoint. The server can also
+# clamp a request at runtime via the account's `max_effort_level` entitlement.
 CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 # Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
@@ -30,6 +30,8 @@ CLAUDE_MODEL_ALIASES: dict[str, str] = {
     "claude-opus-5": "opus",
     "claude-opus-4-8": "opus",
     "claude-opus-4-7": "opus",
+    "claude-opus-4-6": "opus",
+    "claude-opus-4-5": "opus",
     "claude-sonnet-5": "sonnet",
     "claude-sonnet-4-6": "sonnet",
     "claude-sonnet-4-5": "sonnet",
@@ -47,6 +49,77 @@ CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
     "fable[1m]": 1_000_000,
 }
 
+# Pinned legacy models reachable on the current CLI by full model name (the CLI's own
+# short picker keys -- `opus48`, `sonnet46`, ... -- are internal and rejected by
+# `--model`). Reachability was probed against the 2.1.220 binary: `claude-opus-4-1` is
+# silently remapped to Opus 5 and `claude-3-5-haiku` is retired, so neither is offered.
+#
+# `supported_efforts` is deliberately None (unknown -> forward unvalidated) rather than
+# a per-model ladder. The binary's capability lists do imply narrower ladders for these,
+# but they are not CLI-level rejection -- `claude --model haiku --effort max` is accepted
+# -- so pinning a narrower list here would make *Waypoint* reject launches the CLI
+# honors, including when only a configured `default_effort` supplies the level.
+_LEGACY_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
+    BackendModelOption(
+        id="claude-opus-4-8",
+        label="Opus 4.8",
+        description="Previous Opus version",
+    ),
+    BackendModelOption(
+        id="claude-opus-4-8[1m]",
+        label="Opus 4.8 (1M context)",
+        description="Previous Opus version, long sessions",
+    ),
+    BackendModelOption(
+        id="claude-opus-4-7",
+        label="Opus 4.7",
+        description="Legacy Opus version",
+    ),
+    BackendModelOption(
+        id="claude-opus-4-7[1m]",
+        label="Opus 4.7 (1M context)",
+        description="Legacy Opus version, long sessions",
+    ),
+    BackendModelOption(
+        id="claude-opus-4-6",
+        label="Opus 4.6",
+        description="Legacy Opus version",
+    ),
+    BackendModelOption(
+        id="claude-opus-4-6[1m]",
+        label="Opus 4.6 (1M context)",
+        description="Legacy Opus version, long sessions",
+    ),
+    # No [1m] pairing: claude-opus-4-5 is on the CLI's own 1M blocklist, and requesting
+    # the suffix fails with "the long context beta is not yet available".
+    BackendModelOption(
+        id="claude-opus-4-5",
+        label="Opus 4.5",
+        description="Legacy Opus version",
+    ),
+    BackendModelOption(
+        id="claude-sonnet-4-6",
+        label="Sonnet 4.6",
+        description="Previous Sonnet version",
+    ),
+    BackendModelOption(
+        id="claude-sonnet-4-6[1m]",
+        label="Sonnet 4.6 (1M context)",
+        description="Previous Sonnet version, long sessions",
+    ),
+    BackendModelOption(
+        id="claude-sonnet-4-5",
+        label="Sonnet 4.5",
+        description="Legacy Sonnet version",
+    ),
+    BackendModelOption(
+        id="claude-sonnet-4-5[1m]",
+        label="Sonnet 4.5 (1M context)",
+        description="Legacy Sonnet version, long sessions",
+    ),
+)
+
+# Grouped by family, newest first, each model immediately followed by its 1M variant.
 DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     BackendModelOption(
         id="opus",
@@ -56,24 +129,17 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         default_effort="high",
     ),
     BackendModelOption(
-        id="sonnet",
-        label="Sonnet 5",
-        description="Best for everyday tasks",
-        supported_efforts=list(CLAUDE_EFFORT_LEVELS),
-        default_effort="high",
-    ),
-    BackendModelOption(
-        id="haiku",
-        label="Haiku 4.5",
-        description="Fast and lightweight",
-        # No effort knob; explicit [] so the None default (unknown) still rejects.
-        supported_efforts=[],
-    ),
-    BackendModelOption(
         id="opus[1m]",
         label="Opus 5 (1M context)",
         description="Long sessions with large codebases",
         is_default=True,
+        supported_efforts=list(CLAUDE_EFFORT_LEVELS),
+        default_effort="high",
+    ),
+    BackendModelOption(
+        id="sonnet",
+        label="Sonnet 5",
+        description="Best for everyday tasks",
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
     ),
@@ -98,6 +164,14 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
     ),
+    BackendModelOption(
+        id="haiku",
+        label="Haiku 4.5",
+        description="Fast and lightweight",
+        # No effort knob; explicit [] so the None default (unknown) still rejects.
+        supported_efforts=[],
+    ),
+    *_LEGACY_CLAUDE_MODELS,
 )
 
 
@@ -248,6 +322,17 @@ _LEGACY_SONNET_LABELS: dict[str, str] = {
     "sonnet[1m]": "Sonnet 4.6 (1M context)",
 }
 
+# Pinned ids each rollback makes redundant: once the alias itself resolves to Opus 4.8,
+# the pinned claude-opus-4-8 entry is the same model under the same label, so the
+# offering would list it twice. Dropping the pin (rather than the alias) keeps the
+# default selection -- which is an alias id -- valid on every epoch.
+_OPUS5_REDUNDANT_IDS: frozenset[str] = frozenset(
+    {"claude-opus-4-8", "claude-opus-4-8[1m]"}
+)
+_SONNET5_REDUNDANT_IDS: frozenset[str] = frozenset(
+    {"claude-sonnet-4-6", "claude-sonnet-4-6[1m]"}
+)
+
 
 def _roll_back_opus5(
     offering: tuple[BackendModelOption, ...],
@@ -258,7 +343,8 @@ def _roll_back_opus5(
     same full effort set as Opus 5 (verified against the 2.1.218 and 2.1.220
     binaries: neither ``claude-opus-4-8`` nor ``claude-opus-5`` appears in the
     ``effort`` / ``xhigh_effort`` / ``max_effort`` exclusion lists), so only
-    the label differs across this boundary.
+    the label differs across this boundary. The pinned ``claude-opus-4-8`` entries drop
+    out, since the rolled-back alias already offers that model under that label.
     """
     return tuple(
         (
@@ -267,6 +353,7 @@ def _roll_back_opus5(
             else option
         )
         for option in offering
+        if option.id not in _OPUS5_REDUNDANT_IDS
     )
 
 
@@ -279,13 +366,16 @@ def _roll_back_sonnet5(
     ``max`` but not ``xhigh`` (verified in the 2.1.175 / 2.1.195 / 2.1.196
     binaries: Sonnet 4.6's capabilities carry ``max_effort`` but not
     ``xhigh_effort``). Fable 5 and Haiku are identical across this boundary, so
-    only the sonnet family is transformed. Applied via ``model_copy`` to
+    only the sonnet family is transformed, and the pinned ``claude-sonnet-4-6`` entries
+    drop out as redundant with the rolled-back alias. Applied via ``model_copy`` to
     whatever offering the newer epochs produced, so unrelated catalogue edits
     (wording, descriptions, new fields) stay in sync automatically.
     """
     sonnet_efforts = [level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"]
     rolled: list[BackendModelOption] = []
     for option in offering:
+        if option.id in _SONNET5_REDUNDANT_IDS:
+            continue
         if option.id.split("[", 1)[0] != "sonnet":
             rolled.append(option)
             continue

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -9,11 +9,12 @@ from collections.abc import Callable, Sequence
 
 from waypoint.schemas import BackendModelOption
 
-# Effort levels the CLI accepts per model (verified against v2.1.197's
-# gate functions: `Jw` for effort at all, `Rne` for xhigh, `c0e` for max).
-# opus-4-8, sonnet-5, and fable-5 accept the full set; haiku and pre-4.6
-# opus/sonnet don't accept --effort at all. The server can still clamp a
-# request at runtime via the account's `max_effort_level` entitlement.
+# Effort levels the CLI accepts per model (verified against the binary's
+# per-capability exclusion lists -- `effort` for effort at all, plus
+# `xhigh_effort` and `max_effort`). opus-5, opus-4-8, sonnet-5, and fable-5
+# accept the full set; haiku and pre-4.6 opus/sonnet don't accept --effort at
+# all. The server can still clamp a request at runtime via the account's
+# `max_effort_level` entitlement.
 CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 # Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
@@ -26,6 +27,7 @@ CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max"
 # claude-sonnet-4-5), and those ids must keep resolving for display and usage
 # tracking for as long as such sessions can be resumed.
 CLAUDE_MODEL_ALIASES: dict[str, str] = {
+    "claude-opus-5": "opus",
     "claude-opus-4-8": "opus",
     "claude-opus-4-7": "opus",
     "claude-sonnet-5": "sonnet",
@@ -48,7 +50,7 @@ CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
 DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     BackendModelOption(
         id="opus",
-        label="Opus 4.8",
+        label="Opus 5",
         description="Most capable for complex work",
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
         default_effort="high",
@@ -69,7 +71,7 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     ),
     BackendModelOption(
         id="opus[1m]",
-        label="Opus 4.8 (1M context)",
+        label="Opus 5 (1M context)",
         description="Long sessions with large codebases",
         is_default=True,
         supported_efforts=list(CLAUDE_EFFORT_LEVELS),
@@ -211,13 +213,20 @@ def resolve_import_model_id(
 #   2.1.154  Opus 4.8 introduced (defaults high; accepts xhigh + max)
 #   2.1.170  Fable 5 introduced (accepts xhigh + max; 1M context)
 #   2.1.197  Sonnet 5 introduced as the `sonnet` alias (native 1M context)
+#   2.1.219  Opus 5 introduced as the `opus` alias (native 1M context)
 #
-# 2.1.197 is the offering boundary we gate on: it swaps the `sonnet` alias from
-# Sonnet 4.6 to Sonnet 5. Sonnet 5 accepts `xhigh` where Sonnet 4.6 did not
-# (4.6 accepts `max` but not `xhigh`); Opus 4.8 and Fable 5 already accept the
-# full set on both sides of the boundary. Verified against the 2.1.175 /
-# 2.1.195 / 2.1.196 / 2.1.197 binaries installed on this host.
+# Each boundary below swaps an alias's target model, so only the affected
+# family's labels/efforts differ across it. Each builder transforms the
+# next-newer epoch's offering rather than DEFAULT_CLAUDE_MODELS, so an older
+# CLI correctly sees *every* rollback that applies to it.
 SONNET5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 197)
+OPUS5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 219)
+
+# Labels pre-Opus-5 CLI builds use for the opus ids.
+_LEGACY_OPUS_LABELS: dict[str, str] = {
+    "opus": "Opus 4.8",
+    "opus[1m]": "Opus 4.8 (1M context)",
+}
 
 # Labels pre-Sonnet-5 CLI builds use for the sonnet ids.
 _LEGACY_SONNET_LABELS: dict[str, str] = {
@@ -226,21 +235,41 @@ _LEGACY_SONNET_LABELS: dict[str, str] = {
 }
 
 
+def _pre_opus5_offering() -> tuple[BackendModelOption, ...]:
+    """The catalogue offered by CLI builds older than OPUS5_MIN_CLI_VERSION.
+
+    On these builds the ``opus`` alias resolves to Opus 4.8, which accepts the
+    same full effort set as Opus 5 (verified against the 2.1.218 and 2.1.220
+    binaries: neither ``claude-opus-4-8`` nor ``claude-opus-5`` appears in the
+    ``effort`` / ``xhigh_effort`` / ``max_effort`` exclusion lists), so only
+    the label differs across this boundary.
+    """
+    return tuple(
+        (
+            option.model_copy(update={"label": _LEGACY_OPUS_LABELS[option.id]})
+            if option.id in _LEGACY_OPUS_LABELS
+            else option
+        )
+        for option in DEFAULT_CLAUDE_MODELS
+    )
+
+
 def _pre_sonnet5_offering() -> tuple[BackendModelOption, ...]:
     """The catalogue offered by CLI builds older than SONNET5_MIN_CLI_VERSION.
 
     On these builds the ``sonnet`` alias resolves to Sonnet 4.6, which accepts
     ``max`` but not ``xhigh`` (verified in the 2.1.175 / 2.1.195 / 2.1.196
     binaries: Sonnet 4.6's capabilities carry ``max_effort`` but not
-    ``xhigh_effort``). Opus 4.8, Fable 5, and Haiku are identical to the
-    current catalogue across this boundary, so only the sonnet family is
-    transformed. Derived from ``DEFAULT_CLAUDE_MODELS`` via ``model_copy`` so
+    ``xhigh_effort``). Fable 5 and Haiku are identical to the current
+    catalogue across this boundary, and the opus rollback comes from
+    ``_pre_opus5_offering`` (every build this old also predates Opus 5), so
+    only the sonnet family is transformed here. Derived via ``model_copy`` so
     unrelated catalogue edits (wording, descriptions, new fields) stay in sync
     automatically.
     """
     sonnet_efforts = [level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"]
     offering: list[BackendModelOption] = []
-    for option in DEFAULT_CLAUDE_MODELS:
+    for option in _pre_opus5_offering():
         if option.id.split("[", 1)[0] != "sonnet":
             offering.append(option)
             continue
@@ -260,7 +289,8 @@ def _pre_sonnet5_offering() -> tuple[BackendModelOption, ...]:
 _CLAUDE_MODEL_EPOCHS: tuple[
     tuple[tuple[int, ...], Callable[[], tuple[BackendModelOption, ...]]], ...
 ] = (
-    (SONNET5_MIN_CLI_VERSION, lambda: DEFAULT_CLAUDE_MODELS),
+    (OPUS5_MIN_CLI_VERSION, lambda: DEFAULT_CLAUDE_MODELS),
+    (SONNET5_MIN_CLI_VERSION, _pre_opus5_offering),
     ((0,), _pre_sonnet5_offering),
 )
 

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -168,7 +168,13 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         id="haiku",
         label="Haiku 4.5",
         description="Fast and lightweight",
-        # No effort knob; explicit [] so the None default (unknown) still rejects.
+        # Explicit [] so the None default (unknown) still rejects. This is a curated
+        # product choice -- offer no effort control for Haiku -- not a claim that the
+        # CLI refuses the flag; it accepts `--effort max` here. The pinned legacy
+        # entries below deliberately go the other way (None) because narrowing them
+        # would newly reject launches that work today. Enforcing [] does mean a
+        # deployment with `default_effort` set cannot launch `haiku` without
+        # overriding the effort -- pre-existing, tracked separately.
         supported_efforts=[],
     ),
     *_LEGACY_CLAUDE_MODELS,
@@ -362,10 +368,13 @@ def _roll_back_sonnet5(
 ) -> tuple[BackendModelOption, ...]:
     """``offering`` as CLI builds older than SONNET5_MIN_CLI_VERSION see it.
 
-    On these builds the ``sonnet`` alias resolves to Sonnet 4.6, which accepts
-    ``max`` but not ``xhigh`` (verified in the 2.1.175 / 2.1.195 / 2.1.196
-    binaries: Sonnet 4.6's capabilities carry ``max_effort`` but not
-    ``xhigh_effort``). Fable 5 and Haiku are identical across this boundary, so
+    On these builds the ``sonnet`` alias resolves to Sonnet 4.6, whose capability
+    lists carry ``max_effort`` but not ``xhigh_effort`` (verified in the 2.1.175 /
+    2.1.195 / 2.1.196 binaries), so the offered ladder drops ``xhigh``. As with
+    Haiku above this is a curated offering, not CLI-level rejection -- and as with
+    Haiku it is left as-is rather than loosened to ``None``, since narrowing an
+    *alias* ladder is pre-existing behavior this catalogue already relies on.
+    Fable 5 and Haiku are identical across this boundary, so
     only the sonnet family is transformed, and the pinned ``claude-sonnet-4-6`` entries
     drop out as redundant with the rolled-back alias. Applied via ``model_copy`` to
     whatever offering the newer epochs produced, so unrelated catalogue edits

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -5,16 +5,14 @@ binary; bumped manually when a new alias ships. Codex has a runtime
 ``model/list`` RPC, Claude does not.
 """
 
-from collections.abc import Callable, Sequence
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple
 
 from waypoint.schemas import BackendModelOption
 
-# The effort vocabulary. Per-model `supported_efforts` below is the ladder Waypoint
-# *offers and enforces*, not a mirror of what the CLI refuses: the binary carries
-# per-capability lists (`effort`, `xhigh_effort`, `max_effort`) that drive its own
-# picker, but the flag itself is accepted regardless -- `claude --model haiku --effort
-# max` runs. So a narrower list here only ever narrows Waypoint. The server can also
-# clamp a request at runtime via the account's `max_effort_level` entitlement.
+# Per-model `supported_efforts` is the ladder Waypoint offers and enforces. The CLI
+# accepts `--effort` for every model, so a narrower list only narrows Waypoint; the
+# server may still clamp a request via the account's `max_effort_level` entitlement.
 CLAUDE_EFFORT_LEVELS: tuple[str, ...] = ("low", "medium", "high", "xhigh", "max")
 
 # Claude's CLI only exposes a small fixed catalog of aliases. The adapter may
@@ -49,16 +47,10 @@ CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
     "fable[1m]": 1_000_000,
 }
 
-# Pinned legacy models reachable on the current CLI by full model name (the CLI's own
-# short picker keys -- `opus48`, `sonnet46`, ... -- are internal and rejected by
-# `--model`). Reachability was probed against the 2.1.220 binary: `claude-opus-4-1` is
-# silently remapped to Opus 5 and `claude-3-5-haiku` is retired, so neither is offered.
-#
-# `supported_efforts` is deliberately None (unknown -> forward unvalidated) rather than
-# a per-model ladder. The binary's capability lists do imply narrower ladders for these,
-# but they are not CLI-level rejection -- `claude --model haiku --effort max` is accepted
-# -- so pinning a narrower list here would make *Waypoint* reject launches the CLI
-# honors, including when only a configured `default_effort` supplies the level.
+# Legacy models the CLI still runs, pinned by full model name; its own short picker
+# keys (`opus48`, `sonnet46`, ...) are internal and rejected by `--model`.
+# `claude-opus-4-1` is remapped to Opus 5 and `claude-3-5-haiku` is retired, so neither
+# is offered. `supported_efforts` stays unset, leaving the CLI the authority.
 _LEGACY_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     BackendModelOption(
         id="claude-opus-4-8",
@@ -90,8 +82,7 @@ _LEGACY_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         label="Opus 4.6 (1M context)",
         description="Legacy Opus version, long sessions",
     ),
-    # No [1m] pairing: claude-opus-4-5 is on the CLI's own 1M blocklist, and requesting
-    # the suffix fails with "the long context beta is not yet available".
+    # No [1m] pairing: claude-opus-4-5 is on the CLI's 1M blocklist.
     BackendModelOption(
         id="claude-opus-4-5",
         label="Opus 4.5",
@@ -168,13 +159,7 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         id="haiku",
         label="Haiku 4.5",
         description="Fast and lightweight",
-        # Explicit [] so the None default (unknown) still rejects. This is a curated
-        # product choice -- offer no effort control for Haiku -- not a claim that the
-        # CLI refuses the flag; it accepts `--effort max` here. The pinned legacy
-        # entries below deliberately go the other way (None) because narrowing them
-        # would newly reject launches that work today. Enforcing [] does mean a
-        # deployment with `default_effort` set cannot launch `haiku` without
-        # overriding the effort -- pre-existing, tracked separately.
+        # Offer no effort control; explicit [] so the None default (unknown) rejects.
         supported_efforts=[],
     ),
     *_LEGACY_CLAUDE_MODELS,
@@ -248,12 +233,9 @@ def normalize_claude_model_id(model: str | None) -> str | None:
         return None
     if candidate in CLAUDE_CONTEXT_WINDOWS:
         return candidate
-    # A concrete id may carry the 1M entitlement as a suffix
-    # (``claude-opus-5[1m]``). Resolve the base family, then re-attach the
-    # suffix so the entitlement survives normalization instead of collapsing to
-    # the bare 200K family id. Families with no 1M offering (haiku) have no
-    # ``[1m]`` catalogue entry, so the suffix is correctly dropped for them. An
-    # id whose base resolves to nothing known keeps passing through untouched.
+    # A concrete id may carry the 1M entitlement as a suffix (`claude-opus-5[1m]`);
+    # re-attach it to the resolved base so the entitlement survives. A family with no
+    # 1M offering (haiku) has no `[1m]` entry, so the suffix resolves away.
     if candidate.endswith(_ONE_M_SUFFIX):
         base = _resolve_claude_model_base(candidate[: -len(_ONE_M_SUFFIX)])
         if base not in CLAUDE_CONTEXT_WINDOWS:
@@ -271,10 +253,8 @@ def claude_model_family(model: str | None) -> str | None:
 
 
 def claude_context_window_for_model(model: str | None) -> int | None:
-    # normalize_claude_model_id resolves anything family-ish to a catalogue id
-    # (including re-attaching a `[1m]` entitlement) and otherwise returns the
-    # input verbatim, so an unresolved id has no family to fall back on --
-    # don't fabricate a window for it.
+    # An unresolved id normalizes to itself, so it has no window rather than a
+    # fabricated default.
     normalized = normalize_claude_model_id(model)
     if normalized is None:
         return None
@@ -302,117 +282,67 @@ def resolve_import_model_id(
     return default_model_id
 
 
-# CLI version milestones, from the official changelog (anthropics/claude-code):
-#   2.1.154  Opus 4.8 introduced (defaults high; accepts xhigh + max)
-#   2.1.170  Fable 5 introduced (accepts xhigh + max; 1M context)
-#   2.1.197  Sonnet 5 introduced as the `sonnet` alias (native 1M context)
-#   2.1.219  Opus 5 introduced as the `opus` alias (native 1M context)
-#
-# Each boundary below swaps an alias's target model, so only the affected
-# family's labels/efforts differ across it. The rollbacks are applied
-# cumulatively (newest first) rather than each rebuilding from
-# DEFAULT_CLAUDE_MODELS, so an older CLI sees *every* rollback that applies to
-# it, not just the newest one.
+# CLI versions that swapped an alias's target model, from the official changelog
+# (anthropics/claude-code). Only the affected family differs across each boundary.
+#   2.1.197  `sonnet` becomes Sonnet 5
+#   2.1.219  `opus` becomes Opus 5
 SONNET5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 197)
 OPUS5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 219)
 
-# Labels pre-Opus-5 CLI builds use for the opus ids.
-_LEGACY_OPUS_LABELS: dict[str, str] = {
-    "opus": "Opus 4.8",
-    "opus[1m]": "Opus 4.8 (1M context)",
-}
 
-# Labels pre-Sonnet-5 CLI builds use for the sonnet ids.
-_LEGACY_SONNET_LABELS: dict[str, str] = {
-    "sonnet": "Sonnet 4.6",
-    "sonnet[1m]": "Sonnet 4.6 (1M context)",
-}
+class _ModelEpoch(NamedTuple):
+    """What an alias swap looks like to CLI builds older than ``min_version``.
 
-# Pinned ids each rollback makes redundant: once the alias itself resolves to Opus 4.8,
-# the pinned claude-opus-4-8 entry is the same model under the same label, so the
-# offering would list it twice. Dropping the pin (rather than the alias) keeps the
-# default selection -- which is an alias id -- valid on every epoch.
-_OPUS5_REDUNDANT_IDS: frozenset[str] = frozenset(
-    {"claude-opus-4-8", "claude-opus-4-8[1m]"}
-)
-_SONNET5_REDUNDANT_IDS: frozenset[str] = frozenset(
-    {"claude-sonnet-4-6", "claude-sonnet-4-6[1m]"}
-)
-
-
-def _roll_back_opus5(
-    offering: tuple[BackendModelOption, ...],
-) -> tuple[BackendModelOption, ...]:
-    """``offering`` as CLI builds older than OPUS5_MIN_CLI_VERSION see it.
-
-    On these builds the ``opus`` alias resolves to Opus 4.8, which accepts the
-    same full effort set as Opus 5 (verified against the 2.1.218 and 2.1.220
-    binaries: neither ``claude-opus-4-8`` nor ``claude-opus-5`` appears in the
-    ``effort`` / ``xhigh_effort`` / ``max_effort`` exclusion lists), so only
-    the label differs across this boundary. The pinned ``claude-opus-4-8`` entries drop
-    out, since the rolled-back alias already offers that model under that label.
+    ``labels`` relabels the affected alias ids and ``efforts`` narrows their ladder.
+    ``drop`` removes the pinned ids the relabelled alias now duplicates; the pin goes
+    rather than the alias so the default selection, an alias id, stays valid.
     """
-    return tuple(
-        (
-            option.model_copy(update={"label": _LEGACY_OPUS_LABELS[option.id]})
-            if option.id in _LEGACY_OPUS_LABELS
-            else option
-        )
-        for option in offering
-        if option.id not in _OPUS5_REDUNDANT_IDS
-    )
+
+    min_version: tuple[int, ...]
+    labels: Mapping[str, str]
+    drop: frozenset[str]
+    efforts: tuple[str, ...] | None = None
 
 
-def _roll_back_sonnet5(
-    offering: tuple[BackendModelOption, ...],
+# Newest first, applied cumulatively, so a build below several boundaries gets every
+# rollback and adding an epoch is one prepended entry.
+_CLAUDE_MODEL_EPOCHS: tuple[_ModelEpoch, ...] = (
+    _ModelEpoch(
+        min_version=OPUS5_MIN_CLI_VERSION,
+        labels={"opus": "Opus 4.8", "opus[1m]": "Opus 4.8 (1M context)"},
+        drop=frozenset({"claude-opus-4-8", "claude-opus-4-8[1m]"}),
+    ),
+    _ModelEpoch(
+        min_version=SONNET5_MIN_CLI_VERSION,
+        labels={"sonnet": "Sonnet 4.6", "sonnet[1m]": "Sonnet 4.6 (1M context)"},
+        drop=frozenset({"claude-sonnet-4-6", "claude-sonnet-4-6[1m]"}),
+        # Sonnet 4.6's capability lists carry `max_effort` but not `xhigh_effort`.
+        efforts=tuple(level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"),
+    ),
+)
+
+
+def _roll_back(
+    offering: tuple[BackendModelOption, ...], epoch: _ModelEpoch
 ) -> tuple[BackendModelOption, ...]:
-    """``offering`` as CLI builds older than SONNET5_MIN_CLI_VERSION see it.
+    """``offering`` as builds older than ``epoch.min_version`` see it.
 
-    On these builds the ``sonnet`` alias resolves to Sonnet 4.6, whose capability
-    lists carry ``max_effort`` but not ``xhigh_effort`` (verified in the 2.1.175 /
-    2.1.195 / 2.1.196 binaries), so the offered ladder drops ``xhigh``. As with
-    Haiku above this is a curated offering, not CLI-level rejection -- and as with
-    Haiku it is left as-is rather than loosened to ``None``, since narrowing an
-    *alias* ladder is pre-existing behavior this catalogue already relies on.
-    Fable 5 and Haiku are identical across this boundary, so
-    only the sonnet family is transformed, and the pinned ``claude-sonnet-4-6`` entries
-    drop out as redundant with the rolled-back alias. Applied via ``model_copy`` to
-    whatever offering the newer epochs produced, so unrelated catalogue edits
-    (wording, descriptions, new fields) stay in sync automatically.
+    Applied to whatever the newer epochs produced, via ``model_copy``, so unrelated
+    catalogue edits stay in sync.
     """
-    sonnet_efforts = [level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"]
     rolled: list[BackendModelOption] = []
     for option in offering:
-        if option.id in _SONNET5_REDUNDANT_IDS:
+        if option.id in epoch.drop:
             continue
-        if option.id.split("[", 1)[0] != "sonnet":
+        label = epoch.labels.get(option.id)
+        if label is None:
             rolled.append(option)
             continue
-        rolled.append(
-            option.model_copy(
-                update={
-                    "label": _LEGACY_SONNET_LABELS.get(option.id, option.label),
-                    "supported_efforts": sonnet_efforts,
-                }
-            )
-        )
+        update: dict[str, Any] = {"label": label}
+        if epoch.efforts is not None:
+            update["supported_efforts"] = list(epoch.efforts)
+        rolled.append(option.model_copy(update=update))
     return tuple(rolled)
-
-
-# Each entry pairs the version a model epoch started at with the rollback that
-# undoes it, i.e. the transform a build *older* than that version needs.
-# Ordered newest first, and applied cumulatively, so introducing a future epoch
-# is exactly one edit: prepend its ``(min_version, rollback)`` pair.
-_CLAUDE_MODEL_EPOCH_ROLLBACKS: tuple[
-    tuple[
-        tuple[int, ...],
-        Callable[[tuple[BackendModelOption, ...]], tuple[BackendModelOption, ...]],
-    ],
-    ...,
-] = (
-    (OPUS5_MIN_CLI_VERSION, _roll_back_opus5),
-    (SONNET5_MIN_CLI_VERSION, _roll_back_sonnet5),
-)
 
 
 def claude_models_for_version(
@@ -427,8 +357,8 @@ def claude_models_for_version(
     if version is None:
         return DEFAULT_CLAUDE_MODELS
     offering = DEFAULT_CLAUDE_MODELS
-    for min_version, roll_back in _CLAUDE_MODEL_EPOCH_ROLLBACKS:
-        if version >= min_version:
+    for epoch in _CLAUDE_MODEL_EPOCHS:
+        if version >= epoch.min_version:
             break
-        offering = roll_back(offering)
+        offering = _roll_back(offering, epoch)
     return offering

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -191,20 +191,14 @@ def claude_model_family(model: str | None) -> str | None:
 
 
 def claude_context_window_for_model(model: str | None) -> int | None:
+    # normalize_claude_model_id resolves anything family-ish to a catalogue id
+    # (including re-attaching a `[1m]` entitlement) and otherwise returns the
+    # input verbatim, so an unresolved id has no family to fall back on --
+    # don't fabricate a window for it.
     normalized = normalize_claude_model_id(model)
     if normalized is None:
         return None
-    if normalized in CLAUDE_CONTEXT_WINDOWS:
-        return CLAUDE_CONTEXT_WINDOWS[normalized]
-    family = claude_model_family(normalized)
-    if family is None or family not in CLAUDE_CONTEXT_WINDOWS:
-        # No family could be inferred at all (genuine garbage) -- don't
-        # fabricate a window.
-        return None
-    candidate = model.strip() if isinstance(model, str) else ""
-    if normalized.endswith("[1m]") or candidate.endswith("[1m]"):
-        return 1_000_000
-    return CLAUDE_CONTEXT_WINDOWS[family]
+    return CLAUDE_CONTEXT_WINDOWS.get(normalized)
 
 
 def claude_default_model_id() -> str | None:
@@ -235,9 +229,10 @@ def resolve_import_model_id(
 #   2.1.219  Opus 5 introduced as the `opus` alias (native 1M context)
 #
 # Each boundary below swaps an alias's target model, so only the affected
-# family's labels/efforts differ across it. Each builder transforms the
-# next-newer epoch's offering rather than DEFAULT_CLAUDE_MODELS, so an older
-# CLI correctly sees *every* rollback that applies to it.
+# family's labels/efforts differ across it. The rollbacks are applied
+# cumulatively (newest first) rather than each rebuilding from
+# DEFAULT_CLAUDE_MODELS, so an older CLI sees *every* rollback that applies to
+# it, not just the newest one.
 SONNET5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 197)
 OPUS5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 219)
 
@@ -254,8 +249,10 @@ _LEGACY_SONNET_LABELS: dict[str, str] = {
 }
 
 
-def _pre_opus5_offering() -> tuple[BackendModelOption, ...]:
-    """The catalogue offered by CLI builds older than OPUS5_MIN_CLI_VERSION.
+def _roll_back_opus5(
+    offering: tuple[BackendModelOption, ...],
+) -> tuple[BackendModelOption, ...]:
+    """``offering`` as CLI builds older than OPUS5_MIN_CLI_VERSION see it.
 
     On these builds the ``opus`` alias resolves to Opus 4.8, which accepts the
     same full effort set as Opus 5 (verified against the 2.1.218 and 2.1.220
@@ -269,30 +266,30 @@ def _pre_opus5_offering() -> tuple[BackendModelOption, ...]:
             if option.id in _LEGACY_OPUS_LABELS
             else option
         )
-        for option in DEFAULT_CLAUDE_MODELS
+        for option in offering
     )
 
 
-def _pre_sonnet5_offering() -> tuple[BackendModelOption, ...]:
-    """The catalogue offered by CLI builds older than SONNET5_MIN_CLI_VERSION.
+def _roll_back_sonnet5(
+    offering: tuple[BackendModelOption, ...],
+) -> tuple[BackendModelOption, ...]:
+    """``offering`` as CLI builds older than SONNET5_MIN_CLI_VERSION see it.
 
     On these builds the ``sonnet`` alias resolves to Sonnet 4.6, which accepts
     ``max`` but not ``xhigh`` (verified in the 2.1.175 / 2.1.195 / 2.1.196
     binaries: Sonnet 4.6's capabilities carry ``max_effort`` but not
-    ``xhigh_effort``). Fable 5 and Haiku are identical to the current
-    catalogue across this boundary, and the opus rollback comes from
-    ``_pre_opus5_offering`` (every build this old also predates Opus 5), so
-    only the sonnet family is transformed here. Derived via ``model_copy`` so
-    unrelated catalogue edits (wording, descriptions, new fields) stay in sync
-    automatically.
+    ``xhigh_effort``). Fable 5 and Haiku are identical across this boundary, so
+    only the sonnet family is transformed. Applied via ``model_copy`` to
+    whatever offering the newer epochs produced, so unrelated catalogue edits
+    (wording, descriptions, new fields) stay in sync automatically.
     """
     sonnet_efforts = [level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"]
-    offering: list[BackendModelOption] = []
-    for option in _pre_opus5_offering():
+    rolled: list[BackendModelOption] = []
+    for option in offering:
         if option.id.split("[", 1)[0] != "sonnet":
-            offering.append(option)
+            rolled.append(option)
             continue
-        offering.append(
+        rolled.append(
             option.model_copy(
                 update={
                     "label": _LEGACY_SONNET_LABELS.get(option.id, option.label),
@@ -300,17 +297,22 @@ def _pre_sonnet5_offering() -> tuple[BackendModelOption, ...]:
                 }
             )
         )
-    return tuple(offering)
+    return tuple(rolled)
 
 
-# Ordered by descending minimum version so adding a future epoch is a small,
-# obvious edit: prepend a new ``(min_version, builder)`` pair at the front.
-_CLAUDE_MODEL_EPOCHS: tuple[
-    tuple[tuple[int, ...], Callable[[], tuple[BackendModelOption, ...]]], ...
+# Each entry pairs the version a model epoch started at with the rollback that
+# undoes it, i.e. the transform a build *older* than that version needs.
+# Ordered newest first, and applied cumulatively, so introducing a future epoch
+# is exactly one edit: prepend its ``(min_version, rollback)`` pair.
+_CLAUDE_MODEL_EPOCH_ROLLBACKS: tuple[
+    tuple[
+        tuple[int, ...],
+        Callable[[tuple[BackendModelOption, ...]], tuple[BackendModelOption, ...]],
+    ],
+    ...,
 ] = (
-    (OPUS5_MIN_CLI_VERSION, lambda: DEFAULT_CLAUDE_MODELS),
-    (SONNET5_MIN_CLI_VERSION, _pre_opus5_offering),
-    ((0,), _pre_sonnet5_offering),
+    (OPUS5_MIN_CLI_VERSION, _roll_back_opus5),
+    (SONNET5_MIN_CLI_VERSION, _roll_back_sonnet5),
 )
 
 
@@ -325,7 +327,9 @@ def claude_models_for_version(
     """
     if version is None:
         return DEFAULT_CLAUDE_MODELS
-    for min_version, builder in _CLAUDE_MODEL_EPOCHS:
+    offering = DEFAULT_CLAUDE_MODELS
+    for min_version, roll_back in _CLAUDE_MODEL_EPOCH_ROLLBACKS:
         if version >= min_version:
-            return builder()
-    return DEFAULT_CLAUDE_MODELS
+            break
+        offering = roll_back(offering)
+    return offering

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -6,7 +6,7 @@ binary; bumped manually when a new alias ships. Codex has a runtime
 """
 
 from collections.abc import Mapping, Sequence
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 from waypoint.schemas import BackendModelOption
 
@@ -50,7 +50,8 @@ CLAUDE_CONTEXT_WINDOWS: dict[str, int] = {
 # Legacy models the CLI still runs, pinned by full model name; its own short picker
 # keys (`opus48`, `sonnet46`, ...) are internal and rejected by `--model`.
 # `claude-opus-4-1` is remapped to Opus 5 and `claude-3-5-haiku` is retired, so neither
-# is offered. `supported_efforts` stays unset, leaving the CLI the authority.
+# is offered. `supported_efforts` stays unset, leaving the CLI the authority. Probed
+# against 2.1.220; the remap/retirement table is server-fetched and can drift.
 _LEGACY_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
     BackendModelOption(
         id="claude-opus-4-8",
@@ -160,6 +161,8 @@ DEFAULT_CLAUDE_MODELS: tuple[BackendModelOption, ...] = (
         label="Haiku 4.5",
         description="Fast and lightweight",
         # Offer no effort control; explicit [] so the None default (unknown) rejects.
+        # A deployment with `default_effort` set therefore cannot launch `haiku`
+        # without overriding the effort -- see issue #361.
         supported_efforts=[],
     ),
     *_LEGACY_CLAUDE_MODELS,
@@ -282,8 +285,12 @@ def resolve_import_model_id(
     return default_model_id
 
 
-# CLI versions that swapped an alias's target model, from the official changelog
-# (anthropics/claude-code). Only the affected family differs across each boundary.
+# Catalogue boundaries from the official changelog (anthropics/claude-code). Only the
+# affected family differs across each. The introduction boundaries carry no rollback:
+# a CLI below them is still offered the model, so `fable` reaches builds older than
+# 2.1.170.
+#   2.1.154  Opus 4.8 introduced      (unhandled)
+#   2.1.170  Fable 5 introduced       (unhandled)
 #   2.1.197  `sonnet` becomes Sonnet 5
 #   2.1.219  `opus` becomes Opus 5
 SONNET5_MIN_CLI_VERSION: tuple[int, ...] = (2, 1, 197)
@@ -305,18 +312,19 @@ class _ModelEpoch(NamedTuple):
 
 
 # Newest first, applied cumulatively, so a build below several boundaries gets every
-# rollback and adding an epoch is one prepended entry.
+# rollback.
 _CLAUDE_MODEL_EPOCHS: tuple[_ModelEpoch, ...] = (
     _ModelEpoch(
         min_version=OPUS5_MIN_CLI_VERSION,
         labels={"opus": "Opus 4.8", "opus[1m]": "Opus 4.8 (1M context)"},
         drop=frozenset({"claude-opus-4-8", "claude-opus-4-8[1m]"}),
+        # No `efforts`: Opus 4.8 is in none of the capability lists, as Opus 5 is not.
     ),
     _ModelEpoch(
         min_version=SONNET5_MIN_CLI_VERSION,
         labels={"sonnet": "Sonnet 4.6", "sonnet[1m]": "Sonnet 4.6 (1M context)"},
         drop=frozenset({"claude-sonnet-4-6", "claude-sonnet-4-6[1m]"}),
-        # Sonnet 4.6's capability lists carry `max_effort` but not `xhigh_effort`.
+        # Sonnet 4.6 is in `xhigh_effort` but not `max_effort` (2.1.196 binary).
         efforts=tuple(level for level in CLAUDE_EFFORT_LEVELS if level != "xhigh"),
     ),
 )
@@ -325,11 +333,7 @@ _CLAUDE_MODEL_EPOCHS: tuple[_ModelEpoch, ...] = (
 def _roll_back(
     offering: tuple[BackendModelOption, ...], epoch: _ModelEpoch
 ) -> tuple[BackendModelOption, ...]:
-    """``offering`` as builds older than ``epoch.min_version`` see it.
-
-    Applied to whatever the newer epochs produced, via ``model_copy``, so unrelated
-    catalogue edits stay in sync.
-    """
+    """``offering`` as builds older than ``epoch.min_version`` see it."""
     rolled: list[BackendModelOption] = []
     for option in offering:
         if option.id in epoch.drop:
@@ -338,7 +342,7 @@ def _roll_back(
         if label is None:
             rolled.append(option)
             continue
-        update: dict[str, Any] = {"label": label}
+        update: dict[str, str | list[str]] = {"label": label}
         if epoch.efforts is not None:
             update["supported_efforts"] = list(epoch.efforts)
         rolled.append(option.model_copy(update=update))

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -696,12 +696,6 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             return list(custom_args)
         return self._config(runtime).cli_args + custom_args
 
-    def static_model_options(self, runtime: "SessionRuntime") -> list[Any]:
-        # Plugin config carries the (configurable) Claude model catalogue.
-        # Deployments patch the list via ``plugin_configs.claude_code.models``
-        # in waypoint.yaml without forking this module.
-        return list(self._config(runtime).models)
-
     @property
     def permission_mode_ids(self) -> tuple[str, ...]:
         return CLAUDE_PERMISSION_MODES

--- a/backend/tests/test_claude_cli_version.py
+++ b/backend/tests/test_claude_cli_version.py
@@ -1,5 +1,6 @@
 """Unit tests for backends/claude_code/version.py's ``claude --version`` probe."""
 
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -13,9 +14,12 @@ from waypoint.launch_targets import SshLaunchTargetConfig
 
 
 @pytest.fixture(autouse=True)
-def _clear_version_cache() -> None:
-    # The TTL cache is keyed by binary path; clear it so one test's fake
-    # subprocess result can't leak into the next.
+def _clear_version_cache() -> Iterator[None]:
+    # The TTL cache is keyed by binary path; clear it around every test so one
+    # test's fake subprocess result can't leak into the next -- or, on teardown,
+    # out of this module into any other test that probes the real binary.
+    version_module._VERSION_STRING_CACHE.clear()
+    yield
     version_module._VERSION_STRING_CACHE.clear()
 
 

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -94,6 +94,25 @@ def test_legacy_offering_below_sonnet5_min_version() -> None:
     assert "xhigh" in opus_1m.supported_efforts and "max" in opus_1m.supported_efforts
 
 
+@pytest.mark.parametrize(
+    ("version", "opus_label", "sonnet_label"),
+    [
+        ((2, 1, 219), "Opus 5", "Sonnet 5"),
+        ((2, 1, 218), "Opus 4.8", "Sonnet 5"),
+        ((2, 1, 197), "Opus 4.8", "Sonnet 5"),
+        ((2, 1, 196), "Opus 4.8", "Sonnet 4.6"),
+    ],
+)
+def test_rollbacks_apply_cumulatively_at_each_boundary(
+    version, opus_label: str, sonnet_label: str
+) -> None:
+    # Each boundary is inclusive of its own epoch, and a build below several
+    # boundaries gets every rollback rather than only the newest.
+    models = claude_models_for_version(version)
+    assert _by_id(models, "opus").label == opus_label
+    assert _by_id(models, "sonnet").label == sonnet_label
+
+
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 190), (2, 1, 218)])
 def test_legacy_offerings_have_same_model_ids_as_default(version) -> None:
     legacy = claude_models_for_version(version)

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -113,12 +113,115 @@ def test_rollbacks_apply_cumulatively_at_each_boundary(
     assert _by_id(models, "sonnet").label == sonnet_label
 
 
-@pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 190), (2, 1, 218)])
-def test_legacy_offerings_have_same_model_ids_as_default(version) -> None:
-    legacy = claude_models_for_version(version)
-    assert {opt.id for opt in legacy} == {opt.id for opt in DEFAULT_CLAUDE_MODELS}
-    assert [opt.id for opt in legacy] == [opt.id for opt in DEFAULT_CLAUDE_MODELS]
-    assert sum(opt.is_default for opt in legacy) == 1
+@pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 190), (2, 1, 218), (2, 1, 220)])
+def test_every_offering_is_an_ordered_subset_with_one_default(version) -> None:
+    # Rollbacks may drop a pinned entry the rolled-back alias makes redundant, so an
+    # older offering is a subset rather than an exact match -- but never a superset,
+    # never reordered, and always with exactly one default (an alias id, which no
+    # rollback removes).
+    offering = claude_models_for_version(version)
+    default_ids = [opt.id for opt in DEFAULT_CLAUDE_MODELS]
+    ids = [opt.id for opt in offering]
+
+    assert set(ids) <= set(default_ids)
+    assert ids == [model_id for model_id in default_ids if model_id in set(ids)]
+    assert sum(opt.is_default for opt in offering) == 1
+
+
+@pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 196), (2, 1, 218), (2, 1, 220)])
+def test_no_offering_lists_a_label_twice(version) -> None:
+    # Below 2.1.219 the `opus` alias itself is labelled "Opus 4.8", which would collide
+    # with the pinned claude-opus-4-8 entry; likewise `sonnet` below 2.1.197.
+    labels = [opt.label for opt in claude_models_for_version(version)]
+    assert len(labels) == len(set(labels)), sorted(
+        label for label in labels if labels.count(label) > 1
+    )
+
+
+def test_rollbacks_drop_the_pin_the_alias_makes_redundant() -> None:
+    below_opus5 = {opt.id for opt in claude_models_for_version((2, 1, 218))}
+    assert "claude-opus-4-8" not in below_opus5
+    assert "claude-opus-4-8[1m]" not in below_opus5
+    # Older opus pins are still distinct models, so they stay.
+    assert "claude-opus-4-7" in below_opus5
+    # Sonnet 5 still shipped at 2.1.218, so its pin is untouched here.
+    assert "claude-sonnet-4-6" in below_opus5
+
+    below_sonnet5 = {opt.id for opt in claude_models_for_version((2, 1, 196))}
+    assert "claude-sonnet-4-6" not in below_sonnet5
+    assert "claude-sonnet-4-6[1m]" not in below_sonnet5
+    assert "claude-sonnet-4-5" in below_sonnet5
+
+
+# --- pinned legacy models -------------------------------------------------
+
+
+_LEGACY_IDS = (
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-opus-4-5",
+    "claude-sonnet-4-6",
+    "claude-sonnet-4-5",
+)
+
+
+@pytest.mark.parametrize("model_id", _LEGACY_IDS)
+def test_reachable_legacy_models_are_offered(model_id: str) -> None:
+    assert _by_id(DEFAULT_CLAUDE_MODELS, model_id).id == model_id
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    # Remapped to Opus 5 / retired respectively -- offering either would let a user
+    # pick a model that silently runs as something else.
+    ["claude-opus-4-1", "claude-3-5-haiku", "opus48", "opus47", "sonnet46"],
+)
+def test_unreachable_models_and_internal_picker_keys_are_not_offered(
+    model_id: str,
+) -> None:
+    assert all(opt.id != model_id for opt in DEFAULT_CLAUDE_MODELS)
+
+
+@pytest.mark.parametrize("model_id", _LEGACY_IDS)
+def test_legacy_models_forward_effort_unvalidated(model_id: str) -> None:
+    # None, not a narrower ladder: the CLI accepts any --effort, so pinning a list
+    # would only make Waypoint reject launches the CLI honors.
+    assert _by_id(DEFAULT_CLAUDE_MODELS, model_id).supported_efforts is None
+
+
+@pytest.mark.parametrize(
+    "model_id",
+    [
+        "claude-opus-4-8",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5",
+    ],
+)
+def test_legacy_models_with_a_1m_variant_are_paired(model_id: str) -> None:
+    variant = _by_id(DEFAULT_CLAUDE_MODELS, f"{model_id}[1m]")
+    assert variant.label.endswith("(1M context)")
+
+
+def test_opus_4_5_has_no_1m_variant() -> None:
+    # On the CLI's own 1M blocklist: requesting the suffix fails with "the long
+    # context beta is not yet available".
+    assert all(opt.id != "claude-opus-4-5[1m]" for opt in DEFAULT_CLAUDE_MODELS)
+
+
+def test_catalogue_groups_families_with_each_1m_variant_after_its_base() -> None:
+    ids = [opt.id for opt in DEFAULT_CLAUDE_MODELS]
+    for index, model_id in enumerate(ids):
+        base = model_id.removesuffix("[1m]")
+        if base != model_id:
+            assert ids[index - 1] == base
+
+
+def test_legacy_models_are_visible() -> None:
+    # The human chose to surface them alongside the current models.
+    assert all(not opt.hidden for opt in DEFAULT_CLAUDE_MODELS)
 
 
 # --- merge_model_catalogue ------------------------------------------------
@@ -194,12 +297,12 @@ def test_offered_appends_extras_and_keeps_version_gate(
 
     models, version = offered_claude_models(config, "claude", None)
 
-    # Version gate preserved (extras did not opt out of it).
+    # Version gate preserved (extras did not opt out of it): extras append after the
+    # *gated* base, not after the current-epoch catalogue.
     assert version == SONNET5_MIN_CLI_VERSION
+    gated = [opt.id for opt in claude_models_for_version(SONNET5_MIN_CLI_VERSION)]
     ids = [opt.id for opt in models]
-    assert ids[: len(DEFAULT_CLAUDE_MODELS)] == [
-        opt.id for opt in DEFAULT_CLAUDE_MODELS
-    ]
+    assert ids[: len(gated)] == gated
     assert ids[-1] == "kimi-k3[1m]"
 
 

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -38,7 +38,6 @@ def test_current_offering_for_none_or_recent_version(version) -> None:
     assert sonnet.label == "Sonnet 5"
     assert "max" in sonnet.supported_efforts
 
-    # Opus 5 accepts the full effort set, same as Opus 4.8 before it.
     opus = _by_id(models, "opus")
     assert opus.label == "Opus 5"
     assert "xhigh" in opus.supported_efforts and "max" in opus.supported_efforts
@@ -48,8 +47,7 @@ def test_current_offering_for_none_or_recent_version(version) -> None:
 def test_legacy_offering_below_opus5_min_version() -> None:
     models = claude_models_for_version((2, 1, 218))
 
-    # Only the opus labels roll back across the 2.1.219 boundary: Opus 4.8
-    # accepts the same full effort set as Opus 5.
+    # Only the opus labels roll back across the 2.1.219 boundary.
     opus = _by_id(models, "opus")
     assert opus.label == "Opus 4.8"
     assert opus.supported_efforts == list(CLAUDE_EFFORT_LEVELS)
@@ -58,7 +56,7 @@ def test_legacy_offering_below_opus5_min_version() -> None:
     assert opus_1m.label == "Opus 4.8 (1M context)"
     assert opus_1m.is_default is True
 
-    # Sonnet 5 already shipped by 2.1.218, so it is not rolled back here.
+    # Sonnet 5 already shipped by 2.1.218.
     sonnet = _by_id(models, "sonnet")
     assert sonnet.label == "Sonnet 5"
     assert "xhigh" in sonnet.supported_efforts
@@ -67,8 +65,7 @@ def test_legacy_offering_below_opus5_min_version() -> None:
 def test_legacy_offering_below_sonnet5_min_version() -> None:
     models = claude_models_for_version((2, 1, 190))
 
-    # Sonnet 4.6 accepts `max` but not `xhigh` (only the sonnet family's
-    # efforts differ across the 2.1.197 boundary).
+    # Sonnet 4.6's offered ladder drops `xhigh`.
     sonnet = _by_id(models, "sonnet")
     assert sonnet.label == "Sonnet 4.6"
     assert sonnet.supported_efforts == ["low", "medium", "high", "max"]
@@ -77,7 +74,7 @@ def test_legacy_offering_below_sonnet5_min_version() -> None:
     assert sonnet_1m.label == "Sonnet 4.6 (1M context)"
     assert sonnet_1m.supported_efforts == ["low", "medium", "high", "max"]
 
-    # A build this old also predates Opus 5, so the opus rollback applies too.
+    # This build also predates Opus 5, so that rollback applies too.
     opus = _by_id(models, "opus")
     assert opus.label == "Opus 4.8"
     assert "xhigh" in opus.supported_efforts and "max" in opus.supported_efforts
@@ -106,8 +103,8 @@ def test_legacy_offering_below_sonnet5_min_version() -> None:
 def test_rollbacks_apply_cumulatively_at_each_boundary(
     version, opus_label: str, sonnet_label: str
 ) -> None:
-    # Each boundary is inclusive of its own epoch, and a build below several
-    # boundaries gets every rollback rather than only the newest.
+    # Each boundary is inclusive of its own epoch; a build below several gets every
+    # rollback.
     models = claude_models_for_version(version)
     assert _by_id(models, "opus").label == opus_label
     assert _by_id(models, "sonnet").label == sonnet_label
@@ -115,10 +112,8 @@ def test_rollbacks_apply_cumulatively_at_each_boundary(
 
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 190), (2, 1, 218), (2, 1, 220)])
 def test_every_offering_is_an_ordered_subset_with_one_default(version) -> None:
-    # Rollbacks may drop a pinned entry the rolled-back alias makes redundant, so an
-    # older offering is a subset rather than an exact match -- but never a superset,
-    # never reordered, and always with exactly one default (an alias id, which no
-    # rollback removes).
+    # A rollback may drop a redundant pin, so an older offering is a subset -- never a
+    # superset, never reordered, always exactly one default.
     offering = claude_models_for_version(version)
     default_ids = [opt.id for opt in DEFAULT_CLAUDE_MODELS]
     ids = [opt.id for opt in offering]
@@ -130,8 +125,8 @@ def test_every_offering_is_an_ordered_subset_with_one_default(version) -> None:
 
 @pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 196), (2, 1, 218), (2, 1, 220)])
 def test_no_offering_lists_a_label_twice(version) -> None:
-    # Below 2.1.219 the `opus` alias itself is labelled "Opus 4.8", which would collide
-    # with the pinned claude-opus-4-8 entry; likewise `sonnet` below 2.1.197.
+    # Below 2.1.219 the `opus` alias is itself labelled "Opus 4.8"; likewise `sonnet`
+    # below 2.1.197.
     labels = [opt.label for opt in claude_models_for_version(version)]
     assert len(labels) == len(set(labels)), sorted(
         label for label in labels if labels.count(label) > 1
@@ -142,9 +137,8 @@ def test_rollbacks_drop_the_pin_the_alias_makes_redundant() -> None:
     below_opus5 = {opt.id for opt in claude_models_for_version((2, 1, 218))}
     assert "claude-opus-4-8" not in below_opus5
     assert "claude-opus-4-8[1m]" not in below_opus5
-    # Older opus pins are still distinct models, so they stay.
+    # Older opus pins are distinct models.
     assert "claude-opus-4-7" in below_opus5
-    # Sonnet 5 still shipped at 2.1.218, so its pin is untouched here.
     assert "claude-sonnet-4-6" in below_opus5
 
     below_sonnet5 = {opt.id for opt in claude_models_for_version((2, 1, 196))}
@@ -173,8 +167,7 @@ def test_reachable_legacy_models_are_offered(model_id: str) -> None:
 
 @pytest.mark.parametrize(
     "model_id",
-    # Remapped to Opus 5 / retired respectively -- offering either would let a user
-    # pick a model that silently runs as something else.
+    # Remapped to Opus 5, retired, and internal picker keys.
     ["claude-opus-4-1", "claude-3-5-haiku", "opus48", "opus47", "sonnet46"],
 )
 def test_unreachable_models_and_internal_picker_keys_are_not_offered(
@@ -185,8 +178,7 @@ def test_unreachable_models_and_internal_picker_keys_are_not_offered(
 
 @pytest.mark.parametrize("model_id", _LEGACY_IDS)
 def test_legacy_models_forward_effort_unvalidated(model_id: str) -> None:
-    # None, not a narrower ladder: the CLI accepts any --effort, so pinning a list
-    # would only make Waypoint reject launches the CLI honors.
+    # The CLI accepts any --effort, so a narrower list would only narrow Waypoint.
     assert _by_id(DEFAULT_CLAUDE_MODELS, model_id).supported_efforts is None
 
 
@@ -206,8 +198,7 @@ def test_legacy_models_with_a_1m_variant_are_paired(model_id: str) -> None:
 
 
 def test_opus_4_5_has_no_1m_variant() -> None:
-    # On the CLI's own 1M blocklist: requesting the suffix fails with "the long
-    # context beta is not yet available".
+    # On the CLI's 1M blocklist.
     assert all(opt.id != "claude-opus-4-5[1m]" for opt in DEFAULT_CLAUDE_MODELS)
 
 
@@ -223,8 +214,7 @@ def test_catalogue_groups_families_with_each_1m_variant_after_its_base() -> None
 
 
 def test_extra_appends_when_the_epoch_already_dropped_that_pin() -> None:
-    # On a rolled-back epoch the pin is gone from the gated base, so an operator
-    # entry reusing its id has nothing to replace and appends instead.
+    # The pin is gone from the gated base, so an entry reusing its id appends.
     gated = claude_models_for_version((2, 1, 218))
     assert all(opt.id != "claude-opus-4-8" for opt in gated)
 
@@ -233,12 +223,11 @@ def test_extra_appends_when_the_epoch_already_dropped_that_pin() -> None:
 
     assert len(merged) == len(gated) + 1
     assert merged[-1] is extra
-    # Collision detection reads the ungated built-in set, so it still reports it.
+    # Collision detection reads the ungated built-in set.
     assert overridden_builtin_ids([extra]) == ["claude-opus-4-8"]
 
 
 def test_legacy_models_are_visible() -> None:
-    # The human chose to surface them alongside the current models.
     assert all(not opt.hidden for opt in DEFAULT_CLAUDE_MODELS)
 
 
@@ -315,8 +304,7 @@ def test_offered_appends_extras_and_keeps_version_gate(
 
     models, version = offered_claude_models(config, "claude", None)
 
-    # Version gate preserved (extras did not opt out of it): extras append after the
-    # *gated* base, not after the current-epoch catalogue.
+    # Extras append after the gated base, not the current-epoch catalogue.
     assert version == SONNET5_MIN_CLI_VERSION
     gated = [opt.id for opt in claude_models_for_version(SONNET5_MIN_CLI_VERSION)]
     ids = [opt.id for opt in models]

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -215,8 +215,26 @@ def test_catalogue_groups_families_with_each_1m_variant_after_its_base() -> None
     ids = [opt.id for opt in DEFAULT_CLAUDE_MODELS]
     for index, model_id in enumerate(ids):
         base = model_id.removesuffix("[1m]")
-        if base != model_id:
-            assert ids[index - 1] == base
+        if base == model_id:
+            continue
+        # Guard the index explicitly: ids[-1] would wrap and pass vacuously.
+        assert index > 0, f"{model_id} is first, so it cannot follow its base"
+        assert ids[index - 1] == base
+
+
+def test_extra_appends_when_the_epoch_already_dropped_that_pin() -> None:
+    # On a rolled-back epoch the pin is gone from the gated base, so an operator
+    # entry reusing its id has nothing to replace and appends instead.
+    gated = claude_models_for_version((2, 1, 218))
+    assert all(opt.id != "claude-opus-4-8" for opt in gated)
+
+    extra = BackendModelOption(id="claude-opus-4-8", label="Opus 4.8 (mine)")
+    merged = merge_model_catalogue(list(gated), [extra])
+
+    assert len(merged) == len(gated) + 1
+    assert merged[-1] is extra
+    # Collision detection reads the ungated built-in set, so it still reports it.
+    assert overridden_builtin_ids([extra]) == ["claude-opus-4-8"]
 
 
 def test_legacy_models_are_visible() -> None:

--- a/backend/tests/test_claude_models_offering.py
+++ b/backend/tests/test_claude_models_offering.py
@@ -11,7 +11,9 @@ import logging
 import pytest
 
 from waypoint.backends.claude_code.models import (
+    CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
+    OPUS5_MIN_CLI_VERSION,
     SONNET5_MIN_CLI_VERSION,
     claude_models_for_version,
     merge_model_catalogue,
@@ -28,7 +30,7 @@ def _by_id(models: tuple, model_id: str):
     return next(opt for opt in models if opt.id == model_id)
 
 
-@pytest.mark.parametrize("version", [None, SONNET5_MIN_CLI_VERSION, (2, 2, 0)])
+@pytest.mark.parametrize("version", [None, OPUS5_MIN_CLI_VERSION, (2, 2, 0)])
 def test_current_offering_for_none_or_recent_version(version) -> None:
     models = claude_models_for_version(version)
     assert models == DEFAULT_CLAUDE_MODELS
@@ -36,12 +38,37 @@ def test_current_offering_for_none_or_recent_version(version) -> None:
     assert sonnet.label == "Sonnet 5"
     assert "max" in sonnet.supported_efforts
 
+    # Opus 5 accepts the full effort set, same as Opus 4.8 before it.
+    opus = _by_id(models, "opus")
+    assert opus.label == "Opus 5"
+    assert "xhigh" in opus.supported_efforts and "max" in opus.supported_efforts
+    assert _by_id(models, "opus[1m]").label == "Opus 5 (1M context)"
+
+
+def test_legacy_offering_below_opus5_min_version() -> None:
+    models = claude_models_for_version((2, 1, 218))
+
+    # Only the opus labels roll back across the 2.1.219 boundary: Opus 4.8
+    # accepts the same full effort set as Opus 5.
+    opus = _by_id(models, "opus")
+    assert opus.label == "Opus 4.8"
+    assert opus.supported_efforts == list(CLAUDE_EFFORT_LEVELS)
+
+    opus_1m = _by_id(models, "opus[1m]")
+    assert opus_1m.label == "Opus 4.8 (1M context)"
+    assert opus_1m.is_default is True
+
+    # Sonnet 5 already shipped by 2.1.218, so it is not rolled back here.
+    sonnet = _by_id(models, "sonnet")
+    assert sonnet.label == "Sonnet 5"
+    assert "xhigh" in sonnet.supported_efforts
+
 
 def test_legacy_offering_below_sonnet5_min_version() -> None:
     models = claude_models_for_version((2, 1, 190))
 
-    # Sonnet 4.6 accepts `max` but not `xhigh` (only the sonnet family differs
-    # across the 2.1.197 boundary).
+    # Sonnet 4.6 accepts `max` but not `xhigh` (only the sonnet family's
+    # efforts differ across the 2.1.197 boundary).
     sonnet = _by_id(models, "sonnet")
     assert sonnet.label == "Sonnet 4.6"
     assert sonnet.supported_efforts == ["low", "medium", "high", "max"]
@@ -50,7 +77,7 @@ def test_legacy_offering_below_sonnet5_min_version() -> None:
     assert sonnet_1m.label == "Sonnet 4.6 (1M context)"
     assert sonnet_1m.supported_efforts == ["low", "medium", "high", "max"]
 
-    # Opus 4.8 and Fable 5 are unchanged across the boundary: full set incl. max.
+    # A build this old also predates Opus 5, so the opus rollback applies too.
     opus = _by_id(models, "opus")
     assert opus.label == "Opus 4.8"
     assert "xhigh" in opus.supported_efforts and "max" in opus.supported_efforts
@@ -62,13 +89,16 @@ def test_legacy_offering_below_sonnet5_min_version() -> None:
     assert haiku.supported_efforts == []
 
     opus_1m = _by_id(models, "opus[1m]")
+    assert opus_1m.label == "Opus 4.8 (1M context)"
     assert opus_1m.is_default is True
     assert "xhigh" in opus_1m.supported_efforts and "max" in opus_1m.supported_efforts
 
 
-def test_legacy_offering_has_same_model_ids_as_default() -> None:
-    legacy = claude_models_for_version((2, 0, 0))
+@pytest.mark.parametrize("version", [(2, 0, 0), (2, 1, 190), (2, 1, 218)])
+def test_legacy_offerings_have_same_model_ids_as_default(version) -> None:
+    legacy = claude_models_for_version(version)
     assert {opt.id for opt in legacy} == {opt.id for opt in DEFAULT_CLAUDE_MODELS}
+    assert [opt.id for opt in legacy] == [opt.id for opt in DEFAULT_CLAUDE_MODELS]
     assert sum(opt.is_default for opt in legacy) == 1
 
 

--- a/backend/tests/test_claude_models_resolution.py
+++ b/backend/tests/test_claude_models_resolution.py
@@ -14,6 +14,7 @@ from waypoint.backends.claude_code.models import (
         ("claude-sonnet-4-5", "sonnet"),
         ("claude-sonnet-4-6", "sonnet"),
         ("claude-opus-4-7", "opus"),
+        ("claude-opus-4-8", "opus"),
     ],
 )
 def test_legacy_concrete_ids_resolve_to_family(model: str, family: str) -> None:
@@ -26,12 +27,50 @@ def test_legacy_concrete_ids_resolve_to_family(model: str, family: str) -> None:
     [
         ("sonnet", 200_000),
         ("sonnet[1m]", 1_000_000),
+        ("opus", 200_000),
         ("opus[1m]", 1_000_000),
         ("haiku", 200_000),
     ],
 )
 def test_bare_aliases(alias: str, window: int) -> None:
     assert claude_context_window_for_model(alias) == window
+
+
+def test_opus5_concrete_id_resolves_to_opus() -> None:
+    # The resolved id the CLI reports for the `opus` selection from 2.1.219 on.
+    assert normalize_claude_model_id("claude-opus-5") == "opus"
+    assert claude_model_family("claude-opus-5") == "opus"
+    assert claude_context_window_for_model("claude-opus-5") == 200_000
+
+
+@pytest.mark.parametrize(
+    ("model", "normalized"),
+    [
+        ("claude-opus-5[1m]", "opus[1m]"),
+        ("claude-opus-4-8[1m]", "opus[1m]"),
+        ("claude-sonnet-5[1m]", "sonnet[1m]"),
+        ("claude-fable-5[1m]", "fable[1m]"),
+    ],
+)
+def test_concrete_id_keeps_1m_entitlement(model: str, normalized: str) -> None:
+    # A concrete id carrying the suffix must not collapse to the bare 200K
+    # family id -- the `[1m]` selection is what grants the 1M window.
+    assert normalize_claude_model_id(model) == normalized
+    assert claude_model_family(model) == normalized.removesuffix("[1m]")
+    assert claude_context_window_for_model(model) == 1_000_000
+
+
+def test_1m_suffix_dropped_for_family_without_a_1m_offering() -> None:
+    # Haiku has no `haiku[1m]` catalogue entry, so the suffix resolves away
+    # rather than fabricating a 1M window.
+    assert normalize_claude_model_id("claude-haiku-4-5[1m]") == "haiku"
+    assert claude_context_window_for_model("claude-haiku-4-5[1m]") == 200_000
+
+
+@pytest.mark.parametrize("model", ["gpt-4o[1m]", "weird[1m]"])
+def test_1m_suffix_on_garbage_still_passes_through(model: str) -> None:
+    assert normalize_claude_model_id(model) == model
+    assert claude_context_window_for_model(model) is None
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -11,6 +11,7 @@ import pytest
 from fastapi import HTTPException
 
 from waypoint.assistant_assets import AssistantAssetError
+from waypoint.backends.claude_code.models import OPUS5_MIN_CLI_VERSION
 from waypoint.backends.claude_code.permission_modes import CLAUDE_AUTO_APPROVE_MODES
 from waypoint.backends.claude_code.schemas import ClaudeThreadImportRequest
 from waypoint.backends.claude_code.threads import ClaudeThreadInfo
@@ -4325,8 +4326,20 @@ async def test_set_model_codex_calls_adapter_and_persists(tmp_path) -> None:
     assert updated.model == "gpt-5"
 
 
+@pytest.fixture
+def _current_epoch_claude_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Model labels are version-gated, so pin the probed CLI version instead of
+    # depending on whichever `claude` binary the host happens to have installed.
+    monkeypatch.setattr(
+        "waypoint.backends.claude_code.plugin.detect_claude_cli_version",
+        lambda binary, launch_target: OPUS5_MIN_CLI_VERSION,
+    )
+
+
 @pytest.mark.asyncio
-async def test_list_backend_models_returns_curated_claude_list(tmp_path) -> None:
+async def test_list_backend_models_returns_curated_claude_list(
+    tmp_path, _current_epoch_claude_cli
+) -> None:
     runtime, _, settings = make_runtime(tmp_path)
     response = await runtime.list_backend_models("claude_code")
 
@@ -4338,11 +4351,13 @@ async def test_list_backend_models_returns_curated_claude_list(tmp_path) -> None
     # Default falls back to the entry flagged is_default in the curated list
     # when no plugin_configs.claude_code.default_model_id override is present.
     assert response["default_model_id"] == "opus[1m]"
-    assert response["default_model_label"] == "Opus 4.8 (1M context)"
+    assert response["default_model_label"] == "Opus 5 (1M context)"
 
 
 @pytest.mark.asyncio
-async def test_list_backend_models_honours_default_models_override(tmp_path) -> None:
+async def test_list_backend_models_honours_default_models_override(
+    tmp_path, _current_epoch_claude_cli
+) -> None:
     settings = Settings(
         data_dir=tmp_path / "data",
         plugin_configs={"claude_code": {"default_model_id": "opus"}},
@@ -4352,7 +4367,7 @@ async def test_list_backend_models_honours_default_models_override(tmp_path) -> 
     runtime = SessionRuntime(settings, storage)
     response = await runtime.list_backend_models("claude_code")
     assert response["default_model_id"] == "opus"
-    assert response["default_model_label"] == "Opus 4.8"
+    assert response["default_model_label"] == "Opus 5"
 
 
 def _seed_session_with_events(

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -409,7 +409,12 @@ Reachability here is a runtime property of the CLI, not a static fact: the
 remap/retirement table is fetched from the server, so a model pinned today can
 start remapping without a CLI upgrade. Operators who had added a legacy model
 through `extra_models` will now find that id collides with a built-in and
-replaces it in place, logging the usual override line at config load.
+replaces it in place, logging the usual override line at config load. On an
+epoch that dropped the pin as redundant, though, there is nothing left to
+replace, so the entry appends instead — and if it reuses the rolled-back alias's
+label, that reintroduces the duplicate the drop existed to remove. The override
+line still logs either way, because collision detection reads the ungated
+built-in id set rather than the version-gated offering.
 
 `import_thread` adopts an externally-created native thread into a brand-new
 session. When the import request's `import_history` flag is set (it defaults to

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -528,7 +528,7 @@ already refreshed in-place is not double-broadcast).
 The runtime invokes it after an explicit inline model change and after a transport
 switch restores, under the session lifecycle lock and before the state broadcast.
 This is a Claude concern: Claude's catalogue distinguishes `opus[1m]` (1M) from
-`opus`/`claude-opus-4-8` (200K), and the transcript records only the resolved base
+`opus`/`claude-opus-5` (200K), and the transcript records only the resolved base
 id, so the durable selection is the sole source of the `[1m]` entitlement. Codex
 and OpenCode take their window from the provider directly (Codex's `token_count`
 `model_context_window`, OpenCode's per-model lookup), so they neither implement

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -402,9 +402,10 @@ model than it names. Reachability is a runtime property: the remap/retirement
 table is fetched from the server, so a pinned model can start remapping without a
 CLI upgrade.
 
-Below `2.1.219` the `opus` alias is itself Opus 4.8, so that epoch drops the
-redundant pin rather than listing the model twice, and an older offering is an
-ordered subset of the current one. An `extra_models` entry reusing a pinned id
+Below `2.1.219` the `opus` alias is itself Opus 4.8, and below `2.1.197` `sonnet`
+is Sonnet 4.6, so each of those epochs drops the pin its alias duplicates rather
+than listing the model twice, and an older offering is an ordered subset of the
+current one. An `extra_models` entry reusing a pinned id
 replaces it in place on the current epoch, and appends on an epoch that already
 dropped it — reintroducing the duplicate label if it reuses the alias's label.
 The override line logs either way, since collision detection reads the ungated

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -383,10 +383,33 @@ Two `waypoint.yaml` keys shape it (both honored identically by `claude_code` and
 
 Leave a custom model's `supported_efforts` unset to offer `effort_levels` in the
 picker and forward the level unvalidated; set an explicit list to enforce it, or
-`[]` for a model with no effort knob. Setting neither catalogue key leaves
-behavior unchanged; the CLI `waypoint launch --model <id>` free-text passthrough
-still warns without blocking, and the merged catalogue is what the frontend
-pickers and `waypoint models` show.
+`[]` for a model with no effort knob. Note that `supported_efforts` is the ladder
+Waypoint offers and enforces, not a mirror of what the CLI refuses — the CLI
+accepts `--effort` for every model, so a narrower list only narrows Waypoint.
+Setting neither catalogue key leaves behavior unchanged; the CLI
+`waypoint launch --model <id>` free-text passthrough still warns without
+blocking, and the merged catalogue is what the frontend pickers and
+`waypoint models` show.
+
+The catalogue is ordered by family, newest first, with each model's `[1m]` entry
+directly after its base. Alongside the current aliases it pins the legacy models
+still reachable on the CLI (`claude-opus-4-8` down to `claude-opus-4-5`,
+`claude-sonnet-4-6`, `claude-sonnet-4-5`, plus a `[1m]` entry for each except
+`claude-opus-4-5`, which the CLI excludes from long context). Pinned ids are the
+full model names, since the CLI's short picker keys (`opus48`, …) are internal
+and rejected by `--model`. Models the CLI silently remaps to the latest
+(`claude-opus-4-1`) or has retired (`claude-3-5-haiku`) are deliberately absent,
+so a picker entry never runs as a different model than it names. Their
+`supported_efforts` is unset for the reason above. Because a rolled-back alias
+already covers one of these versions on an older CLI (below `2.1.219` the `opus`
+alias *is* Opus 4.8), that epoch drops the now-redundant pin instead of listing
+the model twice — so an older offering is an ordered subset of the current one.
+
+Reachability here is a runtime property of the CLI, not a static fact: the
+remap/retirement table is fetched from the server, so a model pinned today can
+start remapping without a CLI upgrade. Operators who had added a legacy model
+through `extra_models` will now find that id collides with a built-in and
+replaces it in place, logging the usual override line at config load.
 
 `import_thread` adopts an externally-created native thread into a brand-new
 session. When the import request's `import_history` flag is set (it defaults to

--- a/docs/coding_agent_plugins.md
+++ b/docs/coding_agent_plugins.md
@@ -383,38 +383,32 @@ Two `waypoint.yaml` keys shape it (both honored identically by `claude_code` and
 
 Leave a custom model's `supported_efforts` unset to offer `effort_levels` in the
 picker and forward the level unvalidated; set an explicit list to enforce it, or
-`[]` for a model with no effort knob. Note that `supported_efforts` is the ladder
-Waypoint offers and enforces, not a mirror of what the CLI refuses — the CLI
-accepts `--effort` for every model, so a narrower list only narrows Waypoint.
-Setting neither catalogue key leaves behavior unchanged; the CLI
-`waypoint launch --model <id>` free-text passthrough still warns without
-blocking, and the merged catalogue is what the frontend pickers and
+`[]` for a model with no effort knob. `supported_efforts` is the ladder Waypoint
+offers and enforces — the CLI accepts `--effort` for every model, so a narrower
+list only narrows Waypoint. Setting neither catalogue key leaves behavior
+unchanged; the CLI `waypoint launch --model <id>` free-text passthrough still
+warns without blocking, and the merged catalogue is what the frontend pickers and
 `waypoint models` show.
 
 The catalogue is ordered by family, newest first, with each model's `[1m]` entry
 directly after its base. Alongside the current aliases it pins the legacy models
-still reachable on the CLI (`claude-opus-4-8` down to `claude-opus-4-5`,
-`claude-sonnet-4-6`, `claude-sonnet-4-5`, plus a `[1m]` entry for each except
-`claude-opus-4-5`, which the CLI excludes from long context). Pinned ids are the
-full model names, since the CLI's short picker keys (`opus48`, …) are internal
-and rejected by `--model`. Models the CLI silently remaps to the latest
-(`claude-opus-4-1`) or has retired (`claude-3-5-haiku`) are deliberately absent,
-so a picker entry never runs as a different model than it names. Their
-`supported_efforts` is unset for the reason above. Because a rolled-back alias
-already covers one of these versions on an older CLI (below `2.1.219` the `opus`
-alias *is* Opus 4.8), that epoch drops the now-redundant pin instead of listing
-the model twice — so an older offering is an ordered subset of the current one.
+the CLI still runs: `claude-opus-4-8` down to `claude-opus-4-5`,
+`claude-sonnet-4-6`, and `claude-sonnet-4-5`, each with a `[1m]` entry except
+`claude-opus-4-5`, which the CLI excludes from long context. Pins use full model
+names; the CLI's short picker keys (`opus48`, …) are internal and rejected by
+`--model`. Models the CLI remaps to the latest (`claude-opus-4-1`) or has retired
+(`claude-3-5-haiku`) are absent, so a picker entry never runs as a different
+model than it names. Reachability is a runtime property: the remap/retirement
+table is fetched from the server, so a pinned model can start remapping without a
+CLI upgrade.
 
-Reachability here is a runtime property of the CLI, not a static fact: the
-remap/retirement table is fetched from the server, so a model pinned today can
-start remapping without a CLI upgrade. Operators who had added a legacy model
-through `extra_models` will now find that id collides with a built-in and
-replaces it in place, logging the usual override line at config load. On an
-epoch that dropped the pin as redundant, though, there is nothing left to
-replace, so the entry appends instead — and if it reuses the rolled-back alias's
-label, that reintroduces the duplicate the drop existed to remove. The override
-line still logs either way, because collision detection reads the ungated
-built-in id set rather than the version-gated offering.
+Below `2.1.219` the `opus` alias is itself Opus 4.8, so that epoch drops the
+redundant pin rather than listing the model twice, and an older offering is an
+ordered subset of the current one. An `extra_models` entry reusing a pinned id
+replaces it in place on the current epoch, and appends on an epoch that already
+dropped it — reintroducing the duplicate label if it reuses the alias's label.
+The override line logs either way, since collision detection reads the ungated
+built-in ids.
 
 `import_thread` adopts an externally-created native thread into a brand-new
 session. When the import request's `import_history` flag is set (it defaults to


### PR DESCRIPTION
## Purpose

CLI `2.1.219` added Claude Opus 5 (`claude-opus-5`) and made it the target of the `opus` alias ([release notes](https://github.com/anthropics/claude-code/releases/tag/v2.1.219)). Waypoint mirrors the CLI catalogue statically — Claude has no runtime `model/list` RPC — so the picker still read "Opus 4.8". This adds `2.1.219` as a new offering epoch, so a current CLI gets Opus 5 while an older binary still sees the labels it ships.

Review then asked for the still-reachable legacy models too, so the catalogue now also pins `claude-opus-4-8` down to `claude-opus-4-5`, `claude-sonnet-4-6`, and `claude-sonnet-4-5`, and is ordered by family with each `[1m]` entry after its base.

## Changes

### Backend
- `backends/claude_code/models.py` — the Opus 5 labels and the `claude-opus-5` alias; `OPUS5_MIN_CLI_VERSION` as a third epoch; `_LEGACY_CLAUDE_MODELS` for the pinned legacy models; family ordering. Epochs are declarative `_ModelEpoch` records applied by one `_roll_back` transform. `normalize_claude_model_id` now preserves a trailing `[1m]`, and `claude_context_window_for_model` collapses to a single catalogue lookup.

### Docs
- `docs/coding_agent_plugins.md` — the catalogue's ordering, the pinned legacy models, and what `supported_efforts` actually governs.

### Tests
- The Opus 5 epoch and both rollbacks, `[1m]` normalization across families, the legacy entries, and two test-isolation fixes the label change exposed.

## Design

**Epochs compose.** Each epoch declares only the rollback that undoes it, and the lookup folds them newest-first, so an older CLI receives every rollback that applies rather than only the newest. With two epochs independent builders worked by accident of ordering; with three, one deriving from `DEFAULT_CLAUDE_MODELS` would show a `2.1.190` CLI "Opus 5". Adding an epoch is one prepended record.

**Rollbacks drop pins, not aliases.** Below `2.1.219` the `opus` alias is itself Opus 4.8, colliding with the pinned `claude-opus-4-8`. The pin drops, because the default selection is an alias id and must stay valid on every epoch. An older offering is therefore an ordered subset of the current one; the tests assert subset, ordering, one default, and unique labels.

**Legacy `supported_efforts` is unset.** The binary's capability lists drive the CLI's own picker, not flag rejection — `claude --model haiku --effort max` is accepted. A narrower list would only make Waypoint reject launches the CLI honors, and with `default_effort` configured it would reject them with no `--effort` passed at all.

**Excluded models.** `claude-opus-4-1` is silently remapped to Opus 5 and `claude-3-5-haiku` is retired, so neither is offered — a picker entry should not run as a different model than it names. Reachability is a runtime property: the remap/retirement table is fetched from the server, so a pinned model can start remapping without a CLI upgrade.

**The `[1m]` fix.** `normalize_claude_model_id` collapsed `claude-opus-5[1m]` to `opus`, and `claude_context_window_for_model` returned on the bare family before reaching its own `endswith("[1m]")` branch — so that branch was dead for every concrete id and such a session reported 200K. Load-bearing for the legacy pins, whose `[1m]` entries all depend on it.

## Test Plan
- `cd backend && uv run pytest`; `cd backend && uv run pre-commit run --all-files`
- Every candidate model id probed against the installed 2.1.220 binary, with windows read back from the CLI's own `modelUsage.contextWindow`
- Deployed via `waypointctl restart`: catalogue over HTTP and `waypoint models` for both transports, plus the launch picker under Playwright at 390×844
- Two real Waypoint sessions launched on legacy ids to exercise the launch path
- No frontend code changed — `modelDisplay.ts` already renders `claude-opus-5` as "Opus 5"

## Test Result
- 2727 passed; isort, black, ruff, codespell, mypy clean
- Reachable: `claude-opus-4-8` / `4-7` / `4-6` / `4-5`, `claude-sonnet-4-6` / `4-5`. `claude-opus-4-1` → "automatically remapped to Opus 5"; `claude-3-5-haiku` → "was retired on February 19, 2026"; `claude --model opus48` → no output, so the short picker keys are internal
- Windows: `claude-opus-4-8` → 200000, `claude-opus-4-8[1m]` → 1000000, bare `opus` → 200000. `claude-opus-4-5[1m]` → 400, "the long context beta is not yet available", so it gets no 1M entry
- Efforts: `claude-opus-4-5 --effort xhigh`, `claude-opus-4-6 --effort xhigh`, and `haiku --effort max` all accepted by the CLI
- Deployed: 18 built-ins in family order for both transports with `extra_models` still last; a session on `claude-opus-4-8` reached idle at a 200000 window and one on `claude-sonnet-4-5[1m]` at 1000000. Both probe sessions were terminated and deleted
- Epoch parity across the cleanup refactor: every version tuple yields byte-identical ids, labels, ladders, and default before and after

Known gap, pre-existing: a CLI older than a pinned model's own introduction version is still offered it, as `fable` already is below `2.1.170`.

Addresses ticket 1231.
