### PR TITLE
fix: allow switching a session back to no profile in settings

### DIFF
--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -3292,10 +3292,6 @@ class SessionRuntime:
             and request.account_profile_id != session.account_profile_id
             and request.account_profile_id is not None
         )
-        # Clearing a real profile back to no profile: not ``profile_changing``
-        # (no target account to probe/verify), but the restored session must
-        # revert to the agent's default config dir rather than keep the old
-        # profile's dir.
         clearing_profile = (
             "account_profile_id" in fields
             and request.account_profile_id is None
@@ -3384,10 +3380,9 @@ class SessionRuntime:
             session.backend, new_env, selected_profile_id, launch_target
         )
         new_profile_label = resolved_label if selected_profile_id is not None else None
-        # ``_apply_account_profile_env`` is a no-op for no profile, so clearing
-        # leaves the old profile's config-dir key stranded in the env — the
-        # session would keep resolving to that account. Drop it so the restore
-        # falls back to the agent's default config dir.
+        # ``_apply_account_profile_env`` leaves the config-dir key untouched for
+        # no profile, so a cleared profile's key would otherwise persist and
+        # keep resolving to that account. Drop it to fall back to the default.
         if clearing_profile and caps.config_dir_env_var is not None:
             new_env.pop(caps.config_dir_env_var, None)
         # Reject before the destructive terminate/restore if the target profile's
@@ -3553,12 +3548,10 @@ class SessionRuntime:
                             )
                         fresh_thread_restarter = plugin
 
-        # Clearing the profile (set -> None) is not ``profile_changing``, but a
-        # de-profiled session must not keep stale provenance, so null the
-        # triple explicitly here; ``profile_changing`` already set the triple
-        # above from the probe just run, and any other update (model/args-only)
-        # leaves it empty so the persisted values are untouched.
-        if not profile_changing and clearing_profile:
+        # A cleared profile must not keep stale provenance; null the triple
+        # here. A profile change stamps it from the probe above; other edits
+        # leave it empty, so persisted values stay untouched.
+        if clearing_profile:
             verified_account_fields = {
                 "verified_account_key": None,
                 "verified_account_label": None,

--- a/backend/src/waypoint/runtime.py
+++ b/backend/src/waypoint/runtime.py
@@ -3292,6 +3292,15 @@ class SessionRuntime:
             and request.account_profile_id != session.account_profile_id
             and request.account_profile_id is not None
         )
+        # Clearing a real profile back to no profile: not ``profile_changing``
+        # (no target account to probe/verify), but the restored session must
+        # revert to the agent's default config dir rather than keep the old
+        # profile's dir.
+        clearing_profile = (
+            "account_profile_id" in fields
+            and request.account_profile_id is None
+            and session.account_profile_id is not None
+        )
         if profile_changing and not gate_caps.supports_account_profile_with_restart:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -3375,6 +3384,12 @@ class SessionRuntime:
             session.backend, new_env, selected_profile_id, launch_target
         )
         new_profile_label = resolved_label if selected_profile_id is not None else None
+        # ``_apply_account_profile_env`` is a no-op for no profile, so clearing
+        # leaves the old profile's config-dir key stranded in the env — the
+        # session would keep resolving to that account. Drop it so the restore
+        # falls back to the agent's default config dir.
+        if clearing_profile and caps.config_dir_env_var is not None:
+            new_env.pop(caps.config_dir_env_var, None)
         # Reject before the destructive terminate/restore if the target profile's
         # config dir would strand this session on an interactive first-run prompt
         # (``caps`` is the session's composed transport capability).
@@ -3543,11 +3558,7 @@ class SessionRuntime:
         # triple explicitly here; ``profile_changing`` already set the triple
         # above from the probe just run, and any other update (model/args-only)
         # leaves it empty so the persisted values are untouched.
-        if not profile_changing and (
-            "account_profile_id" in fields
-            and request.account_profile_id is None
-            and session.account_profile_id is not None
-        ):
+        if not profile_changing and clearing_profile:
             verified_account_fields = {
                 "verified_account_key": None,
                 "verified_account_label": None,

--- a/backend/tests/test_verified_account_persistence.py
+++ b/backend/tests/test_verified_account_persistence.py
@@ -258,6 +258,42 @@ async def test_switch_clearing_profile_nulls_verified_fields(
     assert refreshed.verified_account_probed_at is None
 
 
+async def test_switch_clearing_profile_strips_config_dir_key(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Clearing a profile must revert the session to the agent's default config
+    # dir: the profile-owned config-dir key is dropped from launch_env so the
+    # restored session no longer resolves to the (now unselected) profile.
+    runtime = _runtime(tmp_path, codex=_codex_profiles())
+    _session(
+        runtime,
+        account_profile_id="work",
+        account_profile_label="Work",
+        launch_env={
+            "CODEX_HOME": "/home/u/.codex-work",
+            "WAYPOINT_SESSION_ID": "s1",
+        },
+    )
+    plugin = runtime.registry.plugin_for(runtime.get_session("s1"))
+
+    async def fake_terminate(*_a: Any, **_k: Any) -> None:
+        return None
+
+    async def fake_restore(_rt: Any, session: SessionRecord) -> None:
+        runtime.storage.update_session(session.id, status=SessionStatus.IDLE)
+
+    monkeypatch.setattr(plugin, "terminate_session", fake_terminate)
+    monkeypatch.setattr(plugin, "restore_session", fake_restore)
+
+    refreshed = await runtime.update_launch_settings(
+        "s1",
+        LaunchSettingsUpdateRequest(account_profile_id=None, restart=True),
+    )
+    assert refreshed.account_profile_id is None
+    assert "CODEX_HOME" not in refreshed.launch_env
+    assert refreshed.launch_env.get("WAYPOINT_SESSION_ID") == "s1"
+
+
 async def test_switch_model_only_edit_leaves_verified_fields_untouched(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -522,15 +522,11 @@ export function SessionSettingsModal({
                       }
                       disabled={busy || assistantReplacementStaged}
                     >
-                      {/* A session may currently run under no profile; show a
-                          disabled placeholder so the value isn't orphaned.
-                          Clearing a profile to none is out of scope, so it
-                          can't be re-selected once a real profile is chosen. */}
-                      {accountProfileId === null ? (
-                        <option value="" disabled>
-                          No profile
-                        </option>
-                      ) : null}
+                      {/* The default no-profile option (the agent's own
+                          config/account). Always selectable so a session
+                          running under a real profile can be switched back to
+                          no profile. */}
+                      <option value="">No profile</option>
                       {accountProfiles.map((profile) => (
                         <option key={profile.id} value={profile.id}>
                           {profile.label}

--- a/frontend/src/components/SessionSettingsModal.tsx
+++ b/frontend/src/components/SessionSettingsModal.tsx
@@ -522,10 +522,6 @@ export function SessionSettingsModal({
                       }
                       disabled={busy || assistantReplacementStaged}
                     >
-                      {/* The default no-profile option (the agent's own
-                          config/account). Always selectable so a session
-                          running under a real profile can be switched back to
-                          no profile. */}
                       <option value="">No profile</option>
                       {accountProfiles.map((profile) => (
                         <option key={profile.id} value={profile.id}>

--- a/frontend/src/lib/useSessionSettings.ts
+++ b/frontend/src/lib/useSessionSettings.ts
@@ -521,8 +521,7 @@ export function useSessionSettings(
   );
   const profileChanged = Boolean(
     session &&
-      (accountProfileId ?? null) !== (session.account_profile_id ?? null) &&
-      accountProfileId !== null,
+      (accountProfileId ?? null) !== (session.account_profile_id ?? null),
   );
   const argsChanged = Boolean(
     launchSettings && !sameStringList(stagedArgs, launchSettings.args),


### PR DESCRIPTION
## Purpose

In session settings, a session running under an account profile (e.g. Codex under the `nus` profile) could not be switched back to the default "no profile" account. The profile selector only offered a disabled "No profile" placeholder, and even a forced clear left the session bound to the old profile's config directory. Addresses ticket 1600.

## Changes

### Backend

- `backend/src/waypoint/runtime.py` — when a launch-settings update clears the account profile (sets it to null), drop the profile-owned config-dir env key (e.g. `CODEX_HOME`) so the restarted session reverts to the agent's default config dir instead of silently keeping the old profile's account. The same "clearing" condition is reused to null the verified-account provenance.
- `backend/tests/test_verified_account_persistence.py` — cover that clearing a profile strips the config-dir key.

### Frontend

- `frontend/src/components/SessionSettingsModal.tsx` — render "No profile" as an always-selectable option instead of a disabled placeholder shown only when the session already had no profile.
- `frontend/src/lib/useSessionSettings.ts` — treat a switch to no profile as a pending change so Apply enables and the launch-settings PATCH is sent.

## Design

The backend already persisted `account_profile_id = null` on clear (with a tested path for it), but `_apply_account_profile_env` is a no-op for no profile, so the previous profile's config-dir key stayed in the launch env and the restored session still authenticated as that account — a clear in name only. Stripping the key on clear makes "no profile" resolve to the agent's default config dir, matching a freshly launched no-profile session. Clearing stays distinct from a profile→profile switch (there is no target account to probe/verify); the existing restart-and-resume warning already covers the Codex fresh-thread case.

## Test Plan

- `cd backend && uv run pytest tests/test_verified_account_persistence.py tests/test_launch_settings.py tests/test_account_profile_selection.py`
- `cd backend && uv run pre-commit run --files backend/src/waypoint/runtime.py backend/tests/test_verified_account_persistence.py`
- `cd frontend && npm run lint && npm run build`
- Live end-to-end against the deployed stack (`waypointctl restart`, backend `:8797` / frontend `:3010`) with Playwright: launched a throwaway Codex session under the `nus` profile, opened session settings, switched the profile to "No profile", and applied.

## Test Result

- Backend: 75 passed; the new test is green; the pre-commit hooks (isort/black/ruff/codespell/mypy) pass on the changed files.
- Frontend: lint clean, production build succeeds.
- End-to-end: the settings modal offered "No profile" as a selectable option, Apply enabled on selecting it, and after apply the session persisted `account_profile_id = null` with `CODEX_HOME` removed from its launch env (reverted to the Codex default) — versus the pre-fix behavior where `CODEX_HOME` stayed pinned to `~/.codex-nus`.

---

<details>
<summary>Pre-submission Checklist</summary>

- [x] I have read the contribution guidelines in `CONTRIBUTING.md`.
- [x] My PR title is a Conventional Commit and all my commits are signed off (`git commit -s`).
- [x] I have run `uv run pre-commit` on the changed files and fixed any issues (all hooks pass).
- [x] I have added or updated tests covering my changes.
- [x] I have verified the relevant suites pass locally (`cd backend && uv run pytest`).
- [x] I touched code that dispatches by launch-settings/profile handling and verified the Codex backend switch-to-no-profile works end-to-end; the change is plugin-neutral (strips the agent's own config-dir env key).
- [x] I changed the frontend and ran `cd frontend && npm run lint && npm run build`; no new styles were added (an existing option changes from disabled to enabled), so theme parity is unaffected.
- [ ] Not a breaking change.
- [ ] No user-facing docs/config examples needed updating.

</details>