### PR TITLE
fix: keep markdown tables readable on mobile

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4368,27 +4368,18 @@ html[data-theme="light"] .tool-call-run-children {
   word-break: break-word;
 }
 
-/* Tables are the one markdown block that must stay dense: reflowing rows into
- * cards loses the column comparison and needs a header→cell map react-markdown
- * doesn't give us. Instead the table stays a table and scrolls horizontally
- * inside its own box. `display: block` makes the table its own scroll viewport
- * (max-width: 100% keeps that box inside the message, so the document never
- * gains horizontal overflow); the th/td rules below stop the columns from
- * crushing so the inner content actually overflows and the scroll engages. */
+/* display: block makes the table its own horizontal scroll box, so a wide
+ * table scrolls within the message instead of crushing its columns. */
 .markdown-message table {
   display: block;
   max-width: 100%;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
   border-collapse: collapse;
 }
 
-/* `.markdown-message` sets overflow-wrap: anywhere / word-break: break-word for
- * prose; left to cascade it breaks every cell word per character, collapsing
- * columns to ~1ch (headers stack as K/i/n/d) so nothing overflows and the
- * scroll never triggers. Reset it here: keep words whole, break only genuinely
- * unbreakable tokens, and floor/cap the column width so labels stay legible
- * while long prose wraps instead of ballooning the row. */
+/* Reset the prose overflow-wrap/word-break inherited from .markdown-message,
+ * which otherwise breaks cell text per character and collapses columns; the
+ * width floor/cap keeps labels legible while long prose wraps. */
 .markdown-message th,
 .markdown-message td {
   min-width: 5rem;
@@ -4397,7 +4388,6 @@ html[data-theme="light"] .tool-call-run-children {
   border: 1px solid var(--line);
   text-align: left;
   vertical-align: top;
-  white-space: normal;
   word-break: normal;
   overflow-wrap: break-word;
 }

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4368,10 +4368,43 @@ html[data-theme="light"] .tool-call-run-children {
   word-break: break-word;
 }
 
+/* Tables are the one markdown block that must stay dense: reflowing rows into
+ * cards loses the column comparison and needs a header→cell map react-markdown
+ * doesn't give us. Instead the table stays a table and scrolls horizontally
+ * inside its own box. `display: block` makes the table its own scroll viewport
+ * (max-width: 100% keeps that box inside the message, so the document never
+ * gains horizontal overflow); the th/td rules below stop the columns from
+ * crushing so the inner content actually overflows and the scroll engages. */
 .markdown-message table {
   display: block;
   max-width: 100%;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  border-collapse: collapse;
+}
+
+/* `.markdown-message` sets overflow-wrap: anywhere / word-break: break-word for
+ * prose; left to cascade it breaks every cell word per character, collapsing
+ * columns to ~1ch (headers stack as K/i/n/d) so nothing overflows and the
+ * scroll never triggers. Reset it here: keep words whole, break only genuinely
+ * unbreakable tokens, and floor/cap the column width so labels stay legible
+ * while long prose wraps instead of ballooning the row. */
+.markdown-message th,
+.markdown-message td {
+  min-width: 5rem;
+  max-width: 22rem;
+  padding: 7px 11px;
+  border: 1px solid var(--line);
+  text-align: left;
+  vertical-align: top;
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: break-word;
+}
+
+.markdown-message thead th {
+  background: var(--bg-card-soft);
+  font-weight: 600;
 }
 
 .markdown-message > :first-child {


### PR DESCRIPTION
## Purpose

Fixes markdown tables rendering crushed on mobile (ticket 1537): column headers stacked one letter per line and cells wrapped per character.

`.markdown-message` sets `overflow-wrap: anywhere` / `word-break: break-word` for prose so long paths and hashes wrap. The table cells were otherwise unstyled, so those rules cascaded into every `<th>`/`<td>` and broke ordinary words at any character. Columns collapsed to ~1ch, so the table content never exceeded its box and the existing `overflow-x: auto` scroll never engaged.

## Changes

### Frontend
- `frontend/src/app/globals.css` (`.markdown-message table` + new `th`/`td`/`thead th` rules) — reset the inherited wrapping on cells (`word-break: normal`, `overflow-wrap: break-word`), floor and cap column width (`min-width: 5rem`, `max-width: 22rem`), and add hairline borders, cell padding, and header background/weight. `border-collapse: collapse` keeps single hairlines.

## Design

The table stays a table and scrolls horizontally inside its own box, keeping the column comparison intact for any table shape; reflowing rows into cards needs a header→cell mapping react-markdown does not provide for arbitrary tables. The treatment stays within the flat-instrument design system (flat opaque surfaces, token hairlines, no glass or shadow on in-flow content). `display: block` makes the table its own scroll box and `max-width: 100%` keeps that box inside the message, so the document gains no horizontal overflow; the cell width floor makes the inner content overflow so the scroll engages.

## Test Plan
- `cd frontend && npm run lint && npm run build`.
- Playwright against the deployed frontend, linking the compiled stylesheet and reproducing the reported `Kind`/`Component`/`Role` table inside the transcript DOM, at 390px and 320px in dark and light themes; measured document horizontal overflow and the table's internal scroll.

## Test Result
- `npm run lint` and `npm run build` clean.
- Both viewports, both themes: document horizontal overflow `0px` (`documentElement` and `body`); the table scrolls internally (338px client vs 463px content at 390px); the first header cell renders at an 80px column instead of the ~1ch per-letter stack.

Addresses ticket 1537.