### PR TITLE
feat: add workspace path completion to session composers

### DIFF
--- a/frontend/src/components/CommandSuggestions.tsx
+++ b/frontend/src/components/CommandSuggestions.tsx
@@ -2,14 +2,16 @@
 
 import { forwardRef, MutableRefObject } from "react";
 
-import type { CommandCompletion } from "@/lib/types";
-
-export function commandLabel(entry: CommandCompletion): string {
-  return `${entry.trigger}${entry.name}`;
-}
+import {
+  rowDescription,
+  rowHint,
+  rowKey,
+  rowLabel,
+  type SuggestionRow,
+} from "@/lib/composer-completions";
 
 interface CommandSuggestionsProps {
-  suggestions: ReadonlyArray<CommandCompletion>;
+  suggestions: ReadonlyArray<SuggestionRow>;
   activeIndex: number;
   itemRefs: MutableRefObject<Array<HTMLButtonElement | null>>;
   onApply: (index: number) => void;
@@ -23,32 +25,36 @@ export const CommandSuggestions = forwardRef<HTMLUListElement, CommandSuggestion
   ) {
     return (
       <ul className="slash-suggestions" role="listbox" ref={ref}>
-        {suggestions.map((entry, index) => (
-          <li key={entry.id}>
-            <button
-              ref={(node) => {
-                itemRefs.current[index] = node;
-              }}
-              type="button"
-              role="option"
-              aria-selected={index === activeIndex}
-              className={`slash-suggestion ${index === activeIndex ? "active" : ""}`}
-              onMouseDown={(event) => {
-                event.preventDefault();
-                onApply(index);
-              }}
-              onMouseEnter={() => onHover(index)}
-            >
-              <span className="slash-name">
-                {commandLabel(entry)}
-                {entry.argument_hint ? (
-                  <span className="slash-hint">{entry.argument_hint}</span>
+        {suggestions.map((entry, index) => {
+          const hint = rowHint(entry);
+          const description = rowDescription(entry);
+          return (
+            <li key={rowKey(entry)}>
+              <button
+                ref={(node) => {
+                  itemRefs.current[index] = node;
+                }}
+                type="button"
+                role="option"
+                aria-selected={index === activeIndex}
+                className={`slash-suggestion ${index === activeIndex ? "active" : ""}`}
+                onMouseDown={(event) => {
+                  event.preventDefault();
+                  onApply(index);
+                }}
+                onMouseEnter={() => onHover(index)}
+              >
+                <span className="slash-name">
+                  {rowLabel(entry)}
+                  {hint ? <span className="slash-hint">{hint}</span> : null}
+                </span>
+                {description ? (
+                  <span className="slash-desc">{description}</span>
                 ) : null}
-              </span>
-              <span className="slash-desc">{entry.description}</span>
-            </button>
-          </li>
-        ))}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     );
   },

--- a/frontend/src/components/SessionDetail.tsx
+++ b/frontend/src/components/SessionDetail.tsx
@@ -2615,6 +2615,7 @@ const ReplyComposer = memo(function ReplyComposer({
     draft,
     setDraft,
     enabled: supportsSlash,
+    pathEnabled: !disabled,
     textareaRef,
   });
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1626,7 +1626,7 @@ export async function fetchWorkspaceTree(
   token: string,
   sessionId: string,
   relPath = "",
-  opts: { offset?: number; limit?: number } = {},
+  opts: { offset?: number; limit?: number; signal?: AbortSignal } = {},
 ): Promise<WorkspaceTreePage> {
   const params = new URLSearchParams();
   if (relPath) params.set("path", relPath);
@@ -1638,6 +1638,7 @@ export async function fetchWorkspaceTree(
     {
       headers: { Authorization: `Bearer ${token}` },
       cache: "no-store",
+      signal: opts.signal,
     },
   );
   await ensureOk(response, "failed to fetch workspace tree");

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -3,8 +3,11 @@
 import type { KeyboardEvent, RefObject } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { commandLabel } from "@/components/CommandSuggestions";
-import { fetchSessionCompletionsResponse } from "@/lib/api";
+import {
+  fetchSessionCompletionsResponse,
+  fetchWorkspaceTree,
+  type WorkspaceTreeEntry,
+} from "@/lib/api";
 import { isInlineMenuAcceptKey } from "@/lib/keyboard";
 import type {
   CommandCompletion,
@@ -13,6 +16,7 @@ import type {
 
 const COMPLETION_FETCH_DEBOUNCE_MS = 180;
 const COMPLETION_REFRESH_POLL_MS = 750;
+const WORKSPACE_PATH_PAGE_LIMIT = 200;
 
 // `/new` works on every structured backend so we surface it locally
 // while the debounced fetch is in flight or if the request fails. Tmux
@@ -30,13 +34,94 @@ export const SLASH_NEW_FALLBACK: CommandCompletion = {
   metadata: {},
 };
 
+// A `./`-triggered workspace path candidate. Frontend-only: unlike a
+// ``CommandCompletion`` it never dispatches, so it carries no id/kind/dispatch
+// contract — selecting it just edits the draft text.
+export interface WorkspacePathSuggestion {
+  type: "workspace_path";
+  label: string; // e.g. "./src/components/"
+  replacement: string; // identical to label
+  description: "Directory" | "File" | "Symlink";
+}
+
+// The menu renders a mix of backend commands and local path suggestions. A
+// discriminated union keeps a filesystem path from ever masquerading as a
+// ``CommandCompletion`` (which would let it reach command dispatch).
+export type SuggestionRow =
+  | { type: "command"; command: CommandCompletion }
+  | WorkspacePathSuggestion;
+
+export function commandLabel(entry: CommandCompletion): string {
+  return `${entry.trigger}${entry.name}`;
+}
+
+export function rowKey(row: SuggestionRow): string {
+  return row.type === "command" ? row.command.id : row.replacement;
+}
+
+export function rowLabel(row: SuggestionRow): string {
+  return row.type === "command" ? commandLabel(row.command) : row.label;
+}
+
+export function rowDescription(row: SuggestionRow): string | null {
+  return row.type === "command"
+    ? row.command.description ?? null
+    : row.description;
+}
+
+export function rowHint(row: SuggestionRow): string | null {
+  return row.type === "command" ? row.command.argument_hint ?? null : null;
+}
+
+// Parse a `./`-prefixed caret token into the directory to list and the leaf
+// name being typed. Returns null when the token isn't a `./` path or contains a
+// `.`/`..` traversal segment — `./` is the only supported relative-root marker,
+// so an out-of-scope prefix must never be normalized into a valid query.
+export function parseWorkspacePathToken(
+  head: string,
+): { dir: string; leaf: string } | null {
+  if (!head.startsWith("./")) return null;
+  const fragment = head.slice(2);
+  const lastSlash = fragment.lastIndexOf("/");
+  const dir = lastSlash === -1 ? "" : fragment.slice(0, lastSlash);
+  const leaf = lastSlash === -1 ? fragment : fragment.slice(lastSlash + 1);
+  const segments = dir.split("/").filter((segment) => segment.length > 0);
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return null;
+  }
+  return { dir, leaf };
+}
+
+function workspacePathRow(
+  dir: string,
+  entry: WorkspaceTreeEntry,
+): WorkspacePathSuggestion {
+  const prefix = dir ? `./${dir}/` : "./";
+  const isDir = entry.kind === "dir";
+  const replacement = isDir
+    ? `${prefix}${entry.name}/`
+    : `${prefix}${entry.name}`;
+  const description =
+    entry.kind === "dir"
+      ? "Directory"
+      : entry.kind === "symlink"
+        ? "Symlink"
+        : "File";
+  return { type: "workspace_path", label: replacement, replacement, description };
+}
+
 interface UseCommandCompletionsOptions {
   host: string;
   token: string;
   sessionId: string;
   draft: string;
   setDraft: (next: string) => void;
+  // Gates `/` and `$` command/skill completions (the structured-transport
+  // surface). Path completion has its own gate.
   enabled: boolean;
+  // Gates `./` workspace-path completion. Defaults to ``enabled``; chat gates it
+  // on the composer being usable rather than on structured transport.
+  pathEnabled?: boolean;
   // Override the local fallback list. Chat composer uses ``/new``; the
   // tmux composer passes ``[]`` because its backend doesn't accept it.
   localFallback?: ReadonlyArray<CommandCompletion>;
@@ -44,7 +129,7 @@ interface UseCommandCompletionsOptions {
 }
 
 export interface CommandCompletionsState {
-  suggestions: ReadonlyArray<CommandCompletion>;
+  suggestions: ReadonlyArray<SuggestionRow>;
   suggestionsOpen: boolean;
   activeIndex: number;
   setActiveIndex: (index: number) => void;
@@ -64,12 +149,20 @@ export function useCommandCompletions({
   draft,
   setDraft,
   enabled,
+  pathEnabled,
   localFallback = [SLASH_NEW_FALLBACK],
   textareaRef,
 }: UseCommandCompletionsOptions): CommandCompletionsState {
+  const pathCompletionEnabled = pathEnabled ?? enabled;
   const [suggestionIndex, setSuggestionIndex] = useState(0);
   const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
   const [backendCompletions, setBackendCompletions] = useState<CommandCompletion[]>([]);
+  // The last workspace directory page, tagged with the directory it lists so a
+  // late response for a different token can be ignored in the memo.
+  const [pathPage, setPathPage] = useState<{
+    dir: string;
+    entries: WorkspaceTreeEntry[];
+  } | null>(null);
   const [selectedCompletion, setSelectedCompletion] =
     useState<CommandCompletion | null>(null);
 
@@ -116,27 +209,44 @@ export function useCommandCompletions({
     : completionHead.startsWith("$")
       ? "$"
       : null;
+  const isPathHead = completionHead.startsWith("./");
+  const onCompletableToken = completionTrigger !== null || isPathHead;
 
-  const suggestions = useMemo<ReadonlyArray<CommandCompletion>>(() => {
-    if (!enabled || suggestionsDismissed || completionTrigger === null) {
-      return [];
+  const suggestions = useMemo<ReadonlyArray<SuggestionRow>>(() => {
+    if (suggestionsDismissed) return [];
+    // `./` paths and `/`/`$` commands can't share a caret token (different lead
+    // char), so a single branch decides which source, if any, is eligible.
+    if (isPathHead) {
+      if (!pathCompletionEnabled) return [];
+      const parsed = parseWorkspacePathToken(completionHead);
+      if (!parsed || !pathPage || pathPage.dir !== parsed.dir) return [];
+      const leaf = parsed.leaf.toLowerCase();
+      return pathPage.entries
+        .filter((entry) => entry.name.toLowerCase().startsWith(leaf))
+        .map((entry) => workspacePathRow(parsed.dir, entry));
     }
+    if (!enabled || completionTrigger === null) return [];
     const pool =
       completionTrigger === "/"
         ? mergeLocalFallback(backendCompletions, localFallback)
         : backendCompletions;
-    return pool.filter((entry) => commandLabel(entry).startsWith(completionHead));
+    return pool
+      .filter((entry) => commandLabel(entry).startsWith(completionHead))
+      .map((command) => ({ type: "command", command }) as const);
   }, [
     backendCompletions,
     completionHead,
     completionTrigger,
     enabled,
+    isPathHead,
     localFallback,
+    pathCompletionEnabled,
+    pathPage,
     suggestionsDismissed,
   ]);
 
-  // ``suggestions`` is already empty unless the caret sits on a ``/``/``$``
-  // word, so its presence is the open condition — no whole-draft test that
+  // ``suggestions`` is already empty unless the caret sits on a completable
+  // token, so its presence is the open condition — no whole-draft test that
   // would suppress mid-prompt triggers.
   const suggestionsOpen = suggestions.length > 0;
   const activeIndex = Math.min(
@@ -192,6 +302,46 @@ export function useCommandCompletions({
   }, [host, token, sessionId, enabled, completionTrigger, completionHead]);
 
   useEffect(() => {
+    const parsed =
+      pathCompletionEnabled && !suggestionsDismissed
+        ? parseWorkspacePathToken(completionHead)
+        : null;
+    if (!parsed) return;
+    const { dir } = parsed;
+    const controller = new AbortController();
+    const debounceTimer = window.setTimeout(() => {
+      fetchWorkspaceTree(host, token, sessionId, dir, {
+        limit: WORKSPACE_PATH_PAGE_LIMIT,
+        signal: controller.signal,
+      })
+        .then((page) => {
+          if (controller.signal.aborted) return;
+          setPathPage({ dir, entries: page.entries });
+        })
+        .catch((error) => {
+          if (error instanceof DOMException && error.name === "AbortError") {
+            return;
+          }
+          // Remote session, disabled preview, 404, denied path: stay silent and
+          // preserve the draft. Drop only a stale page for this same directory
+          // so a different open token's candidates are never overwritten.
+          setPathPage((current) => (current?.dir === dir ? null : current));
+        });
+    }, COMPLETION_FETCH_DEBOUNCE_MS);
+    return () => {
+      controller.abort();
+      window.clearTimeout(debounceTimer);
+    };
+  }, [
+    host,
+    token,
+    sessionId,
+    pathCompletionEnabled,
+    suggestionsDismissed,
+    completionHead,
+  ]);
+
+  useEffect(() => {
     setSuggestionIndex(0);
   }, [completionHead]);
 
@@ -212,12 +362,12 @@ export function useCommandCompletions({
   }, [activeIndex, suggestionsOpen, suggestions.length]);
 
   useEffect(() => {
-    // Re-arm once the caret leaves the trigger word, so a fresh ``/``/``$``
-    // re-opens the list after a prior Escape.
-    if (completionTrigger === null) {
+    // Re-arm once the caret leaves the completable word, so a fresh
+    // ``/``/``$``/``./`` re-opens the list after a prior Escape.
+    if (!onCompletableToken) {
       setSuggestionsDismissed(false);
     }
-  }, [completionTrigger]);
+  }, [onCompletableToken]);
 
   useEffect(() => {
     if (
@@ -234,18 +384,32 @@ export function useCommandCompletions({
     // Replace the whole word the caret is in (its run on both sides), not the
     // entire draft, so mid-prompt completions leave surrounding text intact.
     const pos = textareaRef ? Math.min(caret, draft.length) : draft.length;
-    const [wordStart, wordEnd] = wordRangeAt(draft, pos);
-    // Replacements carry a trailing space; drop a redundant one from the tail
-    // so completing inside "see /to|do here" doesn't double the gap.
-    const tail = draft.slice(wordEnd);
+    const [start, end] = wordRangeAt(draft, pos);
+    const replacement =
+      chosen.type === "command" ? chosen.command.replacement : chosen.replacement;
+    // Command replacements carry a trailing space; drop a redundant one from the
+    // tail so completing inside "see /to|do here" doesn't double the gap. Path
+    // replacements carry no trailing blank, so this never applies to them.
+    const tail = draft.slice(end);
     const joinedTail =
-      chosen.replacement.endsWith(" ") && tail.startsWith(" ") ? tail.slice(1) : tail;
-    const next = draft.slice(0, wordStart) + chosen.replacement + joinedTail;
-    const nextCaret = wordStart + chosen.replacement.length;
+      chosen.type === "command" &&
+      replacement.endsWith(" ") &&
+      tail.startsWith(" ")
+        ? tail.slice(1)
+        : tail;
+    const next = draft.slice(0, start) + replacement + joinedTail;
+    const nextCaret = start + replacement.length;
     setDraft(next);
     setCaret(nextCaret);
-    setSelectedCompletion(chosen);
-    setSuggestionsDismissed(true);
+    if (chosen.type === "command") {
+      setSelectedCompletion(chosen.command);
+      setSuggestionsDismissed(true);
+    } else {
+      // A directory's trailing slash leaves the caret on a fresh `./dir/` token,
+      // so keep the menu armed to offer its children; a file is complete, so
+      // dismiss until the caret leaves the token.
+      setSuggestionsDismissed(chosen.description !== "Directory");
+    }
     if (textareaRef) {
       requestAnimationFrame(() => {
         const el = textareaRef.current;

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -34,19 +34,16 @@ export const SLASH_NEW_FALLBACK: CommandCompletion = {
   metadata: {},
 };
 
-// A `./`-triggered workspace path candidate. Frontend-only: unlike a
-// ``CommandCompletion`` it never dispatches, so it carries no id/kind/dispatch
-// contract — selecting it just edits the draft text.
+// A `./` workspace path candidate; selecting it edits the draft, never dispatches.
 export interface WorkspacePathSuggestion {
   type: "workspace_path";
-  label: string; // e.g. "./src/components/"
-  replacement: string; // identical to label
+  label: string;
+  replacement: string;
   description: "Directory" | "File" | "Symlink";
 }
 
-// The menu renders a mix of backend commands and local path suggestions. A
-// discriminated union keeps a filesystem path from ever masquerading as a
-// ``CommandCompletion`` (which would let it reach command dispatch).
+// A menu row: a backend command or a workspace path. The discriminated union
+// keeps a path from reaching command dispatch.
 export type SuggestionRow =
   | { type: "command"; command: CommandCompletion }
   | WorkspacePathSuggestion;
@@ -73,10 +70,9 @@ export function rowHint(row: SuggestionRow): string | null {
   return row.type === "command" ? row.command.argument_hint ?? null : null;
 }
 
-// Parse a `./`-prefixed caret token into the directory to list and the leaf
-// name being typed. Returns null when the token isn't a `./` path or contains a
-// `.`/`..` traversal segment — `./` is the only supported relative-root marker,
-// so an out-of-scope prefix must never be normalized into a valid query.
+// Split a `./` caret token into the directory to list and the leaf being typed.
+// Null when the token isn't `./`-rooted or a directory segment is `.`/`..`, so
+// an out-of-scope prefix never becomes a valid query.
 export function parseWorkspacePathToken(
   head: string,
 ): { dir: string; leaf: string } | null {
@@ -116,11 +112,9 @@ interface UseCommandCompletionsOptions {
   sessionId: string;
   draft: string;
   setDraft: (next: string) => void;
-  // Gates `/` and `$` command/skill completions (the structured-transport
-  // surface). Path completion has its own gate.
+  // Gates `/` and `$` completions.
   enabled: boolean;
-  // Gates `./` workspace-path completion. Defaults to ``enabled``; chat gates it
-  // on the composer being usable rather than on structured transport.
+  // Gates `./` path completion. Defaults to ``enabled``.
   pathEnabled?: boolean;
   // Override the local fallback list. Chat composer uses ``/new``; the
   // tmux composer passes ``[]`` because its backend doesn't accept it.
@@ -157,8 +151,8 @@ export function useCommandCompletions({
   const [suggestionIndex, setSuggestionIndex] = useState(0);
   const [suggestionsDismissed, setSuggestionsDismissed] = useState(false);
   const [backendCompletions, setBackendCompletions] = useState<CommandCompletion[]>([]);
-  // The last workspace directory page, tagged with the directory it lists so a
-  // late response for a different token can be ignored in the memo.
+  // The last workspace directory page, tagged with its directory so a stale
+  // response for another token is ignored.
   const [pathPage, setPathPage] = useState<{
     dir: string;
     entries: WorkspaceTreeEntry[];
@@ -214,8 +208,7 @@ export function useCommandCompletions({
 
   const suggestions = useMemo<ReadonlyArray<SuggestionRow>>(() => {
     if (suggestionsDismissed) return [];
-    // `./` paths and `/`/`$` commands can't share a caret token (different lead
-    // char), so a single branch decides which source, if any, is eligible.
+    // A token can't be both `./` and `/`/`$`, so at most one source is eligible.
     if (isPathHead) {
       if (!pathCompletionEnabled) return [];
       const parsed = parseWorkspacePathToken(completionHead);
@@ -322,9 +315,8 @@ export function useCommandCompletions({
           if (error instanceof DOMException && error.name === "AbortError") {
             return;
           }
-          // Remote session, disabled preview, 404, denied path: stay silent and
-          // preserve the draft. Drop only a stale page for this same directory
-          // so a different open token's candidates are never overwritten.
+          // Remote, disabled, 404, or denied: stay silent. Drop only this
+          // directory's own stale page, never another token's.
           setPathPage((current) => (current?.dir === dir ? null : current));
         });
     }, COMPLETION_FETCH_DEBOUNCE_MS);
@@ -362,8 +354,7 @@ export function useCommandCompletions({
   }, [activeIndex, suggestionsOpen, suggestions.length]);
 
   useEffect(() => {
-    // Re-arm once the caret leaves the completable word, so a fresh
-    // ``/``/``$``/``./`` re-opens the list after a prior Escape.
+    // Re-arm when the caret leaves the token, so a new trigger reopens the list.
     if (!onCompletableToken) {
       setSuggestionsDismissed(false);
     }
@@ -387,9 +378,8 @@ export function useCommandCompletions({
     const [start, end] = wordRangeAt(draft, pos);
     const replacement =
       chosen.type === "command" ? chosen.command.replacement : chosen.replacement;
-    // Command replacements carry a trailing space; drop a redundant one from the
-    // tail so completing inside "see /to|do here" doesn't double the gap. Path
-    // replacements carry no trailing blank, so this never applies to them.
+    // Command replacements carry a trailing space; drop a redundant one so
+    // completing inside "see /to|do here" doesn't double the gap.
     const tail = draft.slice(end);
     const joinedTail =
       chosen.type === "command" &&
@@ -405,10 +395,9 @@ export function useCommandCompletions({
       setSelectedCompletion(chosen.command);
       setSuggestionsDismissed(true);
     } else {
-      // A directory's trailing slash leaves the caret on a fresh `./dir/` token,
-      // so keep the menu armed to offer its children; a file is complete, so
-      // dismiss until the caret leaves the token.
-      setSuggestionsDismissed(chosen.description !== "Directory");
+      // Keep the menu armed after a directory (trailing slash) to offer its
+      // children; dismiss after a file.
+      setSuggestionsDismissed(!replacement.endsWith("/"));
     }
     if (textareaRef) {
       requestAnimationFrame(() => {

--- a/frontend/src/lib/composer-completions.ts
+++ b/frontend/src/lib/composer-completions.ts
@@ -37,7 +37,6 @@ export const SLASH_NEW_FALLBACK: CommandCompletion = {
 // A `./` workspace path candidate; selecting it edits the draft, never dispatches.
 export interface WorkspacePathSuggestion {
   type: "workspace_path";
-  label: string;
   replacement: string;
   description: "Directory" | "File" | "Symlink";
 }
@@ -57,7 +56,7 @@ export function rowKey(row: SuggestionRow): string {
 }
 
 export function rowLabel(row: SuggestionRow): string {
-  return row.type === "command" ? commandLabel(row.command) : row.label;
+  return row.type === "command" ? commandLabel(row.command) : row.replacement;
 }
 
 export function rowDescription(row: SuggestionRow): string | null {
@@ -93,17 +92,18 @@ function workspacePathRow(
   entry: WorkspaceTreeEntry,
 ): WorkspacePathSuggestion {
   const prefix = dir ? `./${dir}/` : "./";
-  const isDir = entry.kind === "dir";
-  const replacement = isDir
-    ? `${prefix}${entry.name}/`
-    : `${prefix}${entry.name}`;
+  const suffix = entry.kind === "dir" ? "/" : "";
   const description =
     entry.kind === "dir"
       ? "Directory"
       : entry.kind === "symlink"
         ? "Symlink"
         : "File";
-  return { type: "workspace_path", label: replacement, replacement, description };
+  return {
+    type: "workspace_path",
+    replacement: `${prefix}${entry.name}${suffix}`,
+    description,
+  };
 }
 
 interface UseCommandCompletionsOptions {
@@ -205,6 +205,13 @@ export function useCommandCompletions({
       : null;
   const isPathHead = completionHead.startsWith("./");
   const onCompletableToken = completionTrigger !== null || isPathHead;
+  // The directory a `./` token would list, or null when no query should run.
+  // Keyed on the directory (not the whole token) so typing the leaf filters the
+  // loaded page client-side instead of re-fetching the same listing.
+  const pathQueryDir =
+    pathCompletionEnabled && !suggestionsDismissed
+      ? parseWorkspacePathToken(completionHead)?.dir ?? null
+      : null;
 
   const suggestions = useMemo<ReadonlyArray<SuggestionRow>>(() => {
     if (suggestionsDismissed) return [];
@@ -295,12 +302,8 @@ export function useCommandCompletions({
   }, [host, token, sessionId, enabled, completionTrigger, completionHead]);
 
   useEffect(() => {
-    const parsed =
-      pathCompletionEnabled && !suggestionsDismissed
-        ? parseWorkspacePathToken(completionHead)
-        : null;
-    if (!parsed) return;
-    const { dir } = parsed;
+    if (pathQueryDir === null) return;
+    const dir = pathQueryDir;
     const controller = new AbortController();
     const debounceTimer = window.setTimeout(() => {
       fetchWorkspaceTree(host, token, sessionId, dir, {
@@ -324,14 +327,7 @@ export function useCommandCompletions({
       controller.abort();
       window.clearTimeout(debounceTimer);
     };
-  }, [
-    host,
-    token,
-    sessionId,
-    pathCompletionEnabled,
-    suggestionsDismissed,
-    completionHead,
-  ]);
+  }, [host, token, sessionId, pathQueryDir]);
 
   useEffect(() => {
     setSuggestionIndex(0);


### PR DESCRIPTION
## Purpose

Referring an agent to a workspace file means typing a long, uncertain path by hand — slow and error-prone, especially on a phone. This adds path suggestions when a caret token begins with `./`, in both the chat composer and the terminal quick-compose drawer, reusing the existing `/`/`$` suggestion popover, keyboard navigation, debounce, and caret-aware replacement. Implements `.waypoint/specs/rfc-1575-workspace-path-completion.md` (Ticket 1575, Option 1). Selecting a path is a text-editing aid only: the result is ordinary user input, never a command invocation. Relates to #1575.

## Changes

### Frontend
- `frontend/src/lib/composer-completions.ts` — classify the caret token into three completion sources — command (`/`), skill (`$`), and workspace path (`./`) — and model menu rows as a `SuggestionRow` discriminated union (`{ type: "command" }` | `WorkspacePathSuggestion`) so a filesystem path can never masquerade as a `CommandCompletion` or reach command dispatch. Adds `parseWorkspacePathToken` (splits `./frag` into the directory to list and the leaf to prefix-match; returns null on a `.`/`..` traversal segment so an out-of-scope prefix is never normalized into a valid query), an abort-aware directory fetch (`limit=200`) tagged with its directory so a late or cross-directory response never overwrites the current token, case-insensitive leaf filtering that preserves the server's directories-first ordering, and a path-aware apply that inserts `./dir/` (re-arming the menu for the directory's children) or `./path` for a file/symlink with no trailing blank, without ever setting `selectedCompletion`. `commandLabel` moves here to keep a one-way dependency with the popover.
- `frontend/src/components/CommandSuggestions.tsx` — render the `SuggestionRow` union through `rowKey`/`rowLabel`/`rowDescription`/`rowHint` helpers, keeping the existing popover markup, listbox roles, and CSS classes so no new floating surface is introduced.
- `frontend/src/lib/api.ts` — thread an optional `AbortSignal` through `fetchWorkspaceTree` so the completion fetch is cancellable.
- `frontend/src/components/SessionDetail.tsx` — gate `./` path completion on the chat composer being usable (`pathEnabled: !disabled`) rather than on the structured-transport capability that gates `/` and `$`. `TerminalCompose` needs no change: `pathEnabled` defaults to its existing `enabled: expanded`.

## Design

- **Reuse the workspace-tree endpoint (RFC Option 1).** Path lookups reuse the authenticated `GET /api/sessions/{id}/workspace/tree` endpoint — one bounded directory page — inheriting its local-only, `workspace_preview_enabled`, denylist, and symlink policy with no new endpoint, cache, or server state. The endpoint stays authoritative for eligibility: a remote session, disabled preview, denied path, or missing directory returns an error the hook swallows silently, so absence of suggestions never surfaces a toast and the feature automatically follows future workspace-preview policy changes.
- **One discriminated union, one menu.** `./` and `/`/`$` can't share a caret token (different lead char), and `@` mentions are a separate hook, so exactly one inline menu is ever eligible. The command path (backend stale-while-revalidate fetch, `/new` fallback, selected-command dispatch) is unchanged; only its rows are wrapped in the union.
- **Directory re-arm.** A directory's trailing slash leaves the caret on a fresh `./dir/` token and keeps the menu live so the next level completes immediately; a file is complete and dismisses until the caret leaves the token. Escape suppresses only the current token and re-arms on a new `./`.

## Test Plan

- `cd frontend && npm run lint`
- `cd frontend && npm run build` (TypeScript type-check)
- Live end-to-end against the deployed stack (`waypointctl restart frontend`, backend `:8797` / frontend `:3010`) with Playwright at mobile width (390px): chat composer path completion (root/nested/mid-prompt tokens, prefix filtering, directory trailing-slash + re-arm, Tab/Enter/arrow accept, file insertion with no trailing slash, Escape dismiss + re-arm, `..`-segment and no-match silence); the terminal quick-compose drawer over the tmux transport (same behavior, directories-first with correct `File`/`Directory` descriptions); and a regression pass confirming `/` command menus still render and `./` also works on a structured session. Denylist behavior spot-checked directly (`GET .../workspace/tree?path=.git` → 403 → silent no-menu).

## Test Result

- `npm run lint` — clean.
- `npm run build` — compiled successfully, TypeScript type-check passed.
- Playwright chat composer suite — 17/17 checks passed.
- Playwright terminal-drawer + command-regression suite — 11/11 checks passed.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run frontend checks (`cd frontend && npm run lint && npm run build`) and kept dark/light theme parity (the feature reuses the shared suggestion surface, adding no new CSS).
- [ ] No backend code changed; backend suites not run.
- [x] The completion change dispatches only by the existing command union and adds a frontend-only path row, so `/` command dispatch and the `claude_code`/`codex`/`opencode` backends are unaffected; verified `/` menus and terminal drawer against live sessions.

</details>