### PR TITLE
feat: add optional context window for custom Claude models

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -17,6 +17,7 @@ from typing import Any
 from waypoint.attachments import ResolvedAttachment, append_attachment_paths
 from waypoint.backends.approvals import is_approve_decision
 from waypoint.backends.claude_code.models import (
+    ClaudeContextWindowResolver,
     claude_context_window_for_model,
     claude_model_family,
     normalize_claude_model_id,
@@ -400,6 +401,9 @@ class ClaudeCliAdapter:
         on_session_update: SessionUpdateCallback | None = None,
         on_token_usage: TokenUsageCallback | None = None,
         default_model_id: str | None = None,
+        context_window_resolver: ClaudeContextWindowResolver = (
+            claude_context_window_for_model
+        ),
     ) -> None:
         self._emit_event = emit_event
         self._binary = binary
@@ -408,6 +412,7 @@ class ClaudeCliAdapter:
         self._on_session_update = on_session_update
         self._on_token_usage = on_token_usage
         self._default_model_id = normalize_claude_model_id(default_model_id)
+        self._context_window_resolver = context_window_resolver
         self._sessions: dict[str, ClaudeSessionState] = {}
         # Folded todo state stashed by terminate_session and consumed by the
         # next resume-spawn, so a respawn (set_effort, reattach) restores the
@@ -1788,6 +1793,7 @@ class ClaudeCliAdapter:
         snapshot = _context_usage_snapshot_from_message(
             state.model,
             usage if isinstance(usage, dict) else {},
+            self._context_window_resolver,
         )
         if snapshot is not None:
             state.context_usage_snapshot = snapshot
@@ -2036,7 +2042,7 @@ class ClaudeCliAdapter:
         model = state.model or self._default_model_id
         if model is None:
             return
-        context_window_tokens = claude_context_window_for_model(model)
+        context_window_tokens = self._context_window_resolver(model)
         if context_window_tokens is None:
             return
         if snapshot.context_window_tokens == context_window_tokens:
@@ -2066,7 +2072,11 @@ class ClaudeCliAdapter:
 
 
 def _context_usage_snapshot_from_message(
-    model: str | None, usage: dict[str, Any]
+    model: str | None,
+    usage: dict[str, Any],
+    context_window_resolver: ClaudeContextWindowResolver = (
+        claude_context_window_for_model
+    ),
 ) -> SessionContextUsage | None:
     input_tokens = _non_negative_int(usage.get("input_tokens"))
     cache_read_input_tokens = _non_negative_int(usage.get("cache_read_input_tokens"))
@@ -2087,7 +2097,7 @@ def _context_usage_snapshot_from_message(
     if used_tokens <= 0:
         return None
 
-    context_window_tokens = claude_context_window_for_model(model)
+    context_window_tokens = context_window_resolver(model)
     if context_window_tokens is None:
         return None
 
@@ -2111,7 +2121,12 @@ def _context_usage_snapshot_from_message(
 
 
 def rebase_claude_context_usage(
-    session: SessionRecord, *, model: str | None = None
+    session: SessionRecord,
+    *,
+    model: str | None = None,
+    context_window_resolver: ClaudeContextWindowResolver = (
+        claude_context_window_for_model
+    ),
 ) -> SessionContextUsage | None:
     """Recompute a stored Claude snapshot's window from the durable model.
 
@@ -2127,14 +2142,18 @@ def rebase_claude_context_usage(
     if snapshot is None:
         return None
     selection = model if model is not None else session.model
-    window = claude_context_window_for_model(selection) if selection else None
+    window = context_window_resolver(selection) if selection else None
     if snapshot.context_window_tokens == window:
         return snapshot
     return snapshot.model_copy(update={"context_window_tokens": window})
 
 
 def seed_context_usage_from_transcript(
-    transcript_path: Path, model: str | None
+    transcript_path: Path,
+    model: str | None,
+    context_window_resolver: ClaudeContextWindowResolver = (
+        claude_context_window_for_model
+    ),
 ) -> SessionContextUsage | None:
     """Initial context snapshot for a freshly-imported thread.
 
@@ -2161,7 +2180,9 @@ def seed_context_usage_from_transcript(
             continue
         message: dict[str, Any] = record.get("message") or {}
         usage: dict[str, Any] = message.get("usage") or {}
-        snapshot = _context_usage_snapshot_from_message(model, usage)
+        snapshot = _context_usage_snapshot_from_message(
+            model, usage, context_window_resolver
+        )
         if snapshot is not None:
             return snapshot
     return None

--- a/backend/src/waypoint/backends/claude_code/history.py
+++ b/backend/src/waypoint/backends/claude_code/history.py
@@ -26,6 +26,10 @@ from waypoint.backends.claude_code.adapter import (
     _context_usage_snapshot_from_message,
     claude_token_usage_record,
 )
+from waypoint.backends.claude_code.models import (
+    ClaudeContextWindowResolver,
+    claude_context_window_for_model,
+)
 from waypoint.backends.claude_code.normalize import (
     is_injected_user_turn,
     iter_content_blocks,
@@ -48,10 +52,13 @@ async def read_local_claude_history(
 
 async def read_local_claude_token_usage_history(
     thread_id: str,
+    context_window_resolver: ClaudeContextWindowResolver = (
+        claude_context_window_for_model
+    ),
 ) -> list[TokenUsageRecord]:
     """Read a local Claude transcript's per-turn ledger rows for thread-history import."""
     records = await asyncio.to_thread(read_local_claude_transcript, thread_id)
-    return token_usage_records_from_history(records)
+    return token_usage_records_from_history(records, context_window_resolver)
 
 
 def convert_transcript_records(
@@ -78,6 +85,9 @@ def convert_transcript_records(
 
 def token_usage_records_from_history(
     records: list[dict[str, Any]],
+    context_window_resolver: ClaudeContextWindowResolver = (
+        claude_context_window_for_model
+    ),
 ) -> list[TokenUsageRecord]:
     """Per-turn ledger rows recoverable from a replayed Claude transcript.
 
@@ -95,7 +105,9 @@ def token_usage_records_from_history(
         message: dict[str, Any] = record.get("message") or {}
         model = str(message.get("model") or "") or None
         usage: dict[str, Any] = message.get("usage") or {}
-        snapshot = _context_usage_snapshot_from_message(model, usage)
+        snapshot = _context_usage_snapshot_from_message(
+            model, usage, context_window_resolver
+        )
         if snapshot is None:
             continue
         record_id = str(message.get("id") or record.get("uuid") or "")

--- a/backend/src/waypoint/backends/claude_code/models.py
+++ b/backend/src/waypoint/backends/claude_code/models.py
@@ -5,7 +5,7 @@ binary; bumped manually when a new alias ships. Codex has a runtime
 ``model/list`` RPC, Claude does not.
 """
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import NamedTuple
 
 from waypoint.schemas import BackendModelOption
@@ -262,6 +262,60 @@ def claude_context_window_for_model(model: str | None) -> int | None:
     if normalized is None:
         return None
     return CLAUDE_CONTEXT_WINDOWS.get(normalized)
+
+
+# A pure "selected model id -> context window tokens" lookup. The static
+# ``claude_context_window_for_model`` is itself a valid resolver and is the
+# default every usage producer falls back to when no configured override applies.
+ClaudeContextWindowResolver = Callable[[str | None], int | None]
+
+
+def configured_context_windows(
+    models: Iterable[BackendModelOption],
+    extra_models: Iterable[BackendModelOption],
+) -> dict[str, int]:
+    """Map configured model ids to their operator-declared context window.
+
+    Only entries carrying a non-null ``context_window`` contribute; the static
+    built-in catalogue (windows unset) never does. ``extra_models`` is overlaid
+    last so it wins a collision with the replacement-style ``models`` list, the
+    same precedence ``merge_model_catalogue`` uses.
+    """
+    mapping: dict[str, int] = {}
+    for option in (*models, *extra_models):
+        if option.context_window is not None:
+            mapping[option.id.strip()] = option.context_window
+    return mapping
+
+
+def resolve_claude_context_window(
+    model: str | None, configured: Mapping[str, int]
+) -> int | None:
+    """Resolve ``model``'s window: exact configured id first, then static table.
+
+    An exact configured id wins over built-in inference (letting an operator
+    override a built-in through replacement semantics); otherwise the static
+    resolver applies, and an id neither source knows resolves to ``None`` rather
+    than a fabricated default.
+    """
+    if isinstance(model, str):
+        window = configured.get(model.strip())
+        if window is not None:
+            return window
+    return claude_context_window_for_model(model)
+
+
+def make_context_window_resolver(
+    models: Iterable[BackendModelOption],
+    extra_models: Iterable[BackendModelOption],
+) -> ClaudeContextWindowResolver:
+    """A resolver bound to a configuration's declared custom windows."""
+    configured = configured_context_windows(models, extra_models)
+    if not configured:
+        # No operator overrides -> the static resolver is exactly equivalent and
+        # avoids an extra dict lookup on every usage update.
+        return claude_context_window_for_model
+    return lambda model: resolve_claude_context_window(model, configured)
 
 
 def claude_default_model_id() -> str | None:

--- a/backend/src/waypoint/backends/claude_code/plugin.py
+++ b/backend/src/waypoint/backends/claude_code/plugin.py
@@ -50,8 +50,11 @@ from waypoint.backends.claude_code.history import (
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
+    ClaudeContextWindowResolver,
+    claude_context_window_for_model,
     claude_default_model_id,
     claude_models_for_version,
+    make_context_window_resolver,
     merge_model_catalogue,
     overridden_builtin_ids,
     resolve_import_model_id,
@@ -326,6 +329,12 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         self.adapter: ClaudeCliAdapter | None = None
         self.support: ClaudeSupportBundle | None = None
         self.thread_enumerator: RemoteClaudeThreadEnumerator | None = None
+        # Rebuilt from the effective config at setup(); the static resolver until
+        # then. rebase_context_usage has no runtime handle, so it reads this
+        # cached value rather than the live Settings.
+        self._context_window_resolver: ClaudeContextWindowResolver = (
+            claude_context_window_for_model
+        )
         self._sq_tasks: dict[str, asyncio.Task[None]] = {}
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
@@ -385,6 +394,10 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # dir, missing scripts, etc.); we log and leave self.adapter=None so
         # the runtime keeps working without Claude support and the tmux
         # fallback path takes over.
+        config = self._config(runtime)
+        self._context_window_resolver = make_context_window_resolver(
+            config.models, config.extra_models
+        )
         try:
             support = ensure_claude_support_bundle(runtime.settings.data_dir)
         except Exception:  # noqa: BLE001
@@ -399,7 +412,8 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             on_init=runtime.handle_completion_source_init,
             on_session_update=runtime.session_update_callback(),
             on_token_usage=runtime.token_usage_callback(),
-            default_model_id=self._config(runtime).default_model_id,
+            default_model_id=config.default_model_id,
+            context_window_resolver=self._context_window_resolver,
         )
         self.thread_enumerator = RemoteClaudeThreadEnumerator(
             support.thread_enumerator_path
@@ -668,6 +682,7 @@ class ClaudeCodePlugin(DefaultLaunchContract):
                 if self.capabilities.config_dir_env_var
                 else None
             ),
+            context_window_resolver=self._context_window_resolver,
         )
 
     def register_routes(self, app: FastAPI, context: Any) -> None:
@@ -777,7 +792,11 @@ class ClaudeCodePlugin(DefaultLaunchContract):
         # ContextUsageRebasing: dispatched by the runtime on the agent plugin,
         # so this one implementation covers every Claude transport (native,
         # claude_tty, tmux). Pure/data-only — see rebase_claude_context_usage.
-        return rebase_claude_context_usage(session, model=model)
+        return rebase_claude_context_usage(
+            session,
+            model=model,
+            context_window_resolver=self._context_window_resolver,
+        )
 
     async def apply_effort(
         self,
@@ -1729,7 +1748,10 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             )
             if artifacts:
                 seeded_context_usage = await asyncio.to_thread(
-                    seed_context_usage_from_transcript, artifacts[0], effective_model
+                    seed_context_usage_from_transcript,
+                    artifacts[0],
+                    effective_model,
+                    self._context_window_resolver,
                 )
         session = SessionRecord(
             id=session_id,
@@ -1814,7 +1836,9 @@ class ClaudeCodePlugin(DefaultLaunchContract):
             # is the only source of per-turn model for the imported turns'
             # ledger (mirrors the remote-skip guard above: no cheap remote
             # transcript read exists yet).
-            for token_record in await read_local_claude_token_usage_history(info.id):
+            for token_record in await read_local_claude_token_usage_history(
+                info.id, self._context_window_resolver
+            ):
                 await runtime.publish_token_usage_record(
                     session.id, token_record, publish=False
                 )

--- a/backend/src/waypoint/backends/claude_code/usage_source.py
+++ b/backend/src/waypoint/backends/claude_code/usage_source.py
@@ -14,6 +14,10 @@ from waypoint.backends.claude_code.adapter import (
     _context_usage_snapshot_from_message,
     claude_token_usage_record,
 )
+from waypoint.backends.claude_code.models import (
+    ClaudeContextWindowResolver,
+    claude_context_window_for_model,
+)
 from waypoint.backends.claude_tty.tailer import transcript_path
 from waypoint.backends.context_usage_source import ContextUsageSource
 
@@ -35,10 +39,14 @@ class TranscriptContextUsageSource(ContextUsageSource):
         cwd: str,
         runtime: "SessionRuntime",
         config_dir: str | None = None,
+        context_window_resolver: ClaudeContextWindowResolver = (
+            claude_context_window_for_model
+        ),
     ) -> None:
         self._session_id = session_id
         self._path = transcript_path(cwd, session_uuid, config_dir)
         self._runtime = runtime
+        self._context_window_resolver = context_window_resolver
         self._offset = 0
         self._context_usage_signature: (
             tuple[int, int | None, tuple[tuple[str, int], ...]] | None
@@ -92,7 +100,9 @@ class TranscriptContextUsageSource(ContextUsageSource):
         model = (session.model if session is not None else None) or (
             str(message.get("model") or "") or None
         )
-        snapshot = _context_usage_snapshot_from_message(model, usage)
+        snapshot = _context_usage_snapshot_from_message(
+            model, usage, self._context_window_resolver
+        )
         if snapshot is None:
             return
         # The ledger's model is the concrete resolved id for *this* turn, taken

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -40,7 +40,10 @@ from waypoint.backends.base import (
 )
 from waypoint.backends.capabilities import BackendCapabilities, ModelSource
 from waypoint.backends.claude_code import side_question as _sq
-from waypoint.backends.claude_code.adapter import seed_context_usage_from_transcript
+from waypoint.backends.claude_code.adapter import (
+    rebase_claude_context_usage,
+    seed_context_usage_from_transcript,
+)
 from waypoint.backends.claude_code.commands import list_claude_command_completions
 from waypoint.backends.claude_code.history import (
     read_local_claude_history,
@@ -49,7 +52,10 @@ from waypoint.backends.claude_code.history import (
 from waypoint.backends.claude_code.models import (
     CLAUDE_EFFORT_LEVELS,
     DEFAULT_CLAUDE_MODELS,
+    ClaudeContextWindowResolver,
+    claude_context_window_for_model,
     claude_default_model_id,
+    make_context_window_resolver,
     resolve_import_model_id,
 )
 from waypoint.backends.claude_code.plugin import (
@@ -88,6 +94,7 @@ from waypoint.schemas import (
     CompletionDispatch,
     EventKind,
     EventRecord,
+    SessionContextUsage,
     SessionCreateRequest,
     SessionRateLimitUsage,
     SessionRecord,
@@ -207,6 +214,12 @@ class ClaudeTtyPlugin:
         self._tailer_tasks: dict[str, asyncio.Task[None]] = {}
         self._pending_approvals: dict[str, PendingTtyApproval] = {}
         self._pending_questions: dict[str, PendingTtyQuestion] = {}
+        # Rebuilt from the effective config at setup(); the static resolver until
+        # then. Threaded into the tailer, import seeding, and rebase so a custom
+        # model's configured window applies on this transport too.
+        self._context_window_resolver: ClaudeContextWindowResolver = (
+            claude_context_window_for_model
+        )
 
     def transport_view(self, runtime: "SessionRuntime") -> TransportAdapter:
         from waypoint.backends.claude_tty.transport import ClaudeTtyTransport
@@ -216,7 +229,10 @@ class ClaudeTtyPlugin:
     # ── Composed transport infrastructure (tmux pane wrapper) ────────────────
 
     def setup(self, runtime: "SessionRuntime") -> None:
-        return None
+        config = self._config(runtime)
+        self._context_window_resolver = make_context_window_resolver(
+            config.models, config.extra_models
+        )
 
     async def start_background_tasks(self, runtime: "SessionRuntime") -> None:
         # claude_code's recovery sweep only covers its own backend id, so legacy
@@ -233,6 +249,19 @@ class ClaudeTtyPlugin:
         self, session: SessionRecord, runtime: "SessionRuntime"
     ) -> "ContextUsageSource | None":
         return None
+
+    def rebase_context_usage(
+        self, session: SessionRecord, *, model: str | None = None
+    ) -> SessionContextUsage | None:
+        # ContextUsageRebasing for backend=claude_tty rows (dispatched on the
+        # agent id, which is this alias — not claude_code). Shares the pure
+        # rebaser with the native transport so a model/transport swap refreshes
+        # the window from the configured custom capacity here too.
+        return rebase_claude_context_usage(
+            session,
+            model=model,
+            context_window_resolver=self._context_window_resolver,
+        )
 
     def register_routes(self, app: Any, context: Any) -> None:
         return None
@@ -545,6 +574,7 @@ class ClaudeTtyPlugin:
             plugin=self,
             start_at_end=start_at_end,
             config_dir=config_dir,
+            context_window_resolver=self._context_window_resolver,
         )
         self._tailer_tasks[session_id] = asyncio.create_task(tailer.run())
 
@@ -1438,7 +1468,10 @@ class ClaudeTtyPlugin:
         artifacts = local_claude_thread_artifacts(request.thread_id, config_dir)
         if artifacts:
             seeded_context_usage = await asyncio.to_thread(
-                seed_context_usage_from_transcript, artifacts[0], effective_model
+                seed_context_usage_from_transcript,
+                artifacts[0],
+                effective_model,
+                self._context_window_resolver,
             )
 
         now = datetime.now(UTC)
@@ -1485,7 +1518,7 @@ class ClaudeTtyPlugin:
             # the resumed tailer starts at EOF (below), so this is the only
             # source of per-turn model/effort for the imported turns' ledger.
             for token_record in await read_local_claude_token_usage_history(
-                request.thread_id
+                request.thread_id, self._context_window_resolver
             ):
                 await runtime.publish_token_usage_record(
                     session.id, token_record, publish=False

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -60,6 +60,7 @@ from waypoint.backends.claude_code.models import (
 )
 from waypoint.backends.claude_code.plugin import (
     ClaudeCodePlugin,
+    ClaudeCodePluginConfig,
     log_extra_model_overrides,
     offered_claude_models,
     raise_for_unsupported_selection,
@@ -214,9 +215,11 @@ class ClaudeTtyPlugin:
         self._tailer_tasks: dict[str, asyncio.Task[None]] = {}
         self._pending_approvals: dict[str, PendingTtyApproval] = {}
         self._pending_questions: dict[str, PendingTtyQuestion] = {}
-        # Rebuilt from the effective config at setup(); the static resolver until
-        # then. Threaded into the tailer, import seeding, and rebase so a custom
-        # model's configured window applies on this transport too.
+        # Resolver from this transport's own config, used only by the
+        # backend=claude_tty rebase hook (the sole path with no runtime handle to
+        # read the session's agent config). The per-session tailer/seed/import
+        # paths build from the driven agent's config via
+        # _context_window_resolver_for instead.
         self._context_window_resolver: ClaudeContextWindowResolver = (
             claude_context_window_for_model
         )
@@ -233,6 +236,24 @@ class ClaudeTtyPlugin:
         self._context_window_resolver = make_context_window_resolver(
             config.models, config.extra_models
         )
+
+    def _context_window_resolver_for(
+        self, runtime: "SessionRuntime", backend_id: str
+    ) -> ClaudeContextWindowResolver:
+        """Resolver built from the driven session's AGENT config, not this
+        transport's own.
+
+        ``claude_tty`` is a transport that also drives the ``claude_code``
+        agent, and the custom-model catalogue (with its ``context_window``)
+        lives under the agent's config block. Resolve from ``backend_id``'s
+        config so a claude_code session over this transport honors the same
+        windows its own catalogue advertises; a standalone ``backend=claude_tty``
+        session reads the claude_tty block identically.
+        """
+        config = runtime.settings.plugin_config(backend_id)
+        if isinstance(config, (ClaudeCodePluginConfig, ClaudeTtyPluginConfig)):
+            return make_context_window_resolver(config.models, config.extra_models)
+        return claude_context_window_for_model
 
     async def start_background_tasks(self, runtime: "SessionRuntime") -> None:
         # claude_code's recovery sweep only covers its own backend id, so legacy
@@ -256,7 +277,9 @@ class ClaudeTtyPlugin:
         # ContextUsageRebasing for backend=claude_tty rows (dispatched on the
         # agent id, which is this alias — not claude_code). Shares the pure
         # rebaser with the native transport so a model/transport swap refreshes
-        # the window from the configured custom capacity here too.
+        # the window from the configured custom capacity here too. This hook has
+        # no runtime handle, but it only ever fires for backend=claude_tty, whose
+        # config is exactly what the setup-cached resolver holds.
         return rebase_claude_context_usage(
             session,
             model=model,
@@ -567,6 +590,8 @@ class ClaudeTtyPlugin:
             source = RemoteClaudeTranscriptByteSource(
                 runtime, session_id, self, launch_target, config_dir
             )
+        session = runtime.storage.get_session(session_id)
+        backend_id = session.backend if session is not None else self.id
         tailer = TranscriptTailer(
             session_id=session_id,
             source=source,
@@ -574,7 +599,9 @@ class ClaudeTtyPlugin:
             plugin=self,
             start_at_end=start_at_end,
             config_dir=config_dir,
-            context_window_resolver=self._context_window_resolver,
+            context_window_resolver=self._context_window_resolver_for(
+                runtime, backend_id
+            ),
         )
         self._tailer_tasks[session_id] = asyncio.create_task(tailer.run())
 
@@ -1471,7 +1498,7 @@ class ClaudeTtyPlugin:
                 seed_context_usage_from_transcript,
                 artifacts[0],
                 effective_model,
-                self._context_window_resolver,
+                self._context_window_resolver_for(runtime, backend),
             )
 
         now = datetime.now(UTC)
@@ -1518,7 +1545,7 @@ class ClaudeTtyPlugin:
             # the resumed tailer starts at EOF (below), so this is the only
             # source of per-turn model/effort for the imported turns' ledger.
             for token_record in await read_local_claude_token_usage_history(
-                request.thread_id, self._context_window_resolver
+                request.thread_id, self._context_window_resolver_for(runtime, backend)
             ):
                 await runtime.publish_token_usage_record(
                     session.id, token_record, publish=False

--- a/backend/src/waypoint/backends/claude_tty/tailer.py
+++ b/backend/src/waypoint/backends/claude_tty/tailer.py
@@ -19,6 +19,10 @@ from waypoint.backends.claude_code.adapter import (
     _context_usage_snapshot_from_message,
     claude_token_usage_record,
 )
+from waypoint.backends.claude_code.models import (
+    ClaudeContextWindowResolver,
+    claude_context_window_for_model,
+)
 from waypoint.backends.claude_code.normalize import format_approval_text
 from waypoint.backends.claude_tty import pane_dialog
 from waypoint.backends.claude_tty._state import PendingTtyApproval, PendingTtyQuestion
@@ -72,11 +76,15 @@ class TranscriptTailer:
         *,
         start_at_end: bool = False,
         config_dir: str | None = None,
+        context_window_resolver: ClaudeContextWindowResolver = (
+            claude_context_window_for_model
+        ),
     ) -> None:
         self._session_id = session_id
         self._source = source
         self._runtime = runtime
         self._plugin = plugin
+        self._context_window_resolver = context_window_resolver
         self._normalizer = TranscriptNormalizer(config_dir)
         self._pane_check_elapsed = 0.0
         self._dialog_check_elapsed = 0.0
@@ -220,7 +228,9 @@ class TranscriptTailer:
         model = (session.model if session is not None else None) or (
             str(message.get("model") or "") or None
         )
-        snapshot = _context_usage_snapshot_from_message(model, usage)
+        snapshot = _context_usage_snapshot_from_message(
+            model, usage, self._context_window_resolver
+        )
         if snapshot is None:
             return
         # The ledger's model is the concrete resolved id for *this* turn, taken

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1,3 +1,4 @@
+import re
 from collections.abc import Mapping
 from datetime import datetime
 from enum import StrEnum
@@ -1298,6 +1299,44 @@ class LaunchSettingsResponse(BaseModel):
     requires_restart: bool = True
 
 
+_CONTEXT_WINDOW_UNITS: dict[str, int] = {"": 1, "k": 1_000, "m": 1_000_000}
+_CONTEXT_WINDOW_RE = re.compile(r"([0-9]+)([kKmM]?)")
+
+
+def _parse_context_window(value: Any) -> int | None:
+    """Normalize an operator ``context_window`` into a positive token count.
+
+    Accepts a positive YAML integer or a string of a positive decimal integer
+    optionally suffixed with case-insensitive ``k`` (×1,000) or ``m``
+    (×1,000,000). Rejects booleans, non-positive values, decimals, embedded
+    whitespace, and unknown units rather than guessing.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("context_window must be a token count, not a boolean")
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError("context_window must be a positive integer token count")
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        match = _CONTEXT_WINDOW_RE.fullmatch(text)
+        if match is None:
+            raise ValueError(
+                f"invalid context_window {value!r}: expected a positive integer "
+                "optionally suffixed with 'k' or 'm' (e.g. 200000, '256k', '1m')"
+            )
+        tokens = int(match.group(1)) * _CONTEXT_WINDOW_UNITS[match.group(2).lower()]
+        if tokens <= 0:
+            raise ValueError("context_window must be greater than zero")
+        return tokens
+    raise ValueError(
+        f"invalid context_window {value!r}: expected an integer or a string "
+        "like '256k' or '1m'"
+    )
+
+
 class BackendModelOption(BaseModel):
     id: str
     label: str
@@ -1310,6 +1349,11 @@ class BackendModelOption(BaseModel):
     #   list -> the accepted set; membership is enforced
     supported_efforts: list[str] | None = None
     default_effort: str | None = None
+    # Operator-declared context capacity in tokens for a custom model whose id
+    # is absent from the static Claude catalogue. Accepts an int or a compact
+    # "256k"/"1m" string, normalized to a positive token count; reporting-only,
+    # never passed to the CLI.
+    context_window: Annotated[int | None, BeforeValidator(_parse_context_window)] = None
 
 
 class BackendModelListResponse(BaseModel):

--- a/backend/tests/test_claude_code_usage_source.py
+++ b/backend/tests/test_claude_code_usage_source.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from waypoint.backends.claude_code.models import make_context_window_resolver
 from waypoint.backends.claude_code.usage_source import TranscriptContextUsageSource
+from waypoint.schemas import BackendModelOption
 
 
 def _make_runtime(
@@ -264,6 +266,33 @@ async def test_session_model_overrides_transcript_for_1m_window(tmp_path: Path) 
     record = _assistant_record(
         model="claude-opus-4-8",
         usage={"input_tokens": 20, "cache_read_input_tokens": 5, "output_tokens": 3},
+    )
+    with patch.object(source, "_read_new_bytes", return_value=_jsonl(record)):
+        await source._drain()
+    snapshot = runtime.update_session_fields.call_args.kwargs["context_usage"]
+    assert snapshot.context_window_tokens == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_configured_custom_model_publishes_declared_window(
+    tmp_path: Path,
+) -> None:
+    # A custom durable model absent from the static table: the injected resolver
+    # supplies the configured window as the pill denominator.
+    runtime = _make_runtime(session_model="kimi-k3[1m]")
+    resolver = make_context_window_resolver(
+        [],
+        [BackendModelOption(id="kimi-k3[1m]", label="Kimi K3", context_window="1m")],
+    )
+    source = TranscriptContextUsageSource(
+        session_id="sess-1",
+        session_uuid="uuid-1",
+        cwd=str(tmp_path),
+        runtime=runtime,
+        context_window_resolver=resolver,
+    )
+    record = _assistant_record(
+        model="kimi-k3-0711", usage={"input_tokens": 20, "output_tokens": 3}
     )
     with patch.object(source, "_read_new_bytes", return_value=_jsonl(record)):
         await source._drain()

--- a/backend/tests/test_context_window_provenance.py
+++ b/backend/tests/test_context_window_provenance.py
@@ -17,13 +17,22 @@ from waypoint.backends.claude_code.adapter import (
     rebase_claude_context_usage,
     seed_context_usage_from_transcript,
 )
-from waypoint.backends.claude_code.models import resolve_import_model_id
+from waypoint.backends.claude_code.models import (
+    make_context_window_resolver,
+    resolve_import_model_id,
+)
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.schemas import (
+    BackendModelOption,
     SessionContextUsage,
     SessionRecord,
     SessionSource,
     SessionStatus,
+)
+
+# A resolver for a custom gateway model absent from the static Claude table.
+_CUSTOM_RESOLVER = make_context_window_resolver(
+    [], [BackendModelOption(id="kimi-k3[1m]", label="Kimi K3", context_window="1m")]
 )
 
 
@@ -108,6 +117,17 @@ def test_rebase_no_snapshot_returns_none() -> None:
     assert rebase_claude_context_usage(session) is None
 
 
+def test_rebase_uses_configured_custom_window() -> None:
+    # A custom id has no static window; the configured resolver supplies it so a
+    # model/transport swap rebases the pill to the operator-declared capacity.
+    session = _session("kimi-k3[1m]", _usage_snapshot(None))
+    rebased = rebase_claude_context_usage(
+        session, context_window_resolver=_CUSTOM_RESOLVER
+    )
+    assert rebased is not None
+    assert rebased.context_window_tokens == 1_000_000
+
+
 def test_rebase_same_window_returns_unchanged_snapshot() -> None:
     # Idempotency signal: an already-correct window round-trips the same object
     # so the runtime can skip the write/broadcast.
@@ -161,6 +181,22 @@ def test_seed_skips_sidechain_records(tmp_path) -> None:
     assert snapshot is not None
     # The subagent (sidechain) turn is skipped; the main turn wins.
     assert snapshot.used_tokens == 500
+
+
+def test_seed_uses_configured_custom_window(tmp_path) -> None:
+    # Seeding an imported thread whose durable model is a custom id resolves the
+    # denominator from configuration rather than dropping the snapshot.
+    transcript = tmp_path / "thread.jsonl"
+    transcript.write_text(
+        _assistant_line({"input_tokens": 300, "cache_read_input_tokens": 40}),
+        encoding="utf-8",
+    )
+    snapshot = seed_context_usage_from_transcript(
+        transcript, "kimi-k3[1m]", _CUSTOM_RESOLVER
+    )
+    assert snapshot is not None
+    assert snapshot.used_tokens == 340
+    assert snapshot.context_window_tokens == 1_000_000
 
 
 def test_seed_missing_file_returns_none(tmp_path) -> None:
@@ -224,5 +260,41 @@ async def test_tailer_uses_durable_1m_model_over_transcript_resolved_id() -> Non
     await tailer._drain()
 
     runtime.update_session_fields.assert_called_once()
+    snapshot = runtime.update_session_fields.call_args.kwargs["context_usage"]
+    assert snapshot.context_window_tokens == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_tailer_uses_configured_custom_window() -> None:
+    # A custom durable model absent from the static table: the injected resolver
+    # supplies the window on this transport too.
+    session = _session("kimi-k3[1m]", None)
+    runtime = MagicMock()
+    runtime.storage.get_session.return_value = session
+    runtime.update_session_fields = AsyncMock()
+    runtime.publish_token_usage_record = AsyncMock()
+    runtime._emit_adapter_event = AsyncMock()
+
+    record = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "model": "kimi-k3-0711",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {"input_tokens": 42, "output_tokens": 1},
+        },
+    }
+    data = (json.dumps(record) + "\n").encode()
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    tailer = TranscriptTailer(
+        session_id="sess-1",
+        source=_FeedOnceSource(data),
+        runtime=runtime,
+        plugin=plugin,
+        context_window_resolver=_CUSTOM_RESOLVER,
+    )
+    await tailer._drain()
+
     snapshot = runtime.update_session_fields.call_args.kwargs["context_usage"]
     assert snapshot.context_window_tokens == 1_000_000

--- a/backend/tests/test_custom_model_context_window.py
+++ b/backend/tests/test_custom_model_context_window.py
@@ -5,6 +5,9 @@ Covers the two pure units of ticket 1405 -- the ``BackendModelOption``
 independent of any transport wiring.
 """
 
+from types import SimpleNamespace
+from typing import Any, cast
+
 import pytest
 from pydantic import ValidationError
 
@@ -14,6 +17,8 @@ from waypoint.backends.claude_code.models import (
     make_context_window_resolver,
     resolve_claude_context_window,
 )
+from waypoint.backends.claude_code.plugin import ClaudeCodePluginConfig
+from waypoint.backends.claude_tty.plugin import ClaudeTtyPlugin, ClaudeTtyPluginConfig
 from waypoint.schemas import BackendModelOption
 
 
@@ -131,3 +136,35 @@ def test_make_resolver_without_overrides_is_the_static_resolver() -> None:
         [BackendModelOption(id="opus", label="Opus")], []
     )
     assert resolver is claude_context_window_for_model
+
+
+# ── claude_tty transport resolves from the DRIVEN agent's config ───────────
+
+
+def test_claude_tty_resolver_reads_driven_agent_config() -> None:
+    # Regression: claude_tty is a transport that also drives the claude_code
+    # agent, and a custom model's context_window lives under the AGENT's config
+    # block. The transport must resolve from the session's backend config, not
+    # its own claude_tty block -- otherwise a claude_code session on its default
+    # claude_tty transport falls back to the static window and the pill is wrong.
+    configs = {
+        "claude_code": ClaudeCodePluginConfig(
+            extra_models=[
+                BackendModelOption(id="kimi-k3[1m]", label="Kimi", context_window="1m")
+            ]
+        ),
+        "claude_tty": ClaudeTtyPluginConfig(),  # no custom models here
+    }
+    runtime = SimpleNamespace(
+        settings=SimpleNamespace(plugin_config=lambda pid: configs[pid])
+    )
+    plugin = ClaudeTtyPlugin()
+
+    agent_resolver = plugin._context_window_resolver_for(
+        cast(Any, runtime), "claude_code"
+    )
+    assert agent_resolver("kimi-k3[1m]") == 1_000_000
+
+    # Reading its own (empty) claude_tty config would return None -- the bug.
+    own_resolver = plugin._context_window_resolver_for(cast(Any, runtime), "claude_tty")
+    assert own_resolver("kimi-k3[1m]") is None

--- a/backend/tests/test_custom_model_context_window.py
+++ b/backend/tests/test_custom_model_context_window.py
@@ -1,0 +1,133 @@
+"""Custom-model ``context_window``: schema parsing and the unified resolver.
+
+Covers the two pure units of ticket 1405 -- the ``BackendModelOption``
+``context_window`` grammar and the configured-then-static Claude resolver --
+independent of any transport wiring.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from waypoint.backends.claude_code.models import (
+    claude_context_window_for_model,
+    configured_context_windows,
+    make_context_window_resolver,
+    resolve_claude_context_window,
+)
+from waypoint.schemas import BackendModelOption
+
+
+def _model(model_id: str, context_window: object) -> BackendModelOption:
+    return BackendModelOption(
+        id=model_id, label=model_id, context_window=context_window
+    )
+
+
+# ── Schema grammar ────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (256_000, 256_000),
+        ("256000", 256_000),
+        ("256k", 256_000),
+        ("256K", 256_000),
+        ("1m", 1_000_000),
+        ("1M", 1_000_000),
+        ("  1m  ", 1_000_000),
+        (200_000, 200_000),
+    ],
+)
+def test_context_window_accepts_and_normalizes(value: object, expected: int) -> None:
+    assert _model("kimi-k3[1m]", value).context_window == expected
+
+
+def test_context_window_absent_defaults_to_none() -> None:
+    assert BackendModelOption(id="x", label="X").context_window is None
+
+
+def test_context_window_explicit_null_is_none() -> None:
+    assert _model("x", None).context_window is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    [True, 0, -1, "1.5m", "256 k", "2g", "", "  ", "abc", "0", "1.5", 1.5],
+)
+def test_context_window_rejects_invalid(value: object) -> None:
+    with pytest.raises(ValidationError) as exc:
+        _model("x", value)
+    # The field-specific error names the offending field so an operator can fix
+    # the exact line in waypoint.yaml.
+    assert "context_window" in str(exc.value)
+
+
+# ── configured_context_windows ────────────────────────────────────────────
+
+
+def test_configured_windows_keeps_only_declared_entries() -> None:
+    mapping = configured_context_windows(
+        [BackendModelOption(id="opus", label="Opus")],  # no context_window
+        [_model("kimi-k3[1m]", "1m")],
+    )
+    assert mapping == {"kimi-k3[1m]": 1_000_000}
+
+
+def test_configured_windows_extra_overlays_models_on_collision() -> None:
+    # extra_models is overlaid last, so it wins a same-id collision with the
+    # replacement-style models list (matching merge_model_catalogue precedence).
+    mapping = configured_context_windows(
+        [_model("opus", "128k")],
+        [_model("opus", "256k")],
+    )
+    assert mapping == {"opus": 256_000}
+
+
+def test_configured_windows_trims_ids() -> None:
+    mapping = configured_context_windows([_model("  spaced  ", "1m")], [])
+    assert mapping == {"spaced": 1_000_000}
+
+
+# ── resolver precedence ───────────────────────────────────────────────────
+
+
+def test_resolver_exact_custom_id_wins() -> None:
+    configured = {"kimi-k3[1m]": 1_000_000}
+    assert resolve_claude_context_window("kimi-k3[1m]", configured) == 1_000_000
+    # Trims the selected id before the exact lookup.
+    assert resolve_claude_context_window("  kimi-k3[1m]  ", configured) == 1_000_000
+
+
+def test_resolver_configured_overrides_builtin() -> None:
+    # An operator may override a built-in id through replacement semantics.
+    configured = {"opus": 256_000}
+    assert resolve_claude_context_window("opus", configured) == 256_000
+
+
+def test_resolver_falls_back_to_static_table() -> None:
+    assert resolve_claude_context_window("opus[1m]", {}) == 1_000_000
+    assert resolve_claude_context_window("claude-opus-4-8", {}) == 200_000
+
+
+def test_resolver_unknown_without_config_is_none() -> None:
+    assert resolve_claude_context_window("gw-mystery", {}) is None
+    assert resolve_claude_context_window(None, {"x": 1}) is None
+
+
+def test_make_resolver_covers_custom_and_static_paths() -> None:
+    resolver = make_context_window_resolver(
+        [BackendModelOption(id="opus", label="Opus")],
+        [_model("kimi-k3[1m]", "1m")],
+    )
+    assert resolver("kimi-k3[1m]") == 1_000_000  # configured custom
+    assert resolver("opus[1m]") == 1_000_000  # static fallback
+    assert resolver("gw-mystery") is None  # neither knows it
+
+
+def test_make_resolver_without_overrides_is_the_static_resolver() -> None:
+    # No declared windows -> the static resolver is returned verbatim (no wrapper).
+    resolver = make_context_window_resolver(
+        [BackendModelOption(id="opus", label="Opus")], []
+    )
+    assert resolver is claude_context_window_for_model

--- a/backend/tests/test_import_history_claude.py
+++ b/backend/tests/test_import_history_claude.py
@@ -7,8 +7,9 @@ from waypoint.backends.claude_code.history import (
     read_local_claude_token_usage_history,
     token_usage_records_from_history,
 )
+from waypoint.backends.claude_code.models import make_context_window_resolver
 from waypoint.backends.claude_code.threads import read_local_claude_transcript
-from waypoint.schemas import EventKind
+from waypoint.schemas import BackendModelOption, EventKind
 
 
 def _assistant_text(
@@ -213,6 +214,25 @@ def test_token_usage_records_from_history_threads_model_no_effort() -> None:
     # turn always surfaces it as unknown rather than guessed.
     assert record.effort is None
     assert record.totals == {"input_tokens": 10, "output_tokens": 5}
+
+
+def test_token_usage_records_from_history_records_configured_custom_model() -> None:
+    # A custom transcript model id absent from the static table would drop as
+    # unresolvable; the configured resolver records it instead of skipping it.
+    records = [
+        _assistant_with_usage(
+            "msg1", "kimi-k3-0711", {"input_tokens": 10, "output_tokens": 5}
+        )
+    ]
+    resolver = make_context_window_resolver(
+        [],
+        [BackendModelOption(id="kimi-k3-0711", label="Kimi K3", context_window="1m")],
+    )
+
+    token_records = token_usage_records_from_history(records, resolver)
+
+    assert len(token_records) == 1
+    assert token_records[0].model == "kimi-k3-0711"
 
 
 def test_token_usage_records_from_history_skips_unresolvable_model() -> None:

--- a/backend/waypoint.example.yaml
+++ b/backend/waypoint.example.yaml
@@ -77,6 +77,12 @@ plugin_configs:
     #   - id: kimi-k3[1m]
     #     label: Kimi K3 (1M context)
     #     description: Custom gateway model
+    #     context_window: 1m               # token capacity for the context pill;
+    #                                      # int (1000000) or "256k"/"1m". Custom
+    #                                      # models aren't in the built-in table,
+    #                                      # so set this to give the pill a
+    #                                      # denominator. Reporting-only -- never
+    #                                      # passed to the CLI as a launch option.
     #     # supported_efforts omitted -> efforts unknown: the picker offers the
     #     # full ladder (low..max) and forwards the choice unvalidated. Set an
     #     # explicit list to enforce it; set [] for a model with no effort knob.
@@ -87,6 +93,7 @@ plugin_configs:
     #   - id: opus
     #     label: Opus 4.7
     #     is_default: true
+    #     context_window: 256k             # valid on replacement entries too
     # account_profiles:                      # named CLAUDE_CONFIG_DIR profiles; see docs/account_profiles.md
     #   personal:
     #     label: Personal


### PR DESCRIPTION
## Purpose

Waypoint knows context windows only through the static `CLAUDE_CONTEXT_WINDOWS` table in `backend/src/waypoint/backends/claude_code/models.py`, so a custom model supplied via `plugin_configs.claude_code.extra_models` (or the replacement-style `models` list) can be selected and its token usage observed, but its context pill has no denominator because its id is absent from that table. This adds an optional `context_window` field beside the custom-model definition and threads one resolution rule through every Claude usage source instead of a one-off fallback in a single adapter. Implements `.waypoint/specs/rfc-1405-custom-model-context-window.md` (Ticket 1405). No storage migration, no schema change on the session/token rows, and no frontend change.

## Changes

### Backend
- `backend/src/waypoint/schemas.py` — add `BackendModelOption.context_window` (a `BeforeValidator`-normalized `int | None`). It accepts a positive YAML integer or a compact string of a positive decimal integer optionally suffixed with case-insensitive `k` (×1,000) or `m` (×1,000,000), normalized to a token count. Booleans, non-positive, decimal, whitespace-embedded, and unknown-unit values are rejected at startup with a `context_window`-named error rather than silently coerced.
- `backend/src/waypoint/backends/claude_code/models.py` — add the `ClaudeContextWindowResolver` type, `configured_context_windows` (build an id→window map from the effective config, keeping only entries whose `context_window` is set, with `extra_models` overlaid last so it wins a collision as `merge_model_catalogue` does), `resolve_claude_context_window` (exact configured id, then the existing static resolver, else `None`), and `make_context_window_resolver` (returns the static resolver verbatim when no overrides are declared).
- `backend/src/waypoint/backends/claude_code/adapter.py`, `history.py`, `usage_source.py` — the shared snapshot/seed/rebase helpers, the native `ClaudeCliAdapter`, the tmux `TranscriptContextUsageSource`, and the import ledger all accept an injected resolver defaulting to the static one, so live snapshots, window refreshes, transcript seeding, rebasing, and imported per-turn telemetry resolve a custom model through configuration.
- `backend/src/waypoint/backends/claude_code/plugin.py` — `setup()` builds the resolver from the typed config and caches it (so `rebase_context_usage`, which has no runtime handle, can read it), passes it to the adapter, the tmux usage source, import seeding, and the import ledger.
- `backend/src/waypoint/backends/claude_tty/plugin.py`, `tailer.py` — the `claude_tty` transport builds and caches the same resolver at `setup()`, passes it to `TranscriptTailer`, import seeding, and the import ledger, and gains a `rebase_context_usage` hook (previously absent) so legacy `backend=claude_tty` rows rebase from the configured capacity too.

### Docs
- `backend/waypoint.example.yaml` — document `context_window` on an `extra_models` entry and a replacement `models` entry, noting it takes an int or a `"256k"`/`"1m"` string and is reporting-only, never a CLI launch option.

### Tests
- `backend/tests/test_custom_model_context_window.py` (new) — the `context_window` grammar (accepts `256000`, `"256k"`, `"1m"`, surrounding whitespace; rejects booleans, `0`, negatives, `"1.5m"`, `"256 k"`, `"2g"`, blank, malformed) and resolver precedence (exact custom match, `extra_models` collision wins, static fallback, built-in override via config, omitted unknown → `None`, and the no-override resolver being the static function itself).
- `backend/tests/test_context_window_provenance.py`, `test_claude_code_usage_source.py`, `test_import_history_claude.py` — cross-path assertions that a configured custom window reaches rebasing, transcript seeding, the `claude_tty` tailer, the tmux source, and the import ledger.

## Design

The declaration lives on `BackendModelOption` (Option 1 in the RFC), not a parallel `custom_context_windows` block, so it travels with the custom model and honors the existing `models`/`extra_models` replacement semantics. Resolution is a single pure `Callable[[str | None], int | None]` injected where message processing happens rather than adapters reading `Settings` or the runtime branching on a backend id, which preserves the agent/transport split. Each producer keeps the static resolver as its default, so existing configs and direct unit callers are unchanged. The resolver prefers the durable selected id (which carries the `[1m]` entitlement) exactly as the current transcript consumers do, and never fuzzy-matches a gateway's provider alias — an unknown custom model with no `context_window` still has no denominator rather than a fabricated one. The `claude_tty` rebase hook is dispatched on the agent id (this alias, not `claude_code`), so it is added here to cover those rows.

## Test Plan
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pre-commit run` (scoped to the changed files) — isort, black, ruff, codespell, mypy.
- Config→resolver verification through the real `Settings.model_validate` dispatch: a custom `extra_models` entry with `context_window: 1m` and one with `256000` on both Claude transports resolve to the configured windows, `opus[1m]` still resolves statically, an unknown id resolves to `None`, and an invalid `"2g"` is rejected at config load.

## Test Result
- `uv run pytest` — 2841 passed (3 pre-existing unrelated warnings: a subprocess `__del__` ResourceWarning and a Codex enum-serialization UserWarning); `pre-commit` clean (isort/black/ruff/codespell/mypy) on the changed files.
- Config verification passed: `claude_code` `kimi-k3[1m]` → 1,000,000; `claude_tty` `gw-256` → 256,000; `opus[1m]` static → 1,000,000; unknown → `None`; `"2g"` rejected during `Settings` validation.
- No frontend change: this ticket feeds the existing context-pill denominator and adds no UI (RFC Non-Goals exclude UI changes), so `/frontend-design` and a Playwright drive do not apply.
- The live pill check against a real custom gateway was not run: it requires a custom-gateway model producing Claude usage, and this change is being built inside a live managed Waypoint session on the target backend whose restart would terminate the session mid-ticket. The unit + cross-path tests and the real `Settings`→resolver verification cover the same resolution the live pill reads.