### PR TITLE
feat: surface Claude Code SendUserFile hand-offs in the session

### DIFF
--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -1783,9 +1783,8 @@ class ClaudeCliAdapter:
                             question.to_metadata()
                         )
                 elif tool_name == SEND_USER_FILE_TOOL:
-                    # Copy the sent files into the session's attachment store (the
-                    # runtime sink consumes ``capture_host_files``), and suppress
-                    # the ack tool_result so the SendUserFile card stands alone.
+                    # Tag the files for the runtime capture sink; suppress the ack
+                    # result so the card stands alone.
                     files = sent_user_file_paths(block.get("input") or {})
                     if files:
                         tool_call_metadata["capture_host_files"] = files

--- a/backend/src/waypoint/backends/claude_code/adapter.py
+++ b/backend/src/waypoint/backends/claude_code/adapter.py
@@ -23,6 +23,7 @@ from waypoint.backends.claude_code.models import (
     normalize_claude_model_id,
 )
 from waypoint.backends.claude_code.normalize import (
+    SEND_USER_FILE_TOOL,
     TASK_TOOL_NAMES,
     TaskListTracker,
     extract_created_task_id,
@@ -32,6 +33,7 @@ from waypoint.backends.claude_code.normalize import (
     format_status_event,
     format_task_snapshot,
     iter_content_blocks,
+    sent_user_file_paths,
     stringify_tool_result,
 )
 
@@ -1780,6 +1782,15 @@ class ClaudeCliAdapter:
                         tool_call_metadata[INTERACTION_METADATA_KEY] = (
                             question.to_metadata()
                         )
+                elif tool_name == SEND_USER_FILE_TOOL:
+                    # Copy the sent files into the session's attachment store (the
+                    # runtime sink consumes ``capture_host_files``), and suppress
+                    # the ack tool_result so the SendUserFile card stands alone.
+                    files = sent_user_file_paths(block.get("input") or {})
+                    if files:
+                        tool_call_metadata["capture_host_files"] = files
+                    if tool_use_id:
+                        state.suppressed_result_tool_use_ids.add(tool_use_id)
                 await self._emit_event(
                     state.session_id,
                     EventKind.TOOL_CALL,

--- a/backend/src/waypoint/backends/claude_code/normalize.py
+++ b/backend/src/waypoint/backends/claude_code/normalize.py
@@ -161,7 +161,24 @@ def stringify_tool_result(content: Any) -> str:
 
 TASK_TOOL_NAMES = frozenset({"TaskCreate", "TaskUpdate", "TaskGet", "TaskList"})
 
+# Claude Code's tool for sending local files to the human. Its files are copied
+# into the session's attachment store (surfaced in the Files browser) via the
+# backend-neutral ``capture_host_files`` metadata contract the runtime consumes.
+SEND_USER_FILE_TOOL = "SendUserFile"
+
 _VALID_TASK_STATUSES = frozenset({"pending", "in_progress", "completed"})
+
+
+def sent_user_file_paths(tool_input: dict[str, Any]) -> list[str]:
+    """The non-empty ``str`` paths from a ``SendUserFile`` tool input's ``files``.
+
+    Paths may be absolute or relative to the session cwd; resolution happens in
+    the runtime sink, so this is a pure coercion (drops non-str/empty entries).
+    """
+    raw = tool_input.get("files")
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, str) and item]
 
 
 def normalize_task_status(value: Any) -> str:

--- a/backend/src/waypoint/backends/claude_code/normalize.py
+++ b/backend/src/waypoint/backends/claude_code/normalize.py
@@ -161,20 +161,14 @@ def stringify_tool_result(content: Any) -> str:
 
 TASK_TOOL_NAMES = frozenset({"TaskCreate", "TaskUpdate", "TaskGet", "TaskList"})
 
-# Claude Code's tool for sending local files to the human. Its files are copied
-# into the session's attachment store (surfaced in the Files browser) via the
-# backend-neutral ``capture_host_files`` metadata contract the runtime consumes.
+# Claude Code's tool for sending local files to the human.
 SEND_USER_FILE_TOOL = "SendUserFile"
 
 _VALID_TASK_STATUSES = frozenset({"pending", "in_progress", "completed"})
 
 
 def sent_user_file_paths(tool_input: dict[str, Any]) -> list[str]:
-    """The non-empty ``str`` paths from a ``SendUserFile`` tool input's ``files``.
-
-    Paths may be absolute or relative to the session cwd; resolution happens in
-    the runtime sink, so this is a pure coercion (drops non-str/empty entries).
-    """
+    """The non-empty ``str`` entries of a ``SendUserFile`` input's ``files``."""
     raw = tool_input.get("files")
     if not isinstance(raw, list):
         return []

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -33,12 +33,14 @@ from typing import Any
 
 from waypoint.backends.claude_code.adapter import _apply_plan_edit, _is_plan_file_path
 from waypoint.backends.claude_code.normalize import (
+    SEND_USER_FILE_TOOL,
     TASK_TOOL_NAMES,
     TaskListTracker,
     extract_created_task_id,
     format_task_snapshot,
     is_injected_user_turn,
     iter_content_blocks,
+    sent_user_file_paths,
     stringify_tool_result,
 )
 from waypoint.backends.diff_preview import (
@@ -282,6 +284,34 @@ class TranscriptNormalizer:
                         # TaskGet / TaskList: suppress result, emit nothing
                         if tool_use_id:
                             self._suppressed_result_tool_use_ids.add(tool_use_id)
+                    continue
+                if tool_name == SEND_USER_FILE_TOOL:
+                    # Copy the sent files into the attachment store (runtime sink
+                    # consumes ``capture_host_files``) and suppress the ack result
+                    # so the card stands alone — mirrors AskUserQuestion/Task by
+                    # not registering a pending tool_use.
+                    files = sent_user_file_paths(block.get("input") or {})
+                    if tool_use_id:
+                        self._suppressed_result_tool_use_ids.add(tool_use_id)
+                    metadata: dict[str, Any] = {
+                        "method": "assistant.tool_use",
+                        "item_id": tool_use_id,
+                        "tool_name": tool_name,
+                        "tool_use_id": tool_use_id,
+                        "payload": block,
+                        "status": SessionStatus.RUNNING,
+                    }
+                    if files:
+                        metadata["capture_host_files"] = files
+                    events.append(
+                        NormalizedEvent(
+                            kind=EventKind.TOOL_CALL,
+                            text=f"{tool_name}\n"
+                            f"{json.dumps(block.get('input') or {}, indent=2)}",
+                            metadata=metadata,
+                            status=SessionStatus.RUNNING,
+                        )
+                    )
                     continue
                 if tool_name in FILE_EDIT_TOOL_NAMES:
                     self._maybe_capture_plan(tool_name, block.get("input") or {})

--- a/backend/src/waypoint/backends/claude_tty/normalize.py
+++ b/backend/src/waypoint/backends/claude_tty/normalize.py
@@ -286,10 +286,8 @@ class TranscriptNormalizer:
                             self._suppressed_result_tool_use_ids.add(tool_use_id)
                     continue
                 if tool_name == SEND_USER_FILE_TOOL:
-                    # Copy the sent files into the attachment store (runtime sink
-                    # consumes ``capture_host_files``) and suppress the ack result
-                    # so the card stands alone — mirrors AskUserQuestion/Task by
-                    # not registering a pending tool_use.
+                    # Tag the files for the runtime capture sink; suppress the ack
+                    # result and skip pending registration (like AskUserQuestion).
                     files = sent_user_file_paths(block.get("input") or {})
                     if tool_use_id:
                         self._suppressed_result_tool_use_ids.add(tool_use_id)

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -2,6 +2,7 @@ import asyncio
 import fnmatch
 import json
 import logging
+import mimetypes
 import os
 import re
 import secrets
@@ -5624,6 +5625,8 @@ class SessionRuntime:
         metadata: dict[str, Any],
         status: SessionStatus,
     ) -> None:
+        if kind == EventKind.TOOL_CALL and metadata.get("capture_host_files"):
+            await self._capture_host_files(session_id, metadata)
         event = EventRecord(
             session_id=session_id,
             ts=datetime.now(UTC),
@@ -5653,6 +5656,75 @@ class SessionRuntime:
             persisted = self.storage.append_event(event)
         self._append_structured_log(session_id, persisted)
         await self._publish_event(persisted)
+
+    async def _capture_host_files(
+        self, session_id: str, metadata: dict[str, Any]
+    ) -> None:
+        """Copy the host files named in the transient ``capture_host_files``
+        metadata into the session's attachment store (pinned so the orphan sweep
+        keeps them) and replace it with a persisted ``attachments`` spec list.
+
+        Backend-neutral: any normalizer can tag a TOOL_CALL with resolved-or-cwd
+        relative host paths and have them surfaced in the Files browser. The key
+        is always removed so it never reaches the persisted event. Best-effort —
+        never raises into the emit path.
+        """
+        raw = metadata.pop("capture_host_files", None)
+        if not isinstance(raw, list):
+            return
+        session = self.storage.get_session(session_id)
+        if session is None:
+            return
+        base = session.worktree_path or session.cwd
+        specs = await asyncio.to_thread(self._persist_host_files, session_id, base, raw)
+        if specs:
+            metadata["attachments"] = [spec.model_dump(mode="json") for spec in specs]
+
+    def _persist_host_files(
+        self, session_id: str, base: str | None, raw_paths: list[Any]
+    ) -> list[AttachmentSpec]:
+        """Read each host path and save it as a pinned attachment. Runs off the
+        event loop. Skips (with a warning) anything missing, oversized, or
+        unreadable; de-duplicates by resolved path so one file is saved once."""
+        max_bytes = self.settings.max_upload_bytes
+        base_dir = Path(base).expanduser() if base else None
+        out: list[AttachmentSpec] = []
+        seen: set[str] = set()
+        for raw in raw_paths:
+            if not isinstance(raw, str) or not raw:
+                continue
+            path = Path(raw).expanduser()
+            if not path.is_absolute() and base_dir is not None:
+                path = base_dir / path
+            try:
+                path = path.resolve()
+            except OSError:
+                log.warning("send_user_file: cannot resolve %r", raw)
+                continue
+            key = str(path)
+            if key in seen:
+                continue
+            seen.add(key)
+            try:
+                if not path.is_file():
+                    log.warning("send_user_file: not a file: %s", path)
+                    continue
+                if path.stat().st_size > max_bytes:
+                    log.warning(
+                        "send_user_file: %s exceeds %d byte limit", path, max_bytes
+                    )
+                    continue
+                data = path.read_bytes()
+            except OSError:
+                log.warning("send_user_file: cannot read %s", path, exc_info=True)
+                continue
+            mime = mimetypes.guess_type(path.name)[0]
+            spec = self.attachments.save(
+                session_id, data=data, filename=path.name, content_type=mime
+            )
+            self.attachments.mark_pinned(session_id, [spec.id])
+            out.append(spec)
+        return out
 
     def handle_completion_source_init(
         self, session_id: str, payload: dict[str, Any]

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -5660,14 +5660,12 @@ class SessionRuntime:
     async def _capture_host_files(
         self, session_id: str, metadata: dict[str, Any]
     ) -> None:
-        """Copy the host files named in the transient ``capture_host_files``
-        metadata into the session's attachment store (pinned so the orphan sweep
-        keeps them) and replace it with a persisted ``attachments`` spec list.
+        """Turn the transient ``capture_host_files`` paths into pinned session
+        attachments exposed on ``metadata["attachments"]``.
 
-        Backend-neutral: any normalizer can tag a TOOL_CALL with resolved-or-cwd
-        relative host paths and have them surfaced in the Files browser. The key
-        is always removed so it never reaches the persisted event. Best-effort —
-        never raises into the emit path.
+        A backend-neutral seam: any normalizer can tag a TOOL_CALL with host
+        paths and have them surface in the Files browser. The transient key is
+        always removed; best-effort, never raises into the emit path.
         """
         raw = metadata.pop("capture_host_files", None)
         if not isinstance(raw, list):
@@ -5683,9 +5681,9 @@ class SessionRuntime:
     def _persist_host_files(
         self, session_id: str, base: str | None, raw_paths: list[Any]
     ) -> list[AttachmentSpec]:
-        """Read each host path and save it as a pinned attachment. Runs off the
-        event loop. Skips (with a warning) anything missing, oversized, or
-        unreadable; de-duplicates by resolved path so one file is saved once."""
+        """Save each readable host path as a pinned attachment, deduped by
+        resolved path. Skips missing, oversized, or unreadable files. Blocking;
+        run off the event loop."""
         max_bytes = self.settings.max_upload_bytes
         base_dir = Path(base).expanduser() if base else None
         out: list[AttachmentSpec] = []

--- a/backend/tests/test_claude_cli.py
+++ b/backend/tests/test_claude_cli.py
@@ -1662,3 +1662,43 @@ async def test_read_stream_line_skips_oversized_line() -> None:
     assert await _read_stream_line(reader, "s", "stdout") is None
     assert await _read_stream_line(reader, "s", "stdout") == b'{"type":"result"}\n'
     assert await _read_stream_line(reader, "s", "stdout") == b""
+
+
+@pytest.mark.asyncio
+async def test_dispatch_send_user_file_tags_capture_and_suppresses_result() -> None:
+    emitted: list = []
+    adapter = _make_adapter(emitted)
+    state, _ = _attach_state(adapter)
+    event = {
+        "type": "assistant",
+        "message": {
+            "id": "msg_1",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_suf",
+                    "name": "SendUserFile",
+                    "input": {"files": ["report.md", "chart.png"], "caption": "fyi"},
+                },
+            ],
+        },
+    }
+    await adapter._dispatch(state, event)
+    tool_calls = [item for item in emitted if item[1] == EventKind.TOOL_CALL]
+    assert len(tool_calls) == 1
+    metadata = tool_calls[0][3]
+    assert metadata["tool_name"] == "SendUserFile"
+    assert metadata["capture_host_files"] == ["report.md", "chart.png"]
+    # The ack tool_result is suppressed so the card stands alone.
+    assert "toolu_suf" in state.suppressed_result_tool_use_ids
+    result_event = {
+        "type": "user",
+        "message": {
+            "content": [
+                {"type": "tool_result", "tool_use_id": "toolu_suf", "content": "sent"}
+            ]
+        },
+    }
+    await adapter._dispatch(state, result_event)
+    assert not any(item[1] == EventKind.TOOL_RESULT for item in emitted)
+    assert "toolu_suf" not in state.suppressed_result_tool_use_ids

--- a/backend/tests/test_claude_tty_normalize.py
+++ b/backend/tests/test_claude_tty_normalize.py
@@ -1233,3 +1233,38 @@ def test_pending_tool_use_cleared_on_turn_complete() -> None:
         _assistant_record("m2", [_text_block("done")], stop_reason="end_turn")
     )
     assert norm.pending_tool_use is None
+
+
+def test_send_user_file_tags_capture_and_suppresses_result() -> None:
+    norm = TranscriptNormalizer()
+    block = _tool_use_block(
+        "tu-suf",
+        "SendUserFile",
+        {"files": ["out/report.md", "chart.png"], "caption": "here"},
+    )
+    events = norm.process_record(
+        _assistant_record("m1", [block], stop_reason="tool_use")
+    )
+    calls = [e for e in events if e.kind == EventKind.TOOL_CALL]
+    assert len(calls) == 1
+    ev = calls[0]
+    assert ev.metadata["tool_name"] == "SendUserFile"
+    assert ev.metadata["capture_host_files"] == ["out/report.md", "chart.png"]
+    # Result is suppressed; the tool_use is not registered as pending.
+    assert norm.pending_tool_use is None
+
+    result_events = norm.process_record(
+        _user_record([_tool_result_block("tu-suf", "sent")])
+    )
+    assert not any(e.kind == EventKind.TOOL_RESULT for e in result_events)
+
+
+def test_send_user_file_without_files_omits_capture_key() -> None:
+    norm = TranscriptNormalizer()
+    block = _tool_use_block("tu-suf2", "SendUserFile", {"caption": "no files"})
+    events = norm.process_record(
+        _assistant_record("m1", [block], stop_reason="tool_use")
+    )
+    calls = [e for e in events if e.kind == EventKind.TOOL_CALL]
+    assert len(calls) == 1
+    assert "capture_host_files" not in calls[0].metadata

--- a/backend/tests/test_runtime_capture_host_files.py
+++ b/backend/tests/test_runtime_capture_host_files.py
@@ -1,0 +1,137 @@
+"""Unit tests for the backend-neutral ``capture_host_files`` sink that turns a
+SendUserFile tool call's host paths into pinned session attachments."""
+
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from waypoint.attachments import AttachmentStore
+from waypoint.runtime import SessionRuntime
+
+
+def _fake_runtime(
+    tmp_path: Path, *, max_upload_bytes: int = 25 * 1024 * 1024, session: Any = ...
+) -> SimpleNamespace:
+    store = AttachmentStore(tmp_path / "attachments")
+    if session is ...:
+        session = SimpleNamespace(worktree_path=None, cwd=str(tmp_path))
+    fake = SimpleNamespace(
+        attachments=store,
+        settings=SimpleNamespace(max_upload_bytes=max_upload_bytes),
+        storage=SimpleNamespace(get_session=lambda _sid: session),
+    )
+    fake._persist_host_files = types.MethodType(
+        SessionRuntime._persist_host_files, fake
+    )
+    return fake
+
+
+def _persist(fake: SimpleNamespace, base: str | None, raw: list[Any]) -> list[Any]:
+    return SessionRuntime._persist_host_files(
+        cast(SessionRuntime, fake), "sess-1", base, raw
+    )
+
+
+async def _capture(fake: SimpleNamespace, metadata: dict[str, Any]) -> None:
+    await SessionRuntime._capture_host_files(
+        cast(SessionRuntime, fake), "sess-1", metadata
+    )
+
+
+def test_persist_absolute_and_relative(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path)
+    (tmp_path / "abs.txt").write_text("A")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "rel.txt").write_text("BB")
+
+    specs = _persist(fake, str(tmp_path), [str(tmp_path / "abs.txt"), "sub/rel.txt"])
+
+    names = {s.filename for s in specs}
+    assert names == {"abs.txt", "rel.txt"}
+    # Both are pinned (survive the orphan sweep).
+    assert fake.attachments.pinned_ids("sess-1") == {s.id for s in specs}
+
+
+def test_persist_dedupes_by_resolved_path(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path)
+    (tmp_path / "dup.txt").write_text("x")
+
+    specs = _persist(
+        fake, str(tmp_path), ["dup.txt", str(tmp_path / "dup.txt"), "./dup.txt"]
+    )
+
+    assert len(specs) == 1
+
+
+def test_persist_skips_missing_and_oversized(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path, max_upload_bytes=4)
+    (tmp_path / "big.bin").write_bytes(b"toolarge")
+    (tmp_path / "ok.txt").write_text("ok")
+
+    specs = _persist(fake, str(tmp_path), ["nope.txt", "big.bin", "ok.txt"])
+
+    assert [s.filename for s in specs] == ["ok.txt"]
+
+
+def test_persist_ignores_non_string_entries(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path)
+    (tmp_path / "real.txt").write_text("r")
+
+    specs = _persist(fake, str(tmp_path), [None, 3, "", "real.txt"])
+
+    assert [s.filename for s in specs] == ["real.txt"]
+
+
+@pytest.mark.asyncio
+async def test_capture_sets_attachments_and_removes_key(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path)
+    (tmp_path / "doc.md").write_text("hello")
+    metadata: dict[str, Any] = {
+        "tool_name": "SendUserFile",
+        "capture_host_files": ["doc.md"],
+    }
+
+    await _capture(fake, metadata)
+
+    assert "capture_host_files" not in metadata
+    assert isinstance(metadata["attachments"], list)
+    assert metadata["attachments"][0]["filename"] == "doc.md"
+
+
+@pytest.mark.asyncio
+async def test_capture_no_attachments_when_all_unreadable(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path)
+    metadata: dict[str, Any] = {"capture_host_files": ["ghost.txt"]}
+
+    await _capture(fake, metadata)
+
+    assert "capture_host_files" not in metadata
+    assert "attachments" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_capture_uses_worktree_over_cwd(tmp_path: Path) -> None:
+    worktree = tmp_path / "wt"
+    worktree.mkdir()
+    (worktree / "w.txt").write_text("w")
+    session = SimpleNamespace(worktree_path=str(worktree), cwd=str(tmp_path))
+    fake = _fake_runtime(tmp_path, session=session)
+    metadata: dict[str, Any] = {"capture_host_files": ["w.txt"]}
+
+    await _capture(fake, metadata)
+
+    assert metadata["attachments"][0]["filename"] == "w.txt"
+
+
+@pytest.mark.asyncio
+async def test_capture_missing_session_is_noop(tmp_path: Path) -> None:
+    fake = _fake_runtime(tmp_path, session=None)
+    metadata: dict[str, Any] = {"capture_host_files": ["whatever.txt"]}
+
+    await _capture(fake, metadata)
+
+    assert "capture_host_files" not in metadata
+    assert "attachments" not in metadata

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7530,15 +7530,21 @@ html[data-theme="light"] .composer-send {
   background: color-mix(in srgb, var(--accent-cool) 8%, var(--bg-card));
 }
 
-/* SendUserFile hand-off: a deliberate delivery from the agent to the human.
- * Tinted in the warm accent (distinct from the cool ask card) so it reads as a
- * highlight rather than an ordinary recessed tool run. */
+/* SendUserFile hand-off: a warm-accent-tinted delivery card, denser than a
+ * content card so the files and shortcut read at a glance. */
 .send-user-file {
+  padding: 11px 13px;
   border-color: color-mix(in srgb, var(--accent) 32%, var(--line));
   background: color-mix(in srgb, var(--accent) 8%, var(--bg-card));
 }
 
+.send-user-file .transcript-role {
+  margin-bottom: 0;
+}
+
 .send-user-file .tool-glyph {
+  width: 22px;
+  height: 22px;
   color: var(--accent);
 }
 
@@ -7551,30 +7557,31 @@ html[data-theme="light"] .composer-send {
 }
 
 .send-user-file-caption {
-  margin: 10px 0 0;
+  margin: 7px 0 0;
   color: var(--text);
-  font-size: 0.9rem;
-  line-height: 1.45;
+  font-size: 0.82rem;
+  line-height: 1.4;
   overflow-wrap: anywhere;
 }
 
 .send-user-file .message-attachments {
-  margin-top: 10px;
+  margin-top: 8px;
+  gap: 6px;
 }
 
 .send-user-file-names {
   list-style: none;
-  margin: 10px 0 0;
+  margin: 8px 0 0;
   padding: 0;
   display: grid;
-  gap: 6px;
+  gap: 5px;
 }
 
 .send-user-file-name {
   font-family: var(--font-mono);
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--text);
-  padding: 6px 10px;
+  padding: 5px 9px;
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   background: var(--bg-card-soft);
@@ -7582,17 +7589,17 @@ html[data-theme="light"] .composer-send {
 }
 
 .send-user-file-open {
-  margin-top: 12px;
+  margin-top: 9px;
   display: inline-flex;
   align-items: center;
   font-family: var(--font-mono);
-  font-size: 0.75rem;
+  font-size: 0.72rem;
   letter-spacing: 0.04em;
   color: var(--accent);
   background: transparent;
   border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
   border-radius: var(--radius-sm);
-  padding: 6px 12px;
+  padding: 4px 10px;
   cursor: pointer;
   transition:
     border-color 160ms ease,

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -3084,7 +3084,7 @@ details[open] > .transcript-summary::after {
  * shadow), inset them slightly, and quiet the typography so they read as
  * sidenotes that the eye can skip when scanning.
  * ──────────────────────────────────────────────────────────────────────── */
-.transcript.codex.tool_call:not(.ask-user-question),
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file),
 .transcript.codex.tool_result,
 .transcript.codex.tool_pair {
   padding: 9px 12px;
@@ -3103,7 +3103,7 @@ details[open] > .transcript-summary::after {
 }
 
 @media (max-width: 720px) {
-  .transcript.codex.tool_call:not(.ask-user-question),
+  .transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file),
   .transcript.codex.tool_result,
   .transcript.codex.tool_pair {
     margin: 0;
@@ -3111,7 +3111,7 @@ details[open] > .transcript-summary::after {
   }
 }
 
-.transcript.codex.tool_call:not(.ask-user-question):hover,
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file):hover,
 .transcript.codex.tool_result:hover,
 .transcript.codex.tool_pair:hover {
   border-color: var(--line-strong);
@@ -3123,13 +3123,13 @@ details.tool-disclosure[open] {
   background: var(--bg-card-soft);
 }
 
-.transcript.codex.tool_call:not(.ask-user-question) .transcript-role,
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file) .transcript-role,
 .transcript.codex.tool_result .transcript-role,
 .transcript.codex.tool_pair .transcript-role {
   margin-bottom: 0;
 }
 
-.transcript.codex.tool_call:not(.ask-user-question) .transcript-role .role-time,
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file) .transcript-role .role-time,
 .transcript.codex.tool_result .transcript-role .role-time,
 .transcript.codex.tool_pair .transcript-role .role-time {
   margin-left: auto;
@@ -3140,7 +3140,7 @@ details.tool-disclosure[open] {
  * (so the user can spot a Bash among Reads at a glance), but the saturated
  * background fill is dropped so the chip reads as a small marker rather
  * than a competing badge. */
-.transcript.codex.tool_call:not(.ask-user-question) .tool-glyph,
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file) .tool-glyph,
 .transcript.codex.tool_result .tool-glyph,
 .transcript.codex.tool_pair .tool-glyph {
   width: 20px;
@@ -3149,7 +3149,7 @@ details.tool-disclosure[open] {
   background: transparent;
 }
 
-.transcript.codex.tool_call:not(.ask-user-question) .tool-name,
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file) .tool-name,
 .transcript.codex.tool_result .tool-name,
 .transcript.codex.tool_pair .tool-name {
   font-size: 0.74rem;
@@ -3209,7 +3209,7 @@ details.tool-disclosure[open] .tool-glyph.todo {
 }
 
 /* Status pill is loud against the recessed card; trim it to a fine label. */
-.transcript.codex.tool_call:not(.ask-user-question) .badge.tool-status,
+.transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file) .badge.tool-status,
 .transcript.codex.tool_result .badge.tool-status,
 .transcript.codex.tool_pair .badge.tool-status {
   background: transparent;
@@ -3225,7 +3225,7 @@ details.tool-disclosure[open] .tool-glyph.todo {
 }
 
 @media (max-width: 540px) {
-  .transcript.codex.tool_call:not(.ask-user-question),
+  .transcript.codex.tool_call:not(.ask-user-question):not(.send-user-file),
   .transcript.codex.tool_result,
   .transcript.codex.tool_pair {
     margin: 0 8px;
@@ -7528,6 +7528,72 @@ html[data-theme="light"] .composer-send {
 .ask-user-question {
   border-color: color-mix(in srgb, var(--accent-cool) 30%, var(--line));
   background: color-mix(in srgb, var(--accent-cool) 8%, var(--bg-card));
+}
+
+/* SendUserFile hand-off: a deliberate delivery from the agent to the human.
+ * Tinted in the warm accent (distinct from the cool ask card) so it reads as a
+ * highlight rather than an ordinary recessed tool run. */
+.send-user-file {
+  border-color: color-mix(in srgb, var(--accent) 32%, var(--line));
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-card));
+}
+
+.send-user-file .tool-glyph {
+  color: var(--accent);
+}
+
+.send-user-file-caption {
+  margin: 10px 0 0;
+  color: var(--text);
+  font-size: 0.9rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.send-user-file .message-attachments {
+  margin-top: 10px;
+}
+
+.send-user-file-names {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.send-user-file-name {
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--text);
+  padding: 6px 10px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card-soft);
+  overflow-wrap: anywhere;
+}
+
+.send-user-file-open {
+  margin-top: 12px;
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: transparent;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
+  border-radius: var(--radius-sm);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease;
+}
+
+.send-user-file-open:hover {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--line));
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
 
 .ask-question + .ask-question {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -7542,6 +7542,14 @@ html[data-theme="light"] .composer-send {
   color: var(--accent);
 }
 
+/* Bare mono count in the card's own hue — a label, not a status pill. */
+.send-user-file-count {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+}
+
 .send-user-file-caption {
   margin: 10px 0 0;
   color: var(--text);

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -98,6 +98,7 @@ import {
   WorkspaceFileLinkProvider,
   type WorkspaceLinkHandler,
 } from "@/components/WorkspaceFileLinkContext";
+import { SessionFilesLinkProvider } from "@/components/SessionFilesLinkContext";
 import { SessionTerminalView } from "@/components/SessionTerminalView";
 import { SessionUsagePill } from "@/components/SessionUsagePill";
 import { CommandSuggestions } from "@/components/CommandSuggestions";
@@ -347,6 +348,9 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // `events` and win the max-sequence comparison in `currentTaskEvent`.
   const [loadedTodoEvent, setLoadedTodoEvent] = useState<EventRecord | null>(null);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
+  // Owned here (not in ReplyComposer) so a transcript SendUserFile card can open
+  // the same Files browser the composer renders.
+  const [filesOpen, setFilesOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | undefined>(undefined);
   const [workspaceInitialDir, setWorkspaceInitialDir] = useState<string | undefined>(undefined);
@@ -1789,6 +1793,10 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
     () => (workspacePreviewEnabled ? { openWorkspacePath } : null),
     [workspacePreviewEnabled, openWorkspacePath],
   );
+  const filesLink = useMemo(
+    () => ({ openFilesBrowser: () => setFilesOpen(true) }),
+    [],
+  );
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1821,6 +1829,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
 
   return (
     <WorkspaceFileLinkProvider value={workspaceLink}>
+    <SessionFilesLinkProvider value={filesLink}>
     <section className="stack" ref={sectionRef}>
       {!terminalOnly && activeView === "chat" && showScrollToTop ? (
         <div className="scroll-top-floater" aria-hidden={false}>
@@ -2369,6 +2378,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
           assistantControls={assistantControls}
           workspacePreviewEnabled={workspacePreviewEnabled}
           onBrowseWorkspace={openWorkspaceRoot}
+          filesOpen={filesOpen}
+          onFilesOpenChange={setFilesOpen}
         />
       ) : null}
       {workspacePreviewEnabled ? (
@@ -2399,6 +2410,7 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
         />
       ) : null}
     </section>
+    </SessionFilesLinkProvider>
     </WorkspaceFileLinkProvider>
   );
 }
@@ -2461,6 +2473,10 @@ interface ReplyComposerProps {
   assistantControls: AssistantControls | null;
   workspacePreviewEnabled: boolean;
   onBrowseWorkspace: () => void;
+  // Files-browser open state, lifted to SessionDetail so a transcript card
+  // (SendUserFile) can open the same panel the composer owns.
+  filesOpen: boolean;
+  onFilesOpenChange: (open: boolean) => void;
 }
 
 const ReplyComposer = memo(function ReplyComposer({
@@ -2513,12 +2529,13 @@ const ReplyComposer = memo(function ReplyComposer({
   assistantControls,
   workspacePreviewEnabled,
   onBrowseWorkspace,
+  filesOpen,
+  onFilesOpenChange,
 }: ReplyComposerProps) {
   const [draft, setDraft] = useState("");
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const attachments = useAttachments({ host, token, sessionId, onError });
-  const [filesOpen, setFilesOpen] = useState(false);
   const [scheduleMsgOpen, setScheduleMsgOpen] = useState(false);
   const [sending, setSending] = useState(false);
   const [overflowOpen, setOverflowOpen] = useState(false);
@@ -3564,7 +3581,7 @@ const ReplyComposer = memo(function ReplyComposer({
                       className="composer-overflow-item"
                       onClick={() => {
                         setOverflowOpen(false);
-                        setFilesOpen(true);
+                        onFilesOpenChange(true);
                       }}
                     >
                       <span className="glyph">▤</span>
@@ -3690,7 +3707,7 @@ const ReplyComposer = memo(function ReplyComposer({
           token={token}
           sessionId={sessionId}
           open={filesOpen}
-          onClose={() => setFilesOpen(false)}
+          onClose={() => onFilesOpenChange(false)}
           onReference={attachments.referenceExisting}
           referencedIds={attachments.attachedIds}
         />
@@ -4009,7 +4026,7 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
     if (item.kind === "pair") {
       const { call, result } = item.pair;
       const isSpecial = (e: EventRecord | null) =>
-        e !== null && readToolName(e) === "AskUserQuestion";
+        e !== null && isStandaloneToolCard(readToolName(e));
       return isSpecial(call) || isSpecial(result) ? "content" : "tool";
     }
     const { event } = item;
@@ -4020,7 +4037,7 @@ function buildTranscriptItems(events: EventRecord[]): TranscriptItem[] {
         return "content";
       case "tool_call":
       case "tool_result":
-        return readToolName(event) === "AskUserQuestion" ? "content" : "tool";
+        return isStandaloneToolCard(readToolName(event)) ? "content" : "tool";
       default:
         return isPlanEvent(event) ? "content" : "absorbed";
     }
@@ -4097,6 +4114,13 @@ function isToolResultDelta(event: EventRecord): boolean {
 
 function isTodoListEvent(event: EventRecord): boolean {
   return event.metadata?.item_type === "todo_list" || readToolName(event) === "TodoWrite";
+}
+
+// Tool calls that render as their own standalone card rather than folding into
+// a collapsed tool run: interactive asks and deliberate file hand-offs. Kept in
+// sync with the dedicated cards in TranscriptCard.
+function isStandaloneToolCard(toolName: string | null): boolean {
+  return toolName === "AskUserQuestion" || toolName === "SendUserFile";
 }
 
 function isAgentBusy(

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -348,8 +348,8 @@ export function SessionDetail({ host, token, sessionId, onAuthFailure, assistant
   // `events` and win the max-sequence comparison in `currentTaskEvent`.
   const [loadedTodoEvent, setLoadedTodoEvent] = useState<EventRecord | null>(null);
   const [workspaceOpen, setWorkspaceOpen] = useState(false);
-  // Owned here (not in ReplyComposer) so a transcript SendUserFile card can open
-  // the same Files browser the composer renders.
+  // Owned here so a transcript SendUserFile card can open the Files browser the
+  // composer renders.
   const [filesOpen, setFilesOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [workspaceInitialPath, setWorkspaceInitialPath] = useState<string | undefined>(undefined);
@@ -2473,8 +2473,7 @@ interface ReplyComposerProps {
   assistantControls: AssistantControls | null;
   workspacePreviewEnabled: boolean;
   onBrowseWorkspace: () => void;
-  // Files-browser open state, lifted to SessionDetail so a transcript card
-  // (SendUserFile) can open the same panel the composer owns.
+  // Files browser open state, owned by SessionDetail (see filesOpen there).
   filesOpen: boolean;
   onFilesOpenChange: (open: boolean) => void;
 }
@@ -4116,9 +4115,8 @@ function isTodoListEvent(event: EventRecord): boolean {
   return event.metadata?.item_type === "todo_list" || readToolName(event) === "TodoWrite";
 }
 
-// Tool calls that render as their own standalone card rather than folding into
-// a collapsed tool run: interactive asks and deliberate file hand-offs. Kept in
-// sync with the dedicated cards in TranscriptCard.
+// Tool calls that render as their own card instead of folding into a collapsed
+// tool run — the dedicated cards in TranscriptCard.
 function isStandaloneToolCard(toolName: string | null): boolean {
   return toolName === "AskUserQuestion" || toolName === "SendUserFile";
 }

--- a/frontend/src/components/SessionFilesLinkContext.tsx
+++ b/frontend/src/components/SessionFilesLinkContext.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+// Lets transcript-deep cards open the session Files browser, which is owned by
+// the composer. Mirrors WorkspaceFileLinkContext so a card doesn't prop-drill
+// through the transcript tree.
+export interface SessionFilesLinkHandler {
+  openFilesBrowser: () => void;
+}
+
+const SessionFilesLinkContext = createContext<SessionFilesLinkHandler | null>(null);
+
+export const SessionFilesLinkProvider = SessionFilesLinkContext.Provider;
+
+export function useSessionFilesLink(): SessionFilesLinkHandler | null {
+  return useContext(SessionFilesLinkContext);
+}

--- a/frontend/src/components/SessionFilesLinkContext.tsx
+++ b/frontend/src/components/SessionFilesLinkContext.tsx
@@ -2,9 +2,8 @@
 
 import { createContext, useContext } from "react";
 
-// Lets transcript-deep cards open the session Files browser, which is owned by
-// the composer. Mirrors WorkspaceFileLinkContext so a card doesn't prop-drill
-// through the transcript tree.
+// Lets a transcript card open the session Files browser without prop-drilling
+// through the transcript tree. Mirrors WorkspaceFileLinkContext.
 export interface SessionFilesLinkHandler {
   openFilesBrowser: () => void;
 }

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -35,9 +35,7 @@ import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 import { TodoListBody } from "@/components/TodoList";
 
-// Claude Code's tool for handing local files to the human. The backend copies
-// the files into the session's attachment store and exposes their specs on
-// metadata.attachments; this card surfaces them as a deliberate hand-off.
+// Claude Code's tool for handing local files to the human.
 const SEND_USER_FILE_TOOL = "SendUserFile";
 
 // Three-state resolution of an AskUserQuestion, derived once over the loaded
@@ -286,8 +284,8 @@ function CodexCard({
           />
         );
       }
-      // Defensive: a SendUserFile call is normally paired (routed via
-      // ToolPairCard); this handles an unpaired/import-path render.
+      // A SendUserFile call is normally paired (ToolPairCard); this covers the
+      // unpaired import-path render.
       if (readToolName(event) === SEND_USER_FILE_TOOL) {
         return <SendUserFileCard event={event} />;
       }
@@ -508,8 +506,6 @@ function toolBadgeFor(toolName: string | null | undefined): ToolBadge {
       return { glyph: "☑", variant: "todo", label: "Todo" };
     case "AskUserQuestion":
       return { glyph: "?", variant: "task", label: "Ask" };
-    case SEND_USER_FILE_TOOL:
-      return { glyph: "↧", variant: "task", label: "Sent you" };
     default:
       if (toolName) {
         return { glyph: "ƒ", variant: "default", label: toolName };
@@ -785,35 +781,31 @@ function ToolPairCard({
   );
 }
 
-function sentFileBasenames(event: EventRecord): string[] {
-  const payload = event.metadata?.payload as { input?: unknown } | undefined;
-  const input = payload?.input as { files?: unknown } | undefined;
-  const files = input?.files;
-  if (!Array.isArray(files)) return [];
-  return files
-    .filter((path): path is string => typeof path === "string" && path.length > 0)
-    .map((path) => path.split(/[\\/]/).pop() || path);
+function sendUserFileInput(event: EventRecord): {
+  files: string[];
+  caption: string | null;
+} {
+  const input = (event.metadata?.payload as { input?: unknown } | undefined)
+    ?.input as { files?: unknown; caption?: unknown } | undefined;
+  const files = Array.isArray(input?.files)
+    ? input.files.filter((p): p is string => typeof p === "string" && p.length > 0)
+    : [];
+  const caption =
+    typeof input?.caption === "string" && input.caption.trim()
+      ? input.caption
+      : null;
+  return { files, caption };
 }
 
-function sentFileCaption(event: EventRecord): string | null {
-  const payload = event.metadata?.payload as { input?: unknown } | undefined;
-  const input = payload?.input as { caption?: unknown } | undefined;
-  return typeof input?.caption === "string" && input.caption.trim()
-    ? input.caption
-    : null;
-}
-
-// A deliberate hand-off: the agent sent file(s) to the human. Stands alone
-// (classified "content") rather than folding into a collapsed tool run, and
-// opens the session Files browser where every sent/uploaded file lives.
+// The agent's SendUserFile hand-off. Rendered standalone (classified "content")
+// with the sent files and a shortcut to the Files browser.
 function SendUserFileCard({ event }: { event: EventRecord }) {
   const filesLink = useSessionFilesLink();
   const specs = Array.isArray(event.metadata?.attachments)
-    ? (event.metadata?.attachments as unknown[])
+    ? (event.metadata.attachments as unknown[])
     : [];
-  const basenames = sentFileBasenames(event);
-  const caption = sentFileCaption(event);
-  const count = specs.length || basenames.length;
+  const { files, caption } = sendUserFileInput(event);
+  const count = specs.length || files.length;
   return (
     <article className="panel transcript codex tool_call send-user-file">
       <div className="transcript-role">
@@ -829,11 +821,11 @@ function SendUserFileCard({ event }: { event: EventRecord }) {
       {caption ? <p className="send-user-file-caption">{caption}</p> : null}
       {specs.length > 0 ? (
         <MessageAttachments event={event} />
-      ) : basenames.length > 0 ? (
+      ) : files.length > 0 ? (
         <ul className="send-user-file-names">
-          {basenames.map((name, index) => (
-            <li key={`${name}-${index}`} className="send-user-file-name">
-              {name}
+          {files.map((path, index) => (
+            <li key={`${path}-${index}`} className="send-user-file-name">
+              {path.split(/[\\/]/).pop() || path}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -821,7 +821,7 @@ function SendUserFileCard({ event }: { event: EventRecord }) {
           ↧
         </span>
         <span className="tool-name">Sent you</span>
-        <span className="badge tool-status complete">
+        <span className="send-user-file-count">
           {count} file{count === 1 ? "" : "s"}
         </span>
         <span className="role-time">{formatTime(event.ts)}</span>

--- a/frontend/src/components/TranscriptCard.tsx
+++ b/frontend/src/components/TranscriptCard.tsx
@@ -28,11 +28,17 @@ import {
   type TodoEntry,
 } from "@/lib/todos";
 import { MessageAttachments } from "@/components/AttachmentTray";
+import { useSessionFilesLink } from "@/components/SessionFilesLinkContext";
 import { PlanApprovalCard } from "@/components/ApprovalCard";
 import { CopyMessageButton } from "@/components/CopyMessageButton";
 import { DiffPreview } from "@/components/DiffPreview";
 import { MarkdownMessage } from "@/components/MarkdownMessage";
 import { TodoListBody } from "@/components/TodoList";
+
+// Claude Code's tool for handing local files to the human. The backend copies
+// the files into the session's attachment store and exposes their specs on
+// metadata.attachments; this card surfaces them as a deliberate hand-off.
+const SEND_USER_FILE_TOOL = "SendUserFile";
 
 // Three-state resolution of an AskUserQuestion, derived once over the loaded
 // events from durable answer evidence: a correlated ask_user_question_answer
@@ -280,6 +286,11 @@ function CodexCard({
           />
         );
       }
+      // Defensive: a SendUserFile call is normally paired (routed via
+      // ToolPairCard); this handles an unpaired/import-path render.
+      if (readToolName(event) === SEND_USER_FILE_TOOL) {
+        return <SendUserFileCard event={event} />;
+      }
       if (isTodoToolEvent(event)) {
         return <TodoToolCard event={event} />;
       }
@@ -497,6 +508,8 @@ function toolBadgeFor(toolName: string | null | undefined): ToolBadge {
       return { glyph: "☑", variant: "todo", label: "Todo" };
     case "AskUserQuestion":
       return { glyph: "?", variant: "task", label: "Ask" };
+    case SEND_USER_FILE_TOOL:
+      return { glyph: "↧", variant: "task", label: "Sent you" };
     default:
       if (toolName) {
         return { glyph: "ƒ", variant: "default", label: toolName };
@@ -711,6 +724,13 @@ function ToolPairCard({
       );
     }
   }
+  const sendUserFileEvent =
+    readToolName(call ?? result ?? ({} as EventRecord)) === SEND_USER_FILE_TOOL
+      ? (call ?? result)
+      : null;
+  if (sendUserFileEvent) {
+    return <SendUserFileCard event={sendUserFileEvent} />;
+  }
   if (isTodoToolEvent(call) || isTodoToolEvent(result)) {
     return <TodoToolPairCard pair={pair} />;
   }
@@ -762,6 +782,72 @@ function ToolPairCard({
         )}
       </div>
     </details>
+  );
+}
+
+function sentFileBasenames(event: EventRecord): string[] {
+  const payload = event.metadata?.payload as { input?: unknown } | undefined;
+  const input = payload?.input as { files?: unknown } | undefined;
+  const files = input?.files;
+  if (!Array.isArray(files)) return [];
+  return files
+    .filter((path): path is string => typeof path === "string" && path.length > 0)
+    .map((path) => path.split(/[\\/]/).pop() || path);
+}
+
+function sentFileCaption(event: EventRecord): string | null {
+  const payload = event.metadata?.payload as { input?: unknown } | undefined;
+  const input = payload?.input as { caption?: unknown } | undefined;
+  return typeof input?.caption === "string" && input.caption.trim()
+    ? input.caption
+    : null;
+}
+
+// A deliberate hand-off: the agent sent file(s) to the human. Stands alone
+// (classified "content") rather than folding into a collapsed tool run, and
+// opens the session Files browser where every sent/uploaded file lives.
+function SendUserFileCard({ event }: { event: EventRecord }) {
+  const filesLink = useSessionFilesLink();
+  const specs = Array.isArray(event.metadata?.attachments)
+    ? (event.metadata?.attachments as unknown[])
+    : [];
+  const basenames = sentFileBasenames(event);
+  const caption = sentFileCaption(event);
+  const count = specs.length || basenames.length;
+  return (
+    <article className="panel transcript codex tool_call send-user-file">
+      <div className="transcript-role">
+        <span className="tool-glyph task" aria-hidden>
+          ↧
+        </span>
+        <span className="tool-name">Sent you</span>
+        <span className="badge tool-status complete">
+          {count} file{count === 1 ? "" : "s"}
+        </span>
+        <span className="role-time">{formatTime(event.ts)}</span>
+      </div>
+      {caption ? <p className="send-user-file-caption">{caption}</p> : null}
+      {specs.length > 0 ? (
+        <MessageAttachments event={event} />
+      ) : basenames.length > 0 ? (
+        <ul className="send-user-file-names">
+          {basenames.map((name, index) => (
+            <li key={`${name}-${index}`} className="send-user-file-name">
+              {name}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {filesLink ? (
+        <button
+          type="button"
+          className="send-user-file-open"
+          onClick={filesLink.openFilesBrowser}
+        >
+          Open in Files
+        </button>
+      ) : null}
+    </article>
   );
 }
 


### PR DESCRIPTION
## Purpose

Claude Code's `SendUserFile` tool hands local files to the human, but a Waypoint-managed Claude session had nowhere to deliver them: the call rendered as a generic collapsed tool run and the files stayed on the session host, invisible in the app. This captures the sent files as session attachments (so they appear in the session Files browser) and surfaces a dedicated hand-off card in the transcript, with each file clickable and an affordance to open the Files browser — not the workspace browser. Ticket 1548.

## Changes

The seam between capture and rendering is a backend-neutral contract: a normalizer tags the `SendUserFile` tool_call with a transient `capture_host_files` path list, and the single runtime event sink turns those into pinned attachments exposed on `metadata.attachments` (the same key sent-message attachments already use). The runtime never branches on a backend id, and any future backend can reuse the contract.

### Backend
- `backend/src/waypoint/backends/claude_code/normalize.py` — add the `SEND_USER_FILE_TOOL` constant and `sent_user_file_paths()`, a pure coercion of the tool input's `files` to a `list[str]`, shared by both claude normalizers.
- `backend/src/waypoint/backends/claude_code/adapter.py` — the structured stream-json path (`_handle_assistant`) tags a `SendUserFile` tool_call with `capture_host_files` and suppresses the ack `tool_result` (mirroring ExitPlanMode) so the card stands alone.
- `backend/src/waypoint/backends/claude_tty/normalize.py` — the TUI-transcript path (`_process_assistant`) does the same, without registering a pending tool_use (mirroring AskUserQuestion). This is the transport the fix was verified against.
- `backend/src/waypoint/runtime.py` — `_emit_adapter_event` (the one async sink both transports emit through) resolves each `capture_host_files` path against the session's `worktree_path or cwd`, reads it (size-capped by `max_upload_bytes`), saves it as a pinned attachment, and replaces the transient key with `metadata.attachments`. Missing, oversized, or unreadable files (including remote sessions, whose paths the backend can't read — consistent with workspace preview being local-only) degrade to no spec; the sink never raises into the event loop, and a deleted session is a no-op.

### Frontend
- `frontend/src/components/SessionFilesLinkContext.tsx` (new) — a small context exposing `openFilesBrowser`, mirroring `WorkspaceFileLinkContext`, so a transcript-deep card can open the Files panel the composer owns.
- `frontend/src/components/TranscriptCard.tsx` — a dedicated `SendUserFileCard`: a flat, stand-alone hand-off card (glyph, "Sent you", quiet file-count label, caption, the clickable files via the existing `MessageAttachments`, and an "Open in Files" action). It hooks `ToolPairCard` (the live paired path) with a defensive `CodexCard` branch for the unpaired/import path, and reads persisted specs when present else falls back to the sent basenames.
- `frontend/src/components/SessionDetail.tsx` — lift the Files-browser open state out of `ReplyComposer` up to `SessionDetail` and provide it through `SessionFilesLinkContext`, and classify a `SendUserFile` call as `content` so it renders standalone instead of folding into a collapsed, hidden-by-default tool run.
- `frontend/src/app/globals.css` — the `.send-user-file` card styling in the flat-instrument design system (warm-accent tint distinct from the cool ask card, a bare-mono count label, file-name fallback tiles, and the Open-in-Files action), all resolving from tokens in both themes.

### Tests
- `backend/tests/test_runtime_capture_host_files.py` (new) — `_persist_host_files` / `_capture_host_files` against a real `AttachmentStore`: absolute + cwd-relative resolution, worktree-over-cwd base, dedup by resolved path, skip missing/oversized, ignore non-string entries, `metadata.attachments` set and `capture_host_files` removed, and the missing-session no-op.
- `backend/tests/test_claude_cli.py`, `backend/tests/test_claude_tty_normalize.py` — both normalizers tag `capture_host_files` from `input.files`, suppress the result, and omit the key when no files are named.

## Design

Capture lives in one place — the runtime sink both claude transports already funnel through — rather than in each sync normalizer, which keeps the blocking file I/O off the event loop (via `asyncio.to_thread`) and avoids triplicating logic across the structured adapter, the claude_tty tailer, and the transcript-import path. The normalizers only tag intent; the sink keys on the generic `capture_host_files` metadata, so it stays backend-neutral. The transcript-import path (`history.py`) deliberately does not capture — it seeds through a different, read-only path, so re-importing a session never double-saves — and its card degrades to file-name labels plus the Open-in-Files affordance. Files are pinned so the orphan sweep keeps them, since a hand-off is not attached to a user message. Reading agent-named host paths grants no new capability: the agent is the human's own local Claude Code and already has full host filesystem access; the `max_upload_bytes` cap bounds the copy and attachment ids remain server-generated.

## Test Plan

- `cd backend && uv run pytest tests/test_runtime_capture_host_files.py tests/test_claude_cli.py tests/test_claude_tty_normalize.py` — the new capture + normalizer coverage.
- `cd backend && uv run pytest` — full backend suite.
- `cd backend && uv run pre-commit run --files <changed>` — isort/black/ruff/codespell/mypy on the changed backend files.
- `cd frontend && npm run lint && npm run build`.
- Live end-to-end against the deployed stack (`waypointctl restart`, backend `:8797` / frontend `:3010`): drove a real `claude_tty` session to call `SendUserFile` on host files and confirmed the backend captured each as a pinned attachment (`sessions attachments list`), then Playwright at 390px in both themes confirmed the hand-off card renders standalone with the caption and clickable files, and that "Open in Files" opens the session Files browser modal.

## Test Result

- `cd backend && uv run pytest` → **2909 passed** (3 pre-existing unrelated warnings).
- `cd backend && uv run pre-commit run --files <changed>` → isort/black/ruff/codespell/mypy clean.
- `cd frontend && npm run lint` → clean; `npm run build` → compiles (typecheck passes).
- Live: a single-file and a two-file `SendUserFile` each landed as `pinned: true` attachments (`text/markdown`, `text/plain`) on the session; the transcript card rendered standalone in dark and light with the caption, the clickable files (image thumbnails path exercised via the shared attachment card), and the quiet accent count; "Open in Files" opened the Files modal (`session-files-modal` present).

Addresses ticket 1548.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `cd backend && uv run pre-commit run` (on the changed files) and fixed any issues.
- [x] I have added or updated tests covering my changes (if applicable).
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] If I touched the coding-agent plugin/transport contract or code that dispatches by plugin id, I checked the affected backends (claude_code, codex, opencode) still work.
- [x] If I changed the frontend, I ran `cd frontend && npm run lint && npm run build` and kept dark/light theme parity.
- [ ] If this is a breaking change, I marked the title (`type!:` or a `BREAKING CHANGE:` footer) and described migration steps above.
- [ ] I have updated documentation or config examples if user-facing behavior changed.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
