### PR TITLE
feat: lazy-load, filter, and sort the ticket board

### DIFF
--- a/backend/src/waypoint/api.py
+++ b/backend/src/waypoint/api.py
@@ -73,6 +73,12 @@ from waypoint.schemas import (
     ManagerNextResponse,
     ManagerReconcileReport,
     ManagerStateResponse,
+    ManagerTicketListQuery,
+    ManagerTicketPage,
+    ManagerTicketScale,
+    ManagerTicketSort,
+    ManagerTicketSortDirection,
+    ManagerTicketState,
     MeResponse,
     ProfileDoctorReport,
     ScheduledMessageCreateRequest,
@@ -1998,6 +2004,37 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         _: Annotated[str, Depends(token_dependency())],
     ) -> ManagerStateResponse:
         return context.runtime.managers.require(manager_id).state()
+
+    @app.get(
+        "/api/manager/{manager_id}/tickets",
+        response_model=ManagerTicketPage,
+    )
+    async def manager_list_tickets(
+        manager_id: str,
+        _: Annotated[str, Depends(token_dependency())],
+        q: str = "",
+        state: Annotated[list[ManagerTicketState] | None, Query()] = None,
+        priority: Annotated[list[str] | None, Query()] = None,
+        scale: Annotated[list[ManagerTicketScale] | None, Query()] = None,
+        sort: ManagerTicketSort = ManagerTicketSort.UPDATED_AT,
+        direction: ManagerTicketSortDirection = ManagerTicketSortDirection.DESC,
+        limit: Annotated[int, Query(ge=1, le=100)] = 50,
+        cursor: str | None = None,
+    ) -> ManagerTicketPage:
+        query = ManagerTicketListQuery(
+            q=q,
+            state=state or [],
+            priority=priority or [],
+            scale=scale or [],
+            sort=sort,
+            direction=direction,
+        )
+        return context.runtime.managers.require(manager_id).list_tickets_page(
+            query,
+            limit=limit,
+            cursor=cursor,
+            cursor_secret=context.settings.password,
+        )
 
     @app.get("/api/manager/{manager_id}/next", response_model=ManagerNextResponse)
     async def manager_next(

--- a/backend/src/waypoint/manager.py
+++ b/backend/src/waypoint/manager.py
@@ -20,10 +20,15 @@ events with one ``(from, to)`` pair (reject vs latency-timeout into
 in ``reason``/meta, not a separate table key.
 """
 
+import base64
+import hashlib
+import hmac
+import json
 import secrets
 import sqlite3
 from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
+from typing import Any
 
 from fastapi import HTTPException, status
 
@@ -37,8 +42,12 @@ from waypoint.schemas import (
     ManagerStateResponse,
     ManagerSummary,
     ManagerTicket,
+    ManagerTicketListQuery,
+    ManagerTicketPage,
     ManagerTicketScale,
+    ManagerTicketSort,
     ManagerTicketState,
+    ManagerTicketSummary,
     ManagerTicketTransitions,
     ManagerTreeState,
     ReconcileDeadLead,
@@ -103,6 +112,116 @@ _RESUMABLE_STATES: frozenset[ManagerTicketState] = frozenset(
         _S.REVIEW_REQUESTED,
     }
 )
+
+# In-flight work: the active build states, for the board rollup's "in flight".
+_IN_FLIGHT_STATES: frozenset[ManagerTicketState] = frozenset(
+    {_S.DELEGATED, _S.BUILDING, _S.REVISING}
+)
+
+# The lifecycle-lane taxonomy the board groups cards by. The keys and their
+# state membership mirror ``frontend/src/lib/board.ts`` (LANES); the backend owns
+# this copy so the query summary can report lane counts without importing the
+# frontend. The dict order is the canonical lane order.
+_LANES: dict[str, tuple[ManagerTicketState, ...]] = {
+    "intake": (_S.INTAKE, _S.TRIAGED),
+    "spec": (_S.SPEC_PENDING, _S.SPEC_REVIEW),
+    "ready": (_S.READY,),
+    "build": (_S.DELEGATED, _S.BUILDING, _S.REVISING),
+    "blocked": (_S.BLOCKED,),
+    "review": (_S.REVIEW_REQUESTED,),
+    "done": (_S.MERGED, _S.DEFERRED, _S.ABANDONED),
+}
+
+
+def _summarize_states(state_counts: dict[str, int]) -> ManagerTicketSummary:
+    """Fold per-state counts into the board's lane and rollup aggregates."""
+    lanes = {
+        lane: sum(state_counts.get(str(state), 0) for state in states)
+        for lane, states in _LANES.items()
+    }
+    return ManagerTicketSummary(
+        total=sum(state_counts.values()),
+        lanes=lanes,
+        awaiting_count=sum(
+            state_counts.get(str(state), 0) for state in _AWAITING_STATES
+        ),
+        in_flight_count=sum(
+            state_counts.get(str(state), 0) for state in _IN_FLIGHT_STATES
+        ),
+        blocked_count=state_counts.get(str(_S.BLOCKED), 0),
+        merged_count=state_counts.get(str(_S.MERGED), 0),
+    )
+
+
+# ─── Ticket-page cursor ───
+
+_CURSOR_VERSION = 1
+
+
+class ManagerCursorError(Exception):
+    """A malformed, tampered, or query-mismatched continuation cursor (→ 422)."""
+
+
+def _priority_rank(priority: str, priority_order: Sequence[str]) -> int:
+    # Mirror ``Storage._priority_case``: configured order first, unknown after.
+    try:
+        return list(priority_order).index(priority)
+    except ValueError:
+        return len(priority_order)
+
+
+def _b64url_encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _cursor_signature(payload: bytes, secret: str) -> bytes:
+    return hmac.new(secret.encode(), payload, hashlib.sha256).digest()
+
+
+def encode_ticket_cursor(
+    query: ManagerTicketListQuery, boundary: list[Any], secret: str
+) -> str:
+    """A signed, query-bound continuation token for the row at ``boundary``."""
+    body = {"v": _CURSOR_VERSION, "fp": query.fingerprint(), "k": boundary}
+    payload = json.dumps(body, separators=(",", ":"), sort_keys=True).encode()
+    signature = _cursor_signature(payload, secret)
+    return f"{_b64url_encode(payload)}.{_b64url_encode(signature)}"
+
+
+def decode_ticket_cursor(
+    cursor: str, query: ManagerTicketListQuery, secret: str
+) -> tuple[Any, ...]:
+    """Validate ``cursor`` against ``query`` and return its keyset boundary.
+
+    Raises ``ManagerCursorError`` for any malformed, tampered, version-stale, or
+    query-mismatched token — the boundary is never guessed.
+    """
+    try:
+        payload_b64, signature_b64 = cursor.split(".", 1)
+        payload = _b64url_decode(payload_b64)
+        signature = _b64url_decode(signature_b64)
+    except (ValueError, TypeError):
+        raise ManagerCursorError("malformed cursor") from None
+    if not hmac.compare_digest(signature, _cursor_signature(payload, secret)):
+        raise ManagerCursorError("bad cursor signature")
+    try:
+        body = json.loads(payload)
+    except json.JSONDecodeError:
+        raise ManagerCursorError("malformed cursor") from None
+    if not isinstance(body, dict) or body.get("v") != _CURSOR_VERSION:
+        raise ManagerCursorError("unsupported cursor version")
+    if body.get("fp") != query.fingerprint():
+        raise ManagerCursorError("cursor does not match query")
+    keyset = body.get("k")
+    if not isinstance(keyset, list) or not keyset:
+        raise ManagerCursorError("malformed cursor")
+    return tuple(keyset)
+
 
 # The transition table as data: legal ``to`` states for each ``from`` state.
 # Self-loops on the six resumable states are the lead/writer-died resume edge.
@@ -391,6 +510,88 @@ class ManagerManager:
 
     def list_tickets(self) -> list[ManagerTicket]:
         return self._storage.list_manager_tickets(manager_id=self._manager_id)
+
+    def list_tickets_page(
+        self,
+        query: ManagerTicketListQuery,
+        *,
+        limit: int,
+        cursor: str | None,
+        cursor_secret: str,
+    ) -> ManagerTicketPage:
+        """One board page for ``query`` plus its full-result summary.
+
+        Priority filter/sort resolve against this manager's configured
+        ``priority_levels``. An out-of-config requested priority raises 422
+        (a typo must not read as an empty board); the cursor is validated and
+        bound to the exact normalized query.
+        """
+        query = query.normalized()
+        config = self.config()
+        priority_order = config.priority_levels
+        unknown = [p for p in query.priority if p not in priority_order]
+        if unknown:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"unknown priority {unknown!r}; "
+                    f"expected one of {priority_order}"
+                ),
+            )
+        keyset: tuple[Any, ...] | None = None
+        if cursor:
+            try:
+                keyset = decode_ticket_cursor(cursor, query, cursor_secret)
+            except ManagerCursorError as exc:
+                raise HTTPException(
+                    status_code=422,
+                    detail=str(exc),
+                ) from exc
+        rows, state_counts = self._storage.query_manager_tickets(
+            manager_id=self._manager_id,
+            q=query.q,
+            states=query.state,
+            priorities=query.priority,
+            scales=query.scale,
+            sort=query.sort,
+            direction=query.direction,
+            priority_order=priority_order,
+            limit=limit,
+            keyset=keyset,
+        )
+        has_more = len(rows) > limit
+        page = rows[:limit]
+        next_cursor: str | None = None
+        if has_more and page:
+            boundary = self._ticket_boundary(page[-1], query.sort, priority_order)
+            next_cursor = encode_ticket_cursor(query, boundary, cursor_secret)
+        return ManagerTicketPage(
+            tickets=page,
+            next_cursor=next_cursor,
+            summary=_summarize_states(state_counts),
+        )
+
+    @staticmethod
+    def _ticket_boundary(
+        ticket: ManagerTicket,
+        sort: ManagerTicketSort,
+        priority_order: Sequence[str],
+    ) -> list[Any]:
+        # The keyset values for ``ticket`` under ``sort``; the timestamp forms use
+        # ``isoformat`` so the boundary is byte-identical to the stored column.
+        if sort == ManagerTicketSort.ID:
+            return [ticket.id]
+        if sort == ManagerTicketSort.PRIORITY:
+            # (unknown-group flag, rank, id) — the three ordering columns.
+            unknown = 0 if ticket.priority in priority_order else 1
+            return [
+                unknown,
+                _priority_rank(ticket.priority, priority_order),
+                ticket.id,
+            ]
+        if sort == ManagerTicketSort.CREATED_AT:
+            return [ticket.created_at.isoformat(), ticket.id]
+        return [ticket.updated_at.isoformat(), ticket.id]
 
     def get_ticket(self, ticket_id: str) -> ManagerTicket:
         ticket = self._storage.get_manager_ticket(

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1072,6 +1072,73 @@ class ManagerListResponse(BaseModel):
     managers: list[ManagerSummary] = Field(default_factory=list)
 
 
+class ManagerTicketSort(StrEnum):
+    UPDATED_AT = "updated_at"
+    CREATED_AT = "created_at"
+    PRIORITY = "priority"
+    ID = "id"
+
+
+class ManagerTicketSortDirection(StrEnum):
+    ASC = "asc"
+    DESC = "desc"
+
+
+class ManagerTicketListQuery(BaseModel):
+    # The normalized, canonical board query. Filters combine with AND; empty
+    # collections and an empty ``q`` mean "no filter on that field". The values
+    # are canonicalized (trimmed ``q``, deduplicated/sorted facets) so an
+    # identical query always produces an identical cursor binding.
+    q: str = ""
+    state: list[ManagerTicketState] = Field(default_factory=list)
+    priority: list[str] = Field(default_factory=list)
+    scale: list[ManagerTicketScale] = Field(default_factory=list)
+    sort: ManagerTicketSort = ManagerTicketSort.UPDATED_AT
+    direction: ManagerTicketSortDirection = ManagerTicketSortDirection.DESC
+
+    def normalized(self) -> "ManagerTicketListQuery":
+        return ManagerTicketListQuery(
+            q=self.q.strip(),
+            state=sorted({str(s) for s in self.state}),
+            priority=sorted(set(self.priority)),
+            scale=sorted({str(s) for s in self.scale}),
+            sort=self.sort,
+            direction=self.direction,
+        )
+
+    def fingerprint(self) -> str:
+        # Deterministic canonical string bound into the cursor so a continuation
+        # token can only be replayed against the exact same query.
+        n = self.normalized()
+        return "|".join(
+            [
+                n.q,
+                ",".join(n.state),
+                ",".join(n.priority),
+                ",".join(n.scale),
+                str(n.sort),
+                str(n.direction),
+            ]
+        )
+
+
+class ManagerTicketSummary(BaseModel):
+    # Aggregates over the ENTIRE matching result, independent of the page limit,
+    # so the board can distinguish an empty lane from an unloaded one.
+    total: int = 0
+    lanes: dict[str, int] = Field(default_factory=dict)
+    awaiting_count: int = 0
+    in_flight_count: int = 0
+    blocked_count: int = 0
+    merged_count: int = 0
+
+
+class ManagerTicketPage(BaseModel):
+    tickets: list[ManagerTicket] = Field(default_factory=list)
+    next_cursor: str | None = None
+    summary: ManagerTicketSummary = Field(default_factory=ManagerTicketSummary)
+
+
 class MeResponse(BaseModel):
     authenticated: bool = True
     default_backend: BackendId = "codex"

--- a/backend/src/waypoint/schemas.py
+++ b/backend/src/waypoint/schemas.py
@@ -1085,10 +1085,9 @@ class ManagerTicketSortDirection(StrEnum):
 
 
 class ManagerTicketListQuery(BaseModel):
-    # The normalized, canonical board query. Filters combine with AND; empty
-    # collections and an empty ``q`` mean "no filter on that field". The values
-    # are canonicalized (trimmed ``q``, deduplicated/sorted facets) so an
-    # identical query always produces an identical cursor binding.
+    # The board query. Filters combine with AND; an empty collection or ``q`` is
+    # no filter. ``normalized()`` canonicalizes the values so an identical query
+    # yields an identical cursor binding.
     q: str = ""
     state: list[ManagerTicketState] = Field(default_factory=list)
     priority: list[str] = Field(default_factory=list)

--- a/backend/src/waypoint/storage.py
+++ b/backend/src/waypoint/storage.py
@@ -5,7 +5,7 @@ import secrets
 import sqlite3
 import threading
 import uuid
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -31,6 +31,9 @@ from waypoint.schemas import (
     InboxStatus,
     ManagerConfig,
     ManagerTicket,
+    ManagerTicketScale,
+    ManagerTicketSort,
+    ManagerTicketSortDirection,
     ManagerTicketState,
     ScheduledMessageRecord,
     ScheduledMessageStatus,
@@ -573,6 +576,15 @@ class Storage:
                 ON manager_tickets(state);
             CREATE INDEX IF NOT EXISTS idx_manager_tickets_priority
                 ON manager_tickets(priority);
+            -- Manager-leading composite indexes for the paged board query's
+            -- keyset sorts (ticket 1504). The trailing id matches the stable
+            -- (sort_value, id) tie-breaker so a page scan is index-ordered.
+            CREATE INDEX IF NOT EXISTS idx_manager_tickets_updated
+                ON manager_tickets(manager_id, updated_at, id);
+            CREATE INDEX IF NOT EXISTS idx_manager_tickets_created
+                ON manager_tickets(manager_id, created_at, id);
+            CREATE INDEX IF NOT EXISTS idx_manager_tickets_mgr_priority
+                ON manager_tickets(manager_id, priority);
             """)
         self.telemetry.init_schema()
         self.usage_providers.init_schema()
@@ -2515,6 +2527,183 @@ class Storage:
         sql += " ORDER BY created_at ASC, id ASC"
         rows = self.connection.execute(sql, params).fetchall()
         return [self._manager_ticket_from_row(row) for row in rows]
+
+    @staticmethod
+    def _escape_like(value: str) -> str:
+        # Make ``q`` a literal substring: neutralize the escape char first, then
+        # the LIKE wildcards, so a title search never behaves as a pattern.
+        return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    @staticmethod
+    def _priority_case(priority_order: Sequence[str]) -> tuple[str, list[Any]]:
+        # Rank priority text by the manager's configured order (first = highest);
+        # any value outside the configuration ranks after all configured ones.
+        parts = ["CASE priority"]
+        params: list[Any] = []
+        for rank, prio in enumerate(priority_order):
+            parts.append("WHEN ? THEN ?")
+            params.extend([prio, rank])
+        parts.append("ELSE ? END")
+        params.append(len(priority_order))
+        return " ".join(parts), params
+
+    def _manager_ticket_filter(
+        self,
+        manager_id: str,
+        q: str,
+        states: Sequence[ManagerTicketState],
+        priorities: Sequence[str],
+        scales: Sequence[ManagerTicketScale],
+    ) -> tuple[str, list[Any]]:
+        conditions = ["manager_id = ?"]
+        params: list[Any] = [manager_id]
+        if q:
+            conditions.append("title LIKE ? ESCAPE '\\'")
+            params.append(f"%{self._escape_like(q)}%")
+        if states:
+            placeholders = ",".join("?" for _ in states)
+            conditions.append(f"state IN ({placeholders})")
+            params.extend(str(state) for state in states)
+        if priorities:
+            placeholders = ",".join("?" for _ in priorities)
+            conditions.append(f"priority IN ({placeholders})")
+            params.extend(priorities)
+        if scales:
+            placeholders = ",".join("?" for _ in scales)
+            conditions.append(f"scale IN ({placeholders})")
+            params.extend(str(scale) for scale in scales)
+        return " AND ".join(conditions), params
+
+    def _order_terms(
+        self,
+        sort: ManagerTicketSort,
+        direction: ManagerTicketSortDirection,
+        priority_order: Sequence[str],
+    ) -> list[tuple[str, list[Any], str]]:
+        # The ordered list of (sql_expr, params, "ASC"|"DESC") columns the page is
+        # sorted by. ``id ASC`` is always the final deterministic tie-breaker.
+        primary_dir = "DESC" if direction == ManagerTicketSortDirection.DESC else "ASC"
+        if sort == ManagerTicketSort.ID:
+            return [("id", [], primary_dir)]  # id is unique — its own tie-break
+        if sort == ManagerTicketSort.PRIORITY:
+            known = list(priority_order)
+            if known:
+                placeholders = ",".join("?" for _ in known)
+                unknown_sql = (
+                    f"CASE WHEN priority IN ({placeholders}) THEN 0 ELSE 1 END"
+                )
+                unknown_params: list[Any] = list(known)
+            else:
+                unknown_sql = "1"  # nothing is configured, so everything is unknown
+                unknown_params = []
+            rank_sql, rank_params = self._priority_case(priority_order)
+            # Unknown priorities sort after configured ones in EITHER direction —
+            # the group flag is always ascending, only the rank flips with it.
+            return [
+                (unknown_sql, unknown_params, "ASC"),
+                (rank_sql, rank_params, primary_dir),
+                ("id", [], "ASC"),
+            ]
+        column = "updated_at" if sort == ManagerTicketSort.UPDATED_AT else "created_at"
+        return [(column, [], primary_dir), ("id", [], "ASC")]
+
+    def _manager_ticket_order(
+        self,
+        sort: ManagerTicketSort,
+        direction: ManagerTicketSortDirection,
+        priority_order: Sequence[str],
+    ) -> tuple[str, list[Any]]:
+        terms = self._order_terms(sort, direction, priority_order)
+        sql = ", ".join(f"({expr}) {order}" for expr, _params, order in terms)
+        params = [
+            param for _expr, term_params, _order in terms for param in term_params
+        ]
+        return sql, params
+
+    def _manager_ticket_keyset(
+        self,
+        sort: ManagerTicketSort,
+        direction: ManagerTicketSortDirection,
+        priority_order: Sequence[str],
+        keyset: tuple[Any, ...],
+    ) -> tuple[str, list[Any]]:
+        # Strict lexicographic "rows after this boundary" predicate matching the
+        # ordering terms: for terms t0..tn with boundary b0..bn,
+        #   (e0 OP0 b0) OR (e0=b0 AND e1 OP1 b1) OR ...
+        # where OPk is ``>`` for an ASC term and ``<`` for a DESC one.
+        terms = self._order_terms(sort, direction, priority_order)
+        disjuncts: list[str] = []
+        params: list[Any] = []
+        for level in range(len(terms)):
+            conjuncts: list[str] = []
+            for prior in range(level):
+                expr, term_params, _order = terms[prior]
+                conjuncts.append(f"({expr}) = ?")
+                params.extend(term_params)
+                params.append(keyset[prior])
+            expr, term_params, order = terms[level]
+            op = ">" if order == "ASC" else "<"
+            conjuncts.append(f"({expr}) {op} ?")
+            params.extend(term_params)
+            params.append(keyset[level])
+            disjuncts.append("(" + " AND ".join(conjuncts) + ")")
+        return " OR ".join(disjuncts), params
+
+    @_synchronized
+    def query_manager_tickets(
+        self,
+        *,
+        manager_id: str,
+        q: str = "",
+        states: Sequence[ManagerTicketState] = (),
+        priorities: Sequence[str] = (),
+        scales: Sequence[ManagerTicketScale] = (),
+        sort: ManagerTicketSort = ManagerTicketSort.UPDATED_AT,
+        direction: ManagerTicketSortDirection = ManagerTicketSortDirection.DESC,
+        priority_order: Sequence[str] = (),
+        limit: int = 50,
+        keyset: tuple[Any, ...] | None = None,
+    ) -> tuple[list[ManagerTicket], dict[str, int]]:
+        """One page of tickets plus per-state counts for the same filter.
+
+        Returns ``(rows, state_counts)`` where ``rows`` holds up to ``limit + 1``
+        ticket payloads — the extra row, when present, signals a further page —
+        ordered by the requested sort with a stable ``id`` tie-breaker, and
+        ``state_counts`` maps each present state to its count across the whole
+        filtered set (independent of ``limit``).
+        """
+        where, params = self._manager_ticket_filter(
+            manager_id, q, states, priorities, scales
+        )
+
+        count_sql = (
+            f"SELECT state, COUNT(*) AS n FROM manager_tickets "
+            f"WHERE {where} GROUP BY state"
+        )
+        state_counts = {
+            str(row["state"]): int(row["n"])
+            for row in self.connection.execute(count_sql, params).fetchall()
+        }
+
+        order_sql, order_params = self._manager_ticket_order(
+            sort, direction, priority_order
+        )
+        page_where = where
+        page_params = list(params)
+        if keyset is not None:
+            keyset_sql, keyset_params = self._manager_ticket_keyset(
+                sort, direction, priority_order, keyset
+            )
+            page_where = f"{page_where} AND ({keyset_sql})"
+            page_params.extend(keyset_params)
+        page_sql = (
+            f"SELECT * FROM manager_tickets WHERE {page_where} "
+            f"ORDER BY {order_sql} LIMIT ?"
+        )
+        page_params.extend(order_params)
+        page_params.append(limit + 1)
+        rows = self.connection.execute(page_sql, page_params).fetchall()
+        return [self._manager_ticket_from_row(row) for row in rows], state_counts
 
     @_synchronized
     def update_manager_ticket(self, ticket: ManagerTicket) -> ManagerTicket:

--- a/backend/tests/test_manager.py
+++ b/backend/tests/test_manager.py
@@ -12,12 +12,14 @@ from fastapi import HTTPException
 
 from waypoint.manager import (
     _ADJACENCY,
+    ManagerCursorError,
     ManagerManager,
     ManagerRegistry,
     ManagerStateError,
     apply_transition,
     check_invariants,
     compute_next,
+    decode_ticket_cursor,
     legal_targets,
     tree_state,
 )
@@ -28,7 +30,10 @@ from waypoint.schemas import (
     ManagerInitRequest,
     ManagerRenderContext,
     ManagerTicket,
+    ManagerTicketListQuery,
     ManagerTicketScale,
+    ManagerTicketSort,
+    ManagerTicketSortDirection,
     ManagerTicketState,
     TicketCreateRequest,
     TicketTransitionRequest,
@@ -1202,3 +1207,474 @@ def test_init_preserves_owner_when_not_resupplied(tmp_path: Path) -> None:
         )
     )
     assert reg.get(first.id).config().owner_session_id == "mgr2"
+
+
+# ── Ticket-list query: paging, filters, sort, cursor, summary (ticket 1504) ──
+
+Sort = ManagerTicketSort
+Dir = ManagerTicketSortDirection
+_SECRET = "cursor-secret"
+
+
+def _seed_query_manager(
+    tmp_path: Path,
+    priority_levels: list[str] | None = None,
+) -> ManagerManager:
+    levels = priority_levels or ["p0", "p1", "p2", "p3"]
+    return _init(
+        _storage(tmp_path),
+        ManagerConfig(priority_levels=levels),
+    )
+
+
+def _seed(mgr: ManagerManager, tickets: list[ManagerTicket]) -> None:
+    for ticket in tickets:
+        mgr._storage.create_manager_ticket(ticket)
+
+
+def _drain(
+    mgr: ManagerManager, query: ManagerTicketListQuery, *, limit: int
+) -> list[str]:
+    """All ticket ids across a full cursor walk of ``query``."""
+    seen: list[str] = []
+    cursor: str | None = None
+    for _ in range(100):  # generous guard against a non-terminating walk
+        page = mgr.list_tickets_page(
+            query, limit=limit, cursor=cursor, cursor_secret=_SECRET
+        )
+        seen.extend(t.id for t in page.tickets)
+        if page.next_cursor is None:
+            return seen
+        cursor = page.next_cursor
+    raise AssertionError("cursor walk did not terminate")
+
+
+def test_query_default_sort_is_updated_desc_id_tiebreak(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    # Two share an updated_at so the id tie-break is exercised.
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, "b", created_at=base).model_copy(
+                update={"updated_at": base + timedelta(hours=2)}
+            ),
+            mk(S.BUILDING, "a", created_at=base).model_copy(
+                update={"updated_at": base + timedelta(hours=2)}
+            ),
+            mk(S.BUILDING, "c", created_at=base).model_copy(
+                update={"updated_at": base + timedelta(hours=1)}
+            ),
+        ],
+    )
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(), limit=50, cursor=None, cursor_secret=_SECRET
+    )
+    # updated_at desc; equal updated_at → id ASC always.
+    assert [t.id for t in page.tickets] == ["a", "b", "c"]
+
+
+def test_query_pagination_covers_all_without_duplicates(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    ids = [f"t{i:03d}" for i in range(23)]
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, tid, created_at=base + timedelta(minutes=i))
+            for i, tid in enumerate(ids)
+        ],
+    )
+    seen = _drain(mgr, ManagerTicketListQuery(), limit=10)
+    assert len(seen) == 23
+    assert set(seen) == set(ids)
+    assert len(seen) == len(set(seen))  # no duplicates across the stable walk
+
+
+def test_query_no_trailing_empty_page(tmp_path: Path) -> None:
+    # A result that is an exact multiple of the limit must not emit a cursor for
+    # an empty final page.
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, f"t{i}", created_at=base + timedelta(minutes=i))
+            for i in range(10)
+        ],
+    )
+    page1 = mgr.list_tickets_page(
+        ManagerTicketListQuery(), limit=5, cursor=None, cursor_secret=_SECRET
+    )
+    assert page1.next_cursor is not None
+    page2 = mgr.list_tickets_page(
+        ManagerTicketListQuery(),
+        limit=5,
+        cursor=page1.next_cursor,
+        cursor_secret=_SECRET,
+    )
+    assert len(page2.tickets) == 5
+    assert page2.next_cursor is None
+
+
+def test_query_priority_sort_uses_config_order_not_lexicographic(
+    tmp_path: Path,
+) -> None:
+    # A non-lexicographic configured order: "high" must sort before "low".
+    mgr = _seed_query_manager(tmp_path, priority_levels=["high", "medium", "low"])
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, "lo", priority="low", created_at=base),
+            mk(S.BUILDING, "hi", priority="high", created_at=base),
+            mk(S.BUILDING, "me", priority="medium", created_at=base),
+        ],
+    )
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(sort=Sort.PRIORITY, direction=Dir.ASC),
+        limit=50,
+        cursor=None,
+        cursor_secret=_SECRET,
+    )
+    assert [t.id for t in page.tickets] == ["hi", "me", "lo"]
+
+
+def test_query_priority_sort_unknown_legacy_sorts_after(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path, priority_levels=["p0", "p1"])
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, "legacy", priority="p9", created_at=base),
+            mk(S.BUILDING, "top", priority="p0", created_at=base),
+        ],
+    )
+    # Unknown "p9" ranks after configured values in ascending order.
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(sort=Sort.PRIORITY, direction=Dir.ASC),
+        limit=50,
+        cursor=None,
+        cursor_secret=_SECRET,
+    )
+    assert [t.id for t in page.tickets] == ["top", "legacy"]
+    # ...and still after in descending order (unknown never floats to the top).
+    page_desc = mgr.list_tickets_page(
+        ManagerTicketListQuery(sort=Sort.PRIORITY, direction=Dir.DESC),
+        limit=50,
+        cursor=None,
+        cursor_secret=_SECRET,
+    )
+    assert page_desc.tickets[-1].id == "legacy"
+
+
+def test_query_priority_sort_paginates_by_config_order(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path, priority_levels=["p0", "p1", "p2", "p3"])
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(
+                S.BUILDING,
+                f"t{i:02d}",
+                priority=f"p{i % 4}",
+                created_at=base + timedelta(minutes=i),
+            )
+            for i in range(12)
+        ],
+    )
+    query = ManagerTicketListQuery(sort=Sort.PRIORITY, direction=Dir.ASC)
+    walked = _drain(mgr, query, limit=5)
+    full = mgr.list_tickets_page(query, limit=50, cursor=None, cursor_secret=_SECRET)
+    assert walked == [t.id for t in full.tickets]  # keyset walk matches one-shot order
+    assert len(walked) == 12
+
+
+def test_query_title_filter_is_literal_substring(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, "a", created_at=base).model_copy(
+                update={"title": "add lazy loading"}
+            ),
+            mk(S.BUILDING, "b", created_at=base).model_copy(
+                update={"title": "Lazy sort order"}
+            ),
+            mk(S.BUILDING, "c", created_at=base).model_copy(
+                update={"title": "unrelated"}
+            ),
+        ],
+    )
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(q="lazy"),  # case-insensitive
+        limit=50,
+        cursor=None,
+        cursor_secret=_SECRET,
+    )
+    assert {t.id for t in page.tickets} == {"a", "b"}
+
+
+def test_query_title_filter_escapes_like_wildcards(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, "pct", created_at=base).model_copy(
+                update={"title": "100% done"}
+            ),
+            mk(S.BUILDING, "und", created_at=base).model_copy(
+                update={"title": "a_b names"}
+            ),
+            mk(S.BUILDING, "plain", created_at=base).model_copy(
+                update={"title": "1000 done"}
+            ),
+        ],
+    )
+    # "%" is a literal, not a wildcard: "% done" must not match "1000 done".
+    pct = mgr.list_tickets_page(
+        ManagerTicketListQuery(q="% done"), limit=50, cursor=None, cursor_secret=_SECRET
+    )
+    assert {t.id for t in pct.tickets} == {"pct"}
+    # "_" is literal: "a_b" must not match via single-char wildcard.
+    und = mgr.list_tickets_page(
+        ManagerTicketListQuery(q="a_b"), limit=50, cursor=None, cursor_secret=_SECRET
+    )
+    assert {t.id for t in und.tickets} == {"und"}
+
+
+def test_query_filters_combine_with_and(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(
+                S.BUILDING,
+                "hit",
+                priority="p0",
+                scale=ManagerTicketScale.SUBSTANTIAL,
+                created_at=base,
+            ).model_copy(update={"title": "alpha"}),
+            mk(
+                S.BUILDING,
+                "wrongstate",
+                priority="p0",
+                scale=ManagerTicketScale.SUBSTANTIAL,
+                created_at=base,
+            ),
+            mk(
+                S.BUILDING,
+                "wrongprio",
+                priority="p3",
+                scale=ManagerTicketScale.SUBSTANTIAL,
+                created_at=base,
+            ).model_copy(update={"title": "alpha"}),
+            mk(
+                S.READY,
+                "wrongstate2",
+                priority="p0",
+                scale=ManagerTicketScale.SUBSTANTIAL,
+                created_at=base,
+            ).model_copy(update={"title": "alpha"}),
+        ],
+    )
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(
+            q="alpha",
+            state=[S.BUILDING],
+            priority=["p0"],
+            scale=[ManagerTicketScale.SUBSTANTIAL],
+        ),
+        limit=50,
+        cursor=None,
+        cursor_secret=_SECRET,
+    )
+    assert {t.id for t in page.tickets} == {"hit"}
+
+
+def test_query_summary_covers_full_result_not_page(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    seed = (
+        [
+            mk(S.INTAKE, f"i{i}", created_at=base + timedelta(minutes=i))
+            for i in range(4)
+        ]
+        + [mk(S.SPEC_REVIEW, f"sr{i}", created_at=base) for i in range(2)]
+        + [mk(S.BUILDING, f"b{i}", created_at=base) for i in range(3)]
+        + [mk(S.BLOCKED, "bl0", created_at=base)]
+        + [mk(S.REVIEW_REQUESTED, "rr0", created_at=base)]
+        + [mk(S.MERGED, f"m{i}", branch=None, created_at=base) for i in range(5)]
+    )
+    _seed(mgr, seed)
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(), limit=3, cursor=None, cursor_secret=_SECRET
+    )
+    assert len(page.tickets) == 3  # page is bounded
+    s = page.summary
+    assert s.total == 16
+    assert s.lanes == {
+        "intake": 4,
+        "spec": 2,
+        "ready": 0,
+        "build": 3,
+        "blocked": 1,
+        "review": 1,
+        "done": 5,
+    }
+    assert s.awaiting_count == 2 + 1 + 1  # spec_review + blocked + review_requested
+    assert s.in_flight_count == 3
+    assert s.blocked_count == 1
+    assert s.merged_count == 5
+
+
+def test_query_summary_reflects_filter(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [mk(S.BUILDING, f"b{i}", created_at=base) for i in range(3)]
+        + [mk(S.MERGED, f"m{i}", created_at=base) for i in range(4)],
+    )
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(state=[S.BUILDING]),
+        limit=50,
+        cursor=None,
+        cursor_secret=_SECRET,
+    )
+    assert page.summary.total == 3
+    assert page.summary.lanes["build"] == 3
+    assert page.summary.lanes["done"] == 0
+
+
+def test_query_all_sorts_walk_matches_one_shot(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(
+                S.BUILDING,
+                f"t{i:02d}",
+                priority=f"p{i % 4}",
+                created_at=base + timedelta(minutes=i),
+            ).model_copy(update={"updated_at": base + timedelta(minutes=(i * 7) % 13)})
+            for i in range(14)
+        ],
+    )
+    for sort in Sort:
+        for direction in (Dir.ASC, Dir.DESC):
+            query = ManagerTicketListQuery(sort=sort, direction=direction)
+            walked = _drain(mgr, query, limit=4)
+            full = [
+                t.id
+                for t in mgr.list_tickets_page(
+                    query, limit=100, cursor=None, cursor_secret=_SECRET
+                ).tickets
+            ]
+            assert walked == full, f"{sort}/{direction} keyset walk diverged"
+            assert len(walked) == 14
+
+
+def test_query_unknown_priority_filter_is_422(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path, priority_levels=["p0", "p1"])
+    with pytest.raises(HTTPException) as exc:
+        mgr.list_tickets_page(
+            ManagerTicketListQuery(priority=["p9"]),
+            limit=50,
+            cursor=None,
+            cursor_secret=_SECRET,
+        )
+    assert exc.value.status_code == 422
+
+
+def test_query_cursor_signature_and_query_binding(tmp_path: Path) -> None:
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, f"t{i}", created_at=base + timedelta(minutes=i))
+            for i in range(6)
+        ],
+    )
+    page = mgr.list_tickets_page(
+        ManagerTicketListQuery(), limit=3, cursor=None, cursor_secret=_SECRET
+    )
+    cursor = page.next_cursor
+    assert cursor is not None
+
+    # Tampered signature → 422.
+    with pytest.raises(HTTPException) as exc_sig:
+        mgr.list_tickets_page(
+            ManagerTicketListQuery(),
+            limit=3,
+            cursor=cursor + "x",
+            cursor_secret=_SECRET,
+        )
+    assert exc_sig.value.status_code == 422
+
+    # Wrong secret → 422.
+    with pytest.raises(HTTPException) as exc_secret:
+        mgr.list_tickets_page(
+            ManagerTicketListQuery(), limit=3, cursor=cursor, cursor_secret="other"
+        )
+    assert exc_secret.value.status_code == 422
+
+    # Cursor bound to the original query: replaying it under a different query is 422.
+    with pytest.raises(HTTPException) as exc_query:
+        mgr.list_tickets_page(
+            ManagerTicketListQuery(state=[S.BUILDING]),
+            limit=3,
+            cursor=cursor,
+            cursor_secret=_SECRET,
+        )
+    assert exc_query.value.status_code == 422
+
+
+def test_query_malformed_cursor_raises(tmp_path: Path) -> None:
+    with pytest.raises(ManagerCursorError):
+        decode_ticket_cursor("not-a-cursor", ManagerTicketListQuery(), _SECRET)
+
+
+def test_query_isolation_by_manager(tmp_path: Path) -> None:
+    storage = _storage(tmp_path)
+    mgr_a = _init(storage, ManagerConfig(), mid="mgr-a")
+    mgr_b = _init(storage, ManagerConfig(), mid="mgr-b")
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    storage.create_manager_ticket(
+        mk(S.BUILDING, "a1", manager_id="mgr-a", created_at=base)
+    )
+    storage.create_manager_ticket(
+        mk(S.BUILDING, "b1", manager_id="mgr-b", created_at=base)
+    )
+    storage.create_manager_ticket(
+        mk(S.BUILDING, "b2", manager_id="mgr-b", created_at=base)
+    )
+    page_a = mgr_a.list_tickets_page(
+        ManagerTicketListQuery(), limit=50, cursor=None, cursor_secret=_SECRET
+    )
+    assert {t.id for t in page_a.tickets} == {"a1"}
+    assert page_a.summary.total == 1
+    page_b = mgr_b.list_tickets_page(
+        ManagerTicketListQuery(), limit=50, cursor=None, cursor_secret=_SECRET
+    )
+    assert {t.id for t in page_b.tickets} == {"b1", "b2"}
+    assert page_b.summary.total == 2
+
+
+def test_state_full_list_unchanged_by_query_addition(tmp_path: Path) -> None:
+    # The /state contract still returns the complete ticket list, unpaged.
+    mgr = _seed_query_manager(tmp_path)
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    _seed(
+        mgr,
+        [
+            mk(S.BUILDING, f"t{i}", created_at=base + timedelta(minutes=i))
+            for i in range(60)
+        ],
+    )
+    assert len(mgr.state().tickets) == 60  # no page bound on /state

--- a/backend/tests/test_manager_api.py
+++ b/backend/tests/test_manager_api.py
@@ -381,3 +381,181 @@ async def test_delete_ticket_endpoint_and_404(tmp_path: Path) -> None:
             f"/api/manager/{mid}/tickets/{tid}", headers=_auth(token)
         )
     assert missing.status_code == 404
+
+
+# ── Ticket-list query route (ticket 1504) ──
+
+from datetime import timedelta  # noqa: E402
+
+from waypoint.schemas import (  # noqa: E402
+    ManagerTicket,
+    ManagerTicketScale,
+    ManagerTicketState,
+)
+
+_QS = ManagerTicketState
+
+
+def _seed_ticket(
+    app: Any,
+    mid: str,
+    ticket_id: str,
+    *,
+    title: str = "ticket",
+    priority: str = "p2",
+    state: ManagerTicketState = _QS.BUILDING,
+    scale: ManagerTicketScale | None = None,
+    created_offset: int = 0,
+) -> None:
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    now = base + timedelta(minutes=created_offset)
+    app.state.context.storage.create_manager_ticket(
+        ManagerTicket(
+            id=ticket_id,
+            manager_id=mid,
+            title=title,
+            priority=priority,
+            state=state,
+            scale=scale,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+
+
+async def _tickets(
+    client: httpx.AsyncClient, token: str, mid: str, **params: Any
+) -> httpx.Response:
+    return await client.get(
+        f"/api/manager/{mid}/tickets", headers=_auth(token), params=params
+    )
+
+
+async def test_tickets_route_requires_auth(tmp_path: Path) -> None:
+    app, _ = _build(tmp_path)
+    async with _client(app) as client:
+        resp = await client.get("/api/manager/x/tickets")
+    assert resp.status_code == 401
+
+
+async def test_tickets_default_page_and_summary(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        for i in range(3):
+            _seed_ticket(app, mid, f"b{i}", state=_QS.BUILDING, created_offset=i)
+        _seed_ticket(app, mid, "m0", state=_QS.MERGED, created_offset=10)
+        resp = await _tickets(client, token, mid)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["next_cursor"] is None
+    assert len(body["tickets"]) == 4
+    assert body["summary"]["total"] == 4
+    assert body["summary"]["lanes"]["build"] == 3
+    assert body["summary"]["lanes"]["done"] == 1
+    assert body["summary"]["in_flight_count"] == 3
+    assert body["summary"]["merged_count"] == 1
+
+
+async def test_tickets_repeated_filter_params(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        _seed_ticket(app, mid, "b0", state=_QS.BUILDING)
+        _seed_ticket(app, mid, "r0", state=_QS.READY)
+        _seed_ticket(app, mid, "m0", state=_QS.MERGED)
+        # Repeated ?state= params → OR within the facet.
+        resp = await _tickets(client, token, mid, state=["building", "ready"])
+    body = resp.json()
+    assert {t["id"] for t in body["tickets"]} == {"b0", "r0"}
+    assert body["summary"]["total"] == 2
+
+
+async def test_tickets_cursor_pagination_over_http(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        for i in range(12):
+            _seed_ticket(app, mid, f"t{i:02d}", created_offset=i)
+        seen: list[str] = []
+        cursor: str | None = None
+        for _ in range(10):
+            params: dict[str, Any] = {"limit": 5}
+            if cursor:
+                params["cursor"] = cursor
+            resp = await _tickets(client, token, mid, **params)
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            seen.extend(t["id"] for t in body["tickets"])
+            cursor = body["next_cursor"]
+            if cursor is None:
+                break
+    assert len(seen) == 12
+    assert len(set(seen)) == 12
+
+
+async def test_tickets_limit_bounds_are_422(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        too_small = await _tickets(client, token, mid, limit=0)
+        too_big = await _tickets(client, token, mid, limit=101)
+    assert too_small.status_code == 422
+    assert too_big.status_code == 422
+
+
+async def test_tickets_unknown_priority_is_422(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        resp = await _tickets(client, token, mid, priority=["nope"])
+    assert resp.status_code == 422
+
+
+async def test_tickets_invalid_cursor_is_422(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        _seed_ticket(app, mid, "t0")
+        resp = await _tickets(client, token, mid, cursor="tampered.value")
+    assert resp.status_code == 422
+
+
+async def test_tickets_cursor_rejected_after_query_change(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        for i in range(8):
+            _seed_ticket(app, mid, f"t{i}", created_offset=i)
+        first = await _tickets(client, token, mid, limit=3)
+        cursor = first.json()["next_cursor"]
+        assert cursor
+        # Same cursor, different filter → 422, never a silently different page.
+        resp = await _tickets(
+            client, token, mid, limit=3, cursor=cursor, state=["ready"]
+        )
+    assert resp.status_code == 422
+
+
+async def test_tickets_isolated_by_manager(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid_a = await _init(client, token, repo_dir="/repo/a")
+        mid_b = await _init(client, token, repo_dir="/repo/b")
+        _seed_ticket(app, mid_a, "a0")
+        _seed_ticket(app, mid_b, "b0")
+        _seed_ticket(app, mid_b, "b1")
+        resp_a = await _tickets(client, token, mid_a)
+        resp_b = await _tickets(client, token, mid_b)
+    assert {t["id"] for t in resp_a.json()["tickets"]} == {"a0"}
+    assert {t["id"] for t in resp_b.json()["tickets"]} == {"b0", "b1"}
+
+
+async def test_state_route_still_returns_full_list(tmp_path: Path) -> None:
+    app, token = _build(tmp_path)
+    async with _client(app) as client:
+        mid = await _init(client, token)
+        for i in range(70):
+            _seed_ticket(app, mid, f"t{i:02d}", created_offset=i)
+        state = await client.get(f"/api/manager/{mid}/state", headers=_auth(token))
+    assert len(state.json()["tickets"]) == 70

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -96,7 +96,7 @@ function shortId(value: string): string {
   return value.length > 16 ? `${value.slice(0, 16)}…` : value;
 }
 
-// Add or remove a facet value, preserving the rest — the multi-select toggle.
+// Toggle a value in a list.
 function toggleInList<T>(list: T[], value: T): T[] {
   return list.includes(value)
     ? list.filter((entry) => entry !== value)
@@ -631,9 +631,7 @@ interface FacetGroup {
   options: { value: string; label: string }[];
 }
 
-// A multi-select facet as a glass popover of checkboxes. The trigger states the
-// facet and its active count; the panel closes on Escape or an outside click and
-// stays fully keyboard-operable.
+// Multi-select facet popover; closes on Escape or an outside click.
 function FacetSelect({
   label,
   groups,
@@ -904,8 +902,7 @@ function ManagerBoard({
 
   const filtered = isFilteredQuery(query);
   const total = summary?.total ?? tickets.length;
-  // A truthful live announcement: what is loaded of what matches, and whether a
-  // fetch is in flight — announced without moving focus.
+  // Screen-reader announcement of the loaded/total count.
   const announce =
     status === "loading"
       ? "Loading tickets…"
@@ -961,8 +958,6 @@ function ManagerBoard({
         {announce}
       </p>
 
-      {/* Needs-you is the global decision queue from the manager state snapshot,
-          so board filters never make an awaiting gate disappear. */}
       {needsYou.length > 0 ? (
         <section className="board-needs" aria-label="Needs you">
           <h3 className="board-needs-title">Needs you</h3>
@@ -1049,8 +1044,7 @@ function ManagerBoard({
                       />
                     ))}
                   </div>
-                  {/* A lane the summary says has cards we haven't paged in yet is
-                      not empty — say how many remain instead of reading as done. */}
+                  {/* Summary shows unpaged cards in this lane. */}
                   {unloaded > 0 ? (
                     <p className="board-lane-pending">
                       {loaded === 0
@@ -1331,8 +1325,7 @@ export default function BoardPage() {
   const [ticketsStatus, setTicketsStatus] = useState<LoadState>("loading");
   const [ticketsLoadingMore, setTicketsLoadingMore] = useState(false);
   const [ticketsLoadMoreError, setTicketsLoadMoreError] = useState(false);
-  // Monotonic request generation: a page/summary from an older query or manager
-  // is ignored, so a slow response can never overwrite a newer one.
+  // Drops a stale page/summary when the query or manager changed mid-request.
   const ticketRequestGen = useRef(0);
   const [search, setSearch] = useState("");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
@@ -1376,8 +1369,7 @@ export default function BoardPage() {
   useEffect(() => {
     selectedManagerRef.current = selectedManagerId;
   }, [selectedManagerId]);
-  // The live socket refetches the board's first page on a board_update without
-  // re-subscribing per query change, so it reads the active query from a ref.
+  // Active query for the socket's board_update refetch, read without re-subscribing.
   const ticketQueryRef = useRef<ManagerTicketListQuery>(ticketQuery);
   useEffect(() => {
     ticketQueryRef.current = ticketQuery;
@@ -1509,8 +1501,7 @@ export default function BoardPage() {
     [host, token, handleAuthFailure],
   );
 
-  // Reset and fetch the first board page for a query. Every fetch claims a new
-  // generation so a slow response for an old query/manager is dropped.
+  // Fetch page one; a new generation drops any stale in-flight response.
   const refreshTicketFirstPage = useCallback(
     async (managerId: string, query: ManagerTicketListQuery) => {
       if (!host || !token) return;
@@ -1702,7 +1693,7 @@ export default function BoardPage() {
     void refreshManagerState(selectedManagerId);
   }, [selectedManagerId, refreshManagerState]);
 
-  // Debounce the search box into the query so typing doesn't refetch per keystroke.
+  // Debounce the search box into the query.
   useEffect(() => {
     const handle = setTimeout(() => {
       const next = ticketSearchInput.trim();
@@ -1711,9 +1702,8 @@ export default function BoardPage() {
     return () => clearTimeout(handle);
   }, [ticketSearchInput]);
 
-  // Any query change (filter, sort, direction, or debounced text) or manager
-  // switch clears the loaded cards and fetches page one. ``ticketQuery`` identity
-  // changes exactly when the result set would, so this never double-fetches.
+  // Refetch page one on any query or manager change; ticketQuery identity changes
+  // only with the result set, so this never double-fetches.
   useEffect(() => {
     if (!managerMode || !selectedManagerId) return;
     void refreshTicketFirstPage(selectedManagerId, ticketQuery);
@@ -1767,8 +1757,7 @@ export default function BoardPage() {
         const manager = selectedManagerRef.current;
         if (manager) {
           void refreshManagerState(manager);
-          // Invalidate the loaded pages and refetch page one with the active
-          // query; the generation guard drops any in-flight stale response.
+          // Refetch page one; the generation guard drops stale responses.
           void refreshTicketFirstPage(manager, ticketQueryRef.current);
         }
         if (entriesDirty) {
@@ -2189,8 +2178,7 @@ export default function BoardPage() {
     managerStateForSelection?.config?.priority_levels ?? [];
   const defaultUpdateChannel = activeChannel ?? channels[0]?.channel ?? null;
 
-  // The global decision queue, from the full manager snapshot — never narrowed
-  // by board-card filters, so an awaiting gate can't be filtered out of view.
+  // Global decision queue from the full snapshot; not narrowed by board filters.
   const needsYou = useMemo(
     () =>
       (managerStateForSelection?.tickets ?? [])

--- a/frontend/src/app/board/page.tsx
+++ b/frontend/src/app/board/page.tsx
@@ -30,6 +30,7 @@ import {
   fetchBoardChannels,
   fetchManagers,
   fetchManagerState,
+  fetchManagerTickets,
   isAuthError,
   postBoardEntry,
   updateBoardEntry,
@@ -38,16 +39,21 @@ import {
   CHANNEL_GROUP_COLLAPSED_DEFAULT,
   CHANNEL_GROUP_LABELS,
   CHANNEL_GROUP_ORDER,
+  DEFAULT_TICKET_QUERY,
   groupChannels,
   isAwaiting,
+  isFilteredQuery,
   kindTone,
   laneForState,
   LANES,
   priorityTone,
-  rollupTickets,
+  SCALE_OPTIONS,
+  SORT_OPTIONS,
+  STATE_FACET_GROUPS,
   stateLabel,
   stateTone,
   ticketIdFromChannel,
+  TICKET_PAGE_LIMIT,
 } from "@/lib/board";
 import { clearToken, readHost, readToken } from "@/lib/store";
 import { useTheme } from "@/lib/theme";
@@ -57,6 +63,12 @@ import {
   ManagerStateResponse,
   ManagerSummary,
   ManagerTicket,
+  ManagerTicketListQuery,
+  ManagerTicketScale,
+  ManagerTicketSort,
+  ManagerTicketSortDirection,
+  ManagerTicketState,
+  ManagerTicketSummary,
   SessionEnvelope,
 } from "@/lib/types";
 import { formatRelativeTime } from "@/lib/usage";
@@ -82,6 +94,13 @@ interface PostConfirm {
 
 function shortId(value: string): string {
   return value.length > 16 ? `${value.slice(0, 16)}…` : value;
+}
+
+// Add or remove a facet value, preserving the rest — the multi-select toggle.
+function toggleInList<T>(list: T[], value: T): T[] {
+  return list.includes(value)
+    ? list.filter((entry) => entry !== value)
+    : [...list, value];
 }
 
 // Card-volume bucket that widens a lane into more grid columns (see globals.css).
@@ -605,21 +624,274 @@ function TicketCard({ ticket, onOpen }: TicketCardProps) {
   );
 }
 
+// ─── Board query controls ───
+
+interface FacetGroup {
+  heading?: string;
+  options: { value: string; label: string }[];
+}
+
+// A multi-select facet as a glass popover of checkboxes. The trigger states the
+// facet and its active count; the panel closes on Escape or an outside click and
+// stays fully keyboard-operable.
+function FacetSelect({
+  label,
+  groups,
+  selected,
+  onToggle,
+}: {
+  label: string;
+  groups: FacetGroup[];
+  selected: Set<string>;
+  onToggle: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocDown = (event: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const count = selected.size;
+  return (
+    <div className="board-facet" ref={rootRef}>
+      <button
+        type="button"
+        className={`board-facet-trigger${count > 0 ? " is-active" : ""}`}
+        aria-expanded={open}
+        aria-haspopup="true"
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="board-facet-label">{label}</span>
+        {count > 0 ? <span className="board-facet-count">{count}</span> : null}
+        <span className="board-facet-caret" aria-hidden="true">
+          ▾
+        </span>
+      </button>
+      {open ? (
+        <div className="board-facet-menu" role="group" aria-label={label}>
+          {groups.map((group, index) => (
+            <div key={group.heading ?? index} className="board-facet-group">
+              {group.heading ? (
+                <p className="board-facet-heading">{group.heading}</p>
+              ) : null}
+              {group.options.map((option) => {
+                const checked = selected.has(option.value);
+                return (
+                  <label key={option.value} className="board-facet-option">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => onToggle(option.value)}
+                    />
+                    <span className="board-facet-option-label">
+                      {option.label}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+interface QueryBarProps {
+  query: ManagerTicketListQuery;
+  priorityLevels: string[];
+  searchInput: string;
+  onSearchInput: (value: string) => void;
+  onToggleState: (state: ManagerTicketState) => void;
+  onTogglePriority: (priority: string) => void;
+  onToggleScale: (scale: ManagerTicketScale) => void;
+  onSort: (sort: ManagerTicketSort) => void;
+  onDirection: (direction: ManagerTicketSortDirection) => void;
+  onClearFilters: () => void;
+}
+
+function QueryBar({
+  query,
+  priorityLevels,
+  searchInput,
+  onSearchInput,
+  onToggleState,
+  onTogglePriority,
+  onToggleScale,
+  onSort,
+  onDirection,
+  onClearFilters,
+}: QueryBarProps) {
+  const stateSet = useMemo(() => new Set<string>(query.state), [query.state]);
+  const prioritySet = useMemo(
+    () => new Set<string>(query.priority),
+    [query.priority],
+  );
+  const scaleSet = useMemo(() => new Set<string>(query.scale), [query.scale]);
+  const filtered = isFilteredQuery(query);
+
+  return (
+    <div className="board-query" role="search">
+      <div className="board-query-search">
+        <span className="board-query-search-cue" aria-hidden="true">
+          ⌕
+        </span>
+        <input
+          className="board-query-search-input"
+          type="search"
+          placeholder="Filter tickets by title"
+          value={searchInput}
+          onChange={(event) => onSearchInput(event.target.value)}
+          aria-label="Filter tickets by title"
+        />
+      </div>
+
+      <div className="board-query-facets">
+        <FacetSelect
+          label="State"
+          selected={stateSet}
+          onToggle={(value) => onToggleState(value as ManagerTicketState)}
+          groups={STATE_FACET_GROUPS.map((group) => ({
+            heading: group.lane,
+            options: group.states.map((state) => ({
+              value: state,
+              label: stateLabel(state),
+            })),
+          }))}
+        />
+        <FacetSelect
+          label="Priority"
+          selected={prioritySet}
+          onToggle={onTogglePriority}
+          groups={[
+            {
+              options: priorityLevels.map((level) => ({
+                value: level,
+                label: level,
+              })),
+            },
+          ]}
+        />
+        <FacetSelect
+          label="Scale"
+          selected={scaleSet}
+          onToggle={(value) => onToggleScale(value as ManagerTicketScale)}
+          groups={[
+            {
+              options: SCALE_OPTIONS.map((option) => ({
+                value: option.value,
+                label: option.label,
+              })),
+            },
+          ]}
+        />
+      </div>
+
+      <div className="board-query-sort">
+        <label className="board-query-sort-field">
+          <span className="board-query-sort-label">Sort</span>
+          <select
+            value={query.sort}
+            onChange={(event) => onSort(event.target.value as ManagerTicketSort)}
+            aria-label="Sort tickets by"
+          >
+            {SORT_OPTIONS.map((option) => (
+              <option key={option.key} value={option.key}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          className="board-query-dir"
+          onClick={() =>
+            onDirection(query.direction === "asc" ? "desc" : "asc")
+          }
+          aria-label={
+            query.direction === "asc"
+              ? "Sorted ascending; switch to descending"
+              : "Sorted descending; switch to ascending"
+          }
+          title={query.direction === "asc" ? "Ascending" : "Descending"}
+        >
+          <span aria-hidden="true">{query.direction === "asc" ? "↑" : "↓"}</span>
+        </button>
+      </div>
+
+      {filtered ? (
+        <button
+          type="button"
+          className="board-query-clear"
+          onClick={onClearFilters}
+        >
+          Clear filters
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
 interface ManagerBoardProps {
-  managerState: ManagerStateResponse;
+  tickets: ManagerTicket[];
+  summary: ManagerTicketSummary | null;
+  needsYou: ManagerTicket[];
+  query: ManagerTicketListQuery;
+  priorityLevels: string[];
+  searchInput: string;
+  onSearchInput: (value: string) => void;
+  onToggleState: (state: ManagerTicketState) => void;
+  onTogglePriority: (priority: string) => void;
+  onToggleScale: (scale: ManagerTicketScale) => void;
+  onSort: (sort: ManagerTicketSort) => void;
+  onDirection: (direction: ManagerTicketSortDirection) => void;
+  onClearFilters: () => void;
+  status: LoadState;
+  onRetry: () => void;
+  hasMore: boolean;
+  loadingMore: boolean;
+  loadMoreError: boolean;
+  onLoadMore: () => void;
   onOpenTicket: (ticket: ManagerTicket) => void;
 }
 
-function ManagerBoard({ managerState, onOpenTicket }: ManagerBoardProps) {
-  const tickets = managerState.tickets;
-  const rollup = useMemo(() => rollupTickets(tickets), [tickets]);
-  const needsYou = useMemo(
-    () =>
-      tickets
-        .filter((ticket) => isAwaiting(ticket.state))
-        .sort((a, b) => a.priority.localeCompare(b.priority)),
-    [tickets],
-  );
+function ManagerBoard({
+  tickets,
+  summary,
+  needsYou,
+  query,
+  priorityLevels,
+  searchInput,
+  onSearchInput,
+  onToggleState,
+  onTogglePriority,
+  onToggleScale,
+  onSort,
+  onDirection,
+  onClearFilters,
+  status,
+  onRetry,
+  hasMore,
+  loadingMore,
+  loadMoreError,
+  onLoadMore,
+  onOpenTicket,
+}: ManagerBoardProps) {
   const byLane = useMemo(() => {
     const map = new Map<string, ManagerTicket[]>();
     for (const lane of LANES) map.set(lane.key, []);
@@ -630,32 +902,67 @@ function ManagerBoard({ managerState, onOpenTicket }: ManagerBoardProps) {
     return map;
   }, [tickets]);
 
+  const filtered = isFilteredQuery(query);
+  const total = summary?.total ?? tickets.length;
+  // A truthful live announcement: what is loaded of what matches, and whether a
+  // fetch is in flight — announced without moving focus.
+  const announce =
+    status === "loading"
+      ? "Loading tickets…"
+      : status === "error"
+        ? "Failed to load tickets."
+        : `${tickets.length} of ${total} matching ${
+            total === 1 ? "ticket" : "tickets"
+          } loaded${loadingMore ? ", loading more" : ""}.`;
+
   return (
     <div className="board-manager">
-      <div className="board-rollup" role="status">
+      <div className="board-rollup" role="status" aria-live="off">
         <span className="board-rollup-item board-rollup-need">
-          <strong>{rollup.needYou}</strong> need you
+          <strong>{summary?.awaiting_count ?? 0}</strong> need you
         </span>
         <span className="board-rollup-sep" aria-hidden="true">
           ·
         </span>
         <span className="board-rollup-item">
-          <strong>{rollup.inFlight}</strong> in flight
+          <strong>{summary?.in_flight_count ?? 0}</strong> in flight
         </span>
         <span className="board-rollup-sep" aria-hidden="true">
           ·
         </span>
         <span className="board-rollup-item">
-          <strong>{rollup.blocked}</strong> blocked
+          <strong>{summary?.blocked_count ?? 0}</strong> blocked
         </span>
         <span className="board-rollup-sep" aria-hidden="true">
           ·
         </span>
         <span className="board-rollup-item">
-          <strong>{rollup.merged}</strong> merged
+          <strong>{summary?.merged_count ?? 0}</strong> merged
         </span>
+        {filtered ? (
+          <span className="board-rollup-scope">· filtered</span>
+        ) : null}
       </div>
 
+      <QueryBar
+        query={query}
+        priorityLevels={priorityLevels}
+        searchInput={searchInput}
+        onSearchInput={onSearchInput}
+        onToggleState={onToggleState}
+        onTogglePriority={onTogglePriority}
+        onToggleScale={onToggleScale}
+        onSort={onSort}
+        onDirection={onDirection}
+        onClearFilters={onClearFilters}
+      />
+
+      <p className="sr-only" role="status" aria-live="polite">
+        {announce}
+      </p>
+
+      {/* Needs-you is the global decision queue from the manager state snapshot,
+          so board filters never make an awaiting gate disappear. */}
       {needsYou.length > 0 ? (
         <section className="board-needs" aria-label="Needs you">
           <h3 className="board-needs-title">Needs you</h3>
@@ -671,43 +978,113 @@ function ManagerBoard({ managerState, onOpenTicket }: ManagerBoardProps) {
         </section>
       ) : null}
 
-      <section className="board-lanes" aria-label="Lifecycle board">
-        {LANES.map((lane) => {
-          const laneTickets = byLane.get(lane.key) ?? [];
-          const isDone = lane.key === "done";
-          if (laneTickets.length === 0) {
-            return (
-              <div key={lane.key} className="board-lane is-empty">
-                <div className="board-lane-head">
-                  <span className="board-lane-label">{lane.label}</span>
-                  <span className="board-lane-count">0</span>
-                </div>
-              </div>
-            );
-          }
-          return (
-            <div
-              key={lane.key}
-              className={`board-lane${isDone ? " is-done" : ""}`}
-              data-density={laneDensity(laneTickets.length)}
+      {status === "loading" ? (
+        <div className="board-lanes-state" aria-busy="true">
+          <p className="board-log-empty">Loading tickets…</p>
+        </div>
+      ) : status === "error" ? (
+        <div className="board-lanes-state">
+          <p className="board-lanes-state-title">Couldn’t load tickets</p>
+          <p className="muted">The request failed. Retry when ready.</p>
+          <button type="button" className="primary" onClick={onRetry}>
+            Retry
+          </button>
+        </div>
+      ) : total === 0 ? (
+        <div className="board-lanes-state">
+          <p className="board-lanes-state-title">
+            {filtered ? "No tickets match these filters" : "No tickets yet"}
+          </p>
+          {filtered ? (
+            <button
+              type="button"
+              className="board-query-clear"
+              onClick={onClearFilters}
             >
-              <div className="board-lane-head">
-                <span className="board-lane-label">{lane.label}</span>
-                <span className="board-lane-count">{laneTickets.length}</span>
-              </div>
-              <div className="board-lane-cards">
-                {laneTickets.map((ticket) => (
-                  <TicketCard
-                    key={ticket.id}
-                    ticket={ticket}
-                    onOpen={onOpenTicket}
-                  />
-                ))}
-              </div>
+              Clear filters
+            </button>
+          ) : (
+            <p className="muted">
+              New requests land here once the manager registers them.
+            </p>
+          )}
+        </div>
+      ) : (
+        <>
+          <section className="board-lanes" aria-label="Lifecycle board">
+            {LANES.map((lane) => {
+              const laneTickets = byLane.get(lane.key) ?? [];
+              const laneTotal = summary?.lanes[lane.key] ?? laneTickets.length;
+              const isDone = lane.key === "done";
+              const loaded = laneTickets.length;
+              const unloaded = Math.max(0, laneTotal - loaded);
+              if (laneTotal === 0) {
+                return (
+                  <div key={lane.key} className="board-lane is-empty">
+                    <div className="board-lane-head">
+                      <span className="board-lane-label">{lane.label}</span>
+                      <span className="board-lane-count">0</span>
+                    </div>
+                  </div>
+                );
+              }
+              return (
+                <div
+                  key={lane.key}
+                  className={`board-lane${isDone ? " is-done" : ""}`}
+                  data-density={laneDensity(Math.max(loaded, 1))}
+                >
+                  <div className="board-lane-head">
+                    <span className="board-lane-label">{lane.label}</span>
+                    <span className="board-lane-count">
+                      {loaded < laneTotal ? `${loaded} / ${laneTotal}` : laneTotal}
+                    </span>
+                  </div>
+                  <div className="board-lane-cards">
+                    {laneTickets.map((ticket) => (
+                      <TicketCard
+                        key={ticket.id}
+                        ticket={ticket}
+                        onOpen={onOpenTicket}
+                      />
+                    ))}
+                  </div>
+                  {/* A lane the summary says has cards we haven't paged in yet is
+                      not empty — say how many remain instead of reading as done. */}
+                  {unloaded > 0 ? (
+                    <p className="board-lane-pending">
+                      {loaded === 0
+                        ? `${unloaded} not loaded yet`
+                        : `${unloaded} more not loaded`}
+                    </p>
+                  ) : null}
+                </div>
+              );
+            })}
+          </section>
+
+          {hasMore ? (
+            <div className="board-more">
+              <button
+                type="button"
+                className="board-load-older"
+                onClick={onLoadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore ? "Loading…" : "Load more tickets"}
+              </button>
+              <span className="board-log-count">
+                {tickets.length} of {total}
+              </span>
+              {loadMoreError ? (
+                <span className="board-more-error" role="alert">
+                  Load failed — retry
+                </span>
+              ) : null}
             </div>
-          );
-        })}
-      </section>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }
@@ -940,6 +1317,23 @@ export default function BoardPage() {
   const [managerState, setManagerState] = useState<ManagerStateResponse | null>(
     null,
   );
+  // Board ticket query: the raw search box, the debounced/normalized query the
+  // API sees, and the accumulated page state (cards, summary, cursor).
+  const [ticketSearchInput, setTicketSearchInput] = useState("");
+  const [ticketQuery, setTicketQuery] = useState<ManagerTicketListQuery>(
+    DEFAULT_TICKET_QUERY,
+  );
+  const [ticketCards, setTicketCards] = useState<ManagerTicket[]>([]);
+  const [ticketSummary, setTicketSummary] = useState<ManagerTicketSummary | null>(
+    null,
+  );
+  const [ticketCursor, setTicketCursor] = useState<string | null>(null);
+  const [ticketsStatus, setTicketsStatus] = useState<LoadState>("loading");
+  const [ticketsLoadingMore, setTicketsLoadingMore] = useState(false);
+  const [ticketsLoadMoreError, setTicketsLoadMoreError] = useState(false);
+  // Monotonic request generation: a page/summary from an older query or manager
+  // is ignored, so a slow response can never overwrite a newer one.
+  const ticketRequestGen = useRef(0);
   const [search, setSearch] = useState("");
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [navOpen, setNavOpen] = useState(false);
@@ -982,6 +1376,12 @@ export default function BoardPage() {
   useEffect(() => {
     selectedManagerRef.current = selectedManagerId;
   }, [selectedManagerId]);
+  // The live socket refetches the board's first page on a board_update without
+  // re-subscribing per query change, so it reads the active query from a ref.
+  const ticketQueryRef = useRef<ManagerTicketListQuery>(ticketQuery);
+  useEffect(() => {
+    ticketQueryRef.current = ticketQuery;
+  }, [ticketQuery]);
 
   // A `?channel=` deep link selects that channel once it loads.
   const pendingChannelRef = useRef<string | null>(null);
@@ -1109,6 +1509,117 @@ export default function BoardPage() {
     [host, token, handleAuthFailure],
   );
 
+  // Reset and fetch the first board page for a query. Every fetch claims a new
+  // generation so a slow response for an old query/manager is dropped.
+  const refreshTicketFirstPage = useCallback(
+    async (managerId: string, query: ManagerTicketListQuery) => {
+      if (!host || !token) return;
+      const gen = ++ticketRequestGen.current;
+      setTicketsStatus("loading");
+      setTicketsLoadingMore(false);
+      setTicketsLoadMoreError(false);
+      try {
+        const page = await fetchManagerTickets(host, token, managerId, query, {
+          limit: TICKET_PAGE_LIMIT,
+        });
+        if (gen !== ticketRequestGen.current) return;
+        setTicketCards(page.tickets);
+        setTicketSummary(page.summary);
+        setTicketCursor(page.next_cursor);
+        setTicketsStatus("ready");
+      } catch (err) {
+        if (isAuthError(err)) {
+          handleAuthFailure();
+          return;
+        }
+        if (gen !== ticketRequestGen.current) return;
+        setTicketsStatus("error");
+      }
+    },
+    [host, token, handleAuthFailure],
+  );
+
+  const loadMoreTickets = useCallback(async () => {
+    if (
+      !host ||
+      !token ||
+      !selectedManagerId ||
+      !ticketCursor ||
+      ticketsLoadingMore
+    ) {
+      return;
+    }
+    const gen = ticketRequestGen.current; // only valid for the current query
+    setTicketsLoadingMore(true);
+    setTicketsLoadMoreError(false);
+    try {
+      const page = await fetchManagerTickets(
+        host,
+        token,
+        selectedManagerId,
+        ticketQuery,
+        { limit: TICKET_PAGE_LIMIT, cursor: ticketCursor },
+      );
+      if (gen !== ticketRequestGen.current) return; // query changed mid-flight
+      setTicketCards((prev) => {
+        const seen = new Set(prev.map((ticket) => ticket.id));
+        const fresh = page.tickets.filter((ticket) => !seen.has(ticket.id));
+        return [...prev, ...fresh]; // defensive de-dup across pages
+      });
+      setTicketSummary(page.summary);
+      setTicketCursor(page.next_cursor);
+    } catch (err) {
+      if (isAuthError(err)) {
+        handleAuthFailure();
+        return;
+      }
+      if (gen !== ticketRequestGen.current) return;
+      setTicketsLoadMoreError(true);
+    } finally {
+      if (gen === ticketRequestGen.current) setTicketsLoadingMore(false);
+    }
+  }, [
+    host,
+    token,
+    selectedManagerId,
+    ticketCursor,
+    ticketsLoadingMore,
+    ticketQuery,
+    handleAuthFailure,
+  ]);
+
+  const toggleTicketState = useCallback((state: ManagerTicketState) => {
+    setTicketQuery((prev) => ({ ...prev, state: toggleInList(prev.state, state) }));
+  }, []);
+  const toggleTicketPriority = useCallback((priority: string) => {
+    setTicketQuery((prev) => ({
+      ...prev,
+      priority: toggleInList(prev.priority, priority),
+    }));
+  }, []);
+  const toggleTicketScale = useCallback((scale: ManagerTicketScale) => {
+    setTicketQuery((prev) => ({ ...prev, scale: toggleInList(prev.scale, scale) }));
+  }, []);
+  const setTicketSort = useCallback((sort: ManagerTicketSort) => {
+    setTicketQuery((prev) => ({ ...prev, sort }));
+  }, []);
+  const setTicketDirection = useCallback(
+    (direction: ManagerTicketSortDirection) => {
+      setTicketQuery((prev) => ({ ...prev, direction }));
+    },
+    [],
+  );
+  const clearTicketFilters = useCallback(() => {
+    setTicketSearchInput("");
+    setTicketQuery((prev) => ({
+      ...prev,
+      q: "",
+      state: [],
+      priority: [],
+      scale: [],
+    }));
+  }, []);
+
   const refreshEntries = useCallback(
     async (channel: string) => {
       if (!host || !token) return;
@@ -1191,6 +1702,23 @@ export default function BoardPage() {
     void refreshManagerState(selectedManagerId);
   }, [selectedManagerId, refreshManagerState]);
 
+  // Debounce the search box into the query so typing doesn't refetch per keystroke.
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      const next = ticketSearchInput.trim();
+      setTicketQuery((prev) => (prev.q === next ? prev : { ...prev, q: next }));
+    }, 250);
+    return () => clearTimeout(handle);
+  }, [ticketSearchInput]);
+
+  // Any query change (filter, sort, direction, or debounced text) or manager
+  // switch clears the loaded cards and fetches page one. ``ticketQuery`` identity
+  // changes exactly when the result set would, so this never double-fetches.
+  useEffect(() => {
+    if (!managerMode || !selectedManagerId) return;
+    void refreshTicketFirstPage(selectedManagerId, ticketQuery);
+  }, [ticketQuery, selectedManagerId, managerMode, refreshTicketFirstPage]);
+
   useEffect(() => {
     setExpandedId(null);
     setEditingId(null);
@@ -1237,7 +1765,12 @@ export default function BoardPage() {
         // without a reload: refresh the switcher and the selected manager.
         void refreshManagers();
         const manager = selectedManagerRef.current;
-        if (manager) void refreshManagerState(manager);
+        if (manager) {
+          void refreshManagerState(manager);
+          // Invalidate the loaded pages and refetch page one with the active
+          // query; the generation guard drops any in-flight stale response.
+          void refreshTicketFirstPage(manager, ticketQueryRef.current);
+        }
         if (entriesDirty) {
           entriesDirty = false;
           const current = activeChannelRef.current;
@@ -1296,6 +1829,7 @@ export default function BoardPage() {
     refreshChannels,
     refreshManagers,
     refreshManagerState,
+    refreshTicketFirstPage,
     refreshEntries,
     handleAuthFailure,
   ]);
@@ -1655,6 +2189,16 @@ export default function BoardPage() {
     managerStateForSelection?.config?.priority_levels ?? [];
   const defaultUpdateChannel = activeChannel ?? channels[0]?.channel ?? null;
 
+  // The global decision queue, from the full manager snapshot — never narrowed
+  // by board-card filters, so an awaiting gate can't be filtered out of view.
+  const needsYou = useMemo(
+    () =>
+      (managerStateForSelection?.tickets ?? [])
+        .filter((ticket) => isAwaiting(ticket.state))
+        .sort((a, b) => a.priority.localeCompare(b.priority)),
+    [managerStateForSelection],
+  );
+
   // Toolbar Post follows the view: Ticket on a manager Board, Update on
   // Channels. Update opens directly for a channel shortcut or the empty state.
   const openPost = useCallback(() => {
@@ -1920,13 +2464,33 @@ export default function BoardPage() {
                   </div>
                 </div>
 
-                {managerMode && managerState ? (
+                {managerMode ? (
                   <ManagerBoard
-                    managerState={managerState}
+                    tickets={ticketCards}
+                    summary={ticketSummary}
+                    needsYou={needsYou}
+                    query={ticketQuery}
+                    priorityLevels={priorityLevels}
+                    searchInput={ticketSearchInput}
+                    onSearchInput={setTicketSearchInput}
+                    onToggleState={toggleTicketState}
+                    onTogglePriority={toggleTicketPriority}
+                    onToggleScale={toggleTicketScale}
+                    onSort={setTicketSort}
+                    onDirection={setTicketDirection}
+                    onClearFilters={clearTicketFilters}
+                    status={ticketsStatus}
+                    onRetry={() => {
+                      if (selectedManagerId) {
+                        void refreshTicketFirstPage(selectedManagerId, ticketQuery);
+                      }
+                    }}
+                    hasMore={ticketCursor !== null}
+                    loadingMore={ticketsLoadingMore}
+                    loadMoreError={ticketsLoadMoreError}
+                    onLoadMore={() => void loadMoreTickets()}
                     onOpenTicket={openTicket}
                   />
-                ) : managerMode ? (
-                  <p className="board-log-empty">Loading manager board…</p>
                 ) : (
                   <ChannelsOverview
                     channels={channels}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14528,6 +14528,296 @@ html[data-theme="light"] .session-switcher-row.selected {
   color: var(--muted-soft);
 }
 
+.board-rollup-scope {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+/* ─── Board query bar (search / facets / sort) ─── */
+/* In-flow control strip: flat token surfaces, no glass (glass is reserved for
+   the facet popover, which floats). */
+.board-query {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.board-query-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1 1 220px;
+  min-width: 160px;
+  padding: 0 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+}
+
+.board-query-search:focus-within {
+  border-color: color-mix(in srgb, var(--accent-cool) 55%, var(--line-strong));
+}
+
+.board-query-search-cue {
+  color: var(--muted-soft);
+  font-size: 0.9rem;
+}
+
+.board-query-search-input {
+  flex: 1;
+  min-width: 0;
+  padding: 7px 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+}
+
+.board-query-search-input:focus {
+  outline: none;
+}
+
+.board-query-facets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.board-facet {
+  position: relative;
+}
+
+.board-facet-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-card-soft);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition:
+    background 0.14s ease,
+    border-color 0.14s ease;
+}
+
+.board-facet-trigger:hover {
+  border-color: var(--line-strong);
+}
+
+.board-facet-trigger.is-active {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line-strong));
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-card-soft));
+}
+
+.board-facet-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: #1d1408;
+  font-size: 0.66rem;
+  font-weight: 600;
+}
+
+.board-facet-caret {
+  color: var(--muted-soft);
+  font-size: 0.62rem;
+}
+
+/* The one floating element here → the glass recipe (thick, it carries text). */
+.board-facet-menu {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 200px;
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-radius: var(--radius-glass);
+  background: var(--glass-bg-thick);
+  border: 1px solid var(--glass-line);
+  box-shadow: inset 0 1px 0 var(--glass-hi), var(--shadow);
+  backdrop-filter: var(--glass-blur);
+}
+
+.board-facet-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.board-facet-group + .board-facet-group {
+  padding-top: 6px;
+  border-top: 1px solid var(--glass-line);
+}
+
+.board-facet-heading {
+  margin: 2px 4px 4px;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-facet-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.board-facet-option:hover {
+  background: color-mix(in srgb, var(--accent-cool) 12%, transparent);
+}
+
+.board-facet-option input {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.board-facet-option-label {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  color: var(--text);
+}
+
+.board-query-sort {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.board-query-sort-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.board-query-sort-label {
+  font-family: var(--font-mono);
+  font-size: 0.64rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--muted-soft);
+}
+
+.board-query-sort select {
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-input);
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.board-query-dir {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--line);
+  background: var(--bg-card-soft);
+  color: var(--accent-cool);
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: border-color 0.14s ease;
+}
+
+.board-query-dir:hover {
+  border-color: var(--line-strong);
+}
+
+.board-query-clear {
+  padding: 7px 10px;
+  border: none;
+  background: transparent;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 0.76rem;
+  cursor: pointer;
+}
+
+.board-query-clear:hover {
+  text-decoration: underline;
+}
+
+.board-query-search-input:focus-visible,
+.board-facet-trigger:focus-visible,
+.board-facet-option input:focus-visible,
+.board-query-sort select:focus-visible,
+.board-query-dir:focus-visible,
+.board-query-clear:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent-cool) 60%, transparent);
+  outline-offset: 1px;
+}
+
+/* Board card region states: first-page loading, error/retry, and empty. */
+.board-lanes-state {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 28px 20px;
+  border: 1px dashed var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card-soft);
+}
+
+.board-lanes-state-title {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  color: var(--text-strong);
+}
+
+/* A lane whose summary count exceeds its loaded cards — states what's not yet
+   paged in, so a partially loaded lane never reads as empty or complete. */
+.board-lane-pending {
+  margin: 2px 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.04em;
+  color: var(--muted-soft);
+}
+
+/* Global load-more affordance, mirroring the channel log's "Load older". */
+.board-more {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.board-more-error {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  color: var(--danger);
+}
+
 /* Needs you — the single glass strip of everything awaiting the human. */
 .board-needs {
   padding: 14px 16px;
@@ -15169,6 +15459,14 @@ a.board-fact-pr:hover {
   }
   .board-needs-strip {
     grid-template-columns: 1fr;
+  }
+  /* The query bar stacks on mobile: search takes its own row, facets + sort
+     wrap onto the next, so nothing is cramped at phone widths. */
+  .board-query-search {
+    flex-basis: 100%;
+  }
+  .board-query-sort {
+    margin-left: auto;
   }
   /* Reset widened lanes to the single-column basis so the board scrolls horizontally. */
   .board-lane[data-density="med"],

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14559,7 +14559,8 @@ html[data-theme="light"] .session-switcher-row.selected {
 }
 
 .board-query-search:focus-within {
-  border-color: color-mix(in srgb, var(--accent-cool) 55%, var(--line-strong));
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .board-query-search-cue {
@@ -14765,13 +14766,14 @@ html[data-theme="light"] .session-switcher-row.selected {
   text-decoration: underline;
 }
 
-.board-query-search-input:focus-visible,
+/* The search wrapper shows focus via its accent ring; the discrete controls take
+   a matching accent keyboard-focus outline. */
 .board-facet-trigger:focus-visible,
 .board-facet-option input:focus-visible,
 .board-query-sort select:focus-visible,
 .board-query-dir:focus-visible,
 .board-query-clear:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--accent-cool) 60%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
   outline-offset: 1px;
 }
 
@@ -15460,13 +15462,17 @@ a.board-fact-pr:hover {
   .board-needs-strip {
     grid-template-columns: 1fr;
   }
-  /* The query bar stacks on mobile: search takes its own row, facets + sort
-     wrap onto the next, so nothing is cramped at phone widths. */
-  .board-query-search {
+  /* Stack the query bar into three full-width rows — search, facets, sort — each
+     left-aligned so nothing floats to a ragged edge. The sort select grows to
+     fill its row with the direction toggle pinned at the end. */
+  .board-query-search,
+  .board-query-facets,
+  .board-query-sort {
     flex-basis: 100%;
   }
-  .board-query-sort {
-    margin-left: auto;
+  .board-query-sort-field,
+  .board-query-sort select {
+    flex: 1;
   }
   /* Reset widened lanes to the single-column basis so the board scrolls horizontally. */
   .board-lane[data-density="med"],

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -20,6 +20,8 @@ import {
   LaunchSettingsUpdate,
   ManagerStateResponse,
   ManagerSummary,
+  ManagerTicketListQuery,
+  ManagerTicketPage,
   MeResponse,
   MessageSchedule,
   ScheduleCreateRequest,
@@ -1364,7 +1366,36 @@ export async function fetchManagers(
   return (payload.managers ?? []) as ManagerSummary[];
 }
 
-// Tickets come from /state; there is no /tickets list route.
+// Board cards come from this paged, filtered, sorted route (not /state).
+export async function fetchManagerTickets(
+  host: string,
+  token: string,
+  managerId: string,
+  query: ManagerTicketListQuery,
+  options: { limit?: number; cursor?: string | null } = {},
+): Promise<ManagerTicketPage> {
+  const params = new URLSearchParams();
+  if (query.q) params.set("q", query.q);
+  for (const state of query.state) params.append("state", state);
+  for (const priority of query.priority) params.append("priority", priority);
+  for (const scale of query.scale) params.append("scale", scale);
+  params.set("sort", query.sort);
+  params.set("direction", query.direction);
+  if (options.limit !== undefined) params.set("limit", String(options.limit));
+  if (options.cursor) params.set("cursor", options.cursor);
+  const response = await fetch(
+    `${host}/api/manager/${encodeURIComponent(managerId)}/tickets?${params.toString()}`,
+    {
+      headers: { Authorization: `Bearer ${token}` },
+      cache: "no-store",
+    },
+  );
+  await ensureOk(response, "failed to fetch tickets");
+  return (await response.json()) as ManagerTicketPage;
+}
+
+// Full manager state (config, tree, complete ticket list) — kept for config,
+// the working-tree indicator, and the global Needs-you strip.
 export async function fetchManagerState(
   host: string,
   token: string,

--- a/frontend/src/lib/board.ts
+++ b/frontend/src/lib/board.ts
@@ -1,7 +1,14 @@
 // Board-workspace taxonomy: channel grouping, ticket-state to lane/lamp
 // mapping, and kind/priority tones.
 
-import { BoardChannel, ManagerTicket, ManagerTicketState } from "@/lib/types";
+import {
+  BoardChannel,
+  ManagerTicket,
+  ManagerTicketListQuery,
+  ManagerTicketScale,
+  ManagerTicketSort,
+  ManagerTicketState,
+} from "@/lib/types";
 
 // ─── Channel grouping (navigator) ───
 
@@ -239,4 +246,45 @@ export function rollupTickets(tickets: ManagerTicket[]): BoardRollup {
     if (ticket.state === "merged") rollup.merged += 1;
   }
   return rollup;
+}
+
+// ─── Board query controls ───
+
+export const TICKET_PAGE_LIMIT = 50;
+
+export const DEFAULT_TICKET_QUERY: ManagerTicketListQuery = {
+  q: "",
+  state: [],
+  priority: [],
+  scale: [],
+  sort: "updated_at",
+  direction: "desc",
+};
+
+export const SORT_OPTIONS: { key: ManagerTicketSort; label: string }[] = [
+  { key: "updated_at", label: "Last updated" },
+  { key: "created_at", label: "Created" },
+  { key: "priority", label: "Priority" },
+  { key: "id", label: "ID" },
+];
+
+export const SCALE_OPTIONS: { value: ManagerTicketScale; label: string }[] = [
+  { value: "substantial", label: "Substantial" },
+  { value: "trivial", label: "Trivial" },
+];
+
+// State facet options grouped by lifecycle lane, so the picker reads in the same
+// order the board lanes do rather than as a flat list of 13 states.
+export const STATE_FACET_GROUPS: { lane: string; states: ManagerTicketState[] }[] =
+  LANES.map((lane) => ({ lane: lane.label, states: lane.states }));
+
+// Whether a query narrows the board at all (any active filter). Sort/direction
+// alone do not count as filtering.
+export function isFilteredQuery(query: ManagerTicketListQuery): boolean {
+  return (
+    query.q.trim().length > 0 ||
+    query.state.length > 0 ||
+    query.priority.length > 0 ||
+    query.scale.length > 0
+  );
 }

--- a/frontend/src/lib/board.ts
+++ b/frontend/src/lib/board.ts
@@ -3,7 +3,6 @@
 
 import {
   BoardChannel,
-  ManagerTicket,
   ManagerTicketListQuery,
   ManagerTicketScale,
   ManagerTicketSort,
@@ -222,32 +221,6 @@ export function priorityTone(priority: string | null | undefined): PriorityTone 
   }
 }
 
-// ─── Board rollup ───
-
-export interface BoardRollup {
-  needYou: number;
-  inFlight: number;
-  blocked: number;
-  merged: number;
-}
-
-const IN_FLIGHT_STATES: ReadonlySet<ManagerTicketState> = new Set([
-  "delegated",
-  "building",
-  "revising",
-]);
-
-export function rollupTickets(tickets: ManagerTicket[]): BoardRollup {
-  const rollup: BoardRollup = { needYou: 0, inFlight: 0, blocked: 0, merged: 0 };
-  for (const ticket of tickets) {
-    if (isAwaiting(ticket.state)) rollup.needYou += 1;
-    if (IN_FLIGHT_STATES.has(ticket.state)) rollup.inFlight += 1;
-    if (ticket.state === "blocked") rollup.blocked += 1;
-    if (ticket.state === "merged") rollup.merged += 1;
-  }
-  return rollup;
-}
-
 // ─── Board query controls ───
 
 export const TICKET_PAGE_LIMIT = 50;
@@ -273,13 +246,11 @@ export const SCALE_OPTIONS: { value: ManagerTicketScale; label: string }[] = [
   { value: "trivial", label: "Trivial" },
 ];
 
-// State facet options grouped by lifecycle lane, so the picker reads in the same
-// order the board lanes do rather than as a flat list of 13 states.
+// State facet options grouped by lifecycle lane.
 export const STATE_FACET_GROUPS: { lane: string; states: ManagerTicketState[] }[] =
   LANES.map((lane) => ({ lane: lane.label, states: lane.states }));
 
-// Whether a query narrows the board at all (any active filter). Sort/direction
-// alone do not count as filtering.
+// True when any filter is active; sort and direction do not count.
 export function isFilteredQuery(query: ManagerTicketListQuery): boolean {
   return (
     query.q.trim().length > 0 ||

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -789,6 +789,36 @@ export interface ManagerSummary {
   attention_count: number;
 }
 
+// Board ticket-list query contract (paged, filtered, sorted).
+export type ManagerTicketSort = "updated_at" | "created_at" | "priority" | "id";
+export type ManagerTicketSortDirection = "asc" | "desc";
+
+export interface ManagerTicketListQuery {
+  q: string;
+  state: ManagerTicketState[];
+  priority: string[];
+  scale: ManagerTicketScale[];
+  sort: ManagerTicketSort;
+  direction: ManagerTicketSortDirection;
+}
+
+// Aggregates over the entire matching result, independent of the current page —
+// lets the board show a lane's true size before all its cards have loaded.
+export interface ManagerTicketSummary {
+  total: number;
+  lanes: Record<string, number>;
+  awaiting_count: number;
+  in_flight_count: number;
+  blocked_count: number;
+  merged_count: number;
+}
+
+export interface ManagerTicketPage {
+  tickets: ManagerTicket[];
+  next_cursor: string | null;
+  summary: ManagerTicketSummary;
+}
+
 export type MessageScheduleStatus = "pending" | "sent" | "cancelled" | "failed";
 
 export interface MessageSchedule {


### PR DESCRIPTION
## Purpose

The manager ticket board rendered every ticket from the full `GET /api/manager/{id}/state` snapshot, so initial load and every WebSocket refresh transferred and re-rendered the whole history (the live board holds 39 tickets, 38 of them merged), and there was no way to narrow the board to relevant work or choose its order. This adds a manager-scoped paginated ticket-list read model and drives the board from it: tickets load in bounded pages, and a designed query bar lets a user filter by title/state/priority/scale and pick a sort key and direction. Implements `.waypoint/specs/rfc-1504-ticket-board-querying.md` (Ticket 1504). The existing `/state` route, the manager state machine, `list_manager_tickets()`, the CLI, and scheduler internals are untouched — the new query is a separate read path.

## Changes

### Backend
- `backend/src/waypoint/schemas.py` — add `ManagerTicketListQuery` (normalized/canonical query with a stable `fingerprint()` bound into the cursor), `ManagerTicketSummary`, `ManagerTicketPage`, and the `ManagerTicketSort` / `ManagerTicketSortDirection` enums.
- `backend/src/waypoint/storage.py` — add `query_manager_tickets()`: one parameterized `WHERE` over `manager_id` + filters (title `LIKE ? ESCAPE '\'` with metacharacters escaped, so `q` is a literal substring), a generalized lexicographic keyset predicate + `ORDER BY` built from the requested sort with a stable `id ASC` final tie-break, and a separate `GROUP BY state` aggregate for the whole filtered set. Priority ordering uses a bounded `CASE` over the manager's configured order with a separate always-ascending unknown-group flag, so legacy priorities sort last in either direction. Adds manager-leading composite indexes (`(manager_id, updated_at, id)`, `(manager_id, created_at, id)`, `(manager_id, priority)`) via `CREATE INDEX IF NOT EXISTS`.
- `backend/src/waypoint/manager.py` — add `ManagerManager.list_tickets_page()` delegation (validates requested priorities against `priority_levels` → 422, decodes/encodes the cursor, folds per-state counts into the board's lane + rollup taxonomy — a backend copy of `frontend/src/lib/board.ts` LANES) and a signed, query-bound, URL-safe-base64 keyset cursor (HMAC-SHA256 over the app secret) that rejects any tampered, malformed, version-stale, or query-mismatched token.
- `backend/src/waypoint/api.py` — add `GET /api/manager/{manager_id}/tickets` with repeated-parameter facets, `limit` bounded `1..100` (default 50), and cursor signing off `settings.password`.

### Frontend
- `frontend/src/lib/types.ts`, `frontend/src/lib/api.ts` — the typed list contract and `fetchManagerTickets()` request helper.
- `frontend/src/lib/board.ts` — query defaults, sort/scale option tables, the lane-grouped state-facet metadata, and an `isFilteredQuery()` helper.
- `frontend/src/app/board/page.tsx` — the board's card collection now comes from the paged API. `board/page.tsx` owns the normalized query, page accumulation, summary, loading/error state, and a monotonic request-generation guard that drops stale responses. A query change (manager switch, filter, sort, direction, or debounced search) clears cards and fetches page one; `Load more` appends the next page with defensive ID de-duplication; a `board_update` for the selected manager invalidates and refetches page one. `fetchManagerState()` is kept for config/tree and the global `Needs you` strip, which stays derived from the state snapshot so an awaiting gate can't be filtered out of view.
- `frontend/src/app/globals.css` — the query-bar and states styling in the flat-instrument design system.

### Tests
- `backend/tests/test_manager.py` — storage/query coverage: default ordering + every sort/direction keyset walk matches a one-shot fetch, priority configured as a non-lexicographic sequence, ties, unknown legacy priorities last in both directions, all filters individually and combined, literal `%`/`_` escaping, query-scoped summary/lane/rollup aggregates, page boundaries with no duplicates and no trailing empty page, cursor signature/secret/query-mismatch/malformed rejection, and cross-manager isolation.
- `backend/tests/test_manager_api.py` — HTTP contract: default page + summary, repeated-parameter facets, cursor pagination over HTTP, `limit` bounds → 422, unknown priority → 422, invalid/query-mismatched cursor → 422, manager isolation, and `/state` still returning the full unpaged list.

## Design notes

- **RFC contract, tech-lead UI.** The RFC fixes the query behavior, accessibility, and API contract but deliberately does not prescribe the visual design; the controls here were chosen with `/frontend-design` within Waypoint's flat-instruments / liquid-glass-chrome design system. The query bar is flat, in-flow content (token surfaces, hairlines, no glass); the one floating element — the facet popover — uses the glass recipe. Nothing is a new hard-coded theme surface.
- **Controls.** A title search (250ms debounce), three multi-select facet popovers (State grouped by lifecycle lane, Priority from the manager's configured `priority_levels`, Scale), and a sort key select + direction toggle. Facets are checkbox popovers that close on Escape / outside click and are keyboard-operable; a `Clear filters` affordance appears only when a filter is active.
- **Lazy loading.** A single global `Load more` affordance backed by the API cursor (mirroring the channel log's existing `Load older`), shown only while `next_cursor` is present and disabled while a request is pending.
- **Summary-driven, not page-derived.** Lane counts and the rollup come from the query-scoped `summary`, not from the loaded page, so a lane whose cards have not all been paged in shows `loaded / total` and an `N not loaded yet` line rather than reading as empty, and the rollup marks itself `filtered` when narrowed.
- **States.** First-page loading, a retryable first-page error, and a distinct no-match empty state (with `Clear filters`); a `Load more` failure keeps the rendered cards and offers an inline retry. A visually-hidden `aria-live` region announces the loaded/total count and loading without moving focus.

## Test Plan

- `cd backend && uv run pytest tests/test_manager.py tests/test_manager_api.py` — the new storage/API coverage.
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pre-commit run` over the changed backend files — black/isort/ruff/codespell/mypy.
- `cd frontend && npm run lint && npm run build`.
- Live end-to-end against the deployed stack (`waypointctl restart`, backend `:8797` / frontend `:3010`): a curl cursor walk of the real 39-ticket manager across all four sorts × both directions, plus `limit`/priority/cursor 422 cases; and Playwright screenshots of `/board?view=board` across default / facet-popover-open / filtered-no-match / sorted states at desktop (1280px) and mobile (390px) in both dark and light themes.

## Test Result

- `cd backend && uv run pytest tests/test_manager.py tests/test_manager_api.py` → **276 passed**.
- `cd backend && uv run pytest` → **2898 passed** (3 pre-existing unrelated warnings).
- `cd frontend && npm run lint` → clean; `npm run build` → compiles.
- Live API: every sort × direction cursor walk returned all 39 tickets with **0 duplicates**; the query-scoped summary reported `total 39` (`build 1`, `done 38`); tampered cursor, `limit=0`/`limit=101`, and unknown priority each returned **422**.
- Playwright: the query bar, glass facet popover, filtered summary + `FILTERED` marker, no-match empty state, sort + direction toggle, and mobile reflow all rendered with **no console errors** in both themes.

Addresses ticket 1504.
