### PR TITLE
fix: support switching to Claude profiles with static token auth

### DIFF
--- a/backend/src/waypoint/backends/account_profiles.py
+++ b/backend/src/waypoint/backends/account_profiles.py
@@ -18,7 +18,11 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from waypoint.backends.base import ConfigDirReadinessReporting
+from waypoint.backends.base import (
+    ConfigDirReadinessReporting,
+    StaticAccountIdentifying,
+    config_dir_for,
+)
 from waypoint.backends.plugin_config import AccountProfileConfig
 from waypoint.backends.registry import get_registry
 from waypoint.schemas import AccountProbeResult, ProfileCheck
@@ -268,6 +272,17 @@ async def probe_account(
     through the registry; no per-backend branching.
     """
     plugin = get_registry().get(backend)
+    # A static-credential profile (e.g. a claude profile whose settings.json env
+    # sets ANTHROPIC_AUTH_TOKEN/API_KEY) has no OAuth creds, so the live probe
+    # below can never verify it. Identify it straight from its config dir instead.
+    # Local only: a remote config dir can't be read here (remote static-auth is a
+    # later phase), matching the remote-skip of the other filesystem checks.
+    if launch_target is None and isinstance(plugin, StaticAccountIdentifying):
+        config_dir = config_dir_for(plugin.capabilities, launch_env)
+        if config_dir is not None:
+            identity = plugin.static_account_identity(config_dir)
+            if identity is not None:
+                return identity
     probe = getattr(plugin, "probe_account_rate_limit", None)
     account_of = getattr(plugin, "rate_limit_account", None)
     if probe is None or account_of is None:

--- a/backend/src/waypoint/backends/account_profiles.py
+++ b/backend/src/waypoint/backends/account_profiles.py
@@ -272,17 +272,19 @@ async def probe_account(
     through the registry; no per-backend branching.
     """
     plugin = get_registry().get(backend)
-    # A static-credential profile (e.g. a claude profile whose settings.json env
-    # sets ANTHROPIC_AUTH_TOKEN/API_KEY) has no OAuth creds, so the live probe
-    # below can never verify it. Identify it straight from its config dir instead.
-    # Local only: a remote config dir can't be read here (remote static-auth is a
-    # later phase), matching the remote-skip of the other filesystem checks.
+    # A static-credential profile (e.g. a claude profile that sets
+    # ANTHROPIC_AUTH_TOKEN/API_KEY in its settings.json or configured env) has no
+    # OAuth creds, so the live probe below can never verify it. Identify it from
+    # that static config instead. ``launch_env`` is the session's configured env
+    # (never ambient os.environ). Local only: a remote config dir can't be read
+    # here (remote static-auth is a later phase), matching the remote-skip of the
+    # other filesystem checks.
     if launch_target is None and isinstance(plugin, StaticAccountIdentifying):
-        config_dir = config_dir_for(plugin.capabilities, launch_env)
-        if config_dir is not None:
-            identity = plugin.static_account_identity(config_dir)
-            if identity is not None:
-                return identity
+        identity = plugin.static_account_identity(
+            config_dir_for(plugin.capabilities, launch_env), launch_env
+        )
+        if identity is not None:
+            return identity
     probe = getattr(plugin, "probe_account_rate_limit", None)
     account_of = getattr(plugin, "rate_limit_account", None)
     if probe is None or account_of is None:

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -115,19 +115,25 @@ class ConfigDirValidating(Protocol):
 class StaticAccountIdentifying(Protocol):
     """An agent that can identify a profile's account from static config, no probe.
 
-    Some profiles authenticate via a static credential baked into the config dir
-    rather than an OAuth login — a claude profile whose ``settings.json`` ``env``
-    block sets ``ANTHROPIC_AUTH_TOKEN`` / ``ANTHROPIC_API_KEY`` (typically against
-    a custom ``ANTHROPIC_BASE_URL``) is the motivating case. No OAuth credential
-    file exists for such a profile, so the live rate-limit probe cannot verify it
-    and a switch onto it is wrongly rejected. This hook derives a stable account
-    identity straight from the profile's config dir; returning ``None`` means
-    "not a static-auth profile" so the caller falls back to the live probe.
+    Some profiles authenticate via a static credential rather than an OAuth
+    login — a claude profile that sets ``ANTHROPIC_AUTH_TOKEN`` /
+    ``ANTHROPIC_API_KEY`` (typically against a custom ``ANTHROPIC_BASE_URL``),
+    either in its config dir's ``settings.json`` ``env`` block or in the session's
+    configured launch env, is the motivating case. No OAuth credential file exists
+    for such a profile, so the live rate-limit probe cannot verify it and a switch
+    onto it is wrongly rejected. This hook derives a stable account identity from
+    the credential wherever it is configured; returning ``None`` means "not a
+    static-auth profile" so the caller falls back to the live probe.
     """
 
-    def static_account_identity(self, config_dir: str) -> AccountProbeResult | None:
-        """Identify the account ``config_dir`` authenticates as from its static
-        credential config, or ``None`` when it uses none (fall back to a probe)."""
+    def static_account_identity(
+        self, config_dir: str | None, env: Mapping[str, str]
+    ) -> AccountProbeResult | None:
+        """Identify the account this profile authenticates as from a static
+        credential in ``config_dir`` or the configured ``env``, or ``None`` when
+        it uses none (fall back to a probe). ``env`` is the session's configured
+        launch env — never the ambient process env — so a stray host key cannot
+        misidentify an OAuth profile."""
         ...
 
 

--- a/backend/src/waypoint/backends/base.py
+++ b/backend/src/waypoint/backends/base.py
@@ -8,7 +8,12 @@ from pydantic import BaseModel
 
 from waypoint.backends.capabilities import BackendCapabilities
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
-from waypoint.schemas import CommandCompletion, SessionContextUsage, SessionRecord
+from waypoint.schemas import (
+    AccountProbeResult,
+    CommandCompletion,
+    SessionContextUsage,
+    SessionRecord,
+)
 from waypoint.transports.base import TransportAdapter
 
 if TYPE_CHECKING:
@@ -103,6 +108,26 @@ class ConfigDirValidating(Protocol):
         """Raise :class:`ConfigDirNotReadyError` if launching or resuming under
         ``config_dir`` would block on an interactive first-run prompt this agent
         cannot clear headlessly; return ``None`` when the dir is ready."""
+        ...
+
+
+@runtime_checkable
+class StaticAccountIdentifying(Protocol):
+    """An agent that can identify a profile's account from static config, no probe.
+
+    Some profiles authenticate via a static credential baked into the config dir
+    rather than an OAuth login — a claude profile whose ``settings.json`` ``env``
+    block sets ``ANTHROPIC_AUTH_TOKEN`` / ``ANTHROPIC_API_KEY`` (typically against
+    a custom ``ANTHROPIC_BASE_URL``) is the motivating case. No OAuth credential
+    file exists for such a profile, so the live rate-limit probe cannot verify it
+    and a switch onto it is wrongly rejected. This hook derives a stable account
+    identity straight from the profile's config dir; returning ``None`` means
+    "not a static-auth profile" so the caller falls back to the live probe.
+    """
+
+    def static_account_identity(self, config_dir: str) -> AccountProbeResult | None:
+        """Identify the account ``config_dir`` authenticates as from its static
+        credential config, or ``None`` when it uses none (fall back to a probe)."""
         ...
 
 

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -12,6 +12,7 @@ import asyncio
 import logging
 import shlex
 import uuid
+from collections.abc import Mapping
 from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
@@ -569,12 +570,15 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         label = f"{org} · {tier}" if tier else org
         return f"{self.id}:{org}", label
 
-    def static_account_identity(self, config_dir: str) -> AccountProbeResult | None:
-        # StaticAccountIdentifying: a profile whose settings.json env carries a
-        # static ANTHROPIC_AUTH_TOKEN/API_KEY authenticates without OAuth creds,
-        # so account verification reads its identity from the config dir instead
-        # of the (impossible) live probe. None => OAuth profile, use the probe.
-        return claude_static_account_identity(self.id, config_dir)
+    def static_account_identity(
+        self, config_dir: str | None, env: Mapping[str, str]
+    ) -> AccountProbeResult | None:
+        # StaticAccountIdentifying: a profile that sets a static
+        # ANTHROPIC_AUTH_TOKEN/API_KEY (in its settings.json or the session's
+        # configured env) authenticates without OAuth creds, so verification reads
+        # its identity from that config instead of the (impossible) live probe.
+        # None => OAuth profile, use the probe.
+        return claude_static_account_identity(self.id, config_dir, env)
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the support

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -61,6 +61,7 @@ from waypoint.backends.claude_code.permission_modes import (
     claude_permission_mode_label,
 )
 from waypoint.backends.claude_code.rate_limits import (
+    claude_static_account_identity,
     invalidate_shared_probe_local,
     invalidate_shared_probe_remote,
     probe_claude_usage_remote_shared,
@@ -106,6 +107,7 @@ from waypoint.backends.tmux.plugin import TmuxPlugin
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
+    AccountProbeResult,
     BackendModelOption,
     CommandCompletion,
     CompletionDispatch,
@@ -566,6 +568,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         tier = _find_prefixed(snapshot.notes, _CLAUDE_ORG_TIER_PREFIX)
         label = f"{org} · {tier}" if tier else org
         return f"{self.id}:{org}", label
+
+    def static_account_identity(self, config_dir: str) -> AccountProbeResult | None:
+        # StaticAccountIdentifying: a profile whose settings.json env carries a
+        # static ANTHROPIC_AUTH_TOKEN/API_KEY authenticates without OAuth creds,
+        # so account verification reads its identity from the config dir instead
+        # of the (impossible) live probe. None => OAuth profile, use the probe.
+        return claude_static_account_identity(self.id, config_dir)
 
     def is_available_for_managed_launch(self, runtime: "SessionRuntime") -> bool:
         # The Claude adapter is wired up lazily by setup() — if the support

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import importlib.resources
 import json
 import logging
@@ -15,12 +16,14 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
+from waypoint.backends.claude_code.threads import claude_settings_env
 from waypoint.backends.claude_code.version import claude_cli_version_string
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.perf import debug_timer
-from waypoint.schemas import SessionRateLimitUsage, UsageWindow
+from waypoint.schemas import AccountProbeResult, SessionRateLimitUsage, UsageWindow
 
 log = logging.getLogger("waypoint.claude_code.rate_limits")
 
@@ -657,6 +660,39 @@ def _fetch_url(request: Request) -> _ClaudeHTTPResponse | None:
         return _ClaudeHTTPResponse(status=exc.code, headers=headers, body=body)
     except (URLError, OSError):
         return None
+
+
+def claude_static_account_identity(
+    account_prefix: str, config_dir: str
+) -> AccountProbeResult | None:
+    """Identify a static-credential profile's account from its ``settings.json``.
+
+    A profile whose ``settings.json`` ``env`` sets ``ANTHROPIC_AUTH_TOKEN`` or
+    ``ANTHROPIC_API_KEY`` authenticates via that static credential (no OAuth
+    ``.credentials.json`` exists), so the live rate-limit probe can't verify it.
+    Derive a stable, network-free identity keyed on the endpoint host plus a
+    short credential fingerprint — enough to accept the switch, match an
+    ``expected_account_key``, and distinguish it from a different endpoint or
+    token. Returns ``None`` when no static credential is configured, so OAuth
+    profiles fall through to the live probe. The token is read from the profile's
+    own file, not the process-merged env, so a stray ambient ``ANTHROPIC_API_KEY``
+    can't produce a false positive on an OAuth profile.
+    """
+    env = claude_settings_env(config_dir)
+    auth_token = env.get("ANTHROPIC_AUTH_TOKEN")
+    token = auth_token or env.get("ANTHROPIC_API_KEY")
+    if not token:
+        return None
+    base_url = env.get("ANTHROPIC_BASE_URL", "").strip()
+    host = urlparse(base_url).netloc if base_url else ""
+    host = host or "api.anthropic.com"
+    fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]
+    kind = "auth token" if auth_token else "API key"
+    return AccountProbeResult(
+        account_key=f"{account_prefix}:token:{host}:{fingerprint}",
+        account_label=f"{host} ({kind})",
+        source="api",
+    )
 
 
 def _read_cli_credentials_for_env(

--- a/backend/src/waypoint/backends/claude_code/rate_limits.py
+++ b/backend/src/waypoint/backends/claude_code/rate_limits.py
@@ -10,7 +10,7 @@ import platform
 import re
 import subprocess
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -662,28 +662,43 @@ def _fetch_url(request: Request) -> _ClaudeHTTPResponse | None:
         return None
 
 
-def claude_static_account_identity(
-    account_prefix: str, config_dir: str
-) -> AccountProbeResult | None:
-    """Identify a static-credential profile's account from its ``settings.json``.
+_ANTHROPIC_AUTH_ENV_KEYS = (
+    "ANTHROPIC_AUTH_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
+)
 
-    A profile whose ``settings.json`` ``env`` sets ``ANTHROPIC_AUTH_TOKEN`` or
-    ``ANTHROPIC_API_KEY`` authenticates via that static credential (no OAuth
-    ``.credentials.json`` exists), so the live rate-limit probe can't verify it.
+
+def claude_static_account_identity(
+    account_prefix: str, config_dir: str | None, env: Mapping[str, str]
+) -> AccountProbeResult | None:
+    """Identify a static-credential profile's account from its configured auth.
+
+    A profile that sets ``ANTHROPIC_AUTH_TOKEN`` or ``ANTHROPIC_API_KEY``
+    authenticates via that static credential (no OAuth ``.credentials.json``
+    exists), so the live rate-limit probe can't verify it. The launched CLI reads
+    such vars from both the session's configured env (which Waypoint populates
+    from the plugin/profile/per-session ``env`` config) and the ``settings.json``
+    ``env`` it auto-loads, so both sources are considered here; ``settings.json``
+    is applied last by the CLI, so it wins a tie. ``env`` is the session's
+    configured launch env, never the ambient ``os.environ``, so a stray host
+    ``ANTHROPIC_API_KEY`` can't produce a false positive on an OAuth profile.
+
     Derive a stable, network-free identity keyed on the endpoint host plus a
     short credential fingerprint — enough to accept the switch, match an
-    ``expected_account_key``, and distinguish it from a different endpoint or
-    token. Returns ``None`` when no static credential is configured, so OAuth
-    profiles fall through to the live probe. The token is read from the profile's
-    own file, not the process-merged env, so a stray ambient ``ANTHROPIC_API_KEY``
-    can't produce a false positive on an OAuth profile.
+    ``expected_account_key``, and distinguish a different endpoint or token.
+    Returns ``None`` when no static credential is configured, so OAuth profiles
+    fall through to the live probe.
     """
-    env = claude_settings_env(config_dir)
-    auth_token = env.get("ANTHROPIC_AUTH_TOKEN")
-    token = auth_token or env.get("ANTHROPIC_API_KEY")
+    resolved = {
+        **{k: env[k] for k in _ANTHROPIC_AUTH_ENV_KEYS if k in env},
+        **(claude_settings_env(config_dir) if config_dir else {}),
+    }
+    auth_token = resolved.get("ANTHROPIC_AUTH_TOKEN")
+    token = auth_token or resolved.get("ANTHROPIC_API_KEY")
     if not token:
         return None
-    base_url = env.get("ANTHROPIC_BASE_URL", "").strip()
+    base_url = resolved.get("ANTHROPIC_BASE_URL", "").strip()
     host = urlparse(base_url).netloc if base_url else ""
     host = host or "api.anthropic.com"
     fingerprint = hashlib.sha256(token.encode("utf-8")).hexdigest()[:12]

--- a/backend/src/waypoint/backends/claude_code/threads.py
+++ b/backend/src/waypoint/backends/claude_code/threads.py
@@ -95,6 +95,27 @@ def claude_onboarding_complete(config_dir: str) -> bool:
     return bool(isinstance(data, dict) and data.get("hasCompletedOnboarding"))
 
 
+def claude_settings_env(config_dir: str) -> dict[str, str]:
+    """The ``env`` block the CLI auto-loads from ``<config_dir>/settings.json``.
+
+    Mirrors what ``CLAUDE_CONFIG_DIR=<config_dir> claude`` applies to its process
+    environment on launch (custom ``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_AUTH_TOKEN``
+    etc.), so Waypoint's own account resolution can see the same auth the session
+    runs under. Only string-valued entries are returned; a missing/unreadable/
+    malformed file or absent ``env`` mapping yields ``{}``.
+    """
+    try:
+        data = json.loads((Path(config_dir).expanduser() / "settings.json").read_text())
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    env = data.get("env")
+    if not isinstance(env, dict):
+        return {}
+    return {str(k): v for k, v in env.items() if isinstance(v, str)}
+
+
 def encode_project_dir(cwd: str) -> str:
     """Encode a cwd to the project-dir name Claude stores transcripts under.
 

--- a/backend/tests/test_static_account_identity.py
+++ b/backend/tests/test_static_account_identity.py
@@ -1,0 +1,161 @@
+"""Static-credential account identity for token-auth claude profiles.
+
+A claude account profile whose ``CLAUDE_CONFIG_DIR/settings.json`` ``env`` block
+sets a static ``ANTHROPIC_AUTH_TOKEN``/``ANTHROPIC_API_KEY`` (typically with a
+custom ``ANTHROPIC_BASE_URL``) has no OAuth ``.credentials.json``. The live
+rate-limit probe therefore can't verify it, and a running-session switch onto
+it used to 400 with "could not verify the target account". ``probe_account``
+now derives a stable identity straight from the profile's config dir for such
+profiles, and falls through to the live probe for OAuth ones.
+"""
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from waypoint.backends.account_profiles import probe_account
+from waypoint.backends.claude_code.rate_limits import claude_static_account_identity
+from waypoint.backends.claude_code.threads import claude_settings_env
+from waypoint.runtime import SessionRuntime
+from waypoint.schemas import AccountProbeResult, SessionRateLimitUsage
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _runtime(tmp_path: Path) -> SessionRuntime:
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    return SessionRuntime(settings, Storage(settings.database_path))
+
+
+def _config_dir(tmp_path: Path, env: dict[str, Any] | None) -> Path:
+    d = tmp_path / "pool"
+    d.mkdir(parents=True, exist_ok=True)
+    if env is not None:
+        (d / "settings.json").write_text(json.dumps({"env": env}))
+    return d
+
+
+# ── claude_settings_env ─────────────────────────────────────────────────────
+
+
+def test_settings_env_reads_string_values(tmp_path: Path) -> None:
+    d = _config_dir(
+        tmp_path, {"ANTHROPIC_BASE_URL": "https://x", "MAX_THINKING_TOKENS": 5}
+    )
+    # Non-string values are dropped (the CLI env block is a string map).
+    assert claude_settings_env(str(d)) == {"ANTHROPIC_BASE_URL": "https://x"}
+
+
+def test_settings_env_missing_file(tmp_path: Path) -> None:
+    assert claude_settings_env(str(tmp_path / "nope")) == {}
+
+
+def test_settings_env_malformed_or_no_env_block(tmp_path: Path) -> None:
+    d = tmp_path / "pool"
+    d.mkdir()
+    (d / "settings.json").write_text("{ not json")
+    assert claude_settings_env(str(d)) == {}
+    (d / "settings.json").write_text(json.dumps({"model": "opus"}))  # no env key
+    assert claude_settings_env(str(d)) == {}
+
+
+# ── claude_static_account_identity ──────────────────────────────────────────
+
+
+def test_identity_from_auth_token(tmp_path: Path) -> None:
+    d = _config_dir(
+        tmp_path,
+        {
+            "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            "ANTHROPIC_AUTH_TOKEN": "t",
+        },
+    )
+    result = claude_static_account_identity("claude_code", str(d))
+    assert result is not None
+    assert result.account_key.startswith("claude_code:token:proxy.example.com:")
+    assert result.account_label == "proxy.example.com (auth token)"
+    assert result.source == "api"
+
+
+def test_identity_from_api_key_defaults_host(tmp_path: Path) -> None:
+    d = _config_dir(tmp_path, {"ANTHROPIC_API_KEY": "k"})
+    result = claude_static_account_identity("claude_code", str(d))
+    assert result is not None
+    assert result.account_key.startswith("claude_code:token:api.anthropic.com:")
+    assert result.account_label == "api.anthropic.com (API key)"
+
+
+def test_identity_stable_and_distinct(tmp_path: Path) -> None:
+    d1 = _config_dir(tmp_path / "a", {"ANTHROPIC_AUTH_TOKEN": "t"})
+    d2 = _config_dir(tmp_path / "b", {"ANTHROPIC_AUTH_TOKEN": "other"})
+    k1 = claude_static_account_identity("claude_code", str(d1))
+    k1_again = claude_static_account_identity("claude_code", str(d1))
+    k2 = claude_static_account_identity("claude_code", str(d2))
+    assert k1 is not None and k1_again is not None and k2 is not None
+    assert k1.account_key == k1_again.account_key  # stable
+    assert k1.account_key != k2.account_key  # distinct credential
+
+
+def test_identity_none_without_token(tmp_path: Path) -> None:
+    # A custom base_url but no static credential is still OAuth -> no identity.
+    d = _config_dir(tmp_path, {"ANTHROPIC_BASE_URL": "https://proxy"})
+    assert claude_static_account_identity("claude_code", str(d)) is None
+
+
+def test_identity_none_without_settings(tmp_path: Path) -> None:
+    d = _config_dir(tmp_path, None)
+    assert claude_static_account_identity("claude_code", str(d)) is None
+
+
+# ── probe_account wiring ────────────────────────────────────────────────────
+
+
+async def test_probe_account_uses_static_identity_and_skips_live_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin = runtime.registry.get("claude_code")
+    d = _config_dir(tmp_path, {"ANTHROPIC_AUTH_TOKEN": "t"})
+
+    calls: list[int] = []
+
+    async def fake_probe(*_a: Any, **_k: Any) -> SessionRateLimitUsage | None:
+        calls.append(1)
+        return None
+
+    monkeypatch.setattr(plugin, "probe_account_rate_limit", fake_probe)
+
+    result = await probe_account(runtime, "claude_code", {"CLAUDE_CONFIG_DIR": str(d)})
+    assert isinstance(result, AccountProbeResult)
+    assert ":token:" in result.account_key
+    assert calls == []  # static identity short-circuits before the live probe
+
+
+async def test_probe_account_falls_through_to_live_probe_for_oauth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin = runtime.registry.get("claude_code")
+    d = _config_dir(tmp_path, None)  # no settings.json token -> OAuth profile
+
+    calls: list[int] = []
+
+    async def fake_probe(*_a: Any, **_k: Any) -> SessionRateLimitUsage:
+        calls.append(1)
+        # rate_limit_account derives the key from the ``org:`` note.
+        return SessionRateLimitUsage(
+            source="claude_code",
+            updated_at=datetime.now(UTC),
+            notes=["org: TestOrg"],
+        )
+
+    monkeypatch.setattr(plugin, "probe_account_rate_limit", fake_probe)
+
+    result = await probe_account(runtime, "claude_code", {"CLAUDE_CONFIG_DIR": str(d)})
+    assert isinstance(result, AccountProbeResult)
+    assert result.account_key == "claude_code:TestOrg"
+    assert calls == [1]  # OAuth profile fell through to the live probe

--- a/backend/tests/test_static_account_identity.py
+++ b/backend/tests/test_static_account_identity.py
@@ -1,12 +1,13 @@
 """Static-credential account identity for token-auth claude profiles.
 
-A claude account profile whose ``CLAUDE_CONFIG_DIR/settings.json`` ``env`` block
-sets a static ``ANTHROPIC_AUTH_TOKEN``/``ANTHROPIC_API_KEY`` (typically with a
-custom ``ANTHROPIC_BASE_URL``) has no OAuth ``.credentials.json``. The live
-rate-limit probe therefore can't verify it, and a running-session switch onto
-it used to 400 with "could not verify the target account". ``probe_account``
-now derives a stable identity straight from the profile's config dir for such
-profiles, and falls through to the live probe for OAuth ones.
+A claude account profile that sets a static ``ANTHROPIC_AUTH_TOKEN``/
+``ANTHROPIC_API_KEY`` (typically with a custom ``ANTHROPIC_BASE_URL``) — either
+in its ``CLAUDE_CONFIG_DIR/settings.json`` ``env`` block or in the session's
+configured launch env — has no OAuth ``.credentials.json``. The live rate-limit
+probe therefore can't verify it, and a running-session switch onto it used to
+400 with "could not verify the target account". ``probe_account`` now derives a
+stable identity from that static config for such profiles, and falls through to
+the live probe for OAuth ones.
 """
 
 import json
@@ -74,7 +75,7 @@ def test_identity_from_auth_token(tmp_path: Path) -> None:
             "ANTHROPIC_AUTH_TOKEN": "t",
         },
     )
-    result = claude_static_account_identity("claude_code", str(d))
+    result = claude_static_account_identity("claude_code", str(d), {})
     assert result is not None
     assert result.account_key.startswith("claude_code:token:proxy.example.com:")
     assert result.account_label == "proxy.example.com (auth token)"
@@ -83,7 +84,7 @@ def test_identity_from_auth_token(tmp_path: Path) -> None:
 
 def test_identity_from_api_key_defaults_host(tmp_path: Path) -> None:
     d = _config_dir(tmp_path, {"ANTHROPIC_API_KEY": "k"})
-    result = claude_static_account_identity("claude_code", str(d))
+    result = claude_static_account_identity("claude_code", str(d), {})
     assert result is not None
     assert result.account_key.startswith("claude_code:token:api.anthropic.com:")
     assert result.account_label == "api.anthropic.com (API key)"
@@ -92,9 +93,9 @@ def test_identity_from_api_key_defaults_host(tmp_path: Path) -> None:
 def test_identity_stable_and_distinct(tmp_path: Path) -> None:
     d1 = _config_dir(tmp_path / "a", {"ANTHROPIC_AUTH_TOKEN": "t"})
     d2 = _config_dir(tmp_path / "b", {"ANTHROPIC_AUTH_TOKEN": "other"})
-    k1 = claude_static_account_identity("claude_code", str(d1))
-    k1_again = claude_static_account_identity("claude_code", str(d1))
-    k2 = claude_static_account_identity("claude_code", str(d2))
+    k1 = claude_static_account_identity("claude_code", str(d1), {})
+    k1_again = claude_static_account_identity("claude_code", str(d1), {})
+    k2 = claude_static_account_identity("claude_code", str(d2), {})
     assert k1 is not None and k1_again is not None and k2 is not None
     assert k1.account_key == k1_again.account_key  # stable
     assert k1.account_key != k2.account_key  # distinct credential
@@ -103,12 +104,50 @@ def test_identity_stable_and_distinct(tmp_path: Path) -> None:
 def test_identity_none_without_token(tmp_path: Path) -> None:
     # A custom base_url but no static credential is still OAuth -> no identity.
     d = _config_dir(tmp_path, {"ANTHROPIC_BASE_URL": "https://proxy"})
-    assert claude_static_account_identity("claude_code", str(d)) is None
+    assert claude_static_account_identity("claude_code", str(d), {}) is None
 
 
 def test_identity_none_without_settings(tmp_path: Path) -> None:
     d = _config_dir(tmp_path, None)
-    assert claude_static_account_identity("claude_code", str(d)) is None
+    assert claude_static_account_identity("claude_code", str(d), {}) is None
+
+
+def test_identity_from_configured_env_without_settings(tmp_path: Path) -> None:
+    # The token comes from the session's configured env (e.g. the plugin `env`
+    # block in waypoint.yaml or a per-session env_set), not settings.json.
+    d = _config_dir(tmp_path, None)  # no settings.json
+    result = claude_static_account_identity(
+        "claude_code",
+        str(d),
+        {
+            "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            "ANTHROPIC_AUTH_TOKEN": "t",
+        },
+    )
+    assert result is not None
+    assert result.account_key.startswith("claude_code:token:proxy.example.com:")
+    assert result.account_label == "proxy.example.com (auth token)"
+
+
+def test_identity_from_env_with_no_config_dir(tmp_path: Path) -> None:
+    # No profile config dir at all — a token in the configured env still verifies.
+    result = claude_static_account_identity(
+        "claude_code", None, {"ANTHROPIC_API_KEY": "k"}
+    )
+    assert result is not None
+    assert result.account_key.startswith("claude_code:token:api.anthropic.com:")
+
+
+def test_settings_json_wins_tie_over_env(tmp_path: Path) -> None:
+    # The CLI applies settings.json env last, so it wins when both set the host.
+    d = _config_dir(tmp_path, {"ANTHROPIC_BASE_URL": "https://from-settings"})
+    result = claude_static_account_identity(
+        "claude_code",
+        str(d),
+        {"ANTHROPIC_AUTH_TOKEN": "t", "ANTHROPIC_BASE_URL": "https://from-env"},
+    )
+    assert result is not None
+    assert result.account_label == "from-settings (auth token)"
 
 
 # ── probe_account wiring ────────────────────────────────────────────────────
@@ -133,6 +172,33 @@ async def test_probe_account_uses_static_identity_and_skips_live_probe(
     assert isinstance(result, AccountProbeResult)
     assert ":token:" in result.account_key
     assert calls == []  # static identity short-circuits before the live probe
+
+
+async def test_probe_account_uses_env_token_from_launch_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime = _runtime(tmp_path)
+    plugin = runtime.registry.get("claude_code")
+    d = _config_dir(tmp_path, None)  # profile config dir without a token settings.json
+
+    calls: list[int] = []
+
+    async def fake_probe(*_a: Any, **_k: Any) -> SessionRateLimitUsage | None:
+        calls.append(1)
+        return None
+
+    monkeypatch.setattr(plugin, "probe_account_rate_limit", fake_probe)
+
+    # The token is set in the session's configured launch env (plugin/per-session
+    # env), alongside the profile's config-dir key.
+    result = await probe_account(
+        runtime,
+        "claude_code",
+        {"CLAUDE_CONFIG_DIR": str(d), "ANTHROPIC_AUTH_TOKEN": "t"},
+    )
+    assert isinstance(result, AccountProbeResult)
+    assert ":token:" in result.account_key
+    assert calls == []  # env token short-circuits before the live probe
 
 
 async def test_probe_account_falls_through_to_live_probe_for_oauth(


### PR DESCRIPTION
## Purpose

A user reported they could not switch a running session onto a Claude Code account profile backed by a custom `base_url` + auth token: they created a `~/.claude-pool` dir, set the auth `env` in its `settings.json`, and added it as a normal profile — `CLAUDE_CONFIG_DIR=~/.claude-pool claude` works because the CLI auto-loads that `env`, but the Waypoint profile switch was rejected. The switch gate verifies the target account via `account_profiles.probe_account`, which reads only the OAuth `.credentials.json` (`_read_cli_credentials_for_env`). A profile that authenticates via a static `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_API_KEY` has no such file, so the probe returned `None` and the switch failed with `400 "could not verify the target account before switching"` — even though launching the profile works, because every transport spawns the `claude` binary and the binary loads its auth `env` itself.

This adds a network-free static-account-identity path to account verification, derived from the profile's configured static credential, so a token-auth profile verifies from its configuration instead of an impossible OAuth probe. The credential is recognized from **both** places a user can configure it: the profile's `settings.json` `env` block, and the session's own configured launch env (the plugin `env` block in `waypoint.yaml` or a per-session `env_set`) — the launched CLI reads the token from either.

## Changes

### Backend
- `backend/src/waypoint/backends/base.py` — new `@runtime_checkable` `StaticAccountIdentifying` Protocol: an agent that can identify a profile's account from a static credential in its config dir or configured env, returning `None` to defer to the live probe.
- `backend/src/waypoint/backends/claude_code/threads.py` — `claude_settings_env(config_dir)` reads the `env` block the CLI auto-loads from `<config_dir>/settings.json` (string values only; `{}` on missing/malformed/no-`env`).
- `backend/src/waypoint/backends/claude_code/rate_limits.py` — `claude_static_account_identity(prefix, config_dir, env)` returns a stable `AccountProbeResult` (`source="api"`) keyed on the endpoint host plus a short credential fingerprint when a static token/API key is set in either `settings.json` or the configured `env` (settings.json applied last, matching the CLI, so it wins a tie), else `None`.
- `backend/src/waypoint/backends/claude_code/plugin.py` — the Claude plugin implements `static_account_identity`.
- `backend/src/waypoint/backends/account_profiles.py` — `probe_account` consults the hook first (local only) with the session's configured launch env and short-circuits when it returns an identity; OAuth profiles fall through to the existing live probe unchanged.

### Tests
- `backend/tests/test_static_account_identity.py` — the `settings.json` reader; the identity helper (auth-token and API-key paths from settings.json and from the configured env, no-config-dir env-only, settings-wins-tie precedence, default host, stable+distinct keys, `None` without a credential); and `probe_account` wiring (token from settings.json and token from launch env each return the static identity without invoking the live probe; an OAuth profile falls through to it).

## Design

The fix lands at the single `account_profiles.probe_account` chokepoint, so every caller — the switch's `target_probe`/`current_probe`, verified-account stamping, `accounts doctor`, and `probe_account_profile` — resolves a token profile uniformly with no per-backend branching in the runtime or transports; dispatch is via `isinstance(plugin, StaticAccountIdentifying)`. A token profile's account is fixed by its static credential, so a config-derived identity is the correct notion of "verified": the key distinguishes endpoint + credential (so `expected_account_key` and the same-account no-op guard both work), and OAuth↔token switches proceed because the key schemes are disjoint. Reading the credential from the configured launch env is safe because every `probe_account` caller passes the session's configured env — the `os.environ` merge happens later, inside the live probe — so a stray host `ANTHROPIC_API_KEY` can't misidentify an OAuth profile. It is local-only: a remote config dir can't be read here, matching the existing remote-skip of the other filesystem checks (remote static-auth is a later phase). The onboarding readiness gate (`_ensure_profile_config_dir_ready`) runs before the probe and is unchanged — the reported `probe_account` 400 proves onboarding already passed for this case.

## Test Plan
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- `cd backend && uv run pytest` — 2741 passed.
- `cd backend && uv run pytest tests/test_static_account_identity.py` — 14 passed.
- In-process runtime checks of `runtime.probe_account_profile("claude_code", <token-profile>)` (the method the `/api` account-probe endpoint and the switch gate feed from) for both a `settings.json` token and a plugin-`env` token.

## Test Result
- Root cause confirmed: `_read_cli_credentials_for_env` returns `None` for a token-auth config dir (no `.credentials.json`), so `probe_account` returned `None` → the switch 400'd.
- Post-fix `runtime.probe_account_profile("claude_code", <token-profile>)` returns `AccountProbeResult(account_key="claude_code:token:proxy.example.com:<fp>", account_label="proxy.example.com (auth token)", source="api")` for both a `settings.json`-configured token and a plugin-`env`-configured token, instead of raising — the switch gate now receives a non-`None` probe and proceeds. Full-suite green as above. A live authenticated end-to-end switch needs a real custom endpoint + token (not available here) and a stack restart would interrupt this managed session; the wired runtime path is exercised in-process against configured token profiles.

Addresses ticket 1258.