### PR TITLE
fix: reap telemetry one-shot tmux sessions on teardown

### DIFF
--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -165,10 +165,8 @@ class TmuxPlugin:
         with suppress(TmuxError):
             await runtime.tmux.stop_pipe(target)
         tmux_session = state.get("tmux_session")
-        # Kill the tmux session for every Waypoint-owned source (MANAGED, the
-        # ASSISTANT singleton, throwaway TELEMETRY one-shots). ATTACHED_TMUX is
-        # the sole external-ownership case: its pane belongs to a user-created
-        # tmux target, so we stop our pipe but never kill it.
+        # Kill the runtime-owned tmux session for every source except
+        # ATTACHED_TMUX, whose pane belongs to a user-created target.
         if session.source != SessionSource.ATTACHED_TMUX and tmux_session:
             with suppress(TmuxError):
                 await runtime.tmux.kill_session(tmux_session)

--- a/backend/src/waypoint/backends/tmux/plugin.py
+++ b/backend/src/waypoint/backends/tmux/plugin.py
@@ -165,7 +165,11 @@ class TmuxPlugin:
         with suppress(TmuxError):
             await runtime.tmux.stop_pipe(target)
         tmux_session = state.get("tmux_session")
-        if session.source == SessionSource.MANAGED and tmux_session:
+        # Kill the tmux session for every Waypoint-owned source (MANAGED, the
+        # ASSISTANT singleton, throwaway TELEMETRY one-shots). ATTACHED_TMUX is
+        # the sole external-ownership case: its pane belongs to a user-created
+        # tmux target, so we stop our pipe but never kill it.
+        if session.source != SessionSource.ATTACHED_TMUX and tmux_session:
             with suppress(TmuxError):
                 await runtime.tmux.kill_session(tmux_session)
         monitor = runtime.monitor_tasks.pop(session.id, None)

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -705,6 +705,89 @@ async def test_restore_session_attached_dead_pane_flips_back_to_exited(
     assert runtime.updates == []
 
 
+def _terminable_session(
+    sid: str, source: SessionSource, tmp_path: Path
+) -> SessionRecord:
+    """A running tmux-wrapped session with pane + tmux-session coordinates,
+    used to drive ``terminate_session`` and assert the ownership guard."""
+    now = datetime.now(UTC)
+    return SessionRecord(
+        id=sid,
+        backend="claude_code",
+        source=source,
+        transport="tmux",
+        title="t",
+        cwd="/Users/me/proj",
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        updated_at=now,
+        last_event_at=now,
+        transport_state={
+            "tmux_session": f"{sid}-tmux",
+            "tmux_window": "0",
+            "tmux_pane": f"{sid}-p",
+            "pid": 4242,
+        },
+        raw_log_path=str(tmp_path / f"{sid}.raw.log"),
+        structured_log_path=str(tmp_path / f"{sid}.events.jsonl"),
+    )
+
+
+async def _idle_task() -> None:
+    await asyncio.sleep(3600)
+
+
+@pytest.mark.asyncio
+async def test_terminate_telemetry_kills_owned_tmux_and_cancels_watchers(
+    plugin: TmuxPlugin, tmp_path: Path
+) -> None:
+    """A throwaway TELEMETRY one-shot is Waypoint-owned: terminate must stop
+    the pipe for its pane, kill its tmux session exactly once, and cancel the
+    monitor/thread-id/rate-limit watchers. Regression for the leak where the
+    managed-only guard skipped ``kill_session`` for the relabeled row, orphaning
+    the tmux server and its claude process."""
+    runtime = _FakeRuntime(inner_plugin=_FakeAgentPlugin(pregenerates=True))
+    session = _terminable_session("sess-tel", SessionSource.TELEMETRY, tmp_path)
+    monitor = asyncio.create_task(_idle_task())
+    thread_watcher = asyncio.create_task(_idle_task())
+    rl_watcher = asyncio.create_task(_idle_task())
+    runtime.monitor_tasks[session.id] = monitor
+    runtime._thread_id_watchers[session.id] = thread_watcher
+    runtime._rate_limit_watchers[session.id] = rl_watcher
+
+    await plugin.terminate_session(cast(Any, runtime), session)
+
+    assert runtime.tmux.stop_pipe_calls == ["sess-tel-p"]
+    assert runtime.tmux.kill_calls == ["sess-tel-tmux"]
+    assert session.id not in runtime.monitor_tasks
+    assert session.id not in runtime._thread_id_watchers
+    assert session.id not in runtime._rate_limit_watchers
+    assert monitor.cancelled()
+    assert thread_watcher.cancelled()
+    assert rl_watcher.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_terminate_attached_tmux_stops_pipe_but_never_kills(
+    plugin: TmuxPlugin, tmp_path: Path
+) -> None:
+    """An ATTACHED_TMUX session's tmux target is user-owned: terminate must
+    stop Waypoint's pipe and cancel local watchers but must never kill the
+    user's tmux session. Direct lifecycle guard — the reattach test alone does
+    not exercise ``terminate_session``."""
+    runtime = _FakeRuntime(inner_plugin=_FakeAgentPlugin(pregenerates=True))
+    session = _terminable_session("sess-att", SessionSource.ATTACHED_TMUX, tmp_path)
+    monitor = asyncio.create_task(_idle_task())
+    runtime.monitor_tasks[session.id] = monitor
+
+    await plugin.terminate_session(cast(Any, runtime), session)
+
+    assert runtime.tmux.stop_pipe_calls == ["sess-att-p"]
+    assert runtime.tmux.kill_calls == []
+    assert session.id not in runtime.monitor_tasks
+    assert monitor.cancelled()
+
+
 @pytest.mark.asyncio
 async def test_import_thread_via_resume_claude_builds_resume_command(
     plugin: TmuxPlugin,

--- a/backend/tests/test_tmux_plugin.py
+++ b/backend/tests/test_tmux_plugin.py
@@ -708,8 +708,7 @@ async def test_restore_session_attached_dead_pane_flips_back_to_exited(
 def _terminable_session(
     sid: str, source: SessionSource, tmp_path: Path
 ) -> SessionRecord:
-    """A running tmux-wrapped session with pane + tmux-session coordinates,
-    used to drive ``terminate_session`` and assert the ownership guard."""
+    """A running tmux-wrapped session with pane + tmux-session coordinates."""
     now = datetime.now(UTC)
     return SessionRecord(
         id=sid,
@@ -738,54 +737,37 @@ async def _idle_task() -> None:
 
 
 @pytest.mark.asyncio
-async def test_terminate_telemetry_kills_owned_tmux_and_cancels_watchers(
+async def test_terminate_telemetry_kills_owned_tmux(
     plugin: TmuxPlugin, tmp_path: Path
 ) -> None:
-    """A throwaway TELEMETRY one-shot is Waypoint-owned: terminate must stop
-    the pipe for its pane, kill its tmux session exactly once, and cancel the
-    monitor/thread-id/rate-limit watchers. Regression for the leak where the
-    managed-only guard skipped ``kill_session`` for the relabeled row, orphaning
-    the tmux server and its claude process."""
+    """A Waypoint-owned TELEMETRY one-shot: terminate stops the pipe, kills the
+    tmux session once, and cancels the session's monitor."""
     runtime = _FakeRuntime(inner_plugin=_FakeAgentPlugin(pregenerates=True))
     session = _terminable_session("sess-tel", SessionSource.TELEMETRY, tmp_path)
     monitor = asyncio.create_task(_idle_task())
-    thread_watcher = asyncio.create_task(_idle_task())
-    rl_watcher = asyncio.create_task(_idle_task())
     runtime.monitor_tasks[session.id] = monitor
-    runtime._thread_id_watchers[session.id] = thread_watcher
-    runtime._rate_limit_watchers[session.id] = rl_watcher
 
     await plugin.terminate_session(cast(Any, runtime), session)
 
     assert runtime.tmux.stop_pipe_calls == ["sess-tel-p"]
     assert runtime.tmux.kill_calls == ["sess-tel-tmux"]
     assert session.id not in runtime.monitor_tasks
-    assert session.id not in runtime._thread_id_watchers
-    assert session.id not in runtime._rate_limit_watchers
     assert monitor.cancelled()
-    assert thread_watcher.cancelled()
-    assert rl_watcher.cancelled()
 
 
 @pytest.mark.asyncio
-async def test_terminate_attached_tmux_stops_pipe_but_never_kills(
+async def test_terminate_attached_tmux_never_kills(
     plugin: TmuxPlugin, tmp_path: Path
 ) -> None:
-    """An ATTACHED_TMUX session's tmux target is user-owned: terminate must
-    stop Waypoint's pipe and cancel local watchers but must never kill the
-    user's tmux session. Direct lifecycle guard — the reattach test alone does
-    not exercise ``terminate_session``."""
+    """A user-owned ATTACHED_TMUX session: terminate stops the pipe but never
+    kills the tmux session."""
     runtime = _FakeRuntime(inner_plugin=_FakeAgentPlugin(pregenerates=True))
     session = _terminable_session("sess-att", SessionSource.ATTACHED_TMUX, tmp_path)
-    monitor = asyncio.create_task(_idle_task())
-    runtime.monitor_tasks[session.id] = monitor
 
     await plugin.terminate_session(cast(Any, runtime), session)
 
     assert runtime.tmux.stop_pipe_calls == ["sess-att-p"]
     assert runtime.tmux.kill_calls == []
-    assert session.id not in runtime.monitor_tasks
-    assert monitor.cancelled()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Telemetry NL-insight one-shots (`SessionSource.TELEMETRY`, tmux-backed via `run_oneshot`) leaked their tmux session, `claude` process, and `lumid_mcp.server` child on every teardown. `TmuxPlugin.terminate_session` issued `tmux kill-session` only for `SessionSource.MANAGED`, so the relabeled `TELEMETRY` row was deleted while its tmux server stayed alive, and the boot reaper never saw it. Implements `.waypoint/specs/rfc-1387-telemetry-oneshot-tmux-teardown.md` (Ticket 1387). No new source, field, API, or migration.

## Changes

### Backend
- `backend/src/waypoint/backends/tmux/plugin.py` — `terminate_session` kills the tmux session for every source except `ATTACHED_TMUX`. `MANAGED`, `ASSISTANT`, and `TELEMETRY` tear down their tmux server; a user-attached pane is left running. Pipe-stop, `TmuxError` suppression, and watcher cancellation are unchanged.

### Tests
- `backend/tests/test_tmux_plugin.py` — a `TELEMETRY` terminate stops the pipe, kills the tmux session once, and cancels the monitor; an `ATTACHED_TMUX` terminate stops the pipe and makes no `kill_session` call.

## Design

The guard lives in the generic tmux transport and keys on `SessionSource`, covering `claude_code` + `claude_tty` and any tmux-wrapped one-shot without a backend branch. `ATTACHED_TMUX` is the only source whose tmux server Waypoint did not create; every other source originates from a Waypoint launch. Teardown stays idempotent and best-effort: a missing or already-dead target is suppressed and local cleanup continues.

## Test Plan
- `cd backend && uv run pytest`
- `cd backend && uv run pre-commit run --all-files`
- Restart the stack and drive telemetry NL-insight Generate; confirm the one-shot's tmux session and `claude --model haiku` process do not survive teardown.

## Test Result
- `uv run pytest` — 2805 passed; `pre-commit run --all-files` clean (isort/black/ruff/codespell/mypy).
- End-to-end on the redeployed stack: each `POST /api/telemetry/nl-insight` spawned a `claude_tty` one-shot (a fresh `claude_code-*` tmux session plus a `claude --model haiku` process) and generated the digest (`has_insight: true`), then reaped both — the tmux session set returned to its pre-run baseline and no `--model haiku` process survived. Verified across two runs; the one-shot row is deleted as before.