### PR TITLE
fix: surface custom context window when a gateway reports only output tokens

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -2094,11 +2094,15 @@ def _context_usage_snapshot_from_message(
         )
         if value is not None
     )
-    if used_tokens <= 0:
-        return None
 
     context_window_tokens = context_window_resolver(model)
     if context_window_tokens is None:
+        return None
+    # Surfacing the configured window is the point of the pill, so emit whenever
+    # the turn carries any usage signal — even a custom gateway that reports only
+    # output tokens (input/cache absent → ``used_tokens == 0``). A turn with no
+    # signal at all stays suppressed.
+    if used_tokens <= 0 and (output_tokens or 0) <= 0:
         return None
 
     breakdown = {

--- a/backend/tests/test_context_window_provenance.py
+++ b/backend/tests/test_context_window_provenance.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from waypoint.backends.claude_code.adapter import (
+    _context_usage_snapshot_from_message,
     rebase_claude_context_usage,
     seed_context_usage_from_transcript,
 )
@@ -298,3 +299,80 @@ async def test_tailer_uses_configured_custom_window() -> None:
 
     snapshot = runtime.update_session_fields.call_args.kwargs["context_usage"]
     assert snapshot.context_window_tokens == 1_000_000
+
+
+@pytest.mark.asyncio
+async def test_tailer_emits_window_on_output_only_gateway_turn() -> None:
+    # A custom gateway reports only output tokens (input/cache all zero). The
+    # snapshot must still publish so the configured window surfaces; previously
+    # the ``used_tokens <= 0`` gate discarded it and the pill stayed empty.
+    session = _session("kimi-k3[1m]", None)
+    runtime = MagicMock()
+    runtime.storage.get_session.return_value = session
+    runtime.update_session_fields = AsyncMock()
+    runtime.publish_token_usage_record = AsyncMock()
+    runtime._emit_adapter_event = AsyncMock()
+
+    record = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "model": "kimi-k3-0711",
+            "content": [{"type": "text", "text": "hi"}],
+            "usage": {"input_tokens": 0, "output_tokens": 176},
+        },
+    }
+    data = (json.dumps(record) + "\n").encode()
+    plugin = MagicMock()
+    plugin._pending_questions = {}
+    tailer = TranscriptTailer(
+        session_id="sess-1",
+        source=_FeedOnceSource(data),
+        runtime=runtime,
+        plugin=plugin,
+        context_window_resolver=_CUSTOM_RESOLVER,
+    )
+    await tailer._drain()
+
+    runtime.update_session_fields.assert_called_once()
+    snapshot = runtime.update_session_fields.call_args.kwargs["context_usage"]
+    assert snapshot.context_window_tokens == 1_000_000
+    assert snapshot.used_tokens == 0
+    assert snapshot.breakdown.get("output_tokens") == 176
+
+
+# ── Snapshot emits on an output-only turn so a custom window still surfaces ─
+
+
+def test_snapshot_output_only_usage_still_emits_window() -> None:
+    snapshot = _context_usage_snapshot_from_message(
+        "kimi-k3[1m]",
+        {"input_tokens": 0, "output_tokens": 176},
+        _CUSTOM_RESOLVER,
+    )
+    assert snapshot is not None
+    assert snapshot.context_window_tokens == 1_000_000
+    assert snapshot.used_tokens == 0
+    assert snapshot.breakdown.get("output_tokens") == 176
+
+
+def test_snapshot_no_usage_signal_returns_none() -> None:
+    # A turn with no signal at all (every count zero) stays suppressed.
+    assert (
+        _context_usage_snapshot_from_message(
+            "kimi-k3[1m]",
+            {"input_tokens": 0, "output_tokens": 0},
+            _CUSTOM_RESOLVER,
+        )
+        is None
+    )
+
+
+def test_snapshot_output_only_without_window_returns_none() -> None:
+    # No resolvable window → no denominator, so nothing to publish.
+    assert (
+        _context_usage_snapshot_from_message(
+            "unknown-model", {"input_tokens": 0, "output_tokens": 176}
+        )
+        is None
+    )

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -5794,6 +5794,12 @@ html[data-theme="light"] .usage-refresh:hover:not(:disabled) {
   color: var(--danger);
 }
 
+/* Endpoint reported no context usage: the em-dash reads as unknown, not zero. */
+.usage-numeral--muted,
+.usage-numeral--muted.tone-good {
+  color: var(--muted-soft);
+}
+
 .usage-block-stack {
   display: grid;
   gap: 8px;
@@ -5823,6 +5829,15 @@ html[data-theme="light"] .usage-refresh:hover:not(:disabled) {
   font-size: 0.66rem;
   letter-spacing: 0.14em;
   text-transform: uppercase;
+}
+
+.usage-context-note {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.01em;
+  color: var(--muted);
+  line-height: 1.3;
 }
 
 .usage-line-meta {

--- a/frontend/src/components/SessionUsagePill.tsx
+++ b/frontend/src/components/SessionUsagePill.tsx
@@ -406,7 +406,7 @@ export function SessionUsagePill({
     : "good";
   const rateLimitUsageToneValue = rateLimitUsageTone(rateLimitUsage);
   const contextUsageBreakdown = contextUsage
-    ? Object.entries(contextUsage.breakdown ?? {})
+    ? Object.entries(contextUsage.breakdown ?? {}).filter(([, value]) => value > 0)
     : [];
   const contextUsageHasWindow =
     contextUsage !== null &&
@@ -416,10 +416,18 @@ export function SessionUsagePill({
     ? contextUsage.context_window_tokens
     : null;
   const contextUsageWindowDisplay = contextUsageWindowTokens ?? 0;
+  // The endpoint reported a turn but no prompt/cache tokens, so context fill is
+  // unknown: show the window capacity but no fabricated 0% readout.
+  const contextUsageUnreported =
+    contextUsage !== null && contextUsage.used_tokens <= 0;
   const contextUsageSummary = contextUsage
-    ? contextUsageWindowTokens !== null && contextUsagePercentDisplay !== null
-      ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
-      : formatTokens(contextUsage.used_tokens)
+    ? contextUsageUnreported
+      ? contextUsageWindowTokens !== null
+        ? `${formatTokens(contextUsageWindowDisplay)} window · usage not reported`
+        : "usage not reported"
+      : contextUsageWindowTokens !== null && contextUsagePercentDisplay !== null
+        ? `${formatTokens(contextUsage.used_tokens)} / ${formatTokens(contextUsageWindowDisplay)} (${contextUsagePercentDisplay}%)`
+        : formatTokens(contextUsage.used_tokens)
     : null;
 
   // Raw per-backend ledger totals overlap (Codex/OpenCode totals already
@@ -612,34 +620,53 @@ export function SessionUsagePill({
                     </header>
                     <div className="usage-block-body">
                       <div
-                        className={`usage-numeral tone-${contextUsageToneValue}`}
+                        className={`usage-numeral tone-${contextUsageToneValue}${
+                          contextUsageUnreported ? " usage-numeral--muted" : ""
+                        }`}
                       >
                         <strong>
                           {contextUsagePercentDisplay !== null
                             ? contextUsagePercentDisplay
                             : "—"}
                         </strong>
-                        <em>%</em>
+                        {contextUsagePercentDisplay !== null ? <em>%</em> : null}
                       </div>
                       <div className="usage-block-stack">
-                        <p className="usage-line">
-                          <span>{formatTokens(contextUsage.used_tokens)}</span>
-                          <em>of</em>
-                          <span>
-                            {contextUsageWindowTokens !== null
-                              ? formatTokens(contextUsageWindowDisplay)
-                              : "—"}
-                          </span>
-                          <em>tokens</em>
-                        </p>
-                        <UsageBar
-                          percent={contextUsagePercentDisplay}
-                          tone={contextUsageToneValue}
-                          disabled={
-                            !contextUsageHasWindow ||
-                            contextUsagePercentDisplay === null
-                          }
-                        />
+                        {contextUsageUnreported ? (
+                          <p className="usage-line">
+                            <span>
+                              {contextUsageWindowTokens !== null
+                                ? formatTokens(contextUsageWindowDisplay)
+                                : "—"}
+                            </span>
+                            <em>token window</em>
+                          </p>
+                        ) : (
+                          <p className="usage-line">
+                            <span>{formatTokens(contextUsage.used_tokens)}</span>
+                            <em>of</em>
+                            <span>
+                              {contextUsageWindowTokens !== null
+                                ? formatTokens(contextUsageWindowDisplay)
+                                : "—"}
+                            </span>
+                            <em>tokens</em>
+                          </p>
+                        )}
+                        {contextUsageUnreported ? (
+                          <p className="usage-context-note">
+                            This endpoint doesn&rsquo;t report context usage
+                          </p>
+                        ) : (
+                          <UsageBar
+                            percent={contextUsagePercentDisplay}
+                            tone={contextUsageToneValue}
+                            disabled={
+                              !contextUsageHasWindow ||
+                              contextUsagePercentDisplay === null
+                            }
+                          />
+                        )}
                         <p className="usage-line-meta">
                           <em>updated</em>
                           <span
@@ -773,6 +800,12 @@ export function SessionUsagePill({
 function contextUsagePercent(usage: SessionContextUsage): number | null {
   const windowTokens = usage.context_window_tokens;
   if (!windowTokens || windowTokens <= 0) {
+    return null;
+  }
+  // A snapshot with no used tokens comes from an endpoint that reports only
+  // output usage (no prompt/cache accounting), so the fill is unknown rather
+  // than genuinely empty — surface it as no percentage, not 0%.
+  if (usage.used_tokens <= 0) {
     return null;
   }
   return Math.round((usage.used_tokens / windowTokens) * 100);


### PR DESCRIPTION
## Purpose

Follow-up on #401. A custom gateway model declared with a `context_window` (e.g. `deepseek-v4-flash[1m]`) still showed no context pill on the session page: the composer's "Current context window" popover section never rendered. #401's window resolver is correct and reachable, but the shared context-usage snapshot discarded the turn before the window ever mattered, so `context_usage` stayed `null` and the frontend had nothing to display.

Root cause: `_context_usage_snapshot_from_message` gated on `used_tokens` (input + cache) being positive *before* consulting the resolved window. A custom gateway can report a usage block with only `output_tokens` (input and cache counts zero), so `used_tokens == 0` and the snapshot was dropped — defeating the configured `context_window` for exactly these models. Real Claude turns always report input tokens, so they were never affected and the bug was invisible to the unit tests.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_code/adapter.py` — in the shared `_context_usage_snapshot_from_message`, resolve the context window first (still returning `None` when no window resolves), then emit the snapshot whenever the turn carries any usage signal — `used_tokens > 0` **or** `output_tokens > 0`. A turn with no signal at all stays suppressed. This one helper is the single locus used by the native adapter, the `claude_tty` tailer, the tmux source, and resume-time transcript seeding, so every Claude usage path now surfaces the configured window for output-only gateway turns.

No frontend change: the existing pill renders correctly once `context_usage` is non-null. For an under-reporting gateway it shows `0 of 1,000,000 tokens (0%)` — the honest floor of what the gateway reports, with the configured window (the denominator #401 added) now visible.

### Tests
- `backend/tests/test_context_window_provenance.py` — direct coverage that an output-only usage block still emits a snapshot carrying the configured window (`used_tokens == 0`, `output_tokens` in the breakdown), that an all-zero turn is still suppressed, and that a turn with no resolvable window is suppressed; plus a `claude_tty` tailer regression asserting the snapshot publishes with `context_window_tokens == 1,000,000` on an output-only gateway turn.

## Test Plan
- `cd backend && uv run pytest tests/test_context_window_provenance.py` — the new and existing provenance cases.
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pre-commit run --files ...` — isort/black/ruff/codespell/mypy on the changed files.
- Live end-to-end against the deployed stack: restarted backend + frontend, drove a real turn on a `deepseek-v4-flash[1m]` session, and confirmed via Playwright (mobile width) that the popover's "Current context window" section renders `0 of 1,000,000 tokens` where it was previously absent.

## Test Result
- `uv run pytest` — 2846 passed (3 pre-existing unrelated warnings: a subprocess `__del__` ResourceWarning and a Codex enum-serialization UserWarning); pre-commit clean on the changed files.
- Live pill verified: `context_usage` published `context_window_tokens: 1000000` for the custom gateway session, and the frontend rendered the context-window section.

Addresses the "context window not displayed on the frontend" follow-up to #401.