### PR TITLE
fix: preserve advanced launch settings when cloning /new sessions

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1115,10 +1115,8 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session_id: str,
         _: Annotated[str, Depends(token_dependency())],
     ) -> Any:
-        # Server-side clone-launch for ``/new``: no request body, so no
-        # environment mapping ever crosses the API boundary. The source's
-        # private launch_env is copied only within the runtime; the response is
-        # the normal redacted session shape.
+        # Body-less clone-launch for ``/new``: the source's private launch_env is
+        # copied inside the runtime and never crosses the API boundary.
         session = await context.runtime.clone_session_launch(session_id)
         return {"session": session.model_dump(mode="json")}
 

--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -1110,6 +1110,18 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         session = await context.runtime.fork_session(session_id)
         return {"session": session.model_dump(mode="json")}
 
+    @app.post("/api/sessions/{session_id}/clone")
+    async def session_clone(
+        session_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+    ) -> Any:
+        # Server-side clone-launch for ``/new``: no request body, so no
+        # environment mapping ever crosses the API boundary. The source's
+        # private launch_env is copied only within the runtime; the response is
+        # the normal redacted session shape.
+        session = await context.runtime.clone_session_launch(session_id)
+        return {"session": session.model_dump(mode="json")}
+
     @app.post("/api/sessions/{session_id}/reattach")
     async def session_reattach(
         session_id: str,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -151,17 +151,13 @@ _USAGE_PROVIDER_HTTP_TIMEOUT = 15.0
 
 @dataclass(frozen=True)
 class CloneLaunchSnapshot:
-    """Runtime-internal effective-settings snapshot for a ``/new`` clone-launch.
+    """A source session's effective launch env and profile label, for ``/new``.
 
-    Carries the source session's already-effective launch environment and
-    account-profile provenance so ``create_session`` reuses them verbatim
-    instead of re-deriving env or re-reading a possibly-edited profile. Never a
-    public request field: it cannot be selected by an HTTP caller, so cloning
-    stays a server-side copy of a private snapshot.
+    Runtime-only — no public request field carries it, so an HTTP caller cannot
+    supply a launch environment.
     """
 
     launch_env: dict[str, str]
-    account_profile_id: str | None
     account_profile_label: str | None
 
 
@@ -1440,10 +1436,9 @@ class SessionRuntime:
             request.launch_target_id, request.backend
         )
         await self._require_live_master(launch_target)
-        # A clone reuses the source's already-effective launch env and profile
-        # provenance verbatim; it must not re-read mutable profile config, so the
-        # remote-home warm (a profile-config read) is skipped along with the
-        # profile-env overlay below.
+        # A clone reuses the source's effective env, so skip the profile-config
+        # reads (remote-home warm here, profile-env overlay and transcript store
+        # below) that would re-resolve a possibly-edited profile.
         if clone_snapshot is None:
             await self._warm_remote_home_for_profile(
                 launch_target, request.backend, request.account_profile_id
@@ -1602,8 +1597,6 @@ class SessionRuntime:
             request.account_profile_id,
             launch_target,
         )
-        # Skipped for a clone: establishing a shared transcript store re-reads the
-        # profile's transcript policy, and the source already owns its store.
         if clone_snapshot is None:
             await self._ensure_new_session_profile_transcript_store(
                 request.backend,
@@ -2369,12 +2362,10 @@ class SessionRuntime:
     async def clone_session_launch(self, session_id: str) -> SessionRecord:
         """Start a fresh managed session from a source session's launch settings.
 
-        Backs the ``/new`` control command: reads the private source record on
-        the server and reuses the ordinary managed-launch pipeline so the child
-        inherits the source's effective launch environment (secrets included),
-        pinned transport, and account-profile provenance without any env value
-        crossing the API boundary. It is not a conversation fork — no events,
-        thread, or transport state are copied. The child gets a new id, a fresh
+        Backs ``/new``: reads the private source record and reuses the managed
+        create pipeline so the child inherits the source's effective launch env
+        (secrets included), pinned transport, and profile provenance. No events,
+        thread, or transport state are copied; the child gets a new id, fresh
         title, and recomputed repo/branch metadata.
         """
         source = self.get_session(session_id)
@@ -2383,10 +2374,8 @@ class SessionRuntime:
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="the persistent personal-assistant session cannot be cloned",
             )
-        # Copy only the non-secret launch-affecting fields. The transport is
-        # pinned explicitly so ``/new`` reproduces the source's channel rather
-        # than re-deriving a possibly-newer default. launch_env is never placed
-        # on the request; it travels only inside the private snapshot below.
+        # Copy the non-secret launch fields; pin the transport so the child keeps
+        # the source's channel. launch_env travels only in the private snapshot.
         request = SessionCreateRequest(
             backend=source.backend,
             cwd=source.cwd,
@@ -2402,7 +2391,6 @@ class SessionRuntime:
         )
         snapshot = CloneLaunchSnapshot(
             launch_env=dict(source.launch_env),
-            account_profile_id=source.account_profile_id,
             account_profile_label=source.account_profile_label,
         )
         return await self.create_session(request, clone_snapshot=snapshot)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -147,6 +147,24 @@ from waypoint.usage_providers.registry import build_providers
 TMUX_TRANSPORT_ID = "tmux"
 # Per-request HTTP timeout for usage-provider fetches (NFR2: bounded I/O).
 _USAGE_PROVIDER_HTTP_TIMEOUT = 15.0
+
+
+@dataclass(frozen=True)
+class CloneLaunchSnapshot:
+    """Runtime-internal effective-settings snapshot for a ``/new`` clone-launch.
+
+    Carries the source session's already-effective launch environment and
+    account-profile provenance so ``create_session`` reuses them verbatim
+    instead of re-deriving env or re-reading a possibly-edited profile. Never a
+    public request field: it cannot be selected by an HTTP caller, so cloning
+    stays a server-side copy of a private snapshot.
+    """
+
+    launch_env: dict[str, str]
+    account_profile_id: str | None
+    account_profile_label: str | None
+
+
 COMPLETION_REFRESH_INTERVAL_SECONDS = 30.0
 # Debounce window for streaming-driven session_state / session_list
 # broadcasts. A burst of streamed events collapses into one broadcast per
@@ -1403,6 +1421,7 @@ class SessionRuntime:
         *,
         preset_id: str | None = None,
         preset_name: str | None = None,
+        clone_snapshot: CloneLaunchSnapshot | None = None,
     ) -> SessionRecord:
         if request.source_mode != SessionSource.MANAGED:
             raise HTTPException(
@@ -1421,9 +1440,14 @@ class SessionRuntime:
             request.launch_target_id, request.backend
         )
         await self._require_live_master(launch_target)
-        await self._warm_remote_home_for_profile(
-            launch_target, request.backend, request.account_profile_id
-        )
+        # A clone reuses the source's already-effective launch env and profile
+        # provenance verbatim; it must not re-read mutable profile config, so the
+        # remote-home warm (a profile-config read) is skipped along with the
+        # profile-env overlay below.
+        if clone_snapshot is None:
+            await self._warm_remote_home_for_profile(
+                launch_target, request.backend, request.account_profile_id
+            )
         # Local cwd is fed to subprocess.Popen / tmux new-session, neither of
         # which expand `~`. Resolve it before storing/launching. The remote
         # cwd is left verbatim so the remote shell can do its own expansion.
@@ -1431,13 +1455,19 @@ class SessionRuntime:
             local_cwd = request.cwd or launch_target.default_cwd
         else:
             local_cwd = require_existing_local_dir(request.cwd)
-        effective_env = self._effective_launch_env_for_request(request, launch_target)
-        effective_env, account_profile_label = self._apply_account_profile_env(
-            request.backend,
-            effective_env,
-            request.account_profile_id,
-            launch_target,
-        )
+        if clone_snapshot is not None:
+            effective_env = dict(clone_snapshot.launch_env)
+            account_profile_label = clone_snapshot.account_profile_label
+        else:
+            effective_env = self._effective_launch_env_for_request(
+                request, launch_target
+            )
+            effective_env, account_profile_label = self._apply_account_profile_env(
+                request.backend,
+                effective_env,
+                request.account_profile_id,
+                launch_target,
+            )
         request = request.model_copy(
             update={
                 "cwd": local_cwd,
@@ -1572,12 +1602,15 @@ class SessionRuntime:
             request.account_profile_id,
             launch_target,
         )
-        await self._ensure_new_session_profile_transcript_store(
-            request.backend,
-            effective_env,
-            request.account_profile_id,
-            launch_target,
-        )
+        # Skipped for a clone: establishing a shared transcript store re-reads the
+        # profile's transcript policy, and the source already owns its store.
+        if clone_snapshot is None:
+            await self._ensure_new_session_profile_transcript_store(
+                request.backend,
+                effective_env,
+                request.account_profile_id,
+                launch_target,
+            )
         session = await plugin.create_session(
             self,
             request,
@@ -2332,6 +2365,47 @@ class SessionRuntime:
         self._warm_command_completions(new_session)
         await self._broadcast_session_list()
         return new_session
+
+    async def clone_session_launch(self, session_id: str) -> SessionRecord:
+        """Start a fresh managed session from a source session's launch settings.
+
+        Backs the ``/new`` control command: reads the private source record on
+        the server and reuses the ordinary managed-launch pipeline so the child
+        inherits the source's effective launch environment (secrets included),
+        pinned transport, and account-profile provenance without any env value
+        crossing the API boundary. It is not a conversation fork — no events,
+        thread, or transport state are copied. The child gets a new id, a fresh
+        title, and recomputed repo/branch metadata.
+        """
+        source = self.get_session(session_id)
+        if self.is_assistant_session(source):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="the persistent personal-assistant session cannot be cloned",
+            )
+        # Copy only the non-secret launch-affecting fields. The transport is
+        # pinned explicitly so ``/new`` reproduces the source's channel rather
+        # than re-deriving a possibly-newer default. launch_env is never placed
+        # on the request; it travels only inside the private snapshot below.
+        request = SessionCreateRequest(
+            backend=source.backend,
+            cwd=source.cwd,
+            launch_target_id=source.launch_target_id,
+            launch_mode=source.launch_mode,
+            transport=source.transport,
+            args=list(source.args),
+            config_overrides=list(source.config_overrides),
+            model=source.model,
+            effort=source.effort,
+            permission_mode=source.permission_mode,
+            account_profile_id=source.account_profile_id,
+        )
+        snapshot = CloneLaunchSnapshot(
+            launch_env=dict(source.launch_env),
+            account_profile_id=source.account_profile_id,
+            account_profile_label=source.account_profile_label,
+        )
+        return await self.create_session(request, clone_snapshot=snapshot)
 
     async def attach_tmux(self, request: SessionAttachRequest) -> SessionRecord:
         try:

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -43,6 +43,7 @@ def _make_session(
     permission_mode: str | None = None,
     launch_args: list[str] | None = None,
     thread_id: str | None = "thread-1",
+    launch_env: dict[str, str] | None = None,
 ) -> SessionRecord:
     now = datetime.now(UTC)
     state: dict[str, object] = {
@@ -72,6 +73,7 @@ def _make_session(
         model=model,
         effort=effort,
         permission_mode=permission_mode,
+        launch_env=launch_env or {},
     )
 
 
@@ -509,7 +511,11 @@ async def test_fork_session_inherits_source_agent_backend() -> None:
     plugin = ClaudeTtyPlugin()
     _stub_lifecycle(plugin)
     runtime, created = _launch_runtime()
-    source = _make_session(session_id="src", thread_id="thread-src")
+    source = _make_session(
+        session_id="src",
+        thread_id="thread-src",
+        launch_env={"SECRET_TOKEN": "sk-tty", "CLAUDE_CONFIG_DIR": "/cfg"},
+    )
     source.backend = "claude_code"
 
     forked = await plugin.fork_session(
@@ -524,6 +530,15 @@ async def test_fork_session_inherits_source_agent_backend() -> None:
     assert forked.backend == "claude_code"
     assert forked.transport == "claude_tty"
     assert created["record"].backend == "claude_code"
+    # The child persists the source's private launch env, and the resumed tmux
+    # command is built with that same environment (secret included).
+    assert created["record"].launch_env == {
+        "SECRET_TOKEN": "sk-tty",
+        "CLAUDE_CONFIG_DIR": "/cfg",
+    }
+    assert (
+        runtime._command_for_backend.call_args.kwargs["launch_env"] == source.launch_env
+    )
 
 
 # ── list_threads dedup ────────────────────────────────────────────────────────

--- a/backend/tests/test_clone_session_launch.py
+++ b/backend/tests/test_clone_session_launch.py
@@ -1,0 +1,358 @@
+"""Clone-launch (`/new`) coverage — ticket 1357.
+
+`clone_session_launch` starts a fresh managed session from a source session's
+effective launch settings, reusing the source's private ``launch_env`` (secrets
+included) without ever serializing it to the API. These tests cover the request
+the clone builds, the env plumbed into the plugin create path, the redaction of
+env from public payloads, the profile-snapshot contract, and the failure paths.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from waypoint.api import create_app
+from waypoint.runtime import CloneLaunchSnapshot, SessionRuntime
+from waypoint.schemas import (
+    LaunchMode,
+    SessionCreateRequest,
+    SessionRecord,
+    SessionSource,
+    SessionStatus,
+)
+from waypoint.settings import Settings
+from waypoint.storage import Storage
+
+
+def _runtime(tmp_path: Path) -> tuple[SessionRuntime, Storage, Settings]:
+    settings = Settings(data_dir=tmp_path / "data")
+    settings.ensure_dirs()
+    storage = Storage(settings.database_path)
+    return SessionRuntime(settings, storage), storage, settings
+
+
+def _codex_source(tmp_path: Path, **overrides: Any) -> SessionRecord:
+    """A codex source session whose cwd exists so create validation passes."""
+    now = datetime.now(UTC)
+    base: dict[str, Any] = dict(
+        id="src",
+        backend="codex",
+        source=SessionSource.MANAGED,
+        transport="codex_app_server",
+        title="Source title",
+        cwd=str(tmp_path),
+        launch_mode=LaunchMode.AUTO,
+        status=SessionStatus.IDLE,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        raw_log_path=str(tmp_path / "raw.log"),
+        structured_log_path=str(tmp_path / "events.jsonl"),
+        transport_state={"thread_id": "thread-src"},
+        model="gpt-5-codex",
+        effort="high",
+        args=["--foo", "bar"],
+        config_overrides=["k=v"],
+        launch_env={"SECRET_TOKEN": "sk-super-secret", "CODEX_HOME": "/snap/dir"},
+    )
+    base.update(overrides)
+    return SessionRecord(**base)
+
+
+class _CloneCodexAdapter:
+    """Minimal codex adapter double capturing the process env at start."""
+
+    def __init__(self) -> None:
+        self.start_env: dict[str, str] | None = None
+
+    async def start_session(
+        self,
+        session_id: str,
+        cwd: str,
+        client_factory: Any,
+        *,
+        model: str | None = None,
+        effort: str | None = None,
+        custom_args: list[str] | None = None,
+        config_overrides: list[str] | None = None,
+        launch_env: dict[str, str] | None = None,
+    ) -> str:
+        self.start_env = dict(launch_env or {})
+        return "thread-child"
+
+    async def register_rate_limit_probe(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def force_refresh_rate_limit_usage(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+# ── request/snapshot contract ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_builds_request_and_snapshot_from_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runtime, storage, _ = _runtime(tmp_path)
+    source = _codex_source(
+        tmp_path,
+        launch_target_id=None,
+        permission_mode="agent",
+        account_profile_id="work",
+        account_profile_label="Work",
+    )
+    storage.create_session(source)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create_session(
+        request: SessionCreateRequest,
+        *,
+        clone_snapshot: CloneLaunchSnapshot | None = None,
+        **_: Any,
+    ) -> SessionRecord:
+        captured["request"] = request
+        captured["snapshot"] = clone_snapshot
+        return source.model_copy(update={"id": "codex-child"})
+
+    monkeypatch.setattr(runtime, "create_session", fake_create_session)
+
+    result = await runtime.clone_session_launch("src")
+
+    request: SessionCreateRequest = captured["request"]
+    snapshot: CloneLaunchSnapshot = captured["snapshot"]
+    # Every launch-affecting field is copied; transport is pinned explicitly.
+    assert request.backend == "codex"
+    assert request.cwd == str(tmp_path)
+    assert request.transport == "codex_app_server"
+    assert request.launch_mode == LaunchMode.AUTO
+    assert request.model == "gpt-5-codex"
+    assert request.effort == "high"
+    assert request.permission_mode == "agent"
+    assert request.args == ["--foo", "bar"]
+    assert request.config_overrides == ["k=v"]
+    assert request.account_profile_id == "work"
+    assert request.source_mode == SessionSource.MANAGED
+    # Fresh session: no title carried, and env never rides on the request.
+    assert request.title is None
+    assert request.launch_env == {}
+    assert "launch_env" not in request.model_fields_set
+    # The snapshot carries the effective env + profile provenance verbatim.
+    assert snapshot is not None
+    assert snapshot.launch_env == {
+        "SECRET_TOKEN": "sk-super-secret",
+        "CODEX_HOME": "/snap/dir",
+    }
+    assert snapshot.launch_env is not source.launch_env
+    assert snapshot.account_profile_id == "work"
+    assert snapshot.account_profile_label == "Work"
+    assert result.id == "codex-child"
+
+
+# ── integration through the real codex create pipeline ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_reaches_plugin_create_with_private_env_and_new_id(
+    tmp_path: Path,
+) -> None:
+    runtime, storage, _ = _runtime(tmp_path)
+    plugin = runtime.registry.get("codex")
+    adapter = _CloneCodexAdapter()
+    plugin.adapter = adapter  # type: ignore[attr-defined]
+    source = _codex_source(tmp_path)
+    storage.create_session(source)
+
+    child = await runtime.clone_session_launch("src")
+
+    # Distinct id and a fresh title, not a copy of the source.
+    assert child.id != "src"
+    assert child.id.startswith("codex-")
+    assert child.title != source.title
+    assert child.source == SessionSource.MANAGED
+    # The child persists the source's private launch env verbatim.
+    assert child.launch_env == source.launch_env
+    assert child.model == "gpt-5-codex"
+    assert child.effort == "high"
+    assert child.args == ["--foo", "bar"]
+    assert child.config_overrides == ["k=v"]
+    assert child.transport == "codex_app_server"
+    # The secret reached the process env, and WAYPOINT_SESSION_ID is the child's
+    # own regenerated id — never an inherited source value.
+    assert adapter.start_env is not None
+    assert adapter.start_env["SECRET_TOKEN"] == "sk-super-secret"
+    assert adapter.start_env["WAYPOINT_SESSION_ID"] == child.id
+    # Source is untouched.
+    assert storage.get_session("src") is not None
+
+
+@pytest.mark.asyncio
+async def test_clone_public_payload_omits_env_while_stored_retains(
+    tmp_path: Path,
+) -> None:
+    runtime, storage, _ = _runtime(tmp_path)
+    plugin = runtime.registry.get("codex")
+    plugin.adapter = _CloneCodexAdapter()  # type: ignore[attr-defined]
+    storage.create_session(_codex_source(tmp_path))
+
+    child = await runtime.clone_session_launch("src")
+
+    public = child.model_dump(mode="json")
+    assert "launch_env" not in public
+    # The list serialization (the /api/sessions payload) is redacted too.
+    listed = [s.model_dump(mode="json") for s in storage.list_sessions()]
+    assert all("launch_env" not in row for row in listed)
+    # But the stored record still carries the values for relaunch/restore.
+    stored = storage.get_session(child.id)
+    assert stored is not None
+    assert stored.launch_env == {
+        "SECRET_TOKEN": "sk-super-secret",
+        "CODEX_HOME": "/snap/dir",
+    }
+
+
+@pytest.mark.asyncio
+async def test_clone_uses_saved_env_even_when_profile_changed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No account profiles are configured on this runtime, yet the source records
+    # provenance for a profile that once existed. A clone must reuse the saved
+    # effective env verbatim (not re-resolve the now-absent profile) and stamp
+    # the saved provenance — never a 400.
+    runtime, storage, _ = _runtime(tmp_path)
+    plugin = runtime.registry.get("codex")
+    plugin.adapter = _CloneCodexAdapter()  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        runtime, "_schedule_verified_account_probe", lambda *a, **k: None
+    )
+    source = _codex_source(
+        tmp_path,
+        account_profile_id="ghost",
+        account_profile_label="Ghost",
+        launch_env={"CODEX_HOME": "/frozen/config", "TOKEN": "t"},
+    )
+    storage.create_session(source)
+
+    child = await runtime.clone_session_launch("src")
+
+    assert child.launch_env == {"CODEX_HOME": "/frozen/config", "TOKEN": "t"}
+    assert child.account_profile_id == "ghost"
+    assert child.account_profile_label == "Ghost"
+
+
+# ── failure paths ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_clone_invalid_inherited_cwd_fails_and_persists_no_child(
+    tmp_path: Path,
+) -> None:
+    runtime, storage, _ = _runtime(tmp_path)
+    plugin = runtime.registry.get("codex")
+    plugin.adapter = _CloneCodexAdapter()  # type: ignore[attr-defined]
+    storage.create_session(_codex_source(tmp_path, cwd="/no/such/dir"))
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.clone_session_launch("src")
+    assert exc.value.status_code == 400
+    # Validation failed before any child record was written.
+    assert [s.id for s in storage.list_sessions()] == ["src"]
+
+
+@pytest.mark.asyncio
+async def test_clone_missing_source_is_404(tmp_path: Path) -> None:
+    runtime, _, _ = _runtime(tmp_path)
+    with pytest.raises(HTTPException) as exc:
+        await runtime.clone_session_launch("nope")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_clone_persistent_assistant_is_rejected(tmp_path: Path) -> None:
+    runtime, storage, _ = _runtime(tmp_path)
+    storage.create_session(_codex_source(tmp_path, source=SessionSource.ASSISTANT))
+
+    with pytest.raises(HTTPException) as exc:
+        await runtime.clone_session_launch("src")
+    assert exc.value.status_code == 400
+    # No child was created off the launchpad.
+    assert [s.id for s in storage.list_sessions()] == ["src"]
+
+
+# ── API endpoint ─────────────────────────────────────────────────────────────
+
+
+def _app(tmp_path: Path, *sessions: SessionRecord) -> tuple[Any, Any, str]:
+    settings = Settings(data_dir=tmp_path / "data")
+    app = create_app(settings)
+    context = app.state.context
+    for session in sessions:
+        context.storage.create_session(session)
+    token = context.tokens.issue().token
+    return app, context, token
+
+
+def _client(app: Any) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test"
+    )
+
+
+@pytest.mark.asyncio
+async def test_clone_endpoint_returns_redacted_session(tmp_path: Path) -> None:
+    app, context, token = _app(tmp_path, _codex_source(tmp_path))
+    context.runtime.registry.get("codex").adapter = _CloneCodexAdapter()
+
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/src/clone",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    session = body["session"]
+    assert session["id"] != "src"
+    # The response carries the normal redacted shape — no env crosses the wire.
+    assert "launch_env" not in session
+    # The clone still retained the private env server-side.
+    stored = context.storage.get_session(session["id"])
+    assert stored is not None
+    assert stored.launch_env["SECRET_TOKEN"] == "sk-super-secret"
+
+
+@pytest.mark.asyncio
+async def test_clone_endpoint_missing_source_404(tmp_path: Path) -> None:
+    app, _, token = _app(tmp_path)
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/nope/clone",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_clone_endpoint_rejects_assistant(tmp_path: Path) -> None:
+    app, _, token = _app(
+        tmp_path, _codex_source(tmp_path, source=SessionSource.ASSISTANT)
+    )
+    async with _client(app) as client:
+        resp = await client.post(
+            "/api/sessions/src/clone",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_clone_endpoint_requires_auth(tmp_path: Path) -> None:
+    app, _, _ = _app(tmp_path, _codex_source(tmp_path))
+    async with _client(app) as client:
+        resp = await client.post("/api/sessions/src/clone")
+    assert resp.status_code in (401, 403)

--- a/backend/tests/test_clone_session_launch.py
+++ b/backend/tests/test_clone_session_launch.py
@@ -142,14 +142,13 @@ async def test_clone_builds_request_and_snapshot_from_source(
     assert request.title is None
     assert request.launch_env == {}
     assert "launch_env" not in request.model_fields_set
-    # The snapshot carries the effective env + profile provenance verbatim.
+    # The snapshot carries the effective env + profile label verbatim.
     assert snapshot is not None
     assert snapshot.launch_env == {
         "SECRET_TOKEN": "sk-super-secret",
         "CODEX_HOME": "/snap/dir",
     }
     assert snapshot.launch_env is not source.launch_env
-    assert snapshot.account_profile_id == "work"
     assert snapshot.account_profile_label == "Work"
     assert result.id == "codex-child"
 

--- a/backend/tests/test_opencode_plugin.py
+++ b/backend/tests/test_opencode_plugin.py
@@ -50,6 +50,7 @@ def _session(**overrides: Any) -> SessionRecord:
         effort=overrides.get("effort"),
         args=overrides.get("args", []),
         config_overrides=overrides.get("config_overrides", []),
+        launch_env=overrides.get("launch_env", {}),
     )
 
 
@@ -1006,6 +1007,7 @@ async def test_fork_plan_session_persists_pre_plan_mode(tmp_path) -> None:
             "pre_plan_mode": "allow",
         },
         permission_mode="plan",
+        launch_env={"SECRET_TOKEN": "sk-oc", "OPENCODE_X": "1"},
     )
 
     class FakeAdapter:
@@ -1034,10 +1036,15 @@ async def test_fork_plan_session_persists_pre_plan_mode(tmp_path) -> None:
             return True
 
     fake_adapter = FakeAdapter()
+    captured_env: dict[str, dict[str, str]] = {}
 
     async def fake_get_or_create_adapter(
         *args: object, **kwargs: object
     ) -> FakeAdapter:
+        launch_env = kwargs.get("launch_env")
+        captured_env["launch_env"] = (
+            dict(launch_env) if isinstance(launch_env, dict) else {}
+        )
         return fake_adapter
 
     cast(Any, plugin)._get_or_create_adapter = fake_get_or_create_adapter
@@ -1080,6 +1087,10 @@ async def test_fork_plan_session_persists_pre_plan_mode(tmp_path) -> None:
         "agent": "plan",
         "pre_plan_mode": "allow",
     }
+    # The child persists the source's private launch env, and the adapter that
+    # starts the fork is keyed with that same environment (secret included).
+    assert forked.launch_env == {"SECRET_TOKEN": "sk-oc", "OPENCODE_X": "1"}
+    assert captured_env["launch_env"]["SECRET_TOKEN"] == "sk-oc"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_runtime.py
+++ b/backend/tests/test_runtime.py
@@ -3597,6 +3597,10 @@ async def test_runtime_fork_codex_session_uses_codex_plugin(tmp_path) -> None:
     runtime, storage, settings = make_runtime(tmp_path)
 
     class CodexForkFake(FakeCodexRuntimeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fork_env: dict[str, str] | None = None
+
         async def fork_session(
             self,
             session_id: str,
@@ -3611,11 +3615,15 @@ async def test_runtime_fork_codex_session_uses_codex_plugin(tmp_path) -> None:
         ) -> str:
             assert session_id.startswith("codex-")
             assert (cwd, thread_id) == ("/tmp/project", "thread-1")
+            self.fork_env = dict(launch_env or {})
             return "thread-forked"
 
     plugin = _codex_plugin(runtime)
-    plugin.adapter = cast(Any, CodexForkFake())
-    session = make_session(settings)
+    adapter = CodexForkFake()
+    plugin.adapter = cast(Any, adapter)
+    session = make_session(
+        settings, launch_env={"SECRET_TOKEN": "sk-fork", "CODEX_HOME": "/c"}
+    )
     storage.create_session(session)
 
     forked = await runtime.fork_session("sess")
@@ -3623,6 +3631,70 @@ async def test_runtime_fork_codex_session_uses_codex_plugin(tmp_path) -> None:
     assert forked.backend == "codex"
     assert forked.title == "Session (fork #1)"
     assert forked.transport_state == {"thread_id": "thread-forked"}
+    # The child inherits the source's private launch env, and the process env
+    # carries the secret with a freshly regenerated WAYPOINT_SESSION_ID.
+    assert forked.launch_env == {"SECRET_TOKEN": "sk-fork", "CODEX_HOME": "/c"}
+    assert adapter.fork_env is not None
+    assert adapter.fork_env["SECRET_TOKEN"] == "sk-fork"
+    assert adapter.fork_env["WAYPOINT_SESSION_ID"] == forked.id
+
+
+@pytest.mark.asyncio
+async def test_runtime_fork_claude_session_propagates_launch_env(
+    tmp_path, monkeypatch
+) -> None:
+    runtime, storage, settings = make_runtime(tmp_path)
+    # Isolate the fork env contract from background command-completion discovery,
+    # which for claude spawns on-disk/subprocess probing off the fake adapter.
+    monkeypatch.setattr(runtime, "_warm_command_completions", lambda *a, **k: None)
+
+    class ClaudeForkFake(FakeClaudeAdapter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fork_env: dict[str, str] | None = None
+            self.fork_from: str | None = None
+
+        async def start_session(
+            self,
+            session_id: str,
+            cwd: str,
+            claude_session_id: str,
+            launch_factory_override: Any = None,
+            permission_mode: str | None = None,
+            model: str | None = None,
+            effort: str | None = None,
+            custom_args: list[str] | None = None,
+            launch_env: dict[str, str] | None = None,
+            fork_from_claude_session_id: str | None = None,
+        ) -> str:
+            self.fork_env = dict(launch_env or {})
+            self.fork_from = fork_from_claude_session_id
+            return claude_session_id
+
+    plugin = _claude_plugin(runtime)
+    adapter = ClaudeForkFake()
+    plugin.adapter = cast(Any, adapter)
+    session = make_session(
+        settings,
+        backend="claude_code",
+        transport="claude_cli",
+        launch_env={"SECRET_TOKEN": "sk-claude", "CLAUDE_CONFIG_DIR": "/cfg"},
+    )
+    storage.create_session(session)
+
+    forked = await runtime.fork_session("sess")
+
+    assert forked.backend == "claude_code"
+    # Child persists the source's private env; the fork resumes the source
+    # thread; and the process env carries the secret with the child's own id.
+    assert forked.launch_env == {
+        "SECRET_TOKEN": "sk-claude",
+        "CLAUDE_CONFIG_DIR": "/cfg",
+    }
+    assert adapter.fork_from == "thread-1"
+    assert adapter.fork_env is not None
+    assert adapter.fork_env["SECRET_TOKEN"] == "sk-claude"
+    assert adapter.fork_env["WAYPOINT_SESSION_ID"] == forked.id
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_side_question.py
+++ b/backend/tests/test_side_question.py
@@ -169,6 +169,7 @@ def _make_session(
     status: SessionStatus = SessionStatus.IDLE,
     launch_target_id: str | None = None,
     transport_state_extra: dict | None = None,
+    launch_env: dict[str, str] | None = None,
 ) -> SessionRecord:
     settings_dir = storage.database_path.parent / "sessions" / session_id
     settings_dir.mkdir(parents=True, exist_ok=True)
@@ -193,6 +194,7 @@ def _make_session(
         transport_state=state,
         raw_log_path=str(settings_dir / "raw.log"),
         structured_log_path=str(settings_dir / "events.jsonl"),
+        launch_env=launch_env or {},
     )
     return storage.create_session(session)
 
@@ -432,7 +434,11 @@ async def test_fork_aside_drops_record_and_brings_up_new_session(
     runtime: Any,
     tmp_path: Path,
 ) -> None:
-    session = _make_session(runtime.storage, thread_id="thread-abc")
+    session = _make_session(
+        runtime.storage,
+        thread_id="thread-abc",
+        launch_env={"SECRET_TOKEN": "sk-btw", "CLAUDE_CONFIG_DIR": "/cfg"},
+    )
     sq = SideQuestion(
         id="sq-ready",
         question="What files changed?",
@@ -475,6 +481,12 @@ async def test_fork_aside_drops_record_and_brings_up_new_session(
 
     # bring_up received the new record and the fork thread id.
     assert bring_up_calls == [("new-sess", "fork-uuid-xyz")]
+
+    # The promoted session inherits the source's private launch env.
+    assert new_sess.launch_env == {
+        "SECRET_TOKEN": "sk-btw",
+        "CLAUDE_CONFIG_DIR": "/cfg",
+    }
 
     # The aside's question and answer were injected into the new transcript.
     injected = [

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -21,9 +21,9 @@ import {
   answerAskQuestion,
   approvePlan,
   approveSession,
+  cloneSession,
   connectSessionSocket,
   connectTerminalSocket,
-  createSession,
   deleteSession as deleteSessionRequest,
   fetchBackendModels,
   fetchEvents,
@@ -1014,17 +1014,11 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       const newArgs = allowNew ? matchControlCommand(text, "new") : null;
       if (newArgs !== null) {
         try {
-          const created = await createSession(host, token, {
-            backend: session.backend,
-            cwd: session.cwd,
-            launch_target_id: session.launch_target_id,
-            launch_mode: session.launch_mode ?? "auto",
-            model: session.model,
-            effort: session.effort,
-            permission_mode: session.permission_mode,
-            args: session.args,
-            config_overrides: session.config_overrides,
-          });
+          // Clone server-side so the child inherits the source's private
+          // launch_env (env vars, config-dir/account profile) that a public
+          // SessionRecord can't carry. The response is the normal redacted
+          // session shape.
+          const created = await cloneSession(host, token, sessionId);
           if (newArgs) {
             await sendInput(host, token, created.id, newArgs);
           }

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -1015,9 +1015,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
       if (newArgs !== null) {
         try {
           // Clone server-side so the child inherits the source's private
-          // launch_env (env vars, config-dir/account profile) that a public
-          // SessionRecord can't carry. The response is the normal redacted
-          // session shape.
+          // launch_env (env vars, account/config-dir profile) that a public
+          // SessionRecord can't carry.
           const created = await cloneSession(host, token, sessionId);
           if (newArgs) {
             await sendInput(host, token, created.id, newArgs);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -371,10 +371,9 @@ export async function forkSession(
   return body.session as SessionRecord;
 }
 
-// Clone the source session's launch settings into a fresh managed session.
-// Body-less by design: the source's launch_env (which may hold secrets) is
-// copied server-side and never serialized to the browser, so unlike
-// createSession there is no payload to assemble.
+// Clone a source session's launch settings into a fresh managed session.
+// Body-less: the source's launch_env (which may hold secrets) is copied
+// server-side and never serialized to the browser.
 export async function cloneSession(
   host: string,
   token: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -371,6 +371,27 @@ export async function forkSession(
   return body.session as SessionRecord;
 }
 
+// Clone the source session's launch settings into a fresh managed session.
+// Body-less by design: the source's launch_env (which may hold secrets) is
+// copied server-side and never serialized to the browser, so unlike
+// createSession there is no payload to assemble.
+export async function cloneSession(
+  host: string,
+  token: string,
+  sessionId: string,
+): Promise<SessionRecord> {
+  const response = await fetch(`${host}/api/sessions/${sessionId}/clone`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  await ensureOk(response, "failed to clone session");
+  const body = await response.json();
+  return body.session as SessionRecord;
+}
+
 export async function attachTmux(
   host: string,
   token: string,


### PR DESCRIPTION
## Purpose

The `/new` control command rebuilt the child session from the browser's public `SessionRecord`, which cannot carry `launch_env` — that field is `exclude=True` precisely because its values are secrets (API tokens, a `CLAUDE_CONFIG_DIR`/`CODEX_HOME` account override). So a cloned session silently lost user-provided environment variables and did not pin the source's resolved transport or account profile, and could behave differently from its source once defaults drifted. Implements `.waypoint/specs/rfc-1357-clone-session-launch-settings.md` (Ticket 1357). `/fork` already inherits `launch_env` server-side on every path; this change adds regression coverage that makes that contract explicit rather than changing fork behavior. No schema change or migration — existing sessions already persist `launch_env`.

## Changes

### Backend
- `backend/src/waypoint/runtime.py` — add a private frozen `CloneLaunchSnapshot` (`launch_env`, `account_profile_id`, `account_profile_label`) and `SessionRuntime.clone_session_launch(session_id)`: it reads the private source record, rejects the persistent assistant with 400, copies only the non-secret launch-affecting fields (backend, cwd, launch target/mode, model, effort, permission mode, args, config overrides) with the source transport pinned explicitly, and drives the normal managed-create pipeline. `create_session` gains a `clone_snapshot` keyword that, when present, uses `dict(source.launch_env)` verbatim as the effective env and stamps the saved profile label — skipping `_warm_remote_home_for_profile`, `_apply_account_profile_env`, and the profile transcript-store setup, all of which would re-read mutable profile config. The public create branch is unchanged, and the snapshot cannot be selected by an HTTP caller. `WAYPOINT_SESSION_ID` is still regenerated for the child by `_agent_process_env`.
- `backend/src/waypoint/api.py` — add body-less `POST /api/sessions/{session_id}/clone` behind the existing token dependency, returning the normal redacted `{ "session": ... }` envelope. No environment mapping ever crosses the API boundary.

### Frontend
- `frontend/src/lib/api.ts` — add `cloneSession(host, token, sessionId)`, a body-less POST mirroring `forkSession`'s error handling and return shape.
- `frontend/src/components/SessionDetail.tsx` — the `/new` branch calls `cloneSession` instead of assembling a `createSession` payload; command matching, trailing-input delivery, navigation, and auth/error handling are unchanged. This removes the only browser-side attempt to reproduce private launch state.

### Tests
- `backend/tests/test_clone_session_launch.py` (new) — the clone builds the expected request + snapshot; a clone reaches the real codex plugin create path with the source's private env, a distinct id, and a fresh title; the public/list serialization omits `launch_env` while the stored child retains it; a clone reuses the saved effective env even when the recorded profile is no longer configured; an invalid inherited cwd fails with no child persisted; a missing source is 404; the persistent assistant is rejected; and the endpoint is covered (redacted 200, 404, 400 assistant, auth-required).
- `backend/tests/test_runtime.py`, `test_opencode_plugin.py`, `test_claude_tty_controls.py`, `test_side_question.py` — assert the fork contract: for codex, claude_code, opencode, claude_tty, and side-question promotion, the child persists the source `launch_env` and the process env handed to the adapter/command carries the secret with a regenerated `WAYPOINT_SESSION_ID`.

## Design

The clone is a server-side copy of a private snapshot, not another public launch form: a body-less resource action has clear authorization and no way to smuggle or log a secret-bearing request (rejected the alternatives of sending `launch_env` from the browser or broadening `POST /api/sessions` with a `clone_from` id). It reuses `create_session` rather than duplicating backend/transport launch logic, so target/cwd/backend/model validation, transport resolution, storage, account probing, and list broadcasts stay identical to a normal create; the only divergence is the narrow, HTTP-unreachable `clone_snapshot` override that pins the durable effective-env snapshot instead of re-resolving a possibly-edited profile. Pinning `transport=source.transport` keeps `/new` on the source's channel. The fork audit adds assertions at the point where the child process env is built rather than a runtime-level post-fork patch, which would be too late for a child already started with the wrong credentials. No runtime/API path branches on a backend id.

## Test Plan
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pre-commit run --all-files` — isort, black, ruff, codespell, mypy.
- `cd frontend && npm run lint && npm run build` — lint + production build + TypeScript check.
- API-level end-to-end via `httpx.ASGITransport` against the real `create_app` runtime (clone endpoint: redacted 200, 404, 400-assistant, auth).

## Test Result
- `uv run pytest` — 2803 passed (3 pre-existing unrelated warnings); `pre-commit run --all-files` clean (isort/black/ruff/codespell/mypy).
- Frontend `npm run lint` clean; `npm run build` compiled with the TypeScript check passing.
- Clone endpoint exercised end-to-end through the real FastAPI app + runtime pipeline down to the plugin/adapter seam: the response omits `launch_env` while the stored child retains the source secret; missing source → 404; assistant → 400; unauthenticated → 401/403.
- Live browser (Playwright) drive of `/new` was not run: this change is being built inside a live managed Waypoint session on the target backend, and exercising the deployed `/clone` route requires restarting that backend, which would terminate the session mid-ticket. The HTTP+runtime e2e above covers the same server path the browser flow hits.