### PR TITLE
fix: never label an AskUserQuestion answered without a recorded answer

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -696,7 +696,7 @@ class ClaudeCliAdapter:
         session_id: str,
         answer_text: str,
         tool_use_id: str | None = None,
-    ) -> bool:
+    ) -> str | None:
         """Answer an AskUserQuestion parked on a ``can_use_tool`` request.
 
         AskUserQuestion arrives over the same ``can_use_tool`` channel as
@@ -704,10 +704,15 @@ class ClaudeCliAdapter:
         we deny the tool and carry the answer payload as the message — that
         string becomes the tool_result Claude reads, matching the binary's
         own `User has answered your questions: …` shape.
+
+        Returns the resolved ``tool_use_id`` that was answered — including the
+        one selected here when the caller omitted it — so the plugin can record
+        it as durable answer evidence (FR5). Returns ``None`` when no pending
+        question could be resolved.
         """
         state = self._sessions.get(session_id)
         if state is None or not state.pending:
-            return False
+            return None
         pending: ClaudePendingApproval | None = None
         if tool_use_id and tool_use_id in state.pending:
             candidate = state.pending[tool_use_id]
@@ -720,7 +725,7 @@ class ClaudeCliAdapter:
                     pending = candidate
                     break
         if pending is None or tool_use_id is None:
-            return False
+            return None
         # Deny the tool and carry the answer in the message — the binary reads
         # that string as the tool_result, matching its own
         # "User has answered your questions: …" shape.
@@ -739,7 +744,7 @@ class ClaudeCliAdapter:
             ),
         )
         state.pending.pop(tool_use_id, None)
-        return True
+        return tool_use_id
 
     def has_pending_ask_question(self, session_id: str) -> bool:
         state = self._sessions.get(session_id)

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -1082,9 +1082,8 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # Stash structured per-question answers + notes so the frontend
         # renders this user_input as a styled "answers" card instead of
         # the raw `"<question>"="<answer>" user notes: …` payload Claude
-        # was tuned around. Persist the resolved tool_use_id — the id the
-        # adapter actually answered, including when the caller omitted one —
-        # so the transcript can correlate this durable answer to its question.
+        # was tuned around. Persist resolved_tool_use_id so the transcript
+        # can correlate this answer to its question.
         extra: dict[str, Any] = {"kind": "ask_user_question_answer"}
         if answers:
             extra["answers"] = answers

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -1067,14 +1067,14 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 detail="answer-question is only supported for Claude sessions",
             )
         try:
-            handled = await self.adapter.respond_to_ask_question(
+            resolved_tool_use_id = await self.adapter.respond_to_ask_question(
                 session.id, answer, tool_use_id
             )
         except ClaudeCliError as exc:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
             ) from exc
-        if not handled:
+        if resolved_tool_use_id is None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="no pending question for this session",
@@ -1082,12 +1082,13 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # Stash structured per-question answers + notes so the frontend
         # renders this user_input as a styled "answers" card instead of
         # the raw `"<question>"="<answer>" user notes: …` payload Claude
-        # was tuned around.
+        # was tuned around. Persist the resolved tool_use_id — the id the
+        # adapter actually answered, including when the caller omitted one —
+        # so the transcript can correlate this durable answer to its question.
         extra: dict[str, Any] = {"kind": "ask_user_question_answer"}
         if answers:
             extra["answers"] = answers
-        if tool_use_id:
-            extra["tool_use_id"] = tool_use_id
+        extra["tool_use_id"] = resolved_tool_use_id
         # Same ordering as handle_input: flip status to RUNNING before
         # _record_user_event broadcasts the session_state snapshot,
         # otherwise the spinner stays off until Claude's next chunk.

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -99,10 +99,9 @@ class TranscriptNormalizer:
         # must fire once, not once per record.
         self._result_emitted_ids: set[str] = set()
         # tool_use ids of surfaced AskUserQuestion cards, so the "user rejected"
-        # result Waypoint's Esc-dismissal produces can be swallowed (the card
-        # stays answerable). Populated for every AskUserQuestion, so a question
-        # whose dismissal did not line up with a one-shot arm is still
-        # answerable; a non-rejection failure result for the id surfaces instead.
+        # result Waypoint's Esc-dismissal produces can be swallowed and the card
+        # stays answerable. A non-rejection failure result for the id surfaces
+        # instead.
         self._dismissed_question_ids: set[str] = set()
         # tool_use ids of file-edit calls, so the matching tool_result record
         # (which carries the applied diff in its toolUseResult) can attach a
@@ -239,12 +238,9 @@ class TranscriptNormalizer:
                 tool_use_id = str(block.get("id") or "")
                 tool_name = str(block.get("name") or "tool")
                 if tool_name == "AskUserQuestion":
-                    # Every AskUserQuestion is an answerable card, independent of
-                    # whether _poll_dialog's dismissal happened to line up with
-                    # this record. The paired "user rejected" result Waypoint's
-                    # Esc produces is suppressed in _process_user so the card
-                    # stays answerable; a genuine failure result surfaces there
-                    # instead and renders the question closed-unanswered.
+                    # Every AskUserQuestion surfaces as an answerable card; the
+                    # paired "user rejected" result Waypoint's Esc produces is
+                    # suppressed in _process_user.
                     if tool_use_id:
                         self._dismissed_question_ids.add(tool_use_id)
                     events.append(

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -98,12 +98,11 @@ class TranscriptNormalizer:
         # thinking record then a text record, both stamped end_turn); the note
         # must fire once, not once per record.
         self._result_emitted_ids: set[str] = set()
-        # Set by the tailer right after it Esc-dismisses an AskUserQuestion
-        # popup. The Esc forces the TUI to flush the tool_use record (and a
-        # "user rejected" result) to the transcript; the latch tells the next
-        # AskUserQuestion record to surface as an answerable card rather than a
-        # plain tool_call, and to swallow the synthetic rejection.
-        self._expect_dismissed_question: bool = False
+        # tool_use ids of surfaced AskUserQuestion cards, so the "user rejected"
+        # result Waypoint's Esc-dismissal produces can be swallowed (the card
+        # stays answerable). Populated for every AskUserQuestion, so a question
+        # whose dismissal did not line up with a one-shot arm is still
+        # answerable; a non-rejection failure result for the id surfaces instead.
         self._dismissed_question_ids: set[str] = set()
         # tool_use ids of file-edit calls, so the matching tool_result record
         # (which carries the applied diff in its toolUseResult) can attach a
@@ -120,9 +119,6 @@ class TranscriptNormalizer:
         # permission dialog blocks, so the tailer recovers the tool from here
         # when a tall dialog overflows the pane and drops its label off-screen.
         self._pending_tool_uses: dict[str, tuple[str, dict[str, Any]]] = {}
-
-    def arm_question_dismissal(self) -> None:
-        self._expect_dismissed_question = True
 
     @property
     def pending_tool_use(self) -> tuple[str, dict[str, Any]] | None:
@@ -242,8 +238,13 @@ class TranscriptNormalizer:
                 has_tool_use = True
                 tool_use_id = str(block.get("id") or "")
                 tool_name = str(block.get("name") or "tool")
-                if tool_name == "AskUserQuestion" and self._expect_dismissed_question:
-                    self._expect_dismissed_question = False
+                if tool_name == "AskUserQuestion":
+                    # Every AskUserQuestion is an answerable card, independent of
+                    # whether _poll_dialog's dismissal happened to line up with
+                    # this record. The paired "user rejected" result Waypoint's
+                    # Esc produces is suppressed in _process_user so the card
+                    # stays answerable; a genuine failure result surfaces there
+                    # instead and renders the question closed-unanswered.
                     if tool_use_id:
                         self._dismissed_question_ids.add(tool_use_id)
                     events.append(
@@ -409,13 +410,17 @@ class TranscriptNormalizer:
             if tool_use_id:
                 self._pending_tool_uses.pop(tool_use_id, None)
             if tool_use_id and tool_use_id in self._dismissed_question_ids:
-                # The "user rejected" result the TUI writes when we Esc the
-                # popup to surface it. Drop it so the question card stays
-                # answerable, and skip the abort note below — the session
-                # waits on the user, it has not ended the turn.
                 self._dismissed_question_ids.discard(tool_use_id)
-                dismissed_question = True
-                continue
+                if turn_aborted:
+                    # The "user rejected" result the TUI writes when Waypoint
+                    # Escs the popup to surface it. Drop it so the question card
+                    # stays answerable, and skip the abort note below — the
+                    # session waits on the user, it has not ended the turn.
+                    dismissed_question = True
+                    continue
+                # A genuine terminal failure (InputValidationError, timeout) for
+                # the same question — not a dismissal artifact. Let it surface so
+                # the card renders closed-unanswered rather than falsely open.
             if tool_use_id and tool_use_id in self._pending_task_creates:
                 create_input = self._pending_task_creates.pop(tool_use_id)
                 task_id = extract_created_task_id(block) or tool_use_id

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1263,6 +1263,24 @@ class ClaudeTtyPlugin:
             "You can now continue with the user's answers in mind.",
         )
 
+        extra: dict[str, Any] = {"kind": "ask_user_question_answer"}
+        if answers:
+            extra["answers"] = answers
+        if resolved_tool_use_id:
+            extra["tool_use_id"] = resolved_tool_use_id
+        # Flip status to RUNNING before recording the answer so the broadcast
+        # snapshot shows the spinner immediately, matching handle_input.
+        updated = runtime.storage.update_session(
+            session.id, status=SessionStatus.RUNNING
+        )
+        # Persist the durable answer event before the synthetic tool_result
+        # (FR6): the transcript derives "answered" from this user event, so a
+        # live client that saw the result first would briefly render the card
+        # as closed-unanswered.
+        await runtime._record_user_event(
+            session.id, answer, submit=True, extra_metadata=extra
+        )
+
         if resolved_tool_use_id:
             await runtime._emit_adapter_event(
                 session.id,
@@ -1277,19 +1295,6 @@ class ClaudeTtyPlugin:
                 SessionStatus.RUNNING,
             )
 
-        extra: dict[str, Any] = {"kind": "ask_user_question_answer"}
-        if answers:
-            extra["answers"] = answers
-        if resolved_tool_use_id:
-            extra["tool_use_id"] = resolved_tool_use_id
-        # Flip status to RUNNING before recording the answer so the broadcast
-        # snapshot shows the spinner immediately, matching handle_input.
-        updated = runtime.storage.update_session(
-            session.id, status=SessionStatus.RUNNING
-        )
-        await runtime._record_user_event(
-            session.id, answer, submit=True, extra_metadata=extra
-        )
         return updated
 
     # ── Thread discovery + import ────────────────────────────────────────────

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -305,10 +305,10 @@ class TranscriptTailer:
             # The AskUserQuestion popup withholds its structured questions from
             # the transcript until it is resolved, so it is invisible to the
             # tailer while it blocks the turn. Esc dismisses it, which flushes
-            # the full tool_use record to the JSONL; the armed normalizer then
-            # surfaces it as an answerable card (and swallows the resulting
-            # "user rejected" result). The answer is delivered later as a normal
-            # user turn via the plugin's answer_question.
+            # the full tool_use record to the JSONL; the normalizer surfaces it
+            # as an answerable card (and swallows the resulting "user rejected"
+            # result). The answer is delivered later as a normal user turn via
+            # the plugin's answer_question.
             if self._prev_dialog_sig == "question":
                 self._dialog_stable_count += 1
             else:
@@ -323,7 +323,6 @@ class TranscriptTailer:
                     extra={"session_id": self._session_id},
                 )
                 await self._runtime.tmux.send_bytes(pane, b"\x1b")
-                self._normalizer.arm_question_dismissal()
                 self._question_dismissed = True
             return
 

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -979,10 +979,10 @@ async def test_ask_user_question_skips_approval_card() -> None:
     assert not any(item[1] == EventKind.APPROVAL_REQUEST for item in emitted)
     assert not _permission_results(process)
 
-    handled = await adapter.respond_to_ask_question(
+    resolved = await adapter.respond_to_ask_question(
         "sess", "**Plan target**: Trivial wrapper-test plan", "toolu_ask"
     )
-    assert handled is True
+    assert resolved == "toolu_ask"
     assert _permission_results(process)[-1] == {
         "behavior": "deny",
         "message": (
@@ -994,12 +994,31 @@ async def test_ask_user_question_skips_approval_card() -> None:
 
 
 @pytest.mark.asyncio
-async def test_respond_to_ask_question_returns_false_without_pending() -> None:
+async def test_respond_to_ask_question_returns_none_without_pending() -> None:
     emitted: list = []
     adapter = _make_adapter(emitted)
     _attach_state(adapter)
-    handled = await adapter.respond_to_ask_question("sess", "anything")
-    assert handled is False
+    resolved = await adapter.respond_to_ask_question("sess", "anything")
+    assert resolved is None
+
+
+@pytest.mark.asyncio
+async def test_respond_to_ask_question_resolves_id_when_omitted() -> None:
+    """A caller that omits tool_use_id gets back the id the adapter selected,
+    so the plugin can persist it as durable answer evidence (FR5)."""
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, process = _attach_state(adapter)
+
+    payload = {
+        "tool_use_id": "toolu_ask",
+        "tool_name": "AskUserQuestion",
+        "tool_input": {"questions": [{"question": "ok?", "options": []}]},
+    }
+    await adapter._handle_can_use_tool(state, _can_use_tool_event(payload))
+
+    resolved = await adapter.respond_to_ask_question("sess", "Spaces")
+    assert resolved == "toolu_ask"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -542,9 +542,9 @@ async def test_question_drain_registers_pending() -> None:
 
 
 async def test_question_drain_stays_answerable_after_rejection() -> None:
-    # A question whose Esc-dismissal did not line up with a one-shot arm still
-    # drains as an answerable WAITING_INPUT card: its "user rejected" result is
-    # swallowed and the pending question stays registered so an answer routes.
+    # A dismissed question drains as an answerable WAITING_INPUT card: its "user
+    # rejected" result is swallowed and the pending question stays registered so
+    # an answer routes.
     plugin = ClaudeTtyPlugin()
     session = _make_session()
     runtime = _make_runtime(session, _load("ready.txt"))

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -587,6 +587,28 @@ async def test_answer_question_delivers_message_and_resolves_card() -> None:
     assert "sess-1" not in plugin._pending_questions
 
 
+async def test_answer_question_records_answer_before_synthetic_result() -> None:
+    """FR6: the durable answer event must be persisted before the synthetic
+    tool_result, so a live client never briefly renders the card as
+    closed-unanswered."""
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    plugin._pending_questions["sess-1"] = PendingTtyQuestion(
+        approval_id="aid", tool_use_id="auq1"
+    )
+    transport = MagicMock()
+    transport.send_input = AsyncMock()
+    runtime = _make_answer_runtime(session, transport)
+
+    order: list[str] = []
+    runtime._record_user_event.side_effect = lambda *a, **k: order.append("answer")
+    runtime._emit_adapter_event.side_effect = lambda *a, **k: order.append("result")
+
+    await plugin.answer_question(runtime, session, "x", "auq1", None)
+
+    assert order == ["answer", "result"]
+
+
 async def test_answer_question_no_pending_raises() -> None:
     plugin = ClaudeTtyPlugin()
     session = _make_session()

--- a/backend/tests/test_claude_tty_approval.py
+++ b/backend/tests/test_claude_tty_approval.py
@@ -490,9 +490,8 @@ async def test_question_dialog_dismissed_when_stable() -> None:
     await tailer._poll_dialog()  # tick 1: debounce
     runtime.tmux.send_bytes.assert_not_called()
 
-    await tailer._poll_dialog()  # tick 2: stable → Esc + arm
+    await tailer._poll_dialog()  # tick 2: stable → Esc
     runtime.tmux.send_bytes.assert_called_once_with("%0", b"\x1b")
-    assert tailer._normalizer._expect_dismissed_question is True
     assert tailer._question_dismissed is True
     runtime._emit_adapter_event.assert_not_called()
 
@@ -510,13 +509,13 @@ async def test_question_dialog_dismissed_only_once() -> None:
 
 
 async def test_question_drain_registers_pending() -> None:
-    # Once the armed normalizer surfaces the flushed tool_use as a WAITING_INPUT
-    # card, the tailer registers the pending question so an answer can route.
+    # Once the normalizer surfaces the flushed tool_use as a WAITING_INPUT card,
+    # the tailer registers the pending question so an answer can route — no
+    # arming step is required.
     plugin = ClaudeTtyPlugin()
     session = _make_session()
     runtime = _make_runtime(session, _load("ready.txt"))
     tailer = _make_tailer(plugin, runtime)
-    tailer._normalizer.arm_question_dismissal()
 
     record = {
         "type": "assistant",
@@ -539,6 +538,60 @@ async def test_question_drain_registers_pending() -> None:
     await tailer._drain()
 
     assert "sess-1" in plugin._pending_questions
+    assert plugin._pending_questions["sess-1"].tool_use_id == "auq1"
+
+
+async def test_question_drain_stays_answerable_after_rejection() -> None:
+    # A question whose Esc-dismissal did not line up with a one-shot arm still
+    # drains as an answerable WAITING_INPUT card: its "user rejected" result is
+    # swallowed and the pending question stays registered so an answer routes.
+    plugin = ClaudeTtyPlugin()
+    session = _make_session()
+    runtime = _make_runtime(session, _load("ready.txt"))
+    tailer = _make_tailer(plugin, runtime)
+
+    tool_use = {
+        "type": "assistant",
+        "message": {
+            "id": "m1",
+            "stop_reason": "tool_use",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "auq1",
+                    "name": "AskUserQuestion",
+                    "input": {"questions": [{"question": "Q", "options": []}]},
+                }
+            ],
+        },
+    }
+    rejection = {
+        "type": "user",
+        "toolUseResult": "User rejected tool use",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "auq1",
+                    "content": "The tool use was rejected",
+                    "is_error": True,
+                }
+            ]
+        },
+    }
+    tailer._source = _ScriptedSource(
+        [(json.dumps(tool_use) + "\n" + json.dumps(rejection) + "\n").encode()]
+    )
+
+    await tailer._drain()
+
+    # The question surfaced as WAITING_INPUT and its rejection was swallowed, so
+    # no tool_result event reached the store for it.
+    kinds = [call.args[1] for call in runtime._emit_adapter_event.call_args_list]
+    statuses = [call.args[4] for call in runtime._emit_adapter_event.call_args_list]
+    assert EventKind.TOOL_CALL in kinds
+    assert EventKind.TOOL_RESULT not in kinds
+    assert SessionStatus.WAITING_INPUT in statuses
     assert plugin._pending_questions["sess-1"].tool_use_id == "auq1"
 
 

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -401,9 +401,10 @@ def _ask_question_block(tool_id: str) -> dict:
     )
 
 
-def test_armed_ask_question_surfaces_as_waiting_input() -> None:
+def test_ask_question_surfaces_as_waiting_input() -> None:
+    # Every AskUserQuestion is an answerable card, regardless of whether the
+    # popup dismissal happened to line up with this exact record.
     norm = TranscriptNormalizer()
-    norm.arm_question_dismissal()
     record = _assistant_record(
         "msg1", [_ask_question_block("auq1")], stop_reason="tool_use"
     )
@@ -419,12 +420,11 @@ def test_armed_ask_question_surfaces_as_waiting_input() -> None:
     )
 
 
-def test_armed_ask_question_swallows_rejection_and_stays_waiting() -> None:
+def test_ask_question_swallows_rejection_and_stays_waiting() -> None:
     # Esc-ing the popup to surface it makes the TUI write a "user rejected"
     # result; it must be dropped so the card stays answerable and the session
-    # does not flip to idle.
+    # does not flip to idle — with no arming step required.
     norm = TranscriptNormalizer()
-    norm.arm_question_dismissal()
     norm.process_record(
         _assistant_record("msg1", [_ask_question_block("auq1")], stop_reason="tool_use")
     )
@@ -436,21 +436,26 @@ def test_armed_ask_question_swallows_rejection_and_stays_waiting() -> None:
     assert events == []
 
 
-def test_unarmed_ask_question_is_a_plain_tool_call() -> None:
-    # Without the dismissal latch (e.g. a historical record), AskUserQuestion
-    # is just a normal tool_call and a genuine rejection still resolves to idle.
+def test_ask_question_genuine_failure_surfaces_as_result() -> None:
+    # A non-dismissal terminal result (validation error, timeout) for a
+    # surfaced question is NOT a "user rejected" artifact: it must surface as a
+    # tool_result so the frontend renders the question closed-unanswered rather
+    # than falsely keeping it open.
     norm = TranscriptNormalizer()
-    events = norm.process_record(
+    norm.process_record(
         _assistant_record("msg1", [_ask_question_block("auq1")], stop_reason="tool_use")
     )
-    assert len(events) == 1
-    assert events[0].status == SessionStatus.RUNNING
-    rejection = _user_record([_tool_result_block("auq1", "rejected")])
-    rejection["toolUseResult"] = "User rejected tool use"
-    note = next(
-        e for e in norm.process_record(rejection) if e.kind == EventKind.SYSTEM_NOTE
+    failure = _user_record(
+        [
+            _tool_result_block(
+                "auq1", "InputValidationError: AskUserQuestion failed", is_error=True
+            )
+        ]
     )
-    assert note.status == SessionStatus.IDLE
+    events = norm.process_record(failure)
+    result = next(e for e in events if e.kind == EventKind.TOOL_RESULT)
+    assert result.metadata["tool_use_id"] == "auq1"
+    assert result.metadata["is_error"] is True
 
 
 def test_injected_task_notification_produces_no_events() -> None:

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4248,6 +4248,16 @@ html[data-theme="light"] .tool-call-run-children {
   border-color: var(--line);
 }
 
+/* Closed-without-answer: a terminally resolved question no one answered. Muted
+   like pending but marked with a dashed edge so it never reads as still
+   awaiting input; the "not answered" label carries the meaning (not color). */
+.badge.tool-status.unanswered {
+  background: color-mix(in srgb, var(--warn) 10%, transparent);
+  color: var(--warn);
+  border-color: color-mix(in srgb, var(--warn) 34%, transparent);
+  border-style: dashed;
+}
+
 .approval {
   border-color: rgba(200, 169, 106, 0.42);
   box-shadow: 0 0 0 1px rgba(200, 169, 106, 0.16);
@@ -7591,6 +7601,35 @@ html[data-theme="light"] .composer-send {
   gap: 8px;
   justify-content: space-between;
   margin-top: 12px;
+}
+
+.ask-question-closed {
+  margin-top: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.ask-question-closed-note {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.ask-question-diagnostic > summary {
+  cursor: pointer;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.ask-question-diagnostic > summary:hover {
+  color: var(--text);
+}
+
+.ask-question-diagnostic .output {
+  margin-top: 8px;
 }
 
 .ask-answer-summary {

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -3915,9 +3915,7 @@ type TranscriptItem =
 
 // Positive proof that Waypoint accepted a human answer to an AskUserQuestion:
 // a user_input event tagged ask_user_question_answer carrying the resolved
-// tool_use_id. This — never the presence of a paired tool_result — is what
-// promotes a question card to "answered". Keeping the latest by sequence makes
-// replay deterministic if a malformed duplicate answer event exists.
+// tool_use_id. The latest by sequence wins.
 function indexAskQuestionAnswerEvents(
   events: EventRecord[],
 ): Map<string, EventRecord> {
@@ -3996,9 +3994,8 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     item.pair.sequence = Math.max(item.pair.sequence, event.sequence);
   }
 
-  // Resolve each AskUserQuestion pair's answer state once, from durable answer
-  // evidence rather than Boolean(result), and attach it so every card reads the
-  // same derivation.
+  // Resolve each AskUserQuestion pair's answer state once and attach it so
+  // every card reads the same derivation.
   for (const item of result) {
     if (item.kind !== "pair" || !item.pair.call) continue;
     if (readToolName(item.pair.call) !== "AskUserQuestion") continue;

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -111,6 +111,7 @@ import {
   ToolCallRunGroup,
   readToolName,
   type AskAnswerEntry,
+  type AskQuestionResolution,
   type ToolPair,
 } from "@/components/TranscriptCard";
 import { TaskProgressDock } from "@/components/TaskProgressDock";
@@ -3912,9 +3913,51 @@ type TranscriptItem =
   | { kind: "pair"; event: EventRecord; pair: ToolPair }
   | { kind: "tool_run"; items: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] };
 
+// Positive proof that Waypoint accepted a human answer to an AskUserQuestion:
+// a user_input event tagged ask_user_question_answer carrying the resolved
+// tool_use_id. This — never the presence of a paired tool_result — is what
+// promotes a question card to "answered". Keeping the latest by sequence makes
+// replay deterministic if a malformed duplicate answer event exists.
+function indexAskQuestionAnswerEvents(
+  events: EventRecord[],
+): Map<string, EventRecord> {
+  const index = new Map<string, EventRecord>();
+  for (const event of events) {
+    if (event.kind !== "user_input") continue;
+    const metadata = event.metadata ?? {};
+    if (metadata.kind !== "ask_user_question_answer") continue;
+    const toolUseId =
+      typeof metadata.tool_use_id === "string" ? metadata.tool_use_id : "";
+    if (!toolUseId) continue;
+    const existing = index.get(toolUseId);
+    if (!existing || event.sequence >= existing.sequence) {
+      index.set(toolUseId, event);
+    }
+  }
+  return index;
+}
+
+// Resolve one question pair against the answer-evidence index: a correlated
+// answer wins; otherwise a paired result means the question closed without an
+// answer; otherwise it is still pending.
+function resolveAskQuestion(
+  pair: ToolPair,
+  answerIndex: Map<string, EventRecord>,
+): AskQuestionResolution {
+  const answerEvent = answerIndex.get(pair.itemId);
+  if (answerEvent) {
+    return { state: "answered", answerEvent };
+  }
+  if (pair.result) {
+    return { state: "closed_unanswered", resultEvent: pair.result };
+  }
+  return { state: "pending" };
+}
+
 function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
   const result: (Extract<TranscriptItem, { kind: "single" | "pair" }>)[] = [];
   const pairIndex = new Map<string, number>();
+  const answerIndex = indexAskQuestionAnswerEvents(events);
   for (const event of events) {
     if (event.kind !== "tool_call" && event.kind !== "tool_result") {
       result.push({ kind: "single", event });
@@ -3951,6 +3994,15 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     }
     item.pair.ts = event.ts;
     item.pair.sequence = Math.max(item.pair.sequence, event.sequence);
+  }
+
+  // Resolve each AskUserQuestion pair's answer state once, from durable answer
+  // evidence rather than Boolean(result), and attach it so every card reads the
+  // same derivation.
+  for (const item of result) {
+    if (item.kind !== "pair" || !item.pair.call) continue;
+    if (readToolName(item.pair.call) !== "AskUserQuestion") continue;
+    item.pair.askResolution = resolveAskQuestion(item.pair, answerIndex);
   }
 
   // Classify each item so the grouping loop is easy to reason about.

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -34,12 +34,23 @@ import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 import { TodoListBody } from "@/components/TodoList";
 
+// Three-state resolution of an AskUserQuestion, derived once over the loaded
+// events from durable answer evidence (a correlated ask_user_question_answer
+// user event) rather than from the mere presence of a paired tool_result.
+export type AskQuestionResolution =
+  | { state: "pending" }
+  | { state: "answered"; answerEvent: EventRecord }
+  | { state: "closed_unanswered"; resultEvent: EventRecord };
+
 export interface ToolPair {
   call: EventRecord | null;
   result: EventRecord | null;
   itemId: string;
   ts: string;
   sequence: number;
+  // Set only for AskUserQuestion pairs; attached by buildTranscriptItems so
+  // grouped runs and ordinary rows agree without re-scanning per card.
+  askResolution?: AskQuestionResolution;
 }
 
 export interface AskQuestionOption {
@@ -265,7 +276,7 @@ function CodexCard({
             event={event}
             questions={ask}
             onAnswer={onAnswerAskQuestion}
-            answered={false}
+            resolution={{ state: "pending" }}
           />
         );
       }
@@ -695,7 +706,7 @@ function ToolPairCard({
           event={call}
           questions={ask}
           onAnswer={onAnswerAskQuestion}
-          answered={Boolean(result)}
+          resolution={pair.askResolution ?? { state: "pending" }}
         />
       );
     }
@@ -839,7 +850,7 @@ function AskUserQuestionCard({
   event,
   questions,
   onAnswer,
-  answered,
+  resolution,
 }: {
   event: EventRecord;
   questions: AskUserQuestion[];
@@ -848,8 +859,12 @@ function AskUserQuestionCard({
     toolUseId?: string,
     answers?: AskAnswerEntry[],
   ) => Promise<boolean> | void;
-  answered: boolean;
+  resolution: AskQuestionResolution;
 }) {
+  const answered = resolution.state === "answered";
+  const closedUnanswered = resolution.state === "closed_unanswered";
+  const closedResultEvent =
+    resolution.state === "closed_unanswered" ? resolution.resultEvent : null;
   const [submitting, setSubmitting] = useState(false);
   const [picked, setPicked] = useState<Record<number, Set<string>>>({});
   const [notes, setNotes] = useState<Record<number, string>>({});
@@ -889,7 +904,7 @@ function AskUserQuestionCard({
   }
 
   async function submit() {
-    if (!onAnswer || answered || submitting) return;
+    if (!onAnswer || resolution.state !== "pending" || submitting) return;
     // Match the Claude binary's mapToolResultToToolResultBlockParam shape so
     // the model parses the answer the same way native Claude Code does:
     // `"<question>"="<answer>" user notes: <notes>`, joined by `, ` across
@@ -941,7 +956,7 @@ function AskUserQuestionCard({
     0,
   );
   const totalNotes = Object.values(notes).filter((value) => value.trim()).length;
-  const interactive = Boolean(onAnswer) && !answered;
+  const interactive = Boolean(onAnswer) && resolution.state === "pending";
   const canSubmit = interactive && !submitting && (totalPicked > 0 || totalNotes > 0);
 
   function handleNoteKeyDown(event: KeyboardEvent<HTMLTextAreaElement>) {
@@ -962,6 +977,8 @@ function AskUserQuestionCard({
         <span className="tool-name">Ask you</span>
         {answered ? (
           <span className="badge tool-status complete">answered</span>
+        ) : closedUnanswered ? (
+          <span className="badge tool-status unanswered">not answered</span>
         ) : (
           <span className="badge tool-status pending">awaiting answer</span>
         )}
@@ -1095,6 +1112,20 @@ function AskUserQuestionCard({
             >
               Clear
             </button>
+          ) : null}
+        </div>
+      ) : null}
+      {closedUnanswered ? (
+        <div className="ask-question-closed">
+          <p className="ask-question-closed-note">
+            Closed without an answer — this question was cancelled, timed out, or
+            failed before anyone responded, so it can no longer be answered.
+          </p>
+          {closedResultEvent?.text?.trim() ? (
+            <details className="ask-question-diagnostic">
+              <summary>Provider result</summary>
+              <pre className="output">{closedResultEvent.text}</pre>
+            </details>
           ) : null}
         </div>
       ) : null}

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -35,8 +35,8 @@ import { MarkdownMessage } from "@/components/MarkdownMessage";
 import { TodoListBody } from "@/components/TodoList";
 
 // Three-state resolution of an AskUserQuestion, derived once over the loaded
-// events from durable answer evidence (a correlated ask_user_question_answer
-// user event) rather than from the mere presence of a paired tool_result.
+// events from durable answer evidence: a correlated ask_user_question_answer
+// user event.
 export type AskQuestionResolution =
   | { state: "pending" }
   | { state: "answered"; answerEvent: EventRecord }

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -1118,8 +1118,8 @@ function AskUserQuestionCard({
       {closedUnanswered ? (
         <div className="ask-question-closed">
           <p className="ask-question-closed-note">
-            Closed without an answer — this question was cancelled, timed out, or
-            failed before anyone responded, so it can no longer be answered.
+            This question ended without a recorded answer and can no longer be
+            answered.
           </p>
           {closedResultEvent?.text?.trim() ? (
             <details className="ask-question-diagnostic">


### PR DESCRIPTION
## Purpose

The chat transcript labelled an AskUserQuestion **answered** whenever its tool call had a paired `tool_result`, regardless of whether anyone actually answered. Over the claude_tty transport, answerability hinged on a fragile one-shot arming latch: `_poll_dialog` Esc-dismisses the popup (which flushes the tool_use record) and arms the normalizer to surface it as a `WAITING_INPUT` card and swallow the resulting "user rejected" result. When the Esc came from another path or the latch did not line up with the exact next AskUserQuestion record, the question surfaced as a plain `RUNNING` tool_call — no pending question registered, rejection not swallowed — so it rendered as answered (`Boolean(result)`) with disabled controls even though no one answered and it was never answerable. The current event store holds 11 such records; 7–8 are Waypoint's own interrupt of a question it never relayed.

This makes two corrections. First, answer state is a durable, correlated fact: a `user_input` event with `metadata.kind = "ask_user_question_answer"` and a resolved `tool_use_id`, never the existence of a result. Second, an AskUserQuestion is answerable independent of the arming latch, so a question Waypoint dismissed but failed to relay is surfaced as a live, answerable card going forward instead of a dead one. Implements `.waypoint/specs/rfc-claude-tty-question-resolution-state.md` and folds in the arming/relay fix its Non-Goals had deferred. No schema or migration.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_code/adapter.py` — `respond_to_ask_question` returns the resolved `tool_use_id` (`str | None`) instead of a `bool`, including the id it selected when the caller omitted one, so the plugin persists real answer evidence (FR5).
- `backend/src/waypoint/backends/claude_code/plugin.py` — `answer_question` records the adapter-resolved id on the answer user event even when the caller passed none.
- `backend/src/waypoint/backends/claude_tty/plugin.py` — `answer_question` persists the durable answer user event **before** emitting its synthetic `tool_result` (FR6), so a live client never briefly sees the closed-unanswered result first.
- `backend/src/waypoint/backends/claude_tty/normalize.py` — surface **every** AskUserQuestion tool_use as a `WAITING_INPUT` card (not only when armed) and swallow only the "user rejected" dismissal result (keyed on `toolUseResult`, the signature the code already uses); a genuine failure result (validation error, timeout) surfaces so the card renders closed-unanswered. Drops the now-dead `arm_question_dismissal` / `_expect_dismissed_question` latch.
- `backend/src/waypoint/backends/claude_tty/tailer.py` — `_poll_dialog` still Escs the popup to flush it, but no longer arms the normalizer; the pending question is registered off `WAITING_INPUT` as before, so answers route.

### Frontend
- `frontend/src/components/SessionDetail.tsx` — an answer-evidence index (`indexAskQuestionAnswerEvents`) built once over the loaded events and a pure `resolveAskQuestion` deriving `pending | answered | closed_unanswered`; `buildTranscriptItems` attaches the resolution to each AskUserQuestion pair so grouped runs and ordinary rows agree without re-scanning per card.
- `frontend/src/components/TranscriptCard.tsx` — the `AskQuestionResolution` union and a `askResolution` field on `ToolPair`; `AskUserQuestionCard` takes the three-state resolution in place of `answered={Boolean(result)}`. `closed_unanswered` shows a textual "not answered" badge, disables the form, and keeps the provider/TUI result as collapsed diagnostic detail; its copy states only that the question ended without a recorded answer (no invented cancel/timeout cause).
- `frontend/src/app/globals.css` — a `.badge.tool-status.unanswered` variant (muted, dashed edge, meaning carried by the label not color) and the closed-state note/diagnostic styles, resolved from tokens for dark/light parity.

### Tests
- `backend/tests/test_claude_cli.py` — `respond_to_ask_question` returns the resolved id, `None` without a pending question, and the adapter-selected id when the caller omits one.
- `backend/tests/test_claude_tty_normalize.py` — AskUserQuestion surfaces `WAITING_INPUT` and swallows the user-rejected result with no arming; a non-rejection failure result surfaces as a tool_result (closed-unanswered).
- `backend/tests/test_claude_tty_approval.py` — the successful claude_tty answer records its durable answer event before the synthetic result (FR6); a full tailer `_drain` of the tool_use + user-rejected pattern stays answerable (WAITING_INPUT emitted, rejection swallowed, pending registered) with no arming.

## Design

Positive proof of an answer is the only reliable business fact — Waypoint's durable record that it accepted one — so results remain pairing/diagnostic data with no answer-state authority; `is_error` and result prose are never trusted to mean answered (rejected Options 2–4 in the RFC). Frontend resolution is pure over persisted events — index in O(loaded events), resolve each in O(1) — with one rule for live events, reloads, and older pages, so replay is deterministic (a duplicate answer event keeps the latest by sequence). Answerability is decoupled from the transient arming latch because the latch was the fragile mechanism causing the drop: a claude_tty answer is delivered as a fresh user turn (`send_input`), not by resurrecting a provider request, so surfacing every AskUserQuestion as `WAITING_INPUT` and swallowing only the Esc-dismissal signature is safe — a genuinely failed/malformed question still surfaces its failure and renders closed-unanswered. This complements, and does not touch, the sibling `rfc-claude-tty-queued-message-active-region` (pane classification of never-surfaced dialogs): that stops the drop at detection, this makes a dismissed-but-unrelayed question answerable and renders every remaining closed question honestly. There is no backend-id dispatch; the answer-evidence convention is shared metadata and every handler (claude_code, claude_tty, OpenCode) records the resolved id.

## Test Plan
- `cd backend && uv run pytest` — full suite.
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy.
- `cd frontend && npm run lint && npm run build` — lint + production build + TypeScript check.
- Playwright against the deployed frontend (mobile width) over real historical sessions exhibiting each transcript state; redeploying only the frontend (managed backend untouched).

## Test Result
- `uv run pytest` — 2770 passed; pre-commit green (isort/black/ruff/codespell/mypy); frontend lint + build green.
- Backend answerability path proven end-to-end at the tailer: a `_drain` of the tool_use + "user rejected" pattern emits a `WAITING_INPUT` card, swallows the rejection, and registers the pending question — with no arming step — so the question is answerable.
- Playwright over real event-store sessions: `claude_tty-b38fd2b0` and `claude_code-31b1ced4` render **not answered** with disabled options and a collapsed "Provider result" disclosure (previously falsely answered); the answered control `claude_tty-b5d30256` still renders **answered** with its structured answer-summary card. Historical records stay closed-unanswered as expected — the answerability fix applies to live/future sessions (a live claude_tty session re-normalized under the new path surfaces the dropped question as answerable); reproducing the unarmed race in a live CC is impractical, so that path is proven at the integration level rather than by a live UI drive.