### PR TITLE
fix: seed forked claude_tty transcript on creation

### DIFF
--- a/backend/src/waypoint/backends/claude_tty/byte_source.py
+++ b/backend/src/waypoint/backends/claude_tty/byte_source.py
@@ -42,7 +42,7 @@ _READ_LIMIT = 256 * 1024  # max bytes fetched per remote read
 
 
 def resolve_remote_config_root(
-    config_dir: str | None, cwd: str, fs: "RemoteTranscriptFilesystem"
+    config_dir: str | None, cwd: str, fs: RemoteTranscriptFilesystem
 ) -> str:
     """Resolve the remote ``CLAUDE_CONFIG_DIR`` root for a session.
 

--- a/backend/src/waypoint/backends/claude_tty/byte_source.py
+++ b/backend/src/waypoint/backends/claude_tty/byte_source.py
@@ -47,9 +47,8 @@ def resolve_remote_config_root(
     """Resolve the remote ``CLAUDE_CONFIG_DIR`` root for a session.
 
     ``None`` defaults to ``~/.claude``; an absolute or ``~``-anchored value is
-    used verbatim; a relative value resolves against the session's remote cwd,
-    mirroring the launch's ``cd cwd`` before it inherits the env var — never
-    against Waypoint's cwd or the SSH login dir.
+    used verbatim; a relative value resolves against the session's remote cwd
+    (not Waypoint's cwd or the SSH login dir).
     """
     if config_dir is None:
         return "~/.claude"

--- a/backend/src/waypoint/backends/claude_tty/byte_source.py
+++ b/backend/src/waypoint/backends/claude_tty/byte_source.py
@@ -41,6 +41,24 @@ _MAX_BACKOFF = 10.0  # cap on the exponential error backoff
 _READ_LIMIT = 256 * 1024  # max bytes fetched per remote read
 
 
+def resolve_remote_config_root(
+    config_dir: str | None, cwd: str, fs: "RemoteTranscriptFilesystem"
+) -> str:
+    """Resolve the remote ``CLAUDE_CONFIG_DIR`` root for a session.
+
+    ``None`` defaults to ``~/.claude``; an absolute or ``~``-anchored value is
+    used verbatim; a relative value resolves against the session's remote cwd,
+    mirroring the launch's ``cd cwd`` before it inherits the env var — never
+    against Waypoint's cwd or the SSH login dir.
+    """
+    if config_dir is None:
+        return "~/.claude"
+    if config_dir.startswith("/") or config_dir.startswith("~"):
+        return config_dir
+    base = fs.expanduser(cwd) if cwd.startswith("~") else cwd
+    return posixpath.join(base, config_dir)
+
+
 def transcript_path(cwd: str, session_uuid: str, config_dir: str | None = None) -> Path:
     """Return the Claude TUI's JSONL transcript path for a local session.
 
@@ -214,17 +232,7 @@ class RemoteClaudeTranscriptByteSource:
     def _resolved_config_root(self, cwd: str) -> str:
         if self._config_root is not None:
             return self._config_root
-        cfg = self._config_dir
-        if cfg is None:
-            root = "~/.claude"
-        elif cfg.startswith("/") or cfg.startswith("~"):
-            root = cfg
-        else:
-            # A relative CLAUDE_CONFIG_DIR resolves against the session's remote
-            # cwd, mirroring the launch's ``cd cwd`` before it inherits the env
-            # var — never against Waypoint's cwd or the SSH login dir.
-            base = self._fs.expanduser(cwd) if cwd.startswith("~") else cwd
-            root = posixpath.join(base, cfg)
+        root = resolve_remote_config_root(self._config_dir, cwd, self._fs)
         self._config_root = root
         return root
 

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -1019,7 +1019,6 @@ class ClaudeTtyPlugin:
             if not src.exists():
                 return False
             dst = transcript_path(session.cwd, new_thread_id, config_dir)
-            dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
             return True
         fs = RemoteTranscriptFilesystem(launch_target)

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -877,16 +877,12 @@ class ClaudeTtyPlugin:
         )
         config_dir = self._config_dir(session)
         new_thread_id = str(uuid.uuid4())
-        # Materialize the fork by copying the parent transcript under the new
-        # thread id, then resume it. Claude's own ``--fork-session`` writes the
-        # forked transcript lazily (only after the first turn), so the pane would
-        # otherwise show no history until the human replies. A materialized copy
-        # is a complete, self-contained conversation the resumed pane reopens
-        # immediately, and ``clone_events`` seeds the event DB so the fork's
-        # transcript renders the instant it is created — mirroring the
-        # promote-side-question path. If the parent transcript cannot be copied
-        # (e.g. a fork before its first turn wrote one), fall back to Claude's
-        # native lazy fork so the behavior never regresses below today's.
+        # Claude writes a --fork-session transcript only after the first turn.
+        # Copying it under the new thread id lets the resumed pane reopen the
+        # full history now, and clone_events seeds the event DB so the fork
+        # renders on creation; the pane re-reads the copied file, so the tailer
+        # starts at its end. Without a parent transcript to copy, fall back to
+        # the native lazy fork.
         materialized = await self._materialize_forked_transcript(
             session, src_thread_id, new_thread_id, config_dir, launch_target
         )
@@ -964,9 +960,6 @@ class ClaudeTtyPlugin:
         )
         runtime.storage.create_session(new_session)
         if materialized:
-            # Seed the fork's transcript from the parent so it renders on
-            # creation; the resumed pane reopens the copied file, so tail from
-            # its end and pick up only turns added from here.
             runtime.storage.clone_events(session.id, new_session_id)
         await runtime._record_system_event(
             new_session_id,
@@ -993,26 +986,15 @@ class ClaudeTtyPlugin:
         config_dir: str | None,
         launch_target: SshLaunchTargetConfig | None,
     ) -> bool:
-        """Copy the parent transcript under ``new_thread_id`` so a resumed pane
-        reopens a complete conversation. Returns ``True`` when the copy landed.
-
-        Best-effort: any failure (a missing parent file, a remote glob miss or
-        copy error) returns ``False`` so the caller falls back to Claude's
-        native ``--fork-session``. Never raises — the copy runs off the event
-        loop since both filesystem and SSH ops block.
+        """Copy the parent transcript under ``new_thread_id``, returning ``True``
+        on success. Any failure returns ``False`` for the caller's native-fork
+        fallback; runs off the event loop since filesystem and SSH ops block.
         """
         try:
-            if launch_target is None:
-                return await asyncio.to_thread(
-                    self._copy_local_transcript,
-                    session.cwd,
-                    src_thread_id,
-                    new_thread_id,
-                    config_dir,
-                )
             return await asyncio.to_thread(
-                self._copy_remote_transcript,
+                self._copy_transcript,
                 session,
+                src_thread_id,
                 new_thread_id,
                 config_dir,
                 launch_target,
@@ -1024,35 +1006,31 @@ class ClaudeTtyPlugin:
             )
             return False
 
-    @staticmethod
-    def _copy_local_transcript(
-        cwd: str, src_thread_id: str, new_thread_id: str, config_dir: str | None
-    ) -> bool:
-        src = transcript_path(cwd, src_thread_id, config_dir)
-        if not src.exists():
-            return False
-        dst = transcript_path(cwd, new_thread_id, config_dir)
-        dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dst)
-        return True
-
-    def _copy_remote_transcript(
+    def _copy_transcript(
         self,
         session: SessionRecord,
+        src_thread_id: str,
         new_thread_id: str,
         config_dir: str | None,
-        launch_target: SshLaunchTargetConfig,
+        launch_target: SshLaunchTargetConfig | None,
     ) -> bool:
+        if launch_target is None:
+            src = transcript_path(session.cwd, src_thread_id, config_dir)
+            if not src.exists():
+                return False
+            dst = transcript_path(session.cwd, new_thread_id, config_dir)
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+            return True
         fs = RemoteTranscriptFilesystem(launch_target)
         config_root = resolve_remote_config_root(config_dir, session.cwd, fs)
         matches = fs.glob_artifacts(session, self, config_root)
         if len(matches) != 1:
             return False
-        src_remote = matches[0]
         dst_remote = posixpath.join(
-            posixpath.dirname(src_remote), f"{new_thread_id}.jsonl"
+            posixpath.dirname(matches[0]), f"{new_thread_id}.jsonl"
         )
-        fs.copy_file(src_remote, dst_remote, 0o600)
+        fs.copy_file(matches[0], dst_remote, 0o600)
         return True
 
     # ── Control swaps (restart-with-resume) ──────────────────────────────────

--- a/backend/src/waypoint/backends/claude_tty/plugin.py
+++ b/backend/src/waypoint/backends/claude_tty/plugin.py
@@ -24,6 +24,7 @@ Output is read by a transcript tailer over ``~/.claude/projects/<cwd>/
 
 import asyncio
 import logging
+import posixpath
 import shutil
 import uuid
 from contextlib import suppress
@@ -81,12 +82,15 @@ from waypoint.backends.claude_tty.byte_source import (
     LocalTranscriptByteSource,
     RemoteClaudeTranscriptByteSource,
     TranscriptByteSource,
+    resolve_remote_config_root,
+    transcript_path,
 )
 from waypoint.backends.claude_tty.tailer import TranscriptTailer
 from waypoint.backends.completions import static_slash_completions
 from waypoint.backends.plugin_config import PluginConfig, PluginLaunchTargetConfig
 from waypoint.backends.tmux.adapter import TmuxError
 from waypoint.backends.tmux.plugin import TmuxPlugin
+from waypoint.backends.transcript_fs_remote import RemoteTranscriptFilesystem
 from waypoint.git_meta import GitMeta
 from waypoint.launch_targets import SshLaunchTargetConfig
 from waypoint.schemas import (
@@ -871,15 +875,32 @@ class ClaudeTtyPlugin:
         base_args = _scrub_session_args(
             stored_args if isinstance(stored_args, list) else []
         )
+        config_dir = self._config_dir(session)
         new_thread_id = str(uuid.uuid4())
-        launch_args = [
-            "--resume",
-            src_thread_id,
-            "--fork-session",
-            "--session-id",
-            new_thread_id,
-            *base_args,
-        ]
+        # Materialize the fork by copying the parent transcript under the new
+        # thread id, then resume it. Claude's own ``--fork-session`` writes the
+        # forked transcript lazily (only after the first turn), so the pane would
+        # otherwise show no history until the human replies. A materialized copy
+        # is a complete, self-contained conversation the resumed pane reopens
+        # immediately, and ``clone_events`` seeds the event DB so the fork's
+        # transcript renders the instant it is created — mirroring the
+        # promote-side-question path. If the parent transcript cannot be copied
+        # (e.g. a fork before its first turn wrote one), fall back to Claude's
+        # native lazy fork so the behavior never regresses below today's.
+        materialized = await self._materialize_forked_transcript(
+            session, src_thread_id, new_thread_id, config_dir, launch_target
+        )
+        if materialized:
+            launch_args = ["--resume", new_thread_id, *base_args]
+        else:
+            launch_args = [
+                "--resume",
+                src_thread_id,
+                "--fork-session",
+                "--session-id",
+                new_thread_id,
+                *base_args,
+            ]
         try:
             command = runtime._command_for_backend(
                 self.id,
@@ -942,6 +963,11 @@ class ClaudeTtyPlugin:
             account_profile_label=session.account_profile_label,
         )
         runtime.storage.create_session(new_session)
+        if materialized:
+            # Seed the fork's transcript from the parent so it renders on
+            # creation; the resumed pane reopens the copied file, so tail from
+            # its end and pick up only turns added from here.
+            runtime.storage.clone_events(session.id, new_session_id)
         await runtime._record_system_event(
             new_session_id,
             f"Claude TUI forked from {session.title or session.id} (thread {new_thread_id})",
@@ -952,11 +978,82 @@ class ClaudeTtyPlugin:
             new_session_id,
             new_thread_id,
             session.cwd,
+            start_at_end=materialized,
             config_dir=self._config_dir(new_session),
             launch_target=launch_target,
         )
         self._spawn_rate_limit_watcher(runtime, new_session)
         return runtime.get_session(new_session_id)
+
+    async def _materialize_forked_transcript(
+        self,
+        session: SessionRecord,
+        src_thread_id: str,
+        new_thread_id: str,
+        config_dir: str | None,
+        launch_target: SshLaunchTargetConfig | None,
+    ) -> bool:
+        """Copy the parent transcript under ``new_thread_id`` so a resumed pane
+        reopens a complete conversation. Returns ``True`` when the copy landed.
+
+        Best-effort: any failure (a missing parent file, a remote glob miss or
+        copy error) returns ``False`` so the caller falls back to Claude's
+        native ``--fork-session``. Never raises — the copy runs off the event
+        loop since both filesystem and SSH ops block.
+        """
+        try:
+            if launch_target is None:
+                return await asyncio.to_thread(
+                    self._copy_local_transcript,
+                    session.cwd,
+                    src_thread_id,
+                    new_thread_id,
+                    config_dir,
+                )
+            return await asyncio.to_thread(
+                self._copy_remote_transcript,
+                session,
+                new_thread_id,
+                config_dir,
+                launch_target,
+            )
+        except Exception:  # noqa: BLE001
+            log.warning(
+                "failed to materialize forked transcript; falling back to native fork",
+                extra={"session_id": session.id, "thread_id": src_thread_id},
+            )
+            return False
+
+    @staticmethod
+    def _copy_local_transcript(
+        cwd: str, src_thread_id: str, new_thread_id: str, config_dir: str | None
+    ) -> bool:
+        src = transcript_path(cwd, src_thread_id, config_dir)
+        if not src.exists():
+            return False
+        dst = transcript_path(cwd, new_thread_id, config_dir)
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dst)
+        return True
+
+    def _copy_remote_transcript(
+        self,
+        session: SessionRecord,
+        new_thread_id: str,
+        config_dir: str | None,
+        launch_target: SshLaunchTargetConfig,
+    ) -> bool:
+        fs = RemoteTranscriptFilesystem(launch_target)
+        config_root = resolve_remote_config_root(config_dir, session.cwd, fs)
+        matches = fs.glob_artifacts(session, self, config_root)
+        if len(matches) != 1:
+            return False
+        src_remote = matches[0]
+        dst_remote = posixpath.join(
+            posixpath.dirname(src_remote), f"{new_thread_id}.jsonl"
+        )
+        fs.copy_file(src_remote, dst_remote, 0o600)
+        return True
 
     # ── Control swaps (restart-with-resume) ──────────────────────────────────
 

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -572,18 +572,16 @@ async def test_fork_session_materializes_transcript_and_seeds_events(
     )
 
     new_thread_id = forked.transport_state["thread_id"]
-    # The parent transcript was copied under the new thread id, so the resumed
-    # pane reopens a complete conversation.
+    # The parent transcript is copied under the new thread id.
     dst_path = transcript_path(cwd, new_thread_id, config_dir)
     assert dst_path.exists()
     assert dst_path.read_text() == src_path.read_text()
-    # A materialized fork resumes the copy directly — no native --fork-session —
-    # and the tailer skips the pre-seeded history by tailing from the end.
+    # A materialized fork resumes the copy and tails from its end; the seeded
+    # history reaches the DB through clone_events, not the tailer.
     built_args = runtime._command_for_backend.call_args.args[1]
     assert built_args == ["--resume", new_thread_id]
     assert "--fork-session" not in built_args
     assert captured["start_at_end"] is True
-    # The parent's events seed the fork's DB so it renders on creation.
     runtime.storage.clone_events.assert_called_once_with("src", "fork-1")
 
 
@@ -592,9 +590,8 @@ async def test_fork_session_falls_back_to_native_fork_without_transcript() -> No
     plugin = ClaudeTtyPlugin()
     captured = _stub_lifecycle(plugin)
     runtime, _ = _launch_runtime()
-    # No transcript on disk (cwd/config point nowhere real), so materialization
-    # fails and the fork degrades to Claude's native lazy fork — never worse
-    # than today's behavior.
+    # No transcript on disk, so materialization fails and the fork uses the
+    # native lazy path.
     source = _make_session(session_id="src", thread_id="thread-src")
 
     forked = await plugin.fork_session(

--- a/backend/tests/test_claude_tty_controls.py
+++ b/backend/tests/test_claude_tty_controls.py
@@ -19,6 +19,7 @@ from fastapi import HTTPException
 from waypoint.backends.claude_code.schemas import ClaudeThreadImportRequest
 from waypoint.backends.claude_code.threads import ClaudeThreadInfo
 from waypoint.backends.claude_tty import plugin as plugin_mod
+from waypoint.backends.claude_tty.byte_source import transcript_path
 from waypoint.backends.claude_tty.plugin import (
     ClaudeTtyPlugin,
     _scrub_session_args,
@@ -539,6 +540,83 @@ async def test_fork_session_inherits_source_agent_backend() -> None:
     assert (
         runtime._command_for_backend.call_args.kwargs["launch_env"] == source.launch_env
     )
+
+
+@pytest.mark.asyncio
+async def test_fork_session_materializes_transcript_and_seeds_events(
+    tmp_path: Path,
+) -> None:
+    plugin = ClaudeTtyPlugin()
+    captured = _stub_lifecycle(plugin)
+    runtime, created = _launch_runtime()
+    cwd = str(tmp_path / "work")
+    config_dir = str(tmp_path / "cfg")
+    source = _make_session(
+        session_id="src",
+        thread_id="thread-src",
+        launch_env={"CLAUDE_CONFIG_DIR": config_dir},
+    )
+    source.cwd = cwd
+    # Give the parent a real transcript so the fork can be materialized.
+    src_path = transcript_path(cwd, "thread-src", config_dir)
+    src_path.parent.mkdir(parents=True, exist_ok=True)
+    src_path.write_text('{"type":"user","sessionId":"thread-src"}\n')
+
+    forked = await plugin.fork_session(
+        runtime,
+        source,
+        new_session_id="fork-1",
+        title="forked",
+        raw_log=tmp_path / "raw.log",
+        structured_log=tmp_path / "events.jsonl",
+    )
+
+    new_thread_id = forked.transport_state["thread_id"]
+    # The parent transcript was copied under the new thread id, so the resumed
+    # pane reopens a complete conversation.
+    dst_path = transcript_path(cwd, new_thread_id, config_dir)
+    assert dst_path.exists()
+    assert dst_path.read_text() == src_path.read_text()
+    # A materialized fork resumes the copy directly — no native --fork-session —
+    # and the tailer skips the pre-seeded history by tailing from the end.
+    built_args = runtime._command_for_backend.call_args.args[1]
+    assert built_args == ["--resume", new_thread_id]
+    assert "--fork-session" not in built_args
+    assert captured["start_at_end"] is True
+    # The parent's events seed the fork's DB so it renders on creation.
+    runtime.storage.clone_events.assert_called_once_with("src", "fork-1")
+
+
+@pytest.mark.asyncio
+async def test_fork_session_falls_back_to_native_fork_without_transcript() -> None:
+    plugin = ClaudeTtyPlugin()
+    captured = _stub_lifecycle(plugin)
+    runtime, _ = _launch_runtime()
+    # No transcript on disk (cwd/config point nowhere real), so materialization
+    # fails and the fork degrades to Claude's native lazy fork — never worse
+    # than today's behavior.
+    source = _make_session(session_id="src", thread_id="thread-src")
+
+    forked = await plugin.fork_session(
+        runtime,
+        source,
+        new_session_id="fork-1",
+        title="forked",
+        raw_log=Path("/tmp/raw.log"),
+        structured_log=Path("/tmp/events.jsonl"),
+    )
+
+    new_thread_id = forked.transport_state["thread_id"]
+    built_args = runtime._command_for_backend.call_args.args[1]
+    assert built_args == [
+        "--resume",
+        "thread-src",
+        "--fork-session",
+        "--session-id",
+        new_thread_id,
+    ]
+    assert captured["start_at_end"] is False
+    runtime.storage.clone_events.assert_not_called()
 
 
 # ── list_threads dedup ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Purpose

Forking a `claude_tty` session showed no history in the fork until the human sent the first message. The reported bug: "claude_tty sessions' messages are not loaded into Waypoint on forking; they are only loaded after the first message."

Root cause (confirmed live): the `claude_tty` transport's `fork_session` launched `claude --resume <src> --fork-session --session-id <new>`. Claude's `--fork-session` materializes the forked transcript **lazily** — the `<new>.jsonl` file is not written until the first turn — so the tailer had nothing to read and the fork's transcript stayed empty until the human replied. Unlike every other fork path (`claude_code` native, `codex`, `opencode`, and the promote-side-question path), it also never called `storage.clone_events`, so the fork's event DB started empty regardless.

The other backends are unaffected: they call `clone_events` and drive structured adapters that emit only new events after the fork, so history renders immediately and never doubles. `tmux` fork is `NotImplementedError`. The gap was `claude_tty`-specific.

## Changes

### Backend
- `backend/src/waypoint/backends/claude_tty/plugin.py` — `fork_session` now materializes the fork eagerly by copying the parent transcript under the new thread id (`_materialize_forked_transcript`: local `shutil.copy2`, remote `RemoteTranscriptFilesystem.copy_file`), then resumes that copy directly with `claude --resume <new>` instead of `--fork-session`. It calls `storage.clone_events(parent, fork)` so the transcript renders the instant the fork is created, and starts the tailer with `start_at_end=True` so the pre-seeded history is not re-emitted when the resumed pane reopens the file — mirroring the existing `_launch_resumed_pane` (promote-side-question) path. When the parent transcript cannot be copied (e.g. a fork before its first turn wrote one, or a remote glob/copy miss), it falls back to Claude's native lazy `--fork-session`, so behavior never regresses below today's.
- `backend/src/waypoint/backends/claude_tty/byte_source.py` — extract the remote `CLAUDE_CONFIG_DIR` root resolution into a reusable `resolve_remote_config_root` helper (previously private to `RemoteClaudeTranscriptByteSource`), used by the new remote materialization path to locate the parent transcript.

### Tests
- `backend/tests/test_claude_tty_controls.py` — cover the materialized path (parent transcript copied under the new thread id, `--resume <new>` with no `--fork-session`, `clone_events` called, tailer `start_at_end=True`) and the no-transcript fallback (native `--fork-session`, no `clone_events`, `start_at_end=False`).

## Design

Forking is modeled as "materialize a self-contained copy of the parent conversation under a new thread id, then resume it" — exactly what the promote-side-question path already does, so the fix reuses the proven `clone_events` + `start_at_end=True` seeding contract rather than inventing a new one. Copying the transcript (verified: Claude resumes a plain copy, loads full history, and appends new turns under the new session id) sidesteps the lazy-materialization race that made `start_at_end` unreliable over `--fork-session`, and needs no transcript dedup. The native `--fork-session` path is retained as a best-effort fallback so any materialization failure degrades to current behavior. The change stays inside the `claude_tty` transport; the runtime and other backends are untouched.

## Test Plan
- `cd backend && uv run pytest tests/test_claude_tty_controls.py` — the new materialized + fallback fork cases and the existing control-swap suite.
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pre-commit run --files ...` — isort/black/ruff/codespell/mypy on the changed files.
- Live end-to-end against the deployed stack (backend + frontend restarted): created a `claude_tty` session, sent one turn to build history, forked it via `POST /api/sessions/{id}/fork`, and confirmed the fork's transcript contained the parent's messages **before** any new message; sent a follow-up turn and confirmed the history was **not** duplicated; confirmed the parent session was unchanged (independent fork). Verified visually with Playwright (mobile width) that the forked session page renders the parent transcript immediately.

## Test Result
- `uv run pytest` — 2848 passed (3 pre-existing unrelated warnings: a subprocess `__del__` ResourceWarning and a Codex enum-serialization UserWarning); pre-commit clean on the changed files.
- Live fork: the fork's event stream showed the parent's `user`/`agent` turns on creation (2 events), a follow-up turn appended cleanly (4 events, no duplicated history), and the parent stayed at its original 2 events.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run --all-files` and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [ ] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity (screenshots optional).
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [x] I have updated documentation or config examples if user-facing behavior changed.

</details>