### PR TITLE
fix: publish Lumid rate-limit reset times

### DIFF
--- a/backend/src/waypoint/usage_providers/lumid.py
+++ b/backend/src/waypoint/usage_providers/lumid.py
@@ -38,6 +38,10 @@ _FIVE_HOUR_MINUTES = 300
 _SEVEN_DAY_MINUTES = 7 * 24 * 60
 _MAX_CONCURRENCY = 4
 
+# Lumid reports this UTC instant when a window has had no usage, meaning no
+# reset time is available. It must become None rather than a real timestamp.
+_NO_RESET_SENTINEL = datetime(1, 1, 1, tzinfo=UTC)
+
 
 # ── Lumid response envelopes (extra ignored) ──
 
@@ -62,8 +66,8 @@ class _UsageRow(BaseModel):
     seven_day_pct: float
     requests_7d: int | None = None
     last_ts: datetime | None = None
-    five_hour_resets_at: datetime | None = None
-    seven_day_resets_at: datetime | None = None
+    five_hour_reset: datetime | None = None
+    seven_day_reset: datetime | None = None
 
 
 class _UsageData(BaseModel):
@@ -271,7 +275,7 @@ class LumidUsageProvider:
                 limit_tokens=usage.five_hour_tokens,
                 remaining_tokens=max(usage.five_hour_tokens - row.five_hour_tokens, 0),
                 window_minutes=_FIVE_HOUR_MINUTES,
-                resets_at=row.five_hour_resets_at,
+                resets_at=_reset_or_none(row.five_hour_reset),
             ),
             UsageWindow(
                 id="lumid-seven-day",
@@ -281,7 +285,7 @@ class LumidUsageProvider:
                 limit_tokens=usage.seven_day_tokens,
                 remaining_tokens=max(usage.seven_day_tokens - row.seven_day_tokens, 0),
                 window_minutes=_SEVEN_DAY_MINUTES,
-                resets_at=row.seven_day_resets_at,
+                resets_at=_reset_or_none(row.seven_day_reset),
             ),
         ]
         account_key = self._store.account_key_digest(self.id, email)
@@ -349,6 +353,12 @@ class LumidUsageProvider:
             last_success_at=self._status.last_success_at,
             errors=errors,
         )
+
+
+def _reset_or_none(value: datetime | None) -> datetime | None:
+    if value is None or value == _NO_RESET_SENTINEL:
+        return None
+    return value
 
 
 def _select_row(rows: list[_UsageRow], email: str) -> _UsageRow | None:

--- a/backend/src/waypoint/usage_providers/lumid.py
+++ b/backend/src/waypoint/usage_providers/lumid.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 import httpx
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
 from waypoint.schemas import (
     ProviderErrorState,
@@ -38,8 +38,7 @@ _FIVE_HOUR_MINUTES = 300
 _SEVEN_DAY_MINUTES = 7 * 24 * 60
 _MAX_CONCURRENCY = 4
 
-# Lumid reports this UTC instant when a window has had no usage, meaning no
-# reset time is available. It must become None rather than a real timestamp.
+# Lumid sends this UTC instant for a window with no usage (no reset available).
 _NO_RESET_SENTINEL = datetime(1, 1, 1, tzinfo=UTC)
 
 
@@ -68,6 +67,11 @@ class _UsageRow(BaseModel):
     last_ts: datetime | None = None
     five_hour_reset: datetime | None = None
     seven_day_reset: datetime | None = None
+
+    @field_validator("five_hour_reset", "seven_day_reset")
+    @classmethod
+    def _drop_no_reset_sentinel(cls, value: datetime | None) -> datetime | None:
+        return None if value == _NO_RESET_SENTINEL else value
 
 
 class _UsageData(BaseModel):
@@ -275,7 +279,7 @@ class LumidUsageProvider:
                 limit_tokens=usage.five_hour_tokens,
                 remaining_tokens=max(usage.five_hour_tokens - row.five_hour_tokens, 0),
                 window_minutes=_FIVE_HOUR_MINUTES,
-                resets_at=_reset_or_none(row.five_hour_reset),
+                resets_at=row.five_hour_reset,
             ),
             UsageWindow(
                 id="lumid-seven-day",
@@ -285,7 +289,7 @@ class LumidUsageProvider:
                 limit_tokens=usage.seven_day_tokens,
                 remaining_tokens=max(usage.seven_day_tokens - row.seven_day_tokens, 0),
                 window_minutes=_SEVEN_DAY_MINUTES,
-                resets_at=_reset_or_none(row.seven_day_reset),
+                resets_at=row.seven_day_reset,
             ),
         ]
         account_key = self._store.account_key_digest(self.id, email)
@@ -353,12 +357,6 @@ class LumidUsageProvider:
             last_success_at=self._status.last_success_at,
             errors=errors,
         )
-
-
-def _reset_or_none(value: datetime | None) -> datetime | None:
-    if value is None or value == _NO_RESET_SENTINEL:
-        return None
-    return value
 
 
 def _select_row(rows: list[_UsageRow], email: str) -> _UsageRow | None:

--- a/backend/tests/test_usage_provider_lumid.py
+++ b/backend/tests/test_usage_provider_lumid.py
@@ -195,7 +195,6 @@ async def test_sentinel_reset_is_hidden_independently(
 ) -> None:
     monkeypatch.setenv("LUMID_TEST_TOKENS", "tok_a")
     storage = _storage(tmp_path)
-    # 5h had no usage (year-1 sentinel) while 7d has a valid reset.
     row = _row(
         five_reset="0001-01-01T00:00:00Z",
         seven_reset="2026-08-01T00:00:00Z",

--- a/backend/tests/test_usage_provider_lumid.py
+++ b/backend/tests/test_usage_provider_lumid.py
@@ -2,6 +2,7 @@
 
 import json
 from collections.abc import Callable
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -35,9 +36,13 @@ def _usage_ok(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _row(
-    email: str = _EMAIL, five: int = 1_240_000, seven: int = 1_350_000
+    email: str = _EMAIL,
+    five: int = 1_240_000,
+    seven: int = 1_350_000,
+    five_reset: str | None = None,
+    seven_reset: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    row: dict[str, Any] = {
         "email": email,
         "five_hour_tokens": five,
         "seven_day_tokens": seven,
@@ -46,6 +51,11 @@ def _row(
         "requests_7d": 355,
         "last_ts": "2026-07-24T12:33:46.107Z",
     }
+    if five_reset is not None:
+        row["five_hour_reset"] = five_reset
+    if seven_reset is not None:
+        row["seven_day_reset"] = seven_reset
+    return row
 
 
 def _routes(
@@ -155,6 +165,68 @@ async def test_zero_usage_row_is_valid(
     assert result.ok_count == 1
     windows = {w.id: w for w in provider.buckets()[0].snapshot.windows}
     assert windows["lumid-five-hour"].used_tokens == 0
+    await provider.aclose()
+
+
+async def test_valid_resets_projected_to_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LUMID_TEST_TOKENS", "tok_a")
+    storage = _storage(tmp_path)
+    row = _row(
+        five_reset="2026-07-27T05:00:00Z",
+        seven_reset="2026-08-01T00:00:00Z",
+    )
+    provider = _provider(storage, _routes(_user_ok(), _usage_ok([row])))
+    result = await provider.refresh(force=True)
+    assert result.ok_count == 1
+    windows = {w.id: w for w in provider.buckets()[0].snapshot.windows}
+    assert windows["lumid-five-hour"].resets_at == datetime(
+        2026, 7, 27, 5, 0, 0, tzinfo=UTC
+    )
+    assert windows["lumid-seven-day"].resets_at == datetime(
+        2026, 8, 1, 0, 0, 0, tzinfo=UTC
+    )
+    await provider.aclose()
+
+
+async def test_sentinel_reset_is_hidden_independently(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("LUMID_TEST_TOKENS", "tok_a")
+    storage = _storage(tmp_path)
+    # 5h had no usage (year-1 sentinel) while 7d has a valid reset.
+    row = _row(
+        five_reset="0001-01-01T00:00:00Z",
+        seven_reset="2026-08-01T00:00:00Z",
+    )
+    provider = _provider(storage, _routes(_user_ok(), _usage_ok([row])))
+    result = await provider.refresh(force=True)
+    assert result.ok_count == 1
+    windows = {w.id: w for w in provider.buckets()[0].snapshot.windows}
+    assert windows["lumid-five-hour"].resets_at is None
+    assert windows["lumid-seven-day"].resets_at == datetime(
+        2026, 8, 1, 0, 0, 0, tzinfo=UTC
+    )
+    await provider.aclose()
+
+
+@pytest.mark.parametrize("reset", [None, "null"])
+async def test_absent_or_null_reset_hidden(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reset: str | None
+) -> None:
+    monkeypatch.setenv("LUMID_TEST_TOKENS", "tok_a")
+    storage = _storage(tmp_path)
+    row = _row()
+    if reset == "null":
+        row["five_hour_reset"] = None
+        row["seven_day_reset"] = None
+    provider = _provider(storage, _routes(_user_ok(), _usage_ok([row])))
+    result = await provider.refresh(force=True)
+    assert result.ok_count == 1
+    windows = {w.id: w for w in provider.buckets()[0].snapshot.windows}
+    assert windows["lumid-five-hour"].resets_at is None
+    assert windows["lumid-seven-day"].resets_at is None
     await provider.aclose()
 
 

--- a/docs/usage-providers.md
+++ b/docs/usage-providers.md
@@ -21,11 +21,9 @@ case-insensitively). Other users returned by the admin endpoint are never shown.
 It maps the row to a 5-hour and a 7-day window with used/limit tokens,
 percentages, and the 7-day request count.
 
-Each window's card shows its rate-limit reset time when Lumid supplies one
-(`five_hour_reset` / `seven_day_reset`). Lumid reports `0001-01-01T00:00:00Z`
-for a window with no usage, meaning no reset is available; that sentinel, an
-omitted field, and an explicit `null` are all treated as no reset and the label
-is hidden, applied independently per window.
+Each window's card shows its reset time when Lumid supplies one. Lumid's
+`0001-01-01T00:00:00Z` sentinel (no usage in the window), an omitted field, and
+`null` are hidden, independently per window.
 
 ### Setup
 

--- a/docs/usage-providers.md
+++ b/docs/usage-providers.md
@@ -21,6 +21,12 @@ case-insensitively). Other users returned by the admin endpoint are never shown.
 It maps the row to a 5-hour and a 7-day window with used/limit tokens,
 percentages, and the 7-day request count.
 
+Each window's card shows its rate-limit reset time when Lumid supplies one
+(`five_hour_reset` / `seven_day_reset`). Lumid reports `0001-01-01T00:00:00Z`
+for a window with no usage, meaning no reset is available; that sentinel, an
+omitted field, and an explicit `null` are all treated as no reset and the label
+is hidden, applied independently per window.
+
 ### Setup
 
 1. **Provide the token(s) by environment variable.** Waypoint never reads a PAT


### PR DESCRIPTION
## Purpose

Waypoint never showed Lumid's 5-hour / 7-day rate-limit reset times even though `GET /api/v1/admin/claude-user-usage` supplies them. `LumidUsageProvider._UsageRow` declared `five_hour_resets_at` / `seven_day_resets_at`, but the endpoint's actual fields are `five_hour_reset` / `seven_day_reset`. With `extra="ignore"`, the real fields were silently discarded and both published `UsageWindow.resets_at` values stayed `None`, so the existing reset label was always hidden.

This is a provider-local mapping correction: parse Lumid's actual field names and normalize its documented `0001-01-01T00:00:00Z` no-usage sentinel — along with omitted and explicit `null` values — to `None` before populating each window. Valid resets then flow through the unchanged shared `resets_at` contract to the existing full and compact reset formatters; unavailable ones keep today's hidden state. No generic usage-provider, API, schema, storage, or frontend change is needed — those layers already carry and conditionally render `resets_at`.

Addresses ticket 1299.

## Changes

### Backend
- `backend/src/waypoint/usage_providers/lumid.py` — rename `_UsageRow` fields to the endpoint's exact `five_hour_reset` / `seven_day_reset`; add a private `_reset_or_none` normalizer that maps `None` and the exact `datetime(1, 1, 1, tzinfo=UTC)` sentinel to `None` (all other timestamps pass through); apply it independently per window in `_build_snapshot`.

### Tests
- `backend/tests/test_usage_provider_lumid.py` — extend the `_row` fixture with optional reset fields; add focused tests: both valid resets project to matching UTC `resets_at`; the year-1 sentinel hides one window while a valid reset in the other survives; and a parameterized missing / explicit-`null` case keeps both resets hidden without failing the refresh.

### Docs
- `docs/usage-providers.md` — document that Lumid cards show a reset time when supplied and that the sentinel, an omitted field, and `null` are all hidden per window.

## Design

Option 1 from the RFC (`.waypoint/specs/rfc-1299-lumid-usage-reset-time.md`): keep Lumid's field names and sentinel handling inside the provider adapter so generic code never branches on the provider id. The sentinel equality check is deliberately exact — only Lumid's documented zero date is special; every other valid timestamp is retained. Existing durable snapshots without a reset remain readable and are replaced by the corrected snapshot on the next successful refresh; no migration or backfill is required.

## Test Plan
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy all pass.
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pytest tests/test_usage_provider_lumid.py` — the Lumid provider suite including the new reset tests.
- Live end-to-end run of the real provider (no mock transport) against `https://lum.id` with the configured PAT.

## Test Result
- Ground truth from the live endpoint confirms the fields are `five_hour_reset` / `seven_day_reset` with ISO-8601 `Z` timestamps — the old `*_resets_at` names never matched.
- `cd backend && uv run pytest tests/test_usage_provider_lumid.py` — 20 passed.
- `cd backend && uv run pytest` — 2768 passed; `pre-commit run --all-files` clean.
- The real `LumidUsageProvider.refresh()` against the live endpoint now yields `lumid-five-hour.resets_at` and `lumid-seven-day.resets_at` as UTC-aware datetimes matching the endpoint (previously `None`). A live frontend screenshot would require restarting the backend, which interrupts this managed session; the change contains no frontend code and the render path already consumes any populated `resets_at`, so it is verified at the provider/API layer where the entire change lives.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`, and `cd waypointctl && uv run pytest` if I touched `waypointctl`).
- [ ] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work. — N/A, no plugin/transport change.
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional). — N/A, no frontend change.
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above. — N/A, not breaking.
- [x] I have updated documentation or config examples (`.env.example`, `backend/waypoint.example.yaml`, `docs/`) if user-facing behavior changed.

</details>