### PR TITLE
feat: attach the spec to manager inbox review gates

### DIFF
--- a/.agents/skills/waypoint-manager/templates/manager/integrate.md
+++ b/.agents/skills/waypoint-manager/templates/manager/integrate.md
@@ -23,7 +23,7 @@ approval fast-forward {{trunk}} onto {{branch}} — you never merge without that
    [ -n "$item" ] || item=$(waypoint inbox post --json - <<'JSON' | jq -r '.item.id'
    { "subject": "{{ticket_channel}}: {{ticket_title}} — PR review",
      "blocks": [
-       { "type": "markdown", "text": "<PR link {{pr_url}}, summary, CI state from gh pr view>" },
+       { "type": "markdown", "text": "[Open pull request]({{pr_url}})\n\n<summary and CI state from gh pr view>" },
        { "type": "approval", "prompt": "Merge this PR?",
          "options": ["merge", "request-changes", "abort"], "required": true } ] }
    JSON

--- a/.agents/skills/waypoint-manager/templates/manager/monitor.md
+++ b/.agents/skills/waypoint-manager/templates/manager/monitor.md
@@ -81,18 +81,16 @@ When the writer posts back, branch on its `kind`. Act on the newest `spec_ready`
 posts in the log.
 
 **`spec_ready`** — move `spec_pending → spec_review` (recording `{{spec_ref}}`) and
-post an **approval** inbox item that **attaches the spec** so the human opens the exact
-RFC/PRD from the gate. On the answer: **approve** → `ready`; **request-changes** →
+post an **approval** inbox item that **attaches the spec**. On the answer: **approve**
+→ `ready`; **request-changes** →
 `spec_pending` (re-spec — see **Re-spec** below); **reject** → `abandoned`. A silent
 latency-timeout is abandoned by the `latency_timeouts` reconcile path in
 `{{templates_dir}}/manager/loop-cycle.md`.
 
-`{{spec_ref}}` must be a local readable regular file for this gate — a symbolic board
-ref (`ticket:<id>`) is not attachable. `--attach` uploads it to your session before the
-post; the runtime pins it against the inbox item so the orphan sweep keeps it while the
-gate is open. If the attach/post fails, **do not** set `--inbox-item`: leave the ticket
-gate-less so the next drain reports the operational failure instead of asking the human
-to approve a spec they cannot open.
+`{{spec_ref}}` must be a local readable regular file for this gate; a symbolic board
+ref (`ticket:<id>`) is not attachable. `--attach` uploads it and pins it against the
+inbox item for the life of the gate. On an attach/post failure, leave `--inbox-item`
+unset so the next drain reports the failure rather than gating on an unopenable spec.
 
 ```bash
 [ "$(waypoint manager ticket show {{ticket_id}} | jq -r '.ticket.state')" = spec_review ] \

--- a/.agents/skills/waypoint-manager/templates/manager/monitor.md
+++ b/.agents/skills/waypoint-manager/templates/manager/monitor.md
@@ -81,25 +81,36 @@ When the writer posts back, branch on its `kind`. Act on the newest `spec_ready`
 posts in the log.
 
 **`spec_ready`** — move `spec_pending → spec_review` (recording `{{spec_ref}}`) and
-post an **approval** inbox item with the spec. On the answer: **approve** → `ready`;
-**request-changes** → `spec_pending` (re-spec — see **Re-spec** below); **reject** →
-`abandoned`. A silent latency-timeout is abandoned by the `latency_timeouts` reconcile
-path in `{{templates_dir}}/manager/loop-cycle.md`.
+post an **approval** inbox item that **attaches the spec** so the human opens the exact
+RFC/PRD from the gate. On the answer: **approve** → `ready`; **request-changes** →
+`spec_pending` (re-spec — see **Re-spec** below); **reject** → `abandoned`. A silent
+latency-timeout is abandoned by the `latency_timeouts` reconcile path in
+`{{templates_dir}}/manager/loop-cycle.md`.
+
+`{{spec_ref}}` must be a local readable regular file for this gate — a symbolic board
+ref (`ticket:<id>`) is not attachable. `--attach` uploads it to your session before the
+post; the runtime pins it against the inbox item so the orphan sweep keeps it while the
+gate is open. If the attach/post fails, **do not** set `--inbox-item`: leave the ticket
+gate-less so the next drain reports the operational failure instead of asking the human
+to approve a spec they cannot open.
 
 ```bash
 [ "$(waypoint manager ticket show {{ticket_id}} | jq -r '.ticket.state')" = spec_review ] \
   || waypoint manager ticket transition {{ticket_id}} --to spec_review --spec-ref {{spec_ref}}
 item=$(waypoint inbox list --status open --q "{{ticket_channel}}: " \
   | jq -r '[.items[] | select((.subject|startswith("{{ticket_channel}}: ")) and (.subject|endswith("— spec review"))) | .id] | first // empty')   # adopt an open gate a crash left behind
-[ -n "$item" ] || item=$(waypoint inbox post --json - <<'JSON' | jq -r '.item.id'
+if [ -z "$item" ]; then
+  [ -f "{{spec_ref}}" ] || { echo "spec_ref is not a local file: {{spec_ref}}" >&2; exit 1; }   # fail closed; no path-only gate
+  item=$(waypoint inbox post --json - --attach "{{spec_ref}}" <<'JSON' | jq -r '.item.id'
 { "subject": "{{ticket_channel}}: {{ticket_title}} — spec review",
   "blocks": [
-    { "type": "markdown", "text": "<spec summary; ref {{spec_ref}}>" },
+    { "type": "markdown", "text": "<spec summary; the attached file is the full RFC/PRD>" },
     { "type": "approval", "prompt": "Approve this spec?",
       "options": ["approve", "request-changes", "reject"], "required": true } ] }
 JSON
 )
-waypoint manager ticket update {{ticket_id}} --inbox-item "$item"
+fi
+[ -n "$item" ] && waypoint manager ticket update {{ticket_id}} --inbox-item "$item"   # only record a gate that was actually posted
 ```
 
 **`infeasible`** — the writer determined the request cannot be specced. Move

--- a/.agents/skills/waypoint/references/inbox.md
+++ b/.agents/skills/waypoint/references/inbox.md
@@ -33,6 +33,16 @@ An item **resolves** once every required question/approval block is answered; an
 item with no required blocks is a pure FYI that resolves when the user reads it.
 Post prints the created item (its `id` and per-block `id`s).
 
+**Attach a local file** with repeatable `--attach PATH` instead of hand-authoring an
+`attachment` block: `waypoint inbox post --json - --attach ./rfc.md`. Each file is
+uploaded to the sender session (`--from-session-id`, `WAYPOINT_SESSION_ID`, or the
+body's `from_session_id` — required when `--attach` is used) and spliced in as an
+`attachment` block immediately before the first question/approval block (appended when
+the item is non-interactive), preserving `--attach` order. The runtime pins each such
+attachment against the item so the orphan sweep keeps it while the item exists;
+deleting the item releases that pin. A `--attach` path that is missing or unreadable,
+or an unresolvable JSON `attachment` ref, fails the post and creates no item.
+
 ## Block until the user decides
 
 `waypoint inbox wait <item-id> [--until resolved|update] [--timeout 30m]` blocks

--- a/.agents/skills/waypoint/references/inbox.md
+++ b/.agents/skills/waypoint/references/inbox.md
@@ -33,15 +33,14 @@ An item **resolves** once every required question/approval block is answered; an
 item with no required blocks is a pure FYI that resolves when the user reads it.
 Post prints the created item (its `id` and per-block `id`s).
 
-**Attach a local file** with repeatable `--attach PATH` instead of hand-authoring an
-`attachment` block: `waypoint inbox post --json - --attach ./rfc.md`. Each file is
-uploaded to the sender session (`--from-session-id`, `WAYPOINT_SESSION_ID`, or the
-body's `from_session_id` — required when `--attach` is used) and spliced in as an
-`attachment` block immediately before the first question/approval block (appended when
-the item is non-interactive), preserving `--attach` order. The runtime pins each such
-attachment against the item so the orphan sweep keeps it while the item exists;
-deleting the item releases that pin. A `--attach` path that is missing or unreadable,
-or an unresolvable JSON `attachment` ref, fails the post and creates no item.
+**Attach a local file** with repeatable `--attach PATH`: `waypoint inbox post --json -
+--attach ./rfc.md`. Each file uploads to the sender session (`--from-session-id`,
+`WAYPOINT_SESSION_ID`, or the body's `from_session_id`, required with `--attach`) and
+becomes an `attachment` block before the first question/approval block (appended when
+the item is non-interactive), in `--attach` order. The runtime pins each attachment
+against the item so the orphan sweep keeps it while the item exists, and releases the
+pin when the item is deleted. A missing/unreadable `--attach` path or an unresolvable
+`attachment` ref fails the post and creates no item.
 
 ## Block until the user decides
 

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -22,10 +22,9 @@ _SENT_INDEX = "_sent.json"
 # Index of ids the user explicitly pinned to survive the orphan sweep even
 # without being sent. Same transparent-to-sidecars shape as _SENT_INDEX.
 _PINNED_INDEX = "_pinned.json"
-# Maps an attachment id to the inbox item ids that reference it as a display
-# block, so the sweep never reaps an attachment an inbox item still points at.
-# Shape: ``{"<attachment-id>": ["<inbox-item-id>", ...]}``. Its stem isn't a
-# uuid, so it's transparent to entries()/sweep like the other indexes.
+# Maps an attachment id to the inbox item ids that pin it against the sweep:
+# ``{"<attachment-id>": ["<inbox-item-id>", ...]}``. Its stem isn't a uuid, so
+# it's transparent to entries()/sweep like the other indexes.
 _INBOX_REFS_INDEX = "_inbox_refs.json"
 
 
@@ -232,9 +231,8 @@ class AttachmentStore:
     def mark_inbox_references(
         self, session_id: str, item_id: str, attachment_ids: list[str]
     ) -> None:
-        """Record that inbox item ``item_id`` references each attachment, so the
-        sweep keeps it while the item exists. Idempotent; only indexes ids whose
-        blob currently resolves so a bogus ref never pins anything."""
+        """Pin each resolvable attachment against ``item_id`` so the sweep keeps
+        it while that inbox item exists. Idempotent."""
         ids = [
             aid
             for aid in attachment_ids
@@ -256,9 +254,8 @@ class AttachmentStore:
     def release_inbox_references(
         self, session_id: str, item_id: str, attachment_ids: list[str]
     ) -> None:
-        """Drop ``item_id`` from each attachment's reference list, re-exposing an
-        attachment to the sweep once nothing else references it. Idempotent and
-        tolerant of an already-discarded session/attachment; never raises."""
+        """Drop ``item_id``'s pin from each attachment. Idempotent and tolerant
+        of an already-discarded session/attachment; never raises."""
         ids = {aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)}
         if not ids:
             return
@@ -279,7 +276,7 @@ class AttachmentStore:
             self._write_inbox_refs(session_dir, index)
 
     def inbox_referenced_ids(self, session_id: str) -> set[str]:
-        """Attachment ids referenced by one or more inbox items in this session."""
+        """Attachment ids pinned by one or more inbox items in this session."""
         session_dir = self._session_dir(session_id)
         if not session_dir.is_dir():
             return set()
@@ -290,10 +287,9 @@ class AttachmentStore:
         }
 
     def reconcile_inbox_references(self, live_item_ids: set[str]) -> int:
-        """Drop memberships for inbox ids that no longer exist across every
-        session index. Bounded startup repair for a crash that indexed a ref
-        before its inbox row committed. Returns the count of memberships removed.
-        Best-effort; never raises and never recreates a blob or session."""
+        """Drop pins whose inbox item is not in ``live_item_ids``, across every
+        session index, and return how many were removed. Startup repair for a
+        crash that pinned a ref before its row committed; never raises."""
         if not self._root.is_dir():
             return 0
         removed = 0
@@ -301,14 +297,14 @@ class AttachmentStore:
             if not session_dir.is_dir():
                 continue
             index = self._read_inbox_refs(session_dir)
-            if not index:
-                continue
             changed = False
             for aid in list(index):
-                kept = [iid for iid in index[aid] if iid in live_item_ids]
-                if len(kept) != len(index[aid]):
-                    removed += len(index[aid]) - len(kept)
-                    changed = True
+                members = index[aid]
+                kept = [iid for iid in members if iid in live_item_ids]
+                if len(kept) == len(members):
+                    continue
+                removed += len(members) - len(kept)
+                changed = True
                 if kept:
                     index[aid] = kept
                 else:

--- a/backend/src/waypoint/attachments.py
+++ b/backend/src/waypoint/attachments.py
@@ -22,6 +22,11 @@ _SENT_INDEX = "_sent.json"
 # Index of ids the user explicitly pinned to survive the orphan sweep even
 # without being sent. Same transparent-to-sidecars shape as _SENT_INDEX.
 _PINNED_INDEX = "_pinned.json"
+# Maps an attachment id to the inbox item ids that reference it as a display
+# block, so the sweep never reaps an attachment an inbox item still points at.
+# Shape: ``{"<attachment-id>": ["<inbox-item-id>", ...]}``. Its stem isn't a
+# uuid, so it's transparent to entries()/sweep like the other indexes.
+_INBOX_REFS_INDEX = "_inbox_refs.json"
 
 
 def _sanitize_component(value: str, *, fallback: str) -> str:
@@ -224,6 +229,114 @@ class AttachmentStore:
             json.dumps(sorted(remaining)), encoding="utf-8"
         )
 
+    def mark_inbox_references(
+        self, session_id: str, item_id: str, attachment_ids: list[str]
+    ) -> None:
+        """Record that inbox item ``item_id`` references each attachment, so the
+        sweep keeps it while the item exists. Idempotent; only indexes ids whose
+        blob currently resolves so a bogus ref never pins anything."""
+        ids = [
+            aid
+            for aid in attachment_ids
+            if _ATTACHMENT_ID.fullmatch(aid)
+            and self.resolve(session_id, aid) is not None
+        ]
+        if not ids:
+            return
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return
+        index = self._read_inbox_refs(session_dir)
+        for aid in ids:
+            members = index.setdefault(aid, [])
+            if item_id not in members:
+                members.append(item_id)
+        self._write_inbox_refs(session_dir, index)
+
+    def release_inbox_references(
+        self, session_id: str, item_id: str, attachment_ids: list[str]
+    ) -> None:
+        """Drop ``item_id`` from each attachment's reference list, re-exposing an
+        attachment to the sweep once nothing else references it. Idempotent and
+        tolerant of an already-discarded session/attachment; never raises."""
+        ids = {aid for aid in attachment_ids if _ATTACHMENT_ID.fullmatch(aid)}
+        if not ids:
+            return
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return
+        index = self._read_inbox_refs(session_dir)
+        changed = False
+        for aid in ids:
+            members = index.get(aid)
+            if members is None or item_id not in members:
+                continue
+            members.remove(item_id)
+            if not members:
+                del index[aid]
+            changed = True
+        if changed:
+            self._write_inbox_refs(session_dir, index)
+
+    def inbox_referenced_ids(self, session_id: str) -> set[str]:
+        """Attachment ids referenced by one or more inbox items in this session."""
+        session_dir = self._session_dir(session_id)
+        if not session_dir.is_dir():
+            return set()
+        return {
+            aid
+            for aid, members in self._read_inbox_refs(session_dir).items()
+            if members
+        }
+
+    def reconcile_inbox_references(self, live_item_ids: set[str]) -> int:
+        """Drop memberships for inbox ids that no longer exist across every
+        session index. Bounded startup repair for a crash that indexed a ref
+        before its inbox row committed. Returns the count of memberships removed.
+        Best-effort; never raises and never recreates a blob or session."""
+        if not self._root.is_dir():
+            return 0
+        removed = 0
+        for session_dir in self._root.iterdir():
+            if not session_dir.is_dir():
+                continue
+            index = self._read_inbox_refs(session_dir)
+            if not index:
+                continue
+            changed = False
+            for aid in list(index):
+                kept = [iid for iid in index[aid] if iid in live_item_ids]
+                if len(kept) != len(index[aid]):
+                    removed += len(index[aid]) - len(kept)
+                    changed = True
+                if kept:
+                    index[aid] = kept
+                else:
+                    del index[aid]
+            if changed:
+                self._write_inbox_refs(session_dir, index)
+        return removed
+
+    def _read_inbox_refs(self, session_dir: Path) -> dict[str, list[str]]:
+        try:
+            data = json.loads(
+                (session_dir / _INBOX_REFS_INDEX).read_text(encoding="utf-8")
+            )
+        except (OSError, json.JSONDecodeError):
+            return {}
+        if not isinstance(data, dict):
+            return {}
+        return {
+            aid: [iid for iid in members if isinstance(iid, str)]
+            for aid, members in data.items()
+            if isinstance(aid, str) and isinstance(members, list)
+        }
+
+    def _write_inbox_refs(self, session_dir: Path, index: dict[str, list[str]]) -> None:
+        (session_dir / _INBOX_REFS_INDEX).write_text(
+            json.dumps(index, sort_keys=True), encoding="utf-8"
+        )
+
     def sweep(self, session_id: str, ttl_seconds: float) -> int:
         """Reap eager uploads that were never sent — blobs older than
         ``ttl_seconds`` that no sent message references and the user hasn't
@@ -231,8 +344,10 @@ class AttachmentStore:
         session_dir = self._session_dir(session_id)
         if not session_dir.is_dir():
             return 0
-        kept = self._read_id_index(session_dir, _SENT_INDEX) | self._read_id_index(
-            session_dir, _PINNED_INDEX
+        kept = (
+            self._read_id_index(session_dir, _SENT_INDEX)
+            | self._read_id_index(session_dir, _PINNED_INDEX)
+            | self.inbox_referenced_ids(session_id)
         )
         cutoff = time.time() - ttl_seconds
         removed = 0

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -3283,8 +3283,8 @@ def inbox_post(
     resolved_session = (
         raw_sender if isinstance(raw_sender, str) and raw_sender else None
     )
-    # Validate every --attach path before any upload, so a bad path fails fast
-    # without leaving a half-attached post.
+    # Validate the sender and paths before any upload, so a bad --attach fails
+    # before posting.
     if attach:
         if resolved_session is None:
             raise typer.BadParameter(

--- a/backend/src/waypoint/cli.py
+++ b/backend/src/waypoint/cli.py
@@ -693,6 +693,27 @@ def _parse_json_object(source: str) -> dict[str, Any]:
     return parsed
 
 
+def _splice_inbox_attachment_blocks(
+    blocks: list[Any], attachment_blocks: list[dict[str, Any]]
+) -> list[Any]:
+    """Insert ``--attach`` blocks immediately before the first interactive
+    (question/approval) block, or append them when the item is non-interactive.
+    JSON-authored blocks keep their explicit order; the uploaded blocks keep the
+    given ``--attach`` order among themselves."""
+    if not attachment_blocks:
+        return blocks
+    interactive = {"question", "approval"}
+    idx = next(
+        (
+            i
+            for i, block in enumerate(blocks)
+            if isinstance(block, dict) and block.get("type") in interactive
+        ),
+        len(blocks),
+    )
+    return [*blocks[:idx], *attachment_blocks, *blocks[idx:]]
+
+
 def _parse_meta(items: list[str] | None) -> dict[str, str]:
     metadata: dict[str, str] = {}
     for item in items or []:
@@ -3236,9 +3257,21 @@ def inbox_post(
             "attachments are pinned into this session's store.",
         ),
     ] = None,
+    attach: Annotated[
+        list[Path] | None,
+        typer.Option(
+            "--attach",
+            help="Local file to upload to the sender session and attach as an "
+            "openable block, inserted before the first question/approval block "
+            "(appended when the item is non-interactive). Repeatable; order is "
+            "preserved.",
+            metavar="PATH",
+        ),
+    ] = None,
 ) -> None:
     """Post an inbox item. The body is JSON because a multi-block item is
-    inherently structured; skills build the block list."""
+    inherently structured; skills build the block list. ``--attach`` uploads a
+    local file to the sender session and threads it in as an openable block."""
     body = _parse_json_object(json_source)
     subject = body.get("subject")
     blocks = body.get("blocks", [])
@@ -3246,13 +3279,41 @@ def inbox_post(
         raise typer.BadParameter("--json must include a non-empty 'subject'")
     if not isinstance(blocks, list):
         raise typer.BadParameter("--json 'blocks' must be a list")
-    resolved_session = from_session_id or body.get("from_session_id")
-    _emit(
-        _settings_from_ctx(ctx),
-        lambda c: {
-            "item": c.post_inbox(subject, blocks, from_session_id=resolved_session)
-        },
+    raw_sender = from_session_id or body.get("from_session_id")
+    resolved_session = (
+        raw_sender if isinstance(raw_sender, str) and raw_sender else None
     )
+    # Validate every --attach path before any upload, so a bad path fails fast
+    # without leaving a half-attached post.
+    if attach:
+        if resolved_session is None:
+            raise typer.BadParameter(
+                "--attach requires a sender session: pass --from-session-id, set "
+                "WAYPOINT_SESSION_ID, or include 'from_session_id' in the --json body."
+            )
+        for path in attach:
+            if not path.is_file():
+                raise typer.BadParameter(f"--attach is not a readable file: {path}")
+
+    def run(c: WaypointClient) -> dict[str, Any]:
+        attachment_blocks: list[dict[str, Any]] = []
+        if attach:
+            assert resolved_session is not None  # guarded above
+            for path in attach:
+                spec = c.upload_attachment(resolved_session, path)
+                attachment_blocks.append(
+                    {
+                        "type": "attachment",
+                        "ref": {
+                            "session_id": resolved_session,
+                            "attachment_id": spec["id"],
+                        },
+                    }
+                )
+        merged = _splice_inbox_attachment_blocks(blocks, attachment_blocks)
+        return {"item": c.post_inbox(subject, merged, from_session_id=resolved_session)}
+
+    _emit(_settings_from_ctx(ctx), run)
 
 
 @inbox_app.command("get")

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -3946,12 +3946,13 @@ class SessionRuntime:
             raise
 
         service = self.notifications
+        with_notifications = (
+            service is not None
+            and service.has_targets()
+            and self.settings.notifications.allows_intent("inbox")
+        )
         try:
-            if (
-                service is not None
-                and service.has_targets()
-                and self.settings.notifications.allows_intent("inbox")
-            ):
+            if with_notifications and service is not None:
                 item = self.storage.create_inbox_item_with_notifications(
                     from_session_id=request.from_session_id or "",
                     from_label=from_label,
@@ -3962,7 +3963,6 @@ class SessionRuntime:
                     ),
                     item_id=item_id,
                 )
-                service.wake()
             else:
                 item = self.storage.create_inbox_item(
                     from_session_id=request.from_session_id or "",
@@ -3974,6 +3974,11 @@ class SessionRuntime:
         except Exception:
             _release_all()
             raise
+        # Past this point the row is durable and its refs are protected — never
+        # roll back. Waking the notifier is a side effect on already-committed
+        # state, so it stays outside the rollback guard.
+        if with_notifications and service is not None:
+            service.wake()
         # The author (a session filing its own item) is not woken; a human/UI
         # post carries no session id, so its subscribers are woken.
         await self._publish_inbox_update(

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -7,6 +7,7 @@ import re
 import secrets
 import shutil
 import subprocess
+import uuid
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
@@ -622,6 +623,16 @@ class SessionRuntime:
         if self.usage_providers is not None:
             await self.usage_providers.start()
         self._reconcile_provider_selections()
+        # Drop attachment-reference memberships for inbox ids that no longer
+        # exist — a crash can index a ref before its row commits (FR-5 ordering).
+        try:
+            removed = self.attachments.reconcile_inbox_references(
+                set(self.storage.all_inbox_item_ids())
+            )
+            if removed:
+                log.info("reconciled %d stale inbox attachment references", removed)
+        except Exception:
+            log.exception("failed to reconcile inbox attachment references")
 
     def _reconcile_provider_selections(self) -> None:
         """Mark provider-selected sessions whose provider is no longer enabled as
@@ -3895,43 +3906,98 @@ class SessionRuntime:
             session = self.storage.get_session(request.from_session_id)
             if session is not None:
                 from_label = session.title
+        # Preallocate the id so the attachment index can pin refs against it
+        # before the row is exposed (FR-4/FR-5 ordering). Resolve every outbound
+        # attachment block up front: an unresolvable ref is a 422 and creates no
+        # item — no index write, no row.
+        item_id = uuid.uuid4().hex
         blocks: list[InboxBlockInput] = [
             (
-                block.model_copy(update={"ref": self._enrich_inbox_ref(block.ref)})
+                block.model_copy(
+                    update={"ref": self._resolve_outbound_inbox_ref(block.ref)}
+                )
                 if isinstance(block, InboxAttachmentBlockInput)
                 else block
             )
             for block in request.blocks
         ]
+        refs_by_session: dict[str, list[str]] = defaultdict(list)
+        for block in blocks:
+            if isinstance(block, InboxAttachmentBlockInput):
+                refs_by_session[block.ref.session_id].append(block.ref.attachment_id)
+
+        # Register references before exposing the item. On any failure — here or
+        # at row insertion — release everything registered in this attempt so no
+        # visible item ever points at a source ref that wasn't protected, and no
+        # stale membership survives a fully-failed post.
+        def _release_all() -> None:
+            for session_id, attachment_ids in refs_by_session.items():
+                self.attachments.release_inbox_references(
+                    session_id, item_id, attachment_ids
+                )
+
+        try:
+            for session_id, attachment_ids in refs_by_session.items():
+                self.attachments.mark_inbox_references(
+                    session_id, item_id, attachment_ids
+                )
+        except Exception:
+            _release_all()
+            raise
+
         service = self.notifications
-        if (
-            service is not None
-            and service.has_targets()
-            and self.settings.notifications.allows_intent("inbox")
-        ):
-            item = self.storage.create_inbox_item_with_notifications(
-                from_session_id=request.from_session_id or "",
-                from_label=from_label,
-                subject=request.subject,
-                blocks=blocks,
-                make_deliveries=lambda created: service.delivery_rows(
-                    intent_from_inbox_item(created)
-                ),
-            )
-            service.wake()
-        else:
-            item = self.storage.create_inbox_item(
-                from_session_id=request.from_session_id or "",
-                from_label=from_label,
-                subject=request.subject,
-                blocks=blocks,
-            )
+        try:
+            if (
+                service is not None
+                and service.has_targets()
+                and self.settings.notifications.allows_intent("inbox")
+            ):
+                item = self.storage.create_inbox_item_with_notifications(
+                    from_session_id=request.from_session_id or "",
+                    from_label=from_label,
+                    subject=request.subject,
+                    blocks=blocks,
+                    make_deliveries=lambda created: service.delivery_rows(
+                        intent_from_inbox_item(created)
+                    ),
+                    item_id=item_id,
+                )
+                service.wake()
+            else:
+                item = self.storage.create_inbox_item(
+                    from_session_id=request.from_session_id or "",
+                    from_label=from_label,
+                    subject=request.subject,
+                    blocks=blocks,
+                    item_id=item_id,
+                )
+        except Exception:
+            _release_all()
+            raise
         # The author (a session filing its own item) is not woken; a human/UI
         # post carries no session id, so its subscribers are woken.
         await self._publish_inbox_update(
             item, actor_session_id=request.from_session_id or None
         )
         return item
+
+    def _resolve_outbound_inbox_ref(
+        self, ref: InboxAttachmentRef
+    ) -> InboxAttachmentRef:
+        # Outbound display attachments must resolve at post time (FR-4): an
+        # unresolvable ref is a client error, not a silently-degraded block.
+        # Denormalize filename/kind from the resolved spec for inline rendering.
+        match = self.attachments.resolve(ref.session_id, ref.attachment_id)
+        if match is None:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "inbox attachment not found: "
+                    f"{ref.session_id}/{ref.attachment_id}"
+                ),
+            )
+        spec = match[0]
+        return ref.model_copy(update={"filename": spec.filename, "kind": spec.kind})
 
     def get_inbox_item(self, item_id: str) -> InboxItem | None:
         return self.storage.get_inbox_item(item_id)
@@ -4001,20 +4067,51 @@ class SessionRuntime:
             )
         return item
 
+    def _release_inbox_attachment_refs(
+        self,
+        refs_by_item: dict[str, list[tuple[str, str]]],
+        deleted_ids: list[str],
+    ) -> None:
+        # Release the display-attachment refs for the rows actually deleted, so a
+        # source upload the sweep was pinning becomes eligible again once nothing
+        # else references it. Idempotent and tolerant of an already-discarded
+        # source session (FR-6).
+        deleted = set(deleted_ids)
+        for item_id, refs in refs_by_item.items():
+            if item_id not in deleted:
+                continue
+            by_session: dict[str, list[str]] = defaultdict(list)
+            for session_id, attachment_id in refs:
+                by_session[session_id].append(attachment_id)
+            for session_id, attachment_ids in by_session.items():
+                self.attachments.release_inbox_references(
+                    session_id, item_id, attachment_ids
+                )
+
     async def delete_inbox_item(self, item_id: str) -> bool:
+        refs = self.storage.inbox_attachment_block_refs([item_id])
         deleted = self.storage.delete_inbox_item(item_id)
         if deleted:
+            self._release_inbox_attachment_refs(refs, [item_id])
             await self._publish_inbox_deleted(item_id)
         return deleted
 
     async def delete_inbox_items(self, item_ids: list[str]) -> list[str]:
+        refs = self.storage.inbox_attachment_block_refs(item_ids)
         deleted = self.storage.delete_inbox_items(item_ids)
+        self._release_inbox_attachment_refs(refs, deleted)
         for item_id in deleted:
             await self._publish_inbox_deleted(item_id)
         return deleted
 
     async def delete_resolved_inbox_items(self) -> list[str]:
+        # Snapshot refs before deletion: the rows are gone by the time
+        # delete_resolved returns the ids it removed.
+        refs = self.storage.inbox_attachment_block_refs(
+            self.storage.resolved_inbox_item_ids()
+        )
         deleted = self.storage.delete_resolved_inbox_items()
+        self._release_inbox_attachment_refs(refs, deleted)
         for item_id in deleted:
             await self._publish_inbox_deleted(item_id)
         return deleted

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import uuid
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -623,8 +623,8 @@ class SessionRuntime:
         if self.usage_providers is not None:
             await self.usage_providers.start()
         self._reconcile_provider_selections()
-        # Drop attachment-reference memberships for inbox ids that no longer
-        # exist — a crash can index a ref before its row commits (FR-5 ordering).
+        # A crash can pin an attachment ref before its inbox row commits; drop
+        # memberships whose item no longer exists.
         try:
             removed = self.attachments.reconcile_inbox_references(
                 set(self.storage.all_inbox_item_ids())
@@ -3906,10 +3906,9 @@ class SessionRuntime:
             session = self.storage.get_session(request.from_session_id)
             if session is not None:
                 from_label = session.title
-        # Preallocate the id so the attachment index can pin refs against it
-        # before the row is exposed (FR-4/FR-5 ordering). Resolve every outbound
-        # attachment block up front: an unresolvable ref is a 422 and creates no
-        # item — no index write, no row.
+        # Resolve every outbound attachment block, then pin each against a
+        # preallocated id before the row is exposed. An unresolvable ref is a 422
+        # that creates no item; a failure after pinning releases what it pinned.
         item_id = uuid.uuid4().hex
         blocks: list[InboxBlockInput] = [
             (
@@ -3921,44 +3920,30 @@ class SessionRuntime:
             )
             for block in request.blocks
         ]
-        refs_by_session: dict[str, list[str]] = defaultdict(list)
-        for block in blocks:
-            if isinstance(block, InboxAttachmentBlockInput):
-                refs_by_session[block.ref.session_id].append(block.ref.attachment_id)
-
-        # Register references before exposing the item. On any failure — here or
-        # at row insertion — release everything registered in this attempt so no
-        # visible item ever points at a source ref that wasn't protected, and no
-        # stale membership survives a fully-failed post.
-        def _release_all() -> None:
-            for session_id, attachment_ids in refs_by_session.items():
-                self.attachments.release_inbox_references(
-                    session_id, item_id, attachment_ids
-                )
-
+        refs_by_session = self._refs_by_session(
+            (block.ref.session_id, block.ref.attachment_id)
+            for block in blocks
+            if isinstance(block, InboxAttachmentBlockInput)
+        )
+        notify = (
+            self.notifications
+            if self.notifications is not None
+            and self.notifications.has_targets()
+            and self.settings.notifications.allows_intent("inbox")
+            else None
+        )
         try:
             for session_id, attachment_ids in refs_by_session.items():
                 self.attachments.mark_inbox_references(
                     session_id, item_id, attachment_ids
                 )
-        except Exception:
-            _release_all()
-            raise
-
-        service = self.notifications
-        with_notifications = (
-            service is not None
-            and service.has_targets()
-            and self.settings.notifications.allows_intent("inbox")
-        )
-        try:
-            if with_notifications and service is not None:
+            if notify is not None:
                 item = self.storage.create_inbox_item_with_notifications(
                     from_session_id=request.from_session_id or "",
                     from_label=from_label,
                     subject=request.subject,
                     blocks=blocks,
-                    make_deliveries=lambda created: service.delivery_rows(
+                    make_deliveries=lambda created: notify.delivery_rows(
                         intent_from_inbox_item(created)
                     ),
                     item_id=item_id,
@@ -3972,13 +3957,15 @@ class SessionRuntime:
                     item_id=item_id,
                 )
         except Exception:
-            _release_all()
+            for session_id, attachment_ids in refs_by_session.items():
+                self.attachments.release_inbox_references(
+                    session_id, item_id, attachment_ids
+                )
             raise
-        # Past this point the row is durable and its refs are protected — never
-        # roll back. Waking the notifier is a side effect on already-committed
-        # state, so it stays outside the rollback guard.
-        if with_notifications and service is not None:
-            service.wake()
+        # The row is durable and its refs protected past this point; the wake is a
+        # side effect on committed state, so it stays outside the rollback guard.
+        if notify is not None:
+            notify.wake()
         # The author (a session filing its own item) is not woken; a human/UI
         # post carries no session id, so its subscribers are woken.
         await self._publish_inbox_update(
@@ -3986,12 +3973,18 @@ class SessionRuntime:
         )
         return item
 
+    @staticmethod
+    def _refs_by_session(refs: Iterable[tuple[str, str]]) -> dict[str, list[str]]:
+        grouped: dict[str, list[str]] = defaultdict(list)
+        for session_id, attachment_id in refs:
+            grouped[session_id].append(attachment_id)
+        return grouped
+
     def _resolve_outbound_inbox_ref(
         self, ref: InboxAttachmentRef
     ) -> InboxAttachmentRef:
-        # Outbound display attachments must resolve at post time (FR-4): an
-        # unresolvable ref is a client error, not a silently-degraded block.
-        # Denormalize filename/kind from the resolved spec for inline rendering.
+        # An outbound display attachment must resolve at post time; denormalize
+        # filename/kind from the spec for inline rendering.
         match = self.attachments.resolve(ref.session_id, ref.attachment_id)
         if match is None:
             raise HTTPException(
@@ -4077,18 +4070,13 @@ class SessionRuntime:
         refs_by_item: dict[str, list[tuple[str, str]]],
         deleted_ids: list[str],
     ) -> None:
-        # Release the display-attachment refs for the rows actually deleted, so a
-        # source upload the sweep was pinning becomes eligible again once nothing
-        # else references it. Idempotent and tolerant of an already-discarded
-        # source session (FR-6).
+        # Release the pins of the rows actually deleted, re-exposing each source
+        # upload to the sweep once nothing else references it.
         deleted = set(deleted_ids)
         for item_id, refs in refs_by_item.items():
             if item_id not in deleted:
                 continue
-            by_session: dict[str, list[str]] = defaultdict(list)
-            for session_id, attachment_id in refs:
-                by_session[session_id].append(attachment_id)
-            for session_id, attachment_ids in by_session.items():
+            for session_id, attachment_ids in self._refs_by_session(refs).items():
                 self.attachments.release_inbox_references(
                     session_id, item_id, attachment_ids
                 )

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -1686,10 +1686,9 @@ class Storage:
         self, item_ids: list[str]
     ) -> dict[str, list[tuple[str, str]]]:
         """For each existing item, its display attachment blocks' ``(session_id,
-        attachment_id)`` refs. The runtime snapshots these before deleting a row
-        so it can release the matching inbox references afterward. Reply-upload
-        refs are excluded: those are pinned into the requester session and own
-        their retention independently."""
+        attachment_id)`` refs, for the runtime to release after deleting the row.
+        Reply-upload refs are excluded: those are pinned and own their
+        retention independently."""
         unique_ids = list(dict.fromkeys(item_ids))
         out: dict[str, list[tuple[str, str]]] = {}
         for start in range(0, len(unique_ids), 500):
@@ -1710,8 +1709,8 @@ class Storage:
 
     @_synchronized
     def all_inbox_item_ids(self) -> list[str]:
-        """Every inbox item id, for startup reconciliation of the attachment
-        reference index against rows that actually exist."""
+        """Every inbox item id, for startup reconciliation of the reference
+        index against rows that still exist."""
         return [
             row["id"]
             for row in self.connection.execute("SELECT id FROM inbox_items").fetchall()
@@ -1719,8 +1718,8 @@ class Storage:
 
     @_synchronized
     def resolved_inbox_item_ids(self) -> list[str]:
-        """Ids of every resolved item, so the runtime can snapshot their
-        attachment refs before ``delete_resolved_inbox_items`` removes the rows."""
+        """Ids of the resolved items, for snapshotting their attachment refs
+        before ``delete_resolved_inbox_items`` removes the rows."""
         return [
             row["id"]
             for row in self.connection.execute(

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -20,6 +20,7 @@ from waypoint.schemas import (
     EventRecord,
     InboxApprovalAnswer,
     InboxApprovalBlock,
+    InboxAttachmentBlock,
     InboxBlock,
     InboxBlockInput,
     InboxItem,
@@ -1259,10 +1260,11 @@ class Storage:
         from_label: str | None,
         subject: str,
         blocks: list[InboxBlockInput],
+        item_id: str | None = None,
     ) -> InboxItem:
         now = datetime.now(UTC)
         item = InboxItem(
-            id=uuid.uuid4().hex,
+            id=item_id or uuid.uuid4().hex,
             from_session_id=from_session_id,
             from_label=from_label,
             subject=subject,
@@ -1305,6 +1307,7 @@ class Storage:
         subject: str,
         blocks: list[InboxBlockInput],
         make_deliveries: Callable[[InboxItem], list[tuple[str, str, str]]],
+        item_id: str | None = None,
     ) -> InboxItem:
         """Create an inbox item and its per-channel outbox rows atomically.
 
@@ -1315,7 +1318,7 @@ class Storage:
         """
         now = datetime.now(UTC)
         item = InboxItem(
-            id=uuid.uuid4().hex,
+            id=item_id or uuid.uuid4().hex,
             from_session_id=from_session_id,
             from_label=from_label,
             subject=subject,
@@ -1677,6 +1680,54 @@ class Storage:
         updated = self.get_inbox_item(item_id)
         assert updated is not None  # just updated it under the lock
         return updated, True
+
+    @_synchronized
+    def inbox_attachment_block_refs(
+        self, item_ids: list[str]
+    ) -> dict[str, list[tuple[str, str]]]:
+        """For each existing item, its display attachment blocks' ``(session_id,
+        attachment_id)`` refs. The runtime snapshots these before deleting a row
+        so it can release the matching inbox references afterward. Reply-upload
+        refs are excluded: those are pinned into the requester session and own
+        their retention independently."""
+        unique_ids = list(dict.fromkeys(item_ids))
+        out: dict[str, list[tuple[str, str]]] = {}
+        for start in range(0, len(unique_ids), 500):
+            chunk = unique_ids[start : start + 500]
+            placeholders = ",".join("?" for _ in chunk)
+            for row in self.connection.execute(
+                f"SELECT id, blocks FROM inbox_items WHERE id IN ({placeholders})",
+                chunk,
+            ).fetchall():
+                refs = [
+                    (block.ref.session_id, block.ref.attachment_id)
+                    for block in self._parse_inbox_blocks(row["blocks"])
+                    if isinstance(block, InboxAttachmentBlock)
+                ]
+                if refs:
+                    out[row["id"]] = refs
+        return out
+
+    @_synchronized
+    def all_inbox_item_ids(self) -> list[str]:
+        """Every inbox item id, for startup reconciliation of the attachment
+        reference index against rows that actually exist."""
+        return [
+            row["id"]
+            for row in self.connection.execute("SELECT id FROM inbox_items").fetchall()
+        ]
+
+    @_synchronized
+    def resolved_inbox_item_ids(self) -> list[str]:
+        """Ids of every resolved item, so the runtime can snapshot their
+        attachment refs before ``delete_resolved_inbox_items`` removes the rows."""
+        return [
+            row["id"]
+            for row in self.connection.execute(
+                "SELECT id FROM inbox_items WHERE status = ?",
+                (InboxStatus.RESOLVED,),
+            ).fetchall()
+        ]
 
     @_synchronized
     def delete_inbox_item(self, item_id: str) -> bool:

--- a/backend/tests/test_attachments.py
+++ b/backend/tests/test_attachments.py
@@ -168,6 +168,94 @@ def test_sweep_missing_session_is_noop(tmp_path: Path) -> None:
     assert _store(tmp_path).sweep("never-existed", ttl_seconds=60) == 0
 
 
+def _age(store: AttachmentStore, session_id: str, attachment_id: str) -> None:
+    resolved = store.resolve(session_id, attachment_id)
+    assert resolved is not None
+    os.utime(resolved[1].parent / f"{attachment_id}.json", (1000, 1000))
+
+
+def test_inbox_reference_survives_sweep(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    _age(store, "s", spec.id)
+    store.mark_inbox_references("s", "item-1", [spec.id])
+
+    assert store.inbox_referenced_ids("s") == {spec.id}
+    # Old, unsent, unpinned — but an inbox item references it.
+    assert store.sweep("s", ttl_seconds=60) == 0
+    assert store.resolve("s", spec.id) is not None
+
+
+def test_two_items_share_one_attachment(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    _age(store, "s", spec.id)
+    store.mark_inbox_references("s", "item-1", [spec.id])
+    store.mark_inbox_references("s", "item-2", [spec.id])
+
+    # Releasing one holder does not expose it while the other still references it.
+    store.release_inbox_references("s", "item-1", [spec.id])
+    assert store.inbox_referenced_ids("s") == {spec.id}
+    assert store.sweep("s", ttl_seconds=60) == 0
+
+    # Releasing the last holder re-exposes the unpinned/unsent upload.
+    store.release_inbox_references("s", "item-2", [spec.id])
+    assert store.inbox_referenced_ids("s") == set()
+    assert store.sweep("s", ttl_seconds=60) == 1
+    assert store.resolve("s", spec.id) is None
+
+
+def test_mark_inbox_references_is_idempotent(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    store.mark_inbox_references("s", "item-1", [spec.id])
+    store.mark_inbox_references("s", "item-1", [spec.id])
+    # A single release clears the (deduplicated) membership.
+    store.release_inbox_references("s", "item-1", [spec.id])
+    assert store.inbox_referenced_ids("s") == set()
+
+
+def test_mark_inbox_references_ignores_unresolvable_id(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    # A well-formed but non-existent id is never pinned.
+    store.mark_inbox_references("s", "item-1", ["0" * 32])
+    assert store.inbox_referenced_ids("s") == set()
+
+
+def test_release_tolerates_missing_session(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    # No blow-up releasing against a never-created / already-discarded session.
+    store.release_inbox_references("gone", "item-1", ["0" * 32])
+    assert store.inbox_referenced_ids("gone") == set()
+
+
+def test_discard_removes_inbox_reference_index(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    store.mark_inbox_references("s", "item-1", [spec.id])
+    store.discard("s")
+    assert store.inbox_referenced_ids("s") == set()
+    assert store.resolve("s", spec.id) is None
+
+
+def test_reconcile_drops_dead_inbox_ids(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    a = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")
+    b = store.save("s", data=PNG_BYTES, filename="b.png", content_type="image/png")
+    store.mark_inbox_references("s", "live", [a.id])
+    store.mark_inbox_references("s", "dead", [b.id])
+
+    # Only "live" still exists; "dead"'s stale membership is pruned.
+    removed = store.reconcile_inbox_references({"live"})
+    assert removed == 1
+    assert store.inbox_referenced_ids("s") == {a.id}
+
+
+def test_reconcile_missing_root_is_noop(tmp_path: Path) -> None:
+    assert _store(tmp_path).reconcile_inbox_references({"anything"}) == 0
+
+
 def test_delete_removes_blob_and_sidecar(tmp_path: Path) -> None:
     store = _store(tmp_path)
     spec = store.save("s", data=PNG_BYTES, filename="a.png", content_type="image/png")

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -3849,3 +3849,160 @@ def test_rebuild_telemetry_confirm_prompt_aborts_on_no(tmp_path: Path) -> None:
 
     assert result.exit_code != 0
     assert _fact_count(db_path) == 0
+
+
+def _inbox_attach_client(
+    captured: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Wire ``waypoint.cli.WaypointClient`` to a mock transport that records the
+    attachment upload and the inbox post body."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/attachments") and request.method == "POST":
+            captured.setdefault("uploads", []).append(request.url.path)
+            return httpx.Response(200, json={"id": "a" * 32, "filename": "rfc.md"})
+        if request.url.path == "/api/inbox" and request.method == "POST":
+            captured["post_body"] = json.loads(request.content)
+            return httpx.Response(200, json={"item": {"id": "item-1", "blocks": []}})
+        return httpx.Response(404, json={"detail": f"unexpected {request.url.path}"})
+
+    def fake_client(settings: Settings, **_: object) -> WaypointClient:
+        http = httpx.Client(transport=httpx.MockTransport(handler), base_url="http://t")
+        return WaypointClient(settings, token="t", client=http)
+
+    monkeypatch.setattr("waypoint.cli.WaypointClient", fake_client)
+
+
+def test_inbox_post_attach_uploads_and_splices_before_interactive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec_file = tmp_path / "rfc.md"
+    spec_file.write_text("# spec", encoding="utf-8")
+    body = {
+        "subject": "chan: title — spec review",
+        "blocks": [
+            {"type": "markdown", "text": "summary"},
+            {
+                "type": "approval",
+                "prompt": "Approve?",
+                "options": ["approve", "reject"],
+                "required": True,
+            },
+        ],
+    }
+    body_file = tmp_path / "body.json"
+    body_file.write_text(json.dumps(body), encoding="utf-8")
+
+    captured: dict[str, Any] = {}
+    _inbox_attach_client(captured, monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "inbox",
+            "post",
+            "--json",
+            str(body_file),
+            "--from-session-id",
+            "sess-x",
+            "--attach",
+            str(spec_file),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert captured["uploads"] == ["/api/sessions/sess-x/attachments"]
+    posted = captured["post_body"]
+    assert posted["from_session_id"] == "sess-x"
+    types = [block["type"] for block in posted["blocks"]]
+    # Attachment spliced immediately before the first interactive (approval) block.
+    assert types == ["markdown", "attachment", "approval"]
+    ref = posted["blocks"][1]["ref"]
+    assert ref == {"session_id": "sess-x", "attachment_id": "a" * 32}
+
+
+def test_inbox_post_attach_appends_when_non_interactive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec_file = tmp_path / "rfc.md"
+    spec_file.write_text("# spec", encoding="utf-8")
+    body_file = tmp_path / "body.json"
+    body_file.write_text(
+        json.dumps({"subject": "s", "blocks": [{"type": "markdown", "text": "fyi"}]}),
+        encoding="utf-8",
+    )
+    captured: dict[str, Any] = {}
+    _inbox_attach_client(captured, monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "inbox",
+            "post",
+            "--json",
+            str(body_file),
+            "--from-session-id",
+            "sess-x",
+            "--attach",
+            str(spec_file),
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+    types = [block["type"] for block in captured["post_body"]["blocks"]]
+    assert types == ["markdown", "attachment"]
+
+
+def test_inbox_post_attach_requires_sender(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WAYPOINT_SESSION_ID", raising=False)
+    spec_file = tmp_path / "rfc.md"
+    spec_file.write_text("# spec", encoding="utf-8")
+    body_file = tmp_path / "body.json"
+    body_file.write_text(json.dumps({"subject": "s", "blocks": []}), encoding="utf-8")
+    captured: dict[str, Any] = {}
+    _inbox_attach_client(captured, monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "inbox",
+            "post",
+            "--json",
+            str(body_file),
+            "--attach",
+            str(spec_file),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "sender session" in result.output
+    assert "uploads" not in captured  # failed before any upload/post
+
+
+def test_inbox_post_attach_missing_file_fails_before_upload(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    body_file = tmp_path / "body.json"
+    body_file.write_text(json.dumps({"subject": "s", "blocks": []}), encoding="utf-8")
+    captured: dict[str, Any] = {}
+    _inbox_attach_client(captured, monkeypatch)
+    result = runner.invoke(
+        app,
+        [
+            "--config",
+            str(_config(tmp_path)),
+            "inbox",
+            "post",
+            "--json",
+            str(body_file),
+            "--from-session-id",
+            "sess-x",
+            "--attach",
+            str(tmp_path / "does-not-exist.md"),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "not a readable file" in result.output
+    assert "uploads" not in captured

--- a/backend/tests/test_inbox_api.py
+++ b/backend/tests/test_inbox_api.py
@@ -133,27 +133,30 @@ async def test_reply_attachment_ref_is_denormalized(tmp_path: Path) -> None:
     assert reply["attachments"][0]["kind"] == "image"
 
 
-async def test_unresolvable_ref_has_no_denormalized_name(tmp_path: Path) -> None:
+async def test_unresolvable_reply_ref_has_no_denormalized_name(tmp_path: Path) -> None:
+    # A user reply may attach a ref that later can't be resolved; that path still
+    # degrades to no label (the backend never trusts a client-supplied name),
+    # unlike an outbound post block, which fails closed with a 422.
     app, token = _build(tmp_path)
     async with _client(app) as client:
         post = await client.post(
             "/api/inbox",
+            json={"subject": "gate", "blocks": [_question_block()]},
+            headers=_auth(token),
+        )
+        item = post.json()["item"]
+        block_id = item["blocks"][0]["id"]
+        submit = await client.post(
+            f"/api/inbox/{item['id']}/blocks/{block_id}",
             json={
-                "subject": "bogus",
-                "from_session_id": "s1",
-                "blocks": [
-                    {
-                        "type": "attachment",
-                        "ref": {"session_id": "s1", "attachment_id": "0" * 32},
-                    }
-                ],
+                "reply": {
+                    "attachments": [{"session_id": "s1", "attachment_id": "0" * 32}]
+                }
             },
             headers=_auth(token),
         )
-        assert post.status_code == 200
-        ref = post.json()["item"]["blocks"][0]["ref"]
-    # A ref that can't be resolved carries no name — the backend never trusts a
-    # client-supplied label.
+        assert submit.status_code == 200
+        ref = submit.json()["item"]["blocks"][0]["reply"]["attachments"][0]
     assert ref["filename"] is None
     assert ref["kind"] is None
 
@@ -425,3 +428,182 @@ def test_ws_rejects_bad_token(tmp_path: Path) -> None:
         with pytest.raises(WebSocketDisconnect):
             with client.websocket_connect("/ws/inbox/x?token=bad") as ws:
                 ws.receive_json()
+
+
+# ── attachment reference indexing (RFC: manager inbox attachments) ──
+
+
+def _approval_block() -> dict[str, Any]:
+    return {
+        "type": "approval",
+        "prompt": "Approve this spec?",
+        "options": ["approve", "reject"],
+        "required": True,
+    }
+
+
+def _seed_attachment(app: Any, session_id: str) -> str:
+    """Store a blob directly (bypassing the session-gated HTTP upload) and return
+    its id."""
+    spec = app.state.context.runtime.attachments.save(
+        session_id, data=b"# rfc", filename="rfc.md", content_type="text/markdown"
+    )
+    return spec.id
+
+
+async def test_post_with_attachment_indexes_and_denormalizes(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    store = app.state.context.runtime.attachments
+    aid = _seed_attachment(app, "mgr")
+    async with _client(app) as client:
+        post = await client.post(
+            "/api/inbox",
+            json={
+                "subject": "chan: t — spec review",
+                "from_session_id": "mgr",
+                "blocks": [
+                    {"type": "markdown", "text": "review"},
+                    {
+                        "type": "attachment",
+                        "ref": {"session_id": "mgr", "attachment_id": aid},
+                    },
+                    _approval_block(),
+                ],
+            },
+            headers=_auth(token),
+        )
+    assert post.status_code == 200, post.text
+    item = post.json()["item"]
+    att = next(b for b in item["blocks"] if b["type"] == "attachment")
+    # Runtime denormalized the display name/kind from the resolved spec.
+    assert att["ref"]["filename"] == "rfc.md"
+    assert att["ref"]["kind"] == "file"
+    # And pinned it against this item so the orphan sweep keeps it.
+    assert store.inbox_referenced_ids("mgr") == {aid}
+
+
+async def test_post_with_unresolvable_attachment_is_422_and_creates_nothing(
+    tmp_path: Path,
+) -> None:
+    app, token = _build(tmp_path)
+    store = app.state.context.runtime.attachments
+    async with _client(app) as client:
+        post = await client.post(
+            "/api/inbox",
+            json={
+                "subject": "bad ref",
+                "from_session_id": "mgr",
+                "blocks": [
+                    {
+                        "type": "attachment",
+                        "ref": {"session_id": "mgr", "attachment_id": "f" * 32},
+                    },
+                    _approval_block(),
+                ],
+            },
+            headers=_auth(token),
+        )
+        assert post.status_code == 422
+        listing = await client.get("/api/inbox", headers=_auth(token))
+    # No item persisted, no membership left behind.
+    assert listing.json()["items"] == []
+    assert store.inbox_referenced_ids("mgr") == set()
+
+
+async def test_delete_item_releases_attachment_ref(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    store = app.state.context.runtime.attachments
+    aid = _seed_attachment(app, "mgr")
+    async with _client(app) as client:
+        post = await client.post(
+            "/api/inbox",
+            json={
+                "subject": "chan: t — spec review",
+                "from_session_id": "mgr",
+                "blocks": [
+                    {
+                        "type": "attachment",
+                        "ref": {"session_id": "mgr", "attachment_id": aid},
+                    },
+                    _approval_block(),
+                ],
+            },
+            headers=_auth(token),
+        )
+        item_id = post.json()["item"]["id"]
+        assert store.inbox_referenced_ids("mgr") == {aid}
+        await client.delete(f"/api/inbox/{item_id}", headers=_auth(token))
+    # Deleting the item releases the pin; the upload is sweep-eligible again.
+    assert store.inbox_referenced_ids("mgr") == set()
+
+
+async def test_delete_resolved_releases_attachment_refs(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    store = app.state.context.runtime.attachments
+    aid = _seed_attachment(app, "mgr")
+    async with _client(app) as client:
+        post = await client.post(
+            "/api/inbox",
+            json={
+                "subject": "chan: t — spec review",
+                "from_session_id": "mgr",
+                "blocks": [
+                    {
+                        "type": "attachment",
+                        "ref": {"session_id": "mgr", "attachment_id": aid},
+                    },
+                    _approval_block(),
+                ],
+            },
+            headers=_auth(token),
+        )
+        item = post.json()["item"]
+        block_id = next(b["id"] for b in item["blocks"] if b["type"] == "approval")
+        await client.post(
+            f"/api/inbox/{item['id']}/blocks/{block_id}",
+            json={"answer": {"decision": "approve"}},
+            headers=_auth(token),
+        )
+        assert store.inbox_referenced_ids("mgr") == {aid}
+        resp = await client.post("/api/inbox/delete-resolved", headers=_auth(token))
+        assert resp.status_code == 200
+    assert store.inbox_referenced_ids("mgr") == set()
+
+
+async def test_batch_delete_releases_refs_only_for_deleted(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    store = app.state.context.runtime.attachments
+    kept_aid = _seed_attachment(app, "mgr")
+    gone_aid = _seed_attachment(app, "mgr")
+
+    async def _post(aid: str) -> str:
+        resp = await client.post(
+            "/api/inbox",
+            json={
+                "subject": "chan: t — spec review",
+                "from_session_id": "mgr",
+                "blocks": [
+                    {
+                        "type": "attachment",
+                        "ref": {"session_id": "mgr", "attachment_id": aid},
+                    },
+                    _approval_block(),
+                ],
+            },
+            headers=_auth(token),
+        )
+        return resp.json()["item"]["id"]
+
+    async with _client(app) as client:
+        kept_id = await _post(kept_aid)
+        gone_id = await _post(gone_aid)
+        assert store.inbox_referenced_ids("mgr") == {kept_aid, gone_aid}
+        resp = await client.post(
+            "/api/inbox/batch-delete",
+            json={"item_ids": [gone_id, "ghost"]},
+            headers=_auth(token),
+        )
+        assert resp.status_code == 200
+        assert kept_id  # still present
+    # Only the deleted item's ref is released; the surviving item keeps its pin.
+    assert store.inbox_referenced_ids("mgr") == {kept_aid}

--- a/backend/tests/test_inbox_cli.py
+++ b/backend/tests/test_inbox_cli.py
@@ -204,3 +204,47 @@ def test_wait_engine_is_awaitable_via_asyncio_run() -> None:
         _wait_for_inbox(client, "i1", frozenset({"resolved"}), None, 1.0)
     )
     assert result.outcome == "resolved"
+
+
+# ── inbox post --attach block splicing ──
+
+
+def test_splice_before_first_interactive_block() -> None:
+    from waypoint.cli import _splice_inbox_attachment_blocks
+
+    blocks = [
+        {"type": "markdown", "text": "m"},
+        {"type": "approval", "prompt": "ok?"},
+    ]
+    attach = [{"type": "attachment", "ref": {"session_id": "s", "attachment_id": "a"}}]
+    merged = _splice_inbox_attachment_blocks(blocks, attach)
+    assert [b["type"] for b in merged] == ["markdown", "attachment", "approval"]
+
+
+def test_splice_appends_when_non_interactive() -> None:
+    from waypoint.cli import _splice_inbox_attachment_blocks
+
+    blocks = [{"type": "markdown", "text": "m"}]
+    attach = [{"type": "attachment", "ref": {"session_id": "s", "attachment_id": "a"}}]
+    merged = _splice_inbox_attachment_blocks(blocks, attach)
+    assert [b["type"] for b in merged] == ["markdown", "attachment"]
+
+
+def test_splice_preserves_attach_order_and_question_target() -> None:
+    from waypoint.cli import _splice_inbox_attachment_blocks
+
+    blocks = [{"type": "question", "question": "q?"}]
+    attach = [
+        {"type": "attachment", "ref": {"session_id": "s", "attachment_id": "a1"}},
+        {"type": "attachment", "ref": {"session_id": "s", "attachment_id": "a2"}},
+    ]
+    merged = _splice_inbox_attachment_blocks(blocks, attach)
+    assert [b["type"] for b in merged] == ["attachment", "attachment", "question"]
+    assert [b["ref"]["attachment_id"] for b in merged[:2]] == ["a1", "a2"]
+
+
+def test_splice_noop_without_attachments() -> None:
+    from waypoint.cli import _splice_inbox_attachment_blocks
+
+    blocks = [{"type": "markdown", "text": "m"}]
+    assert _splice_inbox_attachment_blocks(blocks, []) is blocks

--- a/backend/tests/test_manager_templates.py
+++ b/backend/tests/test_manager_templates.py
@@ -1,0 +1,35 @@
+"""Guards for the shipped manager template contract (RFC: manager inbox
+attachments). These checked-in templates drive the manager's human gates; a
+drift here silently reverts the attachment behavior, so pin the command pattern.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_TEMPLATES = (
+    Path(__file__).resolve().parents[2]
+    / ".agents/skills/waypoint-manager/templates/manager"
+)
+
+
+def _read(name: str) -> str:
+    path = _TEMPLATES / name
+    if not path.is_file():
+        pytest.skip(f"shipped template not present: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def test_spec_gate_attaches_the_spec_and_keeps_adoption_guard() -> None:
+    monitor = _read("monitor.md")
+    # The spec-review gate uploads and attaches the RFC/PRD file.
+    assert 'inbox post --json - --attach "{{spec_ref}}"' in monitor
+    # It fails closed rather than posting a path-only gate.
+    assert '[ -f "{{spec_ref}}" ]' in monitor
+    # And it still adopts an open gate a crash left behind before posting a new one.
+    assert 'endswith("— spec review")' in monitor
+
+
+def test_pr_gate_renders_an_explicit_pull_request_link() -> None:
+    integrate = _read("integrate.md")
+    assert "[Open pull request]({{pr_url}})" in integrate


### PR DESCRIPTION
## Purpose

The manager's human review gates are durable and asynchronous, but a `spec_review` gate's only pointer to the RFC/PRD was a workspace path inside its Markdown, so the human had to locate the file separately and risked reviewing the wrong revision. This makes a manager `spec_review` gate carry the spec itself as an openable attachment, backed by the existing authenticated attachment endpoint and Inbox attachment UI. Attachments stay session-owned per the re-spec constraint: the sender uploads the artifact to its own session, a new per-session inbox-reference index pins it from the orphan sweep while an inbox item references it, and releasing the item or reaping the session returns it to normal cleanup — no inbox-owned blob namespace or synthetic session. Implements `.waypoint/specs/rfc-1442-manager-inbox-attachments.md` (Ticket 1442). No storage migration, no schema change on the inbox rows, and no frontend product change — the Inbox attachment block already renders openable files.

## Changes

### Backend
- `backend/src/waypoint/attachments.py` — add a session-owned inbox-reference index (`_inbox_refs.json`, shape `{attachment_id: [inbox_item_id, ...]}`) with idempotent `mark_inbox_references` / `release_inbox_references` / `inbox_referenced_ids` helpers, extend `sweep`'s keep set with the referenced ids, and add `reconcile_inbox_references(live_item_ids)` for bounded startup repair. `discard` still removes the whole session dir including this index. The index stores opaque ids only, is never exposed through the public attachment API, and `mark_inbox_references` pins only ids whose blob currently resolves.
- `backend/src/waypoint/runtime.py` — `post_inbox_item` preallocates the item id, resolves every outbound attachment block up front (an unresolvable ref is a 422 that creates no item), registers references before exposing the item and rolls every registration back if registration or row insertion fails, and wakes the notifier only after the row is durably persisted so a wake failure can never release a live item's references. `delete_inbox_item` / `delete_inbox_items` / `delete_resolved_inbox_items` snapshot each affected item's attachment-block refs before deletion and release them afterward for the ids actually deleted (idempotent, tolerant of an already-discarded source session). Startup reconciles stale memberships against the live inbox rows. Reply-attachment refs keep their existing degrade-to-unresolved behavior; only outbound post blocks fail closed.
- `backend/src/waypoint/storage.py` — `create_inbox_item` and `create_inbox_item_with_notifications` accept an optional preallocated `item_id`; add `inbox_attachment_block_refs(item_ids)` (display attachment-block refs per existing item, excluding reply uploads), `resolved_inbox_item_ids()`, and `all_inbox_item_ids()` for the deletion-release and startup-reconciliation paths.
- `backend/src/waypoint/cli.py` — `inbox post` gains a repeatable `--attach PATH`. It validates every path and the effective sender (`--from-session-id`, `WAYPOINT_SESSION_ID`, or the JSON body's `from_session_id`) before any upload, uploads each file to the sender session, and splices one attachment block per upload immediately before the first question/approval block (appending them when the item is non-interactive), preserving `--attach` order and composing with JSON-authored attachment blocks.

### Docs
- `.agents/skills/waypoint-manager/templates/manager/monitor.md` — the `spec_review` gate posts with `inbox post --json - --attach "{{spec_ref}}"`, requires `{{spec_ref}}` to be a local readable regular file, and fails closed (no `--inbox-item` recorded) rather than emitting a path-only approval gate, while keeping the open-gate adoption guard.
- `.agents/skills/waypoint-manager/templates/manager/integrate.md` — the PR gate renders an explicit `[Open pull request]({{pr_url}})` Markdown link instead of a copied artifact.
- `.agents/skills/waypoint/references/inbox.md` — document `inbox post --attach`, sender resolution, block placement, and the pin/release lifecycle.

### Tests
- `backend/tests/test_attachments.py` — reference membership survives a sweep, two items share one source file safely, releasing the final ref re-exposes an unpinned/unsent upload, idempotent mark/release, unresolvable ids are never pinned, `discard` removes the index, and startup reconciliation drops dead inbox ids.
- `backend/tests/test_inbox_api.py` — a post with an attachment indexes and denormalizes the ref; an unresolvable outbound ref returns 422 and creates nothing; single, batch, and delete-resolved release refs only for deleted items; an unresolvable reply ref still degrades to no label.
- `backend/tests/test_cli.py`, `backend/tests/test_inbox_cli.py` — `--attach` uploads under the effective sender and splices before the first interactive block (or appends when non-interactive), preserves order, and fails before any upload/post on a missing sender or unreadable path; plus the pure block-splice helper.
- `backend/tests/test_manager_templates.py` (new) — guard the shipped spec gate's `--attach` command and adoption guard and the PR gate's explicit link against template drift.

## Design

Attachments remain ordinary refs in their real source session (RFC Option 2); the reference index protects them exactly while inbox items need them, and session reaping plus the existing orphan retention still own deletion — no synthetic ownership domain, no new frontend or API concept. The SQLite row and the filesystem index cannot be one atomic transaction, so the runtime registers references before the row is exposed: a crash after registration but before insertion leaves only a stale keep entry (never a visible item pointing at an unprotected ref), and bounded startup reconciliation removes memberships whose inbox id no longer exists. Deletion releases are best-effort and idempotent so an already-discarded source session is not an error. The manager fails closed on a missing/unreadable spec so it never asks the human to approve a spec they cannot open, and a PR URL stays an ordinary Markdown link because it opens directly and has its own external lifecycle.

## Validation

- `cd backend && uv run pytest` — 2871 passed (3 pre-existing unrelated warnings).
- `cd backend && uv run pre-commit run --files <changed>` — isort, black, ruff, codespell, mypy all clean.
- End-to-end on the live stack (`waypointctl restart`, backend :8797 / frontend :3010): `waypoint inbox post --json - --attach <rfc>` produced a gate with block order markdown → attachment → approval and the filename denormalized (`rfc-1442-manager-inbox-attachments.md`, kind `file`); the authenticated serve endpoint returned 200 with the file bytes; the on-disk `_inbox_refs.json` pinned the item; a Playwright drive at 390px width rendered the attachment as an openable link to the authenticated serve URL; and deleting the item released the reference (index → `{}`) leaving the now-unreferenced upload eligible for the normal TTL sweep.

Addresses ticket 1442.