### PR TITLE
feat: render LaTeX math in all markdown surfaces

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,23 +1,26 @@
 {
   "name": "waypoint-frontend",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "waypoint-frontend",
-      "version": "0.15.2",
+      "version": "0.16.0",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "katex": "^0.18.4",
         "lowlight": "^3.3.0",
         "next": "^16.3.1",
         "react": "^19.0.0",
         "react-dom": "^19.2.8",
         "react-markdown": "^10.1.0",
+        "rehype-katex": "^7.0.1",
         "remark-breaks": "^4.0.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "@types/node": "^26.2.0",
@@ -643,9 +646,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -661,9 +661,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -681,9 +678,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -699,9 +693,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -719,9 +710,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -737,9 +725,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -757,9 +742,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -776,9 +758,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -794,9 +773,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -820,9 +796,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -844,9 +817,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -870,9 +840,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -894,9 +861,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -920,9 +884,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -945,9 +906,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -969,9 +927,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1199,9 +1154,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1217,9 +1169,6 @@
       "integrity": "sha512-JUiPXZKK9wOhjf4MgDiH29GZLxfqOesbLtHq2pDxwH/WwscTRV2ToymnOTh1egzaZf0ueUf8T2+CeYTGHjW0Iw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1237,9 +1186,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1201,6 @@
       "integrity": "sha512-6yy3FT13KgUFOj5H8bl8w/6nKiJwHIvbtwh1V+1acsu+7y4tJjnemSa6mhsh53BeoVrlozE+fMgZhXH46WmjMA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1420,6 +1363,12 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
       "license": "MIT"
     },
     "node_modules/@types/mdast": {
@@ -2606,6 +2555,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2848,6 +2806,18 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3913,6 +3883,101 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3940,6 +4005,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -3947,6 +4028,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4630,6 +4728,22 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/katex": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.4.tgz",
+      "integrity": "sha512-IMPntbRLOU+eu88XDiFKqQ8Akhr9Tv7jDMXqPhjG9SI1JMA4DIgXk4x9k4skJz2NZJXBRbC+2pYBLj9olqcZow==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4912,6 +5026,25 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5259,6 +5392,41 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -6036,6 +6204,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6282,6 +6462,41 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-katex/node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
     "node_modules/remark-breaks": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
@@ -6308,6 +6523,22 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -7271,6 +7502,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unist-util-is": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
@@ -7291,6 +7536,20 @@
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-remove-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7429,6 +7688,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -7441,6 +7714,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/which": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,9 +20,11 @@
         "rehype-katex": "^7.0.1",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
-        "remark-math": "^6.0.0"
+        "remark-math": "^6.0.0",
+        "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {
+        "@types/hast": "^3.0.4",
         "@types/node": "^26.2.0",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,9 +21,11 @@
     "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
-    "remark-math": "^6.0.0"
+    "remark-math": "^6.0.0",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
+    "@types/hast": "^3.0.4",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,13 +12,16 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",
+    "katex": "^0.18.4",
     "lowlight": "^3.3.0",
     "next": "^16.3.1",
     "react": "^19.0.0",
     "react-dom": "^19.2.8",
     "react-markdown": "^10.1.0",
+    "rehype-katex": "^7.0.1",
     "remark-breaks": "^4.0.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0"
   },
   "devDependencies": {
     "@types/node": "^26.2.0",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4423,6 +4423,23 @@ html[data-theme="light"] .tool-call-run-children {
   text-underline-offset: 0.16em;
 }
 
+/* KaTeX math: rehype-katex renders inline `$…$` as `.katex` inline flow and
+ * display `$$…$$` as a block `.katex-display`; both inherit message color and
+ * are already themed by the bundled katex stylesheet. A long display formula
+ * must scroll inside its own box so it never widens the viewport on mobile;
+ * the .markdown-message grid gap already spaces block children, so drop
+ * KaTeX's own vertical margin there. */
+.markdown-message .katex-display,
+.tm-nl-prose .katex-display {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.markdown-message .katex-display {
+  margin: 0;
+}
+
 .inline-code {
   padding: 0.1rem 0.32rem;
   border-radius: 6px;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -4423,12 +4423,9 @@ html[data-theme="light"] .tool-call-run-children {
   text-underline-offset: 0.16em;
 }
 
-/* KaTeX math: rehype-katex renders inline `$…$` as `.katex` inline flow and
- * display `$$…$$` as a block `.katex-display`; both inherit message color and
- * are already themed by the bundled katex stylesheet. A long display formula
- * must scroll inside its own box so it never widens the viewport on mobile;
- * the .markdown-message grid gap already spaces block children, so drop
- * KaTeX's own vertical margin there. */
+/* A long display formula scrolls inside its own box instead of widening the
+ * mobile viewport; the .markdown-message grid gap spaces block children, so
+ * KaTeX's own vertical margin is dropped there. */
 .markdown-message .katex-display,
 .tm-nl-prose .katex-display {
   max-width: 100%;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,8 +3,8 @@ import { JetBrains_Mono, Source_Serif_4 } from "next/font/google";
 
 import { SwitcherProvider } from "@/components/SwitcherProvider";
 import { ThemeProvider } from "@/lib/theme";
-// KaTeX ships its own bundled stylesheet and fonts; import it before globals.css
-// so Next bundles the assets locally (no CDN) and token-aware rules can refine it.
+// Bundles KaTeX's stylesheet and fonts locally; precedes globals.css so token
+// rules can refine it.
 import "katex/dist/katex.min.css";
 import "./globals.css";
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -3,6 +3,9 @@ import { JetBrains_Mono, Source_Serif_4 } from "next/font/google";
 
 import { SwitcherProvider } from "@/components/SwitcherProvider";
 import { ThemeProvider } from "@/lib/theme";
+// KaTeX ships its own bundled stylesheet and fonts; import it before globals.css
+// so Next bundles the assets locally (no CDN) and token-aware rules can refine it.
+import "katex/dist/katex.min.css";
 import "./globals.css";
 
 const displaySerif = Source_Serif_4({

--- a/frontend/src/components/MarkdownMessage.tsx
+++ b/frontend/src/components/MarkdownMessage.tsx
@@ -10,12 +10,11 @@ import {
 } from "react";
 
 import ReactMarkdown, { type Components } from "react-markdown";
-import remarkBreaks from "remark-breaks";
-import remarkGfm from "remark-gfm";
 
 import { CopyCodeButton } from "@/components/CopyCodeButton";
 import { useWorkspaceFileLink } from "@/components/WorkspaceFileLinkContext";
 import { highlightFenceToLines, type HighlightToken } from "@/lib/highlight";
+import { COMMON_REHYPE_PLUGINS, COMMON_REMARK_PLUGINS } from "@/lib/markdown";
 import { isWorkspacePathHref, remarkLinkifyPaths } from "@/lib/workspacePaths";
 
 interface MarkdownMessageProps {
@@ -25,7 +24,9 @@ interface MarkdownMessageProps {
 // Hoisted to module scope so the plugin array and component overrides keep a
 // stable identity across renders — combined with the memo() below, an
 // unchanged `text` skips the remark parse entirely during streaming.
-const REMARK_PLUGINS = [remarkGfm, remarkBreaks, remarkLinkifyPaths];
+// remarkLinkifyPaths runs after remarkMath so a path-like TeX fragment is
+// already a math node and cannot be turned into a workspace link.
+const REMARK_PLUGINS = [...COMMON_REMARK_PLUGINS, remarkLinkifyPaths];
 
 // react-markdown renders fenced blocks as <pre><code>…</code></pre>; the pre
 // override only receives the rendered tree, so recover the raw code by walking
@@ -176,7 +177,11 @@ export const MarkdownMessage = memo(function MarkdownMessage({
 }: MarkdownMessageProps) {
   return (
     <div className="markdown-message">
-      <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={COMPONENTS}>
+      <ReactMarkdown
+        remarkPlugins={REMARK_PLUGINS}
+        rehypePlugins={COMMON_REHYPE_PLUGINS}
+        components={COMPONENTS}
+      >
         {text}
       </ReactMarkdown>
     </div>

--- a/frontend/src/components/MarkdownMessage.tsx
+++ b/frontend/src/components/MarkdownMessage.tsx
@@ -24,8 +24,8 @@ interface MarkdownMessageProps {
 // Hoisted to module scope so the plugin array and component overrides keep a
 // stable identity across renders — combined with the memo() below, an
 // unchanged `text` skips the remark parse entirely during streaming.
-// remarkLinkifyPaths runs after remarkMath so a path-like TeX fragment is
-// already a math node and cannot be turned into a workspace link.
+// remarkLinkifyPaths runs after remarkMath so a path-like TeX fragment is a
+// math node, not a workspace link.
 const REMARK_PLUGINS = [...COMMON_REMARK_PLUGINS, remarkLinkifyPaths];
 
 // react-markdown renders fenced blocks as <pre><code>…</code></pre>; the pre

--- a/frontend/src/components/telemetry/NLInsightCard.tsx
+++ b/frontend/src/components/telemetry/NLInsightCard.tsx
@@ -3,9 +3,8 @@
 import { useId, useState } from "react";
 
 import ReactMarkdown from "react-markdown";
-import remarkBreaks from "remark-breaks";
-import remarkGfm from "remark-gfm";
 
+import { COMMON_REHYPE_PLUGINS, COMMON_REMARK_PLUGINS } from "@/lib/markdown";
 import { confidenceLabel } from "@/lib/telemetry";
 import {
   NLGenerationStatus,
@@ -13,10 +12,6 @@ import {
   NLInsightResponse,
 } from "@/lib/types";
 import { formatRelativeTime } from "@/lib/usage";
-
-// The summarizer returns markdown (a "- " bullet list, occasional **bold**);
-// render it so inline formatting resolves instead of showing literal "**".
-const NL_REMARK_PLUGINS = [remarkGfm, remarkBreaks];
 
 interface NLInsightCardProps {
   nlEnabled: boolean;
@@ -122,7 +117,8 @@ export function NLInsightCard({
 
       <div className="tm-nl-prose">
         <ReactMarkdown
-          remarkPlugins={NL_REMARK_PLUGINS}
+          remarkPlugins={COMMON_REMARK_PLUGINS}
+          rehypePlugins={COMMON_REHYPE_PLUGINS}
           components={{
             ul: (props) => <ul className="tm-nl-prose-list" {...props} />,
             // Flatten stray paragraphs the model may emit between bullets.

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -38,13 +38,10 @@ function rehypePreserveMathFences() {
   };
 }
 
-// throwOnError renders KaTeX's own error in place so malformed streamed TeX
-// can't crash a message; trust and maxExpand bound untrusted input; errorColor
-// is a token so the error resolves per theme.
+// rehype-katex renders KaTeX's own error markup in place of throwing, so
+// malformed streamed TeX can't crash a message. trust and maxExpand bound
+// untrusted input; errorColor is a token so the error resolves per theme.
 export const COMMON_REHYPE_PLUGINS: PluggableList = [
   rehypePreserveMathFences,
-  [
-    rehypeKatex,
-    { throwOnError: false, trust: false, maxExpand: 1000, errorColor: "var(--danger)" },
-  ],
+  [rehypeKatex, { trust: false, maxExpand: 1000, errorColor: "var(--danger)" }],
 ];

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -1,75 +1,50 @@
+import type { Root } from "hast";
 import rehypeKatex from "rehype-katex";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import type { PluggableList } from "unified";
+import { visit } from "unist-util-visit";
 
-// Shared remark/rehype plugin arrays for every direct ReactMarkdown call site.
-// Hoisted to module scope so their identity is stable across renders: combined
-// with a memoized renderer, unchanged text skips the remark parse during
-// streaming. remarkMath must precede any text-node walker (e.g. path linkify)
-// so equation text becomes a math node before that walker sees it.
 export const COMMON_REMARK_PLUGINS: PluggableList = [
   remarkGfm,
   remarkBreaks,
   remarkMath,
 ];
 
-// Minimal hast shapes — a dependency-free walk avoids pulling unist-util-visit
-// in as a direct dependency for a dozen lines.
-interface HastElement {
-  type: string;
-  tagName?: string;
-  properties?: { className?: unknown };
-  children?: HastElement[];
-}
-
-// remark-math tags real math with `math-inline`/`math-display` alongside
-// `language-math`; a ```` ```math ```` fence carries only `language-math`.
-// rehype-katex renders any `language-math` element, so without this it would
-// swallow that fence and turn agent-authored code into a formula. Strip the
-// bare `language-math` from genuine fences before rehype-katex runs so they
-// stay ordinary, copyable code blocks — this ticket only renders the
-// dollar-delimited `$...$`/`$$...$$` syntax.
+// rehype-katex renders every `language-math` element, including a ```math fence
+// that remark-math never parsed as math (real math also carries math-inline or
+// math-display). Drop the bare class so such a fence stays a code block.
 function rehypePreserveMathFences() {
-  return (tree: HastElement) => {
-    const walk = (node: HastElement, parent: HastElement | null) => {
+  return (tree: Root) => {
+    visit(tree, "element", (node, _index, parent) => {
       if (
-        node.tagName === "code" &&
-        parent?.tagName === "pre" &&
-        Array.isArray(node.properties?.className)
+        node.tagName !== "code" ||
+        parent?.type !== "element" ||
+        parent.tagName !== "pre" ||
+        !Array.isArray(node.properties.className)
       ) {
-        const classes = node.properties.className as string[];
-        if (
-          classes.includes("language-math") &&
-          !classes.includes("math-display") &&
-          !classes.includes("math-inline")
-        ) {
-          node.properties.className = classes.filter(
-            (name) => name !== "language-math",
-          );
-        }
+        return;
       }
-      node.children?.forEach((child) => walk(child, node));
-    };
-    walk(tree, null);
+      const classes = node.properties.className;
+      if (
+        classes.includes("language-math") &&
+        !classes.includes("math-display") &&
+        !classes.includes("math-inline")
+      ) {
+        node.properties.className = classes.filter((c) => c !== "language-math");
+      }
+    });
   };
 }
 
-// trust:false and the bounded maxExpand keep hostile TeX from producing HTML or
-// unbounded expansion; throwOnError:false renders a local KaTeX error in place
-// of throwing, so partial/streamed agent TeX can't break a whole message.
-// errorColor is a design token so a parse error resolves to the theme's danger
-// hue in both light and dark rather than KaTeX's fixed red.
+// throwOnError renders KaTeX's own error in place so malformed streamed TeX
+// can't crash a message; trust and maxExpand bound untrusted input; errorColor
+// is a token so the error resolves per theme.
 export const COMMON_REHYPE_PLUGINS: PluggableList = [
   rehypePreserveMathFences,
   [
     rehypeKatex,
-    {
-      throwOnError: false,
-      trust: false,
-      maxExpand: 1000,
-      errorColor: "var(--danger)",
-    },
+    { throwOnError: false, trust: false, maxExpand: 1000, errorColor: "var(--danger)" },
   ],
 ];

--- a/frontend/src/lib/markdown.ts
+++ b/frontend/src/lib/markdown.ts
@@ -1,0 +1,75 @@
+import rehypeKatex from "rehype-katex";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
+import type { PluggableList } from "unified";
+
+// Shared remark/rehype plugin arrays for every direct ReactMarkdown call site.
+// Hoisted to module scope so their identity is stable across renders: combined
+// with a memoized renderer, unchanged text skips the remark parse during
+// streaming. remarkMath must precede any text-node walker (e.g. path linkify)
+// so equation text becomes a math node before that walker sees it.
+export const COMMON_REMARK_PLUGINS: PluggableList = [
+  remarkGfm,
+  remarkBreaks,
+  remarkMath,
+];
+
+// Minimal hast shapes — a dependency-free walk avoids pulling unist-util-visit
+// in as a direct dependency for a dozen lines.
+interface HastElement {
+  type: string;
+  tagName?: string;
+  properties?: { className?: unknown };
+  children?: HastElement[];
+}
+
+// remark-math tags real math with `math-inline`/`math-display` alongside
+// `language-math`; a ```` ```math ```` fence carries only `language-math`.
+// rehype-katex renders any `language-math` element, so without this it would
+// swallow that fence and turn agent-authored code into a formula. Strip the
+// bare `language-math` from genuine fences before rehype-katex runs so they
+// stay ordinary, copyable code blocks — this ticket only renders the
+// dollar-delimited `$...$`/`$$...$$` syntax.
+function rehypePreserveMathFences() {
+  return (tree: HastElement) => {
+    const walk = (node: HastElement, parent: HastElement | null) => {
+      if (
+        node.tagName === "code" &&
+        parent?.tagName === "pre" &&
+        Array.isArray(node.properties?.className)
+      ) {
+        const classes = node.properties.className as string[];
+        if (
+          classes.includes("language-math") &&
+          !classes.includes("math-display") &&
+          !classes.includes("math-inline")
+        ) {
+          node.properties.className = classes.filter(
+            (name) => name !== "language-math",
+          );
+        }
+      }
+      node.children?.forEach((child) => walk(child, node));
+    };
+    walk(tree, null);
+  };
+}
+
+// trust:false and the bounded maxExpand keep hostile TeX from producing HTML or
+// unbounded expansion; throwOnError:false renders a local KaTeX error in place
+// of throwing, so partial/streamed agent TeX can't break a whole message.
+// errorColor is a design token so a parse error resolves to the theme's danger
+// hue in both light and dark rather than KaTeX's fixed red.
+export const COMMON_REHYPE_PLUGINS: PluggableList = [
+  rehypePreserveMathFences,
+  [
+    rehypeKatex,
+    {
+      throwOnError: false,
+      trust: false,
+      maxExpand: 1000,
+      errorColor: "var(--danger)",
+    },
+  ],
+];


### PR DESCRIPTION
## Purpose

Markdown-rendering surfaces show equation delimiters literally (ticket 1562): `$E = mc^2$` and `$$…$$` in agent responses, plans, inbox messages, and workspace Markdown never typeset. The two direct `ReactMarkdown` call sites used only `remark-gfm` + `remark-breaks`, so no math extension ran. This adds dollar-delimited TeX rendering via KaTeX across every Markdown surface, offline and safe-by-default, without changing any other Markdown behavior.

## Changes

### Frontend

- `frontend/src/lib/markdown.ts` (new) — the shared, module-scope plugin config both direct renderers use: `COMMON_REMARK_PLUGINS` (`remark-gfm`, `remark-breaks`, `remark-math`) and `COMMON_REHYPE_PLUGINS` (`rehype-katex` with `throwOnError: false`, `trust: false`, `maxExpand: 1000`, and a token-based `errorColor: var(--danger)`). It also carries a tiny dependency-free `rehypePreserveMathFences` pass that strips the bare `language-math` class from genuine fenced code before `rehype-katex` runs, so a ```` ```math ```` fence stays an ordinary copyable code block and only `$…$`/`$$…$$` syntax becomes math.
- `frontend/src/components/MarkdownMessage.tsx` — wire the shared remark + rehype arrays (covers transcript, approval prompts/plans, inbox blocks, and Markdown file previews). `remarkLinkifyPaths` now runs after `remark-math`, so a path-like TeX fragment is already a math node and cannot be turned into a workspace link.
- `frontend/src/components/telemetry/NLInsightCard.tsx` — wire the same shared arrays, keeping its existing `ul`/`p` overrides.
- `frontend/src/app/layout.tsx` — import `katex/dist/katex.min.css` once at root scope, before `globals.css`, so KaTeX fonts/assets are bundled by Next locally (no CDN).
- `frontend/src/app/globals.css` — scoped rules so a long display equation scrolls inside its own box (`overflow-x: auto`) instead of widening the mobile viewport, and drop KaTeX's own vertical margin inside the `.markdown-message` grid.
- `frontend/package.json` — add `remark-math`, `rehype-katex`, `katex`.

## Design

`rehype-katex` fully replaces the `<pre><code class="math-display">` / `<code class="math-inline">` nodes with `.katex-display` / `.katex` before `react-markdown` maps components, so display math never reaches the existing `pre`/`code` overrides — it gets no copy button or code highlighting, and inline math gets no inline-code styling, with no per-node guard needed there. The one case that does need handling is that `rehype-katex` also renders a bare `language-math` fence, which would silently convert an agent-authored ```` ```math ```` code block into a formula; the pre-katex pass keeps that behavior unchanged so this change is confined to dollar-delimited math. Error handling stays local and theme-aware: invalid TeX renders in place in the danger token color and leaves surrounding content intact, matching the flat-instrument design system in both themes.

## Test Plan

- `cd frontend && npm run lint && npm run build`.
- Playwright against the deployed stack (frontend :3010, backend :8797) at 390px mobile width in dark and light themes, driving a Markdown file preview through `MarkdownMessage` with inline, display, ```` ```math ```` fence, inline-code `$x$`, path-like `$./src/file$`, invalid TeX, and an over-wide display equation.

## Test Result

- `npm run lint` and `npm run build` clean (TypeScript included).
- 26/26 Playwright checks pass in both themes: inline + display render as `.katex`/`.katex-display` with delimiters absent; display math has no copy button and is not inside a code block; a ```` ```math ```` fence stays a code fence; inline code `$x$` stays literal; a path-like expression is not linkified; invalid TeX shows a local error resolving to the danger token (`rgb(226,108,112)` dark / `rgb(184,48,56)` light) with the following sentence still rendered; the long equation scrolls internally with zero document-level horizontal overflow; and no CDN/external KaTeX asset is requested.

Addresses ticket 1562.