### PR TITLE
fix: switch onto a Claude account profile that declares its own auth in settings.json

### DIFF
--- a/backend/src/waypoint/backends/account_profiles.py
+++ b/backend/src/waypoint/backends/account_profiles.py
@@ -18,7 +18,10 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from waypoint.backends.base import ConfigDirReadinessReporting
+from waypoint.backends.base import (
+    ConfigDirReadinessReporting,
+    ConfiguredAccountIdentifying,
+)
 from waypoint.backends.plugin_config import AccountProfileConfig
 from waypoint.backends.registry import get_registry
 from waypoint.schemas import AccountProbeResult, ProfileCheck
@@ -260,14 +263,27 @@ async def probe_account(
 ) -> AccountProbeResult | None:
     """Identify the account a ``backend`` authenticates as under ``launch_env``.
 
-    Composes the account rate-limit probe (run with the target ``launch_env`` so
-    it authenticates as that config dir's account, ``force`` to bypass any TTL
-    cache) with the plugin's ``rate_limit_account`` mapping. Returns ``None``
-    when the backend can't probe or can't produce a stable account key — the
-    runtime treats that as "cannot verify" and refuses a switch. Dispatches
-    through the registry; no per-backend branching.
+    Two tiers, in the order the agent itself resolves credentials. First, a config
+    dir that declares its own credential (:class:`ConfiguredAccountIdentifying`)
+    is identified from that declaration — it is what the agent will authenticate
+    as, and such a dir usually has no provider login for a probe to find. Local
+    launch targets only: the resolution reads the config dir, which for a remote
+    target lives on the remote host, so a same-path local dir would otherwise
+    yield a false identity.
+
+    Otherwise, composes the account rate-limit probe (run with the target
+    ``launch_env`` so it authenticates as that config dir's account, ``force`` to
+    bypass any TTL cache) with the plugin's ``rate_limit_account`` mapping.
+
+    Returns ``None`` when the backend can't probe or can't produce a stable
+    account key — the runtime treats that as "cannot verify" and refuses a switch.
+    Dispatches through the registry; no per-backend branching.
     """
     plugin = get_registry().get(backend)
+    if launch_target is None and isinstance(plugin, ConfiguredAccountIdentifying):
+        configured = plugin.configured_account_identity(launch_env)
+        if configured is not None:
+            return configured
     probe = getattr(plugin, "probe_account_rate_limit", None)
     account_of = getattr(plugin, "rate_limit_account", None)
     if probe is None or account_of is None:

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -8,7 +8,12 @@ from pydantic import BaseModel
 
 from waypoint.backends.capabilities import BackendCapabilities
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
-from waypoint.schemas import CommandCompletion, SessionContextUsage, SessionRecord
+from waypoint.schemas import (
+    AccountProbeResult,
+    CommandCompletion,
+    SessionContextUsage,
+    SessionRecord,
+)
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
@@ -103,6 +108,42 @@ class ConfigDirValidating(Protocol):
         """Raise :class:`ConfigDirNotReadyError` if launching or resuming under
         ``config_dir`` would block on an interactive first-run prompt this agent
         cannot clear headlessly; return ``None`` when the dir is ready."""
+        ...
+
+
+@runtime_checkable
+class ConfiguredAccountIdentifying(Protocol):
+    """An agent that can name the account a config dir declares, without probing.
+
+    The account behind a config dir is normally identified by probing the
+    provider — but a dir may instead declare its own credential in its local
+    configuration (a bearer token, often against a custom endpoint), in which case
+    the provider probe finds no login and cannot identify anything. The runtime
+    then has no account to verify and refuses to switch a session onto that
+    profile at all.
+
+    An agent implementing this supplies the identity from the dir's configuration
+    instead: local, deterministic, no network. It takes precedence over the live
+    probe because a declared credential is what the agent process authenticates
+    as — a dir holding *both* a declared token and a stale login would otherwise
+    verify as the login it will not use.
+
+    Returning ``None`` means "this dir declares no credential of its own", which
+    leaves the caller on the live probe. Implementations must be conservative
+    about that: claiming an identity for a dir that really authenticates as its
+    provider login would flip a working profile's key and break a configured
+    ``expected_account_key``. Because the resolution is filesystem-local, callers
+    only use it for local launch targets.
+    """
+
+    def configured_account_identity(
+        self, launch_env: Mapping[str, str]
+    ) -> AccountProbeResult | None:
+        """The account this session's config dir declares, or ``None``.
+
+        ``launch_env`` locates the config dir (the agent's ``config_dir_env_var``);
+        credentials are read from that dir, not from the env.
+        """
         ...
 
 

--- a/backend/src/waypoint/backends/claude_code/configured_account.py
+++ b/backend/src/waypoint/backends/claude_code/configured_account.py
@@ -1,0 +1,196 @@
+"""Identify a Claude config dir that declares its own auth in ``settings.json``.
+
+A config dir does not have to hold an OAuth login. Writing an ``env`` block into
+``<config_dir>/settings.json`` — typically a bearer token, often against a custom
+``ANTHROPIC_BASE_URL`` — is a supported way to point one at a gateway or a
+separate credential, and the CLI applies that block over the inherited process
+env, so it is what the agent actually authenticates as.
+
+Such a dir has no OAuth credentials and no ``oauthAccount``, so the rate-limit
+probe that normally identifies an account returns nothing and the runtime refuses
+to switch a session onto it. This module supplies the missing identity from the
+dir's own configuration instead: deterministic, local, and free of network calls.
+
+Auth is read from **that dir's** ``settings.json`` only. It is the sole layer
+that is per-profile, and therefore the only one that can distinguish one account
+from another: a token in ``plugin_configs.<agent>.env`` reaches every session of
+every profile, so deriving identity from it would collapse them all onto one key
+and make the runtime's "this switch would not change the account" guard refuse
+every switch. The endpoint is the one exception — see :func:`_resolve_base_url`.
+"""
+
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from waypoint.schemas import AccountProbeResult
+
+DEFAULT_ANTHROPIC_HOST = "api.anthropic.com"
+
+_BASE_URL_VAR = "ANTHROPIC_BASE_URL"
+
+# Env vars whose presence in a profile's own settings.json means "this dir
+# authenticates as this secret, not as an OAuth login". Both sit ahead of stored
+# OAuth credentials in the CLI's credential chain unconditionally, so an identity
+# derived from either matches the process on every transport.
+#
+# ANTHROPIC_API_KEY is deliberately absent: the CLI gates the env api key on
+# *interactivity*, not on the endpoint — a headless ``--print`` run uses it, while
+# the interactive TUI uses it only once its hash is recorded in .claude.json's
+# ``customApiKeyResponses.approved`` and otherwise falls back to OAuth. An
+# identity that cannot know the transport would be right for one and wrong for
+# the other, so the api key only ever contributes to the digest below.
+_TRIGGER_SECRET_VARS = ("ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN")
+
+# Everything that can differentiate two dirs pointed at the same endpoint. Wider
+# than the trigger set on purpose: a var that is not digested cannot distinguish
+# accounts, so two profiles differing only in it would collapse onto one key.
+_DIGESTED_VARS = (
+    *_TRIGGER_SECRET_VARS,
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_CUSTOM_HEADERS",
+)
+
+_DIGEST_CHARS = 12
+
+
+def settings_file(config_dir: str | None) -> Path:
+    """The user-layer settings file for ``config_dir`` (else the default home).
+
+    ``<config_dir>/settings.json`` when a profile is active, else
+    ``~/.claude/settings.json``. There is no user-layer ``settings.local.json``:
+    the CLI reads that name only for project settings.
+    """
+    home = Path(config_dir).expanduser() if config_dir else Path.home() / ".claude"
+    return home / "settings.json"
+
+
+def read_settings_env(config_dir: str | None) -> dict[str, str]:
+    """The ``env`` block of ``config_dir``'s settings file, string entries only.
+
+    Degrades to ``{}`` on a missing, unreadable, or malformed file and on a
+    non-object ``env`` — a broken settings file must leave the caller falling
+    back to the live probe, never raise into a launch or a switch.
+    """
+    path = settings_file(config_dir)
+    try:
+        if not path.is_file():
+            return {}
+        data: Any = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    env = data.get("env")
+    if not isinstance(env, dict):
+        return {}
+    return {
+        str(key): value
+        for key, value in env.items()
+        if isinstance(value, str) and value
+    }
+
+
+def _present(env: Mapping[str, str], name: str) -> str | None:
+    value = env.get(name, "").strip()
+    return value or None
+
+
+def _resolve_base_url(
+    settings_env: Mapping[str, str], launch_env: Mapping[str, str]
+) -> str | None:
+    """The endpoint this dir talks to: launch env, overridden by settings.
+
+    The only value not confined to the settings layer. A dir whose settings file
+    carries just the token while the endpoint comes from a plugin-level ``env``
+    would otherwise be keyed and *labelled* ``api.anthropic.com`` while actually
+    talking to a gateway. Reading it cannot collapse profiles the way reading a
+    secret would: an endpoint alone never yields an identity, and a shared one
+    contributes identical material to every profile, leaving the per-profile
+    secret digest to discriminate. Settings wins, matching the CLI.
+    """
+    return _present(settings_env, _BASE_URL_VAR) or _present(launch_env, _BASE_URL_VAR)
+
+
+def _endpoint_host(base_url: str | None) -> str:
+    """``hostname[:port]`` of ``base_url``, lowercased and userinfo-stripped.
+
+    Built from ``hostname``/``port`` rather than ``netloc`` because this string is
+    plaintext in both the account key and the human-facing label: a gateway URL
+    of the form ``https://user:pw@host/v1`` has a ``netloc`` that carries the
+    password. ``hostname`` also normalises case, so one endpoint cannot mint two
+    keys. An absent or unparsable URL resolves to the default host.
+    """
+    if not base_url:
+        return DEFAULT_ANTHROPIC_HOST
+    try:
+        parts = urlsplit(base_url)
+        host = parts.hostname
+        port = parts.port
+    except ValueError:
+        return DEFAULT_ANTHROPIC_HOST
+    if not host:
+        return DEFAULT_ANTHROPIC_HOST
+    return f"{host}:{port}" if port else host
+
+
+def _normalized_base_url(base_url: str | None) -> str:
+    """A comparable form of ``base_url`` for the digest, without userinfo.
+
+    Scheme and path are digested even though only the host is shown: two
+    endpoints that share a host still differ — ``http://`` vs ``https://``, or a
+    path-routed ``https://gw/v1/team-a`` vs ``…/team-b`` — and folding them in
+    keeps two such profiles from resolving to the same account.
+    """
+    if not base_url:
+        return ""
+    try:
+        parts = urlsplit(base_url)
+    except ValueError:
+        return base_url.strip().rstrip("/")
+    host = _endpoint_host(base_url)
+    path = parts.path.rstrip("/")
+    return f"{parts.scheme.lower()}://{host}{path}"
+
+
+def _digest(settings_env: Mapping[str, str], base_url: str | None) -> str:
+    material = [f"{_BASE_URL_VAR}={_normalized_base_url(base_url)}"]
+    material.extend(
+        f"{name}={value}"
+        for name in sorted(_DIGESTED_VARS)
+        if (value := _present(settings_env, name)) is not None
+    )
+    return hashlib.sha256("\n".join(material).encode("utf-8")).hexdigest()[
+        :_DIGEST_CHARS
+    ]
+
+
+def configured_account_identity(
+    config_dir: str | None, launch_env: Mapping[str, str]
+) -> AccountProbeResult | None:
+    """The account ``config_dir`` authenticates as by its own configuration.
+
+    Returns an identity only when the dir's ``settings.json`` declares a bearer
+    secret (see ``_TRIGGER_SECRET_VARS``); ``None`` otherwise, which leaves the
+    caller on the live OAuth probe. Requiring a declared secret is what keeps
+    this from re-identifying a dir that really does authenticate as its OAuth
+    account: a custom endpoint alone does not imply a different account (a
+    gateway can proxy an OAuth login), and flipping such a profile's key would
+    break a configured ``expected_account_key`` that matches today.
+
+    The key carries the endpoint host and a digest, never a secret; both it and
+    the label reach API payloads, and the label is not redacted.
+    """
+    settings_env = read_settings_env(config_dir)
+    if not any(_present(settings_env, name) for name in _TRIGGER_SECRET_VARS):
+        return None
+    base_url = _resolve_base_url(settings_env, launch_env)
+    host = _endpoint_host(base_url)
+    return AccountProbeResult(
+        account_key=f"claude_code:endpoint:{host}:{_digest(settings_env, base_url)}",
+        account_label=f"{host} · token auth",
+        source="api",
+    )

--- a/backend/src/waypoint/backends/claude_code/configured_account.py
+++ b/backend/src/waypoint/backends/claude_code/configured_account.py
@@ -17,6 +17,15 @@ from another: a token in ``plugin_configs.<agent>.env`` reaches every session of
 every profile, so deriving identity from it would collapse them all onto one key
 and make the runtime's "this switch would not change the account" guard refuse
 every switch. The endpoint is the one exception — see :func:`_resolve_base_url`.
+
+The CLI's *project* settings layers (``<cwd>/.claude/settings.local.json`` and
+``<cwd>/.claude/settings.json``, see ``terminal_theme``) outrank the config dir,
+so a project that declares its own token in one of them authenticates as that
+token while this resolves the profile dir's. They are deliberately not consulted:
+identity has to be a property of the profile, not of a directory, or the same
+profile would resolve differently under ``accounts probe`` and ``accounts doctor``
+— which have no session cwd at all — than under a live switch. A project-scoped
+token is therefore an accepted limitation, recorded in ``docs/account_profiles.md``.
 """
 
 import hashlib
@@ -28,7 +37,7 @@ from urllib.parse import urlsplit
 
 from waypoint.schemas import AccountProbeResult
 
-DEFAULT_ANTHROPIC_HOST = "api.anthropic.com"
+_DEFAULT_ANTHROPIC_HOST = "api.anthropic.com"
 
 _BASE_URL_VAR = "ANTHROPIC_BASE_URL"
 
@@ -57,7 +66,7 @@ _DIGESTED_VARS = (
 _DIGEST_CHARS = 12
 
 
-def settings_file(config_dir: str | None) -> Path:
+def _settings_file(config_dir: str | None) -> Path:
     """The user-layer settings file for ``config_dir`` (else the default home).
 
     ``<config_dir>/settings.json`` when a profile is active, else
@@ -75,7 +84,7 @@ def read_settings_env(config_dir: str | None) -> dict[str, str]:
     non-object ``env`` — a broken settings file must leave the caller falling
     back to the live probe, never raise into a launch or a switch.
     """
-    path = settings_file(config_dir)
+    path = _settings_file(config_dir)
     try:
         if not path.is_file():
             return {}
@@ -100,19 +109,20 @@ def _present(env: Mapping[str, str], name: str) -> str | None:
 
 
 def _resolve_base_url(
-    settings_env: Mapping[str, str], launch_env: Mapping[str, str]
+    settings_env: Mapping[str, str], process_env: Mapping[str, str]
 ) -> str | None:
-    """The endpoint this dir talks to: launch env, overridden by settings.
+    """The endpoint this dir talks to: the settings layer, else the process env.
 
     The only value not confined to the settings layer. A dir whose settings file
-    carries just the token while the endpoint comes from a plugin-level ``env``
-    would otherwise be keyed and *labelled* ``api.anthropic.com`` while actually
-    talking to a gateway. Reading it cannot collapse profiles the way reading a
-    secret would: an endpoint alone never yields an identity, and a shared one
-    contributes identical material to every profile, leaving the per-profile
-    secret digest to discriminate. Settings wins, matching the CLI.
+    carries just the token while the endpoint comes from a plugin-level ``env`` or
+    the host environment the agent inherits would otherwise be keyed and
+    *labelled* ``api.anthropic.com`` while actually talking to a gateway. Reading
+    it cannot collapse profiles the way reading a secret would: an endpoint alone
+    never yields an identity, and a shared one contributes identical material to
+    every profile, leaving the per-profile secret digest to discriminate. Settings
+    wins over the env, matching the CLI.
     """
-    return _present(settings_env, _BASE_URL_VAR) or _present(launch_env, _BASE_URL_VAR)
+    return _present(settings_env, _BASE_URL_VAR) or _present(process_env, _BASE_URL_VAR)
 
 
 def _endpoint_host(base_url: str | None) -> str:
@@ -125,15 +135,15 @@ def _endpoint_host(base_url: str | None) -> str:
     keys. An absent or unparsable URL resolves to the default host.
     """
     if not base_url:
-        return DEFAULT_ANTHROPIC_HOST
+        return _DEFAULT_ANTHROPIC_HOST
     try:
         parts = urlsplit(base_url)
         host = parts.hostname
         port = parts.port
     except ValueError:
-        return DEFAULT_ANTHROPIC_HOST
+        return _DEFAULT_ANTHROPIC_HOST
     if not host:
-        return DEFAULT_ANTHROPIC_HOST
+        return _DEFAULT_ANTHROPIC_HOST
     return f"{host}:{port}" if port else host
 
 
@@ -169,7 +179,7 @@ def _digest(settings_env: Mapping[str, str], base_url: str | None) -> str:
 
 
 def configured_account_identity(
-    config_dir: str | None, launch_env: Mapping[str, str]
+    config_dir: str | None, process_env: Mapping[str, str]
 ) -> AccountProbeResult | None:
     """The account ``config_dir`` authenticates as by its own configuration.
 
@@ -181,13 +191,16 @@ def configured_account_identity(
     gateway can proxy an OAuth login), and flipping such a profile's key would
     break a configured ``expected_account_key`` that matches today.
 
+    ``process_env`` is what the agent process will see — the session's launch env
+    over the host env — and supplies the endpoint only, never the credential.
+
     The key carries the endpoint host and a digest, never a secret; both it and
     the label reach API payloads, and the label is not redacted.
     """
     settings_env = read_settings_env(config_dir)
     if not any(_present(settings_env, name) for name in _TRIGGER_SECRET_VARS):
         return None
-    base_url = _resolve_base_url(settings_env, launch_env)
+    base_url = _resolve_base_url(settings_env, process_env)
     host = _endpoint_host(base_url)
     return AccountProbeResult(
         account_key=f"claude_code:endpoint:{host}:{_digest(settings_env, base_url)}",

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -611,16 +611,21 @@ class ClaudeCodePlugin(DefaultLaunchContract):
     def configured_account_identity(
         self, launch_env: Mapping[str, str]
     ) -> AccountProbeResult | None:
-        # Mirrors the config-dir chain the CLI itself would resolve for a local
-        # process: the session's override, else the host env, else ~/.claude
-        # (claude does not implement DefaultConfigDirProviding, and adding it here
-        # would also change how the switch resolves the *current* config dir for
-        # the transcript step). Only the dir's location comes from launch_env; the
-        # credential is read from the dir. See ConfiguredAccountIdentifying.
-        config_dir = config_dir_for(self.capabilities, launch_env) or os.environ.get(
-            "CLAUDE_CONFIG_DIR"
+        # Resolve both the config dir and the endpoint the way a local agent
+        # process would: the session's launch env, else the host env the process
+        # inherits. (claude does not implement DefaultConfigDirProviding, and
+        # adding it here would also change how the switch resolves the *current*
+        # config dir for the transcript step, so the ~/.claude default stays inside
+        # the identity helper.) Only the dir's location and the endpoint come from
+        # the env; the credential is read from the dir. See
+        # ConfiguredAccountIdentifying.
+        config_dir_key = self.capabilities.config_dir_env_var
+        config_dir = config_dir_for(self.capabilities, launch_env) or (
+            os.environ.get(config_dir_key) if config_dir_key else None
         )
-        return configured_account_identity(config_dir, launch_env)
+        # Same composition the live probe and the launched process see: the
+        # session's launch env over the host env (cf. runtime.account_lookup_env).
+        return configured_account_identity(config_dir, {**os.environ, **launch_env})
 
     def config_dir_readiness(self, config_dir: str) -> ConfigDirReadiness:
         # Setting CLAUDE_CONFIG_DIR moves .claude.json into the profile dir; if

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -10,8 +10,10 @@ no longer leak into runtime.py.
 
 import asyncio
 import logging
+import os
 import shlex
 import uuid
+from collections.abc import Mapping
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -41,6 +43,9 @@ from waypoint.backends.claude_code.adapter import (
 from waypoint.backends.claude_code.commands import (
     CLAUDE_BUILTIN_SLASH_COMMANDS,
     list_claude_command_completions,
+)
+from waypoint.backends.claude_code.configured_account import (
+    configured_account_identity,
 )
 from waypoint.backends.claude_code.history import (
     read_local_claude_history,
@@ -106,6 +111,7 @@ from waypoint.backends.tmux.plugin import TmuxPlugin
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
+    AccountProbeResult,
     BackendModelOption,
     CommandCompletion,
     CompletionDispatch,
@@ -601,6 +607,20 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         if thread_id is None or not UUID_RE.match(thread_id):
             return None
         return f"projects/*/{thread_id}.jsonl"
+
+    def configured_account_identity(
+        self, launch_env: Mapping[str, str]
+    ) -> AccountProbeResult | None:
+        # Mirrors the config-dir chain the CLI itself would resolve for a local
+        # process: the session's override, else the host env, else ~/.claude
+        # (claude does not implement DefaultConfigDirProviding, and adding it here
+        # would also change how the switch resolves the *current* config dir for
+        # the transcript step). Only the dir's location comes from launch_env; the
+        # credential is read from the dir. See ConfiguredAccountIdentifying.
+        config_dir = config_dir_for(self.capabilities, launch_env) or os.environ.get(
+            "CLAUDE_CONFIG_DIR"
+        )
+        return configured_account_identity(config_dir, launch_env)
 
     def config_dir_readiness(self, config_dir: str) -> ConfigDirReadiness:
         # Setting CLAUDE_CONFIG_DIR moves .claude.json into the profile dir; if

--- a/backend/tests/test_configured_account_identity.py
+++ b/backend/tests/test_configured_account_identity.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from waypoint.backends.account_profiles import probe_account
+from waypoint.backends.base import ConfiguredAccountIdentifying
 from waypoint.backends.claude_code.configured_account import (
     configured_account_identity,
     read_settings_env,
@@ -172,6 +173,25 @@ def test_base_url_comes_from_launch_env_when_settings_omits_it(tmp_path: Path) -
     )
     assert identity is not None
     assert identity.account_key.startswith("claude_code:endpoint:gw.example.com:")
+
+
+def test_base_url_comes_from_the_host_env_as_a_last_resort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Exporting the endpoint in the shell that runs the service is a normal way to
+    # point at a gateway, and the agent process inherits it, so the key and label
+    # must name that gateway rather than the default host. The plugin composes the
+    # chain; the mapper only sees the composed view.
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://gw.example.com")
+    config_dir = _pool_dir(tmp_path, ANTHROPIC_AUTH_TOKEN=TOKEN)
+    plugin = _runtime(tmp_path).registry.get("claude_code")
+    assert isinstance(plugin, ConfiguredAccountIdentifying)
+
+    identity = plugin.configured_account_identity({"CLAUDE_CONFIG_DIR": config_dir})
+
+    assert identity is not None
+    assert identity.account_key.startswith("claude_code:endpoint:gw.example.com:")
+    assert identity.account_label == "gw.example.com · token auth"
 
 
 def test_settings_base_url_overrides_launch_env(tmp_path: Path) -> None:

--- a/backend/tests/test_configured_account_identity.py
+++ b/backend/tests/test_configured_account_identity.py
@@ -1,0 +1,416 @@
+"""Configured-account identity: a Claude config dir that declares its own auth.
+
+A ``CLAUDE_CONFIG_DIR`` whose ``settings.json`` carries an ``env`` block with a
+bearer token (typically against a custom ``ANTHROPIC_BASE_URL``) has no OAuth
+credentials and no ``oauthAccount``, so the rate-limit probe that normally
+identifies an account returns nothing and the runtime refused to switch a session
+onto such a profile at all. These pin the local identity that replaces the probe
+for those dirs, the conservatism that keeps OAuth profiles resolving exactly as
+before, and the two-tier resolution in ``probe_account``.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from waypoint.backends.account_profiles import probe_account
+from waypoint.backends.claude_code.configured_account import (
+    configured_account_identity,
+    read_settings_env,
+)
+from waypoint.launch_targets import SshLaunchTargetConfig
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import AccountProbeResult, SessionRateLimitUsage
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+TOKEN = "sk-ant-oat01-secret-token-value"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # The fallback chain reads CLAUDE_CONFIG_DIR before ~/.claude, and this host
+    # runs Waypoint itself, so both have to be neutralised or a test with no
+    # explicit dir would read the developer's real config.
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+
+def _pool_dir(base: Path, name: str = "pool", **env: str) -> str:
+    config_dir = base / name
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "settings.json").write_text(json.dumps({"env": env}))
+    return str(config_dir)
+
+
+# ── settings-env reader ─────────────────────────────────────────────────────
+
+
+def test_reads_env_block(tmp_path: Path) -> None:
+    config_dir = _pool_dir(tmp_path, ANTHROPIC_AUTH_TOKEN=TOKEN, OTHER="x")
+    assert read_settings_env(config_dir) == {
+        "ANTHROPIC_AUTH_TOKEN": TOKEN,
+        "OTHER": "x",
+    }
+
+
+def test_reader_degrades_on_unusable_settings(tmp_path: Path) -> None:
+    missing = tmp_path / "absent"
+    assert read_settings_env(str(missing)) == {}
+
+    malformed = tmp_path / "malformed"
+    malformed.mkdir()
+    (malformed / "settings.json").write_text("{not json")
+    assert read_settings_env(str(malformed)) == {}
+
+    not_an_object = tmp_path / "list"
+    not_an_object.mkdir()
+    (not_an_object / "settings.json").write_text("[]")
+    assert read_settings_env(str(not_an_object)) == {}
+
+    env_not_an_object = tmp_path / "env-scalar"
+    env_not_an_object.mkdir()
+    (env_not_an_object / "settings.json").write_text(json.dumps({"env": "nope"}))
+    assert read_settings_env(str(env_not_an_object)) == {}
+
+
+def test_reader_skips_non_string_and_empty_values(tmp_path: Path) -> None:
+    config_dir = tmp_path / "mixed"
+    config_dir.mkdir()
+    (config_dir / "settings.json").write_text(
+        json.dumps({"env": {"A": "keep", "B": 5, "C": None, "D": ""}})
+    )
+    assert read_settings_env(str(config_dir)) == {"A": "keep"}
+
+
+def test_reader_ignores_user_level_settings_local(tmp_path: Path) -> None:
+    # The CLI reads settings.local.json only as a *project* layer; at the config
+    # dir it honours settings.json alone (verified against the real CLI).
+    config_dir = _pool_dir(tmp_path, ANTHROPIC_AUTH_TOKEN=TOKEN)
+    (Path(config_dir) / "settings.local.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_AUTH_TOKEN": "other"}})
+    )
+    assert read_settings_env(config_dir)["ANTHROPIC_AUTH_TOKEN"] == TOKEN
+
+
+# ── identity: positive cases ─────────────────────────────────────────────────
+
+
+def test_token_and_custom_endpoint_yield_identity(tmp_path: Path) -> None:
+    config_dir = _pool_dir(
+        tmp_path,
+        ANTHROPIC_BASE_URL="https://gw.example.com",
+        ANTHROPIC_AUTH_TOKEN=TOKEN,
+    )
+    identity = configured_account_identity(config_dir, {})
+    assert identity is not None
+    assert identity.account_key.startswith("claude_code:endpoint:gw.example.com:")
+    assert identity.account_label == "gw.example.com · token auth"
+    assert identity.source == "api"
+
+
+def test_setup_token_alone_yields_identity(tmp_path: Path) -> None:
+    # `claude setup-token` writes CLAUDE_CODE_OAUTH_TOKEN; it authenticates a pool
+    # dir with no interactive login and no custom endpoint.
+    config_dir = _pool_dir(tmp_path, CLAUDE_CODE_OAUTH_TOKEN=TOKEN)
+    identity = configured_account_identity(config_dir, {})
+    assert identity is not None
+    assert identity.account_key.startswith("claude_code:endpoint:api.anthropic.com:")
+
+
+def test_identity_never_carries_the_secret_or_url_userinfo(tmp_path: Path) -> None:
+    config_dir = _pool_dir(
+        tmp_path,
+        ANTHROPIC_BASE_URL="https://svc:gateway-password@gw.example.com:8443/v1",
+        ANTHROPIC_AUTH_TOKEN=TOKEN,
+        ANTHROPIC_CUSTOM_HEADERS="X-Auth: header-secret",
+    )
+    identity = configured_account_identity(config_dir, {})
+    assert identity is not None
+    # The label is not redacted by the probe endpoint and both fields reach the
+    # frontend through the usage dashboard, so neither may carry a secret.
+    for field in (identity.account_key, identity.account_label or ""):
+        assert TOKEN not in field
+        assert "gateway-password" not in field
+        assert "header-secret" not in field
+        assert "svc" not in field
+    assert identity.account_label == "gw.example.com:8443 · token auth"
+
+
+def test_endpoint_case_and_path_do_not_split_the_plaintext_host(tmp_path: Path) -> None:
+    upper = _pool_dir(
+        tmp_path,
+        "upper",
+        ANTHROPIC_BASE_URL="HTTPS://GW.Example.COM/v1",
+        ANTHROPIC_AUTH_TOKEN=TOKEN,
+    )
+    lower = _pool_dir(
+        tmp_path,
+        "lower",
+        ANTHROPIC_BASE_URL="https://gw.example.com/v1",
+        ANTHROPIC_AUTH_TOKEN=TOKEN,
+    )
+    upper_identity = configured_account_identity(upper, {})
+    lower_identity = configured_account_identity(lower, {})
+    assert upper_identity is not None and lower_identity is not None
+    # One endpoint, one key — a user who normalises their URL keeps the same
+    # expected_account_key.
+    assert upper_identity.account_key == lower_identity.account_key
+
+
+def test_base_url_comes_from_launch_env_when_settings_omits_it(tmp_path: Path) -> None:
+    # Token in the profile's settings.json, endpoint from a plugin-level env: the
+    # session talks to the gateway, so the key and label must say so.
+    config_dir = _pool_dir(tmp_path, ANTHROPIC_AUTH_TOKEN=TOKEN)
+    identity = configured_account_identity(
+        config_dir, {"ANTHROPIC_BASE_URL": "https://gw.example.com"}
+    )
+    assert identity is not None
+    assert identity.account_key.startswith("claude_code:endpoint:gw.example.com:")
+
+
+def test_settings_base_url_overrides_launch_env(tmp_path: Path) -> None:
+    # The CLI applies settings.json's env over the inherited process env.
+    config_dir = _pool_dir(
+        tmp_path,
+        ANTHROPIC_BASE_URL="https://from-settings.example.com",
+        ANTHROPIC_AUTH_TOKEN=TOKEN,
+    )
+    identity = configured_account_identity(
+        config_dir, {"ANTHROPIC_BASE_URL": "https://from-launch-env.example.com"}
+    )
+    assert identity is not None
+    assert "from-settings.example.com" in identity.account_key
+    assert "from-launch-env" not in identity.account_key
+
+
+# ── identity: the key must distinguish accounts ──────────────────────────────
+
+
+def _key(config_dir: str) -> str:
+    identity = configured_account_identity(config_dir, {})
+    assert identity is not None
+    return identity.account_key
+
+
+def test_same_endpoint_and_token_resolve_to_the_same_key(tmp_path: Path) -> None:
+    env = {
+        "ANTHROPIC_BASE_URL": "https://gw.example.com",
+        "ANTHROPIC_AUTH_TOKEN": TOKEN,
+    }
+    # Two dirs, same credential: genuinely the same account, so the runtime's
+    # no-op guard should still refuse a switch between them.
+    assert _key(_pool_dir(tmp_path, "a", **env)) == _key(
+        _pool_dir(tmp_path, "b", **env)
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "left", "right"),
+    [
+        ("ANTHROPIC_AUTH_TOKEN", TOKEN, "sk-ant-oat01-a-different-token"),
+        ("ANTHROPIC_API_KEY", "key-a", "key-b"),
+        ("ANTHROPIC_CUSTOM_HEADERS", "X-Team: a", "X-Team: b"),
+        ("ANTHROPIC_BASE_URL", "https://gw.example.com", "http://gw.example.com"),
+        (
+            "ANTHROPIC_BASE_URL",
+            "https://gw.example.com/v1/team-a",
+            "https://gw.example.com/v1/team-b",
+        ),
+    ],
+)
+def test_differing_credential_material_yields_a_different_key(
+    tmp_path: Path, field: str, left: str, right: str
+) -> None:
+    # Scheme and path matter as much as the token: a path-routed gateway is a
+    # normal shape, and collapsing two of its accounts onto one key would make the
+    # no-op guard refuse a legitimate switch.
+    base = {
+        "ANTHROPIC_BASE_URL": "https://gw.example.com",
+        "ANTHROPIC_AUTH_TOKEN": TOKEN,
+    }
+    assert _key(_pool_dir(tmp_path, "a", **{**base, field: left})) != _key(
+        _pool_dir(tmp_path, "b", **{**base, field: right})
+    )
+
+
+# ── identity: negative cases (must not re-identify a working OAuth profile) ──
+
+
+def test_no_identity_without_a_declared_bearer_secret(tmp_path: Path) -> None:
+    oauth_dir = tmp_path / "oauth"
+    oauth_dir.mkdir()
+    assert configured_account_identity(str(oauth_dir), {}) is None
+
+    # A gateway can proxy an OAuth login, so an endpoint alone says nothing about
+    # which account authenticates.
+    assert (
+        configured_account_identity(
+            _pool_dir(
+                tmp_path, "url-only", ANTHROPIC_BASE_URL="https://gw.example.com"
+            ),
+            {},
+        )
+        is None
+    )
+
+    # The CLI gates an env api key on interactivity, not on the endpoint: the
+    # headless transport uses it, the TUI needs it pre-approved in .claude.json.
+    # A transport-blind identity can't be right for both, so it never triggers.
+    assert (
+        configured_account_identity(_pool_dir(tmp_path, "k", ANTHROPIC_API_KEY="k"), {})
+        is None
+    )
+    assert (
+        configured_account_identity(
+            _pool_dir(
+                tmp_path,
+                "k-url",
+                ANTHROPIC_BASE_URL="https://gw.example.com",
+                ANTHROPIC_API_KEY="k",
+            ),
+            {},
+        )
+        is None
+    )
+
+    # Header-only gateway auth, same reasoning as the bare endpoint.
+    assert (
+        configured_account_identity(
+            _pool_dir(
+                tmp_path,
+                "hdr",
+                ANTHROPIC_BASE_URL="https://gw.example.com",
+                ANTHROPIC_CUSTOM_HEADERS="X-Auth: v",
+            ),
+            {},
+        )
+        is None
+    )
+
+
+def test_no_identity_from_a_secret_outside_the_profiles_settings(
+    tmp_path: Path,
+) -> None:
+    # A token in the launch env comes from the global plugin env for *every*
+    # profile, so it cannot distinguish accounts; honouring it would collapse a
+    # working multi-profile setup onto one key and refuse every switch.
+    config_dir = tmp_path / "oauth"
+    config_dir.mkdir()
+    assert (
+        configured_account_identity(str(config_dir), {"ANTHROPIC_AUTH_TOKEN": TOKEN})
+        is None
+    )
+
+
+def test_no_identity_from_an_empty_secret(tmp_path: Path) -> None:
+    assert (
+        configured_account_identity(
+            _pool_dir(tmp_path, "blank", ANTHROPIC_AUTH_TOKEN="   "), {}
+        )
+        is None
+    )
+
+
+# ── probe_account: two-tier resolution ───────────────────────────────────────
+
+
+def _runtime(tmp_path: Path) -> SessionRuntime:
+    settings = Settings(data_dir=tmp_path / "data")
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+def _record_probe(
+    monkeypatch: pytest.MonkeyPatch, runtime: SessionRuntime, calls: list[str]
+) -> None:
+    plugin = runtime.registry.get("claude_code")
+
+    async def fake_probe(*_a: Any, **_k: Any) -> SessionRateLimitUsage:
+        calls.append("probed")
+        return SessionRateLimitUsage(
+            source="claude_code",
+            updated_at=datetime.now(UTC),
+            windows=[],
+            notes=["org: acme"],
+        )
+
+    monkeypatch.setattr(plugin, "probe_account_rate_limit", fake_probe)
+    monkeypatch.setattr(
+        plugin, "rate_limit_account", lambda _s: ("claude_code:acme", "acme")
+    )
+
+
+async def test_probe_account_prefers_the_configured_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    calls: list[str] = []
+    _record_probe(monkeypatch, runtime, calls)
+    config_dir = _pool_dir(
+        tmp_path,
+        ANTHROPIC_BASE_URL="https://gw.example.com",
+        ANTHROPIC_AUTH_TOKEN=TOKEN,
+    )
+
+    result = await probe_account(
+        runtime, "claude_code", {"CLAUDE_CONFIG_DIR": config_dir}
+    )
+
+    assert isinstance(result, AccountProbeResult)
+    assert result.account_key.startswith("claude_code:endpoint:gw.example.com:")
+    # A declared credential is what the agent authenticates as, so the live probe
+    # is not just redundant here — for a dir holding stale OAuth credentials too,
+    # it would name the account the agent will *not* use.
+    assert calls == []
+
+
+async def test_probe_account_falls_back_to_the_live_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    calls: list[str] = []
+    _record_probe(monkeypatch, runtime, calls)
+    oauth_dir = tmp_path / "oauth"
+    oauth_dir.mkdir()
+
+    result = await probe_account(
+        runtime, "claude_code", {"CLAUDE_CONFIG_DIR": str(oauth_dir)}
+    )
+
+    assert result is not None
+    assert result.account_key == "claude_code:acme"
+    assert calls == ["probed"]
+
+
+async def test_probe_account_ignores_local_settings_for_a_remote_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The config dir named by a remote profile lives on the remote host; reading a
+    # same-path local dir would mint a false identity for it.
+    runtime = _runtime(tmp_path)
+    calls: list[str] = []
+    _record_probe(monkeypatch, runtime, calls)
+    config_dir = _pool_dir(tmp_path, ANTHROPIC_AUTH_TOKEN=TOKEN)
+    target = SshLaunchTargetConfig(
+        id="rover",
+        name="rover",
+        ssh_destination="user@rover.lan",
+        ssh_args=[],
+        remote_shell="",
+    )
+
+    result = await probe_account(
+        runtime,
+        "claude_code",
+        {"CLAUDE_CONFIG_DIR": config_dir},
+        launch_target=target,
+    )
+
+    assert result is not None
+    assert result.account_key == "claude_code:acme"
+    assert calls == ["probed"]

--- a/backend/tests/test_launch_settings.py
+++ b/backend/tests/test_launch_settings.py
@@ -14,6 +14,9 @@ from typing import Any
 import pytest
 
 from waypoint.backends.account_profiles import probe_account
+from waypoint.backends.claude_code.configured_account import (
+    configured_account_identity,
+)
 from waypoint.backends.transcripts import ThreadAvailability
 from waypoint.runtime import SessionRuntime
 from waypoint.schemas import (
@@ -1128,3 +1131,151 @@ async def test_update_rejects_unpersisted_thread_with_conversation_events(
     assert getattr(exc.value, "status_code", None) == 400
     assert "conversation events" in str(getattr(exc.value, "detail", ""))
     assert terminated == []
+
+
+# ── switching onto a profile that declares its own auth ─────────────────────
+#
+# The reported bug: a config dir whose settings.json carries a token (typically
+# against a custom endpoint) has no OAuth credentials for the rate-limit probe to
+# read, so probe_account returned None and the switch was refused with "could not
+# verify the target account before switching" — before expected_account_key could
+# even be consulted. These deliberately do NOT patch probe_account: the real
+# two-tier resolution is what is under test.
+
+
+def _write_claude_settings_env(config_dir: Path, **env: str) -> None:
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "settings.json").write_text(json.dumps({"env": env}))
+
+
+@pytest.fixture
+def _offline_claude_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    # Both sides of the switch must resolve without a network call or a read of
+    # the developer's real config: the fallback chain consults CLAUDE_CONFIG_DIR
+    # and then ~/.claude, and the current-side probe runs for real here.
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    home = tmp_path / "fake-home"
+    (home / ".claude").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: home)
+
+
+def _write_pool_dirs(tmp_path: Path, target_token: str) -> tuple[Path, Path]:
+    current_dir = tmp_path / "claude-current"
+    target_dir = tmp_path / "claude-pool"
+    _write_claude_settings_env(
+        current_dir,
+        ANTHROPIC_BASE_URL="https://gw.example.com",
+        ANTHROPIC_AUTH_TOKEN="token-current",
+    )
+    _write_claude_settings_env(
+        target_dir,
+        ANTHROPIC_BASE_URL="https://gw.example.com",
+        ANTHROPIC_AUTH_TOKEN=target_token,
+    )
+    # claude has no fresh-thread restart path, so an unpersisted thread is a hard
+    # 400; the artifact makes the transcript step return PERSISTED and leaves the
+    # account gate as the thing this test exercises.
+    _write_claude_thread(target_dir)
+    _write_claude_onboarding_complete(target_dir)
+    return current_dir, target_dir
+
+
+def _pool_switch_runtime(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    current_dir: Path,
+    target_dir: Path,
+    *,
+    expected_account_key: str | None = None,
+) -> SessionRuntime:
+    profile: dict[str, Any] = {
+        "label": "Pool",
+        "config_dir": str(target_dir),
+        "transcript_policy": "require_existing",
+    }
+    if expected_account_key is not None:
+        profile["expected_account_key"] = expected_account_key
+    runtime = _runtime(tmp_path, claude_code={"account_profiles": {"pool": profile}})
+    _session(
+        runtime,
+        backend="claude_code",
+        transport="tmux",
+        cwd="/repo/app",
+        launch_env={"CLAUDE_CONFIG_DIR": str(current_dir)},
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_self_rt: Any, session: SessionRecord) -> None:
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+    return runtime
+
+
+async def test_update_switches_onto_a_profile_that_declares_its_own_auth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _offline_claude_config: None
+) -> None:
+    current_dir, target_dir = _write_pool_dirs(tmp_path, "token-pool")
+    runtime = _pool_switch_runtime(tmp_path, monkeypatch, current_dir, target_dir)
+
+    updated = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(account_profile_id="pool", restart=True)
+    )
+
+    assert updated.account_profile_id == "pool"
+    assert updated.launch_env["CLAUDE_CONFIG_DIR"] == str(target_dir)
+    # Verified synchronously from the same probe the gate used, so the identity is
+    # the endpoint-and-digest one, not an OAuth org.
+    session = runtime.get_session("s1")
+    assert session.verified_account_key is not None
+    assert session.verified_account_key.startswith(
+        "claude_code:endpoint:gw.example.com:"
+    )
+    assert session.verified_account_label == "gw.example.com · token auth"
+    assert "token-pool" not in session.verified_account_key
+
+
+async def test_update_rejects_a_switch_between_profiles_sharing_one_credential(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _offline_claude_config: None
+) -> None:
+    # Same endpoint and same token on both sides is genuinely the same account, so
+    # the no-op guard must still refuse — the configured identity has to
+    # discriminate accounts, not merely unblock switching.
+    current_dir, target_dir = _write_pool_dirs(tmp_path, "token-current")
+    runtime = _pool_switch_runtime(tmp_path, monkeypatch, current_dir, target_dir)
+
+    with pytest.raises(Exception) as exc:
+        await runtime.update_launch_settings(
+            "s1", LaunchSettingsUpdateRequest(account_profile_id="pool", restart=True)
+        )
+
+    assert getattr(exc.value, "status_code", None) == 400
+    assert "same account" in str(getattr(exc.value, "detail", ""))
+
+
+async def test_update_allows_a_shared_credential_switch_with_an_expected_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, _offline_claude_config: None
+) -> None:
+    # The documented escape hatch for two profiles on one account still applies to
+    # a configured identity — and it is now reachable at all, since the gate no
+    # longer fails before consulting it.
+    current_dir, target_dir = _write_pool_dirs(tmp_path, "token-current")
+    expected = configured_account_identity(str(target_dir), {})
+    assert expected is not None
+    runtime = _pool_switch_runtime(
+        tmp_path,
+        monkeypatch,
+        current_dir,
+        target_dir,
+        expected_account_key=expected.account_key,
+    )
+
+    updated = await runtime.update_launch_settings(
+        "s1", LaunchSettingsUpdateRequest(account_profile_id="pool", restart=True)
+    )
+
+    assert updated.launch_env["CLAUDE_CONFIG_DIR"] == str(target_dir)

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -73,13 +73,13 @@ Set one up once, before selecting the profile:
 
 - **Claude** — run `CLAUDE_CONFIG_DIR=<config_dir> claude` interactively and finish
   the first-run wizard (theme, login), or copy an already-onboarded
-  `~/.claude.json` into `<config_dir>/.claude.json`. The wizard runs even for a
-  dir that authenticates by token rather than by login, so this step applies to
-  those too. Waypoint refuses to launch or
-  switch an **interactive** session (the `claude_tty` / tmux transports) onto a
-  profile whose `<config_dir>/.claude.json` hasn't completed onboarding — the TUI
-  would relaunch into the wizard and a headless-driven turn can't dismiss it, so it
-  would hang. The rejection is a 400 (`account profile '<id>' is not set up: …`).
+  `~/.claude.json` into `<config_dir>/.claude.json`. The wizard runs even for a dir
+  that authenticates by token rather than by login, so this step applies to those
+  too. Waypoint refuses to launch or switch an **interactive** session (the
+  `claude_tty` / tmux transports) onto a profile whose `<config_dir>/.claude.json`
+  hasn't completed onboarding — the TUI would relaunch into the wizard and a
+  headless-driven turn can't dismiss it, so it would hang. The rejection is a 400
+  (`account profile '<id>' is not set up: …`).
   The headless `claude --print` transport doesn't onboard and isn't blocked.
 - **Codex** — run `CODEX_HOME=<config_dir> codex login` to write `auth.json`. Codex
   has no onboarding wizard: its default app-server transport fails fast on an
@@ -137,14 +137,26 @@ profile dir's** `settings.json`. The deliberate exclusions:
   login, so those profiles keep resolving through the account probe.
 - Remote (SSH launch target) profiles resolve through the probe as before; the
   settings file for a remote profile lives on the remote host.
+- The CLI's project settings (`<cwd>/.claude/settings.json` and
+  `settings.local.json`) outrank the config dir but are not consulted: identity
+  has to be a property of the profile, not of a directory, since `accounts probe`
+  and `accounts doctor` have no session cwd. A token declared in a project's
+  settings is therefore not reflected in the profile's identity.
 
-Two further limits: such a session has no rate-limit snapshot, so it does not
-appear in the usage dashboard, and a dir that holds *both* a login and a declared
-token reports its usage windows under the declared identity — keep a
-credential-carrying profile dir free of interactive logins. To switch a *running*
-session onto a fresh profile dir, pair it with `copy_thread_on_switch` or
-`symlink_shared`; the default `require_existing` policy rejects a dir that cannot
-already see the session's thread (see below).
+Further limits:
+
+- Such a session has no rate-limit snapshot, so it does not appear in the usage
+  dashboard.
+- A dir that holds *both* a login and a declared token reports its usage windows
+  under the declared identity, and its key changes from `claude_code:<org>` to the
+  endpoint form — refresh `expected_account_key` for such a profile after
+  upgrading. Keep a credential-carrying profile dir free of interactive logins.
+- An endpoint key and an OAuth-org key are not comparable, so a `setup-token`
+  profile and an interactive-login profile for the *same* Anthropic account
+  resolve to different keys and a switch between them counts as an account change.
+- To switch a *running* session onto a fresh profile dir, pair it with
+  `copy_thread_on_switch` or `symlink_shared`; the default `require_existing`
+  policy rejects a dir that cannot already see the session's thread (see below).
 
 ### Transcript policies
 

--- a/docs/account_profiles.md
+++ b/docs/account_profiles.md
@@ -73,7 +73,9 @@ Set one up once, before selecting the profile:
 
 - **Claude** — run `CLAUDE_CONFIG_DIR=<config_dir> claude` interactively and finish
   the first-run wizard (theme, login), or copy an already-onboarded
-  `~/.claude.json` into `<config_dir>/.claude.json`. Waypoint refuses to launch or
+  `~/.claude.json` into `<config_dir>/.claude.json`. The wizard runs even for a
+  dir that authenticates by token rather than by login, so this step applies to
+  those too. Waypoint refuses to launch or
   switch an **interactive** session (the `claude_tty` / tmux transports) onto a
   profile whose `<config_dir>/.claude.json` hasn't completed onboarding — the TUI
   would relaunch into the wizard and a headless-driven turn can't dismiss it, so it
@@ -83,6 +85,66 @@ Set one up once, before selecting the profile:
   has no onboarding wizard: its default app-server transport fails fast on an
   unauthenticated home (surfaced error, no hang), so profiles aren't guarded the
   way Claude's are.
+
+### Profiles that carry their own credential (Claude)
+
+A profile dir does not have to hold an interactive login. Writing an `env` block
+into `<config_dir>/settings.json` points the CLI at a gateway or a separate
+credential, and the CLI applies that block **over** the inherited process
+environment, so it is what the agent authenticates as:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://gateway.example.com",
+    "ANTHROPIC_AUTH_TOKEN": "..."
+  }
+}
+```
+
+Such a dir has no OAuth credentials, so the account probe that normally
+identifies a profile finds nothing. Waypoint therefore identifies it from the
+dir's own configuration: the account key is
+`claude_code:endpoint:<host>:<digest>`, where `<host>` is the endpoint's hostname
+(and port) and `<digest>` is the first 12 hex characters of a SHA-256 over the
+declared credential material and the normalized endpoint URL. Neither the key nor
+the label ever contains the credential itself. Read the key the same way as any
+other:
+
+```bash
+waypoint accounts probe claude_code pool --show-key
+```
+
+Rotating the credential changes the digest, so refresh `expected_account_key`
+after a rotation.
+
+Two profiles that declare the *same* endpoint and credential resolve to the same
+key — correctly, since they are one account — so a switch between them is refused
+as a no-op unless both carry a matching `expected_account_key`.
+
+The identity is recognized from `ANTHROPIC_AUTH_TOKEN` or
+`CLAUDE_CODE_OAUTH_TOKEN` (what `claude setup-token` writes) declared in **that
+profile dir's** `settings.json`. The deliberate exclusions:
+
+- A token in `plugin_configs.<agent>.env` reaches every session of every profile,
+  so it cannot distinguish accounts — put it in the profile dir's `settings.json`.
+- `ANTHROPIC_API_KEY` is not recognized: the CLI's use of an environment API key
+  depends on whether the session is interactive, and on an approval recorded in
+  `.claude.json`, so it is not a reliable account signal. It still contributes to
+  the digest.
+- A custom `ANTHROPIC_BASE_URL` alone, `ANTHROPIC_CUSTOM_HEADERS` alone, and
+  `apiKeyHelper` are not recognized either — a gateway can proxy an ordinary
+  login, so those profiles keep resolving through the account probe.
+- Remote (SSH launch target) profiles resolve through the probe as before; the
+  settings file for a remote profile lives on the remote host.
+
+Two further limits: such a session has no rate-limit snapshot, so it does not
+appear in the usage dashboard, and a dir that holds *both* a login and a declared
+token reports its usage windows under the declared identity — keep a
+credential-carrying profile dir free of interactive logins. To switch a *running*
+session onto a fresh profile dir, pair it with `copy_thread_on_switch` or
+`symlink_shared`; the default `require_existing` policy rejects a dir that cannot
+already see the session's thread (see below).
 
 ### Transcript policies
 


### PR DESCRIPTION
## Purpose

A user reported they cannot switch a running session onto a Claude account profile whose config dir authenticates by a custom endpoint + token rather than by an interactive login: they created `~/.claude-pool`, put `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` in `~/.claude-pool/settings.json`'s `env` block, registered it as a normal profile, and `CLAUDE_CONFIG_DIR=~/.claude-pool claude` works because the CLI auto-loads that block.

Root cause, confirmed empirically. Such a dir has no `.credentials.json` and no `oauthAccount` in `.claude.json`, so `probe_claude_usage` returns `None` ("claude rate-limit probe found no CLI credentials") and `ClaudeCodePlugin.rate_limit_account` has no `org:` note to map — `probe_account` yields `None` and `update_launch_settings` raises `400 could not verify the target account before switching`. That check runs *before* `profile.expected_account_key` is consulted, so declaring the expected key was not a workaround. The same `None` also made `accounts probe` and `accounts doctor`'s `account_matches_expected` fail on the profile. Onboarding was **not** the blocker: an interactive run in the pool dir does set `hasCompletedOnboarding` (the theme/trust wizard runs even under token auth), so launching a *new* session under the profile already worked — only the running-session switch and the diagnostics failed.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_code/configured_account.py` (new) — reads `<config_dir>/settings.json`'s `env` block and derives a deterministic account identity when it declares a bearer secret. Key is `claude_code:endpoint:<hostname[:port]>:<sha256-12>`, label `<hostname[:port]> · token auth`, `source="api"`. The digest covers `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_CUSTOM_HEADERS`, and the normalized full base URL (scheme + host + port + path), so two profiles behind one path-routed gateway do not collapse onto one key. A malformed or unreadable settings file degrades to "no identity" rather than raising into a launch.
- `backend/src/waypoint/backends/base.py` — new `ConfiguredAccountIdentifying` protocol (`configured_account_identity(launch_env)`), documenting that it takes precedence over the live probe and that returning `None` must be the conservative default.
- `backend/src/waypoint/backends/claude_code/plugin.py` — implements it, resolving the config dir through `config_dir_for` → host env → `~/.claude` (the chain the CLI itself resolves for a local process). Only the dir's *location* comes from `launch_env`.
- `backend/src/waypoint/backends/account_profiles.py` — `probe_account` resolves in two tiers: a config dir that declares its own credential is identified from that declaration, otherwise the live rate-limit probe runs. Local launch targets only, since the resolution reads the config dir. One protocol-dispatched branch at the single chokepoint every consumer already funnels through, so the switch gate, `accounts probe`, `accounts doctor`, and the `verified_account_*` stamp all fix together.

### Docs
- `docs/account_profiles.md` — a subsection on profiles that carry their own credential: how the identity is derived, which env vars count and which deliberately do not, and the limits (local targets only, no usage panel, the transcript policy such a profile needs for a running-session switch).

### Tests
- `backend/tests/test_configured_account_identity.py` (new) — the reader, the identity mapper, and `probe_account`'s two-tier resolution including the remote-target case.
- `backend/tests/test_launch_settings.py` — three switch tests that deliberately do **not** patch `probe_account`, so the real resolution is what they pin.

## Design

Identity is read from the **profile dir's own `settings.json` only**, and that scoping is the load-bearing decision. `launch_env` also carries the global agent plugin env — which `waypoint.example.yaml` documents as the place to put `ANTHROPIC_AUTH_TOKEN` — and that layer is identical across every profile, so keying off it would mint one key for all of them: a user with a global token plus several OAuth profiles would get an `expected_account_key` mismatch, a red doctor, and a no-op refusal on *every* switch. Only a per-profile declaration can distinguish accounts. `ANTHROPIC_BASE_URL` is the single exception, read from `launch_env` overlaid by the settings env, so a dir with the token in `settings.json` and the endpoint in a plugin-level env is not keyed and labelled `api.anthropic.com` while talking to a gateway; an endpoint never triggers an identity on its own, so reading it cannot collapse profiles.

The trigger requires an actual bearer secret. Three exclusions, each to avoid re-identifying a profile that works today:

- **`ANTHROPIC_API_KEY`** — the CLI gates an env api key on *interactivity*, not on the endpoint (verified in the 2.1.220 bundle: the headless `--print` path uses it directly, while the interactive TUI uses it only once its hash is in `.claude.json`'s `customApiKeyResponses.approved`, and otherwise falls back to OAuth). A transport-blind, agent-axis identity would therefore agree with `claude_cli` and disagree with `claude_tty`/`tmux` — the one way this could produce a confidently *wrong* key instead of a conservative `None`. It still feeds the digest.
- **A bare custom `ANTHROPIC_BASE_URL`** — a corporate gateway can proxy an OAuth login, and that profile verifies correctly today because the OAuth probe hits the hardcoded `api.anthropic.com` usage endpoint with the stored credentials.
- **`ANTHROPIC_CUSTOM_HEADERS` alone** — same reasoning; digested but not identity-bearing.

Configured auth taking precedence over the live probe also fixes an inverse correctness bug: a dir holding both a declared token and stale OAuth credentials previously verified as the login the agent will not use (the CLI's credential chain puts `ANTHROPIC_AUTH_TOKEN` and `CLAUDE_CODE_OAUTH_TOKEN` ahead of the stored OAuth token unconditionally).

The key carries only the endpoint hostname and a digest. That constraint is deliberate: `account_label` is *not* redacted by the probe endpoint, and both key and label reach the frontend through `/api/usage`, so the host is taken from `urlsplit(...).hostname` rather than `netloc` — the latter retains URL userinfo, which would have written a gateway password into both fields.

## Test Plan
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- `cd backend && uv run pytest` — 2752 passed.
- `cd backend && uv run pytest tests/test_configured_account_identity.py tests/test_launch_settings.py` — 62 passed.
- Live end-to-end against a running server (an isolated instance on port 8799 with its own config and data dir, so the shared stack's config was untouched): two pool profiles with distinct tokens at stub endpoints, plus a control profile with no `settings.json`.

## Test Result
- Pre-fix behavior reproduced directly: `probe_claude_usage(env={"CLAUDE_CONFIG_DIR": <pool>})` returns `None`, and with the new resolution disabled all three switch tests fail with the reported `400 could not verify the target account before switching` — so they pin the fix rather than passing incidentally.
- CLI facts the design rests on were verified against the real binary rather than assumed: `settings.json`'s `env` overrides the inherited process env (two loopback listeners; the settings endpoint received the request), a config-dir-level `settings.local.json` is *not* read at the user layer, and the interactive wizard sets `hasCompletedOnboarding` even under token auth.
- Live e2e, all green: `accounts probe claude_code pool-b --show-key` → `claude_code:endpoint:127.0.0.1:9952:3de5f60ce766` (previously a verification failure); with that written to `expected_account_key`, `accounts doctor` reports `account_matches_expected — matches the expected account`; `sessions set-account <id> pool-b` is accepted, the session restores, and `sessions launch-settings` reports the new profile with the pool dir as its `CLAUDE_CONFIG_DIR`. The stored `verified_account_key`/`label` carry no token.
- Regression control on the same server: the profile whose config dir has no `settings.json` still resolves through the live probe and reports `could not verify account` — unchanged behavior, confirming an OAuth profile is not re-identified. After deploying this branch to the shared stack, `accounts doctor` on the host's real codex profile is green.
- The stub endpoints mean no *turn* can complete against them; the gate, the diagnostics, and the restart under the new config dir are what the e2e covers.

Addresses ticket 1258.